### PR TITLE
feat(ai-sdk): add server history mode

### DIFF
--- a/.changeset/late-clocks-roll.md
+++ b/.changeset/late-clocks-roll.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed repeated message saves to keep the original createdAt value and replace old semantic recall vectors before inserting updated embeddings.

--- a/.changeset/quiet-grapes-worry.md
+++ b/.changeset/quiet-grapes-worry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': minor
+---
+
+Added server history mode for AI SDK chat routes so clients can submit compact chat events while Mastra loads stored memory history. Includes a transport helper for AI SDK UI submit, regenerate, and approval resume requests.

--- a/.changeset/violet-mammals-stay.md
+++ b/.changeset/violet-mammals-stay.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed memory history regeneration to recall only messages before the target assistant response and delete the replaced branch after the new response is saved. Server-history recovery also removes server-marked incomplete assistant responses before recalling stored history.
+Fixed memory history regeneration to recall only messages before the target assistant response and delete the replaced branch after the new response is saved. Server-history recovery also removes server-marked incomplete assistant responses before recalling stored history, while completed streams are no longer marked as aborted if the request signal fires after the model finish chunk.

--- a/.changeset/violet-mammals-stay.md
+++ b/.changeset/violet-mammals-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed memory history regeneration to recall only messages before the target assistant response and delete the replaced branch after the new response is saved. Server-history recovery also removes server-marked incomplete assistant responses before recalling stored history.

--- a/client-sdks/ai-sdk/README.md
+++ b/client-sdks/ai-sdk/README.md
@@ -57,6 +57,51 @@ const { error, status, sendMessage, messages, regenerate, stop } = useChat<MyMes
 
 `chatRoute()` forwards the incoming request `AbortSignal` to `agent.stream()`. If the client disconnects, Mastra aborts the in-flight generation. If you need generation to continue and persist server-side after disconnect, build a custom route around `agent.stream()`, avoid passing the request signal, and call `consumeStream()` on the returned `MastraModelOutput`.
 
+### Server-side message history
+
+When your agent uses Mastra memory, set `historySource: 'server'` and send only the new user message from the browser. Mastra loads the stored thread history on the server.
+
+```typescript
+import { chatRoute } from '@mastra/ai-sdk';
+
+export const mastra = new Mastra({
+  server: {
+    apiRoutes: [
+      chatRoute({
+        path: '/chat',
+        agent: 'weatherAgent',
+        historySource: 'server',
+        defaultOptions: {
+          memory: {
+            resource: 'user-123',
+          },
+        },
+      }),
+    ],
+  },
+});
+```
+
+Use the transport helper with AI SDK UI so submit, regenerate, and approval resume requests do not include the full browser history.
+
+```typescript
+import { prepareServerHistoryRequest } from '@mastra/ai-sdk/transport';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+
+const { sendMessage, regenerate } = useChat({
+  id: 'thread-123',
+  transport: new DefaultChatTransport({
+    api: 'http://localhost:4111/chat',
+    prepareSendMessagesRequest: prepareServerHistoryRequest(),
+  }),
+});
+```
+
+In server history mode, the request body may include only `id`, `message`, `messageId`, `trigger`, `resumeData`, and `runId`. Browser-provided `messages`, `memory`, `threadId`, `resourceId`, `requestContext`, and execution options are rejected.
+
+If a streamed assistant response is aborted and an incomplete response is persisted, the next server-history turn removes that incomplete response before loading history. Regenerate still uses server-stored messages as the source of truth.
+
 ### Workflow route
 
 Stream a workflow in AI SDK-compatible format.

--- a/client-sdks/ai-sdk/package.json
+++ b/client-sdks/ai-sdk/package.json
@@ -25,6 +25,16 @@
         "default": "./dist/ui.cjs"
       }
     },
+    "./transport": {
+      "import": {
+        "types": "./dist/transport.d.ts",
+        "default": "./dist/transport.js"
+      },
+      "require": {
+        "types": "./dist/transport.d.ts",
+        "default": "./dist/transport.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/client-sdks/ai-sdk/src/__tests__/server-history.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/server-history.test.ts
@@ -146,6 +146,67 @@ describe('server history', () => {
     expect(agent.stream).not.toHaveBeenCalled();
   });
 
+  it('rejects malformed server-history trigger and field combinations', async () => {
+    const { mastra } = createMockMastra();
+    const options = {
+      mastra: mastra as any,
+      agentId: 'test-agent',
+      historySource: 'server' as const,
+      defaultOptions: {
+        memory: {
+          resource: 'resource-1',
+        },
+      } as any,
+    };
+
+    await expect(
+      handleChatStream({
+        ...options,
+        params: {
+          id: 'thread-1',
+          trigger: 'bad-trigger',
+          message: { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+        } as any,
+      }),
+    ).rejects.toThrow('Server-history trigger must be "submit-message" or "regenerate-message"');
+
+    await expect(
+      handleChatStream({
+        ...options,
+        params: {
+          id: 'thread-1',
+          trigger: 'submit-message',
+          message: { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+          messageId: 'assistant-1',
+        },
+      }),
+    ).rejects.toThrow('Server-history submit requests cannot include messageId');
+
+    await expect(
+      handleChatStream({
+        ...options,
+        params: {
+          id: 'thread-1',
+          trigger: 'regenerate-message',
+          messageId: 'assistant-1',
+          message: { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+        },
+      }),
+    ).rejects.toThrow('Server-history regenerate requests cannot include a message');
+
+    await expect(
+      handleChatStream({
+        ...options,
+        params: {
+          id: 'thread-1',
+          runId: 'run-1',
+          resumeData: { approved: true },
+          message: { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+        },
+      }),
+    ).rejects.toThrow('Server-history resume requests cannot include a message');
+  });
+
   it('does not mutate a default requestContext with internal history overrides', async () => {
     const { mastra } = createMockMastra();
     const requestContext = new RequestContext();

--- a/client-sdks/ai-sdk/src/__tests__/server-history.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/server-history.test.ts
@@ -1,0 +1,268 @@
+import type { UIMessage } from '@internal/ai-sdk-v5';
+import { MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, RequestContext } from '@mastra/core/request-context';
+import { describe, expect, it, vi } from 'vitest';
+
+import { chatRoute, handleChatStream } from '../chat-route';
+
+const emptyAgentStream = {
+  fullStream: new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  }),
+};
+
+function createMockMastra() {
+  const agent = {
+    stream: vi.fn().mockResolvedValue(emptyAgentStream),
+    resumeStream: vi.fn().mockResolvedValue(emptyAgentStream),
+  };
+
+  const mastra = {
+    getAgentById: vi.fn().mockReturnValue(agent),
+    getLogger: vi.fn().mockReturnValue({ warn: vi.fn() }),
+  };
+
+  return { agent, mastra };
+}
+
+describe('server history', () => {
+  it('sends only the submitted message and uses a server-controlled resource scope', async () => {
+    const { agent, mastra } = createMockMastra();
+    const message: UIMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Hello' }],
+    };
+
+    await handleChatStream({
+      mastra: mastra as any,
+      agentId: 'test-agent',
+      historySource: 'server',
+      defaultOptions: {
+        memory: {
+          resource: 'resource-1',
+        },
+      } as any,
+      params: {
+        id: 'thread-1',
+        trigger: 'submit-message',
+        message,
+      },
+    });
+
+    expect(agent.stream).toHaveBeenCalledWith(
+      [message],
+      expect.objectContaining({
+        memory: {
+          thread: 'thread-1',
+          resource: 'resource-1',
+        },
+      }),
+    );
+  });
+
+  it('rejects client-provided message history in server history mode', async () => {
+    const { mastra } = createMockMastra();
+
+    await expect(
+      handleChatStream({
+        mastra: mastra as any,
+        agentId: 'test-agent',
+        historySource: 'server',
+        defaultOptions: {
+          memory: {
+            resource: 'resource-1',
+          },
+        } as any,
+        params: {
+          id: 'thread-1',
+          messages: [{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+        } as any,
+      }),
+    ).rejects.toThrow('Server-history requests cannot include "messages"');
+  });
+
+  it('sets a regenerate memory override and streams with no browser-provided history', async () => {
+    const { agent, mastra } = createMockMastra();
+
+    await handleChatStream({
+      mastra: mastra as any,
+      agentId: 'test-agent',
+      historySource: 'server',
+      defaultOptions: {
+        memory: {
+          resource: 'resource-1',
+        },
+      } as any,
+      params: {
+        id: 'thread-1',
+        trigger: 'regenerate-message',
+        messageId: 'assistant-1',
+      },
+    });
+
+    expect(agent.stream).toHaveBeenCalledTimes(1);
+    const [messages, options] = agent.stream.mock.calls[0]!;
+    expect(messages).toEqual([]);
+    expect(options?.requestContext).toBeInstanceOf(RequestContext);
+    expect(options?.requestContext.get(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY)).toEqual({
+      type: 'regenerate',
+      targetMessageId: 'assistant-1',
+    });
+  });
+
+  it('resumes compact server-history requests without browser-provided history', async () => {
+    const { agent, mastra } = createMockMastra();
+
+    await handleChatStream({
+      mastra: mastra as any,
+      agentId: 'test-agent',
+      historySource: 'server',
+      defaultOptions: {
+        memory: {
+          resource: 'resource-1',
+        },
+      } as any,
+      params: {
+        id: 'thread-1',
+        runId: 'run-1',
+        resumeData: { approved: true },
+        messageId: 'assistant-1',
+      },
+    });
+
+    expect(agent.resumeStream).toHaveBeenCalledWith(
+      { approved: true },
+      expect.objectContaining({
+        runId: 'run-1',
+        memory: {
+          thread: 'thread-1',
+          resource: 'resource-1',
+        },
+        requestContext: expect.any(RequestContext),
+      }),
+    );
+    expect(agent.stream).not.toHaveBeenCalled();
+  });
+
+  it('does not mutate a default requestContext with internal history overrides', async () => {
+    const { mastra } = createMockMastra();
+    const requestContext = new RequestContext();
+
+    await handleChatStream({
+      mastra: mastra as any,
+      agentId: 'test-agent',
+      historySource: 'server',
+      defaultOptions: {
+        requestContext,
+        memory: {
+          resource: 'resource-1',
+        },
+      } as any,
+      params: {
+        id: 'thread-1',
+        trigger: 'submit-message',
+        message: { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+      },
+    });
+
+    expect(requestContext.has(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY)).toBe(false);
+  });
+
+  it('rejects execution options in server history mode', async () => {
+    const { mastra } = createMockMastra();
+
+    await expect(
+      handleChatStream({
+        mastra: mastra as any,
+        agentId: 'test-agent',
+        historySource: 'server',
+        defaultOptions: {
+          memory: {
+            resource: 'resource-1',
+          },
+        } as any,
+        params: {
+          id: 'thread-1',
+          message: { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+          savePerStep: true,
+        } as any,
+      }),
+    ).rejects.toThrow('Server-history requests cannot include "savePerStep"');
+  });
+
+  it('returns 400 from chatRoute when server history requests include messages', async () => {
+    const { mastra } = createMockMastra();
+    const route = chatRoute({
+      path: '/chat/:agentId',
+      historySource: 'server',
+      defaultOptions: {
+        memory: {
+          resource: 'resource-1',
+        },
+      } as any,
+    });
+    const body = {
+      id: 'thread-1',
+      messages: [{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+    };
+    const contextStore = new Map<string, any>([['mastra', mastra]]);
+
+    const response = await (route as any).handler({
+      req: {
+        raw: new Request('http://localhost/chat/test-agent', { method: 'POST' }),
+        json: () => Promise.resolve(body),
+        param: (name: string) => (name === 'agentId' ? 'test-agent' : undefined),
+        query: () => undefined,
+      },
+      get: (key: string) => contextStore.get(key),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Server-history requests cannot include "messages"',
+    });
+  });
+
+  it('accepts chatRoute server-history requests with the server-provided abort signal', async () => {
+    const { agent, mastra } = createMockMastra();
+    const route = chatRoute({
+      path: '/chat/:agentId',
+      historySource: 'server',
+      defaultOptions: {
+        memory: {
+          resource: 'resource-1',
+        },
+      } as any,
+    });
+    const body = {
+      id: 'thread-1',
+      trigger: 'submit-message',
+      message: { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+    };
+    const contextStore = new Map<string, any>([['mastra', mastra]]);
+
+    const response = await (route as any).handler({
+      req: {
+        raw: new Request('http://localhost/chat/test-agent', { method: 'POST' }),
+        json: () => Promise.resolve(body),
+        param: (name: string) => (name === 'agentId' ? 'test-agent' : undefined),
+        query: () => undefined,
+      },
+      get: (key: string) => contextStore.get(key),
+    });
+
+    expect(response.status).not.toBe(400);
+    expect(agent.stream).toHaveBeenCalledWith(
+      [body.message],
+      expect.objectContaining({
+        abortSignal: expect.any(AbortSignal),
+        memory: {
+          thread: 'thread-1',
+          resource: 'resource-1',
+        },
+      }),
+    );
+  });
+});

--- a/client-sdks/ai-sdk/src/__tests__/transport.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transport.test.ts
@@ -1,0 +1,97 @@
+import type { UIMessage } from '@internal/ai-sdk-v5';
+import { describe, expect, it } from 'vitest';
+
+import { prepareServerHistoryRequest } from '../transport';
+
+describe('prepareServerHistoryRequest', () => {
+  it('sends only the latest submitted message', () => {
+    const prepareRequest = prepareServerHistoryRequest<UIMessage>();
+    const latestMessage: UIMessage = {
+      id: 'user-2',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Second question' }],
+    };
+
+    expect(
+      prepareRequest({
+        id: 'thread-1',
+        trigger: 'submit-message',
+        messages: [{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'First question' }] }, latestMessage],
+      }),
+    ).toEqual({
+      body: {
+        id: 'thread-1',
+        trigger: 'submit-message',
+        message: latestMessage,
+      },
+    });
+  });
+
+  it('sends only the target assistant message id for regeneration', () => {
+    const prepareRequest = prepareServerHistoryRequest<UIMessage>();
+
+    expect(
+      prepareRequest({
+        id: 'thread-1',
+        trigger: 'regenerate-message',
+        messageId: 'assistant-1',
+        messages: [{ id: 'assistant-1', role: 'assistant', parts: [{ type: 'text', text: 'Old answer' }] }],
+      }),
+    ).toEqual({
+      body: {
+        id: 'thread-1',
+        trigger: 'regenerate-message',
+        messageId: 'assistant-1',
+      },
+    });
+  });
+
+  it('requires a message for submit requests', () => {
+    const prepareRequest = prepareServerHistoryRequest<UIMessage>();
+
+    expect(() =>
+      prepareRequest({
+        id: 'thread-1',
+        trigger: 'submit-message',
+        messages: [],
+      }),
+    ).toThrow('A message is required when submitting with server history');
+  });
+
+  it('sends compact resume data for a trailing approval response', () => {
+    const prepareRequest = prepareServerHistoryRequest<any>();
+
+    expect(
+      prepareRequest({
+        id: 'thread-1',
+        messages: [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'dynamic-tool',
+                state: 'approval-responded',
+                approval: {
+                  id: 'run-123::tool-call-1',
+                  approved: false,
+                  reason: 'No',
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({
+      body: {
+        id: 'thread-1',
+        runId: 'run-123',
+        resumeData: {
+          approved: false,
+          reason: 'No',
+        },
+        messageId: 'assistant-1',
+      },
+    });
+  });
+});

--- a/client-sdks/ai-sdk/src/__tests__/transport.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transport.test.ts
@@ -27,6 +27,28 @@ describe('prepareServerHistoryRequest', () => {
     });
   });
 
+  it('defaults submit requests to submit-message', () => {
+    const prepareRequest = prepareServerHistoryRequest<UIMessage>();
+    const latestMessage: UIMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Hello' }],
+    };
+
+    expect(
+      prepareRequest({
+        id: 'thread-1',
+        messages: [latestMessage],
+      }),
+    ).toEqual({
+      body: {
+        id: 'thread-1',
+        trigger: 'submit-message',
+        message: latestMessage,
+      },
+    });
+  });
+
   it('sends only the target assistant message id for regeneration', () => {
     const prepareRequest = prepareServerHistoryRequest<UIMessage>();
 
@@ -44,6 +66,39 @@ describe('prepareServerHistoryRequest', () => {
         messageId: 'assistant-1',
       },
     });
+  });
+
+  it('uses the latest message id as the regeneration target when messageId is omitted', () => {
+    const prepareRequest = prepareServerHistoryRequest<UIMessage>();
+
+    expect(
+      prepareRequest({
+        id: 'thread-1',
+        trigger: 'regenerate-message',
+        messages: [
+          { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Question' }] },
+          { id: 'assistant-1', role: 'assistant', parts: [{ type: 'text', text: 'Old answer' }] },
+        ],
+      }),
+    ).toEqual({
+      body: {
+        id: 'thread-1',
+        trigger: 'regenerate-message',
+        messageId: 'assistant-1',
+      },
+    });
+  });
+
+  it('requires a message id for regenerate requests without messages', () => {
+    const prepareRequest = prepareServerHistoryRequest<UIMessage>();
+
+    expect(() =>
+      prepareRequest({
+        id: 'thread-1',
+        trigger: 'regenerate-message',
+        messages: [],
+      }),
+    ).toThrow('messageId is required when regenerating with server history');
   });
 
   it('requires a message for submit requests', () => {
@@ -91,6 +146,68 @@ describe('prepareServerHistoryRequest', () => {
           reason: 'No',
         },
         messageId: 'assistant-1',
+      },
+    });
+  });
+
+  it('ignores approval responses without a run id separator', () => {
+    const prepareRequest = prepareServerHistoryRequest<any>();
+    const assistantMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'dynamic-tool',
+          state: 'approval-responded',
+          approval: {
+            id: 'tool-call-1',
+            approved: true,
+          },
+        },
+      ],
+    };
+
+    expect(
+      prepareRequest({
+        id: 'thread-1',
+        messages: [assistantMessage],
+      }),
+    ).toEqual({
+      body: {
+        id: 'thread-1',
+        trigger: 'submit-message',
+        message: assistantMessage,
+      },
+    });
+  });
+
+  it('only extracts approval resumes from trailing assistant messages', () => {
+    const prepareRequest = prepareServerHistoryRequest<any>();
+    const userMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [
+        {
+          type: 'dynamic-tool',
+          state: 'approval-responded',
+          approval: {
+            id: 'run-123::tool-call-1',
+            approved: true,
+          },
+        },
+      ],
+    };
+
+    expect(
+      prepareRequest({
+        id: 'thread-1',
+        messages: [userMessage],
+      }),
+    ).toEqual({
+      body: {
+        id: 'thread-1',
+        trigger: 'submit-message',
+        message: userMessage,
       },
     });
   });

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -277,7 +277,12 @@ function normalizeServerHistoryParams<OUTPUT>({
 
   const trustedScope = getTrustedMemoryScope({
     bodyId: id,
-    requestContext: rawRequestContext instanceof RequestContext ? rawRequestContext : undefined,
+    requestContext:
+      rawRequestContext instanceof RequestContext
+        ? rawRequestContext
+        : defaultOptions?.requestContext instanceof RequestContext
+          ? defaultOptions.requestContext
+          : undefined,
     defaultOptions,
   });
   const requestContext = cloneRequestContext(trustedScope.requestContext);

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -344,7 +344,7 @@ function normalizeServerHistoryParams<OUTPUT>({
 
   return {
     messages,
-    lastMessageId: typeof messageId === 'string' ? messageId : undefined,
+    lastMessageId: undefined,
     resumeData,
     runId,
     requestContext,

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -165,6 +165,12 @@ function validateServerHistoryParams(params: unknown): asserts params is Record<
   }
 }
 
+function validateServerHistoryTrigger(trigger: unknown): asserts trigger is 'submit-message' | 'regenerate-message' {
+  if (trigger !== 'submit-message' && trigger !== 'regenerate-message') {
+    throw new ServerHistoryRequestError('Server-history trigger must be "submit-message" or "regenerate-message"');
+  }
+}
+
 function getMemoryOptionParts(memory: unknown): { threadId?: string; resourceId?: string; options?: unknown } {
   if (!isRecord(memory)) return {};
   const rawThread = memory.thread;
@@ -241,17 +247,28 @@ function normalizeServerHistoryParams<OUTPUT>({
     messageId,
     resumeData,
     runId,
-    trigger = 'submit-message',
+    trigger: rawTrigger = 'submit-message',
     requestContext: rawRequestContext,
     ...restOptions
   } = params as ChatStreamHandlerParams<SupportedUIMessage, OUTPUT> & { requestContext?: RequestContext };
+  validateServerHistoryTrigger(rawTrigger);
+  const trigger = rawTrigger;
 
   if (!id || typeof id !== 'string') {
     throw new ServerHistoryRequestError('Server-history requests require an id');
   }
 
-  if (resumeData && !runId) {
+  const hasResumeData = resumeData !== undefined;
+  if (hasResumeData && !isRecord(resumeData)) {
+    throw new ServerHistoryRequestError('Server-history resumeData must be an object');
+  }
+
+  if (hasResumeData && !runId) {
     throw new ServerHistoryRequestError('runId is required when resumeData is provided');
+  }
+
+  if (hasResumeData && message !== undefined) {
+    throw new ServerHistoryRequestError('Server-history resume requests cannot include a message');
   }
 
   if (rawRequestContext !== undefined && !(rawRequestContext instanceof RequestContext)) {
@@ -270,9 +287,27 @@ function normalizeServerHistoryParams<OUTPUT>({
     type: 'server-history',
   } satisfies MastraMemoryHistoryOverride);
 
+  if (hasResumeData) {
+    return {
+      messages: [],
+      lastMessageId: typeof messageId === 'string' ? messageId : undefined,
+      resumeData,
+      runId,
+      requestContext,
+      restOptions: {
+        ...restOptions,
+        ...(memory ? { memory } : {}),
+      },
+    };
+  }
+
   if (trigger === 'regenerate-message') {
     if (!messageId || typeof messageId !== 'string') {
       throw new ServerHistoryRequestError('messageId is required when regenerating with server history');
+    }
+
+    if (message !== undefined) {
+      throw new ServerHistoryRequestError('Server-history regenerate requests cannot include a message');
     }
 
     requestContext.set(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, {
@@ -291,6 +326,10 @@ function normalizeServerHistoryParams<OUTPUT>({
         ...(memory ? { memory } : {}),
       },
     };
+  }
+
+  if (messageId !== undefined) {
+    throw new ServerHistoryRequestError('Server-history submit requests cannot include messageId');
   }
 
   const messages = message ? [message] : [];
@@ -562,6 +601,72 @@ export function chatRoute<OUTPUT = undefined>({
     throw new Error('Path must include :agentId to route to the correct agent or pass the agent explicitly');
   }
 
+  const clientHistoryRequestSchema: any = {
+    type: 'object',
+    properties: {
+      resumeData: {
+        type: 'object',
+        description: 'Resume data for the agent',
+      },
+      runId: {
+        type: 'string',
+        description: 'The run ID required when resuming an agent execution',
+      },
+      messages: {
+        type: 'array',
+        description: 'Array of messages in the conversation',
+        items: {
+          type: 'object',
+          properties: {
+            role: {
+              type: 'string',
+              enum: ['user', 'assistant', 'system'],
+              description: 'The role of the message sender',
+            },
+            content: {
+              type: 'string',
+              description: 'The content of the message',
+            },
+          },
+          required: ['role', 'content'],
+        },
+      },
+    },
+    required: ['messages'],
+  };
+  const serverHistoryRequestSchema: any = {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      id: {
+        type: 'string',
+        description: 'Chat ID used as a thread hint when the server provides a memory resource but no thread.',
+      },
+      message: {
+        type: 'object',
+        description: 'Latest submitted UI message for submit-message requests.',
+      },
+      messageId: {
+        type: 'string',
+        description: 'Assistant message ID for regenerate-message requests or compact resume continuity.',
+      },
+      trigger: {
+        type: 'string',
+        enum: ['submit-message', 'regenerate-message'],
+        description: 'AI SDK UI request trigger.',
+      },
+      resumeData: {
+        type: 'object',
+        description: 'Resume data for suspended executions or tool approvals.',
+      },
+      runId: {
+        type: 'string',
+        description: 'The run ID required when resumeData is provided.',
+      },
+    },
+    required: ['id'],
+  };
+
   return registerApiRoute(path, {
     method: 'POST',
     openapi: {
@@ -603,39 +708,7 @@ export function chatRoute<OUTPUT = undefined>({
         required: true,
         content: {
           'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                resumeData: {
-                  type: 'object',
-                  description: 'Resume data for the agent',
-                },
-                runId: {
-                  type: 'string',
-                  description: 'The run ID required when resuming an agent execution',
-                },
-                messages: {
-                  type: 'array',
-                  description: 'Array of messages in the conversation',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      role: {
-                        type: 'string',
-                        enum: ['user', 'assistant', 'system'],
-                        description: 'The role of the message sender',
-                      },
-                      content: {
-                        type: 'string',
-                        description: 'The content of the message',
-                      },
-                    },
-                    required: ['role', 'content'],
-                  },
-                },
-              },
-              required: ['messages'],
-            },
+            schema: historySource === 'server' ? serverHistoryRequestSchema : clientHistoryRequestSchema,
           },
         },
       },

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -11,7 +11,13 @@ import {
 import type { UIMessageStreamOptions as UIMessageStreamOptionsV6 } from '@internal/ai-v6';
 import type { AgentExecutionOptions, AgentExecutionOptionsBase } from '@mastra/core/agent';
 import type { Mastra } from '@mastra/core/mastra';
-import type { RequestContext } from '@mastra/core/request-context';
+import {
+  MASTRA_MEMORY_HISTORY_OVERRIDE_KEY,
+  MASTRA_RESOURCE_ID_KEY,
+  MASTRA_THREAD_ID_KEY,
+  RequestContext,
+} from '@mastra/core/request-context';
+import type { MastraMemoryHistoryOverride } from '@mastra/core/request-context';
 import { registerApiRoute } from '@mastra/core/server';
 import { toAISdkStream } from './convert-streams';
 import { APPROVAL_ID_SEPARATOR } from './helpers';
@@ -67,11 +73,16 @@ export type ChatStreamHandlerParams<
   UI_MESSAGE extends SupportedUIMessage = SupportedUIMessage,
   OUTPUT = undefined,
 > = AgentExecutionOptions<OUTPUT> & {
-  messages: UI_MESSAGE[];
+  messages?: UI_MESSAGE[];
+  id?: string;
+  message?: UI_MESSAGE;
+  messageId?: string;
   resumeData?: Record<string, any>;
   /** The trigger for the request - sent by AI SDK's useChat hook */
   trigger?: 'submit-message' | 'regenerate-message';
 };
+
+export type HistorySource = 'client' | 'server';
 
 /**
  * Extracted from the second parameter of `Mastra.getAgentById` so the type
@@ -86,6 +97,7 @@ export type ChatStreamHandlerOptions<UI_MESSAGE extends SupportedUIMessage = Sup
   params: ChatStreamHandlerParams<UI_MESSAGE, OUTPUT>;
   defaultOptions?: AgentExecutionOptions<OUTPUT>;
   version?: 'v5' | 'v6';
+  historySource?: HistorySource;
   sendStart?: boolean;
   sendFinish?: boolean;
   sendReasoning?: boolean;
@@ -113,6 +125,191 @@ type ChatStreamHandlerOptionsV6<UI_MESSAGE extends V6UIMessage = V6UIMessage, OU
   version: 'v6';
   messageMetadata?: UIMessageStreamOptionsV6<UI_MESSAGE>['messageMetadata'];
 };
+
+const SERVER_HISTORY_BODY_FIELDS = ['id', 'message', 'messageId', 'resumeData', 'runId', 'trigger'] as const;
+const SERVER_HISTORY_PARAM_FIELDS = [...SERVER_HISTORY_BODY_FIELDS, 'abortSignal', 'requestContext'] as const;
+
+class ServerHistoryRequestError extends Error {
+  readonly name = 'ServerHistoryRequestError';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function cloneRequestContext(requestContext: RequestContext): RequestContext {
+  return new RequestContext(requestContext.entries() as Iterable<readonly [string, unknown]>);
+}
+
+function validateServerHistoryBody(body: unknown): asserts body is Record<string, unknown> {
+  if (!isRecord(body)) {
+    throw new ServerHistoryRequestError('Server-history requests must be JSON objects');
+  }
+
+  const allowedFields = new Set<string>(SERVER_HISTORY_BODY_FIELDS);
+  const forbiddenField = Object.keys(body).find(field => !allowedFields.has(field));
+  if (forbiddenField) {
+    throw new ServerHistoryRequestError(`Server-history requests cannot include "${forbiddenField}"`);
+  }
+}
+
+function validateServerHistoryParams(params: unknown): asserts params is Record<string, unknown> {
+  if (!isRecord(params)) {
+    throw new ServerHistoryRequestError('Server-history requests must be JSON objects');
+  }
+
+  const allowedFields = new Set<string>(SERVER_HISTORY_PARAM_FIELDS);
+  const forbiddenField = Object.keys(params).find(field => !allowedFields.has(field));
+  if (forbiddenField) {
+    throw new ServerHistoryRequestError(`Server-history requests cannot include "${forbiddenField}"`);
+  }
+}
+
+function getMemoryOptionParts(memory: unknown): { threadId?: string; resourceId?: string; options?: unknown } {
+  if (!isRecord(memory)) return {};
+  const rawThread = memory.thread;
+  const threadId =
+    typeof rawThread === 'string'
+      ? rawThread
+      : isRecord(rawThread) && typeof rawThread.id === 'string'
+        ? rawThread.id
+        : undefined;
+  const resourceId = typeof memory.resource === 'string' ? memory.resource : undefined;
+  return { threadId, resourceId, options: memory.options };
+}
+
+function getTrustedMemoryScope(args: {
+  bodyId?: string;
+  requestContext?: RequestContext;
+  defaultOptions?: AgentExecutionOptions<any>;
+}): { memory?: AgentExecutionOptionsBase<unknown>['memory']; requestContext: RequestContext } {
+  const requestContext = args.requestContext ?? new RequestContext();
+  const contextThreadId = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
+  const contextResourceId = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+  const defaultMemory = getMemoryOptionParts(args.defaultOptions?.memory);
+
+  if (contextThreadId) {
+    return { requestContext };
+  }
+
+  if (defaultMemory.threadId) {
+    return { requestContext };
+  }
+
+  if (!args.bodyId) {
+    return { requestContext };
+  }
+
+  const resourceId = contextResourceId ?? defaultMemory.resourceId;
+  if (!resourceId) {
+    throw new ServerHistoryRequestError(
+      'Server-history requests require a server-controlled resourceId when using body.id as thread',
+    );
+  }
+
+  return {
+    requestContext,
+    memory: {
+      thread: args.bodyId,
+      resource: resourceId,
+      ...(isRecord(args.defaultOptions?.memory) && 'options' in args.defaultOptions.memory
+        ? { options: args.defaultOptions.memory.options as any }
+        : {}),
+    },
+  };
+}
+
+function normalizeServerHistoryParams<OUTPUT>({
+  params,
+  defaultOptions,
+}: {
+  params: ChatStreamHandlerParams<SupportedUIMessage, OUTPUT>;
+  defaultOptions?: AgentExecutionOptions<OUTPUT>;
+}): {
+  messages: SupportedUIMessage[];
+  lastMessageId?: string;
+  resumeData?: Record<string, any>;
+  runId?: string;
+  requestContext: RequestContext;
+  restOptions: Record<string, any>;
+} {
+  validateServerHistoryParams(params);
+
+  const {
+    id,
+    message,
+    messageId,
+    resumeData,
+    runId,
+    trigger = 'submit-message',
+    requestContext: rawRequestContext,
+    ...restOptions
+  } = params as ChatStreamHandlerParams<SupportedUIMessage, OUTPUT> & { requestContext?: RequestContext };
+
+  if (!id || typeof id !== 'string') {
+    throw new ServerHistoryRequestError('Server-history requests require an id');
+  }
+
+  if (resumeData && !runId) {
+    throw new ServerHistoryRequestError('runId is required when resumeData is provided');
+  }
+
+  if (rawRequestContext !== undefined && !(rawRequestContext instanceof RequestContext)) {
+    throw new ServerHistoryRequestError('Server-history requestContext must be provided by server code');
+  }
+
+  const trustedScope = getTrustedMemoryScope({
+    bodyId: id,
+    requestContext: rawRequestContext instanceof RequestContext ? rawRequestContext : undefined,
+    defaultOptions,
+  });
+  const requestContext = cloneRequestContext(trustedScope.requestContext);
+  const { memory } = trustedScope;
+
+  requestContext.set(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, {
+    type: 'server-history',
+  } satisfies MastraMemoryHistoryOverride);
+
+  if (trigger === 'regenerate-message') {
+    if (!messageId || typeof messageId !== 'string') {
+      throw new ServerHistoryRequestError('messageId is required when regenerating with server history');
+    }
+
+    requestContext.set(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, {
+      type: 'regenerate',
+      targetMessageId: messageId,
+    } satisfies MastraMemoryHistoryOverride);
+
+    return {
+      messages: [],
+      lastMessageId: messageId,
+      resumeData,
+      runId,
+      requestContext,
+      restOptions: {
+        ...restOptions,
+        ...(memory ? { memory } : {}),
+      },
+    };
+  }
+
+  const messages = message ? [message] : [];
+  if (!resumeData && messages.length === 0) {
+    throw new ServerHistoryRequestError('Server-history submit requests require a message');
+  }
+
+  return {
+    messages,
+    lastMessageId: typeof messageId === 'string' ? messageId : undefined,
+    resumeData,
+    runId,
+    requestContext,
+    restOptions: {
+      ...restOptions,
+      ...(memory ? { memory } : {}),
+    },
+  };
+}
 
 /**
  * Framework-agnostic handler for streaming agent chat in AI SDK-compatible format.
@@ -149,6 +346,7 @@ export async function handleChatStream<OUTPUT = undefined>({
   params,
   defaultOptions,
   version = 'v5',
+  historySource = 'client',
   sendStart = true,
   sendFinish = true,
   sendReasoning = false,
@@ -156,7 +354,30 @@ export async function handleChatStream<OUTPUT = undefined>({
   onError,
   messageMetadata,
 }: ChatStreamHandlerOptions<any, OUTPUT>): Promise<ReadableStream<any>> {
-  const { messages, resumeData, runId, requestContext, trigger, ...rest } = params;
+  const normalized =
+    historySource === 'server'
+      ? normalizeServerHistoryParams({ params, defaultOptions })
+      : {
+          messages: params.messages,
+          lastMessageId: undefined as string | undefined,
+          resumeData: params.resumeData,
+          runId: (params as any).runId,
+          requestContext: params.requestContext,
+          restOptions: (() => {
+            const {
+              messages: _messages,
+              resumeData: _resumeData,
+              runId: _runId,
+              requestContext: _requestContext,
+              trigger: _trigger,
+              ...rest
+            } = params;
+            return rest;
+          })(),
+        };
+
+  const { messages, resumeData, runId, requestContext, restOptions: rest } = normalized;
+  const trigger = params.trigger;
 
   if (resumeData && !runId) {
     throw new Error('runId is required when resumeData is provided');
@@ -181,7 +402,7 @@ export async function handleChatStream<OUTPUT = undefined>({
 
   // Capture the last assistant message ID for the stream response.
   // This helps the frontend identify which message the response corresponds to.
-  let lastMessageId: string | undefined;
+  let lastMessageId: string | undefined = normalized.lastMessageId;
   let messagesToSend = messages;
 
   if (messages.length > 0) {
@@ -264,6 +485,7 @@ export async function handleChatStream<OUTPUT = undefined>({
 export type chatRouteOptions<OUTPUT = undefined> = {
   defaultOptions?: AgentExecutionOptions<OUTPUT>;
   version?: 'v5' | 'v6';
+  historySource?: HistorySource;
   agentVersion?: AgentVersionOptions;
 } & (
   | {
@@ -329,6 +551,7 @@ export function chatRoute<OUTPUT = undefined>({
   agent,
   defaultOptions,
   version = 'v5',
+  historySource = 'client',
   agentVersion,
   sendStart = true,
   sendFinish = true,
@@ -465,6 +688,14 @@ export function chatRoute<OUTPUT = undefined>({
       const mastra = c.get('mastra');
       const contextRequestContext = (c as any).get('requestContext') as RequestContext | undefined;
 
+      try {
+        if (historySource === 'server') {
+          validateServerHistoryBody(params);
+        }
+      } catch (error) {
+        return Response.json({ error: error instanceof Error ? error.message : String(error) }, { status: 400 });
+      }
+
       let agentToUse: string | undefined = agent;
       if (!agent) {
         const agentId = c.req.param('agentId');
@@ -479,8 +710,12 @@ export function chatRoute<OUTPUT = undefined>({
           );
       }
 
-      // Prioritize requestContext from middleware/route options over body
-      const effectiveRequestContext = contextRequestContext || defaultOptions?.requestContext || params.requestContext;
+      // Prioritize requestContext from middleware/route options over body.
+      // Server-history mode never accepts browser-provided requestContext.
+      const effectiveRequestContext =
+        contextRequestContext ||
+        defaultOptions?.requestContext ||
+        (historySource === 'server' ? undefined : params.requestContext);
 
       if (
         (contextRequestContext && defaultOptions?.requestContext) ||
@@ -525,23 +760,31 @@ export function chatRoute<OUTPUT = undefined>({
           abortSignal: c.req.raw.signal,
         } as any,
         defaultOptions,
+        historySource,
         sendStart,
         sendFinish,
         sendReasoning,
         sendSources,
       };
 
-      if (version === 'v6') {
-        const uiMessageStream = await handleChatStream({
-          ...handlerOptions,
-          version: 'v6',
-        });
+      try {
+        if (version === 'v6') {
+          const uiMessageStream = await handleChatStream({
+            ...handlerOptions,
+            version: 'v6',
+          });
 
-        return createUIMessageStreamResponseV6({ stream: uiMessageStream });
+          return createUIMessageStreamResponseV6({ stream: uiMessageStream });
+        }
+
+        const uiMessageStream = await handleChatStream(handlerOptions);
+        return createUIMessageStreamResponseV5({ stream: uiMessageStream });
+      } catch (error) {
+        if (historySource === 'server' && error instanceof ServerHistoryRequestError) {
+          return Response.json({ error: error.message }, { status: 400 });
+        }
+        throw error;
       }
-
-      const uiMessageStream = await handleChatStream(handlerOptions);
-      return createUIMessageStreamResponseV5({ stream: uiMessageStream });
     },
   });
 }

--- a/client-sdks/ai-sdk/src/index.ts
+++ b/client-sdks/ai-sdk/src/index.ts
@@ -4,6 +4,7 @@ export type {
   ChatStreamHandlerParams,
   ChatStreamHandlerOptions,
   AgentVersionOptions,
+  HistorySource,
 } from './chat-route';
 export { workflowRoute, handleWorkflowStream } from './workflow-route';
 export type { WorkflowRouteOptions, WorkflowStreamHandlerParams, WorkflowStreamHandlerOptions } from './workflow-route';

--- a/client-sdks/ai-sdk/src/server-history.test.ts
+++ b/client-sdks/ai-sdk/src/server-history.test.ts
@@ -2,7 +2,7 @@ import type { UIMessage } from '@internal/ai-sdk-v5';
 import { MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, RequestContext } from '@mastra/core/request-context';
 import { describe, expect, it, vi } from 'vitest';
 
-import { chatRoute, handleChatStream } from '../chat-route';
+import { chatRoute, handleChatStream } from './chat-route';
 
 const emptyAgentStream = {
   fullStream: new ReadableStream({
@@ -208,8 +208,9 @@ describe('server history', () => {
   });
 
   it('does not mutate a default requestContext with internal history overrides', async () => {
-    const { mastra } = createMockMastra();
+    const { agent, mastra } = createMockMastra();
     const requestContext = new RequestContext();
+    requestContext.set('tenant', 'tenant-1');
 
     await handleChatStream({
       mastra: mastra as any,
@@ -229,6 +230,12 @@ describe('server history', () => {
     });
 
     expect(requestContext.has(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY)).toBe(false);
+    const [, options] = agent.stream.mock.calls[0]!;
+    expect(options?.requestContext).not.toBe(requestContext);
+    expect(options?.requestContext.get('tenant')).toBe('tenant-1');
+    expect(options?.requestContext.get(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY)).toEqual({
+      type: 'server-history',
+    });
   });
 
   it('rejects execution options in server history mode', async () => {

--- a/client-sdks/ai-sdk/src/server-history.test.ts
+++ b/client-sdks/ai-sdk/src/server-history.test.ts
@@ -403,7 +403,7 @@ describe('server history', () => {
       get: (key: string) => contextStore.get(key),
     });
 
-    expect(response.status).not.toBe(400);
+    expect(response.ok).toBe(true);
     expect(agent.stream).toHaveBeenCalledWith(
       [body.message],
       expect.objectContaining({

--- a/client-sdks/ai-sdk/src/server-history.test.ts
+++ b/client-sdks/ai-sdk/src/server-history.test.ts
@@ -1,5 +1,10 @@
 import type { UIMessage } from '@internal/ai-sdk-v5';
-import { MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, RequestContext } from '@mastra/core/request-context';
+import {
+  MASTRA_MEMORY_HISTORY_OVERRIDE_KEY,
+  MASTRA_RESOURCE_ID_KEY,
+  MASTRA_THREAD_ID_KEY,
+  RequestContext,
+} from '@mastra/core/request-context';
 import { describe, expect, it, vi } from 'vitest';
 
 import { chatRoute, handleChatStream } from './chat-route';
@@ -280,6 +285,36 @@ describe('server history', () => {
     const [, options] = agent.stream.mock.calls[0]!;
     expect(options?.requestContext).not.toBe(requestContext);
     expect(options?.requestContext.get('tenant')).toBe('tenant-1');
+    expect(options?.requestContext.get(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY)).toEqual({
+      type: 'server-history',
+    });
+  });
+
+  it('keeps server-provided memory scope authoritative over body id', async () => {
+    const { agent, mastra } = createMockMastra();
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_THREAD_ID_KEY, 'server-thread');
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'server-resource');
+
+    await handleChatStream({
+      mastra: mastra as any,
+      agentId: 'test-agent',
+      historySource: 'server',
+      defaultOptions: {
+        requestContext,
+      } as any,
+      params: {
+        id: 'body-thread',
+        trigger: 'submit-message',
+        message: { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+      },
+    });
+
+    const [, options] = agent.stream.mock.calls[0]!;
+    expect(options?.memory).toBeUndefined();
+    expect(options?.requestContext).not.toBe(requestContext);
+    expect(options?.requestContext.get(MASTRA_THREAD_ID_KEY)).toBe('server-thread');
+    expect(options?.requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBe('server-resource');
     expect(options?.requestContext.get(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY)).toEqual({
       type: 'server-history',
     });

--- a/client-sdks/ai-sdk/src/server-history.test.ts
+++ b/client-sdks/ai-sdk/src/server-history.test.ts
@@ -207,6 +207,53 @@ describe('server history', () => {
     ).rejects.toThrow('Server-history resume requests cannot include a message');
   });
 
+  it('rejects malformed server-history validation edge cases', async () => {
+    const { mastra } = createMockMastra();
+    const message: UIMessage = { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] };
+    const options = {
+      mastra: mastra as any,
+      agentId: 'test-agent',
+      historySource: 'server' as const,
+      defaultOptions: {
+        memory: {
+          resource: 'resource-1',
+        },
+      } as any,
+    };
+
+    await expect(
+      handleChatStream({
+        ...options,
+        params: {
+          trigger: 'submit-message',
+          message,
+        } as any,
+      }),
+    ).rejects.toThrow('Server-history requests require an id');
+
+    await expect(
+      handleChatStream({
+        ...options,
+        params: {
+          id: 'thread-1',
+          resumeData: { approved: true },
+        },
+      }),
+    ).rejects.toThrow('runId is required when resumeData is provided');
+
+    await expect(
+      handleChatStream({
+        ...options,
+        defaultOptions: {} as any,
+        params: {
+          id: 'thread-1',
+          trigger: 'submit-message',
+          message,
+        },
+      }),
+    ).rejects.toThrow('Server-history requests require a server-controlled resourceId when using body.id as thread');
+  });
+
   it('does not mutate a default requestContext with internal history overrides', async () => {
     const { agent, mastra } = createMockMastra();
     const requestContext = new RequestContext();

--- a/client-sdks/ai-sdk/src/transport.test.ts
+++ b/client-sdks/ai-sdk/src/transport.test.ts
@@ -1,7 +1,7 @@
 import type { UIMessage } from '@internal/ai-sdk-v5';
 import { describe, expect, it } from 'vitest';
 
-import { prepareServerHistoryRequest } from '../transport';
+import { prepareServerHistoryRequest } from './transport';
 
 describe('prepareServerHistoryRequest', () => {
   it('sends only the latest submitted message', () => {
@@ -78,6 +78,28 @@ describe('prepareServerHistoryRequest', () => {
         messages: [
           { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Question' }] },
           { id: 'assistant-1', role: 'assistant', parts: [{ type: 'text', text: 'Old answer' }] },
+        ],
+      }),
+    ).toEqual({
+      body: {
+        id: 'thread-1',
+        trigger: 'regenerate-message',
+        messageId: 'assistant-1',
+      },
+    });
+  });
+
+  it('uses the latest assistant message id as the regeneration target when a user message trails it', () => {
+    const prepareRequest = prepareServerHistoryRequest<UIMessage>();
+
+    expect(
+      prepareRequest({
+        id: 'thread-1',
+        trigger: 'regenerate-message',
+        messages: [
+          { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Question' }] },
+          { id: 'assistant-1', role: 'assistant', parts: [{ type: 'text', text: 'Old answer' }] },
+          { id: 'user-2', role: 'user', parts: [{ type: 'text', text: 'Follow-up' }] },
         ],
       }),
     ).toEqual({

--- a/client-sdks/ai-sdk/src/transport.ts
+++ b/client-sdks/ai-sdk/src/transport.ts
@@ -1,0 +1,108 @@
+type ServerHistoryTrigger = 'submit-message' | 'regenerate-message';
+const APPROVAL_ID_SEPARATOR = '::';
+
+export type PrepareServerHistoryRequestOptions<UI_MESSAGE extends { id?: string }> = {
+  id: string;
+  messages: UI_MESSAGE[];
+  trigger?: ServerHistoryTrigger;
+  messageId?: string;
+};
+
+export type ServerHistoryRequestBody<UI_MESSAGE extends { id?: string }> =
+  | {
+      id: string;
+      trigger: 'submit-message';
+      message: UI_MESSAGE;
+    }
+  | {
+      id: string;
+      trigger: 'regenerate-message';
+      messageId: string;
+    }
+  | {
+      id: string;
+      runId: string;
+      resumeData: Record<string, unknown>;
+      messageId?: string;
+    };
+
+function extractApprovalResume(messages: Array<{ id?: string; role?: string; parts?: unknown[] }>) {
+  const lastMessage = messages.at(-1);
+  if (!lastMessage || lastMessage.role !== 'assistant') return null;
+
+  for (const part of lastMessage.parts ?? []) {
+    if (!part || typeof part !== 'object') continue;
+    const maybePart = part as {
+      state?: unknown;
+      approval?: {
+        id?: unknown;
+        approved?: unknown;
+        reason?: unknown;
+      };
+    };
+    if (maybePart.state !== 'approval-responded' || typeof maybePart.approval?.id !== 'string') continue;
+
+    const lastSep = maybePart.approval.id.lastIndexOf(APPROVAL_ID_SEPARATOR);
+    if (lastSep === -1) continue;
+    const runId = maybePart.approval.id.slice(0, lastSep);
+    if (!runId) continue;
+
+    return {
+      runId,
+      resumeData: {
+        approved: maybePart.approval.approved,
+        ...(maybePart.approval.reason != null ? { reason: maybePart.approval.reason } : {}),
+      },
+      ...(lastMessage.id ? { messageId: lastMessage.id } : {}),
+    };
+  }
+
+  return null;
+}
+
+export function prepareServerHistoryRequest<UI_MESSAGE extends { id?: string }>() {
+  return ({
+    id,
+    messages,
+    trigger = 'submit-message',
+    messageId,
+  }: PrepareServerHistoryRequestOptions<UI_MESSAGE>): { body: ServerHistoryRequestBody<UI_MESSAGE> } => {
+    const approvalResume = extractApprovalResume(messages);
+    if (approvalResume) {
+      return {
+        body: {
+          id,
+          ...approvalResume,
+        },
+      };
+    }
+
+    if (trigger === 'regenerate-message') {
+      const targetMessageId = messageId ?? messages.at(-1)?.id;
+      if (!targetMessageId) {
+        throw new Error('messageId is required when regenerating with server history');
+      }
+
+      return {
+        body: {
+          id,
+          trigger,
+          messageId: targetMessageId,
+        },
+      };
+    }
+
+    const message = messages.at(-1);
+    if (!message) {
+      throw new Error('A message is required when submitting with server history');
+    }
+
+    return {
+      body: {
+        id,
+        trigger,
+        message,
+      },
+    };
+  };
+}

--- a/client-sdks/ai-sdk/src/transport.ts
+++ b/client-sdks/ai-sdk/src/transport.ts
@@ -1,14 +1,14 @@
 type ServerHistoryTrigger = 'submit-message' | 'regenerate-message';
 const APPROVAL_ID_SEPARATOR = '::';
 
-export type PrepareServerHistoryRequestOptions<UI_MESSAGE extends { id?: string }> = {
+export type PrepareServerHistoryRequestOptions<UI_MESSAGE extends { id?: string; role?: string }> = {
   id: string;
   messages: UI_MESSAGE[];
   trigger?: ServerHistoryTrigger;
   messageId?: string;
 };
 
-export type ServerHistoryRequestBody<UI_MESSAGE extends { id?: string }> =
+export type ServerHistoryRequestBody<UI_MESSAGE extends { id?: string; role?: string }> =
   | {
       id: string;
       trigger: 'submit-message';
@@ -60,7 +60,18 @@ function extractApprovalResume(messages: Array<{ id?: string; role?: string; par
   return null;
 }
 
-export function prepareServerHistoryRequest<UI_MESSAGE extends { id?: string }>() {
+function getLatestAssistantMessageId(messages: Array<{ id?: string; role?: string }>) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role === 'assistant' && message.id) {
+      return message.id;
+    }
+  }
+
+  return undefined;
+}
+
+export function prepareServerHistoryRequest<UI_MESSAGE extends { id?: string; role?: string }>() {
   return ({
     id,
     messages,
@@ -78,7 +89,7 @@ export function prepareServerHistoryRequest<UI_MESSAGE extends { id?: string }>(
     }
 
     if (trigger === 'regenerate-message') {
-      const targetMessageId = messageId ?? messages.at(-1)?.id;
+      const targetMessageId = messageId ?? getLatestAssistantMessageId(messages);
       if (!targetMessageId) {
         throw new Error('messageId is required when regenerating with server history');
       }

--- a/client-sdks/ai-sdk/tsup.config.ts
+++ b/client-sdks/ai-sdk/tsup.config.ts
@@ -2,7 +2,7 @@ import { generateTypes } from '@internal/types-builder';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/ui.ts'],
+  entry: ['src/index.ts', 'src/ui.ts', 'src/transport.ts'],
   format: ['esm', 'cjs'],
   clean: true,
   dts: false,

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -250,37 +250,57 @@ Use [`prepareSendMessagesRequest`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/u
 
 ## Using Mastra Memory
 
-When your agent has [memory](/docs/memory/overview) configured, Mastra loads conversation history from storage on the server. Send only the new message from the client instead of the full conversation history.
+When your agent has [memory](/docs/memory/overview) configured, Mastra loads conversation history from storage on the server. Use server history mode to send only the new message from the client instead of the full conversation history.
 
 Sending the full history is redundant and can cause message-ordering bugs because client-side timestamps can conflict with the timestamps stored in your database.
+
+Configure the route with `historySource: 'server'`. The server must control the memory resource. If the route provides a resource but no thread, the request `id` is used as the thread ID.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { chatRoute } from '@mastra/ai-sdk'
+
+export const mastra = new Mastra({
+  server: {
+    apiRoutes: [
+      chatRoute({
+        path: '/chat',
+        agent: 'weatherAgent',
+        historySource: 'server',
+        defaultOptions: {
+          memory: {
+            resource: 'user-123',
+          },
+        },
+      }),
+    ],
+  },
+})
+```
+
+On the client, use `prepareServerHistoryRequest()` from `@mastra/ai-sdk/transport`. It sends the latest submitted message for normal turns, the target message ID for regeneration, and compact resume data for tool approval responses.
 
 ```typescript
 import { useChat } from '@ai-sdk/react'
 import { DefaultChatTransport } from 'ai'
+import { prepareServerHistoryRequest } from '@mastra/ai-sdk/transport'
 
 const { messages, sendMessage } = useChat({
+  id: 'user-thread-123',
   transport: new DefaultChatTransport({
-    api: 'http://localhost:4111/chat/weatherAgent',
-    prepareSendMessagesRequest({ messages }) {
-      return {
-        body: {
-          messages: [messages[messages.length - 1]],
-          memory: {
-            thread: 'user-thread-123',
-            resource: 'user-123',
-          },
-        },
-      }
-    },
+    api: 'http://localhost:4111/chat',
+    prepareSendMessagesRequest: prepareServerHistoryRequest(),
   }),
 })
 ```
 
-Set `memory.thread` and `memory.resource` from your app's own state, such as URL params, auth context, or your database.
+Server history mode accepts only `id`, `message`, `messageId`, `trigger`, `resumeData`, and `runId`. It rejects browser-provided `messages`, `memory`, `threadId`, `resourceId`, `requestContext`, and execution options. Use server code to set memory scope and execution options.
+
+When a browser disconnects or aborts while an assistant response is still being streamed, Mastra treats server memory as the source of truth. Incomplete assistant responses marked by the server are removed on the next server-history turn before stored history is recalled.
 
 See [Message history](/docs/memory/message-history) for more on how Mastra memory loads and stores messages.
 
-[`chatRoute()`](/reference/ai-sdk/chat-route) and [`handleChatStream()`](/reference/ai-sdk/handle-chat-stream) already work with memory. Configure the client to send only the new message and include the thread and resource identifiers.
+[`chatRoute()`](/reference/ai-sdk/chat-route) and [`handleChatStream()`](/reference/ai-sdk/handle-chat-stream) both support server history mode.
 
 ### `useCompletion()`
 

--- a/docs/src/content/en/reference/ai-sdk/chat-route.mdx
+++ b/docs/src/content/en/reference/ai-sdk/chat-route.mdx
@@ -199,7 +199,7 @@ export const mastra = new Mastra({
 })
 ```
 
-Use `prepareServerHistoryRequest()` on the client so AI SDK UI sends only the new message, regeneration target, or approval resume data:
+Use [`prepareServerHistoryRequest()`](/reference/ai-sdk/prepare-server-history-request) on the client so AI SDK UI sends only the new message, regeneration target, or approval resume data:
 
 ```typescript
 import { useChat } from '@ai-sdk/react'

--- a/docs/src/content/en/reference/ai-sdk/chat-route.mdx
+++ b/docs/src/content/en/reference/ai-sdk/chat-route.mdx
@@ -74,6 +74,14 @@ export const mastra = new Mastra({
     defaultValue: "'v5'",
   },
   {
+    name: 'historySource',
+    type: "'client' | 'server'",
+    description:
+      "Controls where chat history comes from. Pass `'client'` to accept `messages` from the request body. Pass `'server'` to load history from Mastra memory and accept only the new `message` or regeneration `messageId` from the browser.",
+    isOptional: true,
+    defaultValue: "'client'",
+  },
+  {
     name: 'path',
     type: 'string',
     description: 'The route path (e.g., `/chat` or `/chat/:agentId`). Include `:agentId` for dynamic agent routing.',
@@ -133,7 +141,7 @@ export const mastra = new Mastra({
 
 ## Additional configuration
 
-You can use [`prepareSendMessagesRequest`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat#transport.default-chat-transport.prepare-send-messages-request) to customize the request sent to the chat route, for example to pass additional configuration to the agent:
+In client history mode, you can use [`prepareSendMessagesRequest`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat#transport.default-chat-transport.prepare-send-messages-request) to customize the request sent to the chat route, for example to pass additional configuration to the agent:
 
 ```typescript
 const { error, status, sendMessage, messages, regenerate, stop } = useChat({
@@ -154,3 +162,57 @@ const { error, status, sendMessage, messages, regenerate, stop } = useChat({
   }),
 })
 ```
+
+## Server history mode
+
+Use `historySource: 'server'` when the agent has [memory](/docs/memory/overview) and the server should load stored conversation history. This mode accepts only the compact request fields listed below and rejects browser-provided history, memory scope, request context, and execution options.
+
+The request body can include:
+
+- `id`: The chat ID from AI SDK UI. If the route has a server-controlled resource but no thread, Mastra uses this as the thread ID.
+- `message`: The latest user message for `submit-message`.
+- `messageId`: The assistant message ID to regenerate for `regenerate-message`.
+- `trigger`: The AI SDK UI trigger.
+- `resumeData` and `runId`: Resume data for suspended executions or tool approvals.
+
+Configure the route with server-controlled memory scope:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { chatRoute } from '@mastra/ai-sdk'
+
+export const mastra = new Mastra({
+  server: {
+    apiRoutes: [
+      chatRoute({
+        path: '/chat',
+        agent: 'weatherAgent',
+        historySource: 'server',
+        defaultOptions: {
+          memory: {
+            resource: 'user-123',
+          },
+        },
+      }),
+    ],
+  },
+})
+```
+
+Use `prepareServerHistoryRequest()` on the client so AI SDK UI sends only the new message, regeneration target, or approval resume data:
+
+```typescript
+import { useChat } from '@ai-sdk/react'
+import { DefaultChatTransport } from 'ai'
+import { prepareServerHistoryRequest } from '@mastra/ai-sdk/transport'
+
+const { messages, sendMessage, regenerate } = useChat({
+  id: 'thread-123',
+  transport: new DefaultChatTransport({
+    api: 'http://localhost:4111/chat',
+    prepareSendMessagesRequest: prepareServerHistoryRequest(),
+  }),
+})
+```
+
+If a stream is aborted while an assistant response is incomplete, server-history mode relies on server-marked response metadata to remove that incomplete assistant message before recalling stored history for the next turn.

--- a/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
@@ -110,7 +110,7 @@ export async function POST(req: Request) {
     name: 'params.id',
     type: 'string',
     description:
-      "Chat ID from AI SDK UI. Required when `historySource` is `'server'`. If the server provides a memory resource but no thread, Mastra uses this value as the thread ID.",
+      "Client-supplied thread hint from AI SDK UI. Required when `historySource` is `'server'`, but the server's memory/thread selection remains authoritative; Mastra only falls back to `params.id` when the server provides a memory resource but no thread.",
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
@@ -68,6 +68,14 @@ export async function POST(req: Request) {
     defaultValue: "'v5'",
   },
   {
+    name: 'historySource',
+    type: "'client' | 'server'",
+    description:
+      "Controls where chat history comes from. Pass `'client'` to read `params.messages`. Pass `'server'` to load history from Mastra memory and accept only `params.message` or `params.messageId` from the request body.",
+    isOptional: true,
+    defaultValue: "'client'",
+  },
+  {
     name: 'mastra',
     type: 'Mastra',
     description: 'The Mastra instance containing registered agents.',
@@ -95,8 +103,28 @@ export async function POST(req: Request) {
   {
     name: 'params.messages',
     type: 'UIMessage[]',
-    description: 'Array of messages in the conversation.',
-    isOptional: false,
+    description: "Array of messages in the conversation. Required when `historySource` is `'client'`.",
+    isOptional: true,
+  },
+  {
+    name: 'params.id',
+    type: 'string',
+    description:
+      "Chat ID from AI SDK UI. Required when `historySource` is `'server'`. If the server provides a memory resource but no thread, Mastra uses this value as the thread ID.",
+    isOptional: true,
+  },
+  {
+    name: 'params.message',
+    type: 'UIMessage',
+    description: "Latest submitted message. Used when `historySource` is `'server'` and `trigger` is `submit-message`.",
+    isOptional: true,
+  },
+  {
+    name: 'params.messageId',
+    type: 'string',
+    description:
+      "Assistant message ID to regenerate. Used when `historySource` is `'server'` and `trigger` is `regenerate-message`.",
+    isOptional: true,
   },
   {
     name: 'params.resumeData',
@@ -174,3 +202,34 @@ export async function POST(req: Request) {
   },
 ]}
 />
+
+## Server history mode
+
+Use `historySource: 'server'` when a framework route should let Mastra memory load stored messages. In this mode, do not pass the browser's full `messages` array to `handleChatStream()`. Pass only the request body produced by `prepareServerHistoryRequest()`, and set memory scope from server code.
+
+```typescript title="app/api/chat/route.ts"
+import { handleChatStream } from '@mastra/ai-sdk'
+import { createUIMessageStreamResponse } from 'ai'
+import { mastra } from '@/src/mastra'
+
+export async function POST(req: Request) {
+  const params = await req.json()
+  const stream = await handleChatStream({
+    mastra,
+    agentId: 'weatherAgent',
+    historySource: 'server',
+    defaultOptions: {
+      memory: {
+        resource: 'user-123',
+      },
+    },
+    params,
+  })
+
+  return createUIMessageStreamResponse({ stream })
+}
+```
+
+Server history mode accepts only `id`, `message`, `messageId`, `trigger`, `resumeData`, `runId`, and a server-provided `RequestContext` instance. It rejects browser-provided history, memory scope, request context, and execution options.
+
+If a stream is aborted while an assistant response is incomplete, server-history mode relies on server-marked response metadata to remove that incomplete assistant message before recalling stored history for the next turn.

--- a/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
@@ -205,7 +205,7 @@ export async function POST(req: Request) {
 
 ## Server history mode
 
-Use `historySource: 'server'` when a framework route should let Mastra memory load stored messages. In this mode, do not pass the browser's full `messages` array to `handleChatStream()`. Pass only the request body produced by `prepareServerHistoryRequest()`, and set memory scope from server code.
+Use `historySource: 'server'` when a framework route should let Mastra memory load stored messages. In this mode, do not pass the browser's full `messages` array to `handleChatStream()`. Pass only the request body produced by [`prepareServerHistoryRequest()`](/reference/ai-sdk/prepare-server-history-request), and set memory scope from server code.
 
 ```typescript title="app/api/chat/route.ts"
 import { handleChatStream } from '@mastra/ai-sdk'

--- a/docs/src/content/en/reference/ai-sdk/prepare-server-history-request.mdx
+++ b/docs/src/content/en/reference/ai-sdk/prepare-server-history-request.mdx
@@ -1,0 +1,156 @@
+---
+title: "Reference: prepareServerHistoryRequest() | AI SDK"
+description: API reference for prepareServerHistoryRequest(), a browser-safe helper for AI SDK UI server history requests.
+packages:
+  - "@mastra/ai-sdk"
+---
+
+import PropertiesTable from "@site/src/components/PropertiesTable";
+
+# prepareServerHistoryRequest()
+
+Creates a `prepareSendMessagesRequest` callback for AI SDK UI server history mode. Use it with [`chatRoute()`](/reference/ai-sdk/chat-route) or [`handleChatStream()`](/reference/ai-sdk/handle-chat-stream) when `historySource` is set to `'server'`.
+
+**Added in:** `@mastra/ai-sdk@1.5.0`
+
+The helper sends compact request bodies for new messages, regeneration, and approval resume responses. It does not send the full browser message history.
+
+## Usage example
+
+Configure the Mastra route with server-controlled memory scope:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { chatRoute } from '@mastra/ai-sdk'
+
+export const mastra = new Mastra({
+  server: {
+    apiRoutes: [
+      chatRoute({
+        path: '/chat',
+        agent: 'weatherAgent',
+        historySource: 'server',
+        defaultOptions: {
+          memory: {
+            resource: 'user-123',
+          },
+        },
+      }),
+    ],
+  },
+})
+```
+
+Use `prepareServerHistoryRequest()` with AI SDK UI:
+
+```typescript
+import { useChat } from '@ai-sdk/react'
+import { DefaultChatTransport } from 'ai'
+import { prepareServerHistoryRequest } from '@mastra/ai-sdk/transport'
+
+const { messages, sendMessage, regenerate } = useChat({
+  id: 'thread-123',
+  transport: new DefaultChatTransport({
+    api: 'http://localhost:4111/chat',
+    prepareSendMessagesRequest: prepareServerHistoryRequest(),
+  }),
+})
+```
+
+## Parameters
+
+`prepareServerHistoryRequest()` does not accept parameters.
+
+The generic type parameter `<UI_MESSAGE>` lets the returned callback preserve the AI SDK UI message type used by your app.
+
+The returned callback receives the AI SDK UI `prepareSendMessagesRequest` options:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description:
+      'The chat ID from AI SDK UI. Mastra can use this as the thread ID when the server provides a memory resource but no thread.',
+    isOptional: false,
+  },
+  {
+    name: 'messages',
+    type: 'UIMessage[]',
+    description:
+      'The current AI SDK UI messages. The helper only sends the latest submitted message, regeneration target, or approval response.',
+    isOptional: false,
+  },
+  {
+    name: 'trigger',
+    type: "'submit-message' | 'regenerate-message'",
+    description: 'The AI SDK UI request trigger. Defaults to `submit-message`.',
+    isOptional: true,
+    defaultValue: "'submit-message'",
+  },
+  {
+    name: 'messageId',
+    type: 'string',
+    description:
+      'The assistant message ID to regenerate. If omitted during regeneration, the helper uses the latest message ID.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Return value
+
+```typescript
+{
+  body: ServerHistoryRequestBody<UI_MESSAGE>
+}
+```
+
+The body is one of the following shapes:
+
+Submit requests include only the latest message.
+
+```json
+{
+  "id": "thread-123",
+  "trigger": "submit-message",
+  "message": {
+    "id": "user-1",
+    "role": "user",
+    "parts": [{ "type": "text", "text": "Hello" }]
+  }
+}
+```
+
+Regenerate requests include only the target assistant message ID.
+
+```json
+{
+  "id": "thread-123",
+  "trigger": "regenerate-message",
+  "messageId": "assistant-1"
+}
+```
+
+Approval resume requests include compact resume data.
+
+```json
+{
+  "id": "thread-123",
+  "runId": "run-123",
+  "resumeData": {
+    "approved": false,
+    "reason": "Not now"
+  },
+  "messageId": "assistant-1"
+}
+```
+
+## Errors
+
+The helper throws these errors:
+
+- `A message is required when submitting with server history`
+- `messageId is required when regenerating with server history`
+
+Server-side validation still rejects browser-provided history, memory scope, request context, and execution options in server history mode.

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -53,6 +53,7 @@ const sidebars = {
         { type: 'doc', id: 'ai-sdk/handle-network-stream', label: 'handleNetworkStream()' },
         { type: 'doc', id: 'ai-sdk/handle-workflow-stream', label: 'handleWorkflowStream()' },
         { type: 'doc', id: 'ai-sdk/network-route', label: 'networkRoute()' },
+        { type: 'doc', id: 'ai-sdk/prepare-server-history-request', label: 'prepareServerHistoryRequest()' },
         { type: 'doc', id: 'ai-sdk/to-ai-sdk-messages', label: 'toAISdkMessages()' },
         { type: 'doc', id: 'ai-sdk/to-ai-sdk-stream', label: 'toAISdkStream()' },
         { type: 'doc', id: 'ai-sdk/to-ai-sdk-v4-messages', label: 'toAISdkV4Messages()' },

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -1252,4 +1252,132 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     expect(assistantMessage?.content.metadata?.modelId).not.toBe(apiResponseModelId);
     expect(assistantMessage?.content.metadata?.provider).toBe('openai');
   });
+
+  const createStreamingExecutionStep = (doStream: Mock, executionOptions?: any) =>
+    createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      options: executionOptions,
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'openai',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream,
+          } as any,
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+        threadId: 'thread-123',
+        resourceId: 'resource-456',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<{}>);
+
+  it('does not mark completed assistant messages as aborted when the signal aborts after finish', async () => {
+    const abortController = new AbortController();
+    const streamParts = [
+      { type: 'response-metadata', id: 'resp-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: 'Hello!' },
+      { type: 'text-end', id: 'text-1' },
+      { type: 'finish', finishReason: 'stop', usage: testUsage },
+      { type: 'text-start', id: 'post-finish' },
+    ];
+    const doStream = vi.fn(async () => ({
+      stream: new ReadableStream({
+        pull(controller) {
+          const next = streamParts.shift();
+          if (next) {
+            if (next.type === 'text-start' && next.id === 'post-finish') {
+              abortController.abort();
+            }
+            controller.enqueue(next);
+            return;
+          }
+          controller.close();
+        },
+      }),
+      request: {},
+      response: { headers: undefined },
+      warnings: [],
+    }));
+
+    const llmExecutionStep = createStreamingExecutionStep(doStream, { abortSignal: abortController.signal });
+
+    const input = createIterationInput();
+    input.stepResult.isContinued = false;
+
+    await llmExecutionStep.execute(createExecuteParams(input));
+
+    const assistantMessage = messageList.get.response.db().find(message => message.role === 'assistant');
+    expect(assistantMessage?.content.metadata?.mastra?.responseStatus).toBeUndefined();
+  });
+
+  it('marks assistant messages as aborted when the signal aborts before finish', async () => {
+    const abortController = new AbortController();
+    const streamParts = [
+      { type: 'response-metadata', id: 'resp-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: 'Hello!' },
+      { type: 'text-delta', id: 'text-1', delta: ' This chunk should not be stored.' },
+      { type: 'text-end', id: 'text-1' },
+    ];
+    const doStream = vi.fn(async () => ({
+      stream: new ReadableStream({
+        pull(controller) {
+          const next = streamParts.shift();
+          if (next) {
+            controller.enqueue(next);
+            return;
+          }
+          controller.close();
+        },
+      }),
+      request: {},
+      response: { headers: undefined },
+      warnings: [],
+    }));
+
+    const llmExecutionStep = createStreamingExecutionStep(doStream, {
+      abortSignal: abortController.signal,
+      onChunk: vi.fn(chunk => {
+        if (chunk.type === 'text-delta') {
+          abortController.abort();
+        }
+      }),
+    });
+
+    const input = createIterationInput();
+    input.stepResult.isContinued = false;
+
+    await llmExecutionStep.execute(createExecuteParams(input));
+
+    const assistantMessage = messageList.get.response.db().find(message => message.role === 'assistant');
+    expect(assistantMessage?.content.metadata?.mastra).toMatchObject({
+      responseStatus: 'aborted',
+      runId: 'test-run',
+    });
+  });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -885,18 +885,13 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               responseModelMetadata: buildResponseModelMetadata(runState, currentStep.model),
               tools: currentStep.tools,
             });
+            const streamFinished = collectedChunks.some(chunk => chunk.type === 'finish');
             for (const msg of builtMessages) {
-              if (options?.abortSignal?.aborted && msg.content && typeof msg.content === 'object') {
+              if (options?.abortSignal?.aborted && !streamFinished && msg.content && typeof msg.content === 'object') {
                 const existingMastraMetadata =
                   typeof msg.content.metadata?.mastra === 'object' && msg.content.metadata.mastra !== null
                     ? msg.content.metadata.mastra
                     : {};
-                const existingStatus = (existingMastraMetadata as { responseStatus?: unknown }).responseStatus;
-                if (existingStatus === 'finished' || existingStatus === 'completed') {
-                  messageList.add(msg, 'response');
-                  continue;
-                }
-
                 msg.content = {
                   ...msg.content,
                   metadata: {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -887,14 +887,22 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             });
             for (const msg of builtMessages) {
               if (options?.abortSignal?.aborted && msg.content && typeof msg.content === 'object') {
+                const existingMastraMetadata =
+                  typeof msg.content.metadata?.mastra === 'object' && msg.content.metadata.mastra !== null
+                    ? msg.content.metadata.mastra
+                    : {};
+                const existingStatus = (existingMastraMetadata as { responseStatus?: unknown }).responseStatus;
+                if (existingStatus === 'finished' || existingStatus === 'completed') {
+                  messageList.add(msg, 'response');
+                  continue;
+                }
+
                 msg.content = {
                   ...msg.content,
                   metadata: {
                     ...msg.content.metadata,
                     mastra: {
-                      ...(typeof msg.content.metadata?.mastra === 'object' && msg.content.metadata.mastra !== null
-                        ? msg.content.metadata.mastra
-                        : {}),
+                      ...existingMastraMetadata,
                       responseStatus: 'aborted',
                       runId,
                     },

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -886,6 +886,21 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               tools: currentStep.tools,
             });
             for (const msg of builtMessages) {
+              if (options?.abortSignal?.aborted && msg.content && typeof msg.content === 'object') {
+                msg.content = {
+                  ...msg.content,
+                  metadata: {
+                    ...msg.content.metadata,
+                    mastra: {
+                      ...(typeof msg.content.metadata?.mastra === 'object' && msg.content.metadata.mastra !== null
+                        ? msg.content.metadata.mastra
+                        : {}),
+                      responseStatus: 'aborted',
+                      runId,
+                    },
+                  },
+                };
+              }
               messageList.add(msg, 'response');
             }
 

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -706,6 +706,8 @@ https://mastra.ai/en/docs/memory/overview`,
           new MessageHistory({
             storage: memoryStore,
             lastMessages: typeof lastMessages === 'number' ? lastMessages : undefined,
+            saveMessages: this.saveMessages.bind(this),
+            deleteMessages: this.deleteMessages.bind(this),
           }),
         );
       }
@@ -865,6 +867,8 @@ https://mastra.ai/en/docs/memory/overview`,
           new MessageHistory({
             storage: memoryStore,
             lastMessages: typeof lastMessages === 'number' ? lastMessages : undefined,
+            saveMessages: this.saveMessages.bind(this),
+            deleteMessages: this.deleteMessages.bind(this),
           }),
         );
       }

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MastraDBMessage } from '../../agent';
 import { MessageList } from '../../agent';
 import type { MemoryRuntimeContext } from '../../memory';
-import { RequestContext } from '../../request-context';
+import { MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, RequestContext } from '../../request-context';
 import { MemoryStorage } from '../../storage';
 import type { StorageListThreadsInput, StorageListThreadsOutput } from '../../storage/types';
 
@@ -24,8 +24,10 @@ class MockStorage extends MemoryStorage {
   private messages: MastraDBMessage[] = [];
 
   async listMessages(params: any): Promise<any> {
-    const { threadId, perPage = false, page = 1, orderBy } = params;
-    const threadMessages = this.messages.filter(m => m.threadId === threadId);
+    const { threadId, resourceId, perPage = false, page = 1, orderBy } = params;
+    const threadMessages = this.messages.filter(
+      m => m.threadId === threadId && (resourceId === undefined || m.resourceId === resourceId),
+    );
 
     // Sort by createdAt if orderBy is specified
     let sortedMessages = threadMessages;
@@ -80,6 +82,9 @@ class MockStorage extends MemoryStorage {
   async saveMessages(args: { messages: MastraDBMessage[] }) {
     return { messages: args.messages };
   }
+  deleteMessages = vi.fn(async (messageIds: string[]) => {
+    this.messages = this.messages.filter(message => !message.id || !messageIds.includes(message.id));
+  });
   async updateMessages(args: any) {
     return args.messages || [];
   }
@@ -166,6 +171,95 @@ describe('MessageHistory', () => {
       expect(resultMessages[0].id).toBe('msg-2');
       expect(resultMessages[1].id).toBe('msg-3');
       expect(resultMessages[2].id).toBe('msg-4');
+    });
+
+    it('should recall only messages before the assistant target when regenerating', async () => {
+      const storedMessages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Question 1' }] },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2024-01-01T10:00:00Z'),
+        },
+        {
+          id: 'msg-2',
+          role: 'assistant',
+          content: { format: 2, parts: [{ type: 'text', text: 'Answer 1' }] },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2024-01-01T10:01:00Z'),
+        },
+        {
+          id: 'msg-3',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Question 2' }] },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2024-01-01T10:02:00Z'),
+        },
+        {
+          id: 'msg-4',
+          role: 'assistant',
+          content: { format: 2, parts: [{ type: 'text', text: 'Answer 2' }] },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2024-01-01T10:03:00Z'),
+        },
+      ];
+      mockStorage.setMessages(storedMessages);
+      const requestContext = createRuntimeContextWithMemory('thread-1', 'resource-1');
+      requestContext.set(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, {
+        type: 'regenerate',
+        targetMessageId: 'msg-2',
+      });
+      const state: Record<string, unknown> = {};
+      processor = new MessageHistory({ storage: mockStorage });
+
+      const result = await processor.processInput({
+        messages: [],
+        messageList: new MessageList(),
+        abort: mockAbort,
+        requestContext,
+        state,
+      });
+
+      expect(result).toBeInstanceOf(MessageList);
+      expect((result as MessageList).get.all.db().map(message => message.id)).toEqual(['msg-1']);
+      expect(state.regenerate).toEqual({
+        type: 'regenerate',
+        branchMessageIds: ['msg-2', 'msg-3', 'msg-4'],
+      });
+    });
+
+    it('should reject regenerate targets that are not assistant messages', async () => {
+      mockStorage.setMessages([
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Question' }] },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2024-01-01T10:00:00Z'),
+        },
+      ]);
+      const requestContext = createRuntimeContextWithMemory('thread-1', 'resource-1');
+      requestContext.set(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, {
+        type: 'regenerate',
+        targetMessageId: 'msg-1',
+      });
+      processor = new MessageHistory({ storage: mockStorage });
+
+      await expect(
+        processor.processInput({
+          messages: [],
+          messageList: new MessageList(),
+          abort: mockAbort,
+          requestContext,
+          state: {},
+        }),
+      ).rejects.toThrow('Cannot regenerate non-assistant message "msg-1"');
     });
 
     it('should merge historical messages with new messages', async () => {
@@ -270,6 +364,54 @@ describe('MessageHistory', () => {
       expect(resultMessages[1].id).toBe('msg-2');
       expect(resultMessages[1].content.content).toBe('Message 2 (new)'); // New version kept
       expect(resultMessages[2].id).toBe('msg-3');
+    });
+
+    it('should delete incomplete assistant messages before recalling server history', async () => {
+      const storedMessages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Question 1' }] },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2024-01-01T10:00:00Z'),
+        },
+        {
+          id: 'msg-2',
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: 'Partial answer' }],
+            metadata: { mastra: { responseStatus: 'aborted' } },
+          },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2024-01-01T10:01:00Z'),
+        },
+        {
+          id: 'msg-3',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Question 2' }] },
+          threadId: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date('2024-01-01T10:02:00Z'),
+        },
+      ];
+      mockStorage.setMessages(storedMessages);
+      processor = new MessageHistory({ storage: mockStorage });
+      const requestContext = createRuntimeContextWithMemory('thread-1', 'resource-1');
+      requestContext.set(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, { type: 'server-history' });
+      const messageList = new MessageList();
+
+      const result = await processor.processInput({
+        messages: [],
+        messageList,
+        abort: mockAbort,
+        requestContext,
+      });
+
+      expect((result as MessageList).get.all.db().map(message => message.id)).toEqual(['msg-1', 'msg-3']);
+      expect(mockStorage.deleteMessages).toHaveBeenCalledWith(['msg-2']);
     });
 
     it('should handle empty storage', async () => {
@@ -750,6 +892,210 @@ describe('MessageHistory', () => {
       });
 
       expect(mockStorage.saveMessages).not.toHaveBeenCalled();
+    });
+
+    it('should delete the regenerated branch only after a replacement response is saved', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        deleteMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+      const processor = new MessageHistory({ storage: mockStorage });
+      const response: MastraDBMessage = {
+        id: 'new-assistant',
+        role: 'assistant',
+        content: { format: 2, parts: [{ type: 'text', text: 'Replacement answer' }] },
+        createdAt: new Date(),
+      };
+      const messageList = new MessageList().add(response, 'response');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [response],
+        abort: ((reason?: string) => {
+          throw new Error(reason || 'Aborted');
+        }) as (reason?: string) => never,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+        state: {
+          regenerate: {
+            type: 'regenerate',
+            branchMessageIds: ['old-assistant', 'follow-up-user', 'follow-up-assistant'],
+          },
+        },
+      });
+
+      expect(mockStorage.saveMessages).toHaveBeenCalledTimes(1);
+      expect(mockStorage.deleteMessages).toHaveBeenCalledWith([
+        'old-assistant',
+        'follow-up-user',
+        'follow-up-assistant',
+      ]);
+    });
+
+    it('should not delete a regenerated branch when no replacement response is produced', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        deleteMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+      const processor = new MessageHistory({ storage: mockStorage });
+      const input: MastraDBMessage = {
+        id: 'new-user',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'New question' }] },
+        createdAt: new Date(),
+      };
+      const messageList = new MessageList().add(input, 'input');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [input],
+        abort: ((reason?: string) => {
+          throw new Error(reason || 'Aborted');
+        }) as (reason?: string) => never,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+        state: {
+          regenerate: {
+            type: 'regenerate',
+            branchMessageIds: ['old-assistant'],
+          },
+        },
+      });
+
+      expect(mockStorage.saveMessages).toHaveBeenCalledTimes(1);
+      expect(mockStorage.deleteMessages).not.toHaveBeenCalled();
+    });
+
+    it('should not delete a regenerated branch when the replacement response is incomplete', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        deleteMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+      const processor = new MessageHistory({ storage: mockStorage });
+      const response: MastraDBMessage = {
+        id: 'partial-assistant',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Partial replacement' }],
+          metadata: { mastra: { responseStatus: 'aborted' } },
+        },
+        createdAt: new Date(),
+      };
+      const messageList = new MessageList().add(response, 'response');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [response],
+        abort: ((reason?: string) => {
+          throw new Error(reason || 'Aborted');
+        }) as (reason?: string) => never,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+        state: {
+          regenerate: {
+            type: 'regenerate',
+            branchMessageIds: ['old-assistant'],
+          },
+        },
+      });
+
+      expect(mockStorage.saveMessages).not.toHaveBeenCalled();
+      expect(mockStorage.deleteMessages).not.toHaveBeenCalled();
+    });
+
+    it('should not persist incomplete assistant responses in client-history mode', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+      const processor = new MessageHistory({ storage: mockStorage });
+      const response: MastraDBMessage = {
+        id: 'partial-assistant',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Partial answer' }],
+          metadata: { mastra: { responseStatus: 'aborted' } },
+        },
+        createdAt: new Date(),
+      };
+      const messageList = new MessageList().add(response, 'response');
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [response],
+        abort: ((reason?: string) => {
+          throw new Error(reason || 'Aborted');
+        }) as (reason?: string) => never,
+        requestContext: createRuntimeContextWithMemory('thread-1'),
+      });
+
+      expect(mockStorage.saveMessages).not.toHaveBeenCalled();
+    });
+
+    it('should persist incomplete assistant responses when server-history recovery is enabled', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+      const processor = new MessageHistory({ storage: mockStorage });
+      const response: MastraDBMessage = {
+        id: 'partial-assistant',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'Partial answer' }],
+          metadata: { mastra: { responseStatus: 'aborted' } },
+        },
+        createdAt: new Date(),
+      };
+      const messageList = new MessageList().add(response, 'response');
+      const requestContext = createRuntimeContextWithMemory('thread-1');
+      requestContext.set(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, { type: 'server-history' });
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [response],
+        abort: ((reason?: string) => {
+          throw new Error(reason || 'Aborted');
+        }) as (reason?: string) => never,
+        requestContext,
+      });
+
+      expect(mockStorage.saveMessages).toHaveBeenCalledWith({
+        messages: [expect.objectContaining({ id: 'partial-assistant' })],
+      });
     });
 
     it('should preserve existing message IDs', async () => {

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -894,9 +894,18 @@ describe('MessageHistory', () => {
       expect(mockStorage.saveMessages).not.toHaveBeenCalled();
     });
 
-    it('should delete the regenerated branch only after a replacement response is saved', async () => {
+    it('should delete the regenerated branch after a storage-assigned replacement response is saved', async () => {
       const mockStorage = {
-        saveMessages: vi.fn().mockResolvedValue(undefined),
+        saveMessages: vi.fn().mockResolvedValue({
+          messages: [
+            {
+              id: 'stored-new-assistant',
+              role: 'assistant',
+              content: { format: 2, parts: [{ type: 'text', text: 'Replacement answer' }] },
+              createdAt: new Date(),
+            },
+          ],
+        }),
         deleteMessages: vi.fn().mockResolvedValue(undefined),
         getThreadById: vi.fn().mockResolvedValue({
           id: 'thread-1',

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -411,10 +411,9 @@ export class MessageHistory implements Processor {
       });
 
       const regenerateState = args.state?.regenerate as RegenerateState | undefined;
-      const persistedMessageIds = new Set(persistedMessages.map(message => message.id).filter(Boolean));
-      const newOutputIds = new Set(newOutput.map(message => message.id).filter(Boolean));
-      const persistedNewOutput = [...newOutputIds].some(messageId => persistedMessageIds.has(messageId));
-      if (regenerateState?.type === 'regenerate' && persistedNewOutput) {
+      const persistedReplacementOutput =
+        newOutput.length > 0 && persistedMessages.some(message => message.role === 'assistant');
+      if (regenerateState?.type === 'regenerate' && persistedReplacementOutput) {
         const savedMessageIds = new Set(messagesToSave.map(message => message.id).filter(Boolean));
         const messageIdsToDelete = regenerateState.branchMessageIds.filter(
           messageId => !savedMessageIds.has(messageId),

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -4,7 +4,8 @@ import { parseMemoryRequestContext } from '../../memory';
 import { removeWorkingMemoryTags } from '../../memory/working-memory-utils';
 import { SpanType, EntityType } from '../../observability';
 import type { ObservabilityContext, MemoryOperationAttributes } from '../../observability';
-import type { RequestContext } from '../../request-context';
+import { MASTRA_MEMORY_HISTORY_OVERRIDE_KEY } from '../../request-context';
+import type { MastraMemoryHistoryOverride, RequestContext } from '../../request-context';
 import type { MemoryStorage } from '../../storage';
 
 /**
@@ -13,7 +14,18 @@ import type { MemoryStorage } from '../../storage';
 export interface MessageHistoryOptions {
   storage: MemoryStorage;
   lastMessages?: number;
+  saveMessages?: (args: { messages: MastraDBMessage[] }) => Promise<{ messages: MastraDBMessage[] }>;
+  deleteMessages?: (messageIds: string[], observabilityContext?: Partial<ObservabilityContext>) => Promise<void>;
 }
+
+type RegenerateState = {
+  type: 'regenerate';
+  branchMessageIds: string[];
+};
+
+type MemoryHistoryOverride = MastraMemoryHistoryOverride;
+
+const INCOMPLETE_RESPONSE_STATUSES = new Set(['partial', 'aborted', 'cancelled', 'canceled']);
 
 /**
  * Hybrid processor that handles both retrieval and persistence of message history.
@@ -28,10 +40,14 @@ export class MessageHistory implements Processor {
   readonly name = 'MessageHistory';
   private storage: MemoryStorage;
   private lastMessages?: number;
+  private saveMessages?: MessageHistoryOptions['saveMessages'];
+  private deleteMessages?: MessageHistoryOptions['deleteMessages'];
 
   constructor(options: MessageHistoryOptions) {
     this.storage = options.storage;
     this.lastMessages = options.lastMessages;
+    this.saveMessages = options.saveMessages;
+    this.deleteMessages = options.deleteMessages;
   }
 
   /**
@@ -80,12 +96,111 @@ export class MessageHistory implements Processor {
     });
   }
 
+  private getMemoryHistoryOverride(requestContext?: RequestContext): MastraMemoryHistoryOverride | null {
+    const override = requestContext?.get(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY);
+    if (!override || typeof override !== 'object') return null;
+
+    const maybeOverride = override as Partial<MastraMemoryHistoryOverride>;
+    if (maybeOverride.type === 'server-history') {
+      return maybeOverride as Extract<MemoryHistoryOverride, { type: 'server-history' }>;
+    }
+
+    if (maybeOverride.type === 'regenerate' && typeof maybeOverride.targetMessageId === 'string') {
+      return maybeOverride as Extract<MemoryHistoryOverride, { type: 'regenerate' }>;
+    }
+
+    throw new Error('Invalid memory history override');
+  }
+
+  private isIncompleteAssistantMessage(message: MastraDBMessage): boolean {
+    if (message.role !== 'assistant') return false;
+
+    const metadata =
+      message.content && typeof message.content === 'object' && !Array.isArray(message.content)
+        ? ((message.content as { metadata?: Record<string, unknown> }).metadata ?? {})
+        : {};
+    const mastra = metadata.mastra;
+    if (!mastra || typeof mastra !== 'object') return false;
+
+    const responseStatus = (mastra as { responseStatus?: unknown }).responseStatus;
+    return typeof responseStatus === 'string' && INCOMPLETE_RESPONSE_STATUSES.has(responseStatus);
+  }
+
+  private async cleanupIncompleteAssistantMessages(
+    messages: MastraDBMessage[],
+    observabilityContext?: Partial<ObservabilityContext>,
+  ): Promise<MastraDBMessage[]> {
+    const incompleteMessageIds = messages
+      .filter(message => this.isIncompleteAssistantMessage(message))
+      .map(message => message.id)
+      .filter((id): id is string => Boolean(id));
+
+    if (incompleteMessageIds.length > 0) {
+      if (this.deleteMessages) {
+        await this.deleteMessages(incompleteMessageIds, observabilityContext);
+      } else {
+        await this.storage.deleteMessages(incompleteMessageIds);
+      }
+    }
+
+    return messages.filter(message => !this.isIncompleteAssistantMessage(message));
+  }
+
+  private async processRegenerateInput(args: {
+    messageList: MessageList;
+    requestContext?: RequestContext;
+    state?: Record<string, unknown>;
+    context: { threadId: string; resourceId?: string };
+    override: Extract<MastraMemoryHistoryOverride, { type: 'regenerate' }>;
+  }): Promise<MessageList> {
+    const { messageList, context, override, state } = args;
+    const result = await this.storage.listMessages({
+      threadId: context.threadId,
+      resourceId: context.resourceId,
+      page: 0,
+      perPage: false,
+      orderBy: { field: 'createdAt', direction: 'ASC' },
+    });
+
+    const storedMessages = result.messages.filter((msg: MastraDBMessage) => msg.role !== 'system');
+    const targetIndex = storedMessages.findIndex(message => message.id === override.targetMessageId);
+    if (targetIndex === -1) {
+      throw new Error(`Cannot regenerate missing message "${override.targetMessageId}"`);
+    }
+
+    const targetMessage = storedMessages[targetIndex]!;
+    if (targetMessage.role !== 'assistant') {
+      throw new Error(`Cannot regenerate non-assistant message "${override.targetMessageId}"`);
+    }
+
+    const branchMessages = storedMessages.slice(targetIndex);
+    const branchMessageIds = branchMessages.map(message => message.id).filter(Boolean);
+    if (state) {
+      state.regenerate = {
+        type: 'regenerate',
+        branchMessageIds,
+      } satisfies RegenerateState;
+    }
+
+    const recallMessages = await this.cleanupIncompleteAssistantMessages(storedMessages.slice(0, targetIndex));
+    const existingMessages = messageList.get.all.db();
+    const messageIds = new Set(existingMessages.map((m: MastraDBMessage) => m.id).filter(Boolean));
+    for (const msg of recallMessages) {
+      if (!msg.id || !messageIds.has(msg.id)) {
+        messageList.add(msg, 'memory');
+      }
+    }
+
+    return messageList;
+  }
+
   async processInput(
     args: {
       messages: MastraDBMessage[];
       messageList: MessageList;
       abort: (reason?: string) => never;
       requestContext?: RequestContext;
+      state?: Record<string, unknown>;
     } & Partial<ObservabilityContext>,
   ): Promise<MessageList | MastraDBMessage[]> {
     const { messageList, requestContext, ...observabilityContext } = args;
@@ -98,6 +213,7 @@ export class MessageHistory implements Processor {
     }
 
     const { threadId, resourceId } = context;
+    const override = this.getMemoryHistoryOverride(requestContext);
 
     const span = this.createMemorySpan(
       'recall',
@@ -109,19 +225,42 @@ export class MessageHistory implements Processor {
     );
 
     try {
+      if (override?.type === 'regenerate') {
+        const regeneratedMessageList = await this.processRegenerateInput({
+          messageList,
+          requestContext,
+          state: args.state,
+          context,
+          override,
+        });
+
+        span?.end({
+          output: { success: true },
+          attributes: { messageCount: regeneratedMessageList.get.all.db().length },
+        });
+
+        return regeneratedMessageList;
+      }
+
       // 1. Fetch historical messages from storage (as DB format)
       const result = await this.storage.listMessages({
         threadId,
         resourceId,
         page: 0,
-        perPage: this.lastMessages,
+        perPage: override?.type === 'server-history' ? false : this.lastMessages,
         orderBy: { field: 'createdAt', direction: 'DESC' },
       });
 
       // 2. Filter out system messages (they should never be stored in DB)
-      const filteredMessages = result.messages.filter((msg: MastraDBMessage) => {
+      let filteredMessages = result.messages.filter((msg: MastraDBMessage) => {
         return msg.role !== 'system';
       });
+      if (override?.type === 'server-history') {
+        filteredMessages = await this.cleanupIncompleteAssistantMessages(filteredMessages, observabilityContext);
+        if (typeof this.lastMessages === 'number' && this.lastMessages > 0) {
+          filteredMessages = filteredMessages.slice(0, this.lastMessages);
+        }
+      }
 
       // 3. Merge with incoming messages and messages already in MessageList (avoiding duplicates by ID)
       // This includes messages added by previous processors like SemanticRecall
@@ -171,9 +310,16 @@ export class MessageHistory implements Processor {
    * - For server-side tools, 'call' should have been converted to 'result' by the time OUTPUT is processed
    * - For client-side tools (no execute function), 'call' is the final state from the server's perspective
    */
-  private filterMessagesForPersistence(messages: MastraDBMessage[]): MastraDBMessage[] {
+  private filterMessagesForPersistence(
+    messages: MastraDBMessage[],
+    { includeIncompleteAssistantMessages = false }: { includeIncompleteAssistantMessages?: boolean } = {},
+  ): MastraDBMessage[] {
     return messages
       .map(m => {
+        if (!includeIncompleteAssistantMessages && this.isIncompleteAssistantMessage(m)) {
+          return null;
+        }
+
         const newMessage = { ...m };
         // Only spread content if it's a proper V2 object
         if (m.content && typeof m.content === 'object' && !Array.isArray(m.content)) {
@@ -225,6 +371,7 @@ export class MessageHistory implements Processor {
       messageList: MessageList;
       abort: (reason?: string) => never;
       requestContext?: RequestContext;
+      state?: Record<string, unknown>;
     } & Partial<ObservabilityContext>,
   ): Promise<MessageList> {
     const { messageList, requestContext, ...observabilityContext } = args;
@@ -242,6 +389,7 @@ export class MessageHistory implements Processor {
 
     const { threadId, resourceId } = context;
 
+    const override = this.getMemoryHistoryOverride(requestContext);
     const newInput = messageList.get.input.db();
     const newOutput = messageList.get.response.db();
     const messagesToSave = [...newInput, ...newOutput];
@@ -255,7 +403,31 @@ export class MessageHistory implements Processor {
     });
 
     try {
-      await this.persistMessages({ messages: messagesToSave, threadId, resourceId });
+      const persistedMessages = await this.persistMessages({
+        messages: messagesToSave,
+        threadId,
+        resourceId,
+        includeIncompleteAssistantMessages: override?.type === 'server-history',
+      });
+
+      const regenerateState = args.state?.regenerate as RegenerateState | undefined;
+      const persistedMessageIds = new Set(persistedMessages.map(message => message.id).filter(Boolean));
+      const newOutputIds = new Set(newOutput.map(message => message.id).filter(Boolean));
+      const persistedNewOutput = [...newOutputIds].some(messageId => persistedMessageIds.has(messageId));
+      if (regenerateState?.type === 'regenerate' && persistedNewOutput) {
+        const savedMessageIds = new Set(messagesToSave.map(message => message.id).filter(Boolean));
+        const messageIdsToDelete = regenerateState.branchMessageIds.filter(
+          messageId => !savedMessageIds.has(messageId),
+        );
+        if (messageIdsToDelete.length > 0) {
+          if (this.deleteMessages) {
+            await this.deleteMessages(messageIdsToDelete, observabilityContext);
+          } else {
+            await this.storage.deleteMessages(messageIdsToDelete);
+          }
+        }
+      }
+
       // add extra 1ms latency to make sure the next generate has not the same input
       await new Promise(resolve => setTimeout(resolve, 10));
 
@@ -277,17 +449,22 @@ export class MessageHistory implements Processor {
    * This method can be called externally by other processors (e.g., ObservationalMemory)
    * that need to save messages incrementally.
    */
-  async persistMessages(args: { messages: MastraDBMessage[]; threadId: string; resourceId?: string }): Promise<void> {
-    const { messages, threadId, resourceId } = args;
+  async persistMessages(args: {
+    messages: MastraDBMessage[];
+    threadId: string;
+    resourceId?: string;
+    includeIncompleteAssistantMessages?: boolean;
+  }): Promise<MastraDBMessage[]> {
+    const { messages, threadId, resourceId, includeIncompleteAssistantMessages } = args;
 
     if (messages.length === 0) {
-      return;
+      return [];
     }
 
-    const filtered = this.filterMessagesForPersistence(messages);
+    const filtered = this.filterMessagesForPersistence(messages, { includeIncompleteAssistantMessages });
 
     if (filtered.length === 0) {
-      return;
+      return [];
     }
 
     // Ensure thread exists (create if needed) before saving messages
@@ -313,6 +490,12 @@ export class MessageHistory implements Processor {
     }
 
     // Persist messages after thread is guaranteed to exist
+    if (this.saveMessages) {
+      await this.saveMessages({ messages: filtered });
+      return filtered;
+    }
+
     await this.storage.saveMessages({ messages: filtered });
+    return filtered;
   }
 }

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -491,11 +491,11 @@ export class MessageHistory implements Processor {
 
     // Persist messages after thread is guaranteed to exist
     if (this.saveMessages) {
-      await this.saveMessages({ messages: filtered });
-      return filtered;
+      const result = await this.saveMessages({ messages: filtered });
+      return result?.messages ?? filtered;
     }
 
-    await this.storage.saveMessages({ messages: filtered });
-    return filtered;
+    const result = await this.storage.saveMessages({ messages: filtered });
+    return result?.messages ?? filtered;
   }
 }

--- a/packages/core/src/request-context/index.ts
+++ b/packages/core/src/request-context/index.ts
@@ -31,6 +31,31 @@ export const MASTRA_RESOURCE_ID_KEY = 'mastra__resourceId';
 export const MASTRA_THREAD_ID_KEY = 'mastra__threadId';
 
 /**
+ * Reserved key for internal memory-history execution overrides.
+ *
+ * This is used by server-controlled route helpers to ask memory processors to
+ * alter history handling for a single request without accepting browser-owned
+ * memory scope.
+ *
+ * @internal
+ */
+export const MASTRA_MEMORY_HISTORY_OVERRIDE_KEY = 'mastra__memoryHistoryOverride';
+
+/**
+ * Internal request-scoped override for message-history behavior.
+ *
+ * @internal
+ */
+export type MastraMemoryHistoryOverride =
+  | {
+      type: 'server-history';
+    }
+  | {
+      type: 'regenerate';
+      targetMessageId: string;
+    };
+
+/**
  * Reserved key for storing version overrides on RequestContext.
  * When set, sub-agent delegation resolves versioned agents from these overrides.
  *

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -322,6 +322,61 @@ describe('Memory', () => {
         }),
       );
     });
+
+    it('should preserve createdAt only within the same thread and resource', async () => {
+      const originalCreatedAt = new Date('2024-01-01T10:00:00Z');
+      const otherCreatedAt = new Date('2024-01-02T10:00:00Z');
+
+      await memory.createThread({
+        threadId: 'thread-save-duplicate-scope-1',
+        resourceId: 'resource-save-duplicate-scope-1',
+      });
+      await memory.createThread({
+        threadId: 'thread-save-duplicate-scope-2',
+        resourceId: 'resource-save-duplicate-scope-2',
+      });
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'duplicate-scoped-msg',
+            threadId: 'thread-save-duplicate-scope-1',
+            resourceId: 'resource-save-duplicate-scope-1',
+            role: 'assistant',
+            createdAt: originalCreatedAt,
+            content: { format: 2, parts: [{ type: 'text', text: 'Original answer' }] },
+          },
+        ],
+      });
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'duplicate-scoped-msg',
+            threadId: 'thread-save-duplicate-scope-2',
+            resourceId: 'resource-save-duplicate-scope-2',
+            role: 'assistant',
+            createdAt: otherCreatedAt,
+            content: { format: 2, parts: [{ type: 'text', text: 'Other answer' }] },
+          },
+        ],
+      });
+
+      const recalled = await memory.recall({
+        threadId: 'thread-save-duplicate-scope-2',
+        resourceId: 'resource-save-duplicate-scope-2',
+        perPage: false,
+      });
+
+      expect(recalled.messages).toHaveLength(1);
+      expect(recalled.messages[0]).toEqual(
+        expect.objectContaining({
+          id: 'duplicate-scoped-msg',
+          createdAt: otherCreatedAt,
+          content: { format: 2, parts: [{ type: 'text', text: 'Other answer' }] },
+        }),
+      );
+    });
   });
 
   describe('cloneThread', () => {
@@ -2258,13 +2313,27 @@ describe('Memory', () => {
         ],
       });
 
-      expect(mockVector.deleteVectors).toHaveBeenCalledWith({
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-vector-replace',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: { format: 2, parts: [{ type: 'text', text: 'Updated replacement text' }] },
+            createdAt: new Date('2024-01-01T10:01:00Z'),
+          },
+        ],
+      });
+
+      expect(mockVector.deleteVectors).toHaveBeenCalledTimes(2);
+      expect(mockVector.deleteVectors).toHaveBeenNthCalledWith(2, {
         indexName: 'memory_messages',
         filter: { message_id: { $in: ['msg-vector-replace'] } },
       });
-      expect(mockVector.upsert).toHaveBeenCalled();
-      expect((mockVector.deleteVectors as any).mock.invocationCallOrder[0]).toBeLessThan(
-        (mockVector.upsert as any).mock.invocationCallOrder[0],
+      expect(mockVector.upsert).toHaveBeenCalledTimes(2);
+      expect((mockVector.deleteVectors as any).mock.invocationCallOrder[1]).toBeLessThan(
+        (mockVector.upsert as any).mock.invocationCallOrder[1],
       );
     });
 

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -270,6 +270,58 @@ describe('Memory', () => {
       expect(recalled.messages.map(message => message.id)).toEqual(['save-msg-1', 'save-msg-2']);
       expect(recalled.messages.map(message => message.content)).toEqual([messages[0].content, messages[1].content]);
     });
+
+    it('should preserve the original createdAt when saving the same message id again', async () => {
+      const threadId = 'thread-save-duplicate';
+      const resourceId = 'resource-save-duplicate';
+      const originalCreatedAt = new Date('2024-01-01T10:00:00Z');
+
+      await memory.createThread({
+        threadId,
+        resourceId,
+      });
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'duplicate-msg',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: originalCreatedAt,
+            content: { format: 2, parts: [{ type: 'text', text: 'Original answer' }] },
+          },
+        ],
+      });
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'duplicate-msg',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: new Date('2024-01-02T10:00:00Z'),
+            content: { format: 2, parts: [{ type: 'text', text: 'Updated answer' }] },
+          },
+        ],
+      });
+
+      const recalled = await memory.recall({
+        threadId,
+        resourceId,
+        perPage: false,
+      });
+
+      expect(recalled.messages).toHaveLength(1);
+      expect(recalled.messages[0]).toEqual(
+        expect.objectContaining({
+          id: 'duplicate-msg',
+          createdAt: originalCreatedAt,
+          content: { format: 2, parts: [{ type: 'text', text: 'Updated answer' }] },
+        }),
+      );
+    });
   });
 
   describe('cloneThread', () => {
@@ -2151,6 +2203,69 @@ describe('Memory', () => {
           filter: { message_id: { $in: [messageId] } },
         });
       });
+    });
+
+    it('should delete existing message vectors before upserting replacements', async () => {
+      const mockVector: MastraVector = {
+        deleteVectors: vi.fn().mockResolvedValue(undefined),
+        listIndexes: vi.fn().mockResolvedValue(['memory_messages']),
+        query: vi.fn(),
+        upsert: vi.fn().mockResolvedValue(undefined),
+        createIndex: vi.fn(),
+        describeIndex: vi.fn().mockResolvedValue({ dimension: 2 }),
+        id: 'mock-vector',
+      } as any;
+      const mockEmbedder = {
+        doEmbed: vi.fn().mockResolvedValue({
+          embeddings: [[0.1, 0.2]],
+        }),
+        modelId: 'mock-embedder',
+        specificationVersion: 'v1',
+        provider: 'mock',
+      } as any;
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        vector: mockVector,
+        embedder: mockEmbedder,
+        options: {
+          semanticRecall: true,
+          generateTitle: false,
+        },
+      });
+      const threadId = 'thread-vector-replace';
+      const resourceId = 'resource-vector-replace';
+
+      await memory.saveThread({
+        thread: {
+          id: threadId,
+          resourceId,
+          title: 'Vector replace',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-vector-replace',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: { format: 2, parts: [{ type: 'text', text: 'Replacement text' }] },
+            createdAt: new Date('2024-01-01T10:00:00Z'),
+          },
+        ],
+      });
+
+      expect(mockVector.deleteVectors).toHaveBeenCalledWith({
+        indexName: 'memory_messages',
+        filter: { message_id: { $in: ['msg-vector-replace'] } },
+      });
+      expect(mockVector.upsert).toHaveBeenCalled();
+      expect((mockVector.deleteVectors as any).mock.invocationCallOrder[0]).toBeLessThan(
+        (mockVector.upsert as any).mock.invocationCallOrder[0],
+      );
     });
 
     it('should delete thread vectors with default separator', async () => {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1031,13 +1031,36 @@ ${workingMemory}`;
         .get.all.db();
 
       const memoryStore = await this.getMemoryStore();
+      const existingMessages =
+        dbMessages.length > 0
+          ? await memoryStore.listMessagesById({ messageIds: dbMessages.map(message => message.id) })
+          : { messages: [] };
+      const existingById = new Map(existingMessages.messages.map(message => [message.id, message]));
+      const messagesToSave = dbMessages.map(message => {
+        const existing = existingById.get(message.id);
+        if (
+          existing &&
+          existing.threadId === message.threadId &&
+          existing.resourceId === message.resourceId &&
+          existing.createdAt
+        ) {
+          return {
+            ...message,
+            createdAt: existing.createdAt,
+          };
+        }
+        return message;
+      });
+
       const result = await memoryStore.saveMessages({
-        messages: dbMessages,
+        messages: messagesToSave,
       });
 
       let totalTokens = 0;
 
       if (this.vector && config.semanticRecall) {
+        await this.deleteMessageVectors(messagesToSave.map(message => message.id));
+
         // Collect all embeddings first (embedding is CPU-bound, doesn't use pool connections)
         const embeddingData: Array<{
           embeddings: number[][];
@@ -1047,7 +1070,7 @@ ${workingMemory}`;
 
         // Process embeddings concurrently - this doesn't use DB connections
         await Promise.all(
-          updatedMessages.map(async message => {
+          messagesToSave.map(async message => {
             let textForEmbedding: string | null = null;
 
             if (

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1035,9 +1035,11 @@ ${workingMemory}`;
         dbMessages.length > 0
           ? await memoryStore.listMessagesById({ messageIds: dbMessages.map(message => message.id) })
           : { messages: [] };
-      const existingById = new Map(existingMessages.messages.map(message => [message.id, message]));
+      const getMessageScopeKey = (message: Pick<MastraDBMessage, 'id' | 'resourceId' | 'threadId'>): string =>
+        `${message.threadId ?? ''}\u0000${message.resourceId ?? ''}\u0000${message.id}`;
+      const existingById = new Map(existingMessages.messages.map(message => [getMessageScopeKey(message), message]));
       const messagesToSave = dbMessages.map(message => {
-        const existing = existingById.get(message.id);
+        const existing = existingById.get(getMessageScopeKey(message));
         if (
           existing &&
           existing.threadId === message.threadId &&


### PR DESCRIPTION
Adds opt-in server-history support for AI SDK chat routes so clients can send compact chat events while Mastra memory remains the source of truth.

The transport helper covers submit, regenerate, and approval resume requests. Server-history validation rejects browser-provided history, memory scope, request context, and execution options, while server-provided memory scope remains authoritative over the browser `id` thread hint.

Core memory history handles regenerate by recalling only messages before the target assistant response and deleting the replaced branch only after a persisted replacement exists. Server-marked incomplete assistant responses are cleaned up before server-history recall, repeated message saves preserve ordering while refreshing semantic recall vectors, and completed streams are no longer marked as aborted if the request signal fires after the model finish chunk.

Docs now cover `historySource: 'server'` for `chatRoute()` and `handleChatStream()`, plus the `prepareServerHistoryRequest()` transport helper.

Closes https://github.com/mastra-ai/mastra/issues/16053

Tests run:
- `pnpm --filter ./client-sdks/ai-sdk exec vitest run src/server-history.test.ts src/__tests__/transport.test.ts`
- `pnpm exec vitest run packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts --project unit:packages/core`
- `pnpm exec vitest run packages/core/src/processors/memory/message-history.test.ts --project unit:packages/core`
- `pnpm exec vitest run packages/memory/src/index.test.ts --project unit:packages/memory`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/memory check`
- `pnpm --filter ./client-sdks/ai-sdk lint`
- `pnpm --filter ./packages/core lint`
- `pnpm --filter ./packages/memory lint`
- `pnpm --dir docs validate`
- `pnpm --dir docs lint:remark`
- `pnpm --filter ./packages/core build:lib`
- `pnpm --filter ./client-sdks/ai-sdk build:lib`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Instead of the browser sending the whole conversation every time, the server keeps the conversation memory and the browser sends only small signals like "new message" or "try again." This makes requests smaller and safer because the server is the single source of truth for history.

---

## Summary

### Core Changes
- Adds opt-in server-history mode to AI SDK chat APIs via new HistorySource = 'client' | 'server' (default 'client'). In server-history mode, Mastra memory is the authoritative conversation history and client requests are compact.

### Transport Layer
- New browser-safe helper prepareServerHistoryRequest that emits minimal request bodies:
  - submit: only the latest user message
  - regenerate: only the target messageId
  - approval resume: compact resumeData/runId (parsed from approval part)
- Exposed via a new ./transport export entry.

### Server-side Validation & Normalization
- Strict server-history request validation rejects browser-supplied fields outside the compact contract (messages, memory/thread/resource, requestContext, provider/model options, maxSteps, structuredOutput, etc.).
- Trusted memory/resource scope is resolved only from server sources: middleware/auth RequestContext reserved keys, chatRoute defaultOptions.memory, or body.id only as a hint when server-controlled resource selection exists.
- Normalizes server-history inputs into existing submit/regenerate/resume paths and injects a trusted RequestContext with a MASTRA_MEMORY_HISTORY_OVERRIDE_KEY for server-history/regenerate.
- chatRoute/handleChatStream return HTTP 400 on server-history validation errors and preserve server-provided RequestContext keys.

### Core Memory Enhancements
- Introduces MastraMemoryHistoryOverride and wiring into MessageHistory via request-context override.
- Regenerate: MessageHistory.processInput recalls only messages before the target assistant message, validates target exists/role/thread/resource, and records branch message IDs for deletion.
- Incomplete assistant messages (partial/aborted/cancelled) are removed before server-history recall.
- processOutputResult replaces the old branch only after a successful persisted assistant replacement; deletion happens after persistence to preserve vector/semantic consistency.
- saveMessages now preserves createdAt for duplicate message IDs in the same thread/resource and refreshes semantic vectors by deleting old vectors before upserting replacements, preventing duplicate-appends and preserving ordering.

### API & Types
- Exports new type HistorySource and updates ChatStreamHandlerParams/Options to support optional messages/id/messageId/message and historySource.
- Added MASTRA_MEMORY_HISTORY_OVERRIDE_KEY and MastraMemoryHistoryOverride types to request-context exports.

### Docs & Examples
- Updated AI SDK docs and README: new server-history sections, prepareServerHistoryRequest reference, usage examples, and a security note that body.id is only a hint and server must provide resource/memory scope.
- Added API docs for prepareServerHistoryRequest and adjusted sidebars.

### Tests & CI
- Added comprehensive Vitest suites and tests:
  - transport.prepareServerHistoryRequest
  - server-history behavior for handleChatStream and chatRoute
  - MessageHistory regenerate/cleanup semantics and incomplete-message handling
  - memory.saveMessages duplicate-id behavior and vector replacement ordering
  - stream abort/status handling tests in LLM execution step
- Builds, lint, types, and git diff checks updated for core/ai-sdk/memory packages.

### Behavior Guarantees
- Client-history remains the default and unchanged.
- Server-history strictly limits client-sent fields and centralizes memory scope/trust to server-side context.
- Regenerations and duplicate-id saves preserve ordering/createdAt and maintain consistent semantic vectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->