### PR TITLE
feat(core): send signals to durable agent streams

### DIFF
--- a/.changeset/good-pears-hide.md
+++ b/.changeset/good-pears-hide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added durable agent signals so callers can send user messages, system reminders, and custom signals into running durable streams. Signals targeting an idle resource/thread start a durable run, and signals received during final text streaming continue the durable loop instead of being stranded.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-signals.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-signals.test.ts
@@ -1,0 +1,250 @@
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { createTool } from '../../../tools';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../create-durable-agent';
+
+describe('DurableAgent signals', () => {
+  it('injects queued signals into the next LLM request after a tool boundary in FIFO order', async () => {
+    const prompts: unknown[] = [];
+    let callCount = 0;
+    let durableAgent: ReturnType<typeof createDurableAgent>;
+
+    const model = new MockLanguageModelV2({
+      doStream: async options => {
+        prompts.push(options.prompt);
+        callCount++;
+        if (callCount === 1) {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'call-1',
+                toolName: 'queueSignal',
+                input: JSON.stringify({}),
+                providerExecuted: false,
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+              },
+            ]),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        }
+
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'done' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    const queueSignal = createTool({
+      id: 'queueSignal',
+      description: 'queues a signal',
+      inputSchema: z.object({}),
+      execute: async () => {
+        durableAgent.sendSignal(
+          { type: 'user-message', contents: 'first signal' },
+          { resourceId: 'user-1', threadId: 'thread-1' },
+        );
+        durableAgent.sendSignal(
+          { type: 'system-reminder', contents: 'second signal' },
+          { resourceId: 'user-1', threadId: 'thread-1' },
+        );
+        return 'queued';
+      },
+    });
+
+    const agent = new Agent({
+      id: 'signal-agent',
+      name: 'Signal Agent',
+      instructions: 'Use tools',
+      model: model as LanguageModelV2,
+      tools: { queueSignal },
+    });
+    durableAgent = createDurableAgent({ agent, pubsub: new EventEmitterPubSub(), cleanupTimeoutMs: 0 });
+
+    const result = await durableAgent.stream('start', { memory: { resource: 'user-1', thread: 'thread-1' } });
+    for await (const _chunk of result.fullStream as AsyncIterable<any>) {
+    }
+    result.cleanup();
+
+    expect(prompts).toHaveLength(2);
+    const secondPrompt = JSON.stringify(prompts[1]);
+    expect(secondPrompt.indexOf('first signal')).toBeLessThan(secondPrompt.indexOf('second signal'));
+    expect(secondPrompt).toContain('system-reminder');
+    expect(secondPrompt).toContain('agent-signal');
+  });
+
+  it('continues the loop when a signal arrives during final text streaming', async () => {
+    const prompts: unknown[] = [];
+    let callCount = 0;
+    let resolveFirstTextStarted!: () => void;
+    let releaseFirstStream!: () => void;
+    const firstTextStarted = new Promise<void>(resolve => {
+      resolveFirstTextStarted = resolve;
+    });
+    const firstStreamCanFinish = new Promise<void>(resolve => {
+      releaseFirstStream = resolve;
+    });
+
+    const model = new MockLanguageModelV2({
+      doStream: async options => {
+        prompts.push(options.prompt);
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            stream: new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'id-0',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                });
+                controller.enqueue({ type: 'text-start', id: 'text-1' });
+                controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'final text' });
+                resolveFirstTextStarted();
+                await firstStreamCanFinish;
+                controller.enqueue({ type: 'text-end', id: 'text-1' });
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+                });
+                controller.close();
+              },
+            }),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        }
+
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-2' },
+            { type: 'text-delta', id: 'text-2', delta: 'responded to signal' },
+            { type: 'text-end', id: 'text-2' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'signal-during-final-agent',
+      name: 'Signal During Final Agent',
+      instructions: 'Respond to signals',
+      model: model as LanguageModelV2,
+    });
+    const durableAgent = createDurableAgent({ agent, pubsub: new EventEmitterPubSub(), cleanupTimeoutMs: 0 });
+
+    const result = await durableAgent.stream('start', { memory: { resource: 'user-1', thread: 'thread-1' } });
+    const drainPromise = (async () => {
+      for await (const _chunk of result.fullStream as AsyncIterable<any>) {
+      }
+    })();
+
+    await firstTextStarted;
+    durableAgent.sendSignal(
+      { type: 'user-message', contents: 'interrupt during final text' },
+      { resourceId: 'user-1', threadId: 'thread-1' },
+    );
+    releaseFirstStream();
+    await drainPromise;
+    result.cleanup();
+
+    expect(prompts).toHaveLength(2);
+    expect(JSON.stringify(prompts[1])).toContain('interrupt during final text');
+  });
+
+  it('rejects run-id-only signals when no active run exists', () => {
+    const model = new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'signal-agent',
+      name: 'Signal Agent',
+      instructions: 'Use tools',
+      model: model as LanguageModelV2,
+    });
+    const durableAgent = createDurableAgent({ agent, pubsub: new EventEmitterPubSub(), cleanupTimeoutMs: 0 });
+
+    expect(() => {
+      durableAgent.sendSignal({ type: 'user-message', contents: 'queued before stream' }, { runId: 'run-1' });
+    }).toThrow('No active durable agent run found for signal target');
+  });
+
+  it('starts an idle thread when sendSignal targets resource and thread', async () => {
+    const prompts: unknown[] = [];
+    let resolvePrompt!: () => void;
+    const promptSeen = new Promise<void>(resolve => {
+      resolvePrompt = resolve;
+    });
+    const model = new MockLanguageModelV2({
+      doStream: async options => {
+        prompts.push(options.prompt);
+        resolvePrompt();
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'done' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'signal-agent',
+      name: 'Signal Agent',
+      instructions: 'Use tools',
+      model: model as LanguageModelV2,
+    });
+    const durableAgent = createDurableAgent({ agent, pubsub: new EventEmitterPubSub(), cleanupTimeoutMs: 0 });
+
+    const result = durableAgent.sendSignal(
+      { type: 'user-message', contents: 'start from signal' },
+      { resourceId: 'user-1', threadId: 'thread-1' },
+    );
+    await promptSeen;
+
+    expect(result.accepted).toBe(true);
+    expect(result.runId).toBeTruthy();
+    expect(JSON.stringify(prompts[0])).toContain('start from signal');
+  });
+});

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -4,8 +4,11 @@ import { CachingPubSub } from '../../events/caching-pubsub';
 import { EventEmitterPubSub } from '../../events/event-emitter';
 import type { PubSub } from '../../events/pubsub';
 import type { Mastra } from '../../mastra';
+import type { MastraMemory } from '../../memory/memory';
 import type { MastraModelOutput } from '../../stream/base/output';
 import type { ChunkType } from '../../stream/types';
+import type { DynamicArgument } from '../../types';
+import type { AnyWorkspace } from '../../workspace';
 import { Agent } from '../agent';
 import type { AgentExecutionOptions } from '../agent.types';
 import type { MessageListInput } from '../message-list';
@@ -15,14 +18,26 @@ import { AGENT_STREAM_TOPIC, AGENT_THREAD_STREAM_TOPIC } from './constants';
 import { runDurableStreamUntilIdle } from './durable-stream-until-idle';
 import { prepareForDurableExecution } from './preparation';
 import { ExtendedRunRegistry, globalRunRegistry } from './run-registry';
+import { signalToMessage } from './signal-message';
 import { createDurableAgentStream, emitErrorEvent } from './stream-adapter';
 import type {
   AgentFinishEventData,
   AgentStepFinishEventData,
   AgentSuspendedEventData,
+  DurableAgentActiveRun,
+  DurableAgentClaimThreadOptions,
+  DurableAgentClaimThreadResult,
   DurableAgenticWorkflowInput,
+  DurableAgentSignal,
+  SendDurableAgentSignalOptions,
 } from './types';
 import { createDurableAgenticWorkflow } from './workflows';
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted.');
+  error.name = 'AbortError';
+  return error;
+}
 
 /**
  * Options for DurableAgent.stream()
@@ -38,6 +53,8 @@ export interface DurableAgentStreamOptions<OUTPUT = undefined> {
   runId?: string;
   /** Request Context containing dynamic configuration and state */
   requestContext?: AgentExecutionOptions<OUTPUT>['requestContext'];
+  /** Abort signal for canceling local durable execution */
+  abortSignal?: AbortSignal;
   /** Maximum number of steps to run */
   maxSteps?: number;
   /** Additional tool sets that can be used for this execution */
@@ -280,8 +297,8 @@ export class DurableAgent<
       name: agentName,
       // Delegate to wrapped agent's instructions
       instructions: ({ requestContext }) => agent.getInstructions({ requestContext }),
-      // We need to provide model to satisfy the base class, but we'll delegate to wrapped agent
-      model: (agent as any).__model ?? agent.getModel(),
+      // Provide a lazy model resolver so wrapping dynamic agents doesn't resolve the model at construction time.
+      model: ({ requestContext }) => agent.getModel({ requestContext }),
     });
 
     this.#wrappedAgent = agent;
@@ -313,6 +330,63 @@ export class DurableAgent<
   get pubsub(): PubSub {
     this.#ensurePubsubInitialized();
     return this.#cachingPubsub!;
+  }
+
+  getActiveRunForThread(options: { resourceId: string; threadId: string }): DurableAgentActiveRun | undefined {
+    const runId = this.#runRegistry.getRunIdForThread(options.resourceId, options.threadId);
+    if (!runId) return undefined;
+    const status = this.#runRegistry.getStatus(runId);
+    if (status !== 'active' && status !== 'suspended') return undefined;
+    return { ...options, runId, status };
+  }
+
+  claimThreadRun(options: DurableAgentClaimThreadOptions): DurableAgentClaimThreadResult {
+    const activeRun = this.getActiveRunForThread({ resourceId: options.resourceId, threadId: options.threadId });
+    if (activeRun) {
+      return { claimed: false, activeRun };
+    }
+    return {
+      claimed: true,
+      activeRun: {
+        resourceId: options.resourceId,
+        threadId: options.threadId,
+        runId: options.runId,
+        ownerId: options.ownerId,
+        status: 'active',
+      },
+    };
+  }
+
+  sendSignal(signal: DurableAgentSignal, target: SendDurableAgentSignalOptions): { accepted: true; runId: string } {
+    let runId: string | undefined;
+    if (target.resourceId && target.threadId) {
+      runId = this.getActiveRunForThread({ resourceId: target.resourceId, threadId: target.threadId })?.runId;
+    }
+    runId ??= target.runId;
+
+    const globalEntry = runId ? globalRunRegistry.get(runId) : undefined;
+    if (runId && globalEntry) {
+      this.#runRegistry.enqueueSignal(runId, signal);
+      globalEntry.signalQueue ??= [];
+      globalEntry.signalQueue.push(signal);
+      return { accepted: true, runId };
+    }
+
+    if (!target.resourceId || !target.threadId) {
+      throw new Error('No active durable agent run found for signal target');
+    }
+
+    runId ??= crypto.randomUUID();
+    const streamOptions = target.streamOptions as DurableAgentStreamOptions<TOutput> | undefined;
+    void this.stream([signalToMessage(signal)], {
+      ...streamOptions,
+      runId,
+      memory: streamOptions?.memory ?? ({ resource: target.resourceId, thread: target.threadId } as any),
+    } as DurableAgentStreamOptions<TOutput>).catch(error => {
+      void this.emitError(runId!, error);
+    });
+
+    return { accepted: true, runId };
   }
 
   /**
@@ -380,8 +454,43 @@ export class DurableAgent<
     return this.#wrappedAgent.listTools(options);
   }
 
-  override getMemory() {
-    return this.#wrappedAgent.getMemory();
+  override hasOwnMemory() {
+    return this.#wrappedAgent.hasOwnMemory();
+  }
+
+  override getMemory(options?: any) {
+    return this.#wrappedAgent.getMemory(options);
+  }
+
+  override __setMemory(memory: DynamicArgument<MastraMemory, any>) {
+    this.#wrappedAgent.__setMemory(memory);
+    super.__setMemory(memory);
+  }
+
+  override hasOwnWorkspace() {
+    return this.#wrappedAgent.hasOwnWorkspace();
+  }
+
+  override getWorkspace(options?: any) {
+    return this.#wrappedAgent.getWorkspace(options);
+  }
+
+  override __setWorkspace(workspace: DynamicArgument<AnyWorkspace | undefined, any>) {
+    this.#wrappedAgent.__setWorkspace(workspace);
+    super.__setWorkspace(workspace);
+  }
+
+  override hasOwnBrowser() {
+    return this.#wrappedAgent.hasOwnBrowser();
+  }
+
+  override get browser() {
+    return this.#wrappedAgent.browser;
+  }
+
+  override setBrowser(browser: Parameters<Agent['setBrowser']>[0]) {
+    this.#wrappedAgent.setBrowser(browser);
+    super.setBrowser(browser);
   }
 
   override getVoice() {
@@ -422,14 +531,33 @@ export class DurableAgent<
    */
   protected async executeWorkflow(runId: string, workflowInput: DurableAgenticWorkflowInput): Promise<void> {
     const workflow = this.getWorkflow();
-    const requestContext = globalRunRegistry.get(runId)?.requestContext;
+    const registryEntry = globalRunRegistry.get(runId);
+    const requestContext = registryEntry?.requestContext;
+    const abortSignal = registryEntry?.abortSignal;
 
     const run = await workflow.createRun({ runId, pubsub: this.pubsub });
-    const result = await run.start({ inputData: workflowInput, requestContext });
+    if (abortSignal?.aborted) {
+      await run.cancel();
+      await this.emitError(runId, createAbortError());
+      return;
+    }
 
-    if (result?.status === 'failed') {
-      const error = new Error((result as any).error?.message || 'Workflow execution failed');
-      await this.emitError(runId, error);
+    const abort = () => {
+      void run.cancel();
+      void this.emitError(runId, createAbortError());
+    };
+    abortSignal?.addEventListener('abort', abort, { once: true });
+    try {
+      const result = await run.start({ inputData: workflowInput, requestContext });
+
+      if (result?.status === 'failed') {
+        const error = new Error((result as any).error?.message || 'Workflow execution failed');
+        await this.emitError(runId, error);
+      } else if ((result as any)?.status === 'canceled' || abortSignal?.aborted) {
+        await this.emitError(runId, createAbortError());
+      }
+    } finally {
+      abortSignal?.removeEventListener('abort', abort);
     }
   }
 
@@ -470,11 +598,7 @@ export class DurableAgent<
     const entry = this.#runRegistry.get(runId);
     if (!entry) return Promise.resolve(undefined);
 
-    const {
-      output,
-      cleanup,
-      ready,
-    } = createDurableAgentStream<TOutput>({
+    const { output, cleanup, ready } = createDurableAgentStream<TOutput>({
       pubsub: this.pubsub,
       runId,
       messageId: runId,
@@ -545,7 +669,10 @@ export class DurableAgent<
 
     await this.pubsub.subscribeWithReplay(topic, handleThreadEvent);
 
-    const activeRunId = this.#runRegistry.getRunIdByThread({ resourceId: options.resourceId, threadId: options.threadId });
+    const activeRunId = this.#runRegistry.getRunIdByThread({
+      resourceId: options.resourceId,
+      threadId: options.threadId,
+    });
     if (activeRunId) {
       void enqueueRun(activeRunId);
     }
@@ -606,10 +733,12 @@ export class DurableAgent<
     });
 
     const { runId, messageId, workflowInput, registryEntry, messageList, threadId, resourceId } = preparation;
+    const streamingPubsub = this.pubsub;
+    const runRegistryEntry = { ...registryEntry, pubsub: streamingPubsub, abortSignal: options?.abortSignal };
 
     // 2. Register non-serializable state (both local and global registries)
-    this.#runRegistry.registerWithMessageList(runId, registryEntry, messageList, { threadId, resourceId });
-    globalRunRegistry.set(runId, { ...registryEntry, messageList, pubsub: this.pubsub });
+    this.#runRegistry.registerWithMessageList(runId, runRegistryEntry, messageList, { threadId, resourceId });
+    globalRunRegistry.set(runId, { ...runRegistryEntry, messageList });
 
     // Track cleanup state to avoid double cleanup
     let cleanedUp = false;
@@ -647,14 +776,19 @@ export class DurableAgent<
       onChunk: options?.onChunk,
       onStepFinish: options?.onStepFinish,
       onFinish: async result => {
+        this.#runRegistry.setStatus(runId, 'completed');
         await options?.onFinish?.(result);
         scheduleAutoCleanup();
       },
       onError: async error => {
+        this.#runRegistry.setStatus(runId, 'error');
         await options?.onError?.(error);
         scheduleAutoCleanup();
       },
-      onSuspended: options?.onSuspended,
+      onSuspended: async data => {
+        this.#runRegistry.setStatus(runId, 'suspended');
+        await options?.onSuspended?.(data);
+      },
     });
 
     // 4. Wait for subscription to be ready, then execute workflow
@@ -765,14 +899,32 @@ export class DurableAgent<
 
     // Wait for subscription to be ready, then resume workflow
     const workflow = this.getWorkflow();
-    const requestContext = globalRunRegistry.get(runId)?.requestContext;
+    const registryEntry = globalRunRegistry.get(runId);
+    const requestContext = registryEntry?.requestContext;
     ready
       .then(async () => {
+        const abortSignal = registryEntry?.abortSignal;
         const run = await workflow.createRun({ runId, pubsub: this.pubsub });
-        const result = await run.resume({ resumeData, requestContext });
-        if (result?.status === 'failed') {
-          const error = new Error((result as any).error?.message || 'Workflow resume failed');
-          void this.emitError(runId, error);
+        if (abortSignal?.aborted) {
+          await run.cancel();
+          void this.emitError(runId, createAbortError());
+          return;
+        }
+
+        const abort = () => {
+          void run.cancel();
+        };
+        abortSignal?.addEventListener('abort', abort, { once: true });
+        try {
+          const result = await run.resume({ resumeData, requestContext });
+          if (result?.status === 'failed') {
+            const error = new Error((result as any).error?.message || 'Workflow resume failed');
+            void this.emitError(runId, error);
+          } else if ((result as any)?.status === 'canceled' || abortSignal?.aborted) {
+            void this.emitError(runId, createAbortError());
+          }
+        } finally {
+          abortSignal?.removeEventListener('abort', abort);
         }
       })
       .catch(error => {
@@ -975,7 +1127,6 @@ export class DurableAgent<
     globalRunRegistry.set(preparation.runId, {
       ...preparation.registryEntry,
       messageList: preparation.messageList,
-      pubsub: this.pubsub,
     });
 
     return {

--- a/packages/core/src/agent/durable/index.ts
+++ b/packages/core/src/agent/durable/index.ts
@@ -136,6 +136,9 @@ export type {
   AgentFinishEventData,
   AgentErrorEventData,
   AgentSuspendedEventData,
+  DurableAgentSignal,
+  DurableAgentSignalType,
+  SendDurableAgentSignalOptions,
   // Registry types
   RunRegistryEntry,
   DurableStepContext,

--- a/packages/core/src/agent/durable/run-registry.ts
+++ b/packages/core/src/agent/durable/run-registry.ts
@@ -4,7 +4,11 @@ import type { CoreTool } from '../../tools/types';
 import type { MessageList } from '../message-list';
 import type { SaveQueueManager } from '../save-queue';
 import { AGENT_STREAM_TOPIC, AgentStreamEventTypes } from './constants';
-import type { RunRegistryEntry } from './types';
+import type { DurableAgentRunStatus, DurableAgentSignal, RunRegistryEntry } from './types';
+
+function threadKey(resourceId: string, threadId: string): string {
+  return `${resourceId}\0${threadId}`;
+}
 
 export const GLOBAL_RUN_REGISTRY_TTL_MS = 2 * 60 * 60 * 1000;
 
@@ -178,6 +182,10 @@ export interface ExtendedRunRegistryEntry extends RunRegistryEntry {
 export class ExtendedRunRegistry extends RunRegistry {
   #messageLists = new Map<string, MessageList>();
   #memoryInfo = new Map<string, { threadId?: string; resourceId?: string }>();
+  #runIdByThread = new Map<string, string>();
+  #threadKeyByRunId = new Map<string, string>();
+  #statusByRunId = new Map<string, DurableAgentRunStatus>();
+  #signalsByRunId = new Map<string, DurableAgentSignal[]>();
 
   /**
    * Register non-serializable state for a run including MessageList
@@ -190,8 +198,14 @@ export class ExtendedRunRegistry extends RunRegistry {
   ): void {
     this.register(runId, entry);
     this.#messageLists.set(runId, messageList);
+    this.#statusByRunId.set(runId, 'active');
     if (memoryInfo) {
       this.#memoryInfo.set(runId, memoryInfo);
+      if (memoryInfo.resourceId && memoryInfo.threadId) {
+        const key = threadKey(memoryInfo.resourceId, memoryInfo.threadId);
+        this.#runIdByThread.set(key, runId);
+        this.#threadKeyByRunId.set(runId, key);
+      }
     }
   }
 
@@ -207,6 +221,38 @@ export class ExtendedRunRegistry extends RunRegistry {
    */
   getMemoryInfo(runId: string): { threadId?: string; resourceId?: string } | undefined {
     return this.#memoryInfo.get(runId);
+  }
+
+  getRunIdForThread(resourceId: string, threadId: string): string | undefined {
+    return this.#runIdByThread.get(threadKey(resourceId, threadId));
+  }
+
+  setStatus(runId: string, status: DurableAgentRunStatus): void {
+    this.#statusByRunId.set(runId, status);
+  }
+
+  getStatus(runId: string): DurableAgentRunStatus | undefined {
+    return this.#statusByRunId.get(runId);
+  }
+
+  enqueueSignal(runId: string, signal: DurableAgentSignal): void {
+    const signals = this.#signalsByRunId.get(runId) ?? [];
+    signals.push(signal);
+    this.#signalsByRunId.set(runId, signals);
+    const entry = this.get(runId);
+    if (entry) {
+      entry.signalQueue = signals;
+    }
+  }
+
+  drainSignals(runId: string): DurableAgentSignal[] {
+    const signals = this.#signalsByRunId.get(runId) ?? [];
+    this.#signalsByRunId.delete(runId);
+    const entry = this.get(runId);
+    if (entry) {
+      entry.signalQueue = [];
+    }
+    return signals;
   }
 
   /**
@@ -229,6 +275,13 @@ export class ExtendedRunRegistry extends RunRegistry {
     super.cleanup(runId);
     this.#messageLists.delete(runId);
     this.#memoryInfo.delete(runId);
+    this.#statusByRunId.delete(runId);
+    this.#signalsByRunId.delete(runId);
+    const key = this.#threadKeyByRunId.get(runId);
+    if (key) {
+      this.#runIdByThread.delete(key);
+      this.#threadKeyByRunId.delete(runId);
+    }
   }
 
   /**
@@ -238,5 +291,9 @@ export class ExtendedRunRegistry extends RunRegistry {
     super.clear();
     this.#messageLists.clear();
     this.#memoryInfo.clear();
+    this.#runIdByThread.clear();
+    this.#threadKeyByRunId.clear();
+    this.#statusByRunId.clear();
+    this.#signalsByRunId.clear();
   }
 }

--- a/packages/core/src/agent/durable/signal-message.ts
+++ b/packages/core/src/agent/durable/signal-message.ts
@@ -1,0 +1,37 @@
+import type { MastraDBMessage } from '../message-list';
+import type { DurableAgentSignal } from './types';
+
+function escapeXml(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXml(value).replaceAll('"', '&quot;');
+}
+
+export function signalToMessage(signal: DurableAgentSignal): MastraDBMessage {
+  const contentMetadata =
+    signal.type === 'system-reminder'
+      ? { systemReminder: { type: 'agent-signal', signalType: signal.type, ...signal.metadata } }
+      : signal.type === 'user-message'
+        ? undefined
+        : { agentSignal: { type: signal.type, ...signal.metadata } };
+
+  const contents =
+    signal.type === 'system-reminder'
+      ? `<system-reminder type="agent-signal">${escapeXml(signal.contents)}</system-reminder>`
+      : signal.type === 'user-message'
+        ? signal.contents
+        : `<agent-signal type="${escapeXmlAttribute(signal.type)}">${escapeXml(signal.contents)}</agent-signal>`;
+
+  return {
+    id: signal.id ?? `signal-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    role: 'user',
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text: contents }],
+      ...(contentMetadata ? { metadata: contentMetadata } : {}),
+    },
+    createdAt: signal.createdAt ? new Date(signal.createdAt) : new Date(),
+  };
+}

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -24,6 +24,41 @@ import type { MessageList } from '../message-list';
 import type { SerializedMessageListState } from '../message-list/state';
 import type { SaveQueueManager } from '../save-queue';
 
+export type DurableAgentSignalType = 'user-message' | 'system-reminder' | string;
+
+export interface DurableAgentSignal {
+  id?: string;
+  type: DurableAgentSignalType;
+  contents: string;
+  createdAt?: Date | string;
+  metadata?: Record<string, unknown>;
+}
+
+export type SendDurableAgentSignalOptions =
+  | { runId: string; resourceId?: string; threadId?: string; streamOptions?: Record<string, unknown> }
+  | { runId?: string; resourceId: string; threadId: string; streamOptions?: Record<string, unknown> };
+
+export type DurableAgentRunStatus = 'active' | 'suspended' | 'completed' | 'error' | 'aborted';
+
+export interface DurableAgentActiveRun {
+  resourceId: string;
+  threadId: string;
+  runId: string;
+  ownerId?: string;
+  status: DurableAgentRunStatus;
+}
+
+export interface DurableAgentClaimThreadOptions {
+  resourceId: string;
+  threadId: string;
+  runId: string;
+  ownerId?: string;
+}
+
+export type DurableAgentClaimThreadResult =
+  | { claimed: true; activeRun: DurableAgentActiveRun }
+  | { claimed: false; activeRun: DurableAgentActiveRun };
+
 /**
  * Metadata about a tool that can be serialized (without the execute function)
  */
@@ -425,8 +460,12 @@ export interface RunRegistryEntry {
   backgroundTaskManager?: BackgroundTaskManager;
   /** Agent background tasks configuration */
   backgroundTasksConfig?: AgentBackgroundConfig;
+  /** Signals queued for injection at the next LLM boundary */
+  signalQueue?: DurableAgentSignal[];
   /** PubSub that streams durable agent events to subscribers */
   pubsub?: PubSub;
+  /** External abort signal for canceling local durable execution */
+  abortSignal?: AbortSignal;
 }
 
 /**

--- a/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
+++ b/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
@@ -10,6 +10,7 @@ import { PUBSUB_SYMBOL } from '../../../workflows/constants';
 import { MessageList } from '../../message-list';
 import { DurableStepIds, DurableAgentDefaults } from '../constants';
 import { globalRunRegistry } from '../run-registry';
+import { signalToMessage } from '../signal-message';
 import { emitFinishEvent } from '../stream-adapter';
 import type {
   DurableToolCallInput,
@@ -180,6 +181,23 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
           currentState: initData,
           executionOutput,
         });
+
+        const registryEntry = globalRunRegistry.get(initData.runId);
+        const pendingSignals = registryEntry?.signalQueue ?? [];
+        if (registryEntry) {
+          registryEntry.signalQueue = [];
+        }
+
+        if (pendingSignals.length > 0) {
+          const messageList = new MessageList();
+          messageList.deserialize(baseUpdate.messageListState);
+          messageList.add(pendingSignals.map(signalToMessage), 'input');
+          baseUpdate.messageListState = messageList.serialize();
+          baseUpdate.lastStepResult = {
+            ...baseUpdate.lastStepResult,
+            isContinued: true,
+          };
+        }
 
         // Extend with core-specific fields
         const newIterationState: IterationState = {

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -15,9 +15,24 @@ import type { MastraDBMessage } from '../../../message-list';
 import { isSupportedLanguageModel } from '../../../utils';
 import { DurableStepIds } from '../../constants';
 import { globalRunRegistry } from '../../run-registry';
+import { signalToMessage } from '../../signal-message';
 import { emitChunkEvent, emitStepStartEvent } from '../../stream-adapter';
-import type { DurableAgenticWorkflowInput, DurableLLMStepOutput, DurableToolCallInput } from '../../types';
+import type {
+  DurableAgenticWorkflowInput,
+  DurableAgentSignal,
+  DurableLLMStepOutput,
+  DurableToolCallInput,
+} from '../../types';
 import { resolveRuntimeDependencies, resolveModelFromListEntry } from '../../utils/resolve-runtime';
+
+function drainGlobalSignals(runId: string): DurableAgentSignal[] {
+  const entry = globalRunRegistry.get(runId);
+  const signals = entry?.signalQueue ?? [];
+  if (entry) {
+    entry.signalQueue = [];
+  }
+  return signals;
+}
 
 /**
  * Input schema for the durable LLM execution step
@@ -184,6 +199,11 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               );
             }
 
+            const signals = drainGlobalSignals(runId);
+            if (signals.length > 0) {
+              messageList.add(signals.map(signalToMessage), 'input');
+            }
+
             let currentMessageId = messageId;
 
             // 5. Prepare tools - cast through unknown as CoreTool and ToolSet are structurally compatible at runtime
@@ -224,12 +244,13 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 : undefined;
 
             const registryEntry = globalRunRegistry.get(runId);
-            const executionAbortSignal = (registryEntry as any)?.abortSignal ?? abortSignal;
+            const streamPubsub = registryEntry?.pubsub ?? pubsub;
+            const executionAbortSignal = registryEntry?.abortSignal ?? abortSignal;
             if (registryEntry?.inputProcessors?.length) {
-              const inputStepWriter = pubsub
+              const inputStepWriter = streamPubsub
                 ? {
                     custom: async (data: { type: string }) => {
-                      await emitChunkEvent(pubsub, runId, data as any);
+                      await emitChunkEvent(streamPubsub, runId, data as any);
                     },
                   }
                 : undefined;
@@ -310,10 +331,9 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 warnings = w || [];
                 request = r || {};
                 rawResponse = rr || {};
-                modelSpanTracker?.updateStep?.({ request, inputMessages, warnings, messageId: currentMessageId });
 
-                if (pubsub) {
-                  void emitStepStartEvent(pubsub, runId, {
+                if (streamPubsub) {
+                  void emitStepStartEvent(streamPubsub, runId, {
                     stepId: DurableStepIds.LLM_EXECUTION,
                     request,
                     warnings,
@@ -352,8 +372,8 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 // Emit chunk via pubsub for streaming to client.
                 // Finish and error chunks are terminal control flow: finish is sent once by the
                 // agentic loop, and errors are sent once after retries/fallbacks are exhausted.
-                if (pubsub && chunk.type !== 'finish' && chunk.type !== 'error') {
-                  await emitChunkEvent(pubsub, runId, chunk);
+                if (streamPubsub && chunk.type !== 'finish' && chunk.type !== 'error') {
+                  await emitChunkEvent(streamPubsub, runId, chunk);
                 }
 
                 // Process different chunk types


### PR DESCRIPTION
This adds the core DurableAgent signal.

`DurableAgent.sendSignal(...)` can deliver user messages, system reminders, and custom signals to an active durable run:

```ts
durableAgent.sendSignal(
  { type: 'user-message', contents: 'continue with this context' },
  { resourceId, threadId },
);
```

If the target thread is idle, the signal starts a durable run for that resource/thread. If a signal arrives while final text is streaming, the durable workflow drains it and continues the loop so it is not stranded after the run finishes.

Verified with focused durable signal tests, core typecheck, lint, and build.
