### PR TITLE
feat: add durable signal usernames

### DIFF
--- a/.changeset/eighty-spiders-like.md
+++ b/.changeset/eighty-spiders-like.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': minor
+'mastracode': minor
+---
+
+Added usernames to durable signal messages so agents and UIs can distinguish who sent each signal.

--- a/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -26,6 +26,7 @@ import type { EventHandlerContext } from '../handlers/types.js';
 import { MastraTUI, consumePendingImages } from '../mastra-tui.js';
 import { setupKeyboardShortcuts } from '../setup.js';
 import type { TUIState } from '../state.js';
+import { getMastraCodeUsername } from '../username.js';
 
 function createQueueState(overrides: Partial<TUIState> = {}): TUIState {
   return {
@@ -298,6 +299,66 @@ describe('MastraTUI queueing', () => {
     expect(state.pendingFollowUpMessages).toEqual([]);
     expect(state.pendingSlashCommands).toEqual([]);
     expect(ctx.updateStatusLine).toHaveBeenCalledTimes(6);
+  });
+
+  it('reads signal usernames from MC_USER, USER, then USERNAME', () => {
+    const previousMcUser = process.env.MC_USER;
+    const previousUser = process.env.USER;
+    const previousUsername = process.env.USERNAME;
+    process.env.MC_USER = 'Alice';
+    process.env.USER = 'tyler';
+    process.env.USERNAME = 'tylerbarnes';
+
+    expect(getMastraCodeUsername()).toBe('Alice');
+
+    delete process.env.MC_USER;
+    expect(getMastraCodeUsername()).toBe('tyler');
+
+    delete process.env.USER;
+    expect(getMastraCodeUsername()).toBe('tylerbarnes');
+
+    if (previousMcUser === undefined) {
+      delete process.env.MC_USER;
+    } else {
+      process.env.MC_USER = previousMcUser;
+    }
+    if (previousUser === undefined) {
+      delete process.env.USER;
+    } else {
+      process.env.USER = previousUser;
+    }
+    if (previousUsername === undefined) {
+      delete process.env.USERNAME;
+    } else {
+      process.env.USERNAME = previousUsername;
+    }
+  });
+
+  it('ignores blank signal username env values', () => {
+    const previousMcUser = process.env.MC_USER;
+    const previousUser = process.env.USER;
+    const previousUsername = process.env.USERNAME;
+    process.env.MC_USER = ' ';
+    process.env.USER = ' ';
+    process.env.USERNAME = ' ';
+
+    expect(getMastraCodeUsername()).toBeUndefined();
+
+    if (previousMcUser === undefined) {
+      delete process.env.MC_USER;
+    } else {
+      process.env.MC_USER = previousMcUser;
+    }
+    if (previousUser === undefined) {
+      delete process.env.USER;
+    } else {
+      process.env.USER = previousUser;
+    }
+    if (previousUsername === undefined) {
+      delete process.env.USERNAME;
+    } else {
+      process.env.USERNAME = previousUsername;
+    }
   });
 
   it('waits for harness-level follow-ups to finish before draining the local queue', () => {

--- a/mastracode/src/tui/components/__tests__/user-message.test.ts
+++ b/mastracode/src/tui/components/__tests__/user-message.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { UserMessageComponent } from '../user-message.js';
+
+describe('UserMessageComponent', () => {
+  it('renders a username in the border when provided', () => {
+    const component = new UserMessageComponent('hello', undefined, { username: 'Alice', currentUsername: 'Bob' });
+
+    const output = component.render(80).join('\n');
+
+    expect(output).toContain('Alice');
+    expect(output).toContain('hello');
+  });
+});

--- a/mastracode/src/tui/components/user-message.ts
+++ b/mastracode/src/tui/components/user-message.ts
@@ -19,9 +19,16 @@ function stripAnsi(s: string): string {
  */
 class BorderedBox {
   private child: { render(width: number): string[]; invalidate?(): void };
+  private username?: string;
+  private currentUsername?: string;
 
-  constructor(child: { render(width: number): string[]; invalidate?(): void }) {
+  constructor(
+    child: { render(width: number): string[]; invalidate?(): void },
+    options: { username?: string; currentUsername?: string } = {},
+  ) {
     this.child = child;
+    this.username = options.username;
+    this.currentUsername = options.currentUsername;
   }
 
   invalidate() {
@@ -29,7 +36,10 @@ class BorderedBox {
   }
 
   render(width: number): string[] {
-    const borderColor = (s: string) => chalk.hex(tintHex(mastra.green, 1))(s);
+    const isOtherUser = !!this.username && this.username !== this.currentUsername;
+    const borderHex = isOtherUser ? mastra.purple : mastra.green;
+    const borderColor = (s: string) => chalk.hex(tintHex(borderHex, 1))(s);
+    const label = this.username ? ` ${this.username} ` : undefined;
 
     // Border uses 4 chars: "│ " (2) on left + " │" (2) on right
     // Plus 2 for the "› " prompt prefix on the first line
@@ -63,8 +73,15 @@ class BorderedBox {
     const promptPrefix = chalk.hex(tintHex(mastra.green, 1))('»') + ' ';
     const promptWidth = 2;
 
-    // Top border: ╭──...──╮
-    lines.push(borderColor(`╭${'─'.repeat(boxWidth - 2)}╮`));
+    // Top border: ╭──...──╮, optionally with username embedded.
+    if (label) {
+      const availableLabelWidth = Math.max(0, boxWidth - 2);
+      const safeLabel = visibleWidth(label) > availableLabelWidth ? `${label.slice(0, Math.max(0, availableLabelWidth - 2))}… ` : label;
+      const rightFill = Math.max(0, boxWidth - 2 - visibleWidth(safeLabel));
+      lines.push(borderColor(`╭${safeLabel}${'─'.repeat(rightFill)}╮`));
+    } else {
+      lines.push(borderColor(`╭${'─'.repeat(boxWidth - 2)}╮`));
+    }
 
     // Content lines with side borders, first line gets "> " prefix
     for (let i = 0; i < trimmedLines.length; i++) {
@@ -87,7 +104,11 @@ class BorderedBox {
 }
 
 export class UserMessageComponent extends Container {
-  constructor(text: string, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
+  constructor(
+    text: string,
+    markdownTheme: MarkdownTheme = getMarkdownTheme(),
+    options: { username?: string; currentUsername?: string } = {},
+  ) {
     super();
 
     const md = new Markdown(text, 0, 0, markdownTheme, {
@@ -95,7 +116,7 @@ export class UserMessageComponent extends Container {
       italic: false,
     });
 
-    this.addChild(new BorderedBox(md));
+    this.addChild(new BorderedBox(md, options));
     this.addChild(new Spacer(1));
   }
 }

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -64,6 +64,7 @@ import { handleShellPassthrough } from './shell.js';
 import type { MastraTUIOptions, TUIState } from './state.js';
 import { createTUIState } from './state.js';
 import { updateStatusLine } from './status-line.js';
+import { getMastraCodeUsername } from './username.js';
 
 // =============================================================================
 // Types
@@ -244,6 +245,7 @@ export class MastraTUI {
 
         const sendWhileRunning = this.state.harness.isRunning() && (this.state.harness as any).canSendWhileRunning?.();
         const messageId = sendWhileRunning ? undefined : `user-${Date.now()}`;
+        const username = getMastraCodeUsername();
         if (messageId) {
           // Add user message to chat immediately. When sending into an active durable stream,
           // the stream's data-user-message event is the source of truth for display.
@@ -259,6 +261,7 @@ export class MastraTUI {
               })) ?? []),
             ],
             createdAt: new Date(),
+            metadata: username ? { username } : undefined,
           });
           this.state.ui.requestRender();
         }
@@ -285,7 +288,7 @@ export class MastraTUI {
         }
 
         // Normal send — fire and forget; events handle the rest
-        this.fireMessage(content, images);
+        this.fireMessage(content, images, undefined, username);
       } catch (error) {
         showError(this.state, error instanceof Error ? error.message : 'Unknown error');
       }
@@ -296,9 +299,20 @@ export class MastraTUI {
    * Fire off a message without blocking the main loop.
    * Errors are handled via harness events.
    */
-  private fireMessage(content: string, images?: Array<{ data: string; mimeType: string }>): void {
+  private fireMessage(
+    content: string,
+    images?: Array<{ data: string; mimeType: string }>,
+    messageId?: string,
+    username?: string,
+  ): void {
     const files = images?.map(img => ({ data: img.data, mediaType: img.mimeType }));
-    this.state.harness.sendMessage({ content, files }).catch(error => {
+    const message: Parameters<TUIState['harness']['sendMessage']>[0] & { messageId?: string; username?: string } = {
+      content,
+      files,
+      messageId,
+      username,
+    };
+    this.state.harness.sendMessage(message).catch(error => {
       showError(this.state, error instanceof Error ? error.message : 'Unknown error');
     });
   }

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -22,6 +22,7 @@ import { UserMessageComponent } from './components/user-message.js';
 import { formatToolResult } from './handlers/tool.js';
 import type { TUIState } from './state.js';
 import { BOX_INDENT, getMarkdownTheme, theme, mastra } from './theme.js';
+import { getMastraCodeUsername } from './username.js';
 
 // Re-export so existing consumers can still import from here
 export { formatToolResult };
@@ -217,7 +218,9 @@ export function addUserMessage(state: TUIState, message: HarnessMessage): void {
 
   const prefix = imageCount > 0 ? `[${imageCount} image${imageCount > 1 ? 's' : ''}] ` : '';
   if (displayText || prefix) {
-    const userComponent = new UserMessageComponent(prefix + displayText);
+    const username = typeof message.metadata?.username === 'string' ? message.metadata.username : undefined;
+    const currentUsername = getMastraCodeUsername();
+    const userComponent = new UserMessageComponent(prefix + displayText, undefined, { username, currentUsername });
 
     state.messageComponentsById.set(message.id, userComponent);
 

--- a/mastracode/src/tui/username.ts
+++ b/mastracode/src/tui/username.ts
@@ -1,0 +1,4 @@
+export function getMastraCodeUsername(): string | undefined {
+  const username = process.env.MC_USER?.trim() || process.env.USER?.trim() || process.env.USERNAME?.trim();
+  return username || undefined;
+}

--- a/packages/core/src/agent/durable/__tests__/durable-agent-signals.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-signals.test.ts
@@ -62,7 +62,7 @@ describe('DurableAgent signals', () => {
       inputSchema: z.object({}),
       execute: async () => {
         durableAgent.sendSignal(
-          { type: 'user-message', contents: 'first signal' },
+          { type: 'user-message', contents: 'first signal', username: 'Tyler' },
           { resourceId: 'user-1', threadId: 'thread-1' },
         );
         durableAgent.sendSignal(
@@ -90,6 +90,7 @@ describe('DurableAgent signals', () => {
     expect(prompts).toHaveLength(2);
     const secondPrompt = JSON.stringify(prompts[1]);
     expect(secondPrompt.indexOf('first signal')).toBeLessThan(secondPrompt.indexOf('second signal'));
+    expect(secondPrompt).toContain('<user name=\\"Tyler\\">');
     expect(secondPrompt).toContain('system-reminder');
     expect(secondPrompt).toContain('agent-signal');
   });
@@ -171,7 +172,7 @@ describe('DurableAgent signals', () => {
 
     await firstTextStarted;
     durableAgent.sendSignal(
-      { type: 'user-message', contents: 'interrupt during final text' },
+      { type: 'user-message', contents: 'interrupt during final text', username: 'Follower' },
       { resourceId: 'user-1', threadId: 'thread-1' },
     );
     releaseFirstStream();
@@ -179,7 +180,9 @@ describe('DurableAgent signals', () => {
     result.cleanup();
 
     expect(prompts).toHaveLength(2);
-    expect(JSON.stringify(prompts[1])).toContain('interrupt during final text');
+    const secondPrompt = JSON.stringify(prompts[1]);
+    expect(secondPrompt).toContain('interrupt during final text');
+    expect(secondPrompt).toContain('<user name=\\"Follower\\">');
   });
 
   it('rejects run-id-only signals when no active run exists', () => {

--- a/packages/core/src/agent/durable/index.ts
+++ b/packages/core/src/agent/durable/index.ts
@@ -138,6 +138,9 @@ export type {
   AgentSuspendedEventData,
   DurableAgentSignal,
   DurableAgentSignalType,
+  DurableAgentUserMessageSignal,
+  DurableAgentSystemReminderSignal,
+  DurableAgentCustomSignal,
   SendDurableAgentSignalOptions,
   // Registry types
   RunRegistryEntry,

--- a/packages/core/src/agent/durable/signal-message.ts
+++ b/packages/core/src/agent/durable/signal-message.ts
@@ -9,7 +9,12 @@ function escapeXmlAttribute(value: string): string {
   return escapeXml(value).replaceAll('"', '&quot;');
 }
 
+function signalUsername(signal: DurableAgentSignal): string | undefined {
+  return signal.type === 'user-message' && typeof signal.username === 'string' ? signal.username : undefined;
+}
+
 export function signalToMessage(signal: DurableAgentSignal): MastraDBMessage {
+  const username = signalUsername(signal);
   const contentMetadata =
     signal.type === 'system-reminder'
       ? { systemReminder: { type: 'agent-signal', signalType: signal.type, ...signal.metadata } }
@@ -21,7 +26,9 @@ export function signalToMessage(signal: DurableAgentSignal): MastraDBMessage {
     signal.type === 'system-reminder'
       ? `<system-reminder type="agent-signal">${escapeXml(signal.contents)}</system-reminder>`
       : signal.type === 'user-message'
-        ? signal.contents
+        ? username
+          ? `<user name="${escapeXmlAttribute(username)}">\n${escapeXml(signal.contents)}\n</user>`
+          : signal.contents
         : `<agent-signal type="${escapeXmlAttribute(signal.type)}">${escapeXml(signal.contents)}</agent-signal>`;
 
   return {

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -26,13 +26,34 @@ import type { SaveQueueManager } from '../save-queue';
 
 export type DurableAgentSignalType = 'user-message' | 'system-reminder' | string;
 
-export interface DurableAgentSignal {
+interface DurableAgentBaseSignal {
   id?: string;
-  type: DurableAgentSignalType;
   contents: string;
   createdAt?: Date | string;
+}
+
+export interface DurableAgentUserMessageSignal extends DurableAgentBaseSignal {
+  type: 'user-message';
+  username?: string;
   metadata?: Record<string, unknown>;
 }
+
+export interface DurableAgentSystemReminderSignal extends DurableAgentBaseSignal {
+  type: 'system-reminder';
+  username?: never;
+  metadata?: Record<string, unknown>;
+}
+
+export interface DurableAgentCustomSignal extends DurableAgentBaseSignal {
+  type: string;
+  username?: never;
+  metadata?: Record<string, unknown>;
+}
+
+export type DurableAgentSignal =
+  | DurableAgentUserMessageSignal
+  | DurableAgentSystemReminderSignal
+  | DurableAgentCustomSignal;
 
 export type SendDurableAgentSignalOptions =
   | { runId: string; resourceId?: string; threadId?: string; streamOptions?: Record<string, unknown> }

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -81,6 +81,48 @@ function isSignalingAgent(agent: Agent): agent is SignalingAgent {
   return 'sendSignal' in agent && typeof agent.sendSignal === 'function';
 }
 
+function decodeXmlEntities(value: string): string {
+  return value.replaceAll('&quot;', '"').replaceAll('&gt;', '>').replaceAll('&lt;', '<').replaceAll('&amp;', '&');
+}
+
+function parseNamedUserMessage(text: string): { username: string; contents: string } | undefined {
+  const match = text.match(/^<user\s+name="([^"]*)">\n?([\s\S]*?)\n?<\/user>$/);
+  if (!match) return undefined;
+  return { username: decodeXmlEntities(match[1] ?? ''), contents: decodeXmlEntities(match[2] ?? '') };
+}
+
+function createDurableSignal({
+  id,
+  type,
+  contents,
+  username,
+  files,
+}: {
+  id?: string;
+  type: string;
+  contents: string;
+  username?: string;
+  files?: Array<{ data: string; mediaType: string; filename?: string }>;
+}): DurableAgentSignal {
+  const metadata = files?.length ? { files } : undefined;
+  if (type === 'user-message') {
+    return {
+      id,
+      type,
+      contents,
+      ...(username ? { username } : {}),
+      ...(metadata ? { metadata } : {}),
+    };
+  }
+
+  return {
+    id,
+    type,
+    contents,
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
 /**
  * The Harness orchestrates multiple agent modes, shared state, memory, and storage.
  * It's the core abstraction that a TUI (or other UI) controls.
@@ -1377,12 +1419,16 @@ export class Harness<TState = {}> {
     tracingContext,
     tracingOptions,
     requestContext: requestContextInput,
+    messageId,
+    username,
   }: {
     content: string;
     files?: Array<{ data: string; mediaType: string; filename?: string }>;
     tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
     requestContext?: RequestContext;
+    messageId?: string;
+    username?: string;
   }): Promise<void> {
     if (!this.currentThreadId) {
       const thread = await this.createThread();
@@ -1392,11 +1438,7 @@ export class Harness<TState = {}> {
     const agent = this.getCurrentAgent();
 
     if (this.isRunning()) {
-      const signal: DurableAgentSignal = {
-        type: 'user-message',
-        contents: content,
-        metadata: files?.length ? { files } : undefined,
-      };
+      const signal = createDurableSignal({ id: messageId, type: 'user-message', contents: content, username, files });
       if (this.currentRunId && isSignalingAgent(agent)) {
         const result = agent.sendSignal(signal, { runId: this.currentRunId });
         this.emit({ type: 'signal_sent', threadId, runId: result.runId, signalType: signal.type });
@@ -1610,6 +1652,7 @@ export class Harness<TState = {}> {
     };
   }): HarnessMessage {
     const content: HarnessMessageContent[] = [];
+    const metadata: HarnessMessage['metadata'] = {};
     const systemReminder =
       typeof msg.content.metadata?.systemReminder === 'object' && msg.content.metadata.systemReminder !== null
         ? msg.content.metadata.systemReminder
@@ -1649,7 +1692,13 @@ export class Harness<TState = {}> {
       switch (part.type) {
         case 'text':
           if (part.text) {
-            content.push({ type: 'text', text: part.text });
+            const namedUserMessage = msg.role === 'user' ? parseNamedUserMessage(part.text) : undefined;
+            if (namedUserMessage) {
+              metadata.username = namedUserMessage.username;
+              content.push({ type: 'text', text: namedUserMessage.contents });
+            } else {
+              content.push({ type: 'text', text: part.text });
+            }
           }
           break;
         case 'reasoning':
@@ -1786,7 +1835,13 @@ export class Harness<TState = {}> {
       }
     }
 
-    return { id: msg.id, role: msg.role, content, createdAt: msg.createdAt };
+    return {
+      id: msg.id,
+      role: msg.role,
+      content,
+      createdAt: msg.createdAt,
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+    };
   }
 
   /**

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -920,6 +920,11 @@ export interface HarnessMessage {
   createdAt: Date;
   stopReason?: 'complete' | 'tool_use' | 'aborted' | 'error';
   errorMessage?: string;
+  metadata?: {
+    source?: 'durable-signal' | string;
+    username?: string;
+    [key: string]: unknown;
+  };
 }
 
 export type HarnessMessageContent =


### PR DESCRIPTION
This adds username metadata to durable user-message signals and threads it through MastraCode rendering.

Durable user-message signals can now carry a sender name, while non-user signal variants keep username out of their type shape:

```ts
{ type: 'user-message', contents: '...', username: 'Alice' }
```

MastraCode resolves the local username from `MC_USER`, then `USER`, then `USERNAME`, passes it with active-run submissions, and renders named user-message borders so collaborators can distinguish who sent a signal.

This PR builds on the MastraCode durable signal routing PR.

Verified with focused durable signal tests, MastraCode queueing/render/user-message tests, typecheck, lint, and builds for core and MastraCode.
