### PR TITLE
feat(mastracode): route active submits through durable signals

### DIFF
--- a/.changeset/lazy-seals-cover.md
+++ b/.changeset/lazy-seals-cover.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastracode': patch
+---
+
+Route MastraCode active-stream submissions through durable agent signals. Signal-capable runs accept editor submissions immediately, keep pending user messages pinned until confirmed by the stream, and move them into chat history at the correct response boundary.

--- a/mastracode/src/tui/__tests__/event-dispatch-thread-state.test.ts
+++ b/mastracode/src/tui/__tests__/event-dispatch-thread-state.test.ts
@@ -153,4 +153,38 @@ describe('thread lifecycle clears per-thread harness state', () => {
     const setStateCall = harness.setState.mock.calls[0]![0];
     expect(setStateCall).not.toHaveProperty('currentModelId');
   });
+
+  it('replaces pinned task progress from final streamed task_write args', async () => {
+    const oldTasks = [
+      { content: 'Old task', status: 'completed' as const, activeForm: 'Old task' },
+      { content: 'Stale task', status: 'pending' as const, activeForm: 'Staling task' },
+    ];
+    const newTasks = [
+      { content: 'New task', status: 'in_progress' as const, activeForm: 'Working new task' },
+      { content: 'Next task', status: 'pending' as const, activeForm: 'Working next task' },
+    ];
+    state.taskProgress = {
+      updateTasks: vi.fn(),
+      getTasks: () => oldTasks,
+    } as any;
+    state.pendingTools = new Map() as any;
+    state.seenToolCallIds = new Set(['tool-1']);
+    state.allToolComponents = [] as any;
+    state.pendingAskUserComponents = new Map() as any;
+    ectx = { ...ectx, state } as EventHandlerContext;
+
+    await dispatchEvent(
+      {
+        type: 'tool_start',
+        toolCallId: 'tool-1',
+        toolName: 'task_write',
+        args: { tasks: newTasks },
+      } as any,
+      ectx,
+      state,
+    );
+
+    expect((state.taskProgress as any).updateTasks).toHaveBeenCalledWith(newTasks);
+    expect(state.ui.requestRender).toHaveBeenCalled();
+  });
 });

--- a/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -24,6 +24,7 @@ vi.mock('../display.js', () => ({
 import { handleAgentEnd } from '../handlers/agent-lifecycle.js';
 import type { EventHandlerContext } from '../handlers/types.js';
 import { MastraTUI, consumePendingImages } from '../mastra-tui.js';
+import { setupKeyboardShortcuts } from '../setup.js';
 import type { TUIState } from '../state.js';
 
 function createQueueState(overrides: Partial<TUIState> = {}): TUIState {
@@ -33,6 +34,7 @@ function createQueueState(overrides: Partial<TUIState> = {}): TUIState {
     },
     gradientAnimator: undefined,
     projectInfo: { rootPath: '.', gitBranch: 'main' } as TUIState['projectInfo'],
+    chatContainer: { children: [] },
     streamingComponent: undefined,
     streamingMessage: undefined,
     followUpComponents: [],
@@ -40,11 +42,6 @@ function createQueueState(overrides: Partial<TUIState> = {}): TUIState {
     pendingQueuedActions: [],
     pendingSlashCommands: [],
     pendingTools: new Map(),
-    chatContainer: { children: [], invalidate: vi.fn() },
-    allToolComponents: [],
-    allSlashCommandComponents: [],
-    allSystemReminderComponents: [],
-    allShellComponents: [],
     ui: { requestRender: vi.fn() } as TUIState['ui'],
     ...overrides,
   } as unknown as TUIState;
@@ -118,7 +115,40 @@ describe('MastraTUI queueing', () => {
     expect(resolution).toEqual({ resolved: false, value: undefined });
   });
 
-  it('queues follow-up messages with images in FIFO order metadata', () => {
+  it('resolves editor submissions while the running harness accepts signals', async () => {
+    const editor = {
+      onSubmit: undefined as ((text: string) => void) | undefined,
+      addToHistory: vi.fn(),
+      setText: vi.fn(),
+    };
+    const state = {
+      editor,
+      harness: { isRunning: vi.fn(() => true), canSendWhileRunning: vi.fn(() => true) },
+      pendingSlashCommands: [],
+      pendingQueuedActions: [],
+      pendingFollowUpMessages: [],
+      pendingImages: [],
+      ui: { requestRender: vi.fn() },
+      chatContainer: {},
+      followUpComponents: [],
+    };
+
+    const tui = Object.create(MastraTUI.prototype) as {
+      state: typeof state;
+      getUserInput: () => Promise<string>;
+      queueFollowUpMessage: (text: string) => void;
+    };
+    tui.state = state;
+    tui.queueFollowUpMessage = vi.fn();
+
+    const pendingInput = tui.getUserInput();
+    editor.onSubmit?.('signal follow-up');
+
+    await expect(pendingInput).resolves.toBe('signal follow-up');
+    expect(tui.queueFollowUpMessage).not.toHaveBeenCalled();
+  });
+
+  it('queues follow-up messages with images in FIFO order metadata without rendering them immediately', () => {
     const tui = Object.create(MastraTUI.prototype) as {
       state: any;
       queueFollowUpMessage: (text: string) => void;
@@ -143,7 +173,95 @@ describe('MastraTUI queueing', () => {
       { content: 'second message', images: undefined },
     ]);
     expect(tui.state.pendingSlashCommands).toEqual(['/help']);
-    expect(tui.state.ui.requestRender).toHaveBeenCalledTimes(3);
+    expect(mocks.addUserMessage).not.toHaveBeenCalled();
+    expect(mocks.showInfo).toHaveBeenCalledWith(tui.state, 'Slash command queued: /help');
+  });
+
+  it('submits Enter while the running harness accepts signals', () => {
+    const actions = new Map<string, () => unknown>();
+    const editor = {
+      onAction: vi.fn((name: string, handler: () => unknown) => actions.set(name, handler)),
+      getExpandedText: vi.fn(() => 'signal me'),
+      onSubmit: vi.fn(),
+    };
+    const state = {
+      editor,
+      harness: {
+        isRunning: vi.fn(() => true),
+        canSendWhileRunning: vi.fn(() => true),
+        listModes: vi.fn(() => []),
+        getState: vi.fn(() => ({})),
+        setState: vi.fn(),
+      },
+      lastCtrlCTime: 0,
+      pendingApprovalDismiss: undefined,
+      activeInlinePlanApproval: undefined,
+      activeInlineQuestion: undefined,
+      pendingInlineQuestions: [],
+      lastClearedText: '',
+      hideThinkingBlock: false,
+      toolOutputExpanded: false,
+      allToolComponents: [],
+      allSlashCommandComponents: [],
+      allSystemReminderComponents: [],
+      allShellComponents: [],
+      ui: { requestRender: vi.fn(), stop: vi.fn(), start: vi.fn() },
+    } as any;
+    const queueFollowUpMessage = vi.fn();
+
+    setupKeyboardShortcuts(state, {
+      stop: vi.fn(),
+      doubleCtrlCMs: 500,
+      queueFollowUpMessage,
+    });
+
+    expect(actions.get('followUp')?.()).toBe(true);
+    expect(editor.onSubmit).toHaveBeenCalledWith('signal me');
+    expect(queueFollowUpMessage).not.toHaveBeenCalled();
+  });
+
+  it('uses Ctrl+F to queue current input while the harness is running', () => {
+    const actions = new Map<string, () => unknown>();
+    const editor = {
+      onAction: vi.fn((name: string, handler: () => unknown) => actions.set(name, handler)),
+      getExpandedText: vi.fn(() => 'queue me'),
+      addToHistory: vi.fn(),
+      setText: vi.fn(),
+    };
+    const state = {
+      editor,
+      harness: {
+        isRunning: vi.fn(() => true),
+        listModes: vi.fn(() => []),
+        getState: vi.fn(() => ({})),
+        setState: vi.fn(),
+      },
+      lastCtrlCTime: 0,
+      pendingApprovalDismiss: undefined,
+      activeInlinePlanApproval: undefined,
+      activeInlineQuestion: undefined,
+      pendingInlineQuestions: [],
+      lastClearedText: '',
+      hideThinkingBlock: false,
+      toolOutputExpanded: false,
+      allToolComponents: [],
+      allSlashCommandComponents: [],
+      allSystemReminderComponents: [],
+      allShellComponents: [],
+      ui: { requestRender: vi.fn(), stop: vi.fn(), start: vi.fn() },
+    } as any;
+    const queueFollowUpMessage = vi.fn();
+
+    setupKeyboardShortcuts(state, {
+      stop: vi.fn(),
+      doubleCtrlCMs: 500,
+      queueFollowUpMessage,
+    });
+
+    expect(actions.get('queueFollowUp')?.()).toBe(true);
+    expect(editor.addToHistory).toHaveBeenCalledWith('queue me');
+    expect(editor.setText).toHaveBeenCalledWith('');
+    expect(queueFollowUpMessage).toHaveBeenCalledWith('queue me');
   });
 
   it('drains queued messages and slash commands in FIFO order on agent end', async () => {

--- a/mastracode/src/tui/__tests__/render-messages.test.ts
+++ b/mastracode/src/tui/__tests__/render-messages.test.ts
@@ -122,6 +122,24 @@ describe('addUserMessage', () => {
     expect(state.allSystemReminderComponents).toHaveLength(0);
     expect(state.messageComponentsById.get('user-1')).toBe(state.chatContainer.children[0]);
   });
+
+  it('pins streamed user messages as follow-ups while assistant text is still streaming', () => {
+    const state = createState();
+    const existing = new Container();
+    state.chatContainer.addChild(existing);
+    state.streamingComponent = existing as any;
+    state.harness = {
+      getDisplayState: () => ({ isRunning: true }),
+    } as unknown as TUIState['harness'];
+
+    addUserMessage(state, createUserMessage('focus on workflows', 'user-signal'));
+
+    expect(state.chatContainer.children).toHaveLength(2);
+    expect(state.chatContainer.children[0]).toBe(existing);
+    expect(state.chatContainer.children[1]).toBeInstanceOf(UserMessageComponent);
+    expect(state.followUpComponents).toEqual([state.chatContainer.children[1]]);
+    expect(state.messageComponentsById.get('user-signal')).toBe(state.chatContainer.children[1]);
+  });
 });
 
 describe('renderExistingMessages subagents', () => {

--- a/mastracode/src/tui/components/custom-editor.ts
+++ b/mastracode/src/tui/components/custom-editor.ts
@@ -36,6 +36,7 @@ export type AppAction =
   | 'toggleThinking'
   | 'expandTools'
   | 'followUp'
+  | 'queueFollowUp'
   | 'cycleMode'
   | 'toggleYolo';
 
@@ -560,6 +561,13 @@ export class CustomEditor extends Editor {
         if (handler() !== false) {
           return;
         }
+      }
+    }
+
+    if (matchesKey(data, 'ctrl+f')) {
+      const handler = this.actionHandlers.get('queueFollowUp');
+      if (handler && handler() !== false) {
+        return;
       }
     }
 

--- a/mastracode/src/tui/handlers/__tests__/message.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/message.test.ts
@@ -5,7 +5,7 @@ import { SystemReminderComponent } from '../../components/system-reminder.js';
 import { TemporalGapComponent } from '../../components/temporal-gap.js';
 import { UserMessageComponent } from '../../components/user-message.js';
 import type { TUIState } from '../../state.js';
-import { handleMessageUpdate } from '../message.js';
+import { handleMessageStart, handleMessageUpdate } from '../message.js';
 import type { EventHandlerContext } from '../types.js';
 
 function createAssistantMessage(content: HarnessMessage['content']): HarnessMessage {
@@ -45,6 +45,22 @@ describe('handleMessageUpdate system reminders', () => {
         state.chatContainer.addChild(child);
       },
     } as EventHandlerContext;
+  });
+
+  it('moves pinned user signal messages into history before the next assistant response', () => {
+    const previousAssistant = new Text('agent loop architecture', 0, 0);
+    const pinnedUserMessage = new UserMessageComponent('thanks');
+    state.chatContainer.addChild(previousAssistant);
+    state.chatContainer.addChild(pinnedUserMessage);
+    state.followUpComponents = [pinnedUserMessage];
+
+    handleMessageStart(ctx, createAssistantMessage([{ type: 'text', text: "You're welcome." }]));
+
+    expect(state.followUpComponents).toHaveLength(0);
+    expect(state.chatContainer.children).toHaveLength(3);
+    expect(state.chatContainer.children[0]).toBe(previousAssistant);
+    expect(state.chatContainer.children[1]).toBe(pinnedUserMessage);
+    expect(state.chatContainer.children[2]).toBe(state.streamingComponent);
   });
 
   it('renders a streamed placeholder when reminder content is not available yet', () => {

--- a/mastracode/src/tui/handlers/message.ts
+++ b/mastracode/src/tui/handlers/message.ts
@@ -153,6 +153,7 @@ export function handleMessageStart(ctx: EventHandlerContext, message: HarnessMes
     state.lastAskUserComponent = undefined;
     state.lastSubmitPlanComponent = undefined;
     if (!state.streamingComponent) {
+      state.followUpComponents = [];
       state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
       ctx.addChildBeforeFollowUps(state.streamingComponent);
       state.streamingMessage = message;

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -113,6 +113,15 @@ export function handleToolApprovalRequired(
 
 export function handleToolStart(ctx: EventHandlerContext, toolCallId: string, toolName: string, args: unknown): void {
   const { state } = ctx;
+
+  if (toolName === 'task_write' && state.taskProgress) {
+    const tasks = (args as { tasks?: TaskItem[] } | undefined)?.tasks;
+    if (Array.isArray(tasks)) {
+      state.taskProgress.updateTasks(tasks);
+      state.ui.requestRender();
+    }
+  }
+
   // Component may already exist if created early by handleToolInputStart
   const existingComponent = state.pendingTools.get(toolCallId);
 

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -242,33 +242,37 @@ export class MastraTUI {
         const { content, images } = consumePendingImages(userInput, this.state.pendingImages);
         this.state.pendingImages = [];
 
-        // Show the user message in the TUI right away — before any async work
-        // (thread creation, hooks, sending) so the UI feels instant even when
-        // GC pauses or I/O slow things down.
-        const messageId = `user-${Date.now()}`;
-        addUserMessage(this.state, {
-          id: messageId,
-          role: 'user',
-          content: [
-            { type: 'text', text: content },
-            ...(images?.map(img => ({
-              type: 'image' as const,
-              data: img.data,
-              mimeType: img.mimeType,
-            })) ?? []),
-          ],
-          createdAt: new Date(),
-        });
-        this.state.ui.requestRender();
+        const sendWhileRunning = this.state.harness.isRunning() && (this.state.harness as any).canSendWhileRunning?.();
+        const messageId = sendWhileRunning ? undefined : `user-${Date.now()}`;
+        if (messageId) {
+          // Add user message to chat immediately. When sending into an active durable stream,
+          // the stream's data-user-message event is the source of truth for display.
+          addUserMessage(this.state, {
+            id: messageId,
+            role: 'user',
+            content: [
+              { type: 'text', text: content },
+              ...(images?.map(img => ({
+                type: 'image' as const,
+                data: img.data,
+                mimeType: img.mimeType,
+              })) ?? []),
+            ],
+            createdAt: new Date(),
+          });
+          this.state.ui.requestRender();
+        }
 
         const allowed = await this.runUserPromptHook(userInput);
         if (!allowed) {
           // Hook blocked the message — remove it from the chat
-          const comp = this.state.messageComponentsById.get(messageId);
-          if (comp) {
-            this.state.chatContainer.removeChild(comp as never);
-            this.state.messageComponentsById.delete(messageId);
-            this.state.ui.requestRender();
+          if (messageId) {
+            const comp = this.state.messageComponentsById.get(messageId);
+            if (comp) {
+              this.state.chatContainer.removeChild(comp as never);
+              this.state.messageComponentsById.delete(messageId);
+              this.state.ui.requestRender();
+            }
           }
           continue;
         }
@@ -303,6 +307,7 @@ export class MastraTUI {
     if (text.startsWith('/')) {
       this.state.pendingSlashCommands.push(text);
       this.state.pendingQueuedActions.push('slash');
+      showInfo(this.state, `Slash command queued: ${text}`);
       updateStatusLine(this.state);
       this.state.ui.requestRender();
       return;
@@ -708,7 +713,7 @@ export class MastraTUI {
         }
         this.state.editor.setText('');
 
-        if (this.state.harness.isRunning()) {
+        if (this.state.harness.isRunning() && !(this.state.harness as any).canSendWhileRunning?.()) {
           this.queueFollowUpMessage(text);
           return;
         }

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -221,16 +221,13 @@ export function addUserMessage(state: TUIState, message: HarnessMessage): void {
 
     state.messageComponentsById.set(message.id, userComponent);
 
-    // Always append to end — follow-ups should stay at the bottom
-    state.chatContainer.addChild(userComponent);
-
-    // Track follow-up components sent while streaming so tool calls
-    // can be inserted before them (keeping them anchored at bottom).
-    // Only track if the agent is already streaming a response — otherwise
-    // this is the initial message that triggers the response, not a follow-up.
-    if (state.harness.getDisplayState().isRunning && state.streamingComponent) {
+    if (state.streamingComponent && state.harness.getDisplayState().isRunning) {
+      state.chatContainer.addChild(userComponent);
       state.followUpComponents.push(userComponent);
+      return;
     }
+
+    addChildBeforeFollowUps(state, userComponent);
   }
 }
 

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -30,6 +30,23 @@ export function setupKeyboardShortcuts(
     queueFollowUpMessage: (text: string) => void;
   },
 ): void {
+  const queueCurrentInput = (): boolean => {
+    if (!state.harness.isRunning()) {
+      return false;
+    }
+
+    const text = state.editor.getExpandedText().trim();
+    if (!text) {
+      return true;
+    }
+
+    state.editor.addToHistory(text);
+    state.editor.setText('');
+    callbacks.queueFollowUpMessage(text);
+    state.ui.requestRender();
+    return true;
+  };
+
   // Ctrl+C / Escape - abort if running, clear input if idle, double-tap always exits
   state.editor.onAction('clear', () => {
     const now = Date.now();
@@ -151,24 +168,18 @@ export function setupKeyboardShortcuts(
     showInfo(state, current ? 'YOLO mode off' : 'YOLO mode on');
   });
 
-  // Enter - submit immediately when idle, queue follow-up input while streaming
+  // Enter submits immediately when idle or when the active durable stream accepts user-message signals.
   state.editor.onAction('followUp', () => {
-    if (!state.harness.isRunning()) {
+    if (!state.harness.isRunning() || (state.harness as any).canSendWhileRunning?.()) {
       state.editor.onSubmit?.(state.editor.getExpandedText());
       return true;
     }
 
-    const text = state.editor.getExpandedText().trim();
-    if (!text) {
-      return true;
-    }
-
-    state.editor.addToHistory(text);
-    state.editor.setText('');
-    callbacks.queueFollowUpMessage(text);
-    state.ui.requestRender();
-    return true;
+    return queueCurrentInput();
   });
+
+  // Ctrl+F preserves the old follow-up behavior: queue until the stream is fully idle.
+  state.editor.onAction('queueFollowUp', queueCurrentInput);
 }
 
 // =============================================================================

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1,4 +1,5 @@
 import type { Agent } from '../agent';
+import type { DurableAgentSignal, SendDurableAgentSignalOptions } from '../agent/durable/types';
 import type { ToolsInput, ToolsetsInput } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
 import { Mastra } from '../mastra';
@@ -70,6 +71,14 @@ function addOptionalUsageField(
   if (value !== undefined) {
     usage[key] = (usage[key] ?? 0) + value;
   }
+}
+
+type SignalingAgent = Agent & {
+  sendSignal(signal: DurableAgentSignal, target: SendDurableAgentSignalOptions): { accepted: true; runId: string };
+};
+
+function isSignalingAgent(agent: Agent): agent is SignalingAgent {
+  return 'sendSignal' in agent && typeof agent.sendSignal === 'function';
 }
 
 /**
@@ -1379,11 +1388,25 @@ export class Harness<TState = {}> {
       const thread = await this.createThread();
       this.currentThreadId = thread.id;
     }
+    const threadId = this.currentThreadId;
+    const agent = this.getCurrentAgent();
+
+    if (this.isRunning()) {
+      const signal: DurableAgentSignal = {
+        type: 'user-message',
+        contents: content,
+        metadata: files?.length ? { files } : undefined,
+      };
+      if (this.currentRunId && isSignalingAgent(agent)) {
+        const result = agent.sendSignal(signal, { runId: this.currentRunId });
+        this.emit({ type: 'signal_sent', threadId, runId: result.runId, signalType: signal.type });
+        return;
+      }
+    }
 
     const operationId = ++this.currentOperationId;
     this.abortController = new AbortController();
     this.currentTraceId = null;
-    const agent = this.getCurrentAgent();
     this.emit({ type: 'agent_start' });
 
     try {
@@ -2326,6 +2349,12 @@ export class Harness<TState = {}> {
 
   isRunning(): boolean {
     return this.abortController !== null;
+  }
+
+  canSendWhileRunning(): boolean {
+    if (!this.abortController || !this.currentThreadId) return false;
+    const agent = this.getCurrentAgent();
+    return isSignalingAgent(agent) && Boolean(this.currentRunId);
   }
 
   getCurrentRunId(): string | null {

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -710,6 +710,7 @@ export type HarnessEvent =
   | { type: 'state_changed'; state: Record<string, unknown>; changedKeys: string[] }
   | { type: 'agent_start' }
   | { type: 'agent_end'; reason?: 'complete' | 'aborted' | 'error' | 'suspended' }
+  | { type: 'signal_sent'; threadId: string; runId: string; signalType: string }
   | { type: 'message_start'; message: HarnessMessage }
   | { type: 'message_update'; message: HarnessMessage }
   | { type: 'message_end'; message: HarnessMessage }


### PR DESCRIPTION
This wires the core durable `sendSignal` primitive into MastraCode.

When the current run is signal-capable, editor submissions are sent directly into the active durable run instead of being queued as follow-ups:

```ts
agent.sendSignal(
  { type: 'user-message', contents },
  { runId },
);
```

MastraCode keeps the submitted user message pending while the active stream continues, then replaces it with the confirmed streamed user message at the correct turn boundary so the next assistant response appears below it.

This PR builds on the previous core-only `DurableAgent.sendSignal` PR.

Verified with focused MastraCode queueing/render tests, typecheck, lint, and build.
