### PR TITLE
fix(server): bypass ownership checks when auth is not configured

### DIFF
--- a/packages/server/src/server/handlers/authorship.test.ts
+++ b/packages/server/src/server/handlers/authorship.test.ts
@@ -278,6 +278,17 @@ describe('authorship', () => {
         }),
       ).toThrow(HTTPException);
     });
+
+    it('allows access to private owned record when auth is not configured (no caller identity)', () => {
+      expect(() =>
+        assertReadAccess({
+          requestContext: new RequestContext(),
+          resource: 'agents',
+          resourceId: 'a1',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
+      ).not.toThrow();
+    });
   });
 
   describe('assertExecuteAccess', () => {
@@ -367,6 +378,17 @@ describe('authorship', () => {
         }),
       ).toThrow(HTTPException);
     });
+
+    it('allows execution of private owned record when auth is not configured (no caller identity)', () => {
+      expect(() =>
+        assertExecuteAccess({
+          requestContext: new RequestContext(),
+          resource: 'agents',
+          resourceId: 'a1',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
+      ).not.toThrow();
+    });
   });
 
   describe('assertWriteAccess', () => {
@@ -429,6 +451,18 @@ describe('authorship', () => {
           record: { authorId: 'owner', visibility: 'private' },
         }),
       ).toThrow(HTTPException);
+    });
+
+    it('allows write to private owned record when auth is not configured (no caller identity)', () => {
+      expect(() =>
+        assertWriteAccess({
+          requestContext: new RequestContext(),
+          resource: 'agents',
+          resourceId: 'a1',
+          action: 'edit',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
+      ).not.toThrow();
     });
   });
 
@@ -629,6 +663,16 @@ describe('authorship', () => {
           record: { authorId: 'owner', visibility: 'private' },
         }),
       ).toThrow(HTTPException);
+    });
+
+    it('allows sharing of private owned record when auth is not configured (no caller identity)', () => {
+      expect(() =>
+        assertShareAccess({
+          requestContext: new RequestContext(),
+          resource: 'stored-agents',
+          record: { authorId: 'owner', visibility: 'private' },
+        }),
+      ).not.toThrow();
     });
   });
 });

--- a/packages/server/src/server/handlers/authorship.ts
+++ b/packages/server/src/server/handlers/authorship.ts
@@ -208,7 +208,12 @@ export function assertReadAccess(args: {
   if (hasAdminBypass(requestContext, resource)) return;
 
   const callerAuthorId = getCallerAuthorId(requestContext);
-  if (callerAuthorId && callerAuthorId === owner) return;
+  // No authenticated user on the request context means auth is not configured
+  // (single-user/dev mode). When auth IS configured, coreAuthMiddleware
+  // rejects unauthenticated requests with 401 before they reach handlers,
+  // so an absent user here genuinely means no auth provider.
+  if (!callerAuthorId && !requestContext.get(MASTRA_USER_KEY)) return;
+  if (callerAuthorId === owner) return;
 
   if (hasScopedPermission({ requestContext, resource, action: 'read', resourceId })) {
     return;
@@ -243,7 +248,8 @@ export function assertExecuteAccess(args: {
   if (hasAdminBypass(requestContext, resource)) return;
 
   const callerAuthorId = getCallerAuthorId(requestContext);
-  if (callerAuthorId && callerAuthorId === owner) return;
+  if (!callerAuthorId && !requestContext.get(MASTRA_USER_KEY)) return; // No auth configured (see assertReadAccess)
+  if (callerAuthorId === owner) return;
 
   if (hasScopedPermission({ requestContext, resource, action: 'execute', resourceId })) {
     return;
@@ -281,7 +287,8 @@ export function assertWriteAccess(args: {
   if (hasAdminBypass(requestContext, resource)) return;
 
   const callerAuthorId = getCallerAuthorId(requestContext);
-  if (callerAuthorId && callerAuthorId === owner) return;
+  if (!callerAuthorId && !requestContext.get(MASTRA_USER_KEY)) return; // No auth configured (see assertReadAccess)
+  if (callerAuthorId === owner) return;
 
   if (hasScopedPermission({ requestContext, resource, action, resourceId })) {
     return;
@@ -321,7 +328,8 @@ export function assertShareAccess(args: {
   if (hasAdminBypass(requestContext, resource)) return;
 
   const callerAuthorId = getCallerAuthorId(requestContext);
-  if (callerAuthorId && callerAuthorId === owner) return;
+  if (!callerAuthorId && !requestContext.get(MASTRA_USER_KEY)) return; // No auth configured (see assertReadAccess)
+  if (callerAuthorId === owner) return;
 
   if (hasScopedPermission({ requestContext, resource, action: 'share', resourceId })) {
     return;


### PR DESCRIPTION
## Problem

When a user creates agents/skills with auth enabled (records get an `authorId`), then later disables auth, the server-side ownership checks (`assertReadAccess`, `assertWriteAccess`, `assertExecuteAccess`, `assertShareAccess`) reject requests with 404 because:

1. The record has a non-null `authorId` (set when auth was on)
2. `getCallerAuthorId()` returns `null` (no auth = no identity)
3. The old check `callerAuthorId && callerAuthorId === owner` was `false`
4. No scoped permissions exist → throws 404

## Fix

All 4 assert functions in `authorship.ts` now check for the absence of `MASTRA_USER_KEY` on the request context:

```ts
if (!callerAuthorId && !requestContext.get(MASTRA_USER_KEY)) return;
```

This is safe because when auth IS configured, `coreAuthMiddleware` rejects unauthenticated requests with 401 before they reach handlers. An absent `MASTRA_USER_KEY` at handler level genuinely means no auth provider is configured (single-user/dev mode).

### Edge cases

| Scenario | `MASTRA_USER_KEY` | `callerAuthorId` | Result |
|---|---|---|---|
| No auth configured | absent | `null` | **Allow** (early return) |
| Auth configured, user has ID | present | `"user-123"` | Check ownership normally |
| Auth configured, user missing ID (misconfiguration) | present | `null` | **Reject** (falls through to 404) |

## Tests

4 new tests in `authorship.test.ts` (60 → 64), one per assert function, verifying that owned private records are accessible when no caller identity exists.

## Test plan

- `pnpm --filter ./packages/server exec vitest run src/server/handlers/authorship.test.ts` — 64/64 ✅
- `pnpm --filter ./packages/server exec tsc --noEmit` — clean
- Manual: create skill with auth on → disable auth → edit skill → succeeds