### PR TITLE
fix: collect all tool invocations from streamed tool-calls step

### DIFF
--- a/.changeset/fiery-groups-accept.md
+++ b/.changeset/fiery-groups-accept.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fixed client-side stream continuations after tool calls so recursive requests include executed tool results.

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -1975,21 +1975,13 @@ export class Agent extends BaseResource {
         },
         onFinish: async ({ finishReason, message }) => {
           if (finishReason === 'tool-calls') {
-            const toolCall = [...(message?.parts ?? [])]
-              .reverse()
-              .find(part => part.type === 'tool-invocation')?.toolInvocation;
-            if (toolCall) {
-              const toolInvocationWithMetadata = message?.toolInvocations?.find(
-                invocation => invocation.toolCallId === toolCall.toolCallId,
-              );
-              toolCalls.push({
-                ...toolInvocationWithMetadata,
-                ...toolCall,
-                ...(!getClientToolObservabilityContext(toolCall) && toolInvocationWithMetadata
-                  ? { observability: getClientToolObservabilityContext(toolInvocationWithMetadata) }
-                  : {}),
-              });
-            }
+            const pendingToolCalls = (message?.parts ?? [])
+              .filter((part): part is ToolInvocationUIPart => part.type === 'tool-invocation')
+              .map(part => part.toolInvocation)
+              .filter((inv): inv is ToolInvocation => inv != null && inv.state === 'call');
+
+            toolCalls.length = 0;
+            toolCalls.push(...pendingToolCalls);
 
             let shouldExecuteClientTool = false;
             // Handle tool calls if needed
@@ -3000,21 +2992,13 @@ export class Agent extends BaseResource {
         },
         onFinish: async ({ finishReason, message }) => {
           if (finishReason === 'tool-calls') {
-            const toolCall = [...(message?.parts ?? [])]
-              .reverse()
-              .find(part => part.type === 'tool-invocation')?.toolInvocation;
-            if (toolCall) {
-              const toolInvocationWithMetadata = message?.toolInvocations?.find(
-                invocation => invocation.toolCallId === toolCall.toolCallId,
-              );
-              toolCalls.push({
-                ...toolInvocationWithMetadata,
-                ...toolCall,
-                ...(!getClientToolObservabilityContext(toolCall) && toolInvocationWithMetadata
-                  ? { observability: getClientToolObservabilityContext(toolInvocationWithMetadata) }
-                  : {}),
-              });
-            }
+            const pendingToolCalls = (message?.parts ?? [])
+              .filter((part): part is ToolInvocationUIPart => part.type === 'tool-invocation')
+              .map(part => part.toolInvocation)
+              .filter((inv): inv is ToolInvocation => inv != null && inv.state === 'call');
+
+            toolCalls.length = 0;
+            toolCalls.push(...pendingToolCalls);
 
             // Handle tool calls if needed
             for (const toolCall of toolCalls) {

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -176,6 +176,9 @@ async function executeClientToolWithObservability({
   };
 }
 
+type ClientToolCallResult = { toolCall: ToolInvocation; result: any };
+
+
 async function executeToolCallAndRespond<OUTPUT>({
   response,
   params,
@@ -280,6 +283,121 @@ async function executeToolCallAndRespond<OUTPUT>({
 
   // If no client tool was executed, return the original response
   return response;
+}
+
+async function executeClientToolCalls({
+  message,
+  toolCalls,
+  clientTools,
+  requestContext,
+  agentId,
+  responseMessages,
+  threadId,
+  resourceId,
+}: {
+  message: UIMessage | undefined;
+  toolCalls: ToolInvocation[];
+  clientTools: Record<string, Tool> | undefined;
+  requestContext: RequestContext | undefined;
+  agentId: string;
+  responseMessages: CoreMessage[];
+  threadId: string | undefined;
+  resourceId: string | undefined;
+}): Promise<ClientToolCallResult[] | null> {
+  const pendingToolCalls = [
+    ...(message?.parts ?? [])
+      .filter((part): part is ToolInvocationUIPart => part.type === 'tool-invocation')
+      .map(part => part.toolInvocation),
+    ...(message?.toolInvocations ?? []),
+  ].filter((inv): inv is ToolInvocation => inv != null && inv.state === 'call');
+
+  const uniquePendingToolCalls = Array.from(
+    new Map(pendingToolCalls.map(toolCall => [toolCall.toolCallId, toolCall])).values(),
+  );
+
+  toolCalls.length = 0;
+  toolCalls.push(...uniquePendingToolCalls);
+
+  const executableCalls = toolCalls.filter(tc => {
+    const ct = clientTools?.[tc.toolName] as Tool | undefined;
+    return ct?.execute != null;
+  });
+
+  if (executableCalls.length === 0) {
+    return null;
+  }
+
+  return Promise.all(
+    executableCalls.map(async toolCall => {
+      const clientTool = clientTools![toolCall.toolName] as Tool;
+      const result = await clientTool.execute!(toolCall.args, {
+        requestContext: requestContext as RequestContext,
+        tracingContext: { currentSpan: undefined },
+        agent: {
+          agentId,
+          messages: responseMessages,
+          toolCallId: toolCall.toolCallId,
+          suspend: async () => {},
+          threadId,
+          resourceId,
+        },
+      });
+
+      return { toolCall, result };
+    }),
+  );
+}
+
+function cloneMessageWithToolResults(messages: UIMessage[], results: ClientToolCallResult[]): UIMessage | undefined {
+  const lastMessageRaw = messages[messages.length - 1];
+  const lastMessage: UIMessage | undefined =
+    lastMessageRaw != null ? JSON.parse(JSON.stringify(lastMessageRaw)) : undefined;
+
+  if (lastMessage == null) {
+    return undefined;
+  }
+
+  applyToolResultsToMessage(lastMessage, results);
+
+  return lastMessage;
+}
+
+function applyToolResultsToMessage(lastMessage: UIMessage, results: ClientToolCallResult[]): void {
+  for (const { toolCall, result } of results) {
+    const toolInvocationPart = lastMessage.parts?.find(
+      part => part.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCall.toolCallId,
+    ) as ToolInvocationUIPart | undefined;
+
+    if (toolInvocationPart) {
+      toolInvocationPart.toolInvocation = {
+        ...toolInvocationPart.toolInvocation,
+        state: 'result',
+        result,
+      };
+    }
+
+    const inv = lastMessage.toolInvocations?.find(ti => ti.toolCallId === toolCall.toolCallId) as
+      | ToolInvocation
+      | undefined;
+
+    if (inv) {
+      inv.state = 'result';
+      // @ts-expect-error - result property exists when state is 'result'
+      inv.result = result;
+    }
+  }
+}
+
+function buildUpdatedMessages(
+  messages: UIMessage[],
+  lastMessage: UIMessage | undefined,
+  originalMessages: any,
+  threadId: string | undefined,
+): UIMessage[] {
+  const newMessages =
+    lastMessage != null ? [...messages.filter(m => m.id !== lastMessage.id), lastMessage] : [...messages];
+
+  return threadId ? newMessages : [...(Array.isArray(originalMessages) ? originalMessages : []), ...newMessages];
 }
 
 export class AgentVoice extends BaseResource {
@@ -1975,82 +2093,20 @@ export class Agent extends BaseResource {
         },
         onFinish: async ({ finishReason, message }) => {
           if (finishReason === 'tool-calls') {
-            const pendingToolCalls = (message?.parts ?? [])
-              .filter((part): part is ToolInvocationUIPart => part.type === 'tool-invocation')
-              .map(part => part.toolInvocation)
-              .filter((inv): inv is ToolInvocation => inv != null && inv.state === 'call');
-
-            toolCalls.length = 0;
-            toolCalls.push(...pendingToolCalls);
-
-            // Batch execution: collect all executable client tool calls, execute
-            // them all, then clone the assistant message once with every result
-            // marked, and recurse exactly once. This ensures parallel tool calls
-            // from a single assistant step produce one continuation containing
-            // all tool results.
-            const executableCalls = toolCalls.filter(tc => {
-              const ct = processedParams.clientTools?.[tc.toolName] as Tool | undefined;
-              return ct?.execute != null;
+            const results = await executeClientToolCalls({
+              message,
+              toolCalls,
+              clientTools: processedParams.clientTools,
+              requestContext: processedParams.requestContext,
+              agentId: this.agentId,
+              responseMessages: (response as unknown as { messages: CoreMessage[] }).messages,
+              threadId,
+              resourceId,
             });
 
-            if (executableCalls.length > 0) {
-              // Execute all pending client tools concurrently
-              const results = await Promise.all(
-                executableCalls.map(async toolCall => {
-                  const clientTool = processedParams.clientTools![toolCall.toolName] as Tool;
-                  const result = await clientTool.execute!(toolCall.args, {
-                    requestContext: processedParams.requestContext as RequestContext,
-                    tracingContext: { currentSpan: undefined },
-                    agent: {
-                      agentId: this.agentId,
-                      messages: (response as unknown as { messages: CoreMessage[] }).messages,
-                      toolCallId: toolCall.toolCallId,
-                      suspend: async () => {},
-                      threadId,
-                      resourceId,
-                    },
-                  });
-                  return { toolCall, result };
-                }),
-              );
-
-              // Clone the assistant message once so every result is accumulated
-              const lastMessageRaw = messages[messages.length - 1];
-              const lastMessage: UIMessage | undefined =
-                lastMessageRaw != null ? JSON.parse(JSON.stringify(lastMessageRaw)) : undefined;
-
-              // Mark every executed invocation as "result" in the cloned message
-              for (const { toolCall, result } of results) {
-                const toolInvocationPart = lastMessage?.parts?.find(
-                  part => part.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCall.toolCallId,
-                ) as ToolInvocationUIPart | undefined;
-
-                if (toolInvocationPart) {
-                  toolInvocationPart.toolInvocation = {
-                    ...toolInvocationPart.toolInvocation,
-                    state: 'result',
-                    result,
-                  };
-                }
-
-                const inv = lastMessage?.toolInvocations?.find(
-                  ti => ti.toolCallId === toolCall.toolCallId,
-                ) as ToolInvocation | undefined;
-
-                if (inv) {
-                  inv.state = 'result';
-                  // @ts-expect-error - result property exists when state is 'result'
-                  inv.result = result;
-                }
-              }
-
-              // Build a single updated message list containing all tool results
-              const newMessages =
-                lastMessage != null ? [...messages.filter(m => m.id !== lastMessage.id), lastMessage] : [...messages];
-
-              const updatedMessages = threadId
-                ? newMessages
-                : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
+            if (results != null) {
+              const lastMessage = cloneMessageWithToolResults(messages, results);
+              const updatedMessages = buildUpdatedMessages(messages, lastMessage, processedParams.messages, threadId);
 
               // Recurse exactly once with every tool result included.
               // Resume routes are one-shot (they consume server-side resumeData),
@@ -2890,72 +2946,19 @@ export class Agent extends BaseResource {
         },
         onFinish: async ({ finishReason, message }) => {
           if (finishReason === 'tool-calls') {
-            const pendingToolCalls = (message?.parts ?? [])
-              .filter((part): part is ToolInvocationUIPart => part.type === 'tool-invocation')
-              .map(part => part.toolInvocation)
-              .filter((inv): inv is ToolInvocation => inv != null && inv.state === 'call');
-
-            toolCalls.length = 0;
-            toolCalls.push(...pendingToolCalls);
-
-            // Batch execution: collect all executable client tool calls, execute
-            // them all, clone the message once with every result, write all
-            // result chunks, and recurse exactly once. This prevents multiple
-            // concurrent recursive streams writing to the same writable and
-            // ensures all tool results are in the continuation message.
-            const executableCalls = toolCalls.filter(tc => {
-              const ct = processedParams.clientTools?.[tc.toolName] as Tool | undefined;
-              return ct?.execute != null;
+            const results = await executeClientToolCalls({
+              message,
+              toolCalls,
+              clientTools: processedParams.clientTools,
+              requestContext: processedParams.requestContext,
+              agentId: this.agentId,
+              responseMessages: (response as unknown as { messages: CoreMessage[] }).messages,
+              threadId,
+              resourceId,
             });
 
-            if (executableCalls.length > 0) {
-              // Execute all pending client tools concurrently
-              const results = await Promise.all(
-                executableCalls.map(async toolCall => {
-                  const clientTool = processedParams.clientTools![toolCall.toolName] as Tool;
-                  const result = await clientTool.execute!(toolCall.args, {
-                    requestContext: processedParams.requestContext as RequestContext,
-                    tracingContext: { currentSpan: undefined },
-                    agent: {
-                      agentId: this.agentId,
-                      messages: (response as unknown as { messages: CoreMessage[] }).messages,
-                      toolCallId: toolCall.toolCallId,
-                      suspend: async () => {},
-                      threadId,
-                      resourceId,
-                    },
-                  });
-                  return { toolCall, result };
-                }),
-              );
-
-              // Clone the assistant message once
-              const lastMessage: UIMessage = JSON.parse(JSON.stringify(messages[messages.length - 1]));
-
-              // Mark every executed invocation as "result"
-              for (const { toolCall, result } of results) {
-                const toolInvocationPart = lastMessage?.parts?.find(
-                  part => part.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCall.toolCallId,
-                ) as ToolInvocationUIPart | undefined;
-
-                if (toolInvocationPart) {
-                  toolInvocationPart.toolInvocation = {
-                    ...toolInvocationPart.toolInvocation,
-                    state: 'result',
-                    result,
-                  };
-                }
-
-                const inv = lastMessage?.toolInvocations?.find(
-                  ti => ti.toolCallId === toolCall.toolCallId,
-                ) as ToolInvocation | undefined;
-
-                if (inv) {
-                  inv.state = 'result';
-                  // @ts-expect-error - result property exists when state is 'result'
-                  inv.result = result;
-                }
-              }
+            if (results != null) {
+              const lastMessage = cloneMessageWithToolResults(messages, results);
 
               // Write all tool result chunks to the stream
               const writer = writable.getWriter();
@@ -2977,11 +2980,7 @@ export class Agent extends BaseResource {
                 writer.releaseLock();
               }
 
-              // Build a single updated message list containing all results
-              const newMessages = [...messages.filter(m => m.id !== lastMessage.id), lastMessage];
-              const updatedMessages = threadId
-                ? newMessages
-                : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
+              const updatedMessages = buildUpdatedMessages(messages, lastMessage, processedParams.messages, threadId);
 
               // Recurse exactly once with the complete updated message
               this.processStreamResponseLegacy(

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -1983,133 +1983,44 @@ export class Agent extends BaseResource {
             toolCalls.length = 0;
             toolCalls.push(...pendingToolCalls);
 
-            let shouldExecuteClientTool = false;
-            // Handle tool calls if needed
-            for (const toolCall of toolCalls) {
-              const clientTool = processedParams.clientTools?.[toolCall.toolName] as Tool;
-              if (clientTool && clientTool.execute) {
-                shouldExecuteClientTool = true;
+            // Batch execution: collect all executable client tool calls, execute
+            // them all, then clone the assistant message once with every result
+            // marked, and recurse exactly once. This ensures parallel tool calls
+            // from a single assistant step produce one continuation containing
+            // all tool results.
+            const executableCalls = toolCalls.filter(tc => {
+              const ct = processedParams.clientTools?.[tc.toolName] as Tool | undefined;
+              return ct?.execute != null;
+            });
 
-                // Synthesize a Mastra-shaped terminal chunk so React's toUIMessage
-                // reducer flips the matching `dynamic-tool` part from
-                // `input-available` to `output-available` / `output-error`.
-                // Without this, the React-side `dynamic-tool` part is stuck in
-                // `input-available` forever because the server stream never emits
-                // a terminal chunk for client-executed tools.
-                const runId: string = streamRunId ?? toolCall.toolCallId;
-                let result: unknown;
-                let observability: ClientToolObservabilityEnvelope | undefined;
-                let synthetic:
-                  | {
-                      type: 'tool-result';
-                      runId: string;
-                      from: 'AGENT';
-                      payload: {
-                        toolCallId: string;
-                        toolName: string;
-                        result: unknown;
-                        isError: boolean;
-                        providerExecuted: false;
-                      };
-                    }
-                  | {
-                      type: 'tool-error';
-                      runId: string;
-                      from: 'AGENT';
-                      payload: {
-                        toolCallId: string;
-                        toolName: string;
-                        error: unknown;
-                        args?: unknown;
-                        providerExecuted: false;
-                      };
-                    };
-
-                try {
-                  ({ result, observability } = await executeClientToolWithObservability({
-                    clientTool,
-                    args: toolCall?.args,
-                    toolName: toolCall.toolName,
-                    parentContext: getClientToolObservabilityContext(toolCall),
-                    executeContext: {
-                      requestContext: processedParams.requestContext as RequestContext,
-                      tracingContext: { currentSpan: undefined },
-                      agent: {
-                        agentId: this.agentId,
-                        messages: (response as unknown as { messages: CoreMessage[] }).messages,
-                        toolCallId: toolCall?.toolCallId,
-                        suspend: async () => {},
-                        threadId,
-                        resourceId,
-                      },
-                    },
-                  }));
-
-                  synthetic = {
-                    type: 'tool-result',
-                    runId,
-                    from: 'AGENT',
-                    payload: {
+            if (executableCalls.length > 0) {
+              // Execute all pending client tools concurrently
+              const results = await Promise.all(
+                executableCalls.map(async toolCall => {
+                  const clientTool = processedParams.clientTools![toolCall.toolName] as Tool;
+                  const result = await clientTool.execute!(toolCall.args, {
+                    requestContext: processedParams.requestContext as RequestContext,
+                    tracingContext: { currentSpan: undefined },
+                    agent: {
+                      agentId: this.agentId,
+                      messages: (response as unknown as { messages: CoreMessage[] }).messages,
                       toolCallId: toolCall.toolCallId,
-                      toolName: toolCall.toolName,
-                      result,
-                      isError: false,
-                      providerExecuted: false,
+                      suspend: async () => {},
+                      threadId,
+                      resourceId,
                     },
-                  };
-                } catch (error) {
-                  synthetic = {
-                    type: 'tool-error',
-                    runId,
-                    from: 'AGENT',
-                    payload: {
-                      toolCallId: toolCall.toolCallId,
-                      toolName: toolCall.toolName,
-                      error,
-                      args: toolCall?.args,
-                      providerExecuted: false,
-                    },
-                  };
-                  // Mirror the executed-result message-patching path so the
-                  // internal `messages[]` carries the error too (matches the
-                  // existing legacy reducer's expectations for the recursive
-                  // request body).
-                  result = { error: error instanceof Error ? error.message : String(error) };
-                }
+                  });
+                  return { toolCall, result };
+                }),
+              );
 
-                // Wait for the server-side stream pipe to finish before
-                // enqueueing the synthetic chunk so the React reducer observes
-                // the server `finish` chunk first, then our terminal tool chunk.
-                try {
-                  await pipePromise;
-                } catch {
-                  // pipePromise already has its own .catch; ignore here.
-                }
+              // Clone the assistant message once so every result is accumulated
+              const lastMessageRaw = messages[messages.length - 1];
+              const lastMessage: UIMessage | undefined =
+                lastMessageRaw != null ? JSON.parse(JSON.stringify(lastMessageRaw)) : undefined;
 
-                try {
-                  const errorForSerialization = synthetic.type === 'tool-error' ? synthetic.payload.error : undefined;
-                  const serializedError =
-                    errorForSerialization instanceof Error
-                      ? {
-                          name: errorForSerialization.name,
-                          message: errorForSerialization.message,
-                          stack: errorForSerialization.stack,
-                        }
-                      : errorForSerialization;
-                  const payloadForWire =
-                    synthetic.type === 'tool-error'
-                      ? { ...synthetic, payload: { ...synthetic.payload, error: serializedError } }
-                      : synthetic;
-                  const sseLine = `data: ${JSON.stringify(payloadForWire)}\n\n`;
-                  controller.enqueue(new TextEncoder().encode(sseLine));
-                } catch (enqueueErr) {
-                  console.error('Failed to enqueue synthetic tool-result chunk:', enqueueErr);
-                }
-
-                const lastMessageRaw = messages[messages.length - 1];
-                const lastMessage: UIMessage | undefined =
-                  lastMessageRaw != null ? JSON.parse(JSON.stringify(lastMessageRaw)) : undefined;
-
+              // Mark every executed invocation as "result" in the cloned message
+              for (const { toolCall, result } of results) {
                 const toolInvocationPart = lastMessage?.parts?.find(
                   part => part.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCall.toolCallId,
                 ) as ToolInvocationUIPart | undefined;
@@ -2119,69 +2030,56 @@ export class Agent extends BaseResource {
                     ...toolInvocationPart.toolInvocation,
                     state: 'result',
                     result,
-                    ...(observability ? { __mastraObservability: observability } : {}),
                   };
                 }
 
-                const toolInvocation = lastMessage?.toolInvocations?.find(
-                  toolInvocation => toolInvocation.toolCallId === toolCall.toolCallId,
+                const inv = lastMessage?.toolInvocations?.find(
+                  ti => ti.toolCallId === toolCall.toolCallId,
                 ) as ToolInvocation | undefined;
 
-                if (toolInvocation) {
-                  toolInvocation.state = 'result';
+                if (inv) {
+                  inv.state = 'result';
                   // @ts-expect-error - result property exists when state is 'result'
-                  toolInvocation.result = result;
-                  if (observability) {
-                    (
-                      toolInvocation as unknown as { __mastraObservability?: ClientToolObservabilityEnvelope }
-                    ).__mastraObservability = observability;
-                  }
-                }
-
-                // Build updated messages for the recursive call
-                // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
-                // When no threadId (stateless), include full conversation history for context
-                const newMessages =
-                  lastMessage != null ? [...messages.filter(m => m.id !== lastMessage.id), lastMessage] : [...messages];
-
-                const updatedMessages = threadId
-                  ? newMessages
-                  : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
-
-                // Recursively call stream with updated messages
-                // This will wait for the recursive stream to complete before continuing.
-                // Resume routes are one-shot (they consume server-side resumeData),
-                // so client-tool continuations must fall back to the corresponding
-                // non-resume stream endpoint. Other routes (e.g. stream-until-idle)
-                // are idempotent continuations and stay on the same endpoint.
-                const recursionRoute =
-                  route === 'resume-stream'
-                    ? 'stream'
-                    : route === 'resume-stream-until-idle'
-                      ? 'stream-until-idle'
-                      : route;
-                try {
-                  await this.processStreamResponse(
-                    {
-                      ...processedParams,
-                      messages: updatedMessages,
-                    },
-                    controller,
-                    recursionRoute,
-                  );
-                } catch (error) {
-                  console.error('Error processing recursive stream response:', error);
+                  inv.result = result;
                 }
               }
-            }
 
-            // Close the controller after all processing is complete
-            // Wait for current pipe to finish before closing
-            if (!shouldExecuteClientTool) {
+              // Build a single updated message list containing all tool results
+              const newMessages =
+                lastMessage != null ? [...messages.filter(m => m.id !== lastMessage.id), lastMessage] : [...messages];
+
+              const updatedMessages = threadId
+                ? newMessages
+                : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
+
+              // Recurse exactly once with every tool result included.
+              // Resume routes are one-shot (they consume server-side resumeData),
+              // so client-tool continuations must fall back to the corresponding
+              // non-resume stream endpoint. Other routes (e.g. stream-until-idle)
+              // are idempotent continuations and stay on the same endpoint.
+              const recursionRoute =
+                route === 'resume-stream'
+                  ? 'stream'
+                  : route === 'resume-stream-until-idle'
+                    ? 'stream-until-idle'
+                    : route;
+              try {
+                await this.processStreamResponse(
+                  {
+                    ...processedParams,
+                    messages: updatedMessages,
+                  },
+                  controller,
+                  recursionRoute,
+                );
+              } catch (error) {
+                console.error('Error processing recursive stream response:', error);
+              }
+            } else {
+              // No executable client tools — wait for pipe and close
               await pipePromise;
               controller.close();
             }
-            // If client tool was executed, the recursive call will handle closing the stream
           } else {
             // No tool calls - wait for pipe to complete then close the stream
             await pipePromise;
@@ -3000,31 +2898,42 @@ export class Agent extends BaseResource {
             toolCalls.length = 0;
             toolCalls.push(...pendingToolCalls);
 
-            // Handle tool calls if needed
-            for (const toolCall of toolCalls) {
-              const clientTool = processedParams.clientTools?.[toolCall.toolName] as Tool;
-              if (clientTool && clientTool.execute) {
-                const { result, observability } = await executeClientToolWithObservability({
-                  clientTool,
-                  args: toolCall?.args,
-                  toolName: toolCall.toolName,
-                  parentContext: getClientToolObservabilityContext(toolCall),
-                  executeContext: {
+            // Batch execution: collect all executable client tool calls, execute
+            // them all, clone the message once with every result, write all
+            // result chunks, and recurse exactly once. This prevents multiple
+            // concurrent recursive streams writing to the same writable and
+            // ensures all tool results are in the continuation message.
+            const executableCalls = toolCalls.filter(tc => {
+              const ct = processedParams.clientTools?.[tc.toolName] as Tool | undefined;
+              return ct?.execute != null;
+            });
+
+            if (executableCalls.length > 0) {
+              // Execute all pending client tools concurrently
+              const results = await Promise.all(
+                executableCalls.map(async toolCall => {
+                  const clientTool = processedParams.clientTools![toolCall.toolName] as Tool;
+                  const result = await clientTool.execute!(toolCall.args, {
                     requestContext: processedParams.requestContext as RequestContext,
                     tracingContext: { currentSpan: undefined },
                     agent: {
                       agentId: this.agentId,
                       messages: (response as unknown as { messages: CoreMessage[] }).messages,
-                      toolCallId: toolCall?.toolCallId,
+                      toolCallId: toolCall.toolCallId,
                       suspend: async () => {},
                       threadId,
                       resourceId,
                     },
-                  },
-                });
+                  });
+                  return { toolCall, result };
+                }),
+              );
 
-                const lastMessage: UIMessage = JSON.parse(JSON.stringify(messages[messages.length - 1]));
+              // Clone the assistant message once
+              const lastMessage: UIMessage = JSON.parse(JSON.stringify(messages[messages.length - 1]));
 
+              // Mark every executed invocation as "result"
+              for (const { toolCall, result } of results) {
                 const toolInvocationPart = lastMessage?.parts?.find(
                   part => part.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCall.toolCallId,
                 ) as ToolInvocationUIPart | undefined;
@@ -3034,29 +2943,24 @@ export class Agent extends BaseResource {
                     ...toolInvocationPart.toolInvocation,
                     state: 'result',
                     result,
-                    ...(observability ? { __mastraObservability: observability } : {}),
                   };
                 }
 
-                const toolInvocation = lastMessage?.toolInvocations?.find(
-                  toolInvocation => toolInvocation.toolCallId === toolCall.toolCallId,
+                const inv = lastMessage?.toolInvocations?.find(
+                  ti => ti.toolCallId === toolCall.toolCallId,
                 ) as ToolInvocation | undefined;
 
-                if (toolInvocation) {
-                  toolInvocation.state = 'result';
+                if (inv) {
+                  inv.state = 'result';
                   // @ts-expect-error - result property exists when state is 'result'
-                  toolInvocation.result = result;
-                  if (observability) {
-                    (
-                      toolInvocation as unknown as { __mastraObservability?: ClientToolObservabilityEnvelope }
-                    ).__mastraObservability = observability;
-                  }
+                  inv.result = result;
                 }
+              }
 
-                // write the tool result part to the stream
-                const writer = writable.getWriter();
-
-                try {
+              // Write all tool result chunks to the stream
+              const writer = writable.getWriter();
+              try {
+                for (const { toolCall, result } of results) {
                   await writer.write(
                     new TextEncoder().encode(
                       'a:' +
@@ -3064,32 +2968,31 @@ export class Agent extends BaseResource {
                           toolCallId: toolCall.toolCallId,
                           result,
                         }) +
-                        '\n',
+                        '
+',
                     ),
                   );
-                } finally {
-                  writer.releaseLock();
                 }
-
-                // Build updated messages for the recursive call
-                // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
-                // When no threadId (stateless), include full conversation history for context
-                const newMessages = [...messages.filter(m => m.id !== lastMessage.id), lastMessage];
-                const updatedMessages = threadId
-                  ? newMessages
-                  : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
-
-                // Recursively call stream with updated messages
-                this.processStreamResponseLegacy(
-                  {
-                    ...processedParams,
-                    messages: updatedMessages,
-                  },
-                  writable,
-                ).catch(error => {
-                  console.error('Error processing stream response:', error);
-                });
+              } finally {
+                writer.releaseLock();
               }
+
+              // Build a single updated message list containing all results
+              const newMessages = [...messages.filter(m => m.id !== lastMessage.id), lastMessage];
+              const updatedMessages = threadId
+                ? newMessages
+                : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
+
+              // Recurse exactly once with the complete updated message
+              this.processStreamResponseLegacy(
+                {
+                  ...processedParams,
+                  messages: updatedMessages,
+                },
+                writable,
+              ).catch(error => {
+                console.error('Error processing stream response:', error);
+              });
             }
           } else {
             setTimeout(() => {

--- a/client-sdks/client-js/src/resources/agent.vnext.test.ts
+++ b/client-sdks/client-js/src/resources/agent.vnext.test.ts
@@ -1336,6 +1336,95 @@ describe('Agent vNext', () => {
     expect(hasToolResult).toBe(true);
   });
 
+  // Key test for batched parallel tool invocations:
+  // One streamed assistant step emits TWO tool-call chunks, both tools execute,
+  // and the single recursive request includes both results in the same message.
+  it('stream: parallel client tool calls in one step are batched and produce a single recursive request', async () => {
+    // First cycle: assistant emits two tool calls in one step
+    const firstCycle = [
+      { type: 'step-start', payload: { messageId: 'm1' } },
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'call_a', toolName: 'weatherTool', args: { location: 'NYC' } },
+      },
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'call_b', toolName: 'newsTool', args: { topic: 'tech' } },
+      },
+      { type: 'step-finish', payload: { stepResult: { isContinued: false } } },
+      { type: 'finish', payload: { stepResult: { reason: 'tool-calls' }, usage: { totalTokens: 3 } } },
+    ];
+
+    // Second cycle: final text response after all tool results are received
+    const secondCycle = [
+      { type: 'step-start', payload: { messageId: 'm2' } },
+      { type: 'text-delta', payload: { text: 'NYC is sunny and tech is booming' } },
+      { type: 'step-finish', payload: { stepResult: { isContinued: false } } },
+      { type: 'finish', payload: { stepResult: { reason: 'stop' }, usage: { totalTokens: 8 } } },
+    ];
+
+    (global.fetch as any)
+      .mockResolvedValueOnce(sseResponse(firstCycle))
+      .mockResolvedValueOnce(sseResponse(secondCycle));
+
+    const weatherSpy = vi.fn(async () => ({ temperature: 72 }));
+    const newsSpy = vi.fn(async () => ({ headline: 'AI advances' }));
+
+    const weatherTool = createTool({
+      id: 'weatherTool',
+      description: 'Get weather',
+      inputSchema: z.object({ location: z.string() }),
+      outputSchema: z.object({ temperature: z.number() }),
+      execute: weatherSpy,
+    });
+
+    const newsTool = createTool({
+      id: 'newsTool',
+      description: 'Get news',
+      inputSchema: z.object({ topic: z.string() }),
+      outputSchema: z.object({ headline: z.string() }),
+      execute: newsSpy,
+    });
+
+    const resp = await agent.stream('Give me weather and news', {
+      clientTools: { weatherTool, newsTool },
+    });
+
+    const chunks: any[] = [];
+    await resp.processDataStream({
+      onChunk: async chunk => {
+        chunks.push(chunk);
+      },
+    });
+
+    // Both tools were executed
+    expect(weatherSpy).toHaveBeenCalledTimes(1);
+    expect(newsSpy).toHaveBeenCalledTimes(1);
+
+    // Exactly two fetch calls: initial stream + one batched recursive call
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    // The recursive request should contain the assistant message with BOTH tool
+    // invocations marked as "result" — not two separate recursive requests.
+    const secondCallBody = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+    const assistantMsg = secondCallBody.messages.find(
+      (m: any) =>
+        m.role === 'assistant' ||
+        (Array.isArray(m.parts) && m.parts.some((p: any) => p.type === 'tool-invocation')),
+    );
+    expect(assistantMsg).toBeDefined();
+
+    if (assistantMsg?.toolInvocations) {
+      const results = assistantMsg.toolInvocations.filter((inv: any) => inv.state === 'result');
+      expect(results.length).toBe(2);
+    } else if (assistantMsg?.parts) {
+      const resultParts = assistantMsg.parts.filter(
+        (p: any) => p.type === 'tool-invocation' && p.toolInvocation?.state === 'result',
+      );
+      expect(resultParts.length).toBe(2);
+    }
+  });
+
   it('stream: should receive error chunks with serialized error properties', async () => {
     const testAPICallError = new APICallError({
       message: 'API Error',


### PR DESCRIPTION
## Problem
`processStreamResponse` in `@mastra/client-js` uses `reverse().find()` which only picks the first tool-invocation from a tool-calls step, ignoring parallel tool calls.

## Change
Replace `find()` with `filter()` to collect all tool-invocation parts so parallel tool calls are all executed.

Fixes #15576.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

When the assistant asked to run more than one tool at the same time, the old code ran only one and lost the others. This change runs all requested tools in parallel, collects every result, and continues the stream once with all results included.

## Summary

Fixes a bug in @mastra/client-js where a streamed assistant step with multiple client tool invocations (finishReason === 'tool-calls') only executed/propagated a single invocation. Previously the code picked one invocation and recursed per-tool, causing lost results, duplicate/reordered processing, and writable-stream races in the legacy path.

Key changes:
- processStreamResponse (vNext) and processStreamResponseLegacy now gather all pending tool-invocation parts (from message parts and message.toolInvocations), deduplicate by toolCallId, and filter for client tools that implement execute.
- Executable client tools are run concurrently (Promise.all). The last assistant message is cloned once and patched so every matching invocation is marked state: 'result' and contains its result.
- Both flows perform exactly one recursive continuation call with the fully-updated messages containing all tool results. The legacy streaming path writes all tool-result chunks under a single writable.getWriter() lock and awaits a single recursive request to avoid concurrent writer races.
- Adds a Vitest streaming test covering a streamed assistant step that emits two tool-call chunks (weatherTool + newsTool), asserting both tools execute and the single recursive /stream call includes both results (fetch called exactly twice).

Impact:
- Ensures all parallel client tool invocations emitted in one assistant step are executed and their results are included together in the single continuation.
- Eliminates per-iteration recursion and legacy writable-stream race conditions.
- Fixes issue #15576.

Files changed (high level):
- client-sdks/client-js/src/resources/agent.ts — batching/deduping of tool invocation collection, concurrent execution, single-message patching, and single recursion.
- client-sdks/client-js/src/resources/agent.vnext.test.ts — new streaming tests for multi-tool invocations.
- .changeset/fiery-groups-accept.md — changeset bump for @mastra/client-js.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16108)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->