### PR TITLE
fix(memory): hoist image-data tool-result blocks into observer attachments

### DIFF
--- a/.changeset/huge-papers-rest.md
+++ b/.changeset/huge-papers-rest.md
@@ -1,0 +1,7 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed an issue where tool results containing AI SDK v5 `image-data` content blocks (returned via `toModelOutput`) were stringified into the observational memory prompt as raw base64 text. The base64 data overflowed the observer's context, causing token-limit errors and degenerate output.
+
+Image and file blocks (`image-data`, `image-url`, `file-data`, `file-url`, and `media`) inside tool results are now hoisted into the observer's input as proper attachments, the same way image and file message parts already are. The text body shows a placeholder like `[Image #1: image/png]` so the observer keeps positional context without seeing the bytes.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1404,6 +1404,71 @@ describe('Observer Agent Helpers', () => {
       expect(formatted).not.toContain('x'.repeat(200));
     });
 
+    // Regression test for https://github.com/mastra-ai/mastra/issues/15883
+    // Tools that return AI SDK v5 image-data blocks via toModelOutput must not
+    // dump the base64 payload into the observer's text body — it blows the
+    // observer's context and causes degenerate output.
+    it('should replace image-data tool-result blocks with attachment placeholders', () => {
+      const base64 = 'A'.repeat(2000);
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'screenshot',
+              args: { url: 'https://example.com' },
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'Captured screenshot of the homepage.' },
+                    { type: 'image-data', data: base64, mediaType: 'image/png' },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const formatted = formatMessagesForObserver([msg]);
+      expect(formatted).toContain('Tool Result screenshot');
+      expect(formatted).toContain('Captured screenshot of the homepage.');
+      expect(formatted).toContain('[Image #1: image/png]');
+      expect(formatted).not.toContain(base64);
+    });
+
+    it('should leave non-content tool-result outputs unchanged', () => {
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-2',
+              toolName: 'getWeather',
+              args: { city: 'NYC' },
+              result: { temperature: 72, conditions: 'sunny' },
+            },
+          },
+        ],
+      } as any;
+
+      const formatted = formatMessagesForObserver([msg]);
+      expect(formatted).toContain('Tool Result getWeather');
+      expect(formatted).toContain('"temperature": 72');
+      expect(formatted).toContain('"conditions": "sunny"');
+    });
+
     // Regression test for https://github.com/mastra-ai/mastra/issues/15573
     // Anthropic rejects bodies containing lone UTF-16 surrogates with
     // `The request body is not valid JSON: no low surrogate in string`.
@@ -1496,6 +1561,56 @@ describe('Observer Agent Helpers', () => {
       expect(content[2]).toMatchObject({ type: 'image', image: 'https://example.com/reference-board.png' });
       expect(content[3]).toMatchObject({ type: 'image', image: 'https://example.com/annotated-photo.jpg' });
       expect(content).not.toContainEqual(expect.objectContaining({ image: 'https://example.com/floorplan.pdf' }));
+    });
+
+    // Regression test for https://github.com/mastra-ai/mastra/issues/15883
+    it('should hoist image-data tool-result blocks into observer input attachments', () => {
+      const base64 = 'B'.repeat(1500);
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'screenshot',
+              args: { url: 'https://example.com' },
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'Captured.' },
+                    { type: 'image-data', data: base64, mediaType: 'image/png' },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const historyMessage = buildObserverHistoryMessage([msg]);
+      const content = historyMessage.content as any[];
+
+      const textParts = content.filter(part => part.type === 'text');
+      const imageParts = content.filter(part => part.type === 'image');
+
+      expect(imageParts).toHaveLength(1);
+      expect(imageParts[0]).toMatchObject({
+        type: 'image',
+        image: `data:image/png;base64,${base64}`,
+        mimeType: 'image/png',
+      });
+
+      const joinedText = textParts.map(part => part.text).join('\n');
+      expect(joinedText).toContain('Tool Result screenshot');
+      expect(joinedText).toContain('[Image #1: image/png]');
+      expect(joinedText).not.toContain(base64);
     });
 
     it('should reuse part-level date grouping without message separators', () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1441,7 +1441,8 @@ describe('Observer Agent Helpers', () => {
       expect(formatted).not.toContain(base64);
     });
 
-    it('should leave non-content tool-result outputs unchanged', () => {
+    it('should hoist file-data tool-result blocks under the file counter', () => {
+      const base64 = 'C'.repeat(2000);
       const msg = createTestMessage('ignored', 'assistant');
       msg.content = {
         format: 2,
@@ -1450,19 +1451,32 @@ describe('Observer Agent Helpers', () => {
             type: 'tool-invocation',
             toolInvocation: {
               state: 'result',
-              toolCallId: 'tool-2',
-              toolName: 'getWeather',
-              args: { city: 'NYC' },
-              result: { temperature: 72, conditions: 'sunny' },
+              toolCallId: 'tool-3',
+              toolName: 'fetchInvoice',
+              args: { id: 'inv-42' },
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'Invoice retrieved.' },
+                    { type: 'file-data', data: base64, mediaType: 'application/pdf', filename: 'invoice-42.pdf' },
+                  ],
+                },
+              },
             },
           },
         ],
       } as any;
 
       const formatted = formatMessagesForObserver([msg]);
-      expect(formatted).toContain('Tool Result getWeather');
-      expect(formatted).toContain('"temperature": 72');
-      expect(formatted).toContain('"conditions": "sunny"');
+      expect(formatted).toContain('Tool Result fetchInvoice');
+      expect(formatted).toContain('Invoice retrieved.');
+      expect(formatted).toContain('[File #1: invoice-42.pdf]');
+      expect(formatted).not.toContain('[Image #1');
+      expect(formatted).not.toContain(base64);
     });
 
     // Regression test for https://github.com/mastra-ai/mastra/issues/15573

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1622,6 +1622,128 @@ describe('Observer Agent Helpers', () => {
       expect(joinedText).not.toContain(base64);
     });
 
+    it('should hoist URL and media tool-result blocks into observer input attachments', () => {
+      const imageData = 'E'.repeat(1500);
+      const fileData = 'F'.repeat(1500);
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'captureAssets',
+              args: {},
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'Assets captured.' },
+                    { type: 'image-url', url: 'https://example.com/chart.png', mediaType: 'image/png' },
+                    {
+                      type: 'file-url',
+                      url: 'https://example.com/report.pdf',
+                      mediaType: 'application/pdf',
+                      filename: 'report.pdf',
+                    },
+                    { type: 'media', data: imageData, mediaType: 'image/jpeg' },
+                    { type: 'media', data: fileData, mediaType: 'application/pdf' },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const historyMessage = buildObserverHistoryMessage([msg]);
+      const content = historyMessage.content as any[];
+      const imageParts = content.filter(part => part.type === 'image');
+      const fileParts = content.filter(part => part.type === 'file');
+      const joinedText = content
+        .filter(part => part.type === 'text')
+        .map(part => part.text)
+        .join('\n');
+
+      expect(imageParts).toHaveLength(2);
+      expect(imageParts[0]).toMatchObject({
+        type: 'image',
+        image: 'https://example.com/chart.png',
+        mimeType: 'image/png',
+      });
+      expect(imageParts[1]).toMatchObject({
+        type: 'image',
+        image: `data:image/jpeg;base64,${imageData}`,
+        mimeType: 'image/jpeg',
+      });
+
+      expect(fileParts).toHaveLength(2);
+      expect(fileParts[0]).toMatchObject({
+        type: 'file',
+        data: 'https://example.com/report.pdf',
+        mimeType: 'application/pdf',
+        filename: 'report.pdf',
+      });
+      expect(fileParts[1]).toMatchObject({
+        type: 'file',
+        data: `data:application/pdf;base64,${fileData}`,
+        mimeType: 'application/pdf',
+      });
+
+      expect(joinedText).toContain('[Image #1: chart.png]');
+      expect(joinedText).toContain('[File #1: report.pdf]');
+      expect(joinedText).toContain('[Image #2: image/jpeg]');
+      expect(joinedText).toContain('[File #2: application/pdf]');
+      expect(joinedText).not.toContain(imageData);
+      expect(joinedText).not.toContain(fileData);
+    });
+
+    it('should hoist image-data without mediaType without leaking base64 into observer text', () => {
+      const base64 = 'G'.repeat(1500);
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'screenshot',
+              args: {},
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [{ type: 'image-data', data: base64 }],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const historyMessage = buildObserverHistoryMessage([msg]);
+      const content = historyMessage.content as any[];
+      const imageParts = content.filter(part => part.type === 'image');
+      const joinedText = content
+        .filter(part => part.type === 'text')
+        .map(part => part.text)
+        .join('\n');
+
+      expect(imageParts).toHaveLength(1);
+      expect(imageParts[0]).toMatchObject({ type: 'image', image: base64 });
+      expect(joinedText).toContain('[Image #1]');
+      expect(joinedText).not.toContain(base64);
+    });
+
     it('should share the image counter between user-attached and tool-result images', () => {
       const toolBase64 = 'D'.repeat(1500);
 

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1622,6 +1622,60 @@ describe('Observer Agent Helpers', () => {
       expect(joinedText).not.toContain(base64);
     });
 
+    it('should share the image counter between user-attached and tool-result images', () => {
+      const toolBase64 = 'D'.repeat(1500);
+
+      const userMsg = createTestMessage('ignored', 'user');
+      userMsg.content = {
+        format: 2,
+        parts: [
+          { type: 'text', text: 'Look at this.' },
+          { type: 'image', image: 'https://example.com/user-photo.png', mimeType: 'image/png' } as any,
+        ],
+      };
+
+      const toolMsg = createTestMessage('ignored', 'assistant');
+      toolMsg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'screenshot',
+              args: { url: 'https://example.com' },
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [{ type: 'image-data', data: toolBase64, mediaType: 'image/png' }],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const historyMessage = buildObserverHistoryMessage([userMsg, toolMsg]);
+      const content = historyMessage.content as any[];
+      const imageParts = content.filter(part => part.type === 'image');
+      const joinedText = content
+        .filter(part => part.type === 'text')
+        .map(part => part.text)
+        .join('\n');
+
+      expect(imageParts).toHaveLength(2);
+      expect(imageParts[0]).toMatchObject({ image: 'https://example.com/user-photo.png' });
+      expect(imageParts[1]).toMatchObject({ image: `data:image/png;base64,${toolBase64}` });
+
+      expect(joinedText).toContain('[Image #1: user-photo.png]');
+      expect(joinedText).toContain('[Image #2: image/png]');
+      expect(joinedText).not.toMatch(/\[Image #1: image\/png\]/);
+    });
+
     it('should reuse part-level date grouping without message separators', () => {
       const assistant = createTestMessage('ignored', 'assistant');
       assistant.createdAt = new Date('2024-12-04T10:30:00Z');

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1404,10 +1404,6 @@ describe('Observer Agent Helpers', () => {
       expect(formatted).not.toContain('x'.repeat(200));
     });
 
-    // Regression test for https://github.com/mastra-ai/mastra/issues/15883
-    // Tools that return AI SDK v5 image-data blocks via toModelOutput must not
-    // dump the base64 payload into the observer's text body — it blows the
-    // observer's context and causes degenerate output.
     it('should replace image-data tool-result blocks with attachment placeholders', () => {
       const base64 = 'A'.repeat(2000);
       const msg = createTestMessage('ignored', 'assistant');
@@ -1563,7 +1559,6 @@ describe('Observer Agent Helpers', () => {
       expect(content).not.toContainEqual(expect.objectContaining({ image: 'https://example.com/floorplan.pdf' }));
     });
 
-    // Regression test for https://github.com/mastra-ai/mastra/issues/15883
     it('should hoist image-data tool-result blocks into observer input attachments', () => {
       const base64 = 'B'.repeat(1500);
       const msg = createTestMessage('ignored', 'assistant');

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -695,6 +695,87 @@ function formatObserverAttachmentPlaceholder(part: ObserverAttachmentPart, count
   return label ? `[${attachmentType} #${attachmentId}: ${label}]` : `[${attachmentType} #${attachmentId}]`;
 }
 
+function mapToolResultBlockToAttachment(block: unknown): ObserverAttachmentPart | undefined {
+  if (!block || typeof block !== 'object') {
+    return undefined;
+  }
+
+  const record = block as Record<string, unknown>;
+  const type = record.type;
+  const mediaType = typeof record.mediaType === 'string' ? record.mediaType : undefined;
+  const filename = typeof record.filename === 'string' ? record.filename : undefined;
+
+  if (type === 'image-data') {
+    const data = record.data;
+    if (typeof data !== 'string') return undefined;
+    const image = mediaType ? `data:${mediaType};base64,${data}` : data;
+    return { type: 'image', image, mimeType: mediaType };
+  }
+
+  if (type === 'image-url') {
+    const url = record.url;
+    if (typeof url !== 'string') return undefined;
+    return { type: 'image', image: url, mimeType: mediaType };
+  }
+
+  if (type === 'media') {
+    const data = record.data;
+    if (typeof data !== 'string' || !mediaType) return undefined;
+    const dataUri = `data:${mediaType};base64,${data}`;
+    if (mediaType.toLowerCase().startsWith('image/')) {
+      return { type: 'image', image: dataUri, mimeType: mediaType };
+    }
+    return { type: 'file', data: dataUri, mimeType: mediaType };
+  }
+
+  if (type === 'file-data') {
+    const data = record.data;
+    if (typeof data !== 'string') return undefined;
+    const dataUri = mediaType ? `data:${mediaType};base64,${data}` : data;
+    return { type: 'file', data: dataUri, mimeType: mediaType, filename };
+  }
+
+  if (type === 'file-url') {
+    const url = record.url;
+    if (typeof url !== 'string') return undefined;
+    return { type: 'file', data: url, mimeType: mediaType, filename };
+  }
+
+  return undefined;
+}
+
+function extractToolResultAttachments(
+  result: unknown,
+  counter: ObserverAttachmentCounter,
+): { residual: unknown; attachments: ObserverInputAttachmentPart[] } {
+  if (!result || typeof result !== 'object') {
+    return { residual: result, attachments: [] };
+  }
+
+  const record = result as Record<string, unknown>;
+  if (record.type !== 'content' || !Array.isArray(record.value)) {
+    return { residual: result, attachments: [] };
+  }
+
+  const attachments: ObserverInputAttachmentPart[] = [];
+  const newValue = (record.value as unknown[]).map(block => {
+    const attachment = mapToolResultBlockToAttachment(block);
+    if (!attachment) {
+      return block;
+    }
+
+    attachments.push(toObserverInputAttachmentPart(attachment));
+    const placeholder = formatObserverAttachmentPlaceholder(attachment, counter);
+    return { type: (block as { type?: unknown }).type, placeholder };
+  });
+
+  if (attachments.length === 0) {
+    return { residual: result, attachments };
+  }
+
+  return { residual: { ...record, value: newValue }, attachments };
+}
+
 function formatObserverPartLine(title: string, body: string, time: string, previousTime?: string): string {
   const timeLabel = time && time !== previousTime ? `(${time})` : '';
 
@@ -823,9 +904,16 @@ function formatObserverMessage(
             part as { providerMetadata?: Record<string, any> },
             inv.result,
           );
+          const { residual, attachments: extractedAttachments } = extractToolResultAttachments(
+            resultForObserver,
+            counter,
+          );
+          if (extractedAttachments.length > 0) {
+            attachments.push(...extractedAttachments);
+          }
           pushLine(
             `Tool Result ${inv.toolName}`,
-            maybeTruncate(formatToolResultForObserver(resultForObserver, { maxTokens: maxToolResultTokens }), maxLen),
+            maybeTruncate(formatToolResultForObserver(residual, { maxTokens: maxToolResultTokens }), maxLen),
             partCreatedAt,
           );
           return;

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -695,67 +695,69 @@ function formatObserverAttachmentPlaceholder(part: ObserverAttachmentPart, count
   return label ? `[${attachmentType} #${attachmentId}: ${label}]` : `[${attachmentType} #${attachmentId}]`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object';
+}
+
 function mapToolResultBlockToAttachment(block: unknown): ObserverAttachmentPart | undefined {
-  if (!block || typeof block !== 'object') {
+  if (!isRecord(block) || typeof block.type !== 'string') {
     return undefined;
   }
 
-  const record = block as Record<string, unknown>;
-  const type = record.type;
-  const mediaType = typeof record.mediaType === 'string' ? record.mediaType : undefined;
-  const filename = typeof record.filename === 'string' ? record.filename : undefined;
+  const mediaType = typeof block.mediaType === 'string' ? block.mediaType : undefined;
+  const filename = typeof block.filename === 'string' ? block.filename : undefined;
 
-  if (type === 'image-data') {
-    const data = record.data;
-    if (typeof data !== 'string') return undefined;
-    const image = mediaType ? `data:${mediaType};base64,${data}` : data;
-    return { type: 'image', image, mimeType: mediaType };
-  }
-
-  if (type === 'image-url') {
-    const url = record.url;
-    if (typeof url !== 'string') return undefined;
-    return { type: 'image', image: url, mimeType: mediaType };
-  }
-
-  if (type === 'media') {
-    const data = record.data;
-    if (typeof data !== 'string' || !mediaType) return undefined;
-    const dataUri = `data:${mediaType};base64,${data}`;
-    if (mediaType.toLowerCase().startsWith('image/')) {
-      return { type: 'image', image: dataUri, mimeType: mediaType };
+  switch (block.type) {
+    case 'image-data': {
+      const data = block.data;
+      if (typeof data !== 'string') return undefined;
+      const image = mediaType ? `data:${mediaType};base64,${data}` : data;
+      return { type: 'image', image, mimeType: mediaType };
     }
-    return { type: 'file', data: dataUri, mimeType: mediaType };
-  }
 
-  if (type === 'file-data') {
-    const data = record.data;
-    if (typeof data !== 'string') return undefined;
-    const dataUri = mediaType ? `data:${mediaType};base64,${data}` : data;
-    return { type: 'file', data: dataUri, mimeType: mediaType, filename };
-  }
+    case 'image-url': {
+      const url = block.url;
+      if (typeof url !== 'string') return undefined;
+      return { type: 'image', image: url, mimeType: mediaType };
+    }
 
-  if (type === 'file-url') {
-    const url = record.url;
-    if (typeof url !== 'string') return undefined;
-    return { type: 'file', data: url, mimeType: mediaType, filename };
-  }
+    case 'media': {
+      const data = block.data;
+      if (typeof data !== 'string' || !mediaType) return undefined;
+      const dataUri = `data:${mediaType};base64,${data}`;
+      if (mediaType.toLowerCase().startsWith('image/')) {
+        return { type: 'image', image: dataUri, mimeType: mediaType };
+      }
+      return { type: 'file', data: dataUri, mimeType: mediaType };
+    }
 
-  return undefined;
+    case 'file-data': {
+      const data = block.data;
+      if (typeof data !== 'string') return undefined;
+      const dataUri = mediaType ? `data:${mediaType};base64,${data}` : data;
+      return { type: 'file', data: dataUri, mimeType: mediaType, filename };
+    }
+
+    case 'file-url': {
+      const url = block.url;
+      if (typeof url !== 'string') return undefined;
+      return { type: 'file', data: url, mimeType: mediaType, filename };
+    }
+
+    default:
+      return undefined;
+  }
 }
 
 function extractToolResultAttachments(
   result: unknown,
   counter: ObserverAttachmentCounter,
-): { residual: unknown; attachments: ObserverInputAttachmentPart[] } {
-  if (!result || typeof result !== 'object') {
-    return { residual: result, attachments: [] };
+): { resultWithoutAttachments: unknown; attachments: ObserverInputAttachmentPart[] } {
+  if (!isRecord(result) || result.type !== 'content' || !Array.isArray(result.value)) {
+    return { resultWithoutAttachments: result, attachments: [] };
   }
 
-  const record = result as Record<string, unknown>;
-  if (record.type !== 'content' || !Array.isArray(record.value)) {
-    return { residual: result, attachments: [] };
-  }
+  const record = result;
 
   const attachments: ObserverInputAttachmentPart[] = [];
   const newValue = (record.value as unknown[]).map(block => {
@@ -766,14 +768,14 @@ function extractToolResultAttachments(
 
     attachments.push(toObserverInputAttachmentPart(attachment));
     const placeholder = formatObserverAttachmentPlaceholder(attachment, counter);
-    return { type: (block as { type?: unknown }).type, placeholder };
+    return { type: isRecord(block) ? block.type : undefined, placeholder };
   });
 
   if (attachments.length === 0) {
-    return { residual: result, attachments };
+    return { resultWithoutAttachments: result, attachments };
   }
 
-  return { residual: { ...record, value: newValue }, attachments };
+  return { resultWithoutAttachments: { ...record, value: newValue }, attachments };
 }
 
 function formatObserverPartLine(title: string, body: string, time: string, previousTime?: string): string {
@@ -904,7 +906,7 @@ function formatObserverMessage(
             part as { providerMetadata?: Record<string, any> },
             inv.result,
           );
-          const { residual, attachments: extractedAttachments } = extractToolResultAttachments(
+          const { resultWithoutAttachments, attachments: extractedAttachments } = extractToolResultAttachments(
             resultForObserver,
             counter,
           );
@@ -913,7 +915,10 @@ function formatObserverMessage(
           }
           pushLine(
             `Tool Result ${inv.toolName}`,
-            maybeTruncate(formatToolResultForObserver(residual, { maxTokens: maxToolResultTokens }), maxLen),
+            maybeTruncate(
+              formatToolResultForObserver(resultWithoutAttachments, { maxTokens: maxToolResultTokens }),
+              maxLen,
+            ),
             partCreatedAt,
           );
           return;


### PR DESCRIPTION
## Description

Tools that return AI SDK v5 `image-data` content blocks via `toModelOutput` were having their base64 payloads stringified into the observational-memory observer's text prompt, blowing past token limits and producing degenerate observer output. This change extracts media blocks out of tool-result outputs and passes them to the observer as real attachments — mirroring the existing handling for user-side `image` and `file` message parts.

- Added `mapToolResultBlockToAttachment` to translate AI SDK v5 content blocks (`image-data`, `image-url`, `media`, `file-data`, `file-url`) into `ObserverAttachmentPart` form, building `data:<mediaType>;base64,<data>` URIs for inline blocks.
- Added `extractToolResultAttachments` which walks `{ type: 'content', value: [...] }` tool outputs, hoists media blocks as attachments, and replaces each block in the residual with `{ type, placeholder: '[Image #N: ...]' }` so the JSON-stringified body stays small and shape-stable.
- Wired the extractor into the `tool-invocation` result branch of `formatObserverMessage` so attachments flow through to `buildObserverHistoryMessage` alongside the existing image/file part path.
- Non-content outputs (`text`, `json`, `error-text`, `error-json`, `execution-denied`) and unknown block types (`image-file-id`, `file-id`, `custom`) pass through unchanged.
- Added three regression tests in `observational-memory.test.ts`: image-data block becomes a placeholder in `formatMessagesForObserver`, plain object tool results still serialize as JSON, and `buildObserverHistoryMessage` emits a real `{ type: 'image' }` attachment with the correct data URI and `mimeType`.

## Related Issue(s)

Fixes #15883

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Tools were embedding full images/files as huge text blobs, which made messages too large and broke prompts. This PR pulls those images/files out of the text and sends them as attachments, leaving small numbered placeholders in the text to keep order and context without the bloat.

## Overview

Detects AI SDK v5 content blocks inside tool-result outputs (image-data, image-url, media, file-data, file-url), hoists recognized media/file blocks into ObserverAttachmentPart entries, and for inline binary blocks builds data:<mediaType>;base64,<data> URIs. The extractor replaces the original blocks in the residual content with compact numbered placeholder blocks (e.g., { type, placeholder: '[Image #1: image/png]' }) so the JSON-stringified body stays small and shape-stable. The extractor is integrated into the tool-invocation result branch of formatObserverMessage so attachments flow into buildObserverHistoryMessage alongside existing user-attached image/file parts. Non-content outputs (text, json, error-text, error-json, execution-denied) and unknown/unsupported block types (image-file-id, file-id, custom) pass through unchanged.

## Key changes

- Added mapToolResultBlockToAttachment: translates content blocks into ObserverAttachmentPart (creates data: URIs for inline blocks).
- Added extractToolResultAttachments: walks content outputs ({ type: 'content', value: [...] }), hoists media/file blocks into attachments, and replaces them with numbered placeholder blocks in the residual content.
- Wired the extractor into formatObserverMessage/observer-agent so hoisted attachments are appended to message attachments and the textual "Tool Result …" parts contain placeholders instead of raw base64.
- Ensures image/file numbering counter is shared between user-attached parts and tool-result attachments so placeholders are sequential and stable.

## Tests

- Added regression tests in observational-memory.test.ts:
  - formatMessagesForObserver produces placeholders for image-data and ensures base64 does not appear in formatted text.
  - Plain-object tool results still serialize to JSON correctly.
  - buildObserverHistoryMessage emits { type: 'image' } attachments with correct data: URI and mimeType, and verifies shared numbering between user-attached and tool-result images.
  - Coverage includes image/file URL blocks, generic media blocks, and image-data without mediaType.

## Docs / Changeset

- .changeset entry describing the fix to prevent token-limit failures by hoisting media/file blocks into attachments and inserting placeholders in text.

## Issue resolved

Fixes #15883 — observational memory now delivers tool-produced image/file data as attachments with placeholder references in text, preventing token-limit overflows while preserving positional context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->