### PR TITLE
fix(editor): forward userId from request context to tool providers

### DIFF
--- a/.changeset/wicked-experts-care.md
+++ b/.changeset/wicked-experts-care.md
@@ -2,13 +2,4 @@
 '@mastra/editor': patch
 ---
 
-Fixed editor tool providers (Composio, Arcade) receiving a hardcoded 'default' userId. The userId is now read from `requestContext.get('userId')` and forwarded to `provider.resolveTools`, matching the documented behavior. Tool calls now scope correctly to the authenticated user.
-
-```typescript
-import { RequestContext } from '@mastra/core/request-context';
-
-const ctx = new RequestContext();
-ctx.set('userId', 'user-123');
-
-await agent.generate('list my repos', { requestContext: ctx });
-```
+Fixed `@mastra/editor` integrations (Composio, Arcade) collapsing every tool call onto a shared `'default'` user. Tools resolved during `agent.generate` now scope to the authenticated user from the request context, so per-user OAuth connections route to the correct account instead of a shared one.

--- a/.changeset/wicked-experts-care.md
+++ b/.changeset/wicked-experts-care.md
@@ -1,0 +1,14 @@
+---
+'@mastra/editor': patch
+---
+
+Fixed editor tool providers (Composio, Arcade) receiving a hardcoded 'default' userId. The userId is now read from `requestContext.get('userId')` and forwarded to `provider.resolveTools`, matching the documented behavior. Tool calls now scope correctly to the authenticated user.
+
+```typescript
+import { RequestContext } from '@mastra/core/request-context';
+
+const ctx = new RequestContext();
+ctx.set('userId', 'user-123');
+
+await agent.generate('list my repos', { requestContext: ctx });
+```

--- a/.changeset/wicked-experts-care.md
+++ b/.changeset/wicked-experts-care.md
@@ -2,4 +2,4 @@
 '@mastra/editor': patch
 ---
 
-Fixed `@mastra/editor` integrations (Composio, Arcade) collapsing every tool call onto a shared `'default'` user. Tools resolved during `agent.generate` now scope to the authenticated user from the request context, so per-user OAuth connections route to the correct account instead of a shared one.
+Fixed `@mastra/editor` integrations (Composio, Arcade) collapsing every tool call onto a shared `'default'` user. Tools resolved during `agent.generate` now scope to the authenticated resource from the request context, so per-user OAuth connections route to the correct account instead of a shared one.

--- a/docs/src/content/en/docs/editor/tools.mdx
+++ b/docs/src/content/en/docs/editor/tools.mdx
@@ -81,7 +81,7 @@ Integration providers connect external tool platforms to the editor. Once regist
    })
    ```
 
-   Composio tool slugs use a format like `GITHUB_CREATE_ISSUE`. Tool calls are scoped to a `userId` passed through request context for per-user authentication.
+   Composio tool slugs use a format like `GITHUB_CREATE_ISSUE`. Tool calls are scoped to the `resourceId` passed through request context for per-user authentication.
 
 ### Arcade
 

--- a/docs/src/content/en/reference/editor/tool-provider.mdx
+++ b/docs/src/content/en/reference/editor/tool-provider.mdx
@@ -36,7 +36,7 @@ Tool providers implement these methods:
     name: 'resolveTools(slugs, options?)',
     type: '(slugs: string[], options?) => Promise<Record<string, ToolAction>>',
     description:
-      'Resolves tool slugs into executable Mastra tool actions. The options object can include userId for per-user authentication.',
+      'Resolves tool slugs into executable Mastra tool actions. Built-in providers use resourceId from request context for per-user authentication.',
   },
 ]}
 />
@@ -80,7 +80,7 @@ Composio tools use uppercase slug format: `GITHUB_CREATE_ISSUE`, `SLACK_SEND_MES
 
 ### Authentication
 
-Tool execution is scoped to a `userId` passed through request context. Each user authenticates with the integration separately through Composio's auth flow.
+Tool execution is scoped to the `resourceId` passed through request context. The provider maps that value to the user identity required by Composio's auth flow.
 
 ---
 
@@ -127,4 +127,4 @@ Arcade tools use `Toolkit.ToolName` format: `Github.GetRepository`, `Slack.SendM
 
 ### Authentication
 
-Like Composio, tool execution requires a `userId` for per-user authorization through Arcade's auth flow.
+Like Composio, tool execution uses `resourceId` from request context for per-user authorization. The provider maps that value to the user identity required by Arcade's auth flow.

--- a/packages/editor/src/editor-integration-tools.test.ts
+++ b/packages/editor/src/editor-integration-tools.test.ts
@@ -12,11 +12,12 @@ import type {
 } from '@mastra/core/tool-provider';
 import type { StorageToolConfig } from '@mastra/core/storage';
 import type { ToolAction } from '@mastra/core/tools';
-import { RequestContext } from '@mastra/core/request-context';
+import { MASTRA_RESOURCE_ID_KEY, RequestContext } from '@mastra/core/request-context';
 import { LibSQLStore } from '@mastra/libsql';
 import { MastraEditor } from './index';
 import { ComposioToolProvider } from './providers/composio';
 import { ArcadeToolProvider } from './providers/arcade';
+import { getProviderUserId } from './providers/identity';
 
 /**
  * A mock tool provider for tests. Implements the full ToolProvider interface.
@@ -171,7 +172,7 @@ describe('Integration Tools (tool providers)', () => {
           GITHUB_CREATE_ISSUE: {},
           SLACK_SEND_MESSAGE: {},
         }),
-        { requestContext: {}, userId: undefined },
+        { requestContext: {} },
       );
     });
 
@@ -248,7 +249,7 @@ describe('Integration Tools (tool providers)', () => {
       expect(mockProvider.resolveTools).toHaveBeenCalledWith(
         expect.arrayContaining(['GITHUB_CREATE_ISSUE', 'GITHUB_LIST_REPOS', 'SLACK_SEND_MESSAGE']),
         {},
-        { requestContext: {}, userId: undefined },
+        { requestContext: {} },
       );
       // All 3 tools should be resolved
       expect(Object.keys(tools).length).toBe(3);
@@ -366,12 +367,12 @@ describe('Integration Tools (tool providers)', () => {
       expect(tools['JIRA_CREATE_TICKET']).toBeDefined();
     });
 
-    it('should forward userId from request context to the tool provider', async () => {
+    it('should forward request context to the tool provider for resource-scoped identity resolution', async () => {
       const agentsStore = await storage.getStore('agents');
       await agentsStore?.create({
         agent: {
-          id: 'agent-userid-forwarding',
-          name: 'UserId Forwarding Agent',
+          id: 'agent-request-context-forwarding',
+          name: 'Request Context Forwarding Agent',
           instructions: 'Test',
           model: { provider: 'openai', name: 'gpt-4' },
           integrationTools: {
@@ -382,12 +383,12 @@ describe('Integration Tools (tool providers)', () => {
         },
       });
 
-      const agent = await editor.agent.getById('agent-userid-forwarding');
+      const agent = await editor.agent.getById('agent-request-context-forwarding');
       expect(agent).toBeInstanceOf(Agent);
 
       await agent!.listTools({
         requestContext: new RequestContext([
-          ['userId', 'user-42'],
+          [MASTRA_RESOURCE_ID_KEY, 'resource-42'],
           ['tier', 'premium'],
         ]),
       });
@@ -396,10 +397,43 @@ describe('Integration Tools (tool providers)', () => {
         expect.arrayContaining(['GITHUB_CREATE_ISSUE']),
         expect.any(Object),
         expect.objectContaining({
-          userId: 'user-42',
-          requestContext: expect.objectContaining({ userId: 'user-42', tier: 'premium' }),
+          requestContext: expect.objectContaining({
+            [MASTRA_RESOURCE_ID_KEY]: 'resource-42',
+            tier: 'premium',
+          }),
         }),
       );
+    });
+  });
+
+  describe('Tool provider identity resolution', () => {
+    it('should prefer Mastra resource identity from request context for provider SDK userId', () => {
+      expect(
+        getProviderUserId({
+          requestContext: {
+            [MASTRA_RESOURCE_ID_KEY]: 'auth-resource',
+            resourceId: 'plain-resource',
+            userId: 'legacy-user',
+          },
+          userId: 'explicit-user',
+        }),
+      ).toBe('auth-resource');
+
+      expect(
+        getProviderUserId({
+          requestContext: {
+            resourceId: 'plain-resource',
+            userId: 'legacy-user',
+          },
+          userId: 'explicit-user',
+        }),
+      ).toBe('plain-resource');
+    });
+
+    it('should keep backwards-compatible userId and default fallbacks', () => {
+      expect(getProviderUserId({ requestContext: { userId: 'legacy-user' } })).toBe('legacy-user');
+      expect(getProviderUserId({ userId: 'explicit-user' })).toBe('explicit-user');
+      expect(getProviderUserId()).toBe('default');
     });
   });
 

--- a/packages/editor/src/editor-integration-tools.test.ts
+++ b/packages/editor/src/editor-integration-tools.test.ts
@@ -405,7 +405,6 @@ describe('Integration Tools (tool providers)', () => {
     });
   });
 
-
   describe.skipIf(!process.env.COMPOSIO_API_KEY)(
     'ComposioToolProvider e2e (real API, requires COMPOSIO_API_KEY)',
     () => {

--- a/packages/editor/src/editor-integration-tools.test.ts
+++ b/packages/editor/src/editor-integration-tools.test.ts
@@ -17,7 +17,6 @@ import { LibSQLStore } from '@mastra/libsql';
 import { MastraEditor } from './index';
 import { ComposioToolProvider } from './providers/composio';
 import { ArcadeToolProvider } from './providers/arcade';
-import { getProviderUserId } from './providers/identity';
 
 /**
  * A mock tool provider for tests. Implements the full ToolProvider interface.
@@ -406,21 +405,6 @@ describe('Integration Tools (tool providers)', () => {
     });
   });
 
-  describe('Tool provider identity resolution', () => {
-    it('should prefer Mastra resource identity from request context over options.userId', () => {
-      expect(
-        getProviderUserId({
-          requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'auth-resource' },
-          userId: 'explicit-user',
-        }),
-      ).toBe('auth-resource');
-    });
-
-    it('should fall back to options.userId, then "default"', () => {
-      expect(getProviderUserId({ userId: 'explicit-user' })).toBe('explicit-user');
-      expect(getProviderUserId()).toBe('default');
-    });
-  });
 
   describe.skipIf(!process.env.COMPOSIO_API_KEY)(
     'ComposioToolProvider e2e (real API, requires COMPOSIO_API_KEY)',

--- a/packages/editor/src/editor-integration-tools.test.ts
+++ b/packages/editor/src/editor-integration-tools.test.ts
@@ -171,7 +171,7 @@ describe('Integration Tools (tool providers)', () => {
           GITHUB_CREATE_ISSUE: {},
           SLACK_SEND_MESSAGE: {},
         }),
-        { requestContext: undefined },
+        { requestContext: {}, userId: undefined },
       );
     });
 
@@ -248,7 +248,7 @@ describe('Integration Tools (tool providers)', () => {
       expect(mockProvider.resolveTools).toHaveBeenCalledWith(
         expect.arrayContaining(['GITHUB_CREATE_ISSUE', 'GITHUB_LIST_REPOS', 'SLACK_SEND_MESSAGE']),
         {},
-        { requestContext: undefined },
+        { requestContext: {}, userId: undefined },
       );
       // All 3 tools should be resolved
       expect(Object.keys(tools).length).toBe(3);
@@ -287,6 +287,7 @@ describe('Integration Tools (tool providers)', () => {
 
       const agent = await editorWithLogger.agent.getById('agent-missing-provider');
       expect(agent).toBeInstanceOf(Agent);
+      await agent!.listTools();
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('nonexistent_provider'));
     });
 
@@ -363,6 +364,42 @@ describe('Integration Tools (tool providers)', () => {
 
       expect(tools['GITHUB_CREATE_ISSUE']).toBeDefined();
       expect(tools['JIRA_CREATE_TICKET']).toBeDefined();
+    });
+
+    it('should forward userId from request context to the tool provider', async () => {
+      const agentsStore = await storage.getStore('agents');
+      await agentsStore?.create({
+        agent: {
+          id: 'agent-userid-forwarding',
+          name: 'UserId Forwarding Agent',
+          instructions: 'Test',
+          model: { provider: 'openai', name: 'gpt-4' },
+          integrationTools: {
+            composio: {
+              tools: { GITHUB_CREATE_ISSUE: {} },
+            },
+          },
+        },
+      });
+
+      const agent = await editor.agent.getById('agent-userid-forwarding');
+      expect(agent).toBeInstanceOf(Agent);
+
+      await agent!.listTools({
+        requestContext: new RequestContext([
+          ['userId', 'user-42'],
+          ['tier', 'premium'],
+        ]),
+      });
+
+      expect(mockProvider.resolveTools).toHaveBeenCalledWith(
+        expect.arrayContaining(['GITHUB_CREATE_ISSUE']),
+        expect.any(Object),
+        expect.objectContaining({
+          userId: 'user-42',
+          requestContext: expect.objectContaining({ userId: 'user-42', tier: 'premium' }),
+        }),
+      );
     });
   });
 

--- a/packages/editor/src/editor-integration-tools.test.ts
+++ b/packages/editor/src/editor-integration-tools.test.ts
@@ -407,31 +407,16 @@ describe('Integration Tools (tool providers)', () => {
   });
 
   describe('Tool provider identity resolution', () => {
-    it('should prefer Mastra resource identity from request context for provider SDK userId', () => {
+    it('should prefer Mastra resource identity from request context over options.userId', () => {
       expect(
         getProviderUserId({
-          requestContext: {
-            [MASTRA_RESOURCE_ID_KEY]: 'auth-resource',
-            resourceId: 'plain-resource',
-            userId: 'legacy-user',
-          },
+          requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'auth-resource' },
           userId: 'explicit-user',
         }),
       ).toBe('auth-resource');
-
-      expect(
-        getProviderUserId({
-          requestContext: {
-            resourceId: 'plain-resource',
-            userId: 'legacy-user',
-          },
-          userId: 'explicit-user',
-        }),
-      ).toBe('plain-resource');
     });
 
-    it('should keep backwards-compatible userId and default fallbacks', () => {
-      expect(getProviderUserId({ requestContext: { userId: 'legacy-user' } })).toBe('legacy-user');
+    it('should fall back to options.userId, then "default"', () => {
       expect(getProviderUserId({ userId: 'explicit-user' })).toBe('explicit-user');
       expect(getProviderUserId()).toBe('default');
     });

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -284,7 +284,6 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
         );
         const integrationTools = await this.resolveStoredIntegrationTools(
           storedConfig.integrationTools as Record<string, StorageMCPClientToolsConfig> | undefined,
-          requestContext,
         );
         fork.__setTools({ ...codeTools, ...registryTools, ...mcpTools, ...integrationTools });
       }

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -890,8 +890,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
 
     const allTools: Record<string, ToolAction<any, any, any, any, any, any>> = {};
 
-    const userId = requestContext?.get('userId') as string | undefined;
-    const providerOptions = { requestContext: requestContext?.toJSON(), userId };
+    const providerOptions = { requestContext: requestContext?.toJSON() };
 
     for (const [providerId, providerConfig] of Object.entries(integrationTools)) {
       try {

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -230,7 +230,8 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
         storedConfig.mcpClients != null && this.isConditionalVariants(storedConfig.mcpClients);
       const hasConditionalIntegrationTools =
         storedConfig.integrationTools != null && this.isConditionalVariants(storedConfig.integrationTools);
-      const isDynamicTools = hasConditionalTools || hasConditionalMCPClients || hasConditionalIntegrationTools;
+      const isDynamicTools =
+        hasConditionalTools || hasConditionalMCPClients || hasConditionalIntegrationTools || hasStoredIntegrationTools;
 
       if (isDynamicTools) {
         // Wrap in a dynamic function that merges at request time
@@ -263,7 +264,10 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
                 ctx,
               )
             : (storedConfig!.integrationTools as Record<string, StorageMCPClientToolsConfig> | undefined);
-          const integrationTools = await this.resolveStoredIntegrationTools(resolvedIntegrationToolsConfig, ctx);
+          const integrationTools = await this.resolveStoredIntegrationTools(
+            resolvedIntegrationToolsConfig,
+            requestContext,
+          );
 
           return { ...codeTools, ...registryTools, ...mcpTools, ...integrationTools };
         };
@@ -280,6 +284,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
         );
         const integrationTools = await this.resolveStoredIntegrationTools(
           storedConfig.integrationTools as Record<string, StorageMCPClientToolsConfig> | undefined,
+          requestContext,
         );
         fork.__setTools({ ...codeTools, ...registryTools, ...mcpTools, ...integrationTools });
       }
@@ -381,7 +386,9 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
 
     // Tools: registry tools, MCP client tools, and integration tools can each be conditional.
     // If any is conditional, the combined result must be a dynamic function.
-    const isDynamicTools = hasConditionalTools || hasConditionalMCPClients || hasConditionalIntegrationTools;
+    const hasIntegrationTools = storedAgent.integrationTools != null;
+    const isDynamicTools =
+      hasConditionalTools || hasConditionalMCPClients || hasConditionalIntegrationTools || hasIntegrationTools;
 
     let tools:
       | Record<string, ToolAction<any, any, any, any, any, any>>
@@ -421,7 +428,10 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
               ctx,
             )
           : (storedAgent.integrationTools as Record<string, StorageMCPClientToolsConfig> | undefined);
-        const integrationTools = await this.resolveStoredIntegrationTools(resolvedIntegrationToolsConfig, ctx);
+        const integrationTools = await this.resolveStoredIntegrationTools(
+          resolvedIntegrationToolsConfig,
+          requestContext,
+        );
 
         return { ...registryTools, ...mcpTools, ...integrationTools };
       };
@@ -874,11 +884,14 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
    */
   private async resolveStoredIntegrationTools(
     integrationTools?: Record<string, StorageMCPClientToolsConfig>,
-    requestContext?: Record<string, unknown>,
+    requestContext?: RequestContext,
   ): Promise<Record<string, ToolAction<any, any, any, any, any, any>>> {
     if (!integrationTools || Object.keys(integrationTools).length === 0) return {};
 
     const allTools: Record<string, ToolAction<any, any, any, any, any, any>> = {};
+
+    const userId = requestContext?.get('userId') as string | undefined;
+    const providerOptions = { requestContext: requestContext?.toJSON(), userId };
 
     for (const [providerId, providerConfig] of Object.entries(integrationTools)) {
       try {
@@ -906,7 +919,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
         }
 
         // Fetch tools from the provider — pass slugs, configs, and request context
-        const providerTools = await provider.resolveTools(slugsToResolve, providerConfig.tools, { requestContext });
+        const providerTools = await provider.resolveTools(slugsToResolve, providerConfig.tools, providerOptions);
 
         for (const [toolId, tool] of Object.entries(providerTools)) {
           // Apply description override if configured at the agent level

--- a/packages/editor/src/providers/arcade.ts
+++ b/packages/editor/src/providers/arcade.ts
@@ -309,8 +309,8 @@ export class ArcadeToolProvider implements ToolProvider {
     if (toolSlugs.length === 0) return {};
 
     const client = this.getClient();
-    const userId =
-      (options?.requestContext?.[MASTRA_RESOURCE_ID_KEY] as string | undefined) ?? options?.userId ?? 'default';
+    const resourceId = options?.requestContext?.[MASTRA_RESOURCE_ID_KEY];
+    const userId = typeof resourceId === 'string' ? resourceId : (options?.userId ?? 'default');
 
     // Fetch tool definitions for the requested slugs
     const toolDefs = await Promise.all(toolSlugs.map(slug => client.tools.get(slug).catch(() => null)));

--- a/packages/editor/src/providers/arcade.ts
+++ b/packages/editor/src/providers/arcade.ts
@@ -9,6 +9,7 @@ import type {
 } from '@mastra/core/tool-provider';
 import type { ToolAction } from '@mastra/core/tools';
 import type { StorageToolConfig } from '@mastra/core/storage';
+import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
 
 import { Arcade } from '@arcadeai/arcadejs';
 import type {
@@ -18,7 +19,6 @@ import type {
 } from '@arcadeai/arcadejs/resources';
 import { toZodToolSet, executeOrAuthorizeZodTool } from '@arcadeai/arcadejs/lib/index';
 import type { ZodTool, ToolAuthorizationResponse } from '@arcadeai/arcadejs/lib/index';
-import { getProviderUserId } from './identity';
 
 export interface ArcadeToolProviderConfig {
   /** Arcade AI API key */
@@ -309,7 +309,8 @@ export class ArcadeToolProvider implements ToolProvider {
     if (toolSlugs.length === 0) return {};
 
     const client = this.getClient();
-    const userId = getProviderUserId(options);
+    const userId =
+      (options?.requestContext?.[MASTRA_RESOURCE_ID_KEY] as string | undefined) ?? options?.userId ?? 'default';
 
     // Fetch tool definitions for the requested slugs
     const toolDefs = await Promise.all(toolSlugs.map(slug => client.tools.get(slug).catch(() => null)));

--- a/packages/editor/src/providers/arcade.ts
+++ b/packages/editor/src/providers/arcade.ts
@@ -18,6 +18,7 @@ import type {
 } from '@arcadeai/arcadejs/resources';
 import { toZodToolSet, executeOrAuthorizeZodTool } from '@arcadeai/arcadejs/lib/index';
 import type { ZodTool, ToolAuthorizationResponse } from '@arcadeai/arcadejs/lib/index';
+import { getProviderUserId } from './identity';
 
 export interface ArcadeToolProviderConfig {
   /** Arcade AI API key */
@@ -308,7 +309,7 @@ export class ArcadeToolProvider implements ToolProvider {
     if (toolSlugs.length === 0) return {};
 
     const client = this.getClient();
-    const userId = (options?.userId as string) ?? 'default';
+    const userId = getProviderUserId(options);
 
     // Fetch tool definitions for the requested slugs
     const toolDefs = await Promise.all(toolSlugs.map(slug => client.tools.get(slug).catch(() => null)));

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -14,6 +14,7 @@ import { Composio } from '@composio/core';
 import type { Tool as ComposioTool, ToolKitItem, ToolListParams as ComposioToolListParams } from '@composio/core';
 import { MastraProvider } from '@composio/mastra';
 import type { MastraTool, MastraToolCollection } from '@composio/mastra';
+import { getProviderUserId } from './identity';
 
 export interface ComposioToolProviderConfig {
   /** Composio API key */
@@ -153,7 +154,7 @@ export class ComposioToolProvider implements ToolProvider {
   ): Promise<Record<string, ToolAction<unknown, unknown>>> {
     if (toolSlugs.length === 0) return {};
 
-    const userId = options?.userId ?? 'default';
+    const userId = getProviderUserId(options);
     const composio = this.getMastraClient();
 
     // composio.tools.get returns MastraToolCollection = Record<string, MastraTool>

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -154,8 +154,8 @@ export class ComposioToolProvider implements ToolProvider {
   ): Promise<Record<string, ToolAction<unknown, unknown>>> {
     if (toolSlugs.length === 0) return {};
 
-    const userId =
-      (options?.requestContext?.[MASTRA_RESOURCE_ID_KEY] as string | undefined) ?? options?.userId ?? 'default';
+    const resourceId = options?.requestContext?.[MASTRA_RESOURCE_ID_KEY];
+    const userId = typeof resourceId === 'string' ? resourceId : (options?.userId ?? 'default');
     const composio = this.getMastraClient();
 
     // composio.tools.get returns MastraToolCollection = Record<string, MastraTool>

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -9,12 +9,12 @@ import type {
 } from '@mastra/core/tool-provider';
 import type { ToolAction } from '@mastra/core/tools';
 import type { StorageToolConfig } from '@mastra/core/storage';
+import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
 
 import { Composio } from '@composio/core';
 import type { Tool as ComposioTool, ToolKitItem, ToolListParams as ComposioToolListParams } from '@composio/core';
 import { MastraProvider } from '@composio/mastra';
 import type { MastraTool, MastraToolCollection } from '@composio/mastra';
-import { getProviderUserId } from './identity';
 
 export interface ComposioToolProviderConfig {
   /** Composio API key */
@@ -154,7 +154,8 @@ export class ComposioToolProvider implements ToolProvider {
   ): Promise<Record<string, ToolAction<unknown, unknown>>> {
     if (toolSlugs.length === 0) return {};
 
-    const userId = getProviderUserId(options);
+    const userId =
+      (options?.requestContext?.[MASTRA_RESOURCE_ID_KEY] as string | undefined) ?? options?.userId ?? 'default';
     const composio = this.getMastraClient();
 
     // composio.tools.get returns MastraToolCollection = Record<string, MastraTool>

--- a/packages/editor/src/providers/identity.ts
+++ b/packages/editor/src/providers/identity.ts
@@ -2,10 +2,6 @@ import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
 import type { ResolveToolProviderToolsOptions } from '@mastra/core/tool-provider';
 
 export function getProviderUserId(options?: ResolveToolProviderToolsOptions): string {
-  const requestContext = options?.requestContext;
-  const resourceId =
-    (requestContext?.[MASTRA_RESOURCE_ID_KEY] as string | undefined) ??
-    (requestContext?.resourceId as string | undefined);
-
-  return resourceId ?? options?.userId ?? (requestContext?.userId as string | undefined) ?? 'default';
+  const resourceId = options?.requestContext?.[MASTRA_RESOURCE_ID_KEY] as string | undefined;
+  return resourceId ?? options?.userId ?? 'default';
 }

--- a/packages/editor/src/providers/identity.ts
+++ b/packages/editor/src/providers/identity.ts
@@ -1,0 +1,11 @@
+import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
+import type { ResolveToolProviderToolsOptions } from '@mastra/core/tool-provider';
+
+export function getProviderUserId(options?: ResolveToolProviderToolsOptions): string {
+  const requestContext = options?.requestContext;
+  const resourceId =
+    (requestContext?.[MASTRA_RESOURCE_ID_KEY] as string | undefined) ??
+    (requestContext?.resourceId as string | undefined);
+
+  return resourceId ?? options?.userId ?? (requestContext?.userId as string | undefined) ?? 'default';
+}

--- a/packages/editor/src/providers/identity.ts
+++ b/packages/editor/src/providers/identity.ts
@@ -1,7 +1,0 @@
-import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
-import type { ResolveToolProviderToolsOptions } from '@mastra/core/tool-provider';
-
-export function getProviderUserId(options?: ResolveToolProviderToolsOptions): string {
-  const resourceId = options?.requestContext?.[MASTRA_RESOURCE_ID_KEY] as string | undefined;
-  return resourceId ?? options?.userId ?? 'default';
-}


### PR DESCRIPTION
## Description

Editor tool providers (Composio, Arcade) were receiving a hardcoded `'default'` userId because the agent hydration path passed only `requestContext` to `provider.resolveTools`, never extracting `userId` from it. Per-user OAuth scoping silently broke for every stored agent using `integrationTools`. This PR forwards `userId` from `requestContext.get('userId')` to providers, matching the documented behavior in `docs/src/content/en/docs/editor/tools.mdx`.

- `resolveStoredIntegrationTools` now accepts `RequestContext` (matching `resolveStoredMCPTools`) and pulls `userId` from it once before the provider loop.
- Passes `{ requestContext: requestContext.toJSON(), userId }` to `provider.resolveTools` so both the top-level `userId` field and the JSONified context reach Composio/Arcade.
- Integration tools are forced through the dynamic resolution path (`isDynamicTools` gate now includes `hasIntegrationTools`). Without this, purely-stored agents bake integration tools at creation time with no `requestContext`, so `userId` would still default to `'default'` for the most common case.
- All four call sites pass the `RequestContext` through, including the previously-missing pass at the `applyStoredOverrides` static branch.

### Usage

```typescript
import { RequestContext } from '@mastra/core/request-context';

const ctx = new RequestContext();
ctx.set('userId', 'user-123');

await agent.generate('list my repos', { requestContext: ctx });
```

## Related Issue(s)

Fixes #16120

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes a bug where all users' tool calls (like Composio and Arcade integrations) were incorrectly routed to a shared 'default' user account instead of each user's own account. The fix passes the authenticated user's ID from the request context through to the tool providers, so each user's OAuth connections work correctly.

## Problem

Editor tool providers (Composio and Arcade) were receiving a hardcoded `'default'` userId when resolving tools during agent execution. This caused all tool calls to be scoped to a shared account rather than the authenticated user's account, breaking per-user OAuth scoping for integrations.

## Solution

The PR forwards `userId` from the request context through the entire tool resolution chain:

- **`resolveStoredIntegrationTools` refactor**: Now accepts a `RequestContext` parameter (matching the pattern of `resolveStoredMCPTools`), extracts the `userId` once before iterating through providers, and passes it along with the full request context to each provider's `resolveTools` call.

- **Dynamic resolution enforcement**: Integration tools are now always treated as "dynamic" (resolved at request-time rather than agent-creation time) whenever `integrationTools` are present, ensuring they have access to the request context with the authenticated user.

- **Provider-level identity resolution**: Both `ComposioToolProvider` and `ArcadeToolProvider` now check for `resourceId` in the request context first (`MASTRA_RESOURCE_ID_KEY`), fall back to `options.userId`, and finally default to `'default'` if neither is available.

- **Comprehensive call-site updates**: All four call sites that invoke `resolveStoredIntegrationTools` now pass the full `RequestContext`, including the previously-missing pass in the `applyStoredOverrides` static branch.

## Changes Made

**Core Logic** (`packages/editor/src/namespaces/agent.ts`):
- `resolveStoredIntegrationTools` now accepts an optional `RequestContext` parameter
- Integration tools are treated as dynamic whenever `hasIntegrationTools` is true
- Providers receive both the JSONified context and the extracted `userId` in options

**Provider Integration** (`packages/editor/src/providers/`):
- `composio.ts`: Updated to read `userId` from `requestContext[MASTRA_RESOURCE_ID_KEY]` with fallbacks
- `arcade.ts`: Updated with the same identity resolution strategy

**Testing** (`packages/editor/src/editor-integration-tools.test.ts`):
- Updated existing tests to expect `requestContext: {}` instead of `undefined`
- Added new test verifying that `agent.listTools({ requestContext })` properly forwards the context to tool providers for resource-scoped identity resolution
- Updated warning test to explicitly call `agent.listTools()`

**Documentation**:
- Updated Composio and ToolProvider documentation to reflect that tool scoping uses `resourceId` from request context instead of a top-level `userId`

**Release** (`.changeset/wicked-experts-care.md`):
- Added patch changeset for `@mastra/editor` documenting the fix

## Outcome

Editor tool integrations now correctly scope tool execution to the authenticated user from the request context, enabling proper per-user OAuth connections for multi-tenant deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->