### PR TITLE
fix: preserve text when filtering tool-only parts

### DIFF
--- a/packages/core/src/processors/processors/tool-call-filter.test.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.test.ts
@@ -121,6 +121,50 @@ describe('ToolCallFilter', () => {
       }
     });
 
+    it('should preserve top-level text when all tool parts are filtered', async () => {
+      const filter = new ToolCallFilter();
+
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'assistant-with-text-fallback',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: 'I found three relevant papers.',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'search_papers',
+                  args: { query: 'attention mechanisms' },
+                  result: { papers: ['paper-1', 'paper-2', 'paper-3'] },
+                },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      expect(resultMessages).toHaveLength(1);
+      expect(resultMessages[0]!.content).toMatchObject({
+        content: 'I found three relevant papers.',
+        parts: [],
+      });
+    });
+
     it('should handle messages without tool calls', async () => {
       const filter = new ToolCallFilter();
 
@@ -313,6 +357,50 @@ describe('ToolCallFilter', () => {
   });
 
   describe('exclude specific tool calls', () => {
+    it('should preserve top-level text when all excluded tool parts are filtered', async () => {
+      const filter = new ToolCallFilter({ exclude: ['search_papers'] });
+
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'assistant-with-specific-text-fallback',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: 'I found three relevant papers.',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'search_papers',
+                  args: { query: 'attention mechanisms' },
+                  result: { papers: ['paper-1', 'paper-2', 'paper-3'] },
+                },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      expect(resultMessages).toHaveLength(1);
+      expect(resultMessages[0]!.content).toMatchObject({
+        content: 'I found three relevant papers.',
+        parts: [],
+      });
+    });
+
     it('should exclude only specified tool calls', async () => {
       const filter = new ToolCallFilter({ exclude: ['weather'] });
 

--- a/packages/core/src/processors/processors/tool-call-filter.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.ts
@@ -152,10 +152,6 @@ export class ToolCallFilter implements Processor {
           return preserveToolCallIds.has(part.toolInvocation?.toolCallId ?? part.toolInvocation?.toolCall?.id);
         });
 
-        if (nonToolParts.length === 0) {
-          return null;
-        }
-
         const { toolInvocations: originalToolInvocations, ...contentWithoutToolInvocations } = message.content as any;
         const updatedContent: any = {
           ...contentWithoutToolInvocations,
@@ -169,6 +165,13 @@ export class ToolCallFilter implements Processor {
           if (preservedToolInvocations.length > 0) {
             updatedContent.toolInvocations = preservedToolInvocations;
           }
+        }
+
+        const hasNoToolParts = nonToolParts.length === 0;
+        const hasNoTextContent = !updatedContent.content || updatedContent.content.trim() === '';
+
+        if (hasNoToolParts && hasNoTextContent) {
+          return null;
         }
 
         return {
@@ -237,10 +240,6 @@ export class ToolCallFilter implements Processor {
 
           return true;
         });
-
-        if (filteredParts.length === 0) {
-          return null;
-        }
 
         const { toolInvocations: originalToolInvocations, ...contentWithoutToolInvocations } = message.content as any;
         const updatedContent: any = {


### PR DESCRIPTION
## Summary
- keep messages with top-level text content after `ToolCallFilter` removes all tool-invocation parts
- cover both default all-tool filtering and named-tool filtering paths

Fixes #16052

## Validation
- `git diff --check`
- `corepack pnpm --filter ./packages/core test:unit src/processors/processors/tool-call-filter.test.ts` could not run in the fresh clone because dependencies are not installed (`vitest` not found)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Summary
When a message contains some spoken text and some tool instructions, a filter was accidentally throwing away the entire message if all the tool parts got filtered out. This fix makes sure the spoken text stays in the message even if all the tools get removed.

## Changes

### Implementation (`tool-call-filter.ts`)
Modified `ToolCallFilter` to preserve messages containing top-level text content when all tool-invocation parts are filtered out:

- **`filterAllToolCalls` method**: Changed the early return condition from `if (nonToolParts.length === 0) return null` to only return `null` when both there are no non-tool parts AND no text content exists. This ensures messages with text fallback are preserved.
- **`filterSpecificToolCalls` method**: Removed the early return `if (filteredParts.length === 0) return null`, allowing the existing downstream logic (`hasNoToolParts && hasNoTextContent`) to determine whether to discard the message. This ensures text-only messages survive filtering.

### Tests (`tool-call-filter.test.ts`)
Added comprehensive test coverage with two new Vitest cases:
1. Default behavior: verifies `ToolCallFilter` preserves top-level text content while filtering all tool-invocation parts, resulting in empty `parts` array
2. Named tool filtering: verifies the same preservation behavior when excluding specific tool names via the `exclude` parameter

Both tests assert that resulting messages retain expected text content and confirm `parts` becomes an empty array when all tool-related content is removed.

## Related Issue
Fixes #16052 – `ToolCallFilter` was incorrectly dropping assistant messages that had top-level text content (`content.content`) but whose `content.parts` consisted entirely of tool-invocation parts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->