### PR TITLE
fix(mcp): support Zod coercion for MCP tool schemas on edge runtimes

### DIFF
--- a/.changeset/shaky-clubs-show.md
+++ b/.changeset/shaky-clubs-show.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': minor
+---
+
+Added an MCP client option to convert MCP tool input schemas to Zod so edge runtimes can avoid AJV code generation during tool input validation.

--- a/.changeset/shaky-clubs-show.md
+++ b/.changeset/shaky-clubs-show.md
@@ -2,4 +2,4 @@
 '@mastra/mcp': minor
 ---
 
-Added an MCP client option to convert MCP tool input schemas to Zod so edge runtimes can avoid AJV code generation during tool input validation.
+Added an MCP client option to convert MCP tool input schemas to Zod so edge runtimes can avoid AJV code generation during tool input validation. Clients now also cache separate instances for different schema coercion modes.

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -77,6 +77,22 @@ const mcp = new MCPClient({
 })
 ```
 
+`coerceSchemasTo` only changes how Mastra exposes MCP tool input schemas. MCP tool output schemas are validated by the MCP SDK during `Client.callTool()` using the server definition's `jsonSchemaValidator`. In Cloudflare Workers or other V8 isolates, pass a Worker-safe validator for servers that advertise `outputSchema`:
+
+```typescript
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker'
+
+const mcp = new MCPClient({
+  coerceSchemasTo: 'zod',
+  servers: {
+    deepwiki: {
+      url: new URL('https://mcp.deepwiki.com/mcp'),
+      jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+    },
+  },
+})
+```
+
 ### `MastraMCPServerDefinition`
 
 Each server in the `servers` map is configured using the `MastraMCPServerDefinition` type. The transport type is detected based on the provided parameters:

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -19,6 +19,7 @@ constructor({
   id?: string;
   servers: Record<string, MastraMCPServerDefinition>;
   timeout?: number;
+  coerceSchemasTo?: 'json-schema' | 'zod';
 }: MCPClientOptions)
 ```
 
@@ -48,8 +49,33 @@ constructor({
     defaultValue: '60000',
     description: 'Global timeout value in milliseconds for all servers unless overridden in individual server configs.',
   },
+  {
+    name: 'coerceSchemasTo',
+    type: "'json-schema' | 'zod'",
+    isOptional: true,
+    defaultValue: "'json-schema'",
+    description:
+      'Controls how MCP-sourced tool input schemas are exposed to Mastra tools. Use `zod` in edge runtimes such as Cloudflare Workers to avoid AJV code generation during Mastra tool input validation.',
+  },
 ]}
 />
+
+## Edge runtime schema validation
+
+MCP servers publish tool input schemas as JSON Schema. By default, Mastra keeps those schemas as JSON Schema and validates them through the JSON Schema compatibility path.
+
+Some edge runtimes, such as Cloudflare Workers, disallow runtime code generation. Set `coerceSchemasTo` to `zod` to convert MCP tool input schemas to Zod when the toolsets are loaded:
+
+```typescript
+const mcp = new MCPClient({
+  coerceSchemasTo: 'zod',
+  servers: {
+    deepwiki: {
+      url: new URL('https://mcp.deepwiki.com/mcp'),
+    },
+  },
+})
+```
 
 ### `MastraMCPServerDefinition`
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "exit-hook": "^5.1.0",
-    "fast-deep-equal": "^3.1.3"
+    "fast-deep-equal": "^3.1.3",
+    "zod-from-json-schema": "^0.1.0"
   },
   "peerDependencies": {
     "@mastra/core": ">=1.0.0-0 <2.0.0-0",

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -182,11 +182,27 @@ describe('InternalMastraMCPClient - MCP schema coercion', () => {
     } as any);
     await client.connect();
 
-    const tools = await client.tools();
-    const greetTool = tools.greet;
+    const sdkClient = (client as any).client as Client;
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'greet',
+          description: 'A simple greeting tool',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              name: { type: 'string' as const, description: 'Name to greet', default: 'World' },
+            },
+          },
+        },
+      ],
+    } as Awaited<ReturnType<Client['listTools']>>);
+
     const functionSpy = vi.spyOn(globalThis, 'Function');
 
     try {
+      const tools = await client.tools();
+      const greetTool = tools.greet;
       const result = await greetTool?.inputSchema?.['~standard'].validate({ name: 'Ada' });
 
       expect(result).toEqual({ value: { name: 'Ada' } });

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -148,6 +148,55 @@ describe('InternalMastraMCPClient - jsonSchemaValidator pass-through', () => {
   });
 });
 
+describe('InternalMastraMCPClient - MCP schema coercion', () => {
+  let testServer: Awaited<ReturnType<typeof setupTestServer>>;
+  let client: InternalMastraMCPClient;
+
+  afterEach(async () => {
+    await client?.disconnect();
+    testServer?.httpServer.close();
+  });
+
+  it("coerces MCP JSON Schema input schemas to Zod when coerceSchemasTo is 'zod'", async () => {
+    testServer = await setupTestServer(false);
+    client = new InternalMastraMCPClient({
+      name: 'zod-coercion-client',
+      server: { url: testServer.baseUrl },
+      coerceSchemasTo: 'zod',
+    } as any);
+    await client.connect();
+
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+
+    expect(greetTool?.inputSchema).toBeDefined();
+    expect(typeof (greetTool?.inputSchema as any).safeParse).toBe('function');
+  });
+
+  it("does not invoke Function during MCP input schema validation when coerceSchemasTo is 'zod'", async () => {
+    testServer = await setupTestServer(false);
+    client = new InternalMastraMCPClient({
+      name: 'zod-no-codegen-client',
+      server: { url: testServer.baseUrl },
+      coerceSchemasTo: 'zod',
+    } as any);
+    await client.connect();
+
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+    const functionSpy = vi.spyOn(globalThis, 'Function');
+
+    try {
+      const result = await greetTool?.inputSchema?.['~standard'].validate({ name: 'Ada' });
+
+      expect(result).toEqual({ value: { name: 'Ada' } });
+      expect(functionSpy).not.toHaveBeenCalled();
+    } finally {
+      functionSpy.mockRestore();
+    }
+  });
+});
+
 describe('MastraMCPClient with Streamable HTTP', () => {
   let testServer: {
     httpServer: HttpServer;

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -322,7 +322,7 @@ describe('MastraMCPClient - outputSchema without structuredContent', () => {
   // return structuredContent in the response, the full CallToolResult envelope
   // should be returned as-is. We don't pass outputSchema to createTool, so
   // Zod won't strip unrecognised keys. The MCP SDK validates structuredContent
-  // against outputSchema internally via AJV.
+  // against outputSchema internally using its configured JSON Schema validator.
   let testServer: {
     httpServer: HttpServer;
     mcpServer: McpServer;
@@ -507,7 +507,8 @@ describe('MastraMCPClient - no outputSchema', () => {
 describe('MastraMCPClient - outputSchema with structuredContent', () => {
   // When a tool has an outputSchema and returns structuredContent, the
   // structuredContent is returned directly. We don't pass outputSchema to
-  // createTool so there's no Zod stripping — the MCP SDK validates via AJV.
+  // createTool so there's no Zod stripping. The MCP SDK validates structuredContent
+  // using its configured JSON Schema validator.
   let testServer: {
     httpServer: HttpServer;
     mcpServer: McpServer;

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -780,7 +780,8 @@ export class InternalMastraMCPClient extends MastraBase {
           inputSchema: await this.convertInputSchema(tool.inputSchema),
           strict: getMastraToolStrictMeta((tool as { _meta?: Record<string, unknown> })._meta),
           // Don't pass outputSchema to createTool — the MCP SDK's Client.callTool()
-          // already validates structuredContent against the tool's outputSchema using AJV.
+          // already validates structuredContent against the tool's outputSchema using its
+          // configured jsonSchemaValidator.
           // Passing it here causes Zod to strip unrecognized keys from the CallToolResult
           // envelope, returning {} for tools without structuredContent.
           requireApproval,

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -6,7 +6,7 @@ import type { RequestContext } from '@mastra/core/di';
 import { createTool } from '@mastra/core/tools';
 import type { Tool } from '@mastra/core/tools';
 
-import type { JSONSchema7 } from '@mastra/schema-compat';
+import type { JSONSchema7, PublicSchema } from '@mastra/schema-compat';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -40,6 +40,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import { asyncExitHook, gracefulExit } from 'exit-hook';
+import { convertJsonSchemaToZod } from 'zod-from-json-schema';
 import { getMastraToolStrictMeta } from '../shared/mastra-tool-meta';
 import { ElicitationClientActions } from './actions/elicitation';
 import { ProgressClientActions } from './actions/progress';
@@ -74,7 +75,7 @@ export type {
 } from './types';
 
 const DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC = 3000;
-const require = createRequire(import.meta.url);
+const convertMcpJsonSchemaToZod = convertJsonSchemaToZod as unknown as (schema: unknown) => PublicSchema;
 
 // Per MCP spec, only fallback to SSE for these status codes
 const SSE_FALLBACK_STATUS_CODES = [400, 404, 405];
@@ -118,7 +119,11 @@ function loadDatadogTracer(): DatadogTracerLike | null {
   }
 
   try {
-    return require('dd-trace') as DatadogTracerLike;
+    if (!import.meta.url) {
+      return null;
+    }
+
+    return createRequire(import.meta.url)('dd-trace') as DatadogTracerLike;
   } catch {
     return null;
   }
@@ -200,6 +205,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private sigHupHandler?: () => void;
   private _roots: Root[];
   private readonly requireToolApproval: RequireToolApproval | undefined;
+  private readonly coerceSchemasTo: InternalMastraMCPClientOptions['coerceSchemasTo'];
 
   /** Provides access to resource operations (list, read, subscribe, etc.) */
   public readonly resources: ResourceClientActions;
@@ -219,6 +225,7 @@ export class InternalMastraMCPClient extends MastraBase {
     server,
     capabilities = {},
     timeout = DEFAULT_REQUEST_TIMEOUT_MSEC,
+    coerceSchemasTo,
   }: InternalMastraMCPClientOptions) {
     super({ name: 'MastraMCPClient' });
     this.name = name;
@@ -228,6 +235,7 @@ export class InternalMastraMCPClient extends MastraBase {
     this.serverConfig = server;
     this.enableProgressTracking = !!server.enableProgressTracking;
     this.requireToolApproval = server.requireToolApproval;
+    this.coerceSchemasTo = coerceSchemasTo ?? 'json-schema';
 
     // Initialize roots from server config
     this._roots = server.roots ?? [];
@@ -729,8 +737,14 @@ export class InternalMastraMCPClient extends MastraBase {
 
   private async convertInputSchema(
     inputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['inputSchema'],
-  ): Promise<JSONSchema7> {
-    return ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
+  ): Promise<PublicSchema> {
+    const jsonSchema = ('jsonSchema' in inputSchema ? inputSchema.jsonSchema : inputSchema) as JSONSchema7;
+
+    if (this.coerceSchemasTo === 'zod') {
+      return convertMcpJsonSchemaToZod(jsonSchema);
+    }
+
+    return jsonSchema;
   }
 
   async tools(): Promise<Record<string, Tool<any, any, any, any>>> {

--- a/packages/mcp/src/client/configuration.test.ts
+++ b/packages/mcp/src/client/configuration.test.ts
@@ -118,4 +118,25 @@ describe('MCPClient tool discovery retries', () => {
     expect(connectSpy).toHaveBeenCalledTimes(1);
     expect(capabilities).toMatchObject(customCapabilities);
   });
+
+  it('forwards coerceSchemasTo into InternalMastraMCPClient', async () => {
+    const connectSpy = vi.spyOn(InternalMastraMCPClient.prototype, 'connect').mockResolvedValue(true);
+
+    const client = new MCPClient({
+      id: `configuration-test-${++clientId}`,
+      coerceSchemasTo: 'zod',
+      servers: {
+        weather: {
+          url: new URL('http://localhost:1234/sse'),
+        },
+      },
+    });
+
+    clients.push(client);
+
+    const internalClient = await (client as any).getConnectedClientForServer('weather');
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect((internalClient as any).coerceSchemasTo).toBe('zod');
+  });
 });

--- a/packages/mcp/src/client/configuration.test.ts
+++ b/packages/mcp/src/client/configuration.test.ts
@@ -139,4 +139,51 @@ describe('MCPClient tool discovery retries', () => {
     expect(connectSpy).toHaveBeenCalledTimes(1);
     expect((internalClient as any).coerceSchemasTo).toBe('zod');
   });
+
+  it('generates distinct ids for matching servers with different schema coercion modes', () => {
+    const servers = {
+      weather: {
+        url: new URL('http://localhost:1234/sse'),
+      },
+    };
+
+    const jsonSchemaClient = new MCPClient({
+      servers,
+    });
+    clients.push(jsonSchemaClient);
+
+    const zodClient = new MCPClient({
+      servers,
+      coerceSchemasTo: 'zod',
+    });
+    clients.push(zodClient);
+
+    expect(zodClient).not.toBe(jsonSchemaClient);
+    expect((zodClient as any).id).not.toBe((jsonSchemaClient as any).id);
+  });
+
+  it('does not reuse an explicit-id cached client when schema coercion mode changes', () => {
+    const id = `configuration-test-${++clientId}`;
+    const servers = {
+      weather: {
+        url: new URL('http://localhost:1234/sse'),
+      },
+    };
+
+    const jsonSchemaClient = new MCPClient({
+      id,
+      servers,
+    });
+    clients.push(jsonSchemaClient);
+
+    const zodClient = new MCPClient({
+      id,
+      servers,
+      coerceSchemasTo: 'zod',
+    });
+    clients.push(zodClient);
+
+    expect(zodClient).not.toBe(jsonSchemaClient);
+    expect((zodClient as any).coerceSchemasTo).toBe('zod');
+  });
 });

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -30,6 +30,13 @@ export interface MCPClientOptions {
   servers: Record<string, MastraMCPServerDefinition>;
   /** Optional global timeout in milliseconds for all servers (default: 60000ms) */
   timeout?: number;
+  /**
+   * Optional schema representation for MCP-sourced tool input schemas.
+   *
+   * Use `zod` in workerd/edge runtimes to avoid AJV code generation during Mastra's
+   * pre-call tool input validation. Defaults to `json-schema` for current behavior.
+   */
+  coerceSchemasTo?: 'json-schema' | 'zod';
 }
 
 /**
@@ -70,6 +77,7 @@ export class MCPClient extends MastraBase {
   private serverConfigs: Record<string, MastraMCPServerDefinition> = {};
   private id: string;
   private defaultTimeout: number;
+  private coerceSchemasTo: MCPClientOptions['coerceSchemasTo'];
   private mcpClientsById = new Map<string, InternalMastraMCPClient>();
   private disconnectPromise: Promise<void> | null = null;
 
@@ -105,6 +113,7 @@ export class MCPClient extends MastraBase {
     super({ name: 'MCPClient' });
     this.defaultTimeout = args.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC;
     this.serverConfigs = args.servers;
+    this.coerceSchemasTo = args.coerceSchemasTo;
     this.id = args.id ?? this.makeId();
 
     if (args.id) {
@@ -930,6 +939,7 @@ To fix this you have three different options:
       server: config,
       timeout: config.timeout ?? this.defaultTimeout,
       capabilities: config.capabilities,
+      coerceSchemasTo: this.coerceSchemasTo,
     });
 
     mcpClient.__setLogger(this.logger);

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -35,6 +35,11 @@ export interface MCPClientOptions {
    *
    * Use `zod` in workerd/edge runtimes to avoid AJV code generation during Mastra's
    * pre-call tool input validation. Defaults to `json-schema` for current behavior.
+   *
+   * This does not change MCP tool output validation. Tool outputs are validated by
+   * the MCP SDK during `Client.callTool()` using the server's `jsonSchemaValidator`.
+   * In edge runtimes, pass a Worker-safe `jsonSchemaValidator` on each server that
+   * advertises an `outputSchema`.
    */
   coerceSchemasTo?: 'json-schema' | 'zod';
 }

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -125,7 +125,7 @@ export class MCPClient extends MastraBase {
       this.id = args.id;
       const cached = mcpClientInstances.get(this.id);
 
-      if (cached && !equal(cached.serverConfigs, args.servers)) {
+      if (cached && !equal(cached.getInstanceIdentity(), this.getInstanceIdentity())) {
         const existingInstance = mcpClientInstances.get(this.id);
         if (existingInstance) {
           void existingInstance.disconnect();
@@ -680,8 +680,15 @@ To fix this you have three different options:
   }
 
   private makeId() {
-    const text = JSON.stringify(this.serverConfigs).normalize('NFKC');
+    const text = JSON.stringify(this.getInstanceIdentity()).normalize('NFKC');
     return createHash('sha256').update('MCPClient').update(text).digest('hex');
+  }
+
+  private getInstanceIdentity() {
+    return {
+      serverConfigs: this.serverConfigs,
+      coerceSchemasTo: this.coerceSchemasTo ?? 'json-schema',
+    };
   }
 
   /**

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -138,6 +138,15 @@ export type RequireToolApprovalFn = (ctx: RequireToolApprovalContext) => boolean
 export type RequireToolApproval = boolean | RequireToolApprovalFn;
 
 /**
+ * Controls how MCP-provided JSON Schemas are exposed to Mastra tools.
+ *
+ * - `json-schema`: Keep the current JSON Schema path, which validates through schema-compat/AJV.
+ * - `zod`: Convert MCP JSON Schemas to Zod schemas when tools are loaded. This avoids AJV codegen
+ *   during Mastra's pre-call input validation, which is required in workerd/edge runtimes.
+ */
+export type McpSchemaCoercionTarget = 'json-schema' | 'zod';
+
+/**
  * Base options common to all MCP server definitions.
  */
 export type BaseServerOptions = {
@@ -385,4 +394,6 @@ export type InternalMastraMCPClientOptions = {
   version?: string;
   /** Optional timeout in milliseconds */
   timeout?: number;
+  /** Optional MCP schema coercion target */
+  coerceSchemasTo?: McpSchemaCoercionTarget;
 };

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -143,6 +143,9 @@ export type RequireToolApproval = boolean | RequireToolApprovalFn;
  * - `json-schema`: Keep the current JSON Schema path, which validates through schema-compat/AJV.
  * - `zod`: Convert MCP JSON Schemas to Zod schemas when tools are loaded. This avoids AJV codegen
  *   during Mastra's pre-call input validation, which is required in workerd/edge runtimes.
+ *
+ * This only affects MCP tool input schemas. MCP tool output schemas are validated by the MCP SDK
+ * during `Client.callTool()` using the server's `jsonSchemaValidator`.
  */
 export type McpSchemaCoercionTarget = 'json-schema' | 'zod';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3785,6 +3785,9 @@ importers:
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
+      zod-from-json-schema:
+        specifier: ^0.1.0
+        version: 0.1.0
     devDependencies:
       '@hono/node-server':
         specifier: ^1.19.11
@@ -26866,6 +26869,9 @@ packages:
 
   zod-from-json-schema@0.0.5:
     resolution: {integrity: sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ==}
+
+  zod-from-json-schema@0.1.0:
+    resolution: {integrity: sha512-yPcDmFziXePHO8iK4WXl4WcqlKolohQKEdhbJadCzZ/+/ayr1IELxWrVQ/NSUKiuIweNiDlZoi6dgle4Bd1baw==}
 
   zod-from-json-schema@0.5.2:
     resolution: {integrity: sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g==}
@@ -51912,6 +51918,10 @@ snapshots:
       readable-stream: 4.7.0
 
   zod-from-json-schema@0.0.5:
+    dependencies:
+      zod: 3.25.76
+
+  zod-from-json-schema@0.1.0:
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## Description

Adds an MCP client option to convert MCP tool input schemas to Zod. This avoids AJV code generation during Mastra tool validation, so MCP tools can work in edge runtimes like Cloudflare Workers.

## Related Issue(s)

Fixes #15926 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This adds a toggle so MCP tool input schemas (published as JSON Schema) can be converted to Zod when toolsets are loaded, letting Mastra validate inputs without AJV's runtime codegen (which is blocked on many edge platforms). Turn it on by constructing MCPClient with coerceSchemasTo: 'zod'.

---

## Overview

Adds an opt-in MCP client option coerceSchemasTo?: 'json-schema' | 'zod' (default 'json-schema') that, when set to 'zod', converts dereferenced MCP input JSON Schemas to Zod at toolset-load time using zod-from-json-schema so Mastra uses the Zod validation path and avoids AJV/codegen during pre-call input validation. Output schema validation remains the MCP SDK's jsonSchemaValidator (recommend a Worker-safe validator for outputs on V8 isolates). Marks this behavior as a breaking change and fixes #15926.

---

## Key changes

- API & types
  - MCPClientOptions gains coerceSchemasTo?: 'json-schema' | 'zod' and MCPClient includes it in instance identity so cached clients are distinct per coercion mode (packages/mcp/src/client/configuration.ts).
  - New exported type McpSchemaCoercionTarget = 'json-schema' | 'zod' and InternalMastraMCPClientOptions now accept coerceSchemasTo (packages/mcp/src/client/types.ts).

- Runtime behavior
  - MCPClient forwards coerceSchemasTo into each InternalMastraMCPClient it creates; conversion to Zod happens at toolset-load time to avoid per-call codegen.
  - InternalMastraMCPClient stores coerceSchemasTo; convertInputSchema returns original JSON Schema (default) or a Zod/PublicSchema when coerceSchemasTo === 'zod' using zod-from-json-schema (packages/mcp/src/client/client.ts).
  - Minor Datadog tracer load change: loadDatadogTracer now guards import.meta.url and uses createRequire(import.meta.url).

- Dependencies
  - Added runtime dependency zod-from-json-schema to packages/mcp/package.json.

---

## Tests

- packages/mcp/src/client/client.test.ts
  - New "InternalMastraMCPClient - MCP schema coercion" suite verifies coerced input schemas expose Zod API (safeParse), that coercion yields expected parsed output, and asserts global Function is never called during coercion/validation (prevents codegen).
- packages/mcp/src/client/configuration.test.ts
  - Tests forwarding of coerceSchemasTo into InternalMastraMCPClient, ensures clients with different coercion modes are not reused from the same cache id, and that explicit-id caching respects coercion mode.

---

## Documentation & release

- docs/src/content/en/reference/tools/mcp-client.mdx
  - Documents MCPClientOptions.coerceSchemasTo and adds "Edge runtime schema validation" guidance recommending coerceSchemasTo: 'zod' for input validation on edge runtimes and recommending Worker-safe validators for outputs.
- .changeset/shaky-clubs-show.md
  - Adds a changeset to bump @mastra/mcp minor version and documents separate client caching per coercion mode.

---

## Notes

- Marked as a breaking change; docs and tests updated. One checklist item (addressing all Coderabbit comments) remains unchecked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->