### PR TITLE
fix(mastracode): normalize Enter/Esc handling in settings submenu

### DIFF
--- a/.changeset/fix-mastracode-settings-enter-esc.md
+++ b/.changeset/fix-mastracode-settings-enter-esc.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Normalize Enter/Escape key handling in the `/settings` storage backend submenu so submit/cancel works reliably across terminal emulators.

--- a/mastracode/src/tui/components/settings.ts
+++ b/mastracode/src/tui/components/settings.ts
@@ -6,7 +6,7 @@
  * Changes apply immediately — Esc closes the panel.
  */
 
-import { Box, Container, SelectList, SettingsList, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, SelectList, SettingsList, Spacer, Text, matchesKey } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, SettingItem } from '@mariozechner/pi-tui';
 import type { StorageBackend } from '../../onboarding/settings.js';
 import type { NotificationMode } from '../notify.js';
@@ -149,7 +149,7 @@ class StorageBackendSubmenu extends Container {
     }
 
     // Connection string input phase
-    if (data === '\r' || data === '\n') {
+    if (matchesKey(data, 'enter') || data === '\r' || data === '\n') {
       const value = this.input.getValue().trim();
       if (this.pendingBackend === 'pg') {
         // PG requires a connection string
@@ -163,7 +163,7 @@ class StorageBackendSubmenu extends Container {
       return;
     }
 
-    if (data === '\x1b' || data === '\x1b\x1b') {
+    if (matchesKey(data, 'escape') || data === '\x1b' || data === '\x1b\x1b') {
       this.onBack();
       return;
     }


### PR DESCRIPTION
Fixes #16134

## Summary
- normalize Enter/Esc handling in /settings storage backend submenu
- use key normalization to improve compatibility across terminal emulators

## Testing
- pnpm --filter ./mastracode check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you try to save or cancel out of the storage settings screen in mastracode, the Enter and Escape keys weren't being recognized in all terminal emulators. This fix makes those keys work reliably everywhere by checking for them in multiple ways at once.

## Changes

### Storage Backend Submenu Input Handling

Updated `StorageBackendSubmenu.handleInput()` in `mastracode/src/tui/components/settings.ts` to normalize Enter and Escape key detection:

- **Added import**: `matchesKey` from `@mariozechner/pi-tui` for normalized key matching
- **Enter (submit)**: Now triggers the save action when data matches `matchesKey(data, 'enter')` OR the raw bytes `'\r'` or `'\n'`
- **Escape (cancel)**: Now triggers the go-back action when data matches `matchesKey(data, 'escape')` OR the raw bytes `'\x1b'` or `'\x1b\x1b'`

This dual-check approach ensures compatibility across different terminal emulators by using the pi-tui library's normalized key matching while maintaining backward compatibility with raw byte checks as fallbacks.

### Changeset

Added `.changeset/fix-mastracode-settings-enter-esc.md` to document the patch-level fix for normalizing Enter/Escape key handling in the settings storage backend submenu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->