### PR TITLE
Add bloom-filter skip indexes to metric_events table

### DIFF
--- a/.changeset/clickhouse-metric-skip-indexes.md
+++ b/.changeset/clickhouse-metric-skip-indexes.md
@@ -1,0 +1,30 @@
+---
+'@mastra/clickhouse': minor
+---
+
+Added bloom-filter skip indexes on the high-cardinality ID columns of `metric_events` so dashboard drilldowns ("metrics for this thread", "metrics for this run", etc.) skip granule chunks that definitely do not contain the filtered ID instead of scanning the full time range.
+
+**Indexed columns**
+
+`traceId`, `threadId`, `resourceId`, `userId`, `organizationId`, `experimentId`, `runId`, `sessionId`, `requestId`. All use `bloom_filter(0.01) GRANULARITY 2` (1% false-positive rate, 16K-row chunks). Tracked via the new `METRIC_SKIP_INDEX_NAMES` export.
+
+**Where this helps**
+
+Equality and `IN` filters on the indexed columns. The sort key `(name, timestamp, metricId)` still drives the time-range scan; bloom filters narrow what is read inside that range. Aggregations and `GROUP BY` without a WHERE on these columns are unaffected.
+
+**Migration**
+
+Existing deployments pick the indexes up via additive `ALTER TABLE … ADD INDEX IF NOT EXISTS …` statements. The DDL is metadata-only and instant — no table lock, no rewrite, no downtime.
+
+Existing parts keep no index until they are merged or `MATERIALIZE INDEX` is run explicitly. New parts written after the migration are bloom-filtered immediately, so under normal metric retention the table converges to full index coverage without operator action.
+
+If you want to backfill existing parts immediately, run during a maintenance window (this rewrites part data and is IO-heavy on large tables):
+
+```sql
+ALTER TABLE mastra_metric_events MATERIALIZE INDEX idx_threadId;
+-- ... and similarly for the other index names in METRIC_SKIP_INDEX_NAMES
+```
+
+**Cost**
+
+A few percent of insert overhead (extra hashes per indexed column). Index storage is well under 1% of typical table size. `DROP INDEX` is also instant if you ever need to roll back.

--- a/.changeset/clickhouse-metric-skip-indexes.md
+++ b/.changeset/clickhouse-metric-skip-indexes.md
@@ -2,29 +2,10 @@
 '@mastra/clickhouse': minor
 ---
 
-Added bloom-filter skip indexes on the high-cardinality ID columns of `metric_events` so dashboard drilldowns ("metrics for this thread", "metrics for this run", etc.) skip granule chunks that definitely do not contain the filtered ID instead of scanning the full time range.
+Improved metric drilldown performance with skip indexes on the high-cardinality ID columns of `metric_events`. Dashboard queries that filter metrics by `traceId`, `threadId`, `resourceId`, `userId`, `organizationId`, `experimentId`, `runId`, `sessionId`, or `requestId` skip data chunks that don't contain the filtered value instead of scanning the full time range.
 
-**Indexed columns**
-
-`traceId`, `threadId`, `resourceId`, `userId`, `organizationId`, `experimentId`, `runId`, `sessionId`, `requestId`. All use `bloom_filter(0.01) GRANULARITY 2` (1% false-positive rate, 16K-row chunks). Tracked via the new `METRIC_SKIP_INDEX_NAMES` export.
-
-**Where this helps**
-
-Equality and `IN` filters on the indexed columns. The sort key `(name, timestamp, metricId)` still drives the time-range scan; bloom filters narrow what is read inside that range. Aggregations and `GROUP BY` without a WHERE on these columns are unaffected.
+Equality (`=`) and `IN` filters benefit automatically. Aggregations and `GROUP BY` queries without a filter on these columns are unaffected.
 
 **Migration**
 
-Existing deployments pick the indexes up via additive `ALTER TABLE … ADD INDEX IF NOT EXISTS …` statements. The DDL is metadata-only and instant — no table lock, no rewrite, no downtime.
-
-Existing parts keep no index until they are merged or `MATERIALIZE INDEX` is run explicitly. New parts written after the migration are bloom-filtered immediately, so under normal metric retention the table converges to full index coverage without operator action.
-
-If you want to backfill existing parts immediately, run during a maintenance window (this rewrites part data and is IO-heavy on large tables):
-
-```sql
-ALTER TABLE mastra_metric_events MATERIALIZE INDEX idx_threadId;
--- ... and similarly for the other index names in METRIC_SKIP_INDEX_NAMES
-```
-
-**Cost**
-
-A few percent of insert overhead (extra hashes per indexed column). Index storage is well under 1% of typical table size. `DROP INDEX` is also instant if you ever need to roll back.
+Existing deployments pick up the indexes on next start. The migration is metadata-only and instant — no table lock, no rewrite, no downtime. Insert overhead is negligible and index storage is well under 1% of table size. Existing data is indexed lazily as parts merge under normal retention; no operator action is required.

--- a/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
@@ -252,7 +252,22 @@ CREATE TABLE IF NOT EXISTS ${TABLE_METRIC_EVENTS} (
   -- Information-only JSON payloads
   costMetadata       Nullable(String),
   metadata           Nullable(String),
-  scope              Nullable(String)
+  scope              Nullable(String),
+
+  -- Bloom-filter skip indexes for high-cardinality ID drilldowns.
+  -- Equality and IN filters on these columns can skip granule chunks that
+  -- definitely do not contain the value. GRANULARITY 2 = 16K-row chunks.
+  -- ID columns are out-of-sort-key, so without these every drilldown scans
+  -- every row in the time range.
+  INDEX idx_traceId traceId TYPE bloom_filter(0.01) GRANULARITY 2,
+  INDEX idx_threadId threadId TYPE bloom_filter(0.01) GRANULARITY 2,
+  INDEX idx_resourceId resourceId TYPE bloom_filter(0.01) GRANULARITY 2,
+  INDEX idx_userId userId TYPE bloom_filter(0.01) GRANULARITY 2,
+  INDEX idx_organizationId organizationId TYPE bloom_filter(0.01) GRANULARITY 2,
+  INDEX idx_experimentId experimentId TYPE bloom_filter(0.01) GRANULARITY 2,
+  INDEX idx_runId runId TYPE bloom_filter(0.01) GRANULARITY 2,
+  INDEX idx_sessionId sessionId TYPE bloom_filter(0.01) GRANULARITY 2,
+  INDEX idx_requestId requestId TYPE bloom_filter(0.01) GRANULARITY 2
 )
 ENGINE = ReplacingMergeTree
 PARTITION BY toDate(timestamp)
@@ -605,7 +620,37 @@ export const ALL_MIGRATIONS = [
   `ALTER TABLE ${TABLE_FEEDBACK_EVENTS} ADD COLUMN IF NOT EXISTS entityVersionId Nullable(String)`,
   `ALTER TABLE ${TABLE_FEEDBACK_EVENTS} ADD COLUMN IF NOT EXISTS parentEntityVersionId Nullable(String)`,
   `ALTER TABLE ${TABLE_FEEDBACK_EVENTS} ADD COLUMN IF NOT EXISTS rootEntityVersionId Nullable(String)`,
+  // Metric skip indexes — additive, instant DDL. Existing parts keep no index
+  // until merged or `MATERIALIZE INDEX` is run; new parts are bloom-filtered
+  // immediately. With normal retention turning over the table, the index
+  // converges to full coverage without an explicit backfill.
+  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_traceId traceId TYPE bloom_filter(0.01) GRANULARITY 2`,
+  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_threadId threadId TYPE bloom_filter(0.01) GRANULARITY 2`,
+  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_resourceId resourceId TYPE bloom_filter(0.01) GRANULARITY 2`,
+  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_userId userId TYPE bloom_filter(0.01) GRANULARITY 2`,
+  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_organizationId organizationId TYPE bloom_filter(0.01) GRANULARITY 2`,
+  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_experimentId experimentId TYPE bloom_filter(0.01) GRANULARITY 2`,
+  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_runId runId TYPE bloom_filter(0.01) GRANULARITY 2`,
+  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_sessionId sessionId TYPE bloom_filter(0.01) GRANULARITY 2`,
+  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_requestId requestId TYPE bloom_filter(0.01) GRANULARITY 2`,
 ];
+
+/**
+ * Names of the bloom-filter skip indexes added to `metric_events`. Exposed so
+ * tooling (e.g. a follow-up `mastra migrate` command) can detect and optionally
+ * `MATERIALIZE INDEX` them across pre-existing parts.
+ */
+export const METRIC_SKIP_INDEX_NAMES = [
+  'idx_traceId',
+  'idx_threadId',
+  'idx_resourceId',
+  'idx_userId',
+  'idx_organizationId',
+  'idx_experimentId',
+  'idx_runId',
+  'idx_sessionId',
+  'idx_requestId',
+] as const;
 
 export const ALL_DDL = [...ALL_TABLE_DDL, ...ALL_MV_DDL, ...DISCOVERY_MV_DDL];
 


### PR DESCRIPTION
part of https://github.com/mastra-ai/mastra/pull/15747

## Description

Added bloom-filter skip indexes on high-cardinality ID columns (`traceId`, `threadId`, `resourceId`, `userId`, `organizationId`, `experimentId`, `runId`, `sessionId`, `requestId`) in the `metric_events` table to optimize dashboard drilldown queries.

These indexes allow ClickHouse to skip granule chunks that definitely do not contain the filtered ID values, eliminating full time-range scans for equality and `IN` filters on these columns. Each index uses `bloom_filter(0.01)` with `GRANULARITY 2` (1% false-positive rate, 16K-row chunks).

The indexes are added to the table DDL definition and exposed via a new `METRIC_SKIP_INDEX_NAMES` export for tooling that may want to materialize them across pre-existing parts.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Migration Notes

Existing deployments receive the indexes via additive `ALTER TABLE … ADD INDEX IF NOT EXISTS …` migrations. The DDL changes are metadata-only and instant with no table lock or rewrite.

- Existing parts keep no index until merged or explicitly materialized
- New parts written after migration are bloom-filtered immediately
- Table converges to full index coverage under normal retention without operator action
- Optional: Run `ALTER TABLE mastra_metric_events MATERIALIZE INDEX idx_*` during maintenance to backfill existing parts

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

https://claude.ai/code/session_01D7CzJuDbA8WBJuAP8ZWxPG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR teaches ClickHouse to skip chunks of metric data that definitely don't contain the ID(s) you're searching for (like a trace or user ID) using bloom-filter indexes, so dashboard drilldowns and ID-based searches run much faster without scanning all the data.

---

## Overview

Adds bloom-filter skip indexes to nine high-cardinality ID/context columns on the mastra_metric_events table: traceId, threadId, resourceId, userId, organizationId, experimentId, runId, sessionId, and requestId. Each index is defined as TYPE bloom_filter(0.01) GRANULARITY 2 (≈1% false-positive rate, ~16K-row granules). These indexes allow ClickHouse to skip entire granule chunks for equality and IN filters on those columns, avoiding full time-range scans and improving drilldown performance.

## Changes

- .changeset/clickhouse-metric-skip-indexes.md
  - New changeset documenting the skip-index behavior, expected benefits (equality/IN filters), migration semantics, and storage/insert overhead estimates.

- stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
  - METRIC_EVENTS_DDL: added nine bloom-filter INDEX definitions for traceId, threadId, resourceId, userId, organizationId, experimentId, runId, sessionId, requestId.
  - ALL_MIGRATIONS: added additive `ALTER TABLE ... ADD INDEX IF NOT EXISTS` statements for each new index.
  - Exported new constant METRIC_SKIP_INDEX_NAMES (array of the nine index names) to allow tooling to enumerate and optionally materialize the indexes across existing parts.

## Migration strategy

- Migration is applied via additive ALTER TABLE ... ADD INDEX IF NOT EXISTS statements (metadata-only and instant; no table lock, no rewrite).
- New parts written after migration include bloom-filter indexes immediately.
- Existing parts remain without the index until they are merged or an explicit `ALTER TABLE mastra_metric_events MATERIALIZE INDEX idx_*` is executed.
- With normal part churn/retention the table will converge to full index coverage; explicit MATERIALIZE INDEX can be used for backfilling if desired.

## Impact

- Performance: Significant reduction in I/O and latency for dashboard drilldowns and queries that filter by these ID columns with = or IN predicates.
- Storage and insert overhead: Minimal (bloom filters are space-efficient and insert overhead is negligible).
- Compatibility: Additive, non-breaking change; existing queries continue to work while benefiting from index skips as parts are indexed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->