### PR TITLE
[fix] Update no-logs state of Logs page

### DIFF
--- a/.changeset/curvy-bobcats-fail.md
+++ b/.changeset/curvy-bobcats-fail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Improved the `NoLogsInfo` empty state. It now accepts optional `datePreset`, `dateFrom`, and `dateTo` props to show why no logs match the active range, suggests lowering the logging level, and links to the docs. Calling `<NoLogsInfo />` without props keeps the original copy.

--- a/packages/playground-ui/src/domains/logs/components/index.ts
+++ b/packages/playground-ui/src/domains/logs/components/index.ts
@@ -3,4 +3,4 @@ export { LogsErrorContent, type LogsErrorContentProps } from './logs-error-conte
 export { LogsLayout, type LogsLayoutProps } from './logs-layout';
 export { LogsListView, type LogsListViewProps } from './logs-list-view';
 export { LogsToolbar, type LogsToolbarProps } from './logs-toolbar';
-export { NoLogsInfo } from './no-logs-info';
+export { NoLogsInfo, type NoLogsInfoProps } from './no-logs-info';

--- a/packages/playground-ui/src/domains/logs/components/no-logs-info.tsx
+++ b/packages/playground-ui/src/domains/logs/components/no-logs-info.tsx
@@ -20,8 +20,7 @@ export interface NoLogsInfoProps {
 
 const DATE_FORMAT = 'MMM d, yyyy HH:mm';
 
-const LEVEL_TIP =
-  'Pick a wider range or lower the logging level — verbose entries (debug, info) may be filtered out.';
+const LEVEL_TIP = 'Pick a wider range or lower the logging level — verbose entries (debug, info) may be filtered out.';
 
 function describeRange({ datePreset, dateFrom, dateTo }: NoLogsInfoProps): { title: string; description: string } {
   if (datePreset && datePreset !== 'all' && datePreset !== 'custom') {
@@ -60,7 +59,7 @@ export const NoLogsInfo = ({ datePreset, dateFrom, dateTo }: NoLogsInfoProps = {
           <Button
             variant="ghost"
             as="a"
-            href="https://mastra.ai/docs/observability/logging"
+            href="https://mastra.ai/en/docs/observability/logging"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/packages/playground-ui/src/domains/logs/components/no-logs-info.tsx
+++ b/packages/playground-ui/src/domains/logs/components/no-logs-info.tsx
@@ -1,12 +1,73 @@
-import { CircleSlashIcon } from 'lucide-react';
+import { format } from 'date-fns';
+import { CircleSlashIcon, ExternalLinkIcon } from 'lucide-react';
+import type { LogsDatePreset } from '../log-filters';
+import { Button } from '@/ds/components/Button';
 import { EmptyState } from '@/ds/components/EmptyState';
 
-export const NoLogsInfo = () => (
-  <div className="flex h-full items-center justify-center">
-    <EmptyState
-      iconSlot={<CircleSlashIcon />}
-      titleSlot="No logs yet"
-      descriptionSlot="Logs will appear here once agents, workflows, or tools are executed."
-    />
-  </div>
-);
+const PRESET_LABELS: Record<Exclude<LogsDatePreset, 'all' | 'custom'>, string> = {
+  'last-24h': 'the last 24 hours',
+  'last-3d': 'the last 3 days',
+  'last-7d': 'the last 7 days',
+  'last-14d': 'the last 14 days',
+  'last-30d': 'the last 30 days',
+};
+
+export interface NoLogsInfoProps {
+  datePreset?: LogsDatePreset;
+  dateFrom?: Date;
+  dateTo?: Date;
+}
+
+const DATE_FORMAT = 'MMM d, yyyy HH:mm';
+
+const LEVEL_TIP =
+  'Pick a wider range or lower the logging level — verbose entries (debug, info) may be filtered out.';
+
+function describeRange({ datePreset, dateFrom, dateTo }: NoLogsInfoProps): { title: string; description: string } {
+  if (datePreset && datePreset !== 'all' && datePreset !== 'custom') {
+    return {
+      title: `No logs for ${PRESET_LABELS[datePreset]}`,
+      description: LEVEL_TIP,
+    };
+  }
+  if (dateFrom && dateTo) {
+    return {
+      title: `No logs between ${format(dateFrom, DATE_FORMAT)} and ${format(dateTo, DATE_FORMAT)}`,
+      description: LEVEL_TIP,
+    };
+  }
+  if (dateFrom) {
+    return {
+      title: `No logs since ${format(dateFrom, DATE_FORMAT)}`,
+      description: LEVEL_TIP,
+    };
+  }
+  return {
+    title: 'No logs yet',
+    description: 'Logs will appear here once agents, workflows, or tools are executed.',
+  };
+}
+
+export const NoLogsInfo = ({ datePreset, dateFrom, dateTo }: NoLogsInfoProps = {}) => {
+  const { title, description } = describeRange({ datePreset, dateFrom, dateTo });
+  return (
+    <div className="flex h-full items-center justify-center">
+      <EmptyState
+        iconSlot={<CircleSlashIcon />}
+        titleSlot={title}
+        descriptionSlot={description}
+        actionSlot={
+          <Button
+            variant="ghost"
+            as="a"
+            href="https://mastra.ai/docs/observability/logging"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Logging Documentation <ExternalLinkIcon />
+          </Button>
+        }
+      />
+    </div>
+  );
+};

--- a/packages/playground/src/pages/logs/index.tsx
+++ b/packages/playground/src/pages/logs/index.tsx
@@ -6,7 +6,6 @@ import {
   LogsLayout,
   LogsListView,
   LogsToolbar,
-  NoDataPageLayout,
   NoLogsInfo,
   PageHeader,
   PageLayout,
@@ -127,78 +126,85 @@ export default function LogsPage() {
     [url],
   );
 
+  const pageTopArea = (
+    <PageLayout.TopArea>
+      <PageLayout.Row>
+        <PageLayout.Column>
+          <PageHeader>
+            <PageHeader.Title isLoading={isLoadingLogs}>
+              <LogsIcon /> Logs
+            </PageHeader.Title>
+          </PageHeader>
+        </PageLayout.Column>
+        <PageLayout.Column className="flex justify-end items-center gap-2">
+          <DateTimeRangePicker
+            preset={url.datePreset}
+            onPresetChange={url.handleDatePresetChange}
+            dateFrom={url.selectedDateFrom}
+            dateTo={url.selectedDateTo}
+            onDateChange={url.handleDateChange}
+            disabled={isLoadingLogs}
+            presets={['last-24h', 'last-3d', 'last-7d', 'last-14d', 'last-30d', 'custom']}
+          />
+          <PropertyFilterCreator
+            fields={filterFields}
+            tokens={url.filterTokens}
+            onTokensChange={url.handleFilterTokensChange}
+            disabled={isLoadingLogs}
+            onStartTextFilter={setAutoFocusFilterFieldId}
+          />
+          <ButtonWithTooltip
+            as="a"
+            href="https://mastra.ai/en/docs/observability/logging"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Logs documentation"
+            tooltipContent="Go to Logs documentation"
+          >
+            <BookIcon />
+          </ButtonWithTooltip>
+        </PageLayout.Column>
+      </PageLayout.Row>
+
+      <LogsToolbar
+        isLoading={isLoadingLogs}
+        filterFields={filterFields}
+        filterTokens={url.filterTokens}
+        onFilterTokensChange={url.handleFilterTokensChange}
+        onClear={handleClear}
+        onRemoveAll={url.handleRemoveAll}
+        onSave={persistence.handleSave}
+        onRemoveSaved={persistence.hasSavedFilters ? persistence.handleRemoveSaved : undefined}
+        autoFocusFilterFieldId={autoFocusFilterFieldId}
+      />
+    </PageLayout.TopArea>
+  );
+
   if (logsError) {
     return (
-      <NoDataPageLayout title="Logs" icon={<LogsIcon />}>
-        <LogsErrorContent error={logsError} resource="logs" errorTitle="Failed to load logs" />
-      </NoDataPageLayout>
+      <PageLayout width="wide" height="full">
+        {pageTopArea}
+        <PageLayout.MainArea isCentered>
+          <LogsErrorContent error={logsError} resource="logs" errorTitle="Failed to load logs" />
+        </PageLayout.MainArea>
+      </PageLayout>
     );
   }
 
-  const hasActiveFilters = url.filterTokens.length > 0 || url.datePreset !== 'last-24h' || !!url.selectedDateTo;
-
-  if (logs.length === 0 && !isLoadingLogs && !hasActiveFilters) {
+  if (logs.length === 0 && !isLoadingLogs && url.filterTokens.length === 0) {
     return (
-      <NoDataPageLayout title="Logs" icon={<LogsIcon />}>
-        <NoLogsInfo />
-      </NoDataPageLayout>
+      <PageLayout width="wide" height="full">
+        {pageTopArea}
+        <PageLayout.MainArea isCentered>
+          <NoLogsInfo datePreset={url.datePreset} dateFrom={url.selectedDateFrom} dateTo={url.selectedDateTo} />
+        </PageLayout.MainArea>
+      </PageLayout>
     );
   }
 
   return (
     <PageLayout width="wide" height="full">
-      <PageLayout.TopArea>
-        <PageLayout.Row>
-          <PageLayout.Column>
-            <PageHeader>
-              <PageHeader.Title isLoading={isLoadingLogs}>
-                <LogsIcon /> Logs
-              </PageHeader.Title>
-            </PageHeader>
-          </PageLayout.Column>
-          <PageLayout.Column className="flex justify-end items-center gap-2">
-            <DateTimeRangePicker
-              preset={url.datePreset}
-              onPresetChange={url.handleDatePresetChange}
-              dateFrom={url.selectedDateFrom}
-              dateTo={url.selectedDateTo}
-              onDateChange={url.handleDateChange}
-              disabled={isLoadingLogs}
-              presets={['last-24h', 'last-3d', 'last-7d', 'last-14d', 'last-30d', 'custom']}
-            />
-            <PropertyFilterCreator
-              fields={filterFields}
-              tokens={url.filterTokens}
-              onTokensChange={url.handleFilterTokensChange}
-              disabled={isLoadingLogs}
-              onStartTextFilter={setAutoFocusFilterFieldId}
-            />
-            <ButtonWithTooltip
-              as="a"
-              href="https://mastra.ai/en/docs/observability/logs/overview"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Logs documentation"
-              tooltipContent="Go to Logs documentation"
-            >
-              <BookIcon />
-            </ButtonWithTooltip>
-          </PageLayout.Column>
-        </PageLayout.Row>
-
-        <LogsToolbar
-          isLoading={isLoadingLogs}
-          filterFields={filterFields}
-          filterTokens={url.filterTokens}
-          onFilterTokensChange={url.handleFilterTokensChange}
-          onClear={handleClear}
-          onRemoveAll={url.handleRemoveAll}
-          onSave={persistence.handleSave}
-          onRemoveSaved={persistence.hasSavedFilters ? persistence.handleRemoveSaved : undefined}
-          autoFocusFilterFieldId={autoFocusFilterFieldId}
-        />
-      </PageLayout.TopArea>
-
+      {pageTopArea}
       <LogsLayout
         logCollapsed={logDetailsCollapsed}
         listSlot={


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

- keep the date/time selector visible
- update No logs info msg

<img width="1439" height="842" alt="Screenshot 2026-05-04 at 10 50 56" src="https://github.com/user-attachments/assets/b7c6b4f5-7c60-4a58-b1b2-b1173affea28" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The Logs page now shows the date/time selector and gives a smarter "No logs" message that tells you what time range you're looking at and links to logging docs with suggestions (e.g., widen the range or lower log level).

## Changes

- Enhanced empty-state messaging:
  - Reworked NoLogsInfo to accept optional props: datePreset, dateFrom, dateTo.
  - Message adapts to preset or explicit date range (e.g., "No logs for the last 24 hours", "No logs between ... and ...", "No logs since ...").
  - Keeps previous fallback copy when no range is provided.
  - Adds a "Logging Documentation" external link button in the empty state.

- Exports:
  - Barrel export updated to re-export NoLogsInfoProps alongside NoLogsInfo.

- Logs page UX/layout:
  - Made the date/time picker and top-area controls more visible by building a shared pageTopArea (header, DateTimeRangePicker, PropertyFilterCreator, docs link, and LogsToolbar) and reusing it across states.
  - Error and empty states now render inside PageLayout (with the shared top area) for consistent layout.
  - Empty-results condition simplified to check url.filterTokens.length === 0.
  - NoLogsInfo is passed the current datePreset/dateFrom/dateTo from URL state.

## Files modified
- .changeset/curvy-bobcats-fail.md
- packages/playground-ui/src/domains/logs/components/index.ts
- packages/playground-ui/src/domains/logs/components/no-logs-info.tsx
- packages/playground/src/pages/logs/index.tsx
<!-- end of auto-generated comment: release notes by coderabbit.ai -->