### PR TITLE
fix(playground-ui): show pointer cursor on interactive form controls

### DIFF
--- a/.changeset/witty-baths-flash.md
+++ b/.changeset/witty-baths-flash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Show pointer cursor on interactive form controls (Button, SelectTrigger, SelectItem) for better affordance.

--- a/.changeset/witty-baths-flash.md
+++ b/.changeset/witty-baths-flash.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Show pointer cursor on interactive form controls (Button, SelectTrigger, SelectItem) for better affordance.
+Fixed pointer cursor on interactive form controls (Button, SelectTrigger, SelectItem) for better affordance.

--- a/packages/playground-ui/src/ds/components/Button/Button.tsx
+++ b/packages/playground-ui/src/ds/components/Button/Button.tsx
@@ -21,7 +21,7 @@ const TEXT_MODE_ADORNMENTS = cn(
 
 export const buttonVariants = cva(
   cn(
-    'inline-flex items-center justify-center leading-0',
+    'inline-flex items-center justify-center leading-0 cursor-pointer',
     'transition-all duration-normal ease-out-custom',
     sharedFormElementDisabledStyle,
     sharedFormElementFocusStyle,

--- a/packages/playground-ui/src/ds/components/Select/select.tsx
+++ b/packages/playground-ui/src/ds/components/Select/select.tsx
@@ -73,7 +73,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-neutral5 text-sm',
+      'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-neutral5 text-sm',
       transitions.colors,
       'hover:bg-surface5 hover:text-neutral5',
       'focus:bg-surface5 focus:text-neutral5',


### PR DESCRIPTION
## Summary
- Add `cursor-pointer` to `Button` base styles, propagating to `SelectTrigger` (which uses `buttonVariants`).
- Replace `cursor-default` with `cursor-pointer` on `SelectItem`.
- `DropdownMenu` triggers and items already had `cursor-pointer` — no change there.
- Disabled affordance preserved via existing `disabled:cursor-not-allowed` and `data-disabled:pointer-events-none`.

## Test plan
- [ ] Open Storybook (`pnpm storybook` in `packages/playground-ui`) and hover Button, SelectTrigger, SelectItem, DropdownMenu trigger and items — pointer cursor visible.
- [ ] Disabled Button still shows `not-allowed` cursor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes buttons and other form controls show a pointing-finger cursor when you hover over them so it's obvious they can be clicked.

## Changes

- **Button component**: Added `cursor-pointer` to the base `buttonVariants` styling so all buttons and components that reuse those styles (e.g., `SelectTrigger`) show the pointer cursor.
- **Select component**: Changed `SelectItem` from `cursor-default` to `cursor-pointer` so select options indicate they are clickable.
- **DropdownMenu**: No changes — triggers and items already had `cursor-pointer`.
- **Disabled state handling**: Existing disabled affordances preserved (`disabled:cursor-not-allowed` and `data-disabled:pointer-events-none`).

## Testing Notes

Open Storybook (`pnpm storybook` in `packages/playground-ui`) and hover Button, SelectTrigger, SelectItem, and DropdownMenu triggers/items — pointer cursor should appear. Verify disabled Button still shows the `not-allowed` cursor.

## Files Modified

- `.changeset/witty-baths-flash.md` — Changesets entry for patch release
- `packages/playground-ui/src/ds/components/Button/Button.tsx` — Add `cursor-pointer` to button base styles
- `packages/playground-ui/src/ds/components/Select/select.tsx` — Change `SelectItem` cursor from `default` to `pointer`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->