### PR TITLE
perf(memory): reuse per-step token count and cross-thread context

### DIFF
--- a/.changeset/some-bears-dream.md
+++ b/.changeset/some-bears-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improved observational memory step performance by reusing token and resource context checks that were already computed during step preparation.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -145,6 +145,31 @@ function createInMemoryStorage(): InMemoryMemory {
   return new InMemoryMemory({ db });
 }
 
+async function saveTestThread(storage: InMemoryMemory, threadId: string, resourceId: string) {
+  await storage.saveThread({
+    thread: {
+      id: threadId,
+      resourceId,
+      title: threadId,
+      createdAt: new Date('2025-01-01T08:00:00Z'),
+      updatedAt: new Date('2025-01-01T08:00:00Z'),
+      metadata: {},
+    },
+  });
+}
+
+function createBasicMockModel() {
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      content: [{ type: 'text' as const, text: 'ok' }],
+      warnings: [],
+    }),
+  });
+}
+
 function createStreamCapableMockModel(config: Record<string, any>) {
   if (config.doGenerate && !config.doStream) {
     const originalDoGenerate = config.doGenerate;
@@ -14484,6 +14509,126 @@ describe('OM context loading with no prior observations', () => {
     expect(saved.length).toBeGreaterThanOrEqual(2);
     expect(saved.find(m => m.id === 'user-msg-1')).toBeDefined();
     expect(saved.find(m => m.id === 'assistant-msg-1')).toBeDefined();
+  });
+
+  it('persists step pending tokens without recounting messages after prepare', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const storage = createInMemoryStorage();
+    const threadId = 'pending-token-thread';
+    const resourceId = 'pending-token-resource';
+
+    await saveTestThread(storage, threadId, resourceId);
+
+    const mockModel = createBasicMockModel();
+    const om = new ObservationalMemory({
+      storage,
+      scope: 'thread',
+      model: mockModel as any,
+      observation: { messageTokens: 500000 },
+      reflection: { observationTokens: 200000 },
+    });
+    const countSpy = vi.spyOn(om.getTokenCounter(), 'countMessagesAsync');
+
+    const message = {
+      ...createTestMessage('Please remember this lightweight request.', 'user', 'pending-token-msg'),
+      createdAt: new Date('2025-01-01T10:00:00Z'),
+      threadId,
+      resourceId,
+    };
+    const messageList = new MessageList({ threadId, resourceId });
+    messageList.add(message, 'input');
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+
+    const processor = new ObservationalMemoryProcessor(om, createMemoryProvider(om));
+    await processor.processInputStep({
+      messageList,
+      messages: [],
+      requestContext,
+      stepNumber: 0,
+      state: {},
+      steps: [],
+      systemMessages: [],
+      model: mockModel as any,
+      retryCount: 0,
+      abort: (() => {
+        throw new Error('aborted');
+      }) as any,
+    });
+
+    expect(countSpy).toHaveBeenCalledTimes(1);
+    const record = await storage.getObservationalMemory(threadId, resourceId);
+    expect(record?.pendingMessageTokens).toBeGreaterThan(0);
+  });
+
+  it('reuses the resource-scope context loaded during status checks', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const storage = createInMemoryStorage();
+    const resourceId = 'resource-context-reuse';
+    const currentThreadId = 'resource-current-thread';
+    const otherThreadId = 'resource-other-thread';
+
+    for (const threadId of [currentThreadId, otherThreadId]) {
+      await saveTestThread(storage, threadId, resourceId);
+    }
+
+    await storage.saveMessages({
+      messages: [
+        {
+          ...createTestMessage('Sibling thread context should be available once.', 'user', 'resource-other-msg'),
+          createdAt: new Date('2025-01-01T09:00:00Z'),
+          threadId: otherThreadId,
+          resourceId,
+        },
+      ],
+    });
+
+    const mockModel = createBasicMockModel();
+    const om = new ObservationalMemory({
+      storage,
+      scope: 'resource',
+      model: mockModel as any,
+      observation: { messageTokens: 500000 },
+      reflection: { observationTokens: 200000 },
+    });
+    const otherThreadsSpy = vi.spyOn(om, 'getOtherThreadsContext');
+
+    const messageList = new MessageList({ threadId: currentThreadId, resourceId });
+    const currentMessage = {
+      ...createTestMessage('Current thread input.', 'user', 'resource-current-msg'),
+      createdAt: new Date('2025-01-01T10:00:00Z'),
+      threadId: currentThreadId,
+      resourceId,
+    };
+    messageList.add(currentMessage, 'input');
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: currentThreadId }, resourceId });
+
+    const processor = new ObservationalMemoryProcessor(om, createMemoryProvider(om));
+    await processor.processInputStep({
+      messageList,
+      messages: [],
+      requestContext,
+      stepNumber: 0,
+      state: {},
+      steps: [],
+      systemMessages: [],
+      model: mockModel as any,
+      retryCount: 0,
+      abort: (() => {
+        throw new Error('aborted');
+      }) as any,
+    });
+
+    expect(otherThreadsSpy).toHaveBeenCalledTimes(1);
+    const record = await storage.getObservationalMemory(null, resourceId);
+    expect(record?.pendingMessageTokens).toBeGreaterThan(om.getTokenCounter().countMessages([currentMessage]));
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -246,7 +246,9 @@ export class ObservationStep {
     }
 
     // ── Refresh cross-thread context (resource scope) ──────────
-    const otherThreadsContext = await this.turn.refreshOtherThreadsContext();
+    const otherThreadsContext =
+      om.scope === 'resource' ? statusSnapshot.otherThreadsContext : await this.turn.refreshOtherThreadsContext();
+    this.turn.context.otherThreadsContext = otherThreadsContext;
 
     // ── Build system messages (one per cache-stable chunk) ────
     const systemMessage = await om.buildContextSystemMessages({
@@ -282,6 +284,7 @@ export class ObservationStep {
         pendingTokens: statusSnapshot.pendingTokens,
         threshold: statusSnapshot.threshold,
         effectiveObservationTokensThreshold: statusSnapshot.effectiveObservationTokensThreshold,
+        otherThreadsContext,
         shouldObserve: statusSnapshot.shouldObserve,
         shouldBuffer: statusSnapshot.shouldBuffer,
         shouldReflect: statusSnapshot.shouldReflect,

--- a/packages/memory/src/processors/observational-memory/observation-turn/types.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/types.ts
@@ -38,6 +38,7 @@ export interface StepContext {
     pendingTokens: number;
     threshold: number;
     effectiveObservationTokensThreshold: number;
+    otherThreadsContext?: string;
     shouldObserve: boolean;
     shouldBuffer: boolean;
     shouldReflect: boolean;

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -2645,6 +2645,7 @@ ${formattedMessages}
     asyncObservationEnabled: boolean;
     asyncReflectionEnabled: boolean;
     scope: 'resource' | 'thread';
+    otherThreadsContext?: string;
   }> {
     const { threadId, resourceId } = opts;
     const record = await this.getOrCreateRecord(threadId, resourceId);
@@ -2666,9 +2667,10 @@ ${formattedMessages}
     // Count tokens
     const contextWindowTokens = await this.tokenCounter.countMessagesAsync(unobservedMessages);
     let otherThreadTokens = 0;
+    let otherThreadsContext: string | undefined;
     if (this.scope === 'resource' && resourceId) {
-      const otherContext = await this.getOtherThreadsContext(resourceId, threadId);
-      otherThreadTokens = otherContext ? this.tokenCounter.countString(otherContext) : 0;
+      otherThreadsContext = await this.getOtherThreadsContext(resourceId, threadId);
+      otherThreadTokens = otherThreadsContext ? this.tokenCounter.countString(otherThreadsContext) : 0;
     }
     const pendingTokens = Math.max(0, contextWindowTokens + otherThreadTokens);
 
@@ -2729,6 +2731,7 @@ ${formattedMessages}
       asyncObservationEnabled,
       asyncReflectionEnabled: this.buffering.isAsyncReflectionEnabled(),
       scope: this.scope,
+      otherThreadsContext,
     };
   }
 

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -256,12 +256,7 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
         });
 
         // ── Token persistence (processor-specific) ──────────
-        const allDbMsgs = messageList.get.all.db();
-        const tokenCounter = this.engine.getTokenCounter();
-        const contextTokens = await tokenCounter.countMessagesAsync(allDbMsgs);
-        const otherThreadsContext = this.turn.context.otherThreadsContext;
-        const otherThreadTokens = otherThreadsContext ? tokenCounter.countString(otherThreadsContext) : 0;
-        const finalTotalPending = contextTokens + otherThreadTokens;
+        const finalTotalPending = ctx.status.pendingTokens;
 
         await this.engine
           .getStorage()


### PR DESCRIPTION
## Description

Removes duplicate work performed every agentic loop step inside `ObservationalMemoryProcessor.processInputStep`. Both the message token count and the resource-scope cross-thread context were being computed once inside `getStatus(...)` and then re-computed by the processor, doubling per-step latency for no behavioral gain. This PR threads the already-computed values through the step context so each is computed at most once per step.

- `getStatus(...)` now returns `otherThreadsContext` alongside the token tally so callers can reuse it
- `ObservationStep.prepare()` reuses `statusSnapshot.otherThreadsContext` in resource scope and falls back to `refreshOtherThreadsContext()` only when the snapshot did not compute one
- `processor.ts` post-prepare block drops its own `countMessagesAsync(allDbMsgs)` and `countString(otherThreadsContext)` and reads `ctx.status.pendingTokens` instead
- `StepContext.status` extended with optional `otherThreadsContext` so downstream consumers can read the value without a second computation
- Tests added in `observational-memory.test.ts` covering the dedup paths

Note: the original report claimed `turn.start(memory)` runs every step, which is not the case (it is gated to once per turn at `processor.ts:165`). This PR addresses the real per-step duplication identified in the issue thread by @truffle-dev. It does not by itself fully explain a 2-4s per-step latency without the reporter confirming `scope` and other-thread count.

## Related Issue(s)

Fixes #15677

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The processor was doing expensive calculations (like counting tokens and checking other threads) multiple times every single step, adding 2-4 seconds of unnecessary delay. This PR makes it compute those values once and reuse them throughout the step, eliminating the duplicate work and speeding things up significantly.

## Summary

This PR optimizes the observational memory processor by eliminating duplicate per-step token counting and context fetching. The optimization threads already-computed values through the step context so each expensive operation happens at most once per step, removing 2-4 seconds of latency on simple agent interactions.

### Key Changes

**Core Logic Refactoring:**
- `getStatus()` now returns `otherThreadsContext` alongside the token tally, enabling downstream consumers to reuse it instead of re-fetching
- `ObservationStep.prepare()` conditionally reuses `statusSnapshot.otherThreadsContext` when available for resource scope, falling back to `refreshOtherThreadsContext()` only when needed
- `processor.ts` post-prepare block now reads `ctx.status.pendingTokens` directly instead of re-calling `countMessagesAsync(allDbMsgs)` and `countString(otherThreadsContext)`

**Type System Updates:**
- Extended `StepContext.status` with optional `otherThreadsContext?: string` field to pass fetched context through the step pipeline

**Test Coverage:**
- Added integration test verifying `processInputStep` persists `pendingMessageTokens` by reusing the pending token count path (asserting `countMessagesAsync` is called exactly once)
- Added integration test verifying the processor reuses resource-scope context loaded during status checks (asserting `getOtherThreadsContext` is called once)
- Added `saveTestThread` and `createBasicMockModel` test helpers for seeding thread records and creating deterministic mock model responses

### Impact

Addresses #15677 by eliminating the blocking DB reads and token counting calls that were occurring unconditionally on every agentic loop step. The deduplication ensures single-message conversations and cases where total tokens are clearly below thresholds no longer incur the full latency penalty of these expensive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->