### PR TITLE
New Design of SpanTokenUsage

### DIFF
--- a/.changeset/wise-parrots-feel.md
+++ b/.changeset/wise-parrots-feel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Redesigned the span token usage panel to show input vs output split with proportional bar and per-side detail breakdowns. `DataKeysAndValues` gained an optional `density='dense'` prop.

--- a/packages/playground-ui/src/domains/traces/components/__tests__/span-token-usage.utils.test.ts
+++ b/packages/playground-ui/src/domains/traces/components/__tests__/span-token-usage.utils.test.ts
@@ -1,0 +1,101 @@
+import type { UsageStats } from '@mastra/core/observability';
+import { describe, expect, it } from 'vitest';
+import { getTokenUsageView } from '../span-token-usage.utils';
+
+describe('getTokenUsageView', () => {
+  it('returns null when usage is undefined', () => {
+    expect(getTokenUsageView(undefined)).toBeNull();
+  });
+
+  it('returns null when usage is null', () => {
+    expect(getTokenUsageView(null)).toBeNull();
+  });
+
+  it('returns null when usage is an empty object', () => {
+    expect(getTokenUsageView({} as UsageStats)).toBeNull();
+  });
+
+  it('returns null when only details are present (no top-level token counts)', () => {
+    const usage = {
+      inputDetails: { text: 50 },
+      outputDetails: { text: 20 },
+    } as UsageStats;
+    expect(getTokenUsageView(usage)).toBeNull();
+  });
+
+  it('renders both columns when only the input side is present, with output defaulting to 0', () => {
+    const view = getTokenUsageView({ inputTokens: 100 } as UsageStats);
+    expect(view).not.toBeNull();
+    expect(view!.inputValue).toBe(100);
+    expect(view!.outputValue).toBe(0);
+    expect(view!.total).toBe(100);
+    expect(view!.showSplit).toBe(true);
+    expect(view!.inputPct).toBe(100);
+    expect(view!.outputPct).toBe(0);
+    expect(view!.inputDetails).toBeUndefined();
+    expect(view!.outputDetails).toBeUndefined();
+  });
+
+  it('drops details on a side that has no top-level token count', () => {
+    const view = getTokenUsageView({
+      inputTokens: 100,
+      outputDetails: { text: 50 },
+    } as UsageStats);
+    expect(view).not.toBeNull();
+    expect(view!.outputValue).toBe(0);
+    expect(view!.outputDetails).toBeUndefined();
+  });
+
+  it('keeps details on a side that has a top-level token count', () => {
+    const view = getTokenUsageView({
+      inputTokens: 100,
+      inputDetails: { text: 80, cacheRead: 20 },
+      outputTokens: 25,
+    } as UsageStats);
+    expect(view).not.toBeNull();
+    expect(view!.inputDetails).toEqual({ text: 80, cacheRead: 20 });
+    expect(view!.outputDetails).toBeUndefined();
+  });
+
+  it('treats a details object with no numeric values as absent', () => {
+    const view = getTokenUsageView({
+      inputTokens: 100,
+      inputDetails: { text: undefined } as unknown as UsageStats['inputDetails'],
+    } as UsageStats);
+    expect(view).not.toBeNull();
+    expect(view!.inputDetails).toBeUndefined();
+  });
+
+  it('renders both columns at 0 with no split bar when both totals are 0', () => {
+    const view = getTokenUsageView({ inputTokens: 0, outputTokens: 0 } as UsageStats);
+    expect(view).not.toBeNull();
+    expect(view!.inputValue).toBe(0);
+    expect(view!.outputValue).toBe(0);
+    expect(view!.total).toBe(0);
+    expect(view!.showSplit).toBe(false);
+    expect(view!.inputPct).toBe(0);
+    expect(view!.outputPct).toBe(0);
+  });
+
+  it('splits 50/50 when input and output are equal', () => {
+    const view = getTokenUsageView({ inputTokens: 100, outputTokens: 100 } as UsageStats);
+    expect(view!.total).toBe(200);
+    expect(view!.inputPct).toBe(50);
+    expect(view!.outputPct).toBe(50);
+  });
+
+  it('produces percentages that always sum to 100 for asymmetric inputs', () => {
+    const view = getTokenUsageView({ inputTokens: 1000, outputTokens: 250 } as UsageStats);
+    expect(view!.total).toBe(1250);
+    expect(view!.inputPct).toBe(80);
+    expect(view!.outputPct).toBe(20);
+    expect(view!.inputPct + view!.outputPct).toBe(100);
+  });
+
+  it('handles one side at 0 with the other positive (100/0 split)', () => {
+    const view = getTokenUsageView({ inputTokens: 100, outputTokens: 0 } as UsageStats);
+    expect(view!.showSplit).toBe(true);
+    expect(view!.inputPct).toBe(100);
+    expect(view!.outputPct).toBe(0);
+  });
+});

--- a/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-data-panel-view.tsx
@@ -142,6 +142,7 @@ function SpanDataPanelContent({
           </Notice>
         </div>
       )}
+
       {usage && <SpanTokenUsage usage={usage} className="mb-3" />}
 
       <DataKeysAndValues>

--- a/packages/playground-ui/src/domains/traces/components/span-token-usage.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-token-usage.tsx
@@ -1,132 +1,111 @@
-import type { InputTokenDetails, OutputTokenDetails } from '@mastra/core/observability';
-import { ArrowRightIcon, ArrowRightToLineIcon, CoinsIcon } from 'lucide-react';
+import type { InputTokenDetails, OutputTokenDetails, UsageStats } from '@mastra/core/observability';
+import { Fragment } from 'react';
+import { DataKeysAndValues } from '@/ds/components/DataKeysAndValues';
 import { cn } from '@/lib/utils';
+import { getTokenUsageView } from './span-token-usage.utils';
 
-// V5 format (AI SDK v5)
-type V5TokenUsage = {
-  inputTokens: number;
-  outputTokens: number;
-  reasoningTokens?: number;
-  cachedInputTokens?: number;
-  totalTokens: number;
-  inputDetails?: InputTokenDetails;
-  outputDetails?: OutputTokenDetails;
-};
-
-// Legacy format
-type LegacyTokenUsage = {
-  promptTokens: number;
-  completionTokens: number;
-  totalTokens: number;
-};
-
-export type TokenUsage = V5TokenUsage | LegacyTokenUsage;
+export type TokenUsage = UsageStats;
 
 type TokenDetailsObject = InputTokenDetails | OutputTokenDetails;
-type UsageValue = number | TokenDetailsObject | undefined;
-
-function isTokenDetailsObject(value: UsageValue): value is TokenDetailsObject {
-  return typeof value === 'object' && value !== null;
-}
 
 const detailKeyLabels: Record<string, string> = {
   text: 'Text',
-  cacheRead: 'Cache Read',
-  cacheWrite: 'Cache Write',
+  cacheRead: 'Cache read',
+  cacheWrite: 'Cache write',
   audio: 'Audio',
   image: 'Image',
   reasoning: 'Reasoning',
 };
 
 type SpanTokenUsageProps = {
-  usage: TokenUsage;
+  usage: UsageStats;
   className?: string;
 };
 
+const INPUT_COLOR = 'oklch(0.78 0.16 320)';
+const OUTPUT_COLOR = 'oklch(0.55 0.18 320)';
+
 export function SpanTokenUsage({ usage, className }: SpanTokenUsageProps) {
-  if (!usage) return null;
-  const isV5 = 'inputTokens' in usage;
+  const view = getTokenUsageView(usage);
+  if (!view) return null;
 
-  const legacyTokenPresentations: Record<string, { label: string; icon: React.ReactNode }> = {
-    promptTokens: { label: 'Prompt Tokens', icon: <ArrowRightIcon /> },
-    completionTokens: { label: 'Completion Tokens', icon: <ArrowRightToLineIcon /> },
-  };
-
-  const v5TokenPresentations: Record<string, { label: string; icon: React.ReactNode }> = {
-    inputTokens: { label: 'Input Tokens', icon: <ArrowRightIcon /> },
-    outputTokens: { label: 'Output Tokens', icon: <ArrowRightToLineIcon /> },
-    reasoningTokens: { label: 'Reasoning Tokens', icon: <ArrowRightToLineIcon /> },
-    cachedInputTokens: { label: 'Cached Input Tokens', icon: <ArrowRightToLineIcon /> },
-    inputDetails: { label: 'Input Details', icon: <ArrowRightIcon /> },
-    outputDetails: { label: 'Output Details', icon: <ArrowRightToLineIcon /> },
-  };
-
-  const commonTokenPresentations: Record<string, { label: string; icon: React.ReactNode }> = {
-    totalTokens: { label: 'Total LLM Tokens', icon: <CoinsIcon /> },
-  };
-
-  const tokenPresentations = {
-    ...commonTokenPresentations,
-    ...v5TokenPresentations,
-    ...legacyTokenPresentations,
-  };
-
-  const usageKeyOrder = isV5
-    ? [
-        'totalTokens',
-        'inputTokens',
-        'outputTokens',
-        'reasoningTokens',
-        'cachedInputTokens',
-        'inputDetails',
-        'outputDetails',
-      ]
-    : ['totalTokens', 'promptTokens', 'completionTokens'];
-
-  const usageAsArray = Object.entries(usage)
-    .filter((entry): entry is [string, number | TokenDetailsObject] => {
-      const value = entry[1];
-      return typeof value === 'number' || isTokenDetailsObject(value);
-    })
-    .map(([key, value]) => ({ key, value }))
-    .sort((a, b) => usageKeyOrder.indexOf(a.key) - usageKeyOrder.indexOf(b.key));
+  const { inputValue, outputValue, total, showSplit, inputPct, outputPct, inputDetails, outputDetails } = view;
 
   return (
-    <div className={cn('flex gap-6 flex-wrap', className)}>
-      {usageAsArray.map(({ key, value }) => {
-        const isObject = isTokenDetailsObject(value);
-
-        return (
-          <div className="bg-surface3 p-3 px-4 rounded-lg text-ui-md grow" key={key}>
-            <div
-              className={cn(
-                'grid grid-cols-[1.5rem_1fr_auto] gap-2 items-center',
-                '[&>svg]:w-[1.5em] [&>svg]:h-[1.5em] [&>svg]:opacity-70',
-              )}
-            >
-              {tokenPresentations?.[key]?.icon}
-              <span className="text-ui-md">{tokenPresentations?.[key]?.label}</span>
-              {!isObject && <b className="text-ui-lg">{value}</b>}
-            </div>
-            {isObject && (
-              <div className="text-ui-md mt-2 pl-8">
-                {Object.entries(value).map(([detailKey, detailValue]) => {
-                  if (typeof detailValue !== 'number') return null;
-                  return (
-                    <dl
-                      key={detailKey}
-                      className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-1 justify-between text-neutral3"
-                    >
-                      <dt>{detailKeyLabels[detailKey] || detailKey}</dt>
-                      <dd>{detailValue}</dd>
-                    </dl>
-                  );
-                })}
-              </div>
-            )}
+    <div
+      className={cn('border-b border-border1 mt-2 mb-8 pb-3 grid grid-cols-1 4xl:grid-cols-2 4xl:gap-12', className)}
+    >
+      {showSplit && (
+        <div className="mb-2">
+          <div className="flex items-baseline text-neutral2 gap-3">
+            <span className="text-ui-md">Tokens Used</span>
+            <span className="text-neutral4 text-ui-md font-semibold">{total.toLocaleString()}</span>
+            <span className="ml-auto text-ui-sm">
+              {Math.round(inputPct)}% Input vs {Math.round(outputPct)}% Output
+            </span>
           </div>
+          <div className="p-1.5 rounded-md bg-surface4 mt-2">
+            <div className="relative w-full h-1.5 rounded-sm overflow-hidden">
+              <div
+                className="absolute h-1.5 top-0 left-0"
+                style={{ width: `${inputPct}%`, backgroundColor: INPUT_COLOR }}
+              />
+              <div
+                className="absolute h-1.5 top-0"
+                style={{ left: `${inputPct}%`, width: `${outputPct}%`, backgroundColor: OUTPUT_COLOR }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="grid gap-6 grid-cols-2">
+        <UsageColumn label="Input" color={INPUT_COLOR} value={inputValue} details={inputDetails} />
+        <UsageColumn label="Output" color={OUTPUT_COLOR} value={outputValue} details={outputDetails} />
+      </div>
+    </div>
+  );
+}
+
+function UsageColumn({
+  label,
+  color,
+  value,
+  details,
+}: {
+  label: string;
+  color: string;
+  value?: number;
+  details?: TokenDetailsObject;
+}) {
+  return (
+    <div>
+      <div className="flex items-baseline text-neutral2 gap-3 mb-2">
+        <span className="text-ui-md">{label}</span>
+        {typeof value === 'number' && (
+          <span className="flex items-baseline gap-1.5">
+            <span className="text-neutral4 text-ui-md font-semibold">{value.toLocaleString()}</span>
+            <span className="size-2 rounded-full self-center" style={{ backgroundColor: color }} />
+          </span>
+        )}
+      </div>
+      {details && <DetailsList details={details} />}
+    </div>
+  );
+}
+
+function DetailsList({ details }: { details: TokenDetailsObject }) {
+  return (
+    <DataKeysAndValues density="dense">
+      {Object.entries(details).map(([detailKey, detailValue]) => {
+        if (typeof detailValue !== 'number') return null;
+        return (
+          <Fragment key={detailKey}>
+            <DataKeysAndValues.Key>{detailKeyLabels[detailKey] || detailKey}</DataKeysAndValues.Key>
+            <DataKeysAndValues.Value className="text-right">{detailValue.toLocaleString()}</DataKeysAndValues.Value>
+          </Fragment>
         );
       })}
-    </div>
+    </DataKeysAndValues>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/span-token-usage.tsx
+++ b/packages/playground-ui/src/domains/traces/components/span-token-usage.tsx
@@ -1,8 +1,8 @@
 import type { InputTokenDetails, OutputTokenDetails, UsageStats } from '@mastra/core/observability';
 import { Fragment } from 'react';
+import { getTokenUsageView } from './span-token-usage.utils';
 import { DataKeysAndValues } from '@/ds/components/DataKeysAndValues';
 import { cn } from '@/lib/utils';
-import { getTokenUsageView } from './span-token-usage.utils';
 
 export type TokenUsage = UsageStats;
 

--- a/packages/playground-ui/src/domains/traces/components/span-token-usage.utils.ts
+++ b/packages/playground-ui/src/domains/traces/components/span-token-usage.utils.ts
@@ -1,0 +1,43 @@
+import type { InputTokenDetails, OutputTokenDetails, UsageStats } from '@mastra/core/observability';
+
+type TokenDetailsObject = InputTokenDetails | OutputTokenDetails;
+
+export type TokenUsageView = {
+  inputValue: number;
+  outputValue: number;
+  total: number;
+  showSplit: boolean;
+  inputPct: number;
+  outputPct: number;
+  inputDetails: TokenDetailsObject | undefined;
+  outputDetails: TokenDetailsObject | undefined;
+};
+
+function hasNumericDetails(details: TokenDetailsObject | undefined): details is TokenDetailsObject {
+  return !!details && Object.values(details).some(v => typeof v === 'number');
+}
+
+export function getTokenUsageView(usage: UsageStats | undefined | null): TokenUsageView | null {
+  if (!usage) return null;
+
+  const hasInput = typeof usage.inputTokens === 'number';
+  const hasOutput = typeof usage.outputTokens === 'number';
+
+  if (!hasInput && !hasOutput) return null;
+
+  const inputValue = usage.inputTokens ?? 0;
+  const outputValue = usage.outputTokens ?? 0;
+  const total = inputValue + outputValue;
+  const showSplit = total > 0;
+
+  return {
+    inputValue,
+    outputValue,
+    total,
+    showSplit,
+    inputPct: showSplit ? (inputValue / total) * 100 : 0,
+    outputPct: showSplit ? (outputValue / total) * 100 : 0,
+    inputDetails: hasInput && hasNumericDetails(usage.inputDetails) ? usage.inputDetails : undefined,
+    outputDetails: hasOutput && hasNumericDetails(usage.outputDetails) ? usage.outputDetails : undefined,
+  };
+}

--- a/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataKeysAndValues/data-keys-and-values-root.tsx
@@ -4,6 +4,7 @@ export interface DataKeysAndValuesProps {
   className?: string;
   children: React.ReactNode;
   numOfCol?: 1 | 2 | 3;
+  density?: 'default' | 'dense';
 }
 
 const GRID_TEMPLATES: Record<NonNullable<DataKeysAndValuesProps['numOfCol']>, string> = {
@@ -12,9 +13,22 @@ const GRID_TEMPLATES: Record<NonNullable<DataKeysAndValuesProps['numOfCol']>, st
   3: 'auto auto auto auto auto 1fr',
 };
 
-export function DataKeysAndValuesRoot({ className, children, numOfCol = 1 }: DataKeysAndValuesProps) {
+const DENSITY_GAP_Y: Record<NonNullable<DataKeysAndValuesProps['density']>, string> = {
+  default: 'gap-y-1.5',
+  dense: 'gap-y-0',
+};
+
+export function DataKeysAndValuesRoot({
+  className,
+  children,
+  numOfCol = 1,
+  density = 'default',
+}: DataKeysAndValuesProps) {
   return (
-    <dl className={cn('grid gap-x-4 gap-y-1.5', className)} style={{ gridTemplateColumns: GRID_TEMPLATES[numOfCol] }}>
+    <dl
+      className={cn('grid gap-x-4', DENSITY_GAP_Y[density], className)}
+      style={{ gridTemplateColumns: GRID_TEMPLATES[numOfCol] }}
+    >
       {children}
     </dl>
   );


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

- redesigned component
- removed legacy code

before

<img width="1437" height="891" alt="Screenshot 2026-05-04 at 11 36 06" src="https://github.com/user-attachments/assets/3b18d5c0-6a66-4d7e-bb74-1e02fc7e302e" />

after

<img width="1436" height="842" alt="Screenshot 2026-05-04 at 11 36 44" src="https://github.com/user-attachments/assets/64c448ae-0861-4dda-b6ca-593035bfa2e0" />


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5

This PR makes the token-usage box in the trace viewer much clearer: it replaces many small legacy cards with a simple two-column Input vs Output view and a proportional split bar, and shows per-side breakdowns only when appropriate.

Changes Overview

- New token-usage view utilities
  - Added getTokenUsageView(usage) → TokenUsageView | null which:
    - Returns null when usage is missing or neither inputTokens nor outputTokens are numeric.
    - Computes inputValue, outputValue, total, showSplit, inputPct, outputPct.
    - Includes inputDetails/outputDetails only when the corresponding top-level count exists and the details contain numeric fields.
    - Guards divide-by-zero and handles various edge cases.

- SpanTokenUsage component redesign
  - Rewrote span-token-usage.tsx to consume UsageStats via getTokenUsageView and render a simplified layout:
    - Removed legacy/V5 union handling and per-token/icon card logic.
    - Renders optional "Tokens Used" split bar when total > 0 and exactly two columns ("Input" and "Output").
    - Each column shows an optional numeric total and a details list rendered with DataKeysAndValues (dense).
    - Detail labels normalized (e.g., cacheRead → "Cache read").
  - Type change: export type TokenUsage = UsageStats (removed previous union).
  - Component now returns null only when getTokenUsageView returns null.

- Utilities & types
  - Added span-token-usage.utils.ts:
    - Exported TokenUsageView type and getTokenUsageView() function.

- Tests
  - Added comprehensive Vitest suite for getTokenUsageView covering:
    - undefined/null/empty usage
    - presence/absence of side totals and detail-dropping behavior
    - details-without-numeric-values treated as absent
    - split bar and percentage calculations for 0, equal, asymmetric, and 100/0 cases

- DataKeysAndValues spacing control
  - data-keys-and-values-root.tsx: added optional density?: 'default' | 'dense' prop and DENSITY_GAP_Y lookup to control vertical spacing.
  - DataKeysAndValuesRoot now accepts density and applies density-specific gap-y classes.

- Minor bugfix
  - span-data-panel-view.tsx: fixed JSX structure around the "Token Limit Exceeded" Notice so subsequent usage rendering is not nested incorrectly.

Changes to exported/public API
- Added export: TokenUsageView and getTokenUsageView.
- Updated export type TokenUsage to be UsageStats (signature change in span-token-usage).
- DataKeysAndValuesProps now accepts optional density?: 'default' | 'dense'.

Impact
- UI: cleaner, more consistent token usage display with a clear visual Input vs Output comparison and controlled detail visibility.
- Code: removes old union/legacy handling, centralizes display logic in a test-covered utility, and provides a small API change (TokenUsage now equals UsageStats) and a new density prop for DataKeysAndValues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->