### PR TITLE
fix(core): type sub-agent wrapper tool conversion

### DIFF
--- a/.changeset/rare-books-scream.md
+++ b/.changeset/rare-books-scream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved sub-agent wrapper tool typings.

--- a/.changeset/rare-books-scream.md
+++ b/.changeset/rare-books-scream.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': patch
----
-
-Improved sub-agent wrapper tool typings.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4248,14 +4248,8 @@ export class Agent<
           backgroundConfig: subAgentBackgroundConfig,
         };
 
-        // Mark the wrapper tool so tool-call-step picks up the background config
-        if (subAgentBackgroundConfig) {
-          (toolObj as any).backgroundConfig = subAgentBackgroundConfig;
-        }
-
-        // TODO; fix recursion type
         convertedAgentTools[`agent-${agentName}`] = makeCoreTool(
-          toolObj as any,
+          toolObj,
           options,
           undefined,
           autoResumeSuspendedTools,

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1,6 +1,7 @@
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
+import type { ToolBackgroundConfig } from './background-tasks';
 import { MastraError } from './error';
 import { ConsoleLogger } from './logger';
 import { RequestContext } from './request-context';
@@ -170,6 +171,9 @@ describe('makeCoreTool', () => {
     requestContext: new RequestContext(),
     tracingContext: {},
   };
+
+  const getCoreToolBackgroundConfig = (tool: ReturnType<typeof makeCoreTool>) =>
+    (tool as unknown as { backgroundConfig?: ToolBackgroundConfig }).backgroundConfig;
 
   it('should convert a Vercel tool correctly', async () => {
     const vercelTool = {
@@ -348,6 +352,78 @@ describe('makeCoreTool', () => {
 
     const coreToolWithoutFlag = makeCoreTool(tool, mockOptions);
     expect((coreToolWithoutFlag as any).requireApproval).toBe(false);
+  });
+
+  it('should accept a createTool wrapper without casting and preserve backgroundConfig from options', () => {
+    const onComplete = vi.fn();
+    const wrapperTool = createTool({
+      id: 'agent-specialist',
+      description: 'Delegates to a specialist agent',
+      inputSchema: z.object({ prompt: z.string() }),
+      outputSchema: z.object({ text: z.string() }),
+      execute: async ({ prompt }) => ({ text: prompt }),
+    });
+
+    const backgroundConfig = {
+      enabled: true,
+      waitTimeoutMs: 250,
+      timeoutMs: 1_000,
+      maxRetries: 2,
+      onComplete,
+    } satisfies ToolBackgroundConfig;
+
+    const coreTool = makeCoreTool(wrapperTool, {
+      ...mockOptions,
+      backgroundConfig,
+    });
+
+    expect(getCoreToolBackgroundConfig(coreTool)).toBe(backgroundConfig);
+  });
+
+  it('should prefer ToolOptions.backgroundConfig over conflicting tool-level background metadata', () => {
+    const wrapperTool = createTool({
+      id: 'agent-specialist',
+      description: 'Delegates to a specialist agent',
+      inputSchema: z.object({ prompt: z.string() }),
+      outputSchema: z.object({ text: z.string() }),
+      execute: async ({ prompt }) => ({ text: prompt }),
+    });
+    const toolWithConflictingBackground = Object.assign(wrapperTool, {
+      background: { enabled: false, waitTimeoutMs: 1 },
+      backgroundConfig: { enabled: false, waitTimeoutMs: 2 },
+    } satisfies {
+      background: ToolBackgroundConfig;
+      backgroundConfig: ToolBackgroundConfig;
+    });
+    const optionsBackgroundConfig = { enabled: true, waitTimeoutMs: 500 } satisfies ToolBackgroundConfig;
+
+    const coreTool = makeCoreTool(toolWithConflictingBackground, {
+      ...mockOptions,
+      backgroundConfig: optionsBackgroundConfig,
+    });
+
+    expect(getCoreToolBackgroundConfig(coreTool)).toBe(optionsBackgroundConfig);
+  });
+
+  it('should not synthesize backgroundConfig from raw tool background fields when options omit it', () => {
+    const wrapperTool = createTool({
+      id: 'agent-specialist',
+      description: 'Delegates to a specialist agent',
+      inputSchema: z.object({ prompt: z.string() }),
+      outputSchema: z.object({ text: z.string() }),
+      execute: async ({ prompt }) => ({ text: prompt }),
+    });
+    const toolWithRawBackground = Object.assign(wrapperTool, {
+      background: { enabled: true, waitTimeoutMs: 100 },
+      backgroundConfig: { enabled: true, waitTimeoutMs: 200 },
+    } satisfies {
+      background: ToolBackgroundConfig;
+      backgroundConfig: ToolBackgroundConfig;
+    });
+
+    const coreTool = makeCoreTool(toolWithRawBackground, mockOptions);
+
+    expect(getCoreToolBackgroundConfig(coreTool)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #16145

🎯 **What:** Removed unnecessary `any` casts from the sub-agent wrapper tool conversion in `agent.ts` and added focused regression coverage for background config propagation through `makeCoreTool`.

💡 **Why:** `createTool(...)` already returns a valid tool type for `makeCoreTool`, and the sub-agent background config is already passed through `ToolOptions`. Keeping this typed avoids masking future tool conversion regressions.

✅ **Verification:**
- `pnpm build:core`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm --filter ./packages/core exec vitest run src/utils.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/agent/durable/workflows/steps/tool-call-bg.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/agent/__tests__/supervisor-integration.test.ts`
- `git diff --check`

✨ **Result:** The sub-agent wrapper tool path no longer needs `any` casts or the stale recursion-type TODO, with behavior preserved.

Related precedent: #15782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5: Explain Like I'm 5

Instead of TypeScript ignoring type safety and the code manually changing objects after creation, this PR properly passes the background configuration through normal function parameters right from the start. It also adds tests to make sure this still works correctly. This makes the code cleaner and less error-prone.

---

## Overview

This PR resolves issue #16145 by removing unnecessary `any` type casts from the sub-agent wrapper tool conversion path in the core agent implementation. It replaces unsafe type casting and object mutation with proper type-safe parameter passing, while adding regression tests to verify the behavior is preserved.

---

## Changes

### `.changeset/rare-books-scream.md`
Added a changeset entry documenting a patch-level update to `@mastra/core` that improves sub-agent wrapper tool typings.

### `packages/core/src/agent/agent.ts`
Refactored the sub-agent wrapper tool creation:
- Removed the `// TODO; fix recursion type` comment and its associated `any` cast
- Changed from mutating `toolObj.backgroundConfig` before calling `makeCoreTool` to passing the derived `subAgentBackgroundConfig` through the `ToolOptions` parameter as `options.backgroundConfig`
- Preserves runtime behavior while improving type safety

### `packages/core/src/utils.test.ts`
Expanded the `makeCoreTool` test suite with three new test cases:
- Verifies that `createTool` wrapper inputs are accepted and `ToolOptions.backgroundConfig` is correctly preserved through the conversion
- Confirms that `ToolOptions.backgroundConfig` takes precedence when both tool-level and option-level background configs are present
- Validates that `backgroundConfig` is not auto-generated from raw tool `background` fields when `ToolOptions.backgroundConfig` is omitted

Added a typed import for `ToolBackgroundConfig` and a helper function (`getCoreToolBackgroundConfig`) to access the created core tool's background configuration during testing.

---

## Rationale

The change leverages the fact that `createTool()` already returns a type compatible with `makeCoreTool`, and sub-agent background configuration should be passed via `ToolOptions` rather than mutating the tool object. This eliminates technical debt while preserving type safety and runtime behavior.

---

## Verification

Changes have been validated with:
- `pnpm build:core`
- `pnpm --filter ./packages/core check`
- Lint checks
- Focused vitest runs for utils, tool-call background, and supervisor integration tests
- `git diff --check`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->