### PR TITLE
fix(playground-ui): homogenize Files/Skills and agent page tabs with DS Tabs

### DIFF
--- a/.changeset/shaggy-goats-smoke.md
+++ b/.changeset/shaggy-goats-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Migrated Files/Skills tabs and agent page tabs (Chat/Editor/Evaluate/Review/Traces) to the design-system Tabs component for consistent styling and accessibility (Radix tablist, arrow-key navigation). Also added a `cursor-pointer` on the Tab trigger and a `disabled` prop on the DS Tab.

--- a/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
+++ b/packages/playground-ui/src/ds/components/Tabs/tabs-tab.tsx
@@ -8,20 +8,23 @@ export type TabProps = {
   value: string;
   onClick?: () => void;
   onClose?: () => void;
+  disabled?: boolean;
   className?: string;
 };
 
-export const Tab = ({ children, value, onClick, onClose, className }: TabProps) => {
+export const Tab = ({ children, value, onClick, onClose, disabled, className }: TabProps) => {
   return (
     <RadixTabs.Trigger
       value={value}
+      disabled={disabled}
       className={cn(
         'py-2 px-5 text-ui-md font-normal text-neutral3 border-b-2 border-transparent',
-        'whitespace-nowrap shrink-0 flex items-center justify-center gap-1.5 outline-none',
+        'whitespace-nowrap shrink-0 flex items-center justify-center gap-1.5 outline-none cursor-pointer',
         transitions.colors,
         focusRing.visible,
         'hover:text-neutral4',
         'data-[state=active]:text-neutral5 data-[state=active]:border-neutral3',
+        'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:hover:text-neutral3',
         className,
       )}
       onClick={onClick}

--- a/packages/playground/e2e/tests/agents/observability-tabs.spec.ts
+++ b/packages/playground/e2e/tests/agents/observability-tabs.spec.ts
@@ -48,9 +48,9 @@ test('requests agent traces when runtime observability is available without pack
   });
 
   await page.goto('/agents/weather-agent/chat/new');
-  await expect(page.getByRole('button', { name: 'Evaluate' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Review' })).toBeVisible();
-  await page.getByRole('button', { name: 'Traces' }).click();
+  await expect(page.getByRole('tab', { name: 'Evaluate' })).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Review' })).toBeVisible();
+  await page.getByRole('tab', { name: 'Traces' }).click();
 
   await expect(page).toHaveURL(/\/agents\/weather-agent\/traces$/);
   await expect(page.getByText('No traces yet.')).toBeVisible();

--- a/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
+++ b/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
@@ -115,8 +115,8 @@ export function AgentPageTabs({
   };
 
   return (
-    <div className="bg-surface2 px-4">
-      <Tabs value={activeTab} defaultTab={activeTab} onValueChange={handleTabChange}>
+    <div className="bg-surface2 px-4 flex items-center gap-2">
+      <Tabs value={activeTab} defaultTab={activeTab} onValueChange={handleTabChange} className="flex-1 min-w-0">
         <TabList>
           <AgentTab value="chat" icon={<MessageSquare />} label="Chat" />
           <AgentTab
@@ -148,9 +148,9 @@ export function AgentPageTabs({
             disabled={!showObservability}
             disabledReason={observabilityDisabledReason}
           />
-          {rightSlot && <div className="ml-auto flex items-center gap-2">{rightSlot}</div>}
         </TabList>
       </Tabs>
+      {rightSlot && <div className="flex items-center gap-2">{rightSlot}</div>}
     </div>
   );
 }

--- a/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
+++ b/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
@@ -1,4 +1,4 @@
-import { Txt, Icon, Tooltip, TooltipContent, TooltipTrigger, cn } from '@mastra/playground-ui';
+import { Tab, TabList, Tabs, Tooltip, TooltipContent, TooltipTrigger, Txt, Icon } from '@mastra/playground-ui';
 import { ExternalLink, EyeIcon, FlaskConical, MessageSquare, ClipboardCheck, GitBranch } from 'lucide-react';
 
 import { useLinkComponent } from '@/lib/framework';
@@ -28,52 +28,23 @@ function DocsLink({ href, children }: { href: string; children: React.ReactNode 
   );
 }
 
-function TabLink({
-  href,
-  active,
+function AgentTab({
+  value,
   icon,
   label,
   badge,
   disabled,
   disabledReason,
 }: {
-  href: string;
-  active: boolean;
+  value: AgentPageTab;
   icon: React.ReactNode;
   label: string;
   badge?: number;
   disabled?: boolean;
   disabledReason?: React.ReactNode;
 }) {
-  const { navigate } = useLinkComponent();
-
-  if (disabled) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="flex items-center gap-1.5 px-3 py-2.5 text-sm border-b-2 border-transparent text-neutral2 cursor-not-allowed opacity-50">
-            <Icon size="sm">{icon}</Icon>
-            <Txt variant="ui-sm" className="text-inherit">
-              {label}
-            </Txt>
-          </span>
-        </TooltipTrigger>
-        {disabledReason && <TooltipContent side="bottom">{disabledReason}</TooltipContent>}
-      </Tooltip>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={() => navigate(href)}
-      className={cn(
-        'flex items-center gap-1.5 px-3 py-2.5 text-sm transition-colors border-b-2',
-        active
-          ? 'border-black/50 dark:border-white/50 text-neutral5'
-          : 'border-transparent text-neutral3 hover:text-neutral5',
-      )}
-    >
+  const tabContent = (
+    <>
       <Icon size="sm">{icon}</Icon>
       <Txt variant="ui-sm" className="text-inherit">
         {label}
@@ -83,7 +54,28 @@ function TabLink({
           {badge}
         </span>
       )}
-    </button>
+    </>
+  );
+
+  if (disabled) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span tabIndex={0} className="inline-flex">
+            <Tab value={value} disabled className="px-3 py-2.5">
+              {tabContent}
+            </Tab>
+          </span>
+        </TooltipTrigger>
+        {disabledReason && <TooltipContent side="bottom">{disabledReason}</TooltipContent>}
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tab value={value} className="px-3 py-2.5">
+      {tabContent}
+    </Tab>
   );
 }
 
@@ -95,6 +87,8 @@ export function AgentPageTabs({
   reviewBadge,
   rightSlot,
 }: AgentPageTabsProps) {
+  const { navigate } = useLinkComponent();
+
   const playgroundDisabledReason = !showPlayground ? (
     <p>
       Configure <code>@mastra/editor</code> to use the Editor.{' '}
@@ -108,48 +102,55 @@ export function AgentPageTabs({
     </p>
   ) : undefined;
 
+  const hrefMap: Record<AgentPageTab, string> = {
+    chat: `/agents/${agentId}/chat/new`,
+    versions: `/agents/${agentId}/editor`,
+    evaluate: `/agents/${agentId}/evaluate`,
+    review: `/agents/${agentId}/review`,
+    traces: `/agents/${agentId}/traces`,
+  };
+
+  const handleTabChange = (value: AgentPageTab) => {
+    navigate(hrefMap[value]);
+  };
+
   return (
-    <div className="flex items-center border-b border-border1 px-4 bg-surface2">
-      <TabLink
-        href={`/agents/${agentId}/chat/new`}
-        active={activeTab === 'chat'}
-        icon={<MessageSquare />}
-        label="Chat"
-      />
-      <TabLink
-        href={`/agents/${agentId}/editor`}
-        active={activeTab === 'versions'}
-        icon={<GitBranch />}
-        label="Editor"
-        disabled={!showPlayground}
-        disabledReason={playgroundDisabledReason}
-      />
-      <TabLink
-        href={`/agents/${agentId}/evaluate`}
-        active={activeTab === 'evaluate'}
-        icon={<FlaskConical />}
-        label="Evaluate"
-        disabled={!showObservability}
-        disabledReason={observabilityDisabledReason}
-      />
-      <TabLink
-        href={`/agents/${agentId}/review`}
-        active={activeTab === 'review'}
-        icon={<ClipboardCheck />}
-        label="Review"
-        badge={reviewBadge}
-        disabled={!showObservability}
-        disabledReason={observabilityDisabledReason}
-      />
-      <TabLink
-        href={`/agents/${agentId}/traces`}
-        active={activeTab === 'traces'}
-        icon={<EyeIcon />}
-        label="Traces"
-        disabled={!showObservability}
-        disabledReason={observabilityDisabledReason}
-      />
-      {rightSlot && <div className="ml-auto flex items-center gap-2">{rightSlot}</div>}
+    <div className="bg-surface2 px-4">
+      <Tabs value={activeTab} defaultTab={activeTab} onValueChange={handleTabChange}>
+        <TabList>
+          <AgentTab value="chat" icon={<MessageSquare />} label="Chat" />
+          <AgentTab
+            value="versions"
+            icon={<GitBranch />}
+            label="Editor"
+            disabled={!showPlayground}
+            disabledReason={playgroundDisabledReason}
+          />
+          <AgentTab
+            value="evaluate"
+            icon={<FlaskConical />}
+            label="Evaluate"
+            disabled={!showObservability}
+            disabledReason={observabilityDisabledReason}
+          />
+          <AgentTab
+            value="review"
+            icon={<ClipboardCheck />}
+            label="Review"
+            badge={reviewBadge}
+            disabled={!showObservability}
+            disabledReason={observabilityDisabledReason}
+          />
+          <AgentTab
+            value="traces"
+            icon={<EyeIcon />}
+            label="Traces"
+            disabled={!showObservability}
+            disabledReason={observabilityDisabledReason}
+          />
+          {rightSlot && <div className="ml-auto flex items-center gap-2">{rightSlot}</div>}
+        </TabList>
+      </Tabs>
     </div>
   );
 }

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -7,6 +7,10 @@ import {
   PermissionDenied,
   SessionExpired,
   Spinner,
+  Tab,
+  TabContent,
+  TabList,
+  Tabs,
   is401UnauthorizedError,
   is403ForbiddenError,
   toast,
@@ -507,98 +511,87 @@ export default function Workspace() {
           />
         )}
 
-        {/* Tab Navigation */}
-        <div className="flex gap-2 border-b border-border1">
-          {hasFilesystem && (
-            <button
-              onClick={() => setActiveTab('files')}
-              className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-                activeTab === 'files'
-                  ? 'border-accent1 text-neutral6'
-                  : 'border-transparent text-neutral4 hover:text-neutral5'
-              }`}
-            >
-              <FileText className="h-4 w-4" />
-              Files
-            </button>
-          )}
-          {hasSkills && (
-            <button
-              onClick={() => setActiveTab('skills')}
-              className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-                activeTab === 'skills'
-                  ? 'border-accent1 text-neutral6'
-                  : 'border-transparent text-neutral4 hover:text-neutral5'
-              }`}
-            >
-              <Wand2 className="h-4 w-4" />
-              Skills
-              {isSkillsConfigured && skills.length > 0 && (
-                <span className="text-xs px-1.5 py-0.5 rounded bg-surface4 text-neutral4">{skills.length}</span>
+        {(hasFilesystem || hasSkills) && (
+          <Tabs value={activeTab} onValueChange={setActiveTab} defaultTab={activeTab}>
+            <TabList>
+              {hasFilesystem && (
+                <Tab value="files">
+                  <FileText className="h-4 w-4" />
+                  Files
+                </Tab>
               )}
-            </button>
-          )}
-        </div>
+              {hasSkills && (
+                <Tab value="skills">
+                  <Wand2 className="h-4 w-4" />
+                  Skills
+                  {isSkillsConfigured && skills.length > 0 && (
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-surface4 text-neutral4">{skills.length}</span>
+                  )}
+                </Tab>
+              )}
+            </TabList>
 
-        {/* Tab Content */}
-        <div className="pb-8">
-          {activeTab === 'files' && hasFilesystem && (
-            <div className="space-y-4">
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <FileBrowser
-                  entries={files}
-                  currentPath={currentPath}
-                  isLoading={isLoadingFiles}
-                  error={filesError}
-                  onNavigate={setCurrentPath}
-                  onFileSelect={setSelectedFile}
-                  onRefresh={() => refetchFiles()}
-                  onCreateDirectory={
-                    isReadOnly ? undefined : path => createDirectory.mutate({ path, workspaceId: effectiveWorkspaceId })
-                  }
-                  onDelete={
-                    isReadOnly
-                      ? undefined
-                      : path =>
-                          deleteFile.mutate({ path, recursive: true, force: true, workspaceId: effectiveWorkspaceId })
-                  }
-                />
-                {selectedFile && (
-                  <FileViewer
-                    path={selectedFile}
-                    content={fileContent?.content ?? ''}
-                    isLoading={isLoadingFileContent}
-                    mimeType={fileContent?.mimeType}
-                    onClose={() => setSelectedFile(null)}
+            {hasFilesystem && (
+              <TabContent value="files" className="pb-8">
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                  <FileBrowser
+                    entries={files}
+                    currentPath={currentPath}
+                    isLoading={isLoadingFiles}
+                    error={filesError}
+                    onNavigate={setCurrentPath}
+                    onFileSelect={setSelectedFile}
+                    onRefresh={() => refetchFiles()}
+                    onCreateDirectory={
+                      isReadOnly
+                        ? undefined
+                        : path => createDirectory.mutate({ path, workspaceId: effectiveWorkspaceId })
+                    }
+                    onDelete={
+                      isReadOnly
+                        ? undefined
+                        : path =>
+                            deleteFile.mutate({ path, recursive: true, force: true, workspaceId: effectiveWorkspaceId })
+                    }
                   />
-                )}
-              </div>
-            </div>
-          )}
+                  {selectedFile && (
+                    <FileViewer
+                      path={selectedFile}
+                      content={fileContent?.content ?? ''}
+                      isLoading={isLoadingFileContent}
+                      mimeType={fileContent?.mimeType}
+                      onClose={() => setSelectedFile(null)}
+                    />
+                  )}
+                </div>
+              </TabContent>
+            )}
 
-          {activeTab === 'skills' && hasSkills && (
-            <SkillsTable
-              skills={skills}
-              isLoading={isLoadingSkills}
-              isSkillsConfigured={isSkillsConfigured}
-              hasUndiscoveredAgentSkills={hasUndiscoveredInstall}
-              basePath={effectiveWorkspaceId ? `/workspaces/${effectiveWorkspaceId}/skills` : '/workspaces'}
-              onAddSkill={canManageSkills ? () => setShowAddSkillDialog(true) : undefined}
-              onUpdateSkill={canManageSkills ? handleUpdateSkill : undefined}
-              onRemoveSkill={canManageSkills ? handleRemoveSkill : undefined}
-              updatingSkillName={updatingSkillName ?? undefined}
-              removingSkillName={removingSkillName ?? undefined}
-              mountPaths={mountPaths}
-            />
-          )}
+            {hasSkills && (
+              <TabContent value="skills" className="pb-8">
+                <SkillsTable
+                  skills={skills}
+                  isLoading={isLoadingSkills}
+                  isSkillsConfigured={isSkillsConfigured}
+                  hasUndiscoveredAgentSkills={hasUndiscoveredInstall}
+                  basePath={effectiveWorkspaceId ? `/workspaces/${effectiveWorkspaceId}/skills` : '/workspaces'}
+                  onAddSkill={canManageSkills ? () => setShowAddSkillDialog(true) : undefined}
+                  onUpdateSkill={canManageSkills ? handleUpdateSkill : undefined}
+                  onRemoveSkill={canManageSkills ? handleRemoveSkill : undefined}
+                  updatingSkillName={updatingSkillName ?? undefined}
+                  removingSkillName={removingSkillName ?? undefined}
+                  mountPaths={mountPaths}
+                />
+              </TabContent>
+            )}
+          </Tabs>
+        )}
 
-          {/* Show default tab if only one is available */}
-          {!hasFilesystem && !hasSkills && !isLoadingInfo && (
-            <div className="py-12 text-center text-neutral4">
-              <p>No workspace capabilities are configured.</p>
-            </div>
-          )}
-        </div>
+        {!hasFilesystem && !hasSkills && !isLoadingInfo && (
+          <div className="py-12 text-center text-neutral4">
+            <p>No workspace capabilities are configured.</p>
+          </div>
+        )}
       </PageLayout.MainArea>
 
       {/* Add Skill Dialog */}


### PR DESCRIPTION
## Summary

- Migrate **Files/Skills** tabs in `/workspaces` (was raw `<button>` with green `border-accent1`) to the design-system `Tabs` component — visual matches Storybook (gray `neutral3` underline) and other consumers.
- Migrate **Chat / Editor / Evaluate / Review / Traces** tabs in the agent layout (`agent-page-tabs.tsx`) to the design-system `Tabs` component — gains Radix `tablist` semantics, arrow-key navigation, and `aria-selected` for free.
- Add `cursor-pointer` on the DS `Tab` trigger and a `disabled` prop with `data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50` styling. The new prop is used to render disabled agent tabs (Editor without `@mastra/editor`, observability tabs without `@mastra/observability`) with a tooltip explaining why.

## Why

The two raw tab strips were visually inconsistent with the rest of the playground (green or white/black active borders depending on the page) and lacked a11y semantics provided by Radix Tabs. This bug was visible at `/workspaces?tab=skills` (green underline) vs. Storybook (gray underline).

## Preview

Before:

<img width="2752" height="2144" alt="CleanShot 2026-05-04 at 13 30 29@2x" src="https://github.com/user-attachments/assets/1f3945c3-1e1a-411d-847a-21e33bffdcfd" />
<img width="2752" height="2144" alt="CleanShot 2026-05-04 at 13 30 10@2x" src="https://github.com/user-attachments/assets/1553d741-1834-4c5b-bc93-f2c197d07cea" />

After:
<img width="2752" height="2144" alt="CleanShot 2026-05-04 at 13 27 08@2x" src="https://github.com/user-attachments/assets/39e8f042-5e76-4142-93ec-08c62951d8c5" />
<img width="2752" height="2144" alt="CleanShot 2026-05-04 at 13 26 18@2x" src="https://github.com/user-attachments/assets/c53bbe79-4e64-48b2-85ff-892648c8a60f" />


## Test plan

- [ ] Visit `/workspaces?tab=files` and `/workspaces?tab=skills` — active tab uses gray `neutral3` underline, no green.
- [ ] Visit `/agents/{id}/chat/new`, `/agents/{id}/editor`, `/agents/{id}/evaluate`, `/agents/{id}/review`, `/agents/{id}/traces` — active tab is correct, navigation works, `rightSlot` (top-bar controls) stays right-aligned on Editor/Evaluate/Review.
- [ ] When `@mastra/editor` is not configured, the **Editor** tab shows as disabled with `cursor-not-allowed`, opacity reduced, and a tooltip with docs link on hover.
- [ ] Same for **Evaluate / Review / Traces** when `@mastra/observability` is missing.
- [ ] Keyboard: tab into the tablist, ←/→ cycles focus, Enter activates, disabled tabs are skipped by arrow nav (the wrapper span keeps tooltip hover/focus available).
- [ ] Storybook → `Navigation/Tabs` — cursor is `pointer` on tabs, all stories render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the tab bars in the Workspace and Agent pages consistent and accessible by switching them to the shared design-system Tabs. It also adds grayed-out, non-interactive tabs with explanatory tooltips when features (Editor/Observability) aren't configured, and improves keyboard navigation.

---

## Changes

### Design System Tab Component
- Added `disabled?: boolean` to DS Tab props and forwarded to Radix Trigger.
- Added base `cursor-pointer` and disabled-state styles: `data-[disabled]:cursor-not-allowed` and `data-[disabled]:opacity-50`.
- Close-button support preserved.

### Workspace (Files / Skills)
- Replaced custom button-based tab strip with DS `Tabs` / `TabList` / `TabContent`.
- Wired URL query param tab state via `value` / `onValueChange` (keeps ?tab=files|skills behavior).
- Kept Skills badge logic and adjusted empty-state placement when no capabilities exist.
- Visual: active underline uses DS neutral3 (gray) instead of previous green accent.

### Agent Page Tabs (Chat / Editor / Evaluate / Review / Traces)
- Replaced custom TabLink implementation with DS `Tabs` + Radix semantics.
- Added `AgentTab` wrapper rendering icon, label, optional badge, and disabled handling.
- Disabled Editor/observability tabs render as disabled `Tab` wrapped with `Tooltip` (hover/focus shows reason).
- Navigation: tab changes routed via `onValueChange` → navigate(hrefMap[value]).
- Accessibility: uses Radix tablist semantics, arrow-key navigation, and proper `role="tab"` behavior; disabled tabs are skipped by keyboard navigation but remain focusable for tooltips.
- Moved non-tab rightSlot out of TabList (fixes previous ARIA violation).

### Tests & Dev utils
- e2e tests updated to select tabs by role="tab" (Playwright) and assert tooltip/disabled behavior for observability tabs.
- Changeset added for patch release of `@mastra/playground-ui`.

---

## Testing checklist
- Workspace tabs at /workspaces?tab=files and ?tab=skills show gray neutral3 underline and preserve URL state.
- Agent routes activate expected tabs and keep rightSlot alignment.
- Keyboard navigation: arrow keys move between enabled tabs, Enter activates; disabled tabs are skipped but tooltip remains on hover/focus.
- Disabled Editor/Observability tabs show reduced opacity, not-allowed cursor, and tooltip explaining missing package integration.
- Storybook `Navigation/Tabs` and e2e observability tests use role="tab" and reflect cursor/disabled rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->