### PR TITLE
perf(convex): batch bulk storage mutations

### DIFF
--- a/.changeset/lazy-doors-listen.md
+++ b/.changeset/lazy-doors-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Improved Convex bulk insert and delete throughput.

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -1,29 +1,43 @@
 import { TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage/constants';
+import type { GenericId } from 'convex/values';
 import { describe, expect, it, vi } from 'vitest';
 
-import { handleTypedOperation } from './storage';
+import type { StorageRequest, StorageResponse } from '../storage/types';
+import { handleTypedOperation, mastraStorage } from './storage';
+
+type TypedOperationCtx = Parameters<typeof handleTypedOperation>[0];
+type StorageHandlerForTest = typeof mastraStorage & {
+  _handler: (ctx: TypedOperationCtx, request: StorageRequest) => Promise<StorageResponse>;
+};
+type TestDoc = { _id: GenericId<string>; id?: string };
+type TestQueryBuilder = {
+  eq: (field: string, value: string) => TestQueryBuilder;
+};
+
+const asConvexId = (id: string) => id as GenericId<string>;
 
 describe('mastraStorage typed load', () => {
   it('uses by_workflow_run for workflow snapshot composite keys', async () => {
     const workflowRun = {
+      _id: asConvexId('snapshot-doc'),
       workflow_name: 'workflow-a',
       run_id: 'run-1',
       snapshot: {},
     };
 
-    const builder = {
+    const builder: TestQueryBuilder = {
       eq: vi.fn((_field: string, _value: string) => builder),
     };
     const unique = vi.fn(async () => workflowRun);
     const take = vi.fn(async () => {
       throw new Error('load should not scan workflow snapshots for composite keys');
     });
-    const withIndex = vi.fn((_indexName: string, queryBuilder: (q: typeof builder) => typeof builder) => {
+    const withIndex = vi.fn((_indexName: string, queryBuilder: (q: TestQueryBuilder) => TestQueryBuilder) => {
       queryBuilder(builder);
       return { unique, take };
     });
     const query = vi.fn(() => ({ withIndex, take }));
-    const ctx = { db: { query } } as any;
+    const ctx = { db: { query } } as unknown as TypedOperationCtx;
 
     const result = await handleTypedOperation(ctx, 'mastra_workflow_snapshots', {
       op: 'load',
@@ -38,5 +52,444 @@ describe('mastraStorage typed load', () => {
     expect(builder.eq).toHaveBeenNthCalledWith(2, 'run_id', 'run-1');
     expect(unique).toHaveBeenCalledTimes(1);
     expect(take).not.toHaveBeenCalled();
+  });
+});
+
+describe('mastraStorage bulk mutations', () => {
+  const waitForConcurrency = () => new Promise(resolve => setTimeout(resolve, 1));
+
+  function createIndexedDeleteCtx(docsByLookupKey: Map<string, TestDoc>) {
+    const lookupKeys: string[] = [];
+    const deletedIds: GenericId<string>[] = [];
+    let activeLookups = 0;
+    let maxConcurrentLookups = 0;
+    let activeDeletes = 0;
+    let maxConcurrentDeletes = 0;
+
+    const query = vi.fn((_table: string) => ({
+      withIndex: vi.fn((_indexName: string, queryBuilder: (q: TestQueryBuilder) => TestQueryBuilder) => {
+        const eqValues: string[] = [];
+        const builder: TestQueryBuilder = {
+          eq: vi.fn((_field: string, value: string) => {
+            eqValues.push(String(value));
+            return builder;
+          }),
+        };
+        queryBuilder(builder);
+
+        const lookupKey = eqValues.join('|');
+        lookupKeys.push(lookupKey);
+
+        return {
+          unique: vi.fn(async () => {
+            activeLookups += 1;
+            maxConcurrentLookups = Math.max(maxConcurrentLookups, activeLookups);
+            await waitForConcurrency();
+            activeLookups -= 1;
+            return docsByLookupKey.get(lookupKey) ?? null;
+          }),
+        };
+      }),
+    }));
+    const deleteDoc = vi.fn(async (id: GenericId<string>) => {
+      activeDeletes += 1;
+      maxConcurrentDeletes = Math.max(maxConcurrentDeletes, activeDeletes);
+      await waitForConcurrency();
+      activeDeletes -= 1;
+      deletedIds.push(id);
+    });
+    const ctx = { db: { query, delete: deleteDoc } } as unknown as TypedOperationCtx;
+
+    return {
+      ctx,
+      lookupKeys,
+      deletedIds,
+      query,
+      deleteDoc,
+      get maxConcurrentLookups() {
+        return maxConcurrentLookups;
+      },
+      get maxConcurrentDeletes() {
+        return maxConcurrentDeletes;
+      },
+    };
+  }
+
+  function createClearTableCtx(docs: TestDoc[]) {
+    const deletedIds: GenericId<string>[] = [];
+    const indexCalls: Array<{ table: string; indexName?: string; eqValues: string[] }> = [];
+    let activeDeletes = 0;
+    let maxConcurrentDeletes = 0;
+
+    const take = vi.fn(async () => docs);
+    const query = vi.fn((table: string) => ({
+      take,
+      withIndex: vi.fn((indexName: string, queryBuilder: (q: TestQueryBuilder) => TestQueryBuilder) => {
+        const eqValues: string[] = [];
+        const builder: TestQueryBuilder = {
+          eq: vi.fn((_field: string, value: string) => {
+            eqValues.push(String(value));
+            return builder;
+          }),
+        };
+        queryBuilder(builder);
+        indexCalls.push({ table, indexName, eqValues });
+        return { take };
+      }),
+    }));
+    const deleteDoc = vi.fn(async (id: GenericId<string>) => {
+      activeDeletes += 1;
+      maxConcurrentDeletes = Math.max(maxConcurrentDeletes, activeDeletes);
+      await waitForConcurrency();
+      activeDeletes -= 1;
+      deletedIds.push(id);
+    });
+    const ctx = { db: { query, delete: deleteDoc } } as unknown as TypedOperationCtx;
+
+    return {
+      ctx,
+      indexCalls,
+      deletedIds,
+      take,
+      get maxConcurrentDeletes() {
+        return maxConcurrentDeletes;
+      },
+    };
+  }
+
+  function createBatchInsertCtx(existingDocsByLookupKey: Map<string, TestDoc>) {
+    const lookupKeys: string[] = [];
+    const patches: Array<{ id: GenericId<string>; data: Record<string, unknown> }> = [];
+    const inserts: Array<{ table: string; record: Record<string, unknown> }> = [];
+    let activeLookups = 0;
+    let maxConcurrentLookups = 0;
+    let activeWrites = 0;
+    let maxConcurrentWrites = 0;
+
+    const query = vi.fn((_table: string) => ({
+      withIndex: vi.fn((_indexName: string, queryBuilder: (q: TestQueryBuilder) => TestQueryBuilder) => {
+        const eqValues: string[] = [];
+        const builder: TestQueryBuilder = {
+          eq: vi.fn((_field: string, value: string) => {
+            eqValues.push(String(value));
+            return builder;
+          }),
+        };
+        queryBuilder(builder);
+
+        const lookupKey = eqValues.join('|');
+        lookupKeys.push(lookupKey);
+
+        return {
+          unique: vi.fn(async () => {
+            activeLookups += 1;
+            maxConcurrentLookups = Math.max(maxConcurrentLookups, activeLookups);
+            await waitForConcurrency();
+            activeLookups -= 1;
+            return existingDocsByLookupKey.get(lookupKey) ?? null;
+          }),
+        };
+      }),
+    }));
+    const patch = vi.fn(async (id: GenericId<string>, data: Record<string, unknown>) => {
+      activeWrites += 1;
+      maxConcurrentWrites = Math.max(maxConcurrentWrites, activeWrites);
+      await waitForConcurrency();
+      activeWrites -= 1;
+      patches.push({ id, data });
+    });
+    const insert = vi.fn(async (table: string, record: Record<string, unknown>) => {
+      activeWrites += 1;
+      maxConcurrentWrites = Math.max(maxConcurrentWrites, activeWrites);
+      await waitForConcurrency();
+      activeWrites -= 1;
+      inserts.push({ table, record });
+    });
+    const ctx = { db: { query, patch, insert } } as unknown as TypedOperationCtx;
+
+    return {
+      ctx,
+      lookupKeys,
+      patches,
+      inserts,
+      get maxConcurrentLookups() {
+        return maxConcurrentLookups;
+      },
+      get maxConcurrentWrites() {
+        return maxConcurrentWrites;
+      },
+    };
+  }
+
+  it('typed batchInsert coalesces duplicate records while preserving patch merge semantics', async () => {
+    const batchCtx = createBatchInsertCtx(new Map([['existing', { _id: asConvexId('doc-existing') }]]));
+
+    const result = await handleTypedOperation(batchCtx.ctx, 'mastra_threads', {
+      op: 'batchInsert',
+      tableName: 'mastra_threads',
+      records: [
+        { id: 'existing', title: 'first' },
+        { id: 'new', title: 'new-first' },
+        { title: 'missing-id' },
+        { id: 'existing', metadata: { keep: true } },
+        { id: 'new', metadata: { latest: true } },
+      ],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(batchCtx.lookupKeys).toEqual(['existing', 'new']);
+    expect(batchCtx.patches).toEqual([
+      {
+        id: asConvexId('doc-existing'),
+        data: { title: 'first', metadata: { keep: true } },
+      },
+    ]);
+    expect(batchCtx.inserts).toEqual([
+      {
+        table: 'mastra_threads',
+        record: { id: 'new', title: 'new-first', metadata: { latest: true } },
+      },
+    ]);
+    expect(batchCtx.maxConcurrentLookups).toBe(2);
+    expect(batchCtx.maxConcurrentWrites).toBe(2);
+  });
+
+  it('typed batchInsert caps lookup and write concurrency to the storage mutation batch size', async () => {
+    const batchCtx = createBatchInsertCtx(
+      new Map(
+        Array.from({ length: 30 }, (_, index) => [
+          `id-${index}`,
+          { _id: asConvexId(`doc-${index}`), id: `id-${index}` },
+        ]),
+      ),
+    );
+
+    const result = await handleTypedOperation(batchCtx.ctx, 'mastra_threads', {
+      op: 'batchInsert',
+      tableName: 'mastra_threads',
+      records: Array.from({ length: 30 }, (_, index) => ({ id: `id-${index}`, title: `thread ${index}` })),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(batchCtx.lookupKeys).toHaveLength(30);
+    expect(batchCtx.patches).toHaveLength(30);
+    expect(batchCtx.inserts).toHaveLength(0);
+    expect(batchCtx.maxConcurrentLookups).toBe(25);
+    expect(batchCtx.maxConcurrentWrites).toBe(25);
+  });
+
+  it('vector batchInsert keeps the last record for duplicate ids and scopes lookups by vector index', async () => {
+    const batchCtx = createBatchInsertCtx(new Map([['embeddings|existing', { _id: asConvexId('vector-existing') }]]));
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(batchCtx.ctx, {
+      op: 'batchInsert',
+      tableName: 'mastra_vector_embeddings',
+      records: [
+        { id: 'existing', embedding: [1], metadata: { version: 1 } },
+        { id: 'new', embedding: [10], metadata: { version: 1 } },
+        { id: 'existing', embedding: [2], metadata: { version: 2 } },
+        { id: 'new', embedding: [20], metadata: { version: 2 } },
+      ],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(batchCtx.lookupKeys).toEqual(['embeddings|existing', 'embeddings|new']);
+    expect(batchCtx.patches).toEqual([
+      {
+        id: asConvexId('vector-existing'),
+        data: { embedding: [2], metadata: { version: 2 } },
+      },
+    ]);
+    expect(batchCtx.inserts).toEqual([
+      {
+        table: 'mastra_vectors',
+        record: { id: 'new', indexName: 'embeddings', embedding: [20], metadata: { version: 2 } },
+      },
+    ]);
+  });
+
+  it('generic batchInsert keeps the last duplicate record for fallback tables', async () => {
+    const batchCtx = createBatchInsertCtx(
+      new Map([['custom_table|existing', { _id: asConvexId('generic-existing') }]]),
+    );
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(batchCtx.ctx, {
+      op: 'batchInsert',
+      tableName: 'custom_table',
+      records: [
+        { id: 'existing', value: 1 },
+        { id: 'new', value: 10 },
+        { id: 'existing', value: 2 },
+        { id: 'new', value: 20 },
+      ],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(batchCtx.lookupKeys).toEqual(['custom_table|existing', 'custom_table|new']);
+    expect(batchCtx.patches).toEqual([
+      {
+        id: asConvexId('generic-existing'),
+        data: { record: { id: 'existing', value: 2 } },
+      },
+    ]);
+    expect(batchCtx.inserts).toEqual([
+      {
+        table: 'mastra_documents',
+        record: { table: 'custom_table', primaryKey: 'new', record: { id: 'new', value: 20 } },
+      },
+    ]);
+  });
+
+  it('deleteMany dedupes ids and resolves indexed lookups and deletes concurrently', async () => {
+    const docsById = new Map([
+      ['one', { _id: asConvexId('doc-one'), id: 'one' }],
+      ['two', { _id: asConvexId('doc-two'), id: 'two' }],
+    ]);
+    const deleteCtx = createIndexedDeleteCtx(docsById);
+
+    const result = await handleTypedOperation(deleteCtx.ctx, 'mastra_threads', {
+      op: 'deleteMany',
+      tableName: 'mastra_threads',
+      ids: ['one', 'missing', 'two', 'one'],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(deleteCtx.lookupKeys).toEqual(['one', 'missing', 'two']);
+    expect(deleteCtx.deletedIds.sort()).toEqual([asConvexId('doc-one'), asConvexId('doc-two')]);
+    expect(deleteCtx.maxConcurrentLookups).toBe(3);
+    expect(deleteCtx.maxConcurrentDeletes).toBe(2);
+  });
+
+  it('deleteMany does not query or delete for an empty id list', async () => {
+    const query = vi.fn();
+    const deleteDoc = vi.fn();
+    const ctx = { db: { query, delete: deleteDoc } } as unknown as TypedOperationCtx;
+
+    const result = await handleTypedOperation(ctx, 'mastra_threads', {
+      op: 'deleteMany',
+      tableName: 'mastra_threads',
+      ids: [],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(query).not.toHaveBeenCalled();
+    expect(deleteDoc).not.toHaveBeenCalled();
+  });
+
+  it('deleteMany caps lookup and delete concurrency to the storage delete batch size', async () => {
+    const docsById = new Map(
+      Array.from({ length: 30 }, (_, index) => [`id-${index}`, { _id: asConvexId(`doc-${index}`), id: `id-${index}` }]),
+    );
+    const deleteCtx = createIndexedDeleteCtx(docsById);
+
+    const result = await handleTypedOperation(deleteCtx.ctx, 'mastra_threads', {
+      op: 'deleteMany',
+      tableName: 'mastra_threads',
+      ids: Array.from({ length: 30 }, (_, index) => `id-${index}`),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(deleteCtx.lookupKeys).toHaveLength(30);
+    expect(deleteCtx.deletedIds).toHaveLength(30);
+    expect(deleteCtx.maxConcurrentLookups).toBe(25);
+    expect(deleteCtx.maxConcurrentDeletes).toBe(25);
+  });
+
+  it('clearTable deletes only the current batch concurrently and reports hasMore', async () => {
+    const docs: TestDoc[] = Array.from({ length: 26 }, (_, index) => ({ _id: asConvexId(`doc-${index}`) }));
+    const clearCtx = createClearTableCtx(docs);
+
+    const result = await handleTypedOperation(clearCtx.ctx, 'mastra_threads', {
+      op: 'clearTable',
+      tableName: 'mastra_threads',
+    });
+
+    expect(result).toEqual({ ok: true, hasMore: true });
+    expect(clearCtx.take).toHaveBeenCalledWith(26);
+    expect(clearCtx.deletedIds).toHaveLength(25);
+    expect(clearCtx.deletedIds).not.toContain(asConvexId('doc-25'));
+    expect(clearCtx.maxConcurrentDeletes).toBe(25);
+  });
+
+  it('deleteMany applies the same concurrent lookup behavior to vector tables', async () => {
+    const deleteCtx = createIndexedDeleteCtx(
+      new Map([
+        ['embeddings|one', { _id: asConvexId('vector-one'), id: 'one' }],
+        ['embeddings|two', { _id: asConvexId('vector-two'), id: 'two' }],
+      ]),
+    );
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(deleteCtx.ctx, {
+      op: 'deleteMany',
+      tableName: 'mastra_vector_embeddings',
+      ids: ['one', 'two', 'one'],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(deleteCtx.lookupKeys).toEqual(['embeddings|one', 'embeddings|two']);
+    expect(deleteCtx.deletedIds.sort()).toEqual([asConvexId('vector-one'), asConvexId('vector-two')]);
+    expect(deleteCtx.maxConcurrentLookups).toBe(2);
+    expect(deleteCtx.maxConcurrentDeletes).toBe(2);
+  });
+
+  it('clearTable scopes vector table deletes by vector index and deletes the current batch concurrently', async () => {
+    const clearCtx = createClearTableCtx(
+      Array.from({ length: 3 }, (_, index) => ({ _id: asConvexId(`vector-doc-${index}`) })),
+    );
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(clearCtx.ctx, {
+      op: 'clearTable',
+      tableName: 'mastra_vector_embeddings',
+    });
+
+    expect(result).toEqual({ ok: true, hasMore: false });
+    expect(clearCtx.indexCalls).toEqual([{ table: 'mastra_vectors', indexName: 'by_index', eqValues: ['embeddings'] }]);
+    expect(clearCtx.take).toHaveBeenCalledWith(26);
+    expect(clearCtx.deletedIds.sort()).toEqual([
+      asConvexId('vector-doc-0'),
+      asConvexId('vector-doc-1'),
+      asConvexId('vector-doc-2'),
+    ]);
+    expect(clearCtx.maxConcurrentDeletes).toBe(3);
+  });
+
+  it('deleteMany applies the same concurrent lookup behavior to generic fallback tables', async () => {
+    const deleteCtx = createIndexedDeleteCtx(
+      new Map([
+        ['custom_table|one', { _id: asConvexId('generic-one'), id: 'one' }],
+        ['custom_table|two', { _id: asConvexId('generic-two'), id: 'two' }],
+      ]),
+    );
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(deleteCtx.ctx, {
+      op: 'deleteMany',
+      tableName: 'custom_table',
+      ids: ['one', 'missing', 'two', 'one'],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(deleteCtx.lookupKeys).toEqual(['custom_table|one', 'custom_table|missing', 'custom_table|two']);
+    expect(deleteCtx.deletedIds.sort()).toEqual([asConvexId('generic-one'), asConvexId('generic-two')]);
+    expect(deleteCtx.maxConcurrentLookups).toBe(3);
+    expect(deleteCtx.maxConcurrentDeletes).toBe(2);
+  });
+
+  it('dropTable scopes generic fallback deletes by table and deletes the current batch concurrently', async () => {
+    const clearCtx = createClearTableCtx(
+      Array.from({ length: 2 }, (_, index) => ({ _id: asConvexId(`generic-doc-${index}`) })),
+    );
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(clearCtx.ctx, {
+      op: 'dropTable',
+      tableName: 'custom_table',
+    });
+
+    expect(result).toEqual({ ok: true, hasMore: false });
+    expect(clearCtx.indexCalls).toEqual([
+      { table: 'mastra_documents', indexName: 'by_table', eqValues: ['custom_table'] },
+    ]);
+    expect(clearCtx.take).toHaveBeenCalledWith(26);
+    expect(clearCtx.deletedIds.sort()).toEqual([asConvexId('generic-doc-0'), asConvexId('generic-doc-1')]);
+    expect(clearCtx.maxConcurrentDeletes).toBe(2);
   });
 });

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -7,6 +7,7 @@ import {
 } from '@mastra/core/storage/constants';
 import type { GenericMutationCtx as MutationCtx } from 'convex/server';
 import { mutationGeneric } from 'convex/server';
+import type { GenericId } from 'convex/values';
 
 import type { StorageRequest, StorageResponse } from '../storage/types';
 import { findBestIndex } from './index-map';
@@ -15,6 +16,56 @@ import { findBestIndex } from './index-map';
 const TABLE_VECTOR_INDEXES = 'mastra_vector_indexes';
 const VECTOR_TABLE_PREFIX = 'mastra_vector_';
 const CONVEX_TABLE_WORKFLOW_SNAPSHOTS = 'mastra_workflow_snapshots';
+const STORAGE_MUTATION_BATCH_SIZE = 25;
+
+type ConvexDocWithId = { _id: GenericId<string> };
+type StorageRecord = Record<string, unknown> & { id?: unknown };
+
+async function mapInBatches<TInput, TOutput>(
+  inputs: TInput[],
+  batchSize: number,
+  mapper: (input: TInput) => Promise<TOutput>,
+): Promise<TOutput[]> {
+  const results: TOutput[] = [];
+  for (let index = 0; index < inputs.length; index += batchSize) {
+    results.push(...(await Promise.all(inputs.slice(index, index + batchSize).map(mapper))));
+  }
+  return results;
+}
+
+async function deleteDocs(ctx: MutationCtx<any>, docs: ConvexDocWithId[]): Promise<void> {
+  await mapInBatches(docs, STORAGE_MUTATION_BATCH_SIZE, doc => ctx.db.delete(doc._id));
+}
+
+async function findExistingDocsByIds(
+  ids: string[],
+  findDoc: (id: string) => Promise<ConvexDocWithId | null | undefined>,
+): Promise<ConvexDocWithId[]> {
+  const docs = await mapInBatches([...new Set(ids)], STORAGE_MUTATION_BATCH_SIZE, findDoc);
+  return docs.filter((doc): doc is ConvexDocWithId => Boolean(doc));
+}
+
+function coalesceTypedRecordsForBatchInsert(records: StorageRecord[]): StorageRecord[] {
+  const recordsById = new Map<string, StorageRecord>();
+  for (const record of records) {
+    const id = record.id;
+    if (!id) continue;
+
+    const key = String(id);
+    recordsById.set(key, { ...(recordsById.get(key) ?? {}), ...record });
+  }
+  return [...recordsById.values()];
+}
+
+function coalesceLastRecordById(records: StorageRecord[]): StorageRecord[] {
+  const recordsById = new Map<string, StorageRecord>();
+  for (const record of records) {
+    const id = record.id;
+    if (!id) continue;
+    recordsById.set(String(id), record);
+  }
+  return [...recordsById.values()];
+}
 
 /**
  * Determines which Convex table to use based on the logical table name.
@@ -109,10 +160,9 @@ export async function handleTypedOperation(
     }
 
     case 'batchInsert': {
-      for (const record of request.records) {
+      const records = coalesceTypedRecordsForBatchInsert(request.records);
+      await mapInBatches(records, STORAGE_MUTATION_BATCH_SIZE, async record => {
         const id = record.id;
-        if (!id) continue;
-
         const existing = await ctx.db
           .query(convexTable)
           .withIndex('by_record_id', (q: any) => q.eq('id', id))
@@ -124,7 +174,7 @@ export async function handleTypedOperation(
         } else {
           await ctx.db.insert(convexTable, record);
         }
-      }
+      });
       return { ok: true };
     }
 
@@ -215,27 +265,22 @@ export async function handleTypedOperation(
     case 'dropTable': {
       // Delete a small batch per call to stay within Convex's 1-second mutation timeout.
       // Client must call repeatedly until hasMore is false.
-      const BATCH_SIZE = 25;
-      const docs = await ctx.db.query(convexTable).take(BATCH_SIZE + 1);
-      const hasMore = docs.length > BATCH_SIZE;
-      const docsToDelete = hasMore ? docs.slice(0, BATCH_SIZE) : docs;
+      const docs = await ctx.db.query(convexTable).take(STORAGE_MUTATION_BATCH_SIZE + 1);
+      const hasMore = docs.length > STORAGE_MUTATION_BATCH_SIZE;
+      const docsToDelete = hasMore ? docs.slice(0, STORAGE_MUTATION_BATCH_SIZE) : docs;
 
-      for (const doc of docsToDelete) {
-        await ctx.db.delete(doc._id);
-      }
+      await deleteDocs(ctx, docsToDelete);
       return { ok: true, hasMore };
     }
 
     case 'deleteMany': {
-      for (const id of request.ids) {
-        const doc = await ctx.db
+      const docsToDelete = await findExistingDocsByIds(request.ids, id =>
+        ctx.db
           .query(convexTable)
           .withIndex('by_record_id', (q: any) => q.eq('id', id))
-          .unique();
-        if (doc) {
-          await ctx.db.delete(doc._id);
-        }
-      }
+          .unique(),
+      );
+      await deleteDocs(ctx, docsToDelete);
       return { ok: true };
     }
 
@@ -284,9 +329,9 @@ async function handleVectorOperation(ctx: MutationCtx<any>, request: StorageRequ
     }
 
     case 'batchInsert': {
-      for (const record of request.records) {
+      const records = coalesceLastRecordById(request.records);
+      await mapInBatches(records, STORAGE_MUTATION_BATCH_SIZE, async record => {
         const id = record.id;
-        if (!id) continue;
 
         // Find existing by composite key (indexName, id) to scope per index
         const existing = await ctx.db
@@ -307,7 +352,7 @@ async function handleVectorOperation(ctx: MutationCtx<any>, request: StorageRequ
             metadata: record.metadata,
           });
         }
-      }
+      });
       return { ok: true };
     }
 
@@ -349,31 +394,26 @@ async function handleVectorOperation(ctx: MutationCtx<any>, request: StorageRequ
     case 'dropTable': {
       // Delete a small batch per call to stay within Convex's 1-second mutation timeout.
       // Client must call repeatedly until hasMore is false.
-      const BATCH_SIZE = 25;
       const docs = await ctx.db
         .query(convexTable)
         .withIndex('by_index', (q: any) => q.eq('indexName', indexName))
-        .take(BATCH_SIZE + 1);
-      const hasMore = docs.length > BATCH_SIZE;
-      const docsToDelete = hasMore ? docs.slice(0, BATCH_SIZE) : docs;
+        .take(STORAGE_MUTATION_BATCH_SIZE + 1);
+      const hasMore = docs.length > STORAGE_MUTATION_BATCH_SIZE;
+      const docsToDelete = hasMore ? docs.slice(0, STORAGE_MUTATION_BATCH_SIZE) : docs;
 
-      for (const doc of docsToDelete) {
-        await ctx.db.delete(doc._id);
-      }
+      await deleteDocs(ctx, docsToDelete);
       return { ok: true, hasMore };
     }
 
     case 'deleteMany': {
-      for (const id of request.ids) {
+      const docsToDelete = await findExistingDocsByIds(request.ids, id =>
         // Use composite key (indexName, id) to scope deletion per index
-        const doc = await ctx.db
+        ctx.db
           .query(convexTable)
           .withIndex('by_index_id', (q: any) => q.eq('indexName', indexName).eq('id', id))
-          .unique();
-        if (doc) {
-          await ctx.db.delete(doc._id);
-        }
-      }
+          .unique(),
+      );
+      await deleteDocs(ctx, docsToDelete);
       return { ok: true };
     }
 
@@ -416,8 +456,8 @@ async function handleGenericOperation(ctx: MutationCtx<any>, request: StorageReq
     }
 
     case 'batchInsert': {
-      for (const record of request.records) {
-        if (!record.id) continue;
+      const records = coalesceLastRecordById(request.records);
+      await mapInBatches(records, STORAGE_MUTATION_BATCH_SIZE, async record => {
         const primaryKey = String(record.id);
 
         const existing = await ctx.db
@@ -434,7 +474,7 @@ async function handleGenericOperation(ctx: MutationCtx<any>, request: StorageReq
             record,
           });
         }
-      }
+      });
       return { ok: true };
     }
 
@@ -483,30 +523,25 @@ async function handleGenericOperation(ctx: MutationCtx<any>, request: StorageReq
     case 'dropTable': {
       // Delete a small batch per call to stay within Convex's 1-second mutation timeout.
       // Client must call repeatedly until hasMore is false.
-      const BATCH_SIZE = 25;
       const docs = await ctx.db
         .query(convexTable)
         .withIndex('by_table', (q: any) => q.eq('table', tableName))
-        .take(BATCH_SIZE + 1);
-      const hasMore = docs.length > BATCH_SIZE;
-      const docsToDelete = hasMore ? docs.slice(0, BATCH_SIZE) : docs;
+        .take(STORAGE_MUTATION_BATCH_SIZE + 1);
+      const hasMore = docs.length > STORAGE_MUTATION_BATCH_SIZE;
+      const docsToDelete = hasMore ? docs.slice(0, STORAGE_MUTATION_BATCH_SIZE) : docs;
 
-      for (const doc of docsToDelete) {
-        await ctx.db.delete(doc._id);
-      }
+      await deleteDocs(ctx, docsToDelete);
       return { ok: true, hasMore };
     }
 
     case 'deleteMany': {
-      for (const id of request.ids) {
-        const existing = await ctx.db
+      const docsToDelete = await findExistingDocsByIds(request.ids, id =>
+        ctx.db
           .query(convexTable)
           .withIndex('by_table_primary', (q: any) => q.eq('table', tableName).eq('primaryKey', String(id)))
-          .unique();
-        if (existing) {
-          await ctx.db.delete(existing._id);
-        }
-      }
+          .unique(),
+      );
+      await deleteDocs(ctx, docsToDelete);
       return { ok: true };
     }
 


### PR DESCRIPTION
Closes #16147.

This PR removes the serial await waterfall from Convex storage bulk mutations by batching independent lookup, insert, patch, and delete work in bounded chunks of 25. It applies the same behavior across typed tables, vector tables, and the generic fallback table, while preserving the existing clear/drop page size and `hasMore` behavior.

`deleteMany` now deduplicates ids before indexed lookup. `batchInsert` now coalesces duplicate records before writing: typed tables merge duplicate records by id to preserve the previous sequential patch behavior, while vector and generic fallback tables keep the last duplicate because those paths replace the stored payload.

The local benchmark compared compiled baseline `HEAD` against the compiled optimized branch using the actual storage handler and a mocked Convex ctx with 5ms latency per DB read/write. This is a focused local latency benchmark, not a production Convex deployment benchmark.

| Path | Baseline avg | Optimized avg | Change | Concurrency |
| --- | ---: | ---: | ---: | --- |
| `deleteMany` with 100 ids | 1024.4ms | 41.2ms | ~24.9x faster | reads/writes `1 -> 25` |
| `batchInsert` with 100 records | 1023.5ms | 41.4ms | ~24.7x faster | reads/writes `1 -> 25` |
| `clearTable` with 100 docs available | 133.0ms | 10.3ms | ~12.9x faster | deletes `1 -> 25` |

Single-item bulk calls were also checked against the same benchmark setup and did not show a measurable slowdown: `deleteMany` stayed at 10.3ms, `batchInsert` moved from 10.2ms to 10.3ms, and `clearTable` stayed at 10.2ms.

Verified with `pnpm --filter ./stores/convex exec vitest run src/server/storage.test.ts`, `pnpm --filter ./stores/convex test`, `pnpm --filter ./stores/convex lint`, `pnpm --filter ./stores/convex build:lib`, and `git diff --check`.
