### PR TITLE
Only in Studio banner

### DIFF
--- a/.changeset/sunny-cars-worry.md
+++ b/.changeset/sunny-cars-worry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Show an info Notice on the trace data panel when neither `onEvaluateTrace` nor `onSaveAsDatasetItem` is provided, telling the user those actions are available in Mastra Studio (local or deployed).

--- a/.changeset/sunny-cars-worry.md
+++ b/.changeset/sunny-cars-worry.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Show an info Notice on the trace data panel when neither `onEvaluateTrace` nor `onSaveAsDatasetItem` is provided, telling the user those actions are available in Mastra Studio (local or deployed).
+Added an informational notice on the trace data panel pointing users to Mastra Studio (local or deployed) when "Evaluate Trace" and "Save as Dataset Item" actions are not available in the current view.

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -189,8 +189,7 @@ export function TraceDataPanelView({
             {!isOnTracePage && !onEvaluateTrace && !onSaveAsDatasetItem && (
               <Notice variant="info" className="mb-6">
                 <Notice.Message>
-                  Evaluating traces and saving them as dataset items is available in Mastra Studio (local or
-                  deployed).
+                  Evaluating traces and saving them as dataset items is available in Mastra Studio (local or deployed).
                 </Notice.Message>
               </Notice>
             )}

--- a/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx
@@ -8,6 +8,7 @@ import { TraceTimeline } from './trace-timeline';
 import { Button, ButtonWithTooltip } from '@/ds/components/Button';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { DataPanel } from '@/ds/components/DataPanel';
+import { Notice } from '@/ds/components/Notice';
 import { Icon } from '@/ds/icons/Icon';
 import type { LinkComponent } from '@/ds/types/link-component';
 import { truncateString } from '@/lib/truncate-string';
@@ -183,6 +184,15 @@ export function TraceDataPanelView({
                   </Button>
                 )}
               </div>
+            )}
+
+            {!isOnTracePage && !onEvaluateTrace && !onSaveAsDatasetItem && (
+              <Notice variant="info" className="mb-6">
+                <Notice.Message>
+                  Evaluating traces and saving them as dataset items is available in Mastra Studio (local or
+                  deployed).
+                </Notice.Message>
+              </Notice>
             )}
 
             <TraceTimeline


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Added Banner informing about missing functionalities/actions at Platform/Observe

in Studio

<img width="1441" height="520" alt="Screenshot 2026-05-04 at 13 37 20" src="https://github.com/user-attachments/assets/edd342f1-0552-4a39-89dd-08597799ea8b" />

. 

in Platform, when `onEvaluateTrace` and `onSaveAsDatasetItem` are not defined, meaning the `TraceDataPanelView` is rendered at Platform > Observe

<img width="1440" height="592" alt="Screenshot 2026-05-04 at 13 38 03" src="https://github.com/user-attachments/assets/d83d86b4-25e7-4c0b-969a-86e54196ab4e" />



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a small message in the traces panel that tells users some actions (evaluating a trace or saving it as a dataset item) only work in Mastra Studio, so they understand why those buttons might be missing elsewhere.

## Changes

Adds a conditional informational notice to the trace data panel view that points users to Mastra Studio when the Evaluate Trace and Save as Dataset Item actions are not available.

### Files Modified

- `.changeset/sunny-cars-worry.md` - Release metadata for `@mastra/playground-ui` (patch)
- `packages/playground-ui/src/domains/traces/components/trace-data-panel-view.tsx` - Render a Notice in the data panel when appropriate

### Key Changes

- TraceDataPanelView now:
  - Imports and uses the Notice component.
  - When not on the trace page and both `onEvaluateTrace` and `onSaveAsDatasetItem` are undefined, displays an informational Notice: "Evaluating traces and saving them as dataset items is available in Mastra Studio (local or deployed)."
  - Preserves existing behavior for loading, no-data, evaluate/save buttons, trace timeline, and other UI.

### Lines Changed
- `.changeset/sunny-cars-worry.md`: +5/-0
- `trace-data-panel-view.tsx`: +9/-0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->