### PR TITLE
Add span type color indicator to timeline 

### DIFF
--- a/.changeset/four-hornets-repeat.md
+++ b/.changeset/four-hornets-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added a Scorer span type style on the trace timeline and a colored type dot before each span name so spans are visually flagged in both the name and timing columns.

--- a/packages/playground-ui/src/domains/traces/components/shared.tsx
+++ b/packages/playground-ui/src/domains/traces/components/shared.tsx
@@ -7,17 +7,7 @@ import { MemoryIcon } from '@/ds/icons/MemoryIcon';
 import { ToolsIcon } from '@/ds/icons/ToolsIcon';
 import { WorkflowIcon } from '@/ds/icons/WorkflowIcon';
 
-export const spanTypePrefixes = [
-  'agent',
-  'workflow',
-  'model',
-  'mcp',
-  'tool',
-  'memory',
-  'workspace',
-  'scorer',
-  'other',
-];
+export const spanTypePrefixes = ['agent', 'workflow', 'model', 'mcp', 'tool', 'memory', 'workspace', 'scorer', 'other'];
 
 const spanTypeToUiElements: Record<string, UISpanStyle> = {
   agent: {

--- a/packages/playground-ui/src/domains/traces/components/shared.tsx
+++ b/packages/playground-ui/src/domains/traces/components/shared.tsx
@@ -1,4 +1,4 @@
-import { BrainIcon } from 'lucide-react';
+import { BrainIcon, GaugeIcon } from 'lucide-react';
 import type { UISpanStyle } from '../types';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { FolderIcon } from '@/ds/icons/FolderIcon';
@@ -7,57 +7,66 @@ import { MemoryIcon } from '@/ds/icons/MemoryIcon';
 import { ToolsIcon } from '@/ds/icons/ToolsIcon';
 import { WorkflowIcon } from '@/ds/icons/WorkflowIcon';
 
-export const spanTypePrefixes = ['agent', 'workflow', 'model', 'mcp', 'tool', 'memory', 'workspace', 'other'];
+export const spanTypePrefixes = [
+  'agent',
+  'workflow',
+  'model',
+  'mcp',
+  'tool',
+  'memory',
+  'workspace',
+  'scorer',
+  'other',
+];
 
 const spanTypeToUiElements: Record<string, UISpanStyle> = {
   agent: {
     icon: <AgentIcon />,
     color: 'oklch(0.75 0.15 250)',
     label: 'Agent',
-    bgColor: 'oklch(0.75 0.15 250 / 0.1)',
     typePrefix: 'agent',
   },
   workflow: {
     icon: <WorkflowIcon />,
     color: 'oklch(0.75 0.15 200)',
     label: 'Workflow',
-    bgColor: 'oklch(0.75 0.15 200 / 0.1)',
     typePrefix: 'workflow',
   },
   model: {
     icon: <BrainIcon />,
     color: 'oklch(0.75 0.15 320)',
     label: 'Model',
-    bgColor: 'oklch(0.75 0.15 320 / 0.1)',
     typePrefix: 'model',
   },
   mcp: {
     icon: <McpServerIcon />,
     color: 'oklch(0.75 0.15 160)',
     label: 'MCP',
-    bgColor: 'oklch(0.75 0.15 160 / 0.1)',
     typePrefix: 'mcp',
   },
   tool: {
     icon: <ToolsIcon />,
     color: 'oklch(0.75 0.15 100)',
     label: 'Tool',
-    bgColor: 'oklch(0.75 0.15 100 / 0.1)',
     typePrefix: 'tool',
   },
   memory: {
     icon: <MemoryIcon />,
     color: 'oklch(0.75 0.15 60)',
     label: 'Memory',
-    bgColor: 'oklch(0.75 0.15 60 / 0.1)',
     typePrefix: 'memory',
   },
   workspace: {
     icon: <FolderIcon />,
     color: 'oklch(0.75 0.15 40)',
     label: 'Workspace',
-    bgColor: 'oklch(0.75 0.15 40 / 0.1)',
     typePrefix: 'workspace',
+  },
+  scorer: {
+    icon: <GaugeIcon />,
+    color: 'oklch(0.75 0.15 280)',
+    label: 'Scorer',
+    typePrefix: 'scorer',
   },
 };
 

--- a/packages/playground-ui/src/domains/traces/components/timeline-name-col.tsx
+++ b/packages/playground-ui/src/domains/traces/components/timeline-name-col.tsx
@@ -17,7 +17,7 @@ type TimelineNameColProps = {
 
 export function TimelineNameCol({
   span,
-  spanUI: _spanUI,
+  spanUI,
   isFaded,
   depth = 0,
   onSpanClick,
@@ -42,12 +42,20 @@ export function TimelineNameCol({
       <button
         onClick={() => onSpanClick?.(span.id)}
         className={cn(
-          'text-ui-sm flex items-center text-left gap-1.5 text-neutral6 w-full min-w-0 rounded-md h-full px-2 py-1 transition-colors',
+          'text-ui-smd flex items-center text-left gap-1.5 text-neutral6 w-full min-w-0 rounded-md h-full px-2 py-1 transition-colors',
           '[&>svg]:transition-all [&>svg]:shrink-0 [&>svg]:opacity-0 [&>svg]:w-[1em] [&>svg]:h-[1em] [&>svg]:ml-auto',
           'hover:bg-surface4 [&:hover>svg]:opacity-60',
           'focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent1',
         )}
       >
+        {spanUI?.color && (
+          <span
+            aria-hidden
+            title={spanUI.label}
+            className="inline-block w-2 h-2 shrink-0 rounded-full"
+            style={{ backgroundColor: spanUI.color }}
+          />
+        )}
         <span className="min-w-0 truncate">{span.name}</span>
       </button>
     </div>

--- a/packages/playground-ui/src/domains/traces/types.ts
+++ b/packages/playground-ui/src/domains/traces/types.ts
@@ -16,7 +16,6 @@ export type UISpanStyle = {
   icon?: ReactNode;
   color?: string;
   label?: string;
-  bgColor?: string;
   typePrefix: string;
 };
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

- add indicator
- add scorer to spanTypeToUiElements
 - remove unused `bgColor` from spanTypeToUiElements

before

<img width="1440" height="853" alt="Screenshot 2026-05-04 at 15 11 22" src="https://github.com/user-attachments/assets/5138eb2c-b199-4584-8cfb-105f2c525dcf" />


after

<img width="1432" height="914" alt="Screenshot 2026-05-04 at 15 11 07" src="https://github.com/user-attachments/assets/93a4af02-3d92-4e7b-8f92-9f8eeaf0d88c" />



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

This PR adds a small colored dot and Scorer icon to timeline entries so you can quickly tell what type of operation each span is (e.g., scorer, agent, workflow) at a glance.

## Changes

- UI: Adds a colored span-type indicator dot in the timeline name column; the dot uses the span type's configured color and shows the span type label on hover.
- New span type: Introduces a "scorer" span type with a GaugeIcon and its own color/label in the span UI mapping.
- Type and mapping updates:
  - Adds "scorer" to spanTypePrefixes.
  - Extends spanTypeToUiElements with a scorer entry.
  - Removes the unused bgColor property from UISpanStyle and existing span UI objects — styling consolidated to use the single color field (and optional icon, label, typePrefix).
- Component adjustments:
  - TimelineNameCol now reads spanUI directly and renders the colored indicator when spanUI.color is present.
  - Shared mapping file imports GaugeIcon for the scorer entry.
- Release metadata: Updates the changeset to release a patch for @mastra/playground-ui documenting the new Scorer span style and colored type indicators.

## Notable implementation details
- getSpanTypeUi resolves a span's UI by lowercasing and splitting the span type and falling back to an "Other" style when unrecognized.
- No exported function signatures were changed; changes are limited to UI types/mappings and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->