### PR TITLE
refactor(playground): rework agent-builder configure panel layout and disabled semantics

### DIFF
--- a/packages/playground/src/domains/agent-builder/components/agent-builder-edit/__tests__/agent-configure-panel.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-edit/__tests__/agent-configure-panel.test.tsx
@@ -316,10 +316,11 @@ describe('AgentConfigurePanel disabled propagation', () => {
     cleanup();
   });
 
-  it('disables name, description, avatar trigger, and config rows when disabled is true', () => {
+  it('disables form mutations but keeps config rows navigable when disabled is true', () => {
+    const onActiveDetailChange = vi.fn();
     render(
       <FormWrapper>
-        <AgentConfigurePanel disabled />
+        <AgentConfigurePanel disabled onActiveDetailChange={onActiveDetailChange} />
       </FormWrapper>,
     );
 
@@ -332,8 +333,11 @@ describe('AgentConfigurePanel disabled propagation', () => {
     expect(nameInput.disabled).toBe(true);
     expect(descInput.disabled).toBe(true);
     expect(avatarBtn.disabled).toBe(true);
-    expect(instructionsRow.disabled).toBe(true);
-    expect(toolsRow.disabled).toBe(true);
+    expect(instructionsRow.disabled).toBe(false);
+    expect(toolsRow.disabled).toBe(false);
+
+    fireEvent.click(instructionsRow);
+    expect(onActiveDetailChange).toHaveBeenCalledWith('instructions');
   });
 
   it('renders enabled controls by default', () => {

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-edit/__tests__/workspace-layout.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-edit/__tests__/workspace-layout.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { TooltipProvider } from '@mastra/playground-ui';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AgentBuilderEditFormValues } from '../../../schemas';
+import { WorkspaceLayout } from '../workspace-layout';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => {
+  const methods = useForm<AgentBuilderEditFormValues>({
+    defaultValues: {
+      name: 'Support agent',
+      instructions: '',
+      tools: {},
+      skills: {},
+    },
+  });
+  return (
+    <MemoryRouter>
+      <TooltipProvider>
+        <FormProvider {...methods}>{children}</FormProvider>
+      </TooltipProvider>
+    </MemoryRouter>
+  );
+};
+
+const renderLayout = (props?: { defaultExpanded?: boolean; detailOpen?: boolean; showConfigure?: boolean }) =>
+  render(
+    <Wrapper>
+      <WorkspaceLayout
+        isLoading={false}
+        mode="build"
+        defaultExpanded={props?.defaultExpanded ?? true}
+        detailOpen={props?.detailOpen ?? false}
+        showConfigure={props?.showConfigure ?? true}
+        chat={<div data-testid="stub-chat">chat</div>}
+        configure={<div data-testid="stub-configure">configure</div>}
+      />
+    </Wrapper>,
+  );
+
+describe('WorkspaceLayout', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the workspace grid wrapper that drives the desktop push transition', () => {
+    const { container } = renderLayout();
+    const root = container.querySelector('.agent-builder-workspace-grid');
+    expect(root).not.toBeNull();
+    // Expanded + no detail open => 320px configure column
+    expect(root?.className).toContain('lg:grid-cols-[1fr_320px]');
+  });
+
+  it('uses the wider grid template when a detail pane is open', () => {
+    const { container } = renderLayout({ defaultExpanded: true, detailOpen: true });
+    const root = container.querySelector('.agent-builder-workspace-grid');
+    expect(root?.className).toContain('lg:grid-cols-[1fr_calc(50%-12px)]');
+  });
+
+  it('collapses the configure column when not expanded', () => {
+    const { container, getByTestId } = renderLayout({ defaultExpanded: false });
+    const root = container.querySelector('.agent-builder-workspace-grid');
+    expect(root?.className).toContain('lg:grid-cols-[1fr_0px]');
+
+    const configurePanel = getByTestId('agent-builder-panel-configure');
+    expect(configurePanel.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('toggles the configure sibling visibility via the Show/Hide configuration button', () => {
+    const { getByLabelText, getByTestId } = renderLayout({ defaultExpanded: false });
+    const configurePanel = getByTestId('agent-builder-panel-configure');
+    expect(configurePanel.getAttribute('aria-hidden')).toBe('true');
+
+    const toggle = getByLabelText('Show configuration');
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+
+    fireEvent.click(toggle);
+
+    expect(configurePanel.getAttribute('aria-hidden')).toBe('false');
+    expect(getByLabelText('Hide configuration').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('renders the configure panel as a sibling of the main column (not nested inside the chat panel)', () => {
+    const { container, getByTestId } = renderLayout();
+    const root = container.querySelector('.agent-builder-workspace-grid') as HTMLElement;
+    const chatPanel = getByTestId('agent-builder-panel-chat');
+    const configurePanel = getByTestId('agent-builder-panel-configure');
+
+    // Configure panel must be a direct child of the workspace grid root.
+    expect(configurePanel.parentElement).toBe(root);
+
+    // Chat panel must NOT live inside the configure panel.
+    expect(configurePanel.contains(chatPanel)).toBe(false);
+
+    // Chat panel must NOT be a direct child of the workspace grid; it's nested
+    // inside the main column wrapper.
+    expect(chatPanel.parentElement).not.toBe(root);
+  });
+
+  it('does not render the desktop configure sibling when showConfigure is false', () => {
+    const { queryByTestId } = renderLayout({ showConfigure: false });
+    expect(queryByTestId('agent-builder-panel-configure')).toBeNull();
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-edit/agent-configure-panel.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-edit/agent-configure-panel.tsx
@@ -85,7 +85,7 @@ function ConfigurePanelContent({
   activeDetail,
   onActiveDetailChange,
   editable,
-  disabled = false,
+  disabled: propDisabled = false,
 }: ConfigurePanelContentProps) {
   const features = useBuilderAgentFeatures();
   const policy = useBuilderModelPolicy();
@@ -97,20 +97,20 @@ function ConfigurePanelContent({
   const draftInstructions = formMethods.watch('instructions') ?? '';
   const draftAvatarUrl = formMethods.watch('avatarUrl');
 
-  const mutationsDisabled = disabled || !editable;
+  const disabled = propDisabled || !editable;
   const panelName = editable ? draftName : (agent?.name ?? draftName);
   const panelDescription = editable ? draftDescription : (agent?.description ?? draftDescription);
   const panelInstructions = editable ? draftInstructions : (agent?.systemPrompt ?? draftInstructions);
   const panelAvatarUrl = editable ? draftAvatarUrl : (agent?.avatarUrl ?? draftAvatarUrl);
 
   const setDraftName = (value: string) => {
-    if (!mutationsDisabled) formMethods.setValue('name', value, { shouldDirty: true });
+    if (!disabled) formMethods.setValue('name', value, { shouldDirty: true });
   };
   const setDraftDescription = (value: string) => {
-    if (!mutationsDisabled) formMethods.setValue('description', value, { shouldDirty: true });
+    if (!disabled) formMethods.setValue('description', value, { shouldDirty: true });
   };
   const setDraftInstructions = (value: string) => {
-    if (!mutationsDisabled) formMethods.setValue('instructions', value, { shouldDirty: true });
+    if (!disabled) formMethods.setValue('instructions', value, { shouldDirty: true });
   };
 
   const activeToolsCount = availableAgentTools.filter(item => item.isChecked).length;
@@ -140,7 +140,7 @@ function ConfigurePanelContent({
   const handleAvatarFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     e.target.value = '';
-    if (!file || mutationsDisabled) return;
+    if (!file || disabled) return;
 
     try {
       const { dataUrl } = await downscaleImageToDataUrl(file);
@@ -154,7 +154,7 @@ function ConfigurePanelContent({
   const modelSectionVisible = features.model || policy.active;
 
   return (
-    <div className="relative h-full border border-border1 bg-surface2 rounded-3xl overflow-hidden">
+    <div className="relative h-full border border-border1 bg-surface2 rounded-3xl overflow-hidden lg:rounded-none lg:border-0 lg:border-l lg:border-l-border1">
       <div
         className={cn(
           'agent-builder-detail-pane absolute inset-0 z-10 overflow-hidden bg-surface2',
@@ -170,7 +170,7 @@ function ConfigurePanelContent({
         <DetailPane
           activeDetail={renderedDetail}
           features={features}
-          editable={!mutationsDisabled}
+          editable={!disabled}
           instructionsPrompt={panelInstructions}
           onInstructionsChange={setDraftInstructions}
           onClose={closeDetail}
@@ -194,7 +194,7 @@ function ConfigurePanelContent({
                   <button
                     type="button"
                     onClick={() => fileInputRef.current?.click()}
-                    disabled={mutationsDisabled}
+                    disabled={disabled}
                     className="group relative rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral3 disabled:cursor-not-allowed disabled:opacity-60"
                     aria-label="Upload avatar"
                     data-testid="agent-configure-avatar-trigger"
@@ -226,7 +226,7 @@ function ConfigurePanelContent({
               value={panelName}
               placeholder="Untitled agent"
               onChange={e => setDraftName(e.target.value)}
-              disabled={mutationsDisabled}
+              disabled={disabled}
               testId="agent-configure-name"
             />
 
@@ -236,11 +236,11 @@ function ConfigurePanelContent({
               value={panelDescription}
               placeholder="What is this agent for?"
               onChange={e => setDraftDescription(e.target.value)}
-              disabled={mutationsDisabled}
+              disabled={disabled}
               testId="agent-configure-description"
             />
 
-            {modelSectionVisible && <ModelSection editable={!mutationsDisabled} />}
+            {modelSectionVisible && <ModelSection editable={!disabled} />}
           </div>
 
           <ConfigRows
@@ -253,7 +253,6 @@ function ConfigurePanelContent({
             activeDetail={activeDetail}
             toggleDetail={toggleDetail}
             disabled={disabled}
-            mutationsDisabled={mutationsDisabled}
           />
         </div>
       </div>
@@ -373,10 +372,7 @@ interface ConfigRowsProps {
   totalSkillsCount: number;
   activeDetail: ActiveDetail;
   toggleDetail: (next: ActiveDetail) => void;
-  /** Blocks row click (e.g. while a stream is running). */
   disabled?: boolean;
-  /** Blocks mutation controls inside rows (e.g. browser toggle) when read-only. */
-  mutationsDisabled?: boolean;
 }
 
 function BrowserToggleRow({ disabled = false }: { disabled?: boolean }) {
@@ -416,7 +412,6 @@ function ConfigRows({
   activeDetail,
   toggleDetail,
   disabled = false,
-  mutationsDisabled = false,
 }: ConfigRowsProps) {
   return (
     <div className="flex flex-col">
@@ -426,7 +421,6 @@ function ConfigRows({
         value={instructionsDescription}
         isActive={activeDetail === 'instructions'}
         onClick={() => toggleDetail('instructions')}
-        disabled={disabled}
         testId="agent-preview-edit-system-prompt"
       />
       {features.tools && (
@@ -437,7 +431,6 @@ function ConfigRows({
           total={totalToolsCount}
           isActive={activeDetail === 'tools'}
           onClick={() => toggleDetail('tools')}
-          disabled={disabled}
           testId="agent-preview-tools-button"
         />
       )}
@@ -449,11 +442,10 @@ function ConfigRows({
           total={totalSkillsCount}
           isActive={activeDetail === 'skills'}
           onClick={() => toggleDetail('skills')}
-          disabled={disabled}
           testId="agent-preview-skills-button"
         />
       )}
-      {features.browser && <BrowserToggleRow disabled={mutationsDisabled} />}
+      {features.browser && <BrowserToggleRow disabled={disabled} />}
     </div>
   );
 }
@@ -508,30 +500,17 @@ interface ConfigRowProps {
   isActive?: boolean;
   onClick: () => void;
   testId: string;
-  disabled?: boolean;
 }
 
-const ConfigRow = ({
-  icon,
-  label,
-  value,
-  count,
-  total,
-  isActive = false,
-  onClick,
-  testId,
-  disabled = false,
-}: ConfigRowProps) => (
+const ConfigRow = ({ icon, label, value, count, total, isActive = false, onClick, testId }: ConfigRowProps) => (
   <button
     type="button"
     onClick={onClick}
-    disabled={disabled}
     data-testid={testId}
     aria-pressed={isActive}
     className={cn(
       'group flex items-center gap-3 px-6 py-4 text-left transition-colors hover:bg-surface3',
       isActive && 'bg-surface3',
-      disabled && 'cursor-not-allowed opacity-60 hover:bg-transparent',
     )}
   >
     <span

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-edit/workspace-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-edit/workspace-layout.tsx
@@ -50,113 +50,126 @@ export const WorkspaceLayout = ({
   const navigate = useNavigate();
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [activeTab, setActiveTab] = useState<ActiveTab>('chat');
-  const gridClass = !expanded
-    ? 'lg:grid-cols-[1fr_0px] lg:gap-0'
-    : detailOpen
-      ? 'lg:grid-cols-[1fr_calc(50%-12px)] lg:gap-6'
-      : 'lg:grid-cols-[1fr_320px] lg:gap-6';
-  const panelWidthClass = 'w-full';
+
+  // On lg+, the entire main column (header + chat) shrinks/pushes left when
+  // the configure panel is open. The configure panel is a full-height sibling
+  // column with no padding so it spans edge to edge.
+  const workspaceGridClass =
+    showConfigure && expanded
+      ? detailOpen
+        ? 'lg:grid-cols-[1fr_calc(50%-12px)]'
+        : 'lg:grid-cols-[1fr_320px]'
+      : 'lg:grid-cols-[1fr_0px]';
 
   return (
-    <div className="flex flex-1 min-w-0 flex-col h-full">
-      <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] lg:grid-cols-[1fr_auto_1fr] items-center gap-2 px-4 pt-4 md:px-10">
-        <div className="justify-self-start">
-          <Button
-            size="icon-sm"
-            variant="ghost"
-            tooltip={backTooltip}
-            onClick={() => navigate(backHref, { viewTransition: true })}
-          >
-            <ArrowLeftIcon />
-          </Button>
-        </div>
-        <AgentBuilderBreadcrumb
-          className="min-w-0 lg:justify-self-center"
-          isLoading={isLoading}
-          mode={mode}
-          creating={creating}
-        />
-        <div className="justify-self-end flex items-center gap-2 shrink-0">
-          {modeAction && <div className="shrink-0">{modeAction}</div>}
-          {primaryAction && <div className="shrink-0 flex">{primaryAction}</div>}
-          {mobileExtra && <div className="shrink-0 lg:hidden">{mobileExtra}</div>}
-          {showConfigure && (
-            <div className="shrink-0 hidden lg:inline-flex">
-              <Button
-                size="icon-sm"
-                variant="ghost"
-                tooltip={expanded ? 'Hide configuration' : 'Show configuration'}
-                onClick={() => setExpanded(prev => !prev)}
-                aria-pressed={expanded}
-                className="shrink-0"
-              >
-                <div
-                  className={cn(
-                    'size-4 border border-current rounded-md grid divide-x divide-current transition-all duration-200 ease-out overflow-hidden',
-                    expanded ? 'grid-cols-[1fr_40%]' : 'grid-cols-[1fr_10%]',
-                  )}
+    <div
+      className={cn(
+        'flex flex-1 min-w-0 flex-col h-full',
+        'lg:grid lg:grid-rows-1 agent-builder-workspace-grid',
+        workspaceGridClass,
+      )}
+    >
+      <div
+        className={cn(
+          'flex min-w-0 flex-col h-full lg:h-auto lg:min-h-0 lg:overflow-hidden',
+          // On mobile, when activeTab === 'configure' the chat panel is hidden;
+          // shrink this column so the configure sibling can claim the space.
+          activeTab === 'configure' ? 'flex-none' : 'flex-1',
+          'lg:flex-1',
+        )}
+      >
+        <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] lg:grid-cols-[1fr_auto_1fr] items-center gap-2 px-4 pt-4 md:px-10">
+          <div className="justify-self-start">
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              tooltip={backTooltip}
+              onClick={() => navigate(backHref, { viewTransition: true })}
+            >
+              <ArrowLeftIcon />
+            </Button>
+          </div>
+          <AgentBuilderBreadcrumb
+            className="min-w-0 lg:justify-self-center"
+            isLoading={isLoading}
+            mode={mode}
+            creating={creating}
+          />
+          <div className="justify-self-end flex items-center gap-2 shrink-0">
+            {modeAction && <div className="shrink-0">{modeAction}</div>}
+            {primaryAction && <div className="shrink-0 flex">{primaryAction}</div>}
+            {mobileExtra && <div className="shrink-0 lg:hidden">{mobileExtra}</div>}
+            {showConfigure && (
+              <div className="shrink-0 hidden lg:inline-flex">
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  tooltip={expanded ? 'Hide configuration' : 'Show configuration'}
+                  onClick={() => setExpanded(prev => !prev)}
+                  aria-pressed={expanded}
+                  className="shrink-0"
                 >
-                  <div />
-                  <div className="bg-neutral1 h-full w-full" />
-                </div>
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
-      {showConfigure && (
-        <div className="lg:hidden px-4 py-4 md:px-10 md:py-5">
-          <div
-            role="tablist"
-            aria-label="Workspace view"
-            className="relative mx-auto flex h-9 w-full max-w-sm items-center rounded-full border border-border1 bg-surface3 p-0.5"
-          >
-            <span
-              aria-hidden="true"
-              className={cn(
-                'absolute inset-y-0.5 left-0.5 w-[calc(50%-2px)] rounded-full bg-surface4',
-                'transition-transform duration-200 ease-out',
-                activeTab === 'configure' && 'translate-x-full',
-              )}
-            />
-            <button
-              type="button"
-              role="tab"
-              aria-selected={activeTab === 'chat'}
-              data-testid="agent-builder-tab-chat"
-              onClick={() => setActiveTab('chat')}
-              className={cn(
-                'relative z-10 flex-1 rounded-full text-ui-md font-medium outline-none',
-                'transition-colors duration-200',
-                activeTab === 'chat' ? 'text-neutral5' : 'text-neutral3 hover:text-neutral4',
-              )}
-            >
-              Chat
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={activeTab === 'configure'}
-              data-testid="agent-builder-tab-configure"
-              onClick={() => setActiveTab('configure')}
-              className={cn(
-                'relative z-10 flex-1 rounded-full text-ui-md font-medium outline-none',
-                'transition-colors duration-200',
-                activeTab === 'configure' ? 'text-neutral5' : 'text-neutral3 hover:text-neutral4',
-              )}
-            >
-              Configuration
-            </button>
+                  <div
+                    className={cn(
+                      'size-4 border border-current rounded-md grid divide-x divide-current transition-all duration-200 ease-out overflow-hidden',
+                      expanded ? 'grid-cols-[1fr_40%]' : 'grid-cols-[1fr_10%]',
+                    )}
+                  >
+                    <div />
+                    <div className="bg-neutral1 h-full w-full" />
+                  </div>
+                </Button>
+              </div>
+            )}
           </div>
         </div>
-      )}
-      <div className="flex flex-1 min-h-0 min-w-0 flex-col px-4 pb-6 pt-4 md:px-10">
-        <div
-          className={cn(
-            'grid relative h-full min-h-0 agent-builder-panel-grid grid-cols-1',
-            showConfigure ? gridClass : 'lg:grid-cols-[1fr_0px] lg:gap-0',
-          )}
-        >
+        {showConfigure && (
+          <div className="lg:hidden px-4 py-4 md:px-10 md:py-5">
+            <div
+              role="tablist"
+              aria-label="Workspace view"
+              className="relative mx-auto flex h-9 w-full max-w-sm items-center rounded-full border border-border1 bg-surface3 p-0.5"
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'absolute inset-y-0.5 left-0.5 w-[calc(50%-2px)] rounded-full bg-surface4',
+                  'transition-transform duration-200 ease-out',
+                  activeTab === 'configure' && 'translate-x-full',
+                )}
+              />
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'chat'}
+                data-testid="agent-builder-tab-chat"
+                onClick={() => setActiveTab('chat')}
+                className={cn(
+                  'relative z-10 flex-1 rounded-full text-ui-md font-medium outline-none',
+                  'transition-colors duration-200',
+                  activeTab === 'chat' ? 'text-neutral5' : 'text-neutral3 hover:text-neutral4',
+                )}
+              >
+                Chat
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'configure'}
+                data-testid="agent-builder-tab-configure"
+                onClick={() => setActiveTab('configure')}
+                className={cn(
+                  'relative z-10 flex-1 rounded-full text-ui-md font-medium outline-none',
+                  'transition-colors duration-200',
+                  activeTab === 'configure' ? 'text-neutral5' : 'text-neutral3 hover:text-neutral4',
+                )}
+              >
+                Configuration
+              </button>
+            </div>
+          </div>
+        )}
+        <div className="flex flex-1 min-h-0 min-w-0 flex-col px-4 pb-6 pt-4 md:px-10">
           <div
             className="h-full w-full min-w-0 overflow-hidden data-[active-tab=configure]:hidden lg:!block"
             data-active-tab={activeTab}
@@ -164,31 +177,50 @@ export const WorkspaceLayout = ({
           >
             <div className="min-h-0 min-w-0 h-full overflow-hidden md:max-w-[80ch] md:mx-auto w-full">{chat}</div>
           </div>
-
-          {showConfigure && (
-            <div
-              className="h-full min-w-0 overflow-hidden data-[active-tab=chat]:hidden lg:!block"
-              data-active-tab={activeTab}
-              data-testid="agent-builder-panel-configure"
-              aria-hidden={!expanded}
-            >
-              <div
-                className={cn(
-                  'agent-builder-panel-slide h-full overflow-y-auto',
-                  panelWidthClass,
-                  // On <lg, when this panel is the active tab, always show fully visible.
-                  // On lg+, fall back to the existing expanded/collapsed transitions.
-                  'translate-x-0 opacity-100 lg:transition-all',
-                  expanded ? 'lg:translate-x-0 lg:opacity-100' : 'lg:translate-x-4 lg:opacity-0 lg:pointer-events-none',
-                )}
-                style={expanded ? { viewTransitionName: 'agent-builder-configure-panel' } : undefined}
-              >
-                {configure}
-              </div>
-            </div>
-          )}
         </div>
       </div>
+
+      {/*
+       * Configure panel:
+       * - On lg+, it is a full-height sibling column of the main content.
+       *   Toggling expanded slides it in/out.
+       * - On <lg, it is a tab-switched pane that occupies the area below the
+       *   header/tabs, replacing the chat panel when activeTab === 'configure'.
+       *   We use data-active-tab and CSS to hide it when activeTab !== 'configure'.
+       */}
+      {showConfigure && (
+        <div
+          className={cn(
+            'min-w-0 overflow-hidden',
+            // Mobile: occupy the full main area below header/tabs when active.
+            // The chat panel hides itself when activeTab === 'configure' so the
+            // outer column has free space; we fill it via flex-1 and px padding
+            // matching the main column.
+            'flex-1 px-4 pb-6 md:px-10 data-[active-tab=chat]:hidden',
+            // Desktop: full-height sibling column, no padding (edge-to-edge),
+            // always rendered (visibility/translate handled via expanded).
+            'lg:flex-none lg:h-full lg:px-0 lg:pb-0 lg:!block',
+          )}
+          data-active-tab={activeTab}
+          data-testid="agent-builder-panel-configure"
+          aria-hidden={!expanded}
+        >
+          <div
+            className={cn(
+              'agent-builder-panel-slide h-full w-full overflow-y-auto',
+              // Mobile: always fully visible when this pane is active.
+              'translate-x-0 opacity-100',
+              // Desktop: slide in/out based on expanded.
+              'lg:transition-all',
+              expanded ? 'lg:translate-x-0 lg:opacity-100' : 'lg:translate-x-4 lg:opacity-0 lg:pointer-events-none',
+            )}
+            style={expanded ? { viewTransitionName: 'agent-builder-configure-panel' } : undefined}
+          >
+            {configure}
+          </div>
+        </div>
+      )}
+
       {browserOverlay}
     </div>
   );

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-starter/__tests__/agent-builder-starter.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-starter/__tests__/agent-builder-starter.test.tsx
@@ -61,16 +61,8 @@ describe('AgentBuilderStarter', () => {
     });
   });
 
-  it('renders a "create manually" button that navigates without a user message', () => {
-    const { getByTestId } = renderStarter();
-    const btn = getByTestId('agent-builder-starter-create-manually');
-
-    fireEvent.click(btn);
-
-    expect(navigateMock).toHaveBeenCalledTimes(1);
-    const [path, opts] = navigateMock.mock.calls[0];
-    expect(path).toMatch(/^\/agent-builder\/agents\/[^/]+\/edit$/);
-    expect(opts).toMatchObject({ viewTransition: true });
-    expect(opts.state).toBeUndefined();
+  it('does not render a "create manually" affordance — users must use the prompt input', () => {
+    const { queryByTestId } = renderStarter();
+    expect(queryByTestId('agent-builder-starter-create-manually')).toBeNull();
   });
 });

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-starter/agent-builder-starter.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-starter/agent-builder-starter.tsx
@@ -47,13 +47,6 @@ export const AgentBuilderStarter = () => {
     });
   };
 
-  const handleCreateManually = () => {
-    const id = nanoid();
-    void navigate(`/agent-builder/agents/${id}/edit`, {
-      viewTransition: true,
-    });
-  };
-
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
@@ -126,17 +119,6 @@ export const AgentBuilderStarter = () => {
               </button>
             );
           })}
-        </div>
-
-        <div className="flex justify-center">
-          <button
-            type="button"
-            onClick={handleCreateManually}
-            data-testid="agent-builder-starter-create-manually"
-            className="text-ui-sm text-neutral3 transition-colors hover:text-neutral5"
-          >
-            or create manually
-          </button>
         </div>
       </div>
     </div>

--- a/packages/playground/src/index.css
+++ b/packages/playground/src/index.css
@@ -265,6 +265,10 @@ th:has(header) {
     transition: grid-template-columns 320ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
+  .agent-builder-workspace-grid {
+    transition: grid-template-columns 320ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
   .agent-builder-panel-slide {
     transition:
       transform 320ms cubic-bezier(0.22, 1, 0.36, 1),
@@ -286,6 +290,7 @@ th:has(header) {
 
   @media (prefers-reduced-motion: reduce) {
     .agent-builder-panel-grid,
+    .agent-builder-workspace-grid,
     .agent-builder-panel-slide,
     .agent-builder-detail-pane {
       transition: none;

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/edit.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/edit.test.tsx
@@ -299,13 +299,14 @@ describe('AgentBuilderAgentEdit', () => {
     it('switching to Configuration tab in edit mode toggles active panel', () => {
       const { getByTestId } = renderAt();
       const chatPanel = getByTestId('agent-builder-panel-chat');
-      const configurePanel = getByTestId('agent-builder-panel-configure');
+      const configureTab = getByTestId('agent-builder-tab-configure');
       expect(chatPanel.getAttribute('data-active-tab')).toBe('chat');
+      expect(configureTab.getAttribute('aria-selected')).toBe('false');
 
-      fireEvent.click(getByTestId('agent-builder-tab-configure'));
+      fireEvent.click(configureTab);
 
       expect(chatPanel.getAttribute('data-active-tab')).toBe('configure');
-      expect(configurePanel.getAttribute('data-active-tab')).toBe('configure');
+      expect(configureTab.getAttribute('aria-selected')).toBe('true');
     });
 
     it('redirects non-owners to the view page after current user loads', () => {

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/view.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/view.test.tsx
@@ -248,13 +248,13 @@ describe('AgentBuilderAgentView', () => {
   it('switching to the Configuration tab toggles which panel is active', () => {
     const { getByTestId } = renderAt();
     const chatPanel = getByTestId('agent-builder-panel-chat');
-    const configurePanel = getByTestId('agent-builder-panel-configure');
+    const configureTab = getByTestId('agent-builder-tab-configure');
     expect(chatPanel.getAttribute('data-active-tab')).toBe('chat');
-    expect(configurePanel.getAttribute('data-active-tab')).toBe('chat');
+    expect(configureTab.getAttribute('aria-selected')).toBe('false');
 
-    fireEvent.click(getByTestId('agent-builder-tab-configure'));
+    fireEvent.click(configureTab);
 
     expect(chatPanel.getAttribute('data-active-tab')).toBe('configure');
-    expect(configurePanel.getAttribute('data-active-tab')).toBe('configure');
+    expect(configureTab.getAttribute('aria-selected')).toBe('true');
   });
 });


### PR DESCRIPTION
Three connected changes for the agent-builder UX.

The configure panel now sits as a sibling of the main content. When it opens, it pushes the chat (and breadcrumbs) sideways instead of overlaying them, so the page feels like a single full-height surface.

The 'or create manually' link on the starter is gone. The prompt input is the only way to start a new agent now.

The configure panel's `disabled` prop used to do two things: block form inputs and also block the Instructions / Tools / Skills row clicks. The second behavior meant users couldn't even read the current configuration while the agent builder was streaming a response. Now `disabled` only blocks mutating controls (name, description, avatar, instructions textarea, model picker, browser switch). Rows stay navigable; the detail panes they open already render read-only via `editable={!disabled}`.