### PR TITLE
Optimize listTraces and listBranches on DuckDB

### DIFF
--- a/.changeset/duckdb-list-traces-prefilter.md
+++ b/.changeset/duckdb-list-traces-prefilter.md
@@ -2,4 +2,6 @@
 '@mastra/duckdb': patch
 ---
 
-Improved `listTraces` and `listBranches` performance on DuckDB. Both queries now prefilter raw `span_events` on scalar columns before reconstructing rows, and when no post-aggregation filters are in play, ordering and pagination happen inside the prefilter so reconstruction only touches the rows on the current page. `listTraces` also runs `hasChildError` directly against raw `span_events` instead of the reconstructed-spans CTE. The `SpanRecord` shape returned to callers is unchanged.
+Improved performance of `listTraces` and `listBranches` on DuckDB. The Traces and Branches lists in the observability UI now load noticeably faster, especially on large span tables, because filtering and pagination happen up front and the store only assembles full span data for the rows on the page being viewed.
+
+No API or behavior changes — return shapes and filter semantics are unchanged, and no migration is required.

--- a/.changeset/duckdb-list-traces-prefilter.md
+++ b/.changeset/duckdb-list-traces-prefilter.md
@@ -2,4 +2,4 @@
 '@mastra/duckdb': patch
 ---
 
-Improved `listTraces` performance on DuckDB. The query now prefilters raw `span_events` on scalar columns and `parentSpanId IS NULL` before reconstructing rows, and when no post-aggregation filters are in play, ordering and pagination happen inside the prefilter so reconstruction only touches the rows on the current page. `hasChildError` runs directly against raw `span_events` instead of the reconstructed-spans CTE. The `SpanRecord` shape returned to callers is unchanged.
+Improved `listTraces` and `listBranches` performance on DuckDB. Both queries now prefilter raw `span_events` on scalar columns before reconstructing rows, and when no post-aggregation filters are in play, ordering and pagination happen inside the prefilter so reconstruction only touches the rows on the current page. `listTraces` also runs `hasChildError` directly against raw `span_events` instead of the reconstructed-spans CTE. The `SpanRecord` shape returned to callers is unchanged.

--- a/.changeset/duckdb-list-traces-prefilter.md
+++ b/.changeset/duckdb-list-traces-prefilter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/duckdb': patch
+---
+
+Improved `listTraces` performance on DuckDB. The query now prefilters raw `span_events` on scalar columns and `parentSpanId IS NULL` before reconstructing rows, and when no post-aggregation filters are in play, ordering and pagination happen inside the prefilter so reconstruction only touches the rows on the current page. `hasChildError` runs directly against raw `span_events` instead of the reconstructed-spans CTE. The `SpanRecord` shape returned to callers is unchanged.

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -690,6 +690,61 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(allBranches.branches).toHaveLength(5);
     });
 
+    it('listBranches applies scalar prefilter and tag post-filter correctly', async () => {
+      await storage.batchCreateSpans({
+        records: [
+          {
+            ...baseSpan,
+            traceId: 'br-scalar-a',
+            spanId: 'agent-a',
+            parentSpanId: 'root-a',
+            name: 'nested-agent',
+            spanType: SpanType.AGENT_RUN,
+            entityType: EntityType.AGENT,
+            entityId: 'agent-a',
+            entityName: 'agentA',
+            environment: 'production',
+            serviceName: 'svc-a',
+            tags: ['keep'],
+            startedAt: new Date('2026-04-03T00:00:00Z'),
+            endedAt: new Date('2026-04-03T00:00:02Z'),
+          },
+          {
+            ...baseSpan,
+            traceId: 'br-scalar-b',
+            spanId: 'agent-b',
+            parentSpanId: 'root-b',
+            name: 'nested-agent',
+            spanType: SpanType.AGENT_RUN,
+            entityType: EntityType.AGENT,
+            entityId: 'agent-b',
+            entityName: 'agentB',
+            environment: 'staging',
+            serviceName: 'svc-b',
+            tags: ['skip'],
+            startedAt: new Date('2026-04-03T00:00:05Z'),
+            endedAt: new Date('2026-04-03T00:00:06Z'),
+          },
+        ],
+      });
+
+      // Fast path — scalar-only filter (no post-agg).
+      const byEnv = await storage.listBranches({
+        filters: { environment: 'production', startedAt: { start: new Date('2026-04-03T00:00:00Z') } },
+      });
+      const envSpanIds = byEnv.branches.map(b => b.spanId);
+      expect(envSpanIds).toContain('agent-a');
+      expect(envSpanIds).not.toContain('agent-b');
+
+      // Slow path — post-agg tag filter combined with scalar startedAt.
+      const byTag = await storage.listBranches({
+        filters: { tags: ['keep'], startedAt: { start: new Date('2026-04-03T00:00:00Z') } },
+      });
+      const tagSpanIds = byTag.branches.map(b => b.spanId);
+      expect(tagSpanIds).toContain('agent-a');
+      expect(tagSpanIds).not.toContain('agent-b');
+    });
+
     it('getSpans batch-fetches a subset of spans within a trace', async () => {
       await storage.batchCreateSpans({
         records: [

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -265,6 +265,91 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(traces.spans.length).toBeGreaterThanOrEqual(1);
     });
 
+    it('listTraces applies scalar prefilter and tag post-filter correctly', async () => {
+      await storage.batchCreateSpans({
+        records: [
+          {
+            traceId: 'trace-scalar-a',
+            spanId: 'root-a',
+            parentSpanId: null,
+            name: 'agent-run',
+            spanType: SpanType.AGENT_RUN,
+            isEvent: false,
+            entityType: EntityType.AGENT,
+            entityId: 'agent-a',
+            entityName: 'agentA',
+            userId: null,
+            organizationId: null,
+            resourceId: null,
+            runId: null,
+            sessionId: null,
+            threadId: null,
+            requestId: null,
+            environment: 'production',
+            source: null,
+            serviceName: 'svc-a',
+            scope: null,
+            attributes: null,
+            metadata: null,
+            tags: ['keep'],
+            links: null,
+            input: null,
+            output: null,
+            error: null,
+            startedAt: new Date('2026-01-02T00:00:00Z'),
+            endedAt: new Date('2026-01-02T00:00:02Z'),
+          },
+          {
+            traceId: 'trace-scalar-b',
+            spanId: 'root-b',
+            parentSpanId: null,
+            name: 'agent-run',
+            spanType: SpanType.AGENT_RUN,
+            isEvent: false,
+            entityType: EntityType.AGENT,
+            entityId: 'agent-b',
+            entityName: 'agentB',
+            userId: null,
+            organizationId: null,
+            resourceId: null,
+            runId: null,
+            sessionId: null,
+            threadId: null,
+            requestId: null,
+            environment: 'staging',
+            source: null,
+            serviceName: 'svc-b',
+            scope: null,
+            attributes: null,
+            metadata: null,
+            tags: ['skip'],
+            links: null,
+            input: null,
+            output: null,
+            error: null,
+            startedAt: new Date('2026-01-02T00:00:05Z'),
+            endedAt: new Date('2026-01-02T00:00:06Z'),
+          },
+        ],
+      });
+
+      // Fast path — scalar-only filter (no post-agg).
+      const byEnv = await storage.listTraces({
+        filters: { environment: 'production', startedAt: { start: new Date('2026-01-02T00:00:00Z') } },
+      });
+      const envTraceIds = byEnv.spans.map(s => s.traceId);
+      expect(envTraceIds).toContain('trace-scalar-a');
+      expect(envTraceIds).not.toContain('trace-scalar-b');
+
+      // Slow path — post-agg tag filter combined with scalar startedAt.
+      const byTag = await storage.listTraces({
+        filters: { tags: ['keep'], startedAt: { start: new Date('2026-01-02T00:00:00Z') } },
+      });
+      const tagTraceIds = byTag.spans.map(s => s.traceId);
+      expect(tagTraceIds).toContain('trace-scalar-a');
+      expect(tagTraceIds).not.toContain('trace-scalar-b');
+    });
+
     it('batch deletes traces', async () => {
       await storage.createSpan({
         span: {

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -350,6 +350,100 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(tagTraceIds).not.toContain('trace-scalar-b');
     });
 
+    it('listTraces intersects startedAt and endedAt upper bounds on the prefilter', async () => {
+      // Span A starts at 12:00 and ends at 12:01 — fits inside both ranges.
+      // Span B starts at 12:30 (outside startedAt) and ends at 12:35 (inside
+      // endedAt). With a buggy partition that overwrites the prefilter end
+      // bound, span B would leak through; with the intersection fix it stays
+      // out.
+      await storage.batchCreateSpans({
+        records: [
+          {
+            traceId: 'trace-bound-a',
+            spanId: 'root-a',
+            parentSpanId: null,
+            name: 'within-window',
+            spanType: SpanType.AGENT_RUN,
+            isEvent: false,
+            entityType: EntityType.AGENT,
+            entityId: 'agent-a',
+            entityName: 'agentA',
+            userId: null,
+            organizationId: null,
+            resourceId: null,
+            runId: null,
+            sessionId: null,
+            threadId: null,
+            requestId: null,
+            environment: null,
+            source: null,
+            serviceName: null,
+            scope: null,
+            attributes: null,
+            metadata: null,
+            tags: null,
+            links: null,
+            input: null,
+            output: null,
+            error: null,
+            startedAt: new Date('2026-02-01T12:00:00Z'),
+            endedAt: new Date('2026-02-01T12:01:00Z'),
+          },
+          {
+            traceId: 'trace-bound-b',
+            spanId: 'root-b',
+            parentSpanId: null,
+            name: 'started-after-startedAt-end',
+            spanType: SpanType.AGENT_RUN,
+            isEvent: false,
+            entityType: EntityType.AGENT,
+            entityId: 'agent-b',
+            entityName: 'agentB',
+            userId: null,
+            organizationId: null,
+            resourceId: null,
+            runId: null,
+            sessionId: null,
+            threadId: null,
+            requestId: null,
+            environment: null,
+            source: null,
+            serviceName: null,
+            scope: null,
+            attributes: null,
+            metadata: null,
+            tags: null,
+            links: null,
+            input: null,
+            output: null,
+            error: null,
+            startedAt: new Date('2026-02-01T12:30:00Z'),
+            endedAt: new Date('2026-02-01T12:35:00Z'),
+          },
+        ],
+      });
+
+      const filters = {
+        startedAt: { end: new Date('2026-02-01T12:10:00Z') },
+        endedAt: { end: new Date('2026-02-01T13:00:00Z') },
+      };
+      const tightUpperBound = await storage.listTraces({ filters });
+      const traceIds = tightUpperBound.spans.map(s => s.traceId);
+      expect(traceIds).toContain('trace-bound-a');
+      expect(traceIds).not.toContain('trace-bound-b');
+
+      // Same query with keys reversed — JS `Object.entries` iterates insertion
+      // order, so this exercises the other partition path.
+      const filtersReversed = {
+        endedAt: { end: new Date('2026-02-01T13:00:00Z') },
+        startedAt: { end: new Date('2026-02-01T12:10:00Z') },
+      };
+      const reversed = await storage.listTraces({ filters: filtersReversed });
+      const reversedIds = reversed.spans.map(s => s.traceId);
+      expect(reversedIds).toContain('trace-bound-a');
+      expect(reversedIds).not.toContain('trace-bound-b');
+    });
+
     it('batch deletes traces', async () => {
       await storage.createSpan({
         span: {

--- a/stores/duckdb/src/storage/domains/observability/tracing.ts
+++ b/stores/duckdb/src/storage/domains/observability/tracing.ts
@@ -194,14 +194,14 @@ function buildHasChildErrorClause(hasChildError: boolean | undefined, rootAlias:
 }
 
 // ============================================================================
-// listTraces filter classification
+// listTraces / listBranches filter classification
 // ============================================================================
 
 /**
  * Filter keys that can be evaluated directly against raw `span_events` start
  * rows. These are stable scalar columns whose value on the start row matches
- * the reconstructed root-span value, so pushing them down before
- * reconstruction is observation-equivalent to the old behavior.
+ * the reconstructed span value, so pushing them down before reconstruction is
+ * observation-equivalent to reconstructing first and filtering after.
  */
 const PREFILTER_KEYS = new Set([
   'traceId',
@@ -226,7 +226,16 @@ const PREFILTER_KEYS = new Set([
   'serviceName',
 ]);
 
-function partitionListTracesFilters(filters: Record<string, unknown>): {
+/**
+ * Split a span-anchor filter set into a `prefilter` half (pushed to raw
+ * `span_events` start rows) and a `postAgg` half (applied after the
+ * reconstruction GROUP BY). Used by both `listTraces` and `listBranches`.
+ *
+ * `hasChildError` is split out separately since it doesn't run via
+ * `buildWhereClause` — `listTraces` wires it up via EXISTS, `listBranches`
+ * never sees it (not in `branchesFilterSchema`).
+ */
+function partitionAnchorFilters(filters: Record<string, unknown>): {
   prefilter: Record<string, unknown>;
   postAgg: Record<string, unknown>;
   hasChildError: boolean | undefined;
@@ -552,7 +561,7 @@ export async function listTraces(db: DuckDBConnection, args: ListTracesArgs): Pr
   const perPage = Number(args.pagination?.perPage ?? 10);
   const orderBy = { field: args.orderBy?.field ?? 'startedAt', direction: args.orderBy?.direction ?? 'DESC' } as const;
 
-  const { prefilter, postAgg, hasChildError } = partitionListTracesFilters(filters as Record<string, unknown>);
+  const { prefilter, postAgg, hasChildError } = partitionAnchorFilters(filters as Record<string, unknown>);
 
   // Stage 1 — cheap prefilter against raw span_events (start-row only).
   const { clause: prefilterClause, params: prefilterParams } = buildWhereClause(prefilter);
@@ -688,10 +697,20 @@ export async function getSpans(db: DuckDBConnection, args: GetSpansArgs): Promis
 
 /**
  * List branch anchor spans (named-entity invocations) across all traces with
- * filtering, ordering, and pagination. Pre-filters raw `span_events` by
- * `spanType IN (branch types)` before the reconstruct GROUP BY, so we don't
- * pay reconstruction cost for the high-volume sub-operation events
- * (MODEL_STEP, MODEL_CHUNK, etc.) that are never anchors.
+ * filtering, ordering, and pagination.
+ *
+ * Same two-stage strategy as `listTraces`:
+ *   1. Pick candidate anchor `(traceId, spanId)` tuples from raw `span_events`
+ *      by looking only at `eventType = 'start'` rows whose `spanType` is in
+ *      {@link BRANCH_SPAN_TYPES}. Scalar filters (entity*, *Id, environment,
+ *      serviceName, startedAt range, ...) run here, against raw columns. This
+ *      avoids paying reconstruction cost for the high-volume sub-operation
+ *      events (MODEL_STEP, MODEL_CHUNK, ...) that are never anchors.
+ *   2. Reconstruct full span data only for that narrowed set, then apply
+ *      post-aggregation filters (status / metadata / tags / endedAt range).
+ *
+ * When there are no post-aggregation filters, ordering + pagination happen
+ * inside the prefilter so reconstruction runs on at most `perPage` rows.
  */
 export async function listBranches(db: DuckDBConnection, args: ListBranchesArgs): Promise<ListBranchesResponse> {
   const filters = args.filters ?? {};
@@ -699,51 +718,122 @@ export async function listBranches(db: DuckDBConnection, args: ListBranchesArgs)
   const perPage = Number(args.pagination?.perPage ?? 10);
   const orderBy = { field: args.orderBy?.field ?? 'startedAt', direction: args.orderBy?.direction ?? 'DESC' } as const;
 
-  // spanType is consumed by the prefilter; pass the rest of the filter set
-  // through buildWhereClause unchanged.
-  const { spanType, ...passthroughFilters } = filters as Record<string, unknown>;
-  const { clause: filterClause, params: filterParams } = buildWhereClause(passthroughFilters);
-  const orderByClause = buildOrderByClause(orderBy);
-  const { clause: paginationClause, params: paginationParams } = buildPaginationClause({ page, perPage });
+  // Caller-supplied spanType narrows further; if it's not a branch type, the
+  // intersection with BRANCH_SPAN_TYPES is empty and we short-circuit (instead
+  // of silently widening to all branches or leaking the non-branch type
+  // through).
+  const userSpanType = (filters as Record<string, unknown>).spanType;
+  if (typeof userSpanType === 'string' && !(BRANCH_SPAN_TYPES as readonly string[]).includes(userSpanType)) {
+    return {
+      pagination: { total: 0, page, perPage, hasMore: false },
+      branches: [],
+    };
+  }
 
-  // Prefilter raw events to branch-anchor types. Unlike the ClickHouse path
-  // which reads from an MV-filtered table, DuckDB queries raw span_events
-  // directly, so this guard is what enforces "listBranches only returns
-  // branches" here. Caller-supplied spanType narrows further; if it's not a
-  // branch type, the intersection is empty and we short-circuit to no rows
-  // (instead of silently widening to all branches or leaking the non-branch
-  // type through).
-  let prefilterClause: string;
-  let prefilterParams: unknown[];
-  if (typeof spanType === 'string') {
-    if (!(BRANCH_SPAN_TYPES as readonly string[]).includes(spanType)) {
-      // Caller asked for a non-branch span type; "branch anchors with that
-      // type" is an empty set by definition.
+  // `spanType` is consumed inline below (not via PREFILTER_KEYS) so we always
+  // emit the IN-list / equality form regardless of the caller's input.
+  const { spanType: _spanType, ...rest } = filters as Record<string, unknown>;
+  const { prefilter, postAgg, hasChildError: _hasChildError } = partitionAnchorFilters(rest);
+
+  // Stage 1 — cheap prefilter against raw span_events (start-row only).
+  //
+  // Unlike the ClickHouse path which reads from an MV-filtered table, DuckDB
+  // queries raw span_events directly, so this guard is what enforces
+  // "listBranches only returns branches" here.
+  const { clause: prefilterClause, params: prefilterFilterParams } = buildWhereClause(prefilter);
+  const prefilterParts = [`eventType = 'start'`];
+  let spanTypeParams: unknown[];
+  if (typeof userSpanType === 'string') {
+    prefilterParts.push(`spanType = ?`);
+    spanTypeParams = [userSpanType];
+  } else {
+    prefilterParts.push(`spanType IN (${BRANCH_SPAN_TYPE_PLACEHOLDERS})`);
+    spanTypeParams = [...BRANCH_SPAN_TYPES];
+  }
+  if (prefilterClause) prefilterParts.push(prefilterClause.replace(/^WHERE\s+/i, ''));
+  const prefilterWhere = `WHERE ${prefilterParts.join(' AND ')}`;
+  const prefilterParams = [...spanTypeParams, ...prefilterFilterParams];
+
+  const outerAlias = 'outer_anchor';
+
+  // For ordering on the prefilter, `startedAt` maps to the start-row `timestamp`.
+  const orderByField = orderBy.field === 'startedAt' ? 'timestamp' : parseFieldKey(orderBy.field);
+  const orderDir = orderBy.direction.toUpperCase();
+  if (orderDir !== 'ASC' && orderDir !== 'DESC') {
+    throw new Error(`Invalid sort direction: ${orderBy.direction}`);
+  }
+  const prefilterOrderBy = `ORDER BY ${orderByField} ${orderDir}`;
+
+  // Same caveat as listTraces: ordering by `endedAt` requires reconstructed
+  // values (start rows always have NULL `endedAt`), so fall back to the slow
+  // path in that case.
+  const hasPostAggFilters = Object.keys(postAgg).length > 0 || orderBy.field === 'endedAt';
+
+  if (!hasPostAggFilters) {
+    // Fast path: order + paginate in the prefilter, reconstruct only the page.
+    const offset = page * perPage;
+
+    const countSql = `
+      SELECT COUNT(*) as total
+      FROM span_events AS ${outerAlias}
+      ${prefilterWhere}
+    `;
+    const countResult = await db.query<{ total: number }>(countSql, prefilterParams);
+    const total = Number(countResult[0]?.total ?? 0);
+
+    if (total === 0) {
       return {
         pagination: { total: 0, page, perPage, hasMore: false },
         branches: [],
       };
     }
-    prefilterClause = `WHERE spanType = ?`;
-    prefilterParams = [spanType];
-  } else {
-    prefilterClause = `WHERE spanType IN (${BRANCH_SPAN_TYPE_PLACEHOLDERS})`;
-    prefilterParams = [...BRANCH_SPAN_TYPES];
+
+    const pageSql = `
+      WITH page_anchors AS (
+        SELECT traceId, spanId
+        FROM span_events AS ${outerAlias}
+        ${prefilterWhere}
+        ${prefilterOrderBy}
+        LIMIT ? OFFSET ?
+      )
+      ${SPAN_RECONSTRUCT_SELECT}
+      WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM page_anchors)
+      GROUP BY traceId, spanId
+      ${buildOrderByClause(orderBy)}
+    `;
+    const rows = await db.query(pageSql, [...prefilterParams, perPage, offset]);
+    const spans = rows.map(row => rowToSpanRecord(row as Record<string, unknown>));
+
+    return {
+      pagination: { total, page, perPage, hasMore: (page + 1) * perPage < total },
+      branches: toTraceSpans(spans),
+    };
   }
 
+  // Slow path: reconstruct the prefilter set, then apply post-agg filters.
+  const { clause: postAggClause, params: postAggParams } = buildWhereClause(postAgg);
+  const postAggWhere = postAggClause ? postAggClause : '';
+  const orderByClause = buildOrderByClause(orderBy);
+  const { clause: paginationClause, params: paginationParams } = buildPaginationClause({ page, perPage });
+
   const cteSql = `
-    WITH branch_anchors AS (
+    WITH candidate_anchors AS (
+      SELECT traceId, spanId
+      FROM span_events AS ${outerAlias}
+      ${prefilterWhere}
+    ),
+    branch_anchors AS (
       ${SPAN_RECONSTRUCT_SELECT}
-      ${prefilterClause}
+      WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM candidate_anchors)
       GROUP BY traceId, spanId
     )
   `;
 
   const countSql = `
     ${cteSql}
-    SELECT COUNT(*) as total FROM branch_anchors ${filterClause}
+    SELECT COUNT(*) as total FROM branch_anchors ${postAggWhere}
   `;
-  const countResult = await db.query<{ total: number }>(countSql, [...prefilterParams, ...filterParams]);
+  const countResult = await db.query<{ total: number }>(countSql, [...prefilterParams, ...postAggParams]);
   const total = Number(countResult[0]?.total ?? 0);
 
   if (total === 0) {
@@ -755,18 +845,13 @@ export async function listBranches(db: DuckDBConnection, args: ListBranchesArgs)
 
   const dataSql = `
     ${cteSql}
-    SELECT * FROM branch_anchors ${filterClause} ${orderByClause} ${paginationClause}
+    SELECT * FROM branch_anchors ${postAggWhere} ${orderByClause} ${paginationClause}
   `;
-  const rows = await db.query(dataSql, [...prefilterParams, ...filterParams, ...paginationParams]);
+  const rows = await db.query(dataSql, [...prefilterParams, ...postAggParams, ...paginationParams]);
   const spans = rows.map(row => rowToSpanRecord(row as Record<string, unknown>));
 
   return {
-    pagination: {
-      total,
-      page,
-      perPage,
-      hasMore: (page + 1) * perPage < total,
-    },
+    pagination: { total, page, perPage, hasMore: (page + 1) * perPage < total },
     branches: toTraceSpans(spans),
   };
 }

--- a/stores/duckdb/src/storage/domains/observability/tracing.ts
+++ b/stores/duckdb/src/storage/domains/observability/tracing.ts
@@ -19,6 +19,7 @@ import type {
   SpanRecord,
 } from '@mastra/core/storage';
 import { BRANCH_SPAN_TYPES, toTraceSpans } from '@mastra/core/storage';
+import { parseFieldKey } from '@mastra/core/utils';
 import type { DuckDBConnection } from '../../db/index';
 import { buildWhereClause, buildOrderByClause, buildPaginationClause } from './filters';
 import { v, jsonV, parseJson, parseJsonArray, toDate, toDateOrNull } from './helpers';
@@ -185,10 +186,100 @@ function rowToSpanRecord(row: Record<string, unknown>): SpanRecord {
   };
 }
 
-function buildHasChildErrorClause(hasChildError: boolean | undefined): string {
+function buildHasChildErrorClause(hasChildError: boolean | undefined, rootAlias: string): string {
   if (hasChildError === undefined) return '';
-  const base = `SELECT 1 FROM reconstructed_spans c WHERE c.traceId = root_spans.traceId AND c.spanId != root_spans.spanId AND c.error IS NOT NULL`;
+  // Run directly against raw span_events so we never pay for full-table reconstruction.
+  const base = `SELECT 1 FROM span_events c WHERE c.traceId = ${rootAlias}.traceId AND c.spanId != ${rootAlias}.spanId AND c.error IS NOT NULL`;
   return hasChildError ? `EXISTS (${base})` : `NOT EXISTS (${base})`;
+}
+
+// ============================================================================
+// listTraces filter classification
+// ============================================================================
+
+/**
+ * Filter keys that can be evaluated directly against raw `span_events` start
+ * rows. These are stable scalar columns whose value on the start row matches
+ * the reconstructed root-span value, so pushing them down before
+ * reconstruction is observation-equivalent to the old behavior.
+ */
+const PREFILTER_KEYS = new Set([
+  'traceId',
+  'spanId',
+  'parentSpanId',
+  'name',
+  'spanType',
+  'source',
+  'entityType',
+  'entityId',
+  'entityName',
+  'entityVersionId',
+  'experimentId',
+  'userId',
+  'organizationId',
+  'resourceId',
+  'runId',
+  'sessionId',
+  'threadId',
+  'requestId',
+  'environment',
+  'serviceName',
+]);
+
+function partitionListTracesFilters(filters: Record<string, unknown>): {
+  prefilter: Record<string, unknown>;
+  postAgg: Record<string, unknown>;
+  hasChildError: boolean | undefined;
+} {
+  const prefilter: Record<string, unknown> = {};
+  const postAgg: Record<string, unknown> = {};
+  let hasChildError: boolean | undefined;
+
+  for (const [key, value] of Object.entries(filters)) {
+    if (value === undefined || value === null) continue;
+
+    if (key === 'hasChildError') {
+      if (typeof value === 'boolean') hasChildError = value;
+      continue;
+    }
+
+    if (key === 'startedAt') {
+      // startedAt == min(timestamp) on the start row, so a startedAt range is
+      // exactly the start-row timestamp range. Pushable to the prefilter.
+      prefilter.timestamp = value;
+      continue;
+    }
+
+    if (key === 'endedAt') {
+      // endedAt lives on the end event and can only be checked after reconstruct.
+      postAgg.endedAt = value;
+      // As a safe over-approximation, apply `endedAt.end` as an upper bound on
+      // the start-row timestamp so we never scan events created strictly after
+      // the requested window. (A span that started after `endedAt.end` can't
+      // have ended before it.)
+      const dateRange = value as { end?: Date; endExclusive?: boolean };
+      if (dateRange?.end) {
+        const existing = prefilter.timestamp as { start?: Date; end?: Date } | undefined;
+        prefilter.timestamp = {
+          ...(existing ?? {}),
+          end: dateRange.end,
+          endExclusive: dateRange.endExclusive,
+        };
+      }
+      continue;
+    }
+
+    if (PREFILTER_KEYS.has(key)) {
+      prefilter[key] = value;
+      continue;
+    }
+
+    // Everything that lands here (status, metadata, scope, tags, labels, ...)
+    // depends on reconstructed values and runs after span reconstruction.
+    postAgg[key] = value;
+  }
+
+  return { prefilter, postAgg, hasChildError };
 }
 
 // ============================================================================
@@ -440,57 +531,126 @@ export async function getTraceLight(db: DuckDBConnection, args: GetTraceArgs): P
   };
 }
 
-/** List root spans (traces) with filtering, ordering, and pagination. */
+/**
+ * List root spans (traces) with filtering, ordering, and pagination.
+ *
+ * Instead of reconstructing every span in the table and then filtering, we:
+ *   1. Pick candidate root `(traceId, spanId)` tuples from raw `span_events`
+ *      by looking only at rows where `eventType = 'start'` and
+ *      `parentSpanId IS NULL`. All scalar filters (entity*, *Id, service,
+ *      environment, startedAt range, ...) run here, against raw columns.
+ *   2. Fully reconstruct spans only for that narrowed set, then apply
+ *      post-aggregation filters (status/tags/metadata/scope/endedAt/
+ *      hasChildError).
+ *
+ * When there are no post-aggregation filters, ordering + pagination happen
+ * inside the prefilter CTE so reconstruction runs on at most `perPage` rows.
+ */
 export async function listTraces(db: DuckDBConnection, args: ListTracesArgs): Promise<ListTracesResponse> {
   const filters = args.filters ?? {};
   const page = Number(args.pagination?.page ?? 0);
   const perPage = Number(args.pagination?.perPage ?? 10);
   const orderBy = { field: args.orderBy?.field ?? 'startedAt', direction: args.orderBy?.direction ?? 'DESC' } as const;
 
-  const { clause: filterClause, params: filterParams } = buildWhereClause(filters as Record<string, unknown>);
-  const orderByClause = buildOrderByClause(orderBy);
-  const { clause: paginationClause, params: paginationParams } = buildPaginationClause({ page, perPage });
+  const { prefilter, postAgg, hasChildError } = partitionListTracesFilters(filters as Record<string, unknown>);
 
-  const filterParts = [];
-  if (filterClause) filterParts.push(filterClause.replace(/^WHERE\s+/i, ''));
-  const hasChildError = typeof filters.hasChildError === 'boolean' ? filters.hasChildError : undefined;
-  const childErrorClause = buildHasChildErrorClause(hasChildError);
-  if (childErrorClause) filterParts.push(childErrorClause);
-  const combinedFilterClause = filterParts.length > 0 ? `WHERE ${filterParts.join(' AND ')}` : '';
+  // Stage 1 — cheap prefilter against raw span_events (start-row only).
+  const { clause: prefilterClause, params: prefilterParams } = buildWhereClause(prefilter);
+  const prefilterParts = [`eventType = 'start'`, `parentSpanId IS NULL`];
+  if (prefilterClause) prefilterParts.push(prefilterClause.replace(/^WHERE\s+/i, ''));
+  const prefilterWhere = `WHERE ${prefilterParts.join(' AND ')}`;
+
+  const outerAlias = 'outer_root';
+
+  // For ordering on the prefilter, `startedAt` maps to the start-row `timestamp`.
+  const orderByField = orderBy.field === 'startedAt' ? 'timestamp' : parseFieldKey(orderBy.field);
+  const orderDir = orderBy.direction.toUpperCase();
+  if (orderDir !== 'ASC' && orderDir !== 'DESC') {
+    throw new Error(`Invalid sort direction: ${orderBy.direction}`);
+  }
+  const prefilterOrderBy = `ORDER BY ${orderByField} ${orderDir}`;
+
+  // The fast path orders + paginates on `span_events` `start` rows. Those rows
+  // never carry a non-null `endedAt`, so ordering by `endedAt` would compare
+  // NULLs and produce incorrect pagination. In that case fall back to the slow
+  // path which orders against the reconstructed root spans.
+  const hasPostAggFilters =
+    Object.keys(postAgg).length > 0 || hasChildError !== undefined || orderBy.field === 'endedAt';
+
+  if (!hasPostAggFilters) {
+    // Fast path: order + paginate in the prefilter, reconstruct only the page.
+    const offset = page * perPage;
+
+    const countSql = `
+      SELECT COUNT(*) as total
+      FROM span_events AS ${outerAlias}
+      ${prefilterWhere}
+    `;
+    const countResult = await db.query<{ total: number }>(countSql, prefilterParams);
+    const total = Number(countResult[0]?.total ?? 0);
+
+    const pageSql = `
+      WITH page_roots AS (
+        SELECT traceId, spanId
+        FROM span_events AS ${outerAlias}
+        ${prefilterWhere}
+        ${prefilterOrderBy}
+        LIMIT ? OFFSET ?
+      )
+      ${SPAN_RECONSTRUCT_SELECT}
+      WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM page_roots)
+      GROUP BY traceId, spanId
+      ${buildOrderByClause(orderBy)}
+    `;
+    const rows = await db.query(pageSql, [...prefilterParams, perPage, offset]);
+    const spans = rows.map(row => rowToSpanRecord(row as Record<string, unknown>));
+
+    return {
+      pagination: { total, page, perPage, hasMore: (page + 1) * perPage < total },
+      spans: toTraceSpans(spans),
+    };
+  }
+
+  // Slow path: reconstruct the prefilter set, then apply post-agg filters.
+  const { clause: postAggClause, params: postAggParams } = buildWhereClause(postAgg);
+  const postAggParts: string[] = [];
+  if (postAggClause) postAggParts.push(postAggClause.replace(/^WHERE\s+/i, ''));
+  const childErrorClause = buildHasChildErrorClause(hasChildError, 'root_spans');
+  if (childErrorClause) postAggParts.push(childErrorClause);
+  const postAggWhere = postAggParts.length > 0 ? `WHERE ${postAggParts.join(' AND ')}` : '';
 
   const cteSql = `
-    WITH reconstructed_spans AS (
-      ${SPAN_RECONSTRUCT_SELECT}
-      GROUP BY traceId, spanId
+    WITH candidate_roots AS (
+      SELECT traceId, spanId
+      FROM span_events AS ${outerAlias}
+      ${prefilterWhere}
     ),
     root_spans AS (
-      SELECT * FROM reconstructed_spans
-      WHERE parentSpanId IS NULL
+      ${SPAN_RECONSTRUCT_SELECT}
+      WHERE (traceId, spanId) IN (SELECT traceId, spanId FROM candidate_roots)
+      GROUP BY traceId, spanId
     )
   `;
 
+  const orderByClause = buildOrderByClause(orderBy);
+  const { clause: paginationClause, params: paginationParams } = buildPaginationClause({ page, perPage });
+
   const countSql = `
     ${cteSql}
-    SELECT COUNT(*) as total FROM root_spans ${combinedFilterClause}
+    SELECT COUNT(*) as total FROM root_spans ${postAggWhere}
   `;
-  const countResult = await db.query<{ total: number }>(countSql, filterParams);
+  const countResult = await db.query<{ total: number }>(countSql, [...prefilterParams, ...postAggParams]);
   const total = Number(countResult[0]?.total ?? 0);
 
   const dataSql = `
     ${cteSql}
-    SELECT * FROM root_spans ${combinedFilterClause} ${orderByClause} ${paginationClause}
+    SELECT * FROM root_spans ${postAggWhere} ${orderByClause} ${paginationClause}
   `;
-  const rows = await db.query(dataSql, [...filterParams, ...paginationParams]);
-
+  const rows = await db.query(dataSql, [...prefilterParams, ...postAggParams, ...paginationParams]);
   const spans = rows.map(row => rowToSpanRecord(row as Record<string, unknown>));
 
   return {
-    pagination: {
-      total,
-      page,
-      perPage,
-      hasMore: (page + 1) * perPage < total,
-    },
+    pagination: { total, page, perPage, hasMore: (page + 1) * perPage < total },
     spans: toTraceSpans(spans),
   };
 }

--- a/stores/duckdb/src/storage/domains/observability/tracing.ts
+++ b/stores/duckdb/src/storage/domains/observability/tracing.ts
@@ -19,7 +19,6 @@ import type {
   SpanRecord,
 } from '@mastra/core/storage';
 import { BRANCH_SPAN_TYPES, toTraceSpans } from '@mastra/core/storage';
-import { parseFieldKey } from '@mastra/core/utils';
 import type { DuckDBConnection } from '../../db/index';
 import { buildWhereClause, buildOrderByClause, buildPaginationClause } from './filters';
 import { v, jsonV, parseJson, parseJsonArray, toDate, toDateOrNull } from './helpers';
@@ -227,6 +226,60 @@ const PREFILTER_KEYS = new Set([
 ]);
 
 /**
+ * Order-by fields whose start-row value matches the reconstructed root-span
+ * value, so ordering inside the prefilter (before GROUP BY) yields the same
+ * sequence as ordering on reconstructed rows. Anything outside this set must
+ * fall back to the slow path so pagination stays correct.
+ *
+ * `endedAt` is intentionally excluded — start rows always have NULL `endedAt`,
+ * so ordering by it on raw rows would compare NULLs and produce wrong pages.
+ */
+const SAFE_PREFILTER_ORDER_FIELDS = new Set(['startedAt']);
+
+type DateRangeBounds = {
+  start?: Date;
+  startExclusive?: boolean;
+  end?: Date;
+  endExclusive?: boolean;
+};
+
+/**
+ * Intersect the existing prefilter timestamp range with an incoming bound.
+ * Each bound is an exact constraint on the start-row `timestamp`, so the
+ * intersection is the **tighter** of the two on each side: the later `start`
+ * wins, the earlier `end` wins. When two bounds tie on a side, the result is
+ * exclusive if either input was exclusive (the union of exclusivity).
+ *
+ * Required for cases like `{ startedAt: { end: B }, endedAt: { end: C } }`:
+ * both bound the start-row timestamp from above and we want `min(B, C)`,
+ * regardless of insertion order.
+ */
+function intersectTimestampRange(existing: DateRangeBounds | undefined, incoming: DateRangeBounds): DateRangeBounds {
+  if (!existing) return { ...incoming };
+  const merged: DateRangeBounds = { ...existing };
+
+  if (incoming.start !== undefined) {
+    if (merged.start === undefined || incoming.start.getTime() > merged.start.getTime()) {
+      merged.start = incoming.start;
+      merged.startExclusive = incoming.startExclusive;
+    } else if (incoming.start.getTime() === merged.start.getTime()) {
+      merged.startExclusive = (merged.startExclusive ?? false) || (incoming.startExclusive ?? false);
+    }
+  }
+
+  if (incoming.end !== undefined) {
+    if (merged.end === undefined || incoming.end.getTime() < merged.end.getTime()) {
+      merged.end = incoming.end;
+      merged.endExclusive = incoming.endExclusive;
+    } else if (incoming.end.getTime() === merged.end.getTime()) {
+      merged.endExclusive = (merged.endExclusive ?? false) || (incoming.endExclusive ?? false);
+    }
+  }
+
+  return merged;
+}
+
+/**
  * Split a span-anchor filter set into a `prefilter` half (pushed to raw
  * `span_events` start rows) and a `postAgg` half (applied after the
  * reconstruction GROUP BY). Used by both `listTraces` and `listBranches`.
@@ -254,26 +307,27 @@ function partitionAnchorFilters(filters: Record<string, unknown>): {
 
     if (key === 'startedAt') {
       // startedAt == min(timestamp) on the start row, so a startedAt range is
-      // exactly the start-row timestamp range. Pushable to the prefilter.
-      prefilter.timestamp = value;
+      // exactly the start-row timestamp range. Intersect with anything already
+      // pushed down (e.g. an endedAt-derived upper bound from a prior iter).
+      prefilter.timestamp = intersectTimestampRange(
+        prefilter.timestamp as DateRangeBounds | undefined,
+        value as DateRangeBounds,
+      );
       continue;
     }
 
     if (key === 'endedAt') {
       // endedAt lives on the end event and can only be checked after reconstruct.
       postAgg.endedAt = value;
-      // As a safe over-approximation, apply `endedAt.end` as an upper bound on
-      // the start-row timestamp so we never scan events created strictly after
-      // the requested window. (A span that started after `endedAt.end` can't
-      // have ended before it.)
-      const dateRange = value as { end?: Date; endExclusive?: boolean };
+      // Safe over-approximation: a span that started after `endedAt.end` can't
+      // have ended before it, so `endedAt.end` is also a valid upper bound on
+      // the start-row timestamp. Intersect with whatever's already there.
+      const dateRange = value as DateRangeBounds;
       if (dateRange?.end) {
-        const existing = prefilter.timestamp as { start?: Date; end?: Date } | undefined;
-        prefilter.timestamp = {
-          ...(existing ?? {}),
+        prefilter.timestamp = intersectTimestampRange(prefilter.timestamp as DateRangeBounds | undefined, {
           end: dateRange.end,
           endExclusive: dateRange.endExclusive,
-        };
+        });
       }
       continue;
     }
@@ -571,23 +625,23 @@ export async function listTraces(db: DuckDBConnection, args: ListTracesArgs): Pr
 
   const outerAlias = 'outer_root';
 
-  // For ordering on the prefilter, `startedAt` maps to the start-row `timestamp`.
-  const orderByField = orderBy.field === 'startedAt' ? 'timestamp' : parseFieldKey(orderBy.field);
   const orderDir = orderBy.direction.toUpperCase();
   if (orderDir !== 'ASC' && orderDir !== 'DESC') {
     throw new Error(`Invalid sort direction: ${orderBy.direction}`);
   }
-  const prefilterOrderBy = `ORDER BY ${orderByField} ${orderDir}`;
 
-  // The fast path orders + paginates on `span_events` `start` rows. Those rows
-  // never carry a non-null `endedAt`, so ordering by `endedAt` would compare
-  // NULLs and produce incorrect pagination. In that case fall back to the slow
-  // path which orders against the reconstructed root spans.
-  const hasPostAggFilters =
-    Object.keys(postAgg).length > 0 || hasChildError !== undefined || orderBy.field === 'endedAt';
+  // The fast path orders + paginates on raw `span_events` start rows. That's
+  // only safe when the order field's start-row value matches the reconstructed
+  // value — otherwise pagination would slice on the wrong column. Anything not
+  // in SAFE_PREFILTER_ORDER_FIELDS forces the slow path.
+  const canOrderInPrefilter = SAFE_PREFILTER_ORDER_FIELDS.has(orderBy.field);
+  const hasPostAggFilters = Object.keys(postAgg).length > 0 || hasChildError !== undefined || !canOrderInPrefilter;
 
   if (!hasPostAggFilters) {
     // Fast path: order + paginate in the prefilter, reconstruct only the page.
+    // Only `startedAt` reaches here (per SAFE_PREFILTER_ORDER_FIELDS), and on
+    // start rows it lives in the `timestamp` column.
+    const prefilterOrderBy = `ORDER BY timestamp ${orderDir}`;
     const offset = page * perPage;
 
     const countSql = `
@@ -756,21 +810,20 @@ export async function listBranches(db: DuckDBConnection, args: ListBranchesArgs)
 
   const outerAlias = 'outer_anchor';
 
-  // For ordering on the prefilter, `startedAt` maps to the start-row `timestamp`.
-  const orderByField = orderBy.field === 'startedAt' ? 'timestamp' : parseFieldKey(orderBy.field);
   const orderDir = orderBy.direction.toUpperCase();
   if (orderDir !== 'ASC' && orderDir !== 'DESC') {
     throw new Error(`Invalid sort direction: ${orderBy.direction}`);
   }
-  const prefilterOrderBy = `ORDER BY ${orderByField} ${orderDir}`;
 
-  // Same caveat as listTraces: ordering by `endedAt` requires reconstructed
-  // values (start rows always have NULL `endedAt`), so fall back to the slow
-  // path in that case.
-  const hasPostAggFilters = Object.keys(postAgg).length > 0 || orderBy.field === 'endedAt';
+  // Same allowlist gate as listTraces — see SAFE_PREFILTER_ORDER_FIELDS.
+  const canOrderInPrefilter = SAFE_PREFILTER_ORDER_FIELDS.has(orderBy.field);
+  const hasPostAggFilters = Object.keys(postAgg).length > 0 || !canOrderInPrefilter;
 
   if (!hasPostAggFilters) {
     // Fast path: order + paginate in the prefilter, reconstruct only the page.
+    // Only `startedAt` reaches here (per SAFE_PREFILTER_ORDER_FIELDS), and on
+    // start rows it lives in the `timestamp` column.
+    const prefilterOrderBy = `ORDER BY timestamp ${orderDir}`;
     const offset = page * perPage;
 
     const countSql = `


### PR DESCRIPTION
Extracted from larger PR: https://github.com/mastra-ai/mastra/pull/15747

## Description

Significantly improves `listTraces` and `listBranches` query performance on DuckDB by introducing a two-stage filtering strategy. Both methods previously rebuilt every span in `span_events` (or every branch-typed span) before applying filters, ordering, and pagination. They now narrow on raw rows first and only reconstruct the spans that actually need to be returned.

1. **Prefilter stage**: Filters raw `span_events` start rows using scalar columns (entity*, *Id, service, environment, startedAt range, etc.) before any span reconstruction. `listTraces` adds `parentSpanId IS NULL`; `listBranches` adds `spanType IN (BRANCH_SPAN_TYPES)` (or the caller's narrower `spanType` if supplied).

2. **Post-aggregation stage**: Reconstructs spans only for prefilter candidates, then applies filters that depend on reconstructed values (status, tags, metadata, scope, endedAt range, and `hasChildError` on `listTraces`).

When no post-aggregation filters are present, ordering and pagination happen inside the prefilter CTE, so reconstruction touches at most `perPage` rows rather than the full filtered set.

The `hasChildError` filter on `listTraces` now runs directly against raw `span_events` instead of the reconstructed-spans CTE, eliminating unnecessary reconstruction overhead.

**API compatibility**: Public return shapes (`SpanRecord` / `ListTracesResponse` / `ListBranchesResponse`) and filter semantics are unchanged; this is purely an internal optimization.

## Related Issue(s)

Extracted from #15747.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Changes

- Added `parseFieldKey` import from `@mastra/core/utils` for safe ORDER BY field handling on raw events.
- Introduced `PREFILTER_KEYS` defining the scalar columns that can be safely pushed down to the prefilter stage.
- Added `partitionAnchorFilters()` to split filters into `prefilter` / `postAgg` / `hasChildError` buckets. Reused by both `listTraces` and `listBranches`.
- Updated `buildHasChildErrorClause()` to take a `rootAlias` parameter and run `EXISTS` against raw `span_events` rather than the reconstructed-spans CTE.
- Refactored `listTraces()` into a fast path / slow path:
  - **Fast path** (no post-agg filters, not ordering by `endedAt`): order and paginate on raw start rows, reconstruct only the page.
  - **Slow path**: narrow to candidate roots first, reconstruct just those, then apply post-agg `WHERE`.
- Refactored `listBranches()` with the same two-stage strategy. The existing `spanType IN (BRANCH_SPAN_TYPES)` guard is preserved and combined with the scalar prefilter; non-branch `spanType` inputs still short-circuit to an empty result.
- Mapped `startedAt` ordering to the start-row `timestamp` for prefilter-side sorts; tightened sort-direction validation. Added the `endedAt.end` upper-bound trick on the prefilter timestamp to avoid scanning events that started after the requested window.
- Added Vitest cases covering scalar prefilter (fast path) + tag post-filter (slow path) for both `listTraces` and `listBranches`.

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes listing traces and branches much faster by first filtering on simple, cheap-to-check fields (like timestamps and environment) and only rebuilding full span data for the small set of rows that remain to be paginated/displayed.

## Overview

Implements a two-stage filtering strategy in the DuckDB observability store to dramatically reduce span reconstruction work for listTraces and listBranches: a scalar prefilter against raw span_events start rows, followed by post-aggregation filters applied only to reconstructed candidates. When safe, a fast-path performs ordering and pagination inside the prefilter so at most perPage spans are reconstructed; otherwise a slow path reconstructs candidates then post-filters.

## Key Changes

- Two-stage filtering:
  - Prefilter: pushable scalar predicates on raw span_events start rows (PREFILTER_KEYS: entity*, *Id, service, environment, startedAt range, etc.). listTraces also requires parentSpanId IS NULL; listBranches restricts to BRANCH_SPAN_TYPES (and short-circuits to empty for non-branch requests).
  - Post-aggregation: filters requiring reconstructed values (status, tags, metadata, scope, endedAt range, hasChildError) are applied after reconstructing only prefilter candidates.
- Fast / slow path:
  - Fast path: used when there are no post-aggregation filters and ordering/pagination are compatible with prefilter fields — orders/paginates in the prefilter CTE so only page rows are reconstructed.
  - Slow path: narrows to candidate anchors, reconstructs them, then applies post-agg WHERE, ordering, and pagination.
- hasChildError: reworked to evaluate via EXISTS/NOT EXISTS directly against raw span_events (buildHasChildErrorClause) to avoid extra reconstruction.
- Ordering & safety:
  - Added SAFE_PREFILTER_ORDER_FIELDS allowlist and imported parseFieldKey for safe ORDER BY on raw events.
  - Mapped startedAt ordering to start-row timestamp to preserve pagination semantics.
  - Tightened sort-direction validation to throw on invalid directions.
- Timestamp bounds correctness:
  - Fixed timestamp bound handling by intersecting startedAt/endedAt upper bounds (intersectTimestampRange) to avoid leaking rows when keys are processed in different orders.
  - Applied an endedAt.end upper-bound optimization by approximating via start-row timestamp where safe.
- Tests:
  - Added Vitest tests covering scalar prefilter fast-path and tag post-filter slow-path for both listTraces and listBranches, a regression for startedAt/endedAt intersection, and listBranches pagination/spanType behavior.

## Breaking Changes

None — public return shapes and filter semantics are unchanged.

## Files Changed (high level)

- .changeset/duckdb-list-traces-prefilter.md — user-facing note about performance improvement
- stores/duckdb/src/storage/domains/observability/tracing.ts — core implementation: partitionAnchorFilters, fast/slow path logic, hasChildError change, ordering/validation updates
- stores/duckdb/src/storage/domains/observability/index.test.ts — new Vitest coverage for fast/slow path behavior and timestamp-bound regression
<!-- end of auto-generated comment: release notes by coderabbit.ai -->