### PR TITLE
feat(playground-ui): add SectionCard primitive

### DIFF
--- a/.changeset/six-otters-flow.md
+++ b/.changeset/six-otters-flow.md
@@ -1,0 +1,13 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added SectionCard component to design system. Provides card primitive with tinted header strip (title, description, optional action slot), transparent body, and `default`/`danger` variants. Composes `CardHeading` for typography. Suitable for settings pages, dashboard sections, and grouped form layouts.
+
+```tsx
+import { SectionCard } from '@mastra/playground-ui';
+
+<SectionCard title="Theme" description="Customize the appearance.">
+  <ThemeSelector />
+</SectionCard>;
+```

--- a/packages/playground-ui/src/ds/components/SectionCard/card-heading.tsx
+++ b/packages/playground-ui/src/ds/components/SectionCard/card-heading.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface CardHeadingProps {
+  title: ReactNode;
+  description?: ReactNode;
+  tone?: 'default' | 'danger';
+  id?: string;
+  className?: string;
+  descriptionClassName?: string;
+}
+
+export function CardHeading({
+  title,
+  description,
+  tone = 'default',
+  id,
+  className,
+  descriptionClassName,
+}: CardHeadingProps) {
+  const danger = tone === 'danger';
+  return (
+    <>
+      <h3
+        id={id}
+        className={cn(
+          'font-serif text-header-md font-normal leading-tight tracking-normal',
+          danger ? 'text-accent2' : 'text-neutral4',
+          className,
+        )}
+      >
+        {title}
+      </h3>
+      {description != null && (
+        <p
+          className={cn(
+            'mt-2 max-w-[62ch] font-sans text-[13.5px] leading-ui-xs',
+            danger ? 'text-accent2/70' : 'text-neutral-500',
+            descriptionClassName,
+          )}
+        >
+          {description}
+        </p>
+      )}
+    </>
+  );
+}

--- a/packages/playground-ui/src/ds/components/SectionCard/index.ts
+++ b/packages/playground-ui/src/ds/components/SectionCard/index.ts
@@ -1,0 +1,2 @@
+export { SectionCard, type SectionCardProps, type SectionCardVariant } from './section-card';
+export { CardHeading, type CardHeadingProps } from './card-heading';

--- a/packages/playground-ui/src/ds/components/SectionCard/section-card.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SectionCard/section-card.stories.tsx
@@ -14,10 +14,7 @@ type Story = StoryObj<typeof SectionCard>;
 
 export const Default: Story = {
   render: () => (
-    <SectionCard
-      title="Activity Over Time"
-      description="Track request volume, cost, and latency over time"
-    >
+    <SectionCard title="Activity Over Time" description="Track request volume, cost, and latency over time">
       <p className="text-neutral3">Body content goes here.</p>
     </SectionCard>
   ),

--- a/packages/playground-ui/src/ds/components/SectionCard/section-card.stories.tsx
+++ b/packages/playground-ui/src/ds/components/SectionCard/section-card.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SectionCard } from './section-card';
+
+const meta: Meta<typeof SectionCard> = {
+  title: 'Layout/SectionCard',
+  component: SectionCard,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SectionCard>;
+
+export const Default: Story = {
+  render: () => (
+    <SectionCard
+      title="Activity Over Time"
+      description="Track request volume, cost, and latency over time"
+    >
+      <p className="text-neutral3">Body content goes here.</p>
+    </SectionCard>
+  ),
+};
+
+export const WithAction: Story = {
+  render: () => (
+    <SectionCard
+      title="Activity Over Time"
+      description="Track request volume, cost, and latency over time"
+      action={
+        <div className="flex gap-2 text-ui-sm text-neutral3">
+          <span>Cost</span>
+          <span>Requests</span>
+          <span>Tokens</span>
+          <span>Errors</span>
+        </div>
+      }
+    >
+      <div className="h-40 rounded-md bg-surface3" />
+    </SectionCard>
+  ),
+};
+
+export const Danger: Story = {
+  render: () => (
+    <SectionCard
+      variant="danger"
+      title="Delete project"
+      description="Irreversible. All data, deployments, and members will be removed."
+    >
+      <p className="text-accent2/80">Confirmation controls go here.</p>
+    </SectionCard>
+  ),
+};
+
+export const FillHeight: Story = {
+  render: () => (
+    <div className="grid h-[420px] grid-cols-2 gap-4">
+      <SectionCard fillHeight title="Left" description="Stretches to grid row height">
+        <div className="h-full rounded-md bg-surface3" />
+      </SectionCard>
+      <SectionCard fillHeight title="Right" description="Same height as sibling">
+        <div className="h-full rounded-md bg-surface3" />
+      </SectionCard>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/SectionCard/section-card.tsx
+++ b/packages/playground-ui/src/ds/components/SectionCard/section-card.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react';
+import { CardHeading } from './card-heading';
+import { cn } from '@/lib/utils';
+
+export type SectionCardVariant = 'default' | 'danger';
+
+export interface SectionCardProps {
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+  variant?: SectionCardVariant;
+  fillHeight?: boolean;
+  className?: string;
+  contentClassName?: string;
+  children: ReactNode;
+}
+
+export function SectionCard({
+  title,
+  description,
+  action,
+  variant = 'default',
+  fillHeight = false,
+  className,
+  contentClassName,
+  children,
+}: SectionCardProps) {
+  const danger = variant === 'danger';
+
+  return (
+    <section
+      data-variant={variant}
+      className={cn(
+        'overflow-hidden rounded-2xl border',
+        fillHeight && 'flex h-full flex-col',
+        danger ? 'border-accent2/25' : 'border-border2/40',
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          'flex flex-col gap-3 px-7 pt-7 pb-6 sm:flex-row sm:items-start sm:justify-between sm:gap-6',
+          danger ? 'bg-accent2/[0.08]' : 'bg-surface2',
+        )}
+      >
+        <div className="min-w-0">
+          <CardHeading title={title} description={description} tone={danger ? 'danger' : 'default'} />
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+      <div
+        className={cn(
+          'min-w-0 px-7 pt-6 pb-7',
+          fillHeight && 'flex-1',
+          danger ? 'bg-accent2/[0.04]' : null,
+          contentClassName,
+        )}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/packages/playground-ui/src/ds/components/SectionCard/section-card.tsx
+++ b/packages/playground-ui/src/ds/components/SectionCard/section-card.tsx
@@ -46,7 +46,7 @@ export function SectionCard({
         <div className="min-w-0">
           <CardHeading title={title} description={description} tone={danger ? 'danger' : 'default'} />
         </div>
-        {action ? <div className="shrink-0">{action}</div> : null}
+        {action != null ? <div className="shrink-0">{action}</div> : null}
       </div>
       <div
         className={cn(

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -69,6 +69,7 @@ export * from './ds/components/KeyValueList';
 export * from './ds/components/MainSidebar';
 export * from './ds/components/PageHeader';
 export * from './ds/components/Section';
+export * from './ds/components/SectionCard';
 export * from './ds/components/SelectElement';
 export * from './ds/components/SideDialog';
 export * from './ds/components/Steps';

--- a/packages/playground/src/pages/settings/index.tsx
+++ b/packages/playground/src/pages/settings/index.tsx
@@ -1,4 +1,4 @@
-import { PageHeader, PageLayout, SelectField, SettingsIcon, useTheme } from '@mastra/playground-ui';
+import { PageHeader, PageLayout, SectionCard, SelectField, SettingsIcon, useTheme } from '@mastra/playground-ui';
 import type { Theme } from '@mastra/playground-ui';
 import { StudioConfigForm } from '@/domains/configuration/components/studio-config-form';
 import { useStudioConfig } from '@/domains/configuration/context/studio-config-context';
@@ -23,21 +23,23 @@ export const StudioSettingsPage = () => {
         </PageHeader>
       </PageLayout.TopArea>
 
-      <PageLayout.MainArea className="grid gap-8 mt-6">
-        <section className="rounded-lg border border-border1 bg-surface3 p-4">
-          <div className="space-y-3">
-            <h2 className="text-icon6 font-medium">Theme</h2>
-            <SelectField
-              name="theme"
-              label="Theme mode"
-              value={theme}
-              onValueChange={value => setTheme(value as Theme)}
-              options={THEME_OPTIONS.map(option => ({ ...option }))}
-            />
-          </div>
-        </section>
+      <PageLayout.MainArea className="flex flex-col gap-5 mt-6">
+        <SectionCard title="Theme" description="Customize the appearance of the studio.">
+          <SelectField
+            name="theme"
+            label="Theme mode"
+            value={theme}
+            onValueChange={value => setTheme(value as Theme)}
+            options={THEME_OPTIONS.map(option => ({ ...option }))}
+          />
+        </SectionCard>
 
-        <StudioConfigForm initialConfig={{ baseUrl, headers, apiPrefix }} />
+        <SectionCard
+          title="Mastra Connection"
+          description="Configure the Mastra instance URL, API prefix, and request headers used by the studio."
+        >
+          <StudioConfigForm initialConfig={{ baseUrl, headers, apiPrefix }} />
+        </SectionCard>
       </PageLayout.MainArea>
     </PageLayout>
   );


### PR DESCRIPTION
## Summary

- Adds `SectionCard` component to the playground-ui DS — card primitive with tinted header strip (title/description/optional action), transparent body, `default`/`danger` variants, optional `fillHeight` for flex grid layouts. Mirrors the platform-side `SectionCard` so the two repos can converge on a single shared primitive.
- Exports `CardHeading` as the underlying heading primitive (used by `SectionCard` and reusable on its own).
- Updates the studio Settings page (`/settings`) to compose two `SectionCard`s — Theme + Mastra Connection — in place of the previous ad-hoc `<section>` markup, mirroring the platform Settings structure.
- 4 Storybook stories: Default, WithAction, Danger, FillHeight.

<img width="2070" height="922" alt="CleanShot 2026-05-04 at 17 23 43@2x" src="https://github.com/user-attachments/assets/b99bec26-4a02-4bdd-be84-b3223fd8cac6" />
<img width="2464" height="2136" alt="CleanShot 2026-05-04 at 18 00 51@2x" src="https://github.com/user-attachments/assets/4c80314b-8fba-4155-a081-3d3fa506d914" />

## Implementation notes

- Chrome uses `border` (not `ring-1`) so it stays in-box and is not clipped by `overflow-auto` on parent layouts (`PageLayout.MainArea`).
- No box-shadow per design pass.
- Header bg uses `bg-surface2` (full alpha).
- Tokens used where exact match available (`text-header-md`, `leading-tight`, `leading-ui-xs`, `font-sans`, `font-serif`); arbitrary values kept only where no exact token exists (`text-[13.5px]`, `max-w-[62ch]`, `bg-accent2/[0.08]`, `bg-accent2/[0.04]`).

## Test plan

- [ ] Open `/settings` in studio — verify Theme and Mastra Connection render as two stacked SectionCards with full borders, header strip + body unified
- [ ] Verify dark + light theme rendering
- [ ] Verify `pnpm storybook` shows the 4 SectionCard stories under `Layout/SectionCard`
- [ ] Verify danger variant renders red-tinted header + body
- [ ] Verify `fillHeight` story stretches cards to grid row height
- [ ] Run `pnpm --filter ./packages/playground-ui build` → typecheck + bundle clean
- [ ] (Follow-up) migrate platform's local `SectionCard.tsx` + `CardHeading.tsx` to import from `@mastra/playground-ui`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a new reusable card component called `SectionCard` to the design system that helps organize content with a styled header section (containing a title, description, and optional action button) and a body area. The Settings page is then updated to use this new card to display Theme and Mastra Connection settings in a cleaner, more consistent way.

## Changes

### New SectionCard Component
Added a new `SectionCard` primitive to `@mastra/playground-ui/src/ds/components/SectionCard/`:
- **`section-card.tsx`**: Main component accepting `title`, optional `description`, optional `action`, optional `variant` (`'default'` | `'danger'`), optional `fillHeight` boolean, and child content. The component renders a bordered `<section>` with a tinted header (using `CardHeading`) and transparent body. Uses CSS `border` instead of `ring-1` to prevent clipping with parent `overflow-auto`. The `fillHeight` prop enables flex column layout for grid/flex layouts.
- **`card-heading.tsx`**: Exported heading primitive (`CardHeading`) used by `SectionCard` and reusable independently. Supports `tone` prop to match the card variant (affecting text color for default vs. danger states).
- **`index.ts`**: Barrel export for `SectionCard`, `SectionCardProps`, `SectionCardVariant`, `CardHeading`, and `CardHeadingProps`.
- **`section-card.stories.tsx`**: Four Storybook stories under `Layout/SectionCard`:
  - `Default`: Basic card with title, description, and body content
  - `WithAction`: Card with an action element in the header
  - `Danger`: Danger variant with conditional styling and content
  - `FillHeight`: Two-column grid layout demonstrating the `fillHeight` prop

### Export Updates
- **`packages/playground-ui/src/index.ts`**: Added re-export of the entire `SectionCard` module to make components available from the package root.

### Settings Page Refactor
- **`packages/playground/src/pages/settings/index.tsx`**: Replaced ad-hoc `<section>` markup with two composed `SectionCard` components:
  - Theme section: Wraps the theme mode selector
  - Mastra Connection section: Wraps the `StudioConfigForm` for API configuration
  - Uses `PageLayout.MainArea` flex-column container for layout
  - Preserves all underlying functionality (theme selection, form wiring)

### Changeset
- **`.changeset/six-otters-flow.md`**: Documents the minor version bump for `@mastra/playground-ui` with the new `SectionCard` component.

## Design Details
- Header background uses `bg-surface2` for full opacity
- Styling uses design tokens where available; arbitrary Tailwind values used only when no exact token exists (e.g., `text-[13.5px]`, `max-w-[62ch]`, `bg-accent2/[0.08]`)
- No box-shadow per design specification
- Supports both default and danger visual variants with conditional border and background colors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->