### PR TITLE
fix(convex): serialize workflow snapshot before insert to avoid $-prefixed key rejection

### DIFF
--- a/.changeset/blue-results-cheer.md
+++ b/.changeset/blue-results-cheer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Fixed @mastra/convex `persistWorkflowSnapshot` failing when a workflow snapshot contained `$`-prefixed keys (e.g. `$schema`, `$ref`, `$defs`, `$id` from serialized Zod-to-JSON-Schema fragments embedded in tool outputs). Convex reserves field names starting with `$`, which caused every agent run with at least one Zod-schema tool to crash on the first persisted turn of the internal `agentic-loop` workflow with: `ArgumentValidationError: Object contains extra field $schema that is not in the validator`. The snapshot is now serialized with `JSON.stringify` before insert, symmetric with the existing `loadWorkflowSnapshot` path that already accepts string-encoded snapshots. Fixes #16110.

--- a/.changeset/blue-results-cheer.md
+++ b/.changeset/blue-results-cheer.md
@@ -2,4 +2,5 @@
 '@mastra/convex': patch
 ---
 
-Fixed @mastra/convex `persistWorkflowSnapshot` failing when a workflow snapshot contained `$`-prefixed keys (e.g. `$schema`, `$ref`, `$defs`, `$id` from serialized Zod-to-JSON-Schema fragments embedded in tool outputs). Convex reserves field names starting with `$`, which caused every agent run with at least one Zod-schema tool to crash on the first persisted turn of the internal `agentic-loop` workflow with: `ArgumentValidationError: Object contains extra field $schema that is not in the validator`. The snapshot is now serialized with `JSON.stringify` before insert, symmetric with the existing `loadWorkflowSnapshot` path that already accepts string-encoded snapshots. Fixes #16110.
+Fixed `@mastra/convex` workflow snapshot persistence when snapshots contain `$`-prefixed JSON Schema keys (for example `$schema` and `$ref`).
+Snapshots are now stored safely, preventing Convex validation failures during workflow runs. Fixes `#16110`.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -12689,7 +12689,7 @@ export type PostObservabilityScoresAggregate_Body = {
   scorerId: string;
   scoreSource?: string | undefined;
   /** Aggregation function */
-  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'last';
+  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   filters?:
     | {
         /** Filter by timestamp range */
@@ -12825,7 +12825,7 @@ export type PostObservabilityScoresBreakdown_Body = {
   /** Fields to group by */
   groupBy: string[];
   /** Aggregation function */
-  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'last';
+  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   filters?:
     | {
         /** Filter by timestamp range */
@@ -12962,7 +12962,7 @@ export type PostObservabilityScoresTimeseries_Body = {
   /** Time bucket interval */
   interval: '1m' | '5m' | '15m' | '1h' | '1d';
   /** Aggregation function */
-  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'last';
+  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   filters?:
     | {
         /** Filter by timestamp range */
@@ -13625,7 +13625,7 @@ export type PostObservabilityFeedbackAggregate_Body = {
   feedbackType: string;
   feedbackSource?: string | undefined;
   /** Aggregation function */
-  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'last';
+  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   filters?:
     | {
         /** Filter by timestamp range */
@@ -13760,7 +13760,7 @@ export type PostObservabilityFeedbackBreakdown_Body = {
   /** Fields to group by */
   groupBy: string[];
   /** Aggregation function */
-  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'last';
+  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   filters?:
     | {
         /** Filter by timestamp range */
@@ -13896,7 +13896,7 @@ export type PostObservabilityFeedbackTimeseries_Body = {
   /** Time bucket interval */
   interval: '1m' | '5m' | '15m' | '1h' | '1d';
   /** Aggregation function */
-  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'last';
+  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
   filters?:
     | {
         /** Filter by timestamp range */
@@ -14170,7 +14170,24 @@ export type PostObservabilityMetricsAggregate_Body = {
   /** Metric name(s) to aggregate */
   name: string[];
   /** Aggregation function */
-  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'last';
+  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
+  /** Column to apply count_distinct over (required when aggregation is 'count_distinct'). Restricted to low/medium-cardinality categorical columns; ID columns are not allowed. */
+  distinctColumn?:
+    | (
+        | 'entityType'
+        | 'entityName'
+        | 'parentEntityType'
+        | 'parentEntityName'
+        | 'rootEntityType'
+        | 'rootEntityName'
+        | 'name'
+        | 'provider'
+        | 'model'
+        | 'environment'
+        | 'executionSource'
+        | 'serviceName'
+      )
+    | undefined;
   filters?:
     | {
         /** Filter by timestamp range */
@@ -14320,7 +14337,24 @@ export type PostObservabilityMetricsBreakdown_Body = {
   /** Fields to group by */
   groupBy: string[];
   /** Aggregation function */
-  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'last';
+  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
+  /** Column to apply count_distinct over (required when aggregation is 'count_distinct'). Restricted to low/medium-cardinality categorical columns; ID columns are not allowed. */
+  distinctColumn?:
+    | (
+        | 'entityType'
+        | 'entityName'
+        | 'parentEntityType'
+        | 'parentEntityName'
+        | 'rootEntityType'
+        | 'rootEntityName'
+        | 'name'
+        | 'provider'
+        | 'model'
+        | 'environment'
+        | 'executionSource'
+        | 'serviceName'
+      )
+    | undefined;
   filters?:
     | {
         /** Filter by timestamp range */
@@ -14422,6 +14456,10 @@ export type PostObservabilityMetricsBreakdown_Body = {
           | undefined;
       }
     | undefined;
+  /** Maximum number of groups to return (server-side TopK). Required for high-cardinality groupBy. */
+  limit?: number | undefined;
+  /** Sort direction for the aggregated value (defaults to 'DESC' at the storage layer; pairs with limit for top/bottom-N). */
+  orderDirection?: ('ASC' | 'DESC') | undefined;
 };
 
 export type PostObservabilityMetricsBreakdown_Response = {
@@ -14467,7 +14505,24 @@ export type PostObservabilityMetricsTimeseries_Body = {
   /** Time bucket interval */
   interval: '1m' | '5m' | '15m' | '1h' | '1d';
   /** Aggregation function */
-  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'last';
+  aggregation: 'sum' | 'avg' | 'min' | 'max' | 'count' | 'count_distinct' | 'last';
+  /** Column to apply count_distinct over (required when aggregation is 'count_distinct'). Restricted to low/medium-cardinality categorical columns; ID columns are not allowed. */
+  distinctColumn?:
+    | (
+        | 'entityType'
+        | 'entityName'
+        | 'parentEntityType'
+        | 'parentEntityName'
+        | 'rootEntityType'
+        | 'rootEntityName'
+        | 'name'
+        | 'provider'
+        | 'model'
+        | 'environment'
+        | 'executionSource'
+        | 'serviceName'
+      )
+    | undefined;
   filters?:
     | {
         /** Filter by timestamp range */

--- a/stores/convex/src/storage/domains/workflows/index.ts
+++ b/stores/convex/src/storage/domains/workflows/index.ts
@@ -87,7 +87,11 @@ export class WorkflowsConvex extends WorkflowsStorage {
         workflow_name: workflowName,
         run_id: runId,
         resourceId,
-        snapshot,
+        // Convex rejects any field whose name starts with `$` (reserved prefix).
+        // Workflow snapshots embed tool outputs whose serialized Zod->JSON Schemas
+        // contain $schema/$ref/$defs/$id keys, so we serialize the snapshot here.
+        // loadWorkflowSnapshot / ensureSnapshot already handle the string case.
+        snapshot: JSON.stringify(snapshot),
         createdAt: existing?.createdAt ?? (createdAt ? new Date(createdAt).toISOString() : now.toISOString()),
         updatedAt: updatedAt ? new Date(updatedAt).toISOString() : now.toISOString(),
       },

--- a/stores/convex/src/storage/domains/workflows/workflows.test.ts
+++ b/stores/convex/src/storage/domains/workflows/workflows.test.ts
@@ -1,0 +1,129 @@
+import type { WorkflowRunState } from '@mastra/core/workflows';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ConvexAdminClient } from '../../client';
+import type { StorageRequest } from '../../types';
+import { WorkflowsConvex } from './index';
+
+/**
+ * Repro for https://github.com/mastra-ai/mastra/issues/16110
+ *
+ * Convex rejects any field whose name starts with `$` (reserved prefix).
+ * Mastra workflow snapshots embed tool-call results, which for any tool defined
+ * with a Zod input schema include a serialized JSON Schema fragment with
+ * `$schema`, `$ref`, `$defs`, `$id` keys. Inserting the raw snapshot object
+ * into Convex therefore fails with:
+ *   ArgumentValidationError: Object contains extra field $schema that is not in the validator.
+ *
+ * `loadWorkflowSnapshot` already handles a string-encoded snapshot
+ * (`typeof row.snapshot === 'string' ? JSON.parse(row.snapshot) : ...`),
+ * so the symmetric fix is to JSON.stringify on persist.
+ */
+
+type CapturedRequest = Extract<StorageRequest, { op: 'insert' }>;
+
+function createFakeClient() {
+  const requests: StorageRequest[] = [];
+  // We mock callStorage directly. Pretend load returns null (no existing row),
+  // so persist takes the "insert new" branch.
+  const callStorage = vi.fn(async (request: StorageRequest) => {
+    requests.push(request);
+    if (request.op === 'load') return null;
+    return undefined;
+  });
+
+  // Build a ConvexAdminClient instance and override callStorage. We bypass the
+  // constructor's url validation by passing dummy values — the mocked
+  // callStorage means no network call is made.
+  const client = new ConvexAdminClient({
+    deploymentUrl: 'https://example.convex.cloud',
+    adminAuthToken: 'test-token',
+  });
+  (client as unknown as { callStorage: typeof callStorage }).callStorage = callStorage;
+
+  return { client, requests };
+}
+
+function snapshotWithDollarKeys(): WorkflowRunState {
+  // Mirrors the structural shape of an `agentic-loop` snapshot whose
+  // tool-output context includes a serialized Zod -> JSON Schema fragment.
+  return {
+    runId: 'run-1',
+    status: 'success',
+    context: {
+      'tool-call-1': {
+        status: 'success',
+        output: {
+          // This is the exact shape produced by tools whose inputSchema is a
+          // Zod object — JSON Schema serialization injects `$schema`, plus
+          // `$ref`/`$defs`/`$id` for nested/recursive shapes.
+          inputSchema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            $id: 'https://example.com/tool-input.json',
+            type: 'object',
+            properties: {
+              query: { type: 'string' },
+              filter: { $ref: '#/$defs/Filter' },
+            },
+            $defs: {
+              Filter: { type: 'object', properties: { kind: { type: 'string' } } },
+            },
+          },
+        },
+      },
+    } as unknown as WorkflowRunState['context'],
+    activePaths: [],
+    activeStepsPath: {},
+    timestamp: Date.now(),
+    suspendedPaths: {},
+    resumeLabels: {},
+    serializedStepGraph: [],
+    value: {},
+    waitingPaths: {},
+  };
+}
+
+describe('WorkflowsConvex.persistWorkflowSnapshot — $-prefixed keys', () => {
+  it('serializes the snapshot before insert so Convex never sees $-prefixed keys', async () => {
+    const { client, requests } = createFakeClient();
+    const workflows = new WorkflowsConvex({ client });
+
+    const snapshot = snapshotWithDollarKeys();
+    await workflows.persistWorkflowSnapshot({
+      workflowName: 'agentic-loop',
+      runId: 'run-1',
+      snapshot,
+    });
+
+    const insert = requests.find((r): r is CapturedRequest => r.op === 'insert');
+    expect(insert, 'persist should issue an insert').toBeDefined();
+
+    const persistedSnapshot = insert!.record.snapshot;
+
+    // The fix: snapshot is stored as a JSON string, symmetric with the load path.
+    expect(typeof persistedSnapshot).toBe('string');
+
+    // No raw $-prefixed *keys* reach the Convex argument validator. The dollar
+    // signs may appear inside the JSON string payload (that's fine — Convex
+    // only rejects them as field names), but they must not be top-level or
+    // nested object keys in the inserted record.
+    const collectKeys = (value: unknown, acc: string[] = []): string[] => {
+      if (Array.isArray(value)) {
+        for (const v of value) collectKeys(v, acc);
+      } else if (value && typeof value === 'object') {
+        for (const k of Object.keys(value as Record<string, unknown>)) {
+          acc.push(k);
+          collectKeys((value as Record<string, unknown>)[k], acc);
+        }
+      }
+      return acc;
+    };
+    const allKeys = collectKeys(insert!.record);
+    const dollarKeys = allKeys.filter(k => k.startsWith('$'));
+    expect(dollarKeys).toEqual([]);
+
+    // Round-trip: the string must deserialize back to the original snapshot
+    // so loadWorkflowSnapshot returns the same data.
+    expect(JSON.parse(persistedSnapshot as string)).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
Fixes #16110.

`@mastra/convex` `persistWorkflowSnapshot` was inserting the snapshot as a raw nested object. Convex reserves field names starting with `$`, and Mastra workflow snapshots embed tool outputs whose serialized Zod-to-JSON-Schema fragments contain `$schema` / `$ref` / `$defs` / `$id`. The result: every agent run with at least one Zod-schema tool crashed on the first persisted turn of the internal `agentic-loop` workflow with `ArgumentValidationError: Object contains extra field $schema that is not in the validator`.

`loadWorkflowSnapshot` already accepts a string-encoded snapshot, so the fix is symmetric — stringify on the way in.

```ts
// before
record: { ..., snapshot, ... }

// after
record: { ..., snapshot: JSON.stringify(snapshot), ... }
```

Added a unit test in `stores/convex/src/storage/domains/workflows/workflows.test.ts` that constructs a snapshot with `$`-prefixed keys, mocks the Convex client, and asserts no `$`-keyed object reaches the inserted record. Test fails on `main`, passes with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5 Explanation

Saving a workflow snapshot sometimes failed because the database rejects keys that start with `$`. This PR fixes it by converting the snapshot into a JSON string before saving so those `$` keys aren't treated as nested fields and the save succeeds.

Problem

WorkflowsConvex.persistWorkflowSnapshot inserted snapshots as nested objects into Convex. Convex rejects document fields whose names start with `$` (a reserved prefix). Mastra workflow snapshots can include Zod-generated JSON Schema fragments (e.g., `$schema`, `$ref`, `$defs`, `$id`), causing inserts to fail with ArgumentValidationError and preventing workflow state from being persisted.

Solution

Serialize the snapshot with JSON.stringify(snapshot) before inserting into Convex. Storing the snapshot as a string avoids Convex’s nested-field validation and matches loadWorkflowSnapshot, which already accepts string-encoded snapshots.

Changes

- stores/convex/src/storage/domains/workflows/index.ts
  - persistWorkflowSnapshot now calls JSON.stringify(snapshot) before inserting into TABLE_WORKFLOW_SNAPSHOT.
  - Added comments explaining Convex’s reserved `$` prefix and why snapshots are serialized.

- stores/convex/src/storage/domains/workflows/workflows.test.ts
  - Added a regression test that builds a snapshot containing `$`-prefixed keys, mocks the Convex client, captures the insert, and asserts:
    - The inserted record.snapshot is a JSON string (not a raw object).
    - No `$`-prefixed field names exist in the inserted structure.
    - Parsing the persisted JSON yields a deep-equal copy of the original snapshot.
  - The test reproduces the failure on main and passes with this fix.

- .changeset/blue-results-cheer.md
  - Changeset documenting the patch for @mastra/convex and referencing Fixes #16110.

Impact

Prevents crashes when persisting workflow snapshots that contain JSON Schema fragments (Zod-derived), fixing agent runs that use Convex-backed storage. No public API/signature changes; behavior is limited to storage serialization.

Fixes

Resolves #16110 — persistWorkflowSnapshot failures when snapshots contain `$`-prefixed keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->