### PR TITLE
feat(processor-runner): support systemMessages in input processors and messageList in output stream

### DIFF
--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -775,6 +775,32 @@ describe('ProcessorRunner', () => {
       expect(result.part?.type === 'text-delta' ? result.part?.payload.text : '').toBe('original text');
       expect(result.blocked).toBe(false);
     });
+
+    it('should close spans on finish chunk when no output processors exist', async () => {
+      runner = new ProcessorRunner({
+        inputProcessors: [],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const mockSpan = {
+        end: vi.fn(),
+      };
+
+      const processorStates = new Map();
+      processorStates.set('test', {
+        span: mockSpan,
+        getFinalOutput: () => ({ totalChunks: 1, accumulatedText: 'done' }),
+      } as any);
+
+      const result = await runner.processPart({ type: 'finish' } as any, processorStates);
+
+      expect(result.blocked).toBe(false);
+      expect(mockSpan.end).toHaveBeenCalledWith({
+        output: { totalChunks: 1, accumulatedText: 'done' },
+      });
+    });
   });
 
   describe('Stateful Stream Processing', () => {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -571,6 +571,12 @@ export class ProcessorRunner {
     processorId?: string;
   }> {
     if (!this.outputProcessors.length) {
+      // Still need to handle finish chunk to close spans
+      if (part.type === 'finish') {
+        for (const state of processorStates.values()) {
+          state.span?.end({ output: state.getFinalOutput() });
+        }
+      }
       return { part, blocked: false };
     }
 


### PR DESCRIPTION
…d messageList in output stream

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a stream finishes processing, the code needs to clean up by closing tracking spans. Previously, this cleanup was skipped if there were no output processors. This PR fixes that by ensuring the spans get properly closed even in that case.

## Changes

**packages/core/src/processors/runner.ts**

Modified the `processPart` method to handle `finish` chunks when no output processors are configured. Previously, the method would return immediately without performing any cleanup work for finish chunks. Now it iterates through all processor states and closes their spans using the accumulated final output data.

**packages/core/src/processors/runner.test.ts**

Added a test case validating that `ProcessorRunner.processPart` correctly closes spans when receiving a `finish` chunk with no output processors configured. The test sets up mock processor states with a mock span, invokes `processPart` with a finish chunk, verifies the run is not blocked, and confirms that `span.end` is called with the final output totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->