### PR TITLE
fix(cli): parse next config without eval

### DIFF
--- a/.changeset/eighty-phones-sit.md
+++ b/.changeset/eighty-phones-sit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Improved agent serialization in Studio.

--- a/.changeset/eighty-phones-sit.md
+++ b/.changeset/eighty-phones-sit.md
@@ -1,5 +1,11 @@
 ---
 '@mastra/server': patch
+'@mastra/hono': patch
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/koa': patch
+'@mastra/nestjs': patch
+'@internal/playground': patch
 ---
 
-Improved agent serialization in Studio.
+Improved Studio agent serialization by making Studio mode and auth-related request context server-controlled across adapters. Playground requests now identify Studio traffic consistently, body and query request context cannot set reserved server values, and Studio placeholder fallback is limited to instruction rendering while serialized models, workspace, skills, tools, and default options use the real request context.

--- a/.changeset/grumpy-places-notice.md
+++ b/.changeset/grumpy-places-notice.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Next.js config linting so project config files are parsed without executing code. #16180

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,9 +52,10 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@expo/devcert": "^1.2.1",
-    "archiver": "^7.0.1",
     "@mastra/deployer": "workspace:^",
     "@mastra/loggers": "workspace:^",
+    "acorn": "^8.16.0",
+    "archiver": "^7.0.1",
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
     "execa": "^9.6.1",

--- a/packages/cli/src/commands/lint/rules/nextConfigRule.test.ts
+++ b/packages/cli/src/commands/lint/rules/nextConfigRule.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { nextConfigRule } from './nextConfigRule.js';
+import type { LintContext } from './types.js';
+
+vi.mock('../../../utils/logger.js', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const exploitMarker = '__MASTRA_NEXT_CONFIG_EVAL_TEST__';
+
+function createContext(rootDir: string): LintContext {
+  return {
+    rootDir,
+    mastraDir: join(rootDir, 'src', 'mastra'),
+    outputDirectory: join(rootDir, '.mastra'),
+    discoveredTools: [],
+    packageJson: {},
+    mastraPackages: [],
+  };
+}
+
+function writeNextConfig(content: string) {
+  const rootDir = mkdtempSync(join(tmpdir(), 'mastra-next-config-rule-'));
+  writeFileSync(join(rootDir, 'next.config.js'), content);
+  return rootDir;
+}
+
+describe('nextConfigRule', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, exploitMarker);
+  });
+
+  test('passes when serverExternalPackages includes Mastra packages', async () => {
+    const rootDir = writeNextConfig(`
+      const nextConfig = {
+        serverExternalPackages: ['@mastra/*'],
+      };
+    `);
+
+    await expect(nextConfigRule.run(createContext(rootDir))).resolves.toBe(true);
+  });
+
+  test('does not execute code while reading next.config.js', async () => {
+    const rootDir = writeNextConfig(`
+      const nextConfig = {
+        serverExternalPackages: ['@mastra/*'],
+        poweredByHeader: (() => {
+          globalThis.${exploitMarker} = true;
+          return false;
+        })(),
+      };
+    `);
+
+    await expect(nextConfigRule.run(createContext(rootDir))).resolves.toBe(true);
+    expect(Reflect.has(globalThis, exploitMarker)).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/lint/rules/nextConfigRule.ts
+++ b/packages/cli/src/commands/lint/rules/nextConfigRule.ts
@@ -1,18 +1,210 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { parse } from 'acorn';
+import type {
+  ArrayExpression,
+  AssignmentExpression,
+  Expression,
+  Identifier,
+  Literal,
+  ObjectExpression,
+  Program,
+  Property,
+} from 'acorn';
 import { logger } from '../../../utils/logger.js';
 import type { LintContext, LintRule } from './types.js';
+
+interface NextConfig {
+  serverExternalPackages?: string[];
+}
+
+function isIdentifier(node: unknown): node is Identifier {
+  return typeof node === 'object' && node !== null && 'type' in node && node.type === 'Identifier';
+}
+
+function isLiteral(node: unknown): node is Literal {
+  return typeof node === 'object' && node !== null && 'type' in node && node.type === 'Literal';
+}
+
+function isObjectExpression(node: unknown): node is ObjectExpression {
+  return typeof node === 'object' && node !== null && 'type' in node && node.type === 'ObjectExpression';
+}
+
+function isArrayExpression(node: unknown): node is ArrayExpression {
+  return typeof node === 'object' && node !== null && 'type' in node && node.type === 'ArrayExpression';
+}
+
+function unwrapExpression(expression: Expression): Expression {
+  if (expression.type === 'ParenthesizedExpression') {
+    return unwrapExpression(expression.expression);
+  }
+
+  return expression;
+}
+
+function getPropertyName(property: Property): string | null {
+  if (property.computed) {
+    return null;
+  }
+
+  if (isIdentifier(property.key)) {
+    return property.key.name;
+  }
+
+  if (isLiteral(property.key) && typeof property.key.value === 'string') {
+    return property.key.value;
+  }
+
+  return null;
+}
+
+function readStringArray(expression: Expression): string[] | null {
+  const arrayExpression = unwrapExpression(expression);
+  if (!isArrayExpression(arrayExpression)) {
+    return null;
+  }
+
+  const values: string[] = [];
+  for (const element of arrayExpression.elements) {
+    if (!isLiteral(element) || typeof element.value !== 'string') {
+      return null;
+    }
+
+    values.push(element.value);
+  }
+
+  return values;
+}
+
+function readServerExternalPackages(config: ObjectExpression): string[] | undefined {
+  for (const property of config.properties) {
+    if (property.type !== 'Property' || property.kind !== 'init' || property.method) {
+      continue;
+    }
+
+    if (getPropertyName(property) !== 'serverExternalPackages') {
+      continue;
+    }
+
+    return readStringArray(property.value) ?? undefined;
+  }
+
+  return undefined;
+}
+
+function parseProgram(nextConfigContent: string): Program {
+  const options = { ecmaVersion: 'latest' as const, allowHashBang: true };
+
+  try {
+    return parse(nextConfigContent, { ...options, sourceType: 'module' }) as Program;
+  } catch {
+    return parse(nextConfigContent, { ...options, sourceType: 'script' }) as Program;
+  }
+}
+
+function collectNextConfigVariables(program: Program): Map<string, ObjectExpression> {
+  const variables = new Map<string, ObjectExpression>();
+
+  for (const node of program.body) {
+    if (node.type !== 'VariableDeclaration') {
+      continue;
+    }
+
+    for (const declaration of node.declarations) {
+      if (!isIdentifier(declaration.id) || !declaration.init) {
+        continue;
+      }
+
+      const initializer = unwrapExpression(declaration.init);
+      if (isObjectExpression(initializer)) {
+        variables.set(declaration.id.name, initializer);
+      }
+    }
+  }
+
+  return variables;
+}
+
+function resolveObjectExpression(
+  expression: Expression,
+  variables: Map<string, ObjectExpression>,
+): ObjectExpression | null {
+  const unwrappedExpression = unwrapExpression(expression);
+
+  if (isObjectExpression(unwrappedExpression)) {
+    return unwrappedExpression;
+  }
+
+  if (isIdentifier(unwrappedExpression)) {
+    return variables.get(unwrappedExpression.name) ?? null;
+  }
+
+  return null;
+}
+
+function isModuleExportsAssignment(expression: Expression): expression is AssignmentExpression {
+  if (expression.type !== 'AssignmentExpression' || expression.operator !== '=') {
+    return false;
+  }
+
+  const { left } = expression;
+  return (
+    left.type === 'MemberExpression' &&
+    !left.computed &&
+    isIdentifier(left.object) &&
+    left.object.name === 'module' &&
+    isIdentifier(left.property) &&
+    left.property.name === 'exports'
+  );
+}
+
+function findNextConfigObject(program: Program): ObjectExpression | null {
+  const nextConfigVariables = collectNextConfigVariables(program);
+  const namedNextConfig = nextConfigVariables.get('nextConfig');
+  if (namedNextConfig) {
+    return namedNextConfig;
+  }
+
+  for (const node of program.body) {
+    if (node.type === 'ExpressionStatement' && isModuleExportsAssignment(node.expression)) {
+      const moduleExportsConfig = resolveObjectExpression(node.expression.right, nextConfigVariables);
+      if (moduleExportsConfig) {
+        return moduleExportsConfig;
+      }
+    }
+
+    if (
+      node.type === 'ExportDefaultDeclaration' &&
+      node.declaration.type !== 'FunctionDeclaration' &&
+      node.declaration.type !== 'ClassDeclaration'
+    ) {
+      const exportedConfig = resolveObjectExpression(node.declaration, nextConfigVariables);
+      if (exportedConfig) {
+        return exportedConfig;
+      }
+    }
+  }
+
+  return null;
+}
+
+function parseNextConfig(nextConfigContent: string): NextConfig | null {
+  const program = parseProgram(nextConfigContent);
+  const config = findNextConfigObject(program);
+  if (!config) {
+    return null;
+  }
+
+  return {
+    serverExternalPackages: readServerExternalPackages(config),
+  };
+}
 
 function readNextConfig(dir: string) {
   const nextConfigPath = join(dir, 'next.config.js');
   try {
     const nextConfigContent = readFileSync(nextConfigPath, 'utf-8');
-    const configMatch = nextConfigContent.match(/const nextConfig = ({[\s\S]*?});/);
-    if (!configMatch?.[1]) {
-      return null;
-    }
-    const configStr = configMatch[1].replace(/\n/g, '').replace(/\s+/g, ' ');
-    return eval(`(${configStr})`);
+    return parseNextConfig(nextConfigContent);
   } catch {
     return null;
   }
@@ -27,7 +219,7 @@ function isNextJsProject(dir: string): boolean {
     return false;
   }
 }
-// TODO: Move to babel
+
 export const nextConfigRule: LintRule = {
   name: 'next-config',
   description: 'Checks if Next.js config is properly configured for Mastra packages',

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -334,6 +334,7 @@ function App() {
     () => (baseUrl ? createFetchWithRefresh(baseUrl, apiPrefix) : undefined),
     [baseUrl, apiPrefix],
   );
+  const studioHeaders = useMemo(() => ({ ...headers, 'x-mastra-client-type': 'studio' }), [headers]);
 
   if (isLoading) {
     // Config is loaded from localStorage. However, there might be a race condition
@@ -348,7 +349,7 @@ function App() {
   const router = createBrowserRouter(routes, { basename: studioBasePath });
 
   return (
-    <MastraReactProvider baseUrl={baseUrl} headers={headers} apiPrefix={apiPrefix} customFetch={customFetch}>
+    <MastraReactProvider baseUrl={baseUrl} headers={studioHeaders} apiPrefix={apiPrefix} customFetch={customFetch}>
       <PostHogProvider>
         <RouterProvider router={router} />
       </PostHogProvider>

--- a/packages/server/src/server/constants.ts
+++ b/packages/server/src/server/constants.ts
@@ -12,6 +12,23 @@ export const MASTRA_THREAD_ID_KEY = 'mastra__threadId';
 
 export const MASTRA_AUTH_TOKEN_KEY = 'mastra__authToken';
 
+export const MASTRA_IS_STUDIO_KEY = 'mastra__isStudio';
+
+export const MASTRA_CLIENT_TYPE_HEADER = 'x-mastra-client-type';
+
+export const MASTRA_STUDIO_CLIENT_TYPE = 'studio';
+
+const RESERVED_CONTEXT_KEYS = new Set([
+  MASTRA_RESOURCE_ID_KEY,
+  MASTRA_THREAD_ID_KEY,
+  MASTRA_AUTH_TOKEN_KEY,
+  MASTRA_IS_STUDIO_KEY,
+]);
+
+export function isReservedRequestContextKey(key: string): boolean {
+  return RESERVED_CONTEXT_KEYS.has(key);
+}
+
 export const WORKSPACE_TOOLS_PREFIX = 'mastra_workspace' as const;
 
 export const WORKSPACE_TOOLS = {

--- a/packages/server/src/server/constants.ts
+++ b/packages/server/src/server/constants.ts
@@ -29,6 +29,10 @@ export function isReservedRequestContextKey(key: string): boolean {
   return RESERVED_CONTEXT_KEYS.has(key);
 }
 
+export function isStudioClientTypeHeader(value: string | undefined): boolean {
+  return value?.toLowerCase() === MASTRA_STUDIO_CLIENT_TYPE;
+}
+
 export const WORKSPACE_TOOLS_PREFIX = 'mastra_workspace' as const;
 
 export const WORKSPACE_TOOLS = {

--- a/packages/server/src/server/handlers/agent.test.ts
+++ b/packages/server/src/server/handlers/agent.test.ts
@@ -9,6 +9,7 @@ import type { MastraStorage } from '@mastra/core/storage';
 import { createWorkflow, createStep } from '@mastra/core/workflows';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod/v4';
+import { MASTRA_IS_STUDIO_KEY } from '../constants';
 import { HTTPException } from '../http-exception';
 import {
   LIST_AGENTS_ROUTE,
@@ -627,7 +628,7 @@ describe('Agent Handlers', () => {
         agents: { 'studio-agent': studioAgent },
       });
       const studioRequestContext = new RequestContext();
-      studioRequestContext.set('isStudio', true);
+      studioRequestContext.set(MASTRA_IS_STUDIO_KEY, true);
 
       const result = await GET_AGENT_BY_ID_ROUTE.handler({
         ...createTestServerContext({ mastra: mastraWithStudioAgent }),
@@ -650,7 +651,7 @@ describe('Agent Handlers', () => {
           agents: { 'non-studio-agent': agent },
         });
         const nonStudioRequestContext = new RequestContext();
-        nonStudioRequestContext.set('isStudio', isStudio);
+        nonStudioRequestContext.set(MASTRA_IS_STUDIO_KEY, isStudio);
 
         const result = await GET_AGENT_BY_ID_ROUTE.handler({
           ...createTestServerContext({ mastra: mastraWithAgent }),
@@ -661,6 +662,27 @@ describe('Agent Handlers', () => {
         expect(result.instructions).toBe('Hello undefined');
       },
     );
+
+    it('should not use Studio placeholder context for user-supplied isStudio request context', async () => {
+      const agent = makeMockAgent({
+        name: 'user-is-studio-agent',
+        instructions: ({ requestContext }) => `Hello ${String(requestContext.get('displayName'))}`,
+      });
+
+      const mastraWithAgent = makeMastraMock({
+        agents: { 'user-is-studio-agent': agent },
+      });
+      const requestContextWithUserKey = new RequestContext();
+      requestContextWithUserKey.set('isStudio', true);
+
+      const result = await GET_AGENT_BY_ID_ROUTE.handler({
+        ...createTestServerContext({ mastra: mastraWithAgent }),
+        agentId: 'user-is-studio-agent',
+        requestContext: requestContextWithUserKey,
+      });
+
+      expect(result.instructions).toBe('Hello undefined');
+    });
 
     it('should return serialized agent without a model list for dynamic single-model selection', async () => {
       const dynamicSingleModelAgent = makeMockAgent({

--- a/packages/server/src/server/handlers/agent.test.ts
+++ b/packages/server/src/server/handlers/agent.test.ts
@@ -617,6 +617,51 @@ describe('Agent Handlers', () => {
       ]);
     });
 
+    it('should use Studio placeholder context when serializing an agent from Studio', async () => {
+      const studioAgent = makeMockAgent({
+        name: 'studio-agent',
+        instructions: ({ requestContext }) => `Hello ${String(requestContext.get('displayName'))}`,
+      });
+
+      const mastraWithStudioAgent = makeMastraMock({
+        agents: { 'studio-agent': studioAgent },
+      });
+      const studioRequestContext = new RequestContext();
+      studioRequestContext.set('isStudio', true);
+
+      const result = await GET_AGENT_BY_ID_ROUTE.handler({
+        ...createTestServerContext({ mastra: mastraWithStudioAgent }),
+        agentId: 'studio-agent',
+        requestContext: studioRequestContext,
+      });
+
+      expect(result.instructions).toBe('Hello <displayName>');
+    });
+
+    it.each([false, 'true', 1])(
+      'should not use Studio placeholder context for non-true isStudio value %s',
+      async isStudio => {
+        const agent = makeMockAgent({
+          name: 'non-studio-agent',
+          instructions: ({ requestContext }) => `Hello ${String(requestContext.get('displayName'))}`,
+        });
+
+        const mastraWithAgent = makeMastraMock({
+          agents: { 'non-studio-agent': agent },
+        });
+        const nonStudioRequestContext = new RequestContext();
+        nonStudioRequestContext.set('isStudio', isStudio);
+
+        const result = await GET_AGENT_BY_ID_ROUTE.handler({
+          ...createTestServerContext({ mastra: mastraWithAgent }),
+          agentId: 'non-studio-agent',
+          requestContext: nonStudioRequestContext,
+        });
+
+        expect(result.instructions).toBe('Hello undefined');
+      },
+    );
+
     it('should return serialized agent without a model list for dynamic single-model selection', async () => {
       const dynamicSingleModelAgent = makeMockAgent({
         name: 'dynamic-single-model-agent',

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -86,6 +86,12 @@ function stashVersionOverrides(ctx: RequestContext, versions: VersionOverrides |
   }
 }
 
+const IS_STUDIO_CONTEXT_KEY = 'isStudio';
+
+function getIsStudioFromContext(requestContext: RequestContext): boolean {
+  return requestContext.get(IS_STUDIO_CONTEXT_KEY) === true;
+}
+
 /**
  * Checks if a provider has its required API key environment variable(s) configured.
  * Handles provider IDs with suffixes (e.g., "openai.chat" -> "openai").
@@ -1044,7 +1050,7 @@ export const GET_AGENT_BY_ID_ROUTE = createRoute({
     try {
       const versionOptions = versionId ? { versionId } : status ? { status } : undefined;
       const agent = await getAgentFromSystem({ mastra, agentId, versionOptions, requestContext });
-      const isStudio = false; // TODO: Get from context if needed
+      const isStudio = getIsStudioFromContext(requestContext);
       const result = await formatAgent({
         mastra,
         agent,

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -20,7 +20,7 @@ import type { PublicSchema } from '@mastra/schema-compat/schema';
 import { stringify } from 'superjson';
 
 import { z } from 'zod/v4';
-import { WORKSPACE_TOOLS, resolveToolConfig } from '../constants';
+import { MASTRA_IS_STUDIO_KEY, WORKSPACE_TOOLS, isReservedRequestContextKey, resolveToolConfig } from '../constants';
 import type { WorkspaceToolName } from '../constants';
 
 import { HTTPException } from '../http-exception';
@@ -86,10 +86,21 @@ function stashVersionOverrides(ctx: RequestContext, versions: VersionOverrides |
   }
 }
 
-const IS_STUDIO_CONTEXT_KEY = 'isStudio';
-
 function getIsStudioFromContext(requestContext: RequestContext): boolean {
-  return requestContext.get(IS_STUDIO_CONTEXT_KEY) === true;
+  return requestContext.get(MASTRA_IS_STUDIO_KEY) === true;
+}
+
+function mergeBodyRequestContext(serverRequestContext: RequestContext, bodyRequestContext: unknown): void {
+  if (!bodyRequestContext || typeof bodyRequestContext !== 'object') {
+    return;
+  }
+
+  for (const [key, value] of Object.entries(bodyRequestContext)) {
+    if (isReservedRequestContextKey(key)) continue;
+    if (serverRequestContext.get(key) === undefined) {
+      serverRequestContext.set(key, value);
+    }
+  }
 }
 
 /**
@@ -821,28 +832,27 @@ async function formatAgent({
     }
   }
 
-  let proxyRequestContext = requestContext;
-  if (isStudio) {
-    proxyRequestContext = new Proxy(requestContext, {
-      get(target, prop) {
-        if (prop === 'get') {
-          return function (key: string) {
-            const value = target.get(key);
-            return value ?? `<${key}>`;
-          };
-        }
-        return Reflect.get(target, prop);
-      },
-    });
-  }
+  const instructionsRequestContext = isStudio
+    ? new Proxy(requestContext, {
+        get(target, prop) {
+          if (prop === 'get') {
+            return function (key: string) {
+              const value = target.get(key);
+              return value ?? `<${key}>`;
+            };
+          }
+          return Reflect.get(target, prop);
+        },
+      })
+    : requestContext;
 
-  const instructions = await agent.getInstructions({ requestContext: proxyRequestContext });
+  const instructions = await agent.getInstructions({ requestContext: instructionsRequestContext });
   const llm = await agent.getLLM({ requestContext });
   const defaultGenerateOptionsLegacy = await agent.getDefaultGenerateOptionsLegacy({
-    requestContext: proxyRequestContext,
+    requestContext,
   });
-  const defaultStreamOptionsLegacy = await agent.getDefaultStreamOptionsLegacy({ requestContext: proxyRequestContext });
-  const defaultOptions = await agent.getDefaultOptions({ requestContext: proxyRequestContext });
+  const defaultStreamOptionsLegacy = await agent.getDefaultStreamOptionsLegacy({ requestContext });
+  const defaultOptions = await agent.getDefaultOptions({ requestContext });
 
   const model = llm?.getModel();
   const models = await agent.getModelList(requestContext);
@@ -855,7 +865,7 @@ async function formatAgent({
     },
   }));
 
-  const serializedAgentAgents = await getSerializedAgentDefinition({ agent, requestContext: proxyRequestContext });
+  const serializedAgentAgents = await getSerializedAgentDefinition({ agent, requestContext });
 
   // Get and serialize only user-configured processors (excludes memory-derived processors)
   // This ensures the UI only shows processors explicitly configured by the user
@@ -872,14 +882,14 @@ async function formatAgent({
   }
 
   // Extract skills, workspace tools, and workspaceId from agent's workspace
-  const serializedSkills = await getSerializedSkillsFromAgent(agent, proxyRequestContext);
-  const workspaceTools = await getWorkspaceToolsFromAgent(agent, proxyRequestContext);
+  const serializedSkills = await getSerializedSkillsFromAgent(agent, requestContext);
+  const workspaceTools = await getWorkspaceToolsFromAgent(agent, requestContext);
   const browserTools = getBrowserToolsFromAgent(agent, createBrowserToolsErrorLogger(mastra.getLogger(), agent.id));
 
   // Get workspaceId if agent has a workspace
   let workspaceId: string | undefined;
   try {
-    const workspace = await agent.getWorkspace({ requestContext: proxyRequestContext });
+    const workspace = await agent.getWorkspace({ requestContext });
     workspaceId = workspace?.id;
   } catch {
     // Agent doesn't have a workspace or can't access it
@@ -1145,16 +1155,9 @@ export const GENERATE_AGENT_ROUTE = createRoute({
         requestContext: serverRequestContext,
       });
 
-      // Merge body's requestContext values into the server's RequestContext instance
-      // Only set values that don't already exist on the server context to prevent
-      // clients from overwriting server-populated auth/tenant values
-      if (bodyRequestContext && typeof bodyRequestContext === 'object') {
-        for (const [key, value] of Object.entries(bodyRequestContext)) {
-          if (serverRequestContext.get(key) === undefined) {
-            serverRequestContext.set(key, value);
-          }
-        }
-      }
+      // Merge body's requestContext values into the server's RequestContext instance.
+      // Reserved keys stay server-controlled.
+      mergeBodyRequestContext(serverRequestContext, bodyRequestContext);
 
       // Stash version overrides from body onto requestContext for sub-agent resolution
       stashVersionOverrides(serverRequestContext, versions);
@@ -1446,16 +1449,9 @@ export const STREAM_GENERATE_ROUTE = createRoute({
         requestContext: serverRequestContext,
       });
 
-      // Merge body's requestContext values into the server's RequestContext instance
-      // Only set values that don't already exist on the server context to prevent
-      // clients from overwriting server-populated auth/tenant values
-      if (bodyRequestContext && typeof bodyRequestContext === 'object') {
-        for (const [key, value] of Object.entries(bodyRequestContext)) {
-          if (serverRequestContext.get(key) === undefined) {
-            serverRequestContext.set(key, value);
-          }
-        }
-      }
+      // Merge body's requestContext values into the server's RequestContext instance.
+      // Reserved keys stay server-controlled.
+      mergeBodyRequestContext(serverRequestContext, bodyRequestContext);
 
       // Stash version overrides from body onto requestContext for sub-agent resolution
       stashVersionOverrides(serverRequestContext, versions);
@@ -1538,16 +1534,9 @@ export const STREAM_UNTIL_IDLE_GENERATE_ROUTE = createRoute({
         requestContext: serverRequestContext,
       });
 
-      // Merge body's requestContext values into the server's RequestContext instance
-      // Only set values that don't already exist on the server context to prevent
-      // clients from overwriting server-populated auth/tenant values
-      if (bodyRequestContext && typeof bodyRequestContext === 'object') {
-        for (const [key, value] of Object.entries(bodyRequestContext)) {
-          if (serverRequestContext.get(key) === undefined) {
-            serverRequestContext.set(key, value);
-          }
-        }
-      }
+      // Merge body's requestContext values into the server's RequestContext instance.
+      // Reserved keys stay server-controlled.
+      mergeBodyRequestContext(serverRequestContext, bodyRequestContext);
 
       // Authorization: apply context overrides to memory option if present
       let authorizedMemoryOption = memoryOption;
@@ -1853,13 +1842,7 @@ export const RESUME_STREAM_ROUTE = createRoute({
         ),
       });
 
-      if (bodyRequestContext && typeof bodyRequestContext === 'object') {
-        for (const [key, value] of Object.entries(bodyRequestContext)) {
-          if (serverRequestContext.get(key) === undefined) {
-            serverRequestContext.set(key, value);
-          }
-        }
-      }
+      mergeBodyRequestContext(serverRequestContext, bodyRequestContext);
 
       stashVersionOverrides(serverRequestContext, versions);
 

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -12,8 +12,8 @@ import { coreAuthMiddleware } from '../auth/helpers';
 import {
   MASTRA_CLIENT_TYPE_HEADER,
   MASTRA_IS_STUDIO_KEY,
-  MASTRA_STUDIO_CLIENT_TYPE,
   isReservedRequestContextKey,
+  isStudioClientTypeHeader,
 } from '../constants';
 import { formatZodError } from '../handlers/error';
 import { normalizeRoutePath } from '../utils';
@@ -28,6 +28,7 @@ export {
   MASTRA_IS_STUDIO_KEY,
   MASTRA_STUDIO_CLIENT_TYPE,
   isReservedRequestContextKey,
+  isStudioClientTypeHeader,
 } from '../constants';
 
 export { WorkflowRegistry, normalizeRoutePath } from '../utils';
@@ -367,7 +368,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     requestContext: RequestContext;
     getHeader: (name: string) => string | undefined;
   }): void {
-    if (getHeader(MASTRA_CLIENT_TYPE_HEADER)?.toLowerCase() === MASTRA_STUDIO_CLIENT_TYPE) {
+    if (isStudioClientTypeHeader(getHeader(MASTRA_CLIENT_TYPE_HEADER))) {
       requestContext.set(MASTRA_IS_STUDIO_KEY, true);
     }
   }

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -9,7 +9,12 @@ import { z } from 'zod/v4';
 
 import type { InMemoryTaskStore } from '../a2a/store';
 import { coreAuthMiddleware } from '../auth/helpers';
-import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../constants';
+import {
+  MASTRA_CLIENT_TYPE_HEADER,
+  MASTRA_IS_STUDIO_KEY,
+  MASTRA_STUDIO_CLIENT_TYPE,
+  isReservedRequestContextKey,
+} from '../constants';
 import { formatZodError } from '../handlers/error';
 import { normalizeRoutePath } from '../utils';
 import { generateOpenAPIDocument, convertCustomRoutesToOpenAPIPaths } from './openapi-utils';
@@ -18,6 +23,12 @@ import type { ServerRoute } from './routes';
 
 export * from './routes';
 export { redactStreamChunk } from './redact';
+export {
+  MASTRA_CLIENT_TYPE_HEADER,
+  MASTRA_IS_STUDIO_KEY,
+  MASTRA_STUDIO_CLIENT_TYPE,
+  isReservedRequestContextKey,
+} from '../constants';
 
 export { WorkflowRegistry, normalizeRoutePath } from '../utils';
 
@@ -326,8 +337,6 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     return !excludePaths.some((excluded: string) => path === excluded || path.startsWith(excluded + '/'));
   }
 
-  private static readonly RESERVED_CONTEXT_KEYS = new Set([MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY]);
-
   protected mergeRequestContext({
     paramsRequestContext,
     bodyRequestContext,
@@ -338,17 +347,29 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     const requestContext = new RequestContext();
     if (bodyRequestContext) {
       for (const [key, value] of Object.entries(bodyRequestContext)) {
-        if (MastraServer.RESERVED_CONTEXT_KEYS.has(key)) continue;
+        if (isReservedRequestContextKey(key)) continue;
         requestContext.set(key, value);
       }
     }
     if (paramsRequestContext) {
       for (const [key, value] of Object.entries(paramsRequestContext)) {
-        if (MastraServer.RESERVED_CONTEXT_KEYS.has(key)) continue;
+        if (isReservedRequestContextKey(key)) continue;
         requestContext.set(key, value);
       }
     }
     return requestContext;
+  }
+
+  protected applyRequestMetadataToContext({
+    requestContext,
+    getHeader,
+  }: {
+    requestContext: RequestContext;
+    getHeader: (name: string) => string | undefined;
+  }): void {
+    if (getHeader(MASTRA_CLIENT_TYPE_HEADER)?.toLowerCase() === MASTRA_STUDIO_CLIENT_TYPE) {
+      requestContext.set(MASTRA_IS_STUDIO_KEY, true);
+    }
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2933,6 +2933,9 @@ importers:
       '@mastra/loggers':
         specifier: workspace:^
         version: link:../loggers
+      acorn:
+        specifier: ^8.16.0
+        version: 8.16.0
       archiver:
         specifier: ^7.0.1
         version: 7.0.1

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -112,6 +112,10 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
       }
 
       const requestContext = this.mergeRequestContext({ paramsRequestContext, bodyRequestContext });
+      this.applyRequestMetadataToContext({
+        requestContext,
+        getHeader: name => req.get(name),
+      });
 
       // Set context in res.locals
       res.locals.requestContext = requestContext;

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -111,6 +111,13 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
       }
 
       const requestContext = this.mergeRequestContext({ paramsRequestContext, bodyRequestContext });
+      this.applyRequestMetadataToContext({
+        requestContext,
+        getHeader: name => {
+          const value = request.headers[name.toLowerCase()];
+          return Array.isArray(value) ? value[0] : value;
+        },
+      });
 
       // Set context in request object
       request.requestContext = requestContext;

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@internal/server-adapter-test-utils';
 import { Mastra } from '@mastra/core';
 import { registerApiRoute } from '@mastra/core/server';
+import { MASTRA_IS_STUDIO_KEY } from '@mastra/server/server-adapter';
 import type { ServerRoute } from '@mastra/server/server-adapter';
 import { Hono } from 'hono';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -820,6 +821,7 @@ describe('Hono Server Adapter', () => {
         handler: async ({ requestContext }) => {
           return {
             resourceId: requestContext?.get('mastra__resourceId') ?? null,
+            isStudio: requestContext?.get(MASTRA_IS_STUDIO_KEY) ?? null,
             customKey: requestContext?.get('myKey') ?? null,
           };
         },
@@ -835,6 +837,7 @@ describe('Hono Server Adapter', () => {
           body: JSON.stringify({
             requestContext: {
               mastra__resourceId: 'injected-victim-id',
+              [MASTRA_IS_STUDIO_KEY]: true,
               myKey: 'safe-value',
             },
           }),
@@ -844,6 +847,7 @@ describe('Hono Server Adapter', () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.resourceId).toBeNull();
+      expect(data.isStudio).toBeNull();
       expect(data.customKey).toBe('safe-value');
     });
 
@@ -901,6 +905,7 @@ describe('Hono Server Adapter', () => {
           return {
             resourceId: requestContext?.get('mastra__resourceId') ?? null,
             threadId: requestContext?.get('mastra__threadId') ?? null,
+            isStudio: requestContext?.get(MASTRA_IS_STUDIO_KEY) ?? null,
             customKey: requestContext?.get('myKey') ?? null,
           };
         },
@@ -912,6 +917,7 @@ describe('Hono Server Adapter', () => {
       const queryContext = JSON.stringify({
         mastra__resourceId: 'injected-victim-id',
         mastra__threadId: 'injected-thread-id',
+        [MASTRA_IS_STUDIO_KEY]: true,
         myKey: 'safe-value',
       });
 
@@ -925,7 +931,39 @@ describe('Hono Server Adapter', () => {
       const data = await response.json();
       expect(data.resourceId).toBeNull();
       expect(data.threadId).toBeNull();
+      expect(data.isStudio).toBeNull();
       expect(data.customKey).toBe('safe-value');
+    });
+
+    it('should set reserved Studio context from x-mastra-client-type header', async () => {
+      const mastra = new Mastra({});
+      const app = new Hono();
+      const adapter = new MastraServer({ app, mastra });
+
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'GET',
+        path: '/test/context',
+        responseType: 'json',
+        handler: async ({ requestContext }) => {
+          return {
+            isStudio: requestContext?.get(MASTRA_IS_STUDIO_KEY) ?? null,
+          };
+        },
+      };
+
+      app.use('*', adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      const response = await app.request(
+        new Request('http://localhost/test/context', {
+          method: 'GET',
+          headers: { 'x-mastra-client-type': 'studio' },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.isStudio).toBe(true);
     });
   });
 });

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -965,5 +965,38 @@ describe('Hono Server Adapter', () => {
       const data = await response.json();
       expect(data.isStudio).toBe(true);
     });
+
+    it('should not set reserved Studio context when x-mastra-client-type is not studio', async () => {
+      const mastra = new Mastra({});
+      const app = new Hono();
+      const adapter = new MastraServer({ app, mastra });
+
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'GET',
+        path: '/test/context',
+        responseType: 'json',
+        handler: async ({ requestContext }) => {
+          return {
+            isStudio: requestContext?.get(MASTRA_IS_STUDIO_KEY) ?? null,
+          };
+        },
+      };
+
+      app.use('*', adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      for (const headers of [{ 'x-mastra-client-type': 'playground' }, {}]) {
+        const response = await app.request(
+          new Request('http://localhost/test/context', {
+            method: 'GET',
+            headers,
+          }),
+        );
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data.isStudio).toBeNull();
+      }
+    });
   });
 });

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -135,6 +135,10 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
       }
 
       const requestContext = this.mergeRequestContext({ paramsRequestContext, bodyRequestContext });
+      this.applyRequestMetadataToContext({
+        requestContext,
+        getHeader: name => c.req.header(name),
+      });
 
       // Add relevant contexts to hono context
       c.set('requestContext', requestContext);

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -241,6 +241,10 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       }
 
       const requestContext = server.mergeRequestContext({ paramsRequestContext, bodyRequestContext });
+      server.applyRequestMetadataToContext({
+        requestContext,
+        getHeader: name => ctx.get(name),
+      });
 
       // Set context in state object
       ctx.state.requestContext = requestContext;

--- a/server-adapters/nestjs/src/services/request-context.service.ts
+++ b/server-adapters/nestjs/src/services/request-context.service.ts
@@ -2,8 +2,8 @@ import { RequestContext } from '@mastra/core/request-context';
 import {
   MASTRA_CLIENT_TYPE_HEADER,
   MASTRA_IS_STUDIO_KEY,
-  MASTRA_STUDIO_CLIENT_TYPE,
   isReservedRequestContextKey,
+  isStudioClientTypeHeader,
 } from '@mastra/server/server-adapter';
 import { Inject, Injectable, Logger, Scope } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
@@ -125,7 +125,7 @@ export class RequestContextService {
   }
 
   private applyRequestMetadata(context: RequestContext): void {
-    if (this.request.get(MASTRA_CLIENT_TYPE_HEADER)?.toLowerCase() === MASTRA_STUDIO_CLIENT_TYPE) {
+    if (isStudioClientTypeHeader(this.request.get(MASTRA_CLIENT_TYPE_HEADER))) {
       context.set(MASTRA_IS_STUDIO_KEY, true);
     }
   }

--- a/server-adapters/nestjs/src/services/request-context.service.ts
+++ b/server-adapters/nestjs/src/services/request-context.service.ts
@@ -1,4 +1,10 @@
 import { RequestContext } from '@mastra/core/request-context';
+import {
+  MASTRA_CLIENT_TYPE_HEADER,
+  MASTRA_IS_STUDIO_KEY,
+  MASTRA_STUDIO_CLIENT_TYPE,
+  isReservedRequestContextKey,
+} from '@mastra/server/server-adapter';
 import { Inject, Injectable, Logger, Scope } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import type { Request, Response } from 'express';
@@ -82,6 +88,7 @@ export class RequestContextService {
       }
     }
 
+    this.applyRequestMetadata(context);
     return context;
   }
 
@@ -112,7 +119,14 @@ export class RequestContextService {
    */
   private mergeContext(context: RequestContext, values: Record<string, unknown>): void {
     for (const [key, value] of Object.entries(values)) {
+      if (isReservedRequestContextKey(key)) continue;
       context.set(key, value);
+    }
+  }
+
+  private applyRequestMetadata(context: RequestContext): void {
+    if (this.request.get(MASTRA_CLIENT_TYPE_HEADER)?.toLowerCase() === MASTRA_STUDIO_CLIENT_TYPE) {
+      context.set(MASTRA_IS_STUDIO_KEY, true);
     }
   }
 


### PR DESCRIPTION
Closed because this PR was opened from the wrong branch and included unrelated existing branch history. Do not review or merge this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR fixes a security problem where the CLI was running unsafe code when checking Next.js config files. Instead of safely reading the config with a parser, it was using `eval()` to run the code—meaning malicious code in a `next.config.js` file could execute inside the Mastra CLI. The fix replaces `eval()` with a safe parser that only reads what's needed without running any code. Additionally, the PR updates how the framework identifies Studio requests by moving that decision to the server side, preventing clients from pretending to be the Studio.

## Summary of Changes

### Security Fix: Remove `eval()` from Next.js Config Linting

**Core Implementation** (`packages/cli/src/commands/lint/rules/nextConfigRule.ts`)
- Replaced unsafe regex and `eval()` approach with AST-based parsing using the `acorn` parser
- New `readNextConfig` function safely extracts `serverExternalPackages` only from literal string arrays in the AST
- Supports standard Next.js config patterns: `const nextConfig = {...}`, `module.exports = {...}`, and `export default {...}`
- Dynamic expressions and code with side effects (like IIFE payloads) are never evaluated
- Invalid or unsupported configs cause the rule to fail gracefully without execution

**Regression Test Coverage** (`packages/cli/src/commands/lint/rules/nextConfigRule.test.ts`)
- Added 64 lines of test cases proving that code embedded in `next.config.js` is not executed
- Tests verify the core functionality still works: `serverExternalPackages` validation passes for safe literal configs
- Includes specific proof via marker-based test that IIFE payloads remain unexecuted

**CLI Dependencies** (`packages/cli/package.json`)
- Added `acorn` parser as a new dependency for safe AST parsing

### Feature: Server-Controlled Studio Mode Identification

**Server-Side Constants & Helpers** (`packages/server/src/server/constants.ts`)
- Introduced `MASTRA_IS_STUDIO_KEY` and `MASTRA_CLIENT_TYPE_HEADER` constants for identifying Studio clients
- Added `isReservedRequestContextKey()` to validate context keys and prevent client tampering
- Added `isStudioClientTypeHeader()` to identify Studio requests from the `x-mastra-client-type` header

**Agent Serialization Logic** (`packages/server/src/server/handlers/agents.ts`)
- Modified agent serialization to apply Studio context (special instruction placeholders) only via the server, not from client input
- Studio placeholder rendering now only affects `agent.getInstructions()` when server identifies Studio mode
- Other agent reads (LLM, options, workspace/tool/model data) use the original unproxied request context
- Introduced `mergeBodyRequestContext()` helper to safely merge client-provided context while filtering reserved keys

**Request Context Validation** (`packages/server/src/server/handlers/agent.test.ts`)
- Added test coverage for Studio-specific instruction serialization behavior
- Validates that reserved context keys cannot be overridden by client input

**Adapter-Wide Integration** (Express, Fastify, Hono, Koa, NestJS adapters)
- All server adapters now call `applyRequestMetadataToContext()` after computing request context
- This server-side logic detects `x-mastra-client-type: studio` header and sets `MASTRA_IS_STUDIO_KEY` in the context
- Clients cannot override the Studio flag via request body or query parameters—only via the HTTP header (which the server controls)

**Server Adapter Exports** (`packages/server/src/server/server-adapter/index.ts`)
- Re-exports new Studio-related constants and validation functions for consistent use across adapters
- Updated reserved keys filtering to use the new centralized `isReservedRequestContextKey()` function

**Playground Client** (`packages/playground/src/App.tsx`)
- Updated to include `x-mastra-client-type: studio` header in all Studio requests

**Adapter-Specific Tests** (`server-adapters/hono/src/__tests__/hono-adapter.test.ts`)
- Expanded reserved context key injection prevention tests for Studio mode
- Added new tests verifying that `x-mastra-client-type: studio` header correctly sets reserved Studio context
- Validates that non-Studio headers leave `isStudio` unset

### Release Notes

**CLI Package** (`.changeset/grumpy-places-notice.md`)
- Patch-level changeset documenting the Next.js config linting security fix

**Server Adapters** (`.changeset/eighty-phones-sit.md`)
- Patch-level changeset for `@mastra/server`, `@mastra/hono`, `@mastra/express`, `@mastra/fastify`, `@mastra/koa`, `@mastra/nestjs`, and `@internal/playground`
- Documents standardized Studio mode identification and request context isolation across all adapters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->