### PR TITLE
fix(core): scope model step spans to provider calls

### DIFF
--- a/.changeset/model-step-provider-call.md
+++ b/.changeset/model-step-provider-call.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/observability': patch
+---
+
+Fixed model step spans so they measure only the provider call. Input step processors, output step processors, and client-side tool execution now appear outside `MODEL_STEP`, making LLM call durations reflect actual model time.

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -398,6 +398,13 @@ export class ModelSpanTracker {
   /**
    * End the current Model execution step with token usage, finish reason, output, and metadata
    */
+  endStep<OUTPUT>(payload: StepFinishPayload<any, OUTPUT>): void {
+    this.#endStepSpan(payload);
+  }
+
+  /**
+   * Internal implementation for ending the current Model execution step.
+   */
   #endStepSpan<OUTPUT>(payload: StepFinishPayload<any, OUTPUT>) {
     // Flush any pending chunk span before ending the step
     // (handles case where text-delta arrives without text-end)

--- a/observability/mastra/src/processor-tracing.test.ts
+++ b/observability/mastra/src/processor-tracing.test.ts
@@ -774,11 +774,11 @@ describe('Processor Tracing Tests', () => {
      * Expected span structure:
      * - test-agent AGENT_RUN (root)
      *   - MODEL_GENERATION
+     *     - input step processor: step-validator PROCESSOR_RUN
      *     - MODEL_STEP
-     *       - input step processor: step-validator PROCESSOR_RUN
      *       - MODEL_CHUNK (1+ chunks)
      *
-     * Execution order within MODEL_STEP: input_step_processor → model_chunks
+     * Execution order: input_step_processor → MODEL_STEP/model_chunks
      */
     it('should trace input step processor with correct entity type', async () => {
       const model = createMockModel();
@@ -828,13 +828,13 @@ describe('Processor Tracing Tests', () => {
       expect(modelSpan?.parentSpanId).toBe(agentSpan?.id);
       // 2. MODEL_STEP is child of MODEL_GENERATION
       expect(modelStepSpan?.parentSpanId).toBe(modelSpan?.id);
-      // 3. Step processor span is child of MODEL_STEP span
-      expect(inputStepSpan?.parentSpanId).toBe(modelStepSpan?.id);
+      // 3. Step processor span is child of MODEL_GENERATION, not MODEL_STEP
+      expect(inputStepSpan?.parentSpanId).toBe(modelSpan?.id);
       // 4. Model chunk spans are children of MODEL_STEP span
       const chunkSpansInStep = modelChunkSpans.filter(s => s.parentSpanId === modelStepSpan?.id);
       expect(chunkSpansInStep.length).toBe(1);
 
-      // EXECUTION ORDER within MODEL_STEP: input_step_processor → model_chunks
+      // EXECUTION ORDER: input_step_processor → model_chunks
       const firstChunkInStep = chunkSpansInStep[0];
       testExporter.expectStartedBefore(inputStepSpan, firstChunkInStep);
 
@@ -847,9 +847,9 @@ describe('Processor Tracing Tests', () => {
      *   - MODEL_GENERATION
      *     - MODEL_STEP
      *       - MODEL_CHUNK (1+ chunks)
-     *       - output step processor: step-formatter PROCESSOR_RUN
+     *     - output step processor: step-formatter PROCESSOR_RUN
      *
-     * Execution order within MODEL_STEP: model_chunks → output_step_processor
+     * Execution order: MODEL_STEP/model_chunks → output_step_processor
      */
     it('should trace output step processor with correct entity type', async () => {
       const model = createMockModel();
@@ -898,13 +898,13 @@ describe('Processor Tracing Tests', () => {
       expect(modelSpan?.parentSpanId).toBe(agentSpan?.id);
       // 2. MODEL_STEP is child of MODEL_GENERATION
       expect(modelStepSpan?.parentSpanId).toBe(modelSpan?.id);
-      // 3. Step processor span is child of MODEL_STEP span
-      expect(outputStepSpan?.parentSpanId).toBe(modelStepSpan?.id);
+      // 3. Step processor span is child of MODEL_GENERATION, not MODEL_STEP
+      expect(outputStepSpan?.parentSpanId).toBe(modelSpan?.id);
       // 4. Model chunk spans are children of MODEL_STEP span
       const chunkSpansInStep = modelChunkSpans.filter(s => s.parentSpanId === modelStepSpan?.id);
       expect(chunkSpansInStep.length).toBe(1);
 
-      // EXECUTION ORDER within MODEL_STEP: model_chunks → output_step_processor
+      // EXECUTION ORDER: model_chunks → output_step_processor
       const lastChunkInStep = chunkSpansInStep[chunkSpansInStep.length - 1];
       testExporter.expectStartedBefore(lastChunkInStep, outputStepSpan);
 
@@ -916,13 +916,13 @@ describe('Processor Tracing Tests', () => {
      * - test-agent AGENT_RUN (root)
      *   - input processor: full-input PROCESSOR_RUN
      *   - MODEL_GENERATION
+     *     - input step processor: full-input PROCESSOR_RUN
      *     - MODEL_STEP
-     *       - input step processor: full-input PROCESSOR_RUN
      *       - MODEL_CHUNK (1+ chunks)
-     *       - output step processor: full-output PROCESSOR_RUN
+     *     - output step processor: full-output PROCESSOR_RUN
      *   - output processor: full-output PROCESSOR_RUN
      *
-     * Execution order within MODEL_STEP: input_step → model_chunks → output_step
+     * Execution order: input_step → MODEL_STEP/model_chunks → output_step
      */
     it('should trace full processor with spans for each phase it implements', async () => {
       const model = createMockModel();
@@ -978,9 +978,9 @@ describe('Processor Tracing Tests', () => {
       expect(modelSpan?.parentSpanId).toBe(agentSpan?.id);
       // 3. MODEL_STEP is child of MODEL_GENERATION
       expect(modelStepSpan?.parentSpanId).toBe(modelSpan?.id);
-      // 4. Step processors are children of MODEL_STEP span
-      expect(inputStepSpan?.parentSpanId).toBe(modelStepSpan?.id);
-      expect(outputStepSpan?.parentSpanId).toBe(modelStepSpan?.id);
+      // 4. Step processors are children of MODEL_GENERATION, not MODEL_STEP
+      expect(inputStepSpan?.parentSpanId).toBe(modelSpan?.id);
+      expect(outputStepSpan?.parentSpanId).toBe(modelSpan?.id);
       // 5. Model chunk spans are children of MODEL_STEP span
       const chunkSpansInStep = modelChunkSpans.filter(s => s.parentSpanId === modelStepSpan?.id);
       expect(chunkSpansInStep.length).toBe(1);
@@ -989,7 +989,7 @@ describe('Processor Tracing Tests', () => {
       testExporter.expectStartedBefore(inputSpan, modelSpan);
       testExporter.expectStartedBefore(modelSpan, outputSpan);
 
-      // EXECUTION ORDER within MODEL_STEP: input_step → model_chunks → output_step
+      // EXECUTION ORDER: input_step → model_chunks → output_step
       const firstChunkInStep = chunkSpansInStep[0];
       const lastChunkInStep = chunkSpansInStep[chunkSpansInStep.length - 1];
       testExporter.expectStartedBefore(inputStepSpan, firstChunkInStep);
@@ -1364,9 +1364,9 @@ describe('Processor Tracing Tests', () => {
      *   - input processor: simple PROCESSOR_RUN (processInput only)
      *   - input processor: full PROCESSOR_RUN (processInput from FullProcessor)
      *   - MODEL_GENERATION
+     *     - input step processor: step PROCESSOR_RUN (processInputStep only)
+     *     - input step processor: full PROCESSOR_RUN (processInputStep from FullProcessor)
      *     - MODEL_STEP
-     *       - input step processor: step PROCESSOR_RUN (processInputStep only)
-     *       - input step processor: full PROCESSOR_RUN (processInputStep from FullProcessor)
      */
     it('should only create spans for phases that have implementing processors', async () => {
       const model = createMockModel();
@@ -1430,9 +1430,9 @@ describe('Processor Tracing Tests', () => {
       expect(modelSpan?.parentSpanId).toBe(agentSpan?.id);
       // 3. MODEL_STEP is child of MODEL_GENERATION
       expect(modelStepSpan?.parentSpanId).toBe(modelSpan?.id);
-      // 4. Step processor spans are children of MODEL_STEP span
-      expect(stepInputStepSpan?.parentSpanId).toBe(modelStepSpan?.id);
-      expect(fullInputStepSpan?.parentSpanId).toBe(modelStepSpan?.id);
+      // 4. Step processor spans are children of MODEL_GENERATION, not MODEL_STEP
+      expect(stepInputStepSpan?.parentSpanId).toBe(modelSpan?.id);
+      expect(fullInputStepSpan?.parentSpanId).toBe(modelSpan?.id);
 
       // EXECUTION ORDER: input processors -> MODEL_GENERATION
       testExporter.expectStartedBefore(simpleInputSpan, modelSpan);

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -274,10 +274,6 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             // Get messages for LLM (using async llmPrompt for proper format conversion)
             const inputMessages = (await messageList.get.all.aiV5.llmPrompt()) as LanguageModelV2Prompt;
 
-            // Enable defer mode - step-finish won't auto-close the step span
-            // This allows us to export the step span and close it later after tool execution
-            modelSpanTracker?.setDeferStepClose(true);
-
             // 7. Track state during streaming
             let warnings: any[] = [];
             let request: any = {};
@@ -439,6 +435,28 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               break; // exhausted retries, try next model
             }
 
+            modelSpanTracker?.endStep?.({
+              messageId: currentMessageId,
+              stepResult: {
+                reason: finishReason as any,
+                warnings,
+                isContinued: false,
+              },
+              output: {
+                text: textDeltas.join(''),
+                toolCalls: toolCalls as any,
+                usage,
+              },
+              metadata: {
+                id: responseMetadata.id,
+                modelId: responseMetadata.modelId || currentModel.modelId,
+                timestamp: responseMetadata.timestamp || new Date().toISOString(),
+                providerMetadata: responseMetadata,
+                headers: rawResponse?.headers,
+                request,
+              },
+            });
+
             // 12. Add assistant response to message list
             if (textDeltas.length > 0 || toolCalls.length > 0) {
               const parts: any[] = [];
@@ -479,10 +497,8 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             const isContinued = toolCalls.length > 0 && finishReason !== 'stop';
             const hasToolCalls = toolCalls.length > 0;
 
-            // 14. Export spans if there are tool calls (so tools can be children of model_step)
-            // Don't end the spans yet - they will be ended after tool execution
-            const stepSpanData = hasToolCalls ? modelSpanTracker?.exportCurrentStep() : undefined;
-            const stepFinishPayload = hasToolCalls ? modelSpanTracker?.getPendingStepFinishPayload() : undefined;
+            // 14. Keep MODEL_STEP scoped to the provider call. Tool execution is
+            // represented by separate spans and should not be a child of MODEL_STEP.
 
             // 15. Build output
             const output: DurableLLMStepOutput = {
@@ -505,38 +521,11 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 request,
               },
               state: typedInput.state,
-              // Pass span data so tool calls can be children of model_step
               modelSpanData: hasToolCalls ? modelSpan?.exportSpan?.() : undefined,
-              stepSpanData,
-              stepFinishPayload,
             };
 
-            // 16. End step span only if there are NO tool calls
-            // If there are tool calls, step span will be ended after tool execution
-            // NOTE: We NEVER close the model span here - it stays open for the entire agent run
-            // and is closed in map-final-output after the agentic loop completes
-            if (!hasToolCalls) {
-              // Close the step span with usage/finish info
-              const pendingPayload = modelSpanTracker?.getPendingStepFinishPayload() as any;
-              if (pendingPayload) {
-                // End step span using the pending payload
-                const stepSpan = modelSpanTracker?.exportCurrentStep();
-                if (stepSpan && observability) {
-                  const rebuiltStepSpan = observability.rebuildSpan(stepSpan);
-                  rebuiltStepSpan?.end({
-                    output: {
-                      text: textDeltas.join(''),
-                      toolCalls: [],
-                    },
-                    attributes: {
-                      usage: pendingPayload.output?.usage,
-                      finishReason: pendingPayload.stepResult?.reason,
-                      isContinued: pendingPayload.stepResult?.isContinued,
-                    },
-                  });
-                }
-              }
-            }
+            // 16. NOTE: We NEVER close the model span here - it stays open for the
+            // entire agent run and is closed in map-final-output after the loop completes.
 
             // Success - return the output
             return output;

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -128,8 +128,10 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
   }
   const baseStream = workflowLoopStream(workflowLoopProps);
 
-  // Apply chunk tracing transform to track MODEL_STEP and MODEL_CHUNK spans
-  const stream = rest.modelSpanTracker?.wrapStream(baseStream) ?? baseStream;
+  // MODEL_STEP and MODEL_CHUNK spans are tracked around the provider stream in
+  // llm-execution-step. Wrapping the full agentic loop here would keep the
+  // MODEL_STEP span open across processors and client-side tool execution.
+  const stream = baseStream;
 
   // Build observability context from modelSpanTracker if tracing context is available
   const observabilityContext = createObservabilityContext(rest.modelSpanTracker?.getTracingContext());

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Mock } from 'vitest';
 import { z } from 'zod/v4';
 import { MessageList } from '../../../agent/message-list';
+import { SpanType } from '../../../observability';
 import { RequestContext } from '../../../request-context';
 import { ToolStream } from '../../../tools/stream';
 import { createTool } from '../../../tools/tool';
@@ -660,6 +661,124 @@ describe('createLLMExecutionStep gateway provider tools', () => {
         }),
       }),
     );
+  });
+
+  it('scopes MODEL_STEP tracing to the provider call only', async () => {
+    const order: string[] = [];
+
+    const createSpan = (type: SpanType, parent?: any): any => {
+      const span: any = {
+        type,
+        parent,
+        createChildSpan: vi.fn((options: { type: SpanType }) => createSpan(options.type, span)),
+        findParent: vi.fn((spanType: SpanType) => {
+          let current = span.parent;
+          while (current) {
+            if (current.type === spanType) return current;
+            current = current.parent;
+          }
+          return undefined;
+        }),
+      };
+      return span;
+    };
+
+    const modelGenerationSpan = createSpan(SpanType.MODEL_GENERATION);
+    const modelStepSpan = createSpan(SpanType.MODEL_STEP, modelGenerationSpan);
+    let currentSpan = modelGenerationSpan;
+
+    const modelSpanTracker = {
+      getTracingContext: vi.fn(() => ({ currentSpan })),
+      startStep: vi.fn(() => {
+        order.push('startStep');
+        currentSpan = modelStepSpan;
+      }),
+      updateStep: vi.fn(),
+      endStep: vi.fn(() => {
+        order.push('endStep');
+        currentSpan = modelGenerationSpan;
+      }),
+      wrapStream: vi.fn(<T>(stream: T) => stream),
+    };
+
+    const doStream = vi.fn(async () => {
+      order.push('doStream');
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'text-delta', textDelta: 'Hello!' },
+          { type: 'finish', finishReason: 'stop', usage: testUsage },
+        ]),
+        request: {},
+        response: { headers: undefined },
+        warnings: [],
+      };
+    });
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream,
+          } as any,
+        },
+      ],
+      inputProcessors: [
+        {
+          id: 'input-step-recorder',
+          processInputStep: vi.fn(async (args: any) => {
+            order.push(`input:${args.tracingContext.currentSpan.parent.type}`);
+            return {};
+          }),
+        },
+      ],
+      outputProcessors: [
+        {
+          id: 'output-step-recorder',
+          processOutputStep: vi.fn(async (args: any) => {
+            order.push(`output:${args.tracingContext.currentSpan.parent.type}`);
+          }),
+        },
+      ],
+      tools: {},
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      modelSpanTracker,
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<{}>);
+
+    const input = createIterationInput();
+    input.stepResult.isContinued = false;
+
+    await llmExecutionStep.execute(createExecuteParams(input));
+
+    expect(order).toEqual([
+      `input:${SpanType.MODEL_GENERATION}`,
+      'startStep',
+      'doStream',
+      'endStep',
+      `output:${SpanType.MODEL_GENERATION}`,
+    ]);
   });
 
   it('stamps step-start.model from the processor-updated model', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -387,9 +387,6 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       let currentMessageId = inputData.isTaskCompleteCheckFailed
         ? `${messageIdPassed}-${currentIteration}`
         : inputData.messageId || messageIdPassed;
-      // Start the MODEL_STEP span at the beginning of LLM execution
-      modelSpanTracker?.startStep();
-
       let modelResult;
       let warnings: any;
       let request: any;
@@ -473,7 +470,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             });
 
             try {
-              // Use MODEL_STEP context so step processor spans are children of MODEL_STEP
+              // Step processors run before the provider call, so they should not be children
+              // of the MODEL_STEP span that represents the provider call itself.
               const stepTracingContext = modelSpanTracker?.getTracingContext() ?? tracingContext;
 
               // Create a ProcessorStreamWriter from outputWriter if available.
@@ -659,6 +657,44 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             _internal: _internal!,
             model: currentStep.model,
           });
+          let modelStepEnded = false;
+          const endModelStep = ({
+            messageId = currentStep.messageId,
+            reason = 'error',
+            text = '',
+            toolCalls = [],
+            usage = inputData.output?.usage,
+            object,
+            metadata = { request, ...rawResponse },
+          }: {
+            messageId?: string;
+            reason?: string;
+            text?: string;
+            toolCalls?: any[];
+            usage?: any;
+            object?: unknown;
+            metadata?: Record<string, unknown>;
+          } = {}) => {
+            if (modelStepEnded) {
+              return;
+            }
+            modelStepEnded = true;
+            modelSpanTracker?.endStep?.({
+              messageId,
+              stepResult: {
+                reason: reason as any,
+                warnings,
+                isContinued: false,
+              },
+              output: {
+                text,
+                toolCalls,
+                usage,
+                ...(object ? { object } : {}),
+              },
+              metadata,
+            });
+          };
 
           // Resolve supportedUrls - it may be a Promise (e.g., from ModelRouterLanguageModel)
           // This allows providers like Mistral to expose their native URL support for PDFs
@@ -755,78 +791,90 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           }
 
           if (isSupportedLanguageModel(currentStep.model)) {
-            modelResult = executeWithContextSync({
-              span: modelSpanTracker?.getTracingContext()?.currentSpan,
-              fn: () =>
-                execute({
-                  runId,
-                  model: currentStep.model,
-                  // Per-model providerOptions deep-merge per provider key on top of call-time providerOptions
-                  providerOptions: mergeProviderOptions(currentStep.providerOptions, modelConfig.providerOptions),
-                  inputMessages,
-                  tools: currentStep.tools,
-                  toolChoice: currentStep.toolChoice,
-                  activeTools: currentStep.activeTools as string[] | undefined,
-                  options,
-                  // Per-model modelSettings shallow-merge on top of call-time modelSettings.
-                  // Per-model maxRetries always wins so p-retry uses the right retry count for this model.
-                  modelSettings: {
-                    ...currentStep.modelSettings,
-                    ...modelConfig.modelSettings,
-                    maxRetries: modelConfig.maxRetries,
-                  },
-                  includeRawChunks,
-                  structuredOutput: currentStep.structuredOutput,
-                  // Merge headers: memory context first, then modelConfig headers, then modelSettings overrides
-                  // x-thread-id / x-resource-id enable server-side memory enrichment (e.g. Memory Gateway)
-                  headers: (() => {
-                    const memoryHeaders: Record<string, string> = {};
-                    if (_internal?.threadId) memoryHeaders['x-thread-id'] = _internal.threadId;
-                    if (_internal?.resourceId) memoryHeaders['x-resource-id'] = _internal.resourceId;
-                    const merged = {
-                      ...memoryHeaders,
-                      ...modelHeaders,
-                      ...currentStep.modelSettings?.headers,
-                    };
-                    return Object.keys(merged).length > 0 ? merged : undefined;
-                  })(),
-                  methodType,
-                  generateId: _internal?.generateId,
-                  onResult: ({
-                    warnings: warningsFromStream,
-                    request: requestFromStream,
-                    rawResponse: rawResponseFromStream,
-                  }) => {
-                    warnings = warningsFromStream;
-                    request = requestFromStream || {};
-                    rawResponse = rawResponseFromStream;
+            // Start the MODEL_STEP span immediately before the provider call so its
+            // duration reflects the actual model call, excluding step processors.
+            modelSpanTracker?.startStep();
 
-                    modelSpanTracker?.updateStep?.({
-                      request: request || {},
-                      inputMessages,
-                      warnings: warnings || [],
-                      messageId: currentStep.messageId,
-                    });
+            try {
+              modelResult = executeWithContextSync({
+                span: modelSpanTracker?.getTracingContext()?.currentSpan,
+                fn: () =>
+                  execute({
+                    runId,
+                    model: currentStep.model,
+                    // Per-model providerOptions deep-merge per provider key on top of call-time providerOptions
+                    providerOptions: mergeProviderOptions(currentStep.providerOptions, modelConfig.providerOptions),
+                    inputMessages,
+                    tools: currentStep.tools,
+                    toolChoice: currentStep.toolChoice,
+                    activeTools: currentStep.activeTools as string[] | undefined,
+                    options,
+                    // Per-model modelSettings shallow-merge on top of call-time modelSettings.
+                    // Per-model maxRetries always wins so p-retry uses the right retry count for this model.
+                    modelSettings: {
+                      ...currentStep.modelSettings,
+                      ...modelConfig.modelSettings,
+                      maxRetries: modelConfig.maxRetries,
+                    },
+                    includeRawChunks,
+                    structuredOutput: currentStep.structuredOutput,
+                    // Merge headers: memory context first, then modelConfig headers, then modelSettings overrides
+                    // x-thread-id / x-resource-id enable server-side memory enrichment (e.g. Memory Gateway)
+                    headers: (() => {
+                      const memoryHeaders: Record<string, string> = {};
+                      if (_internal?.threadId) memoryHeaders['x-thread-id'] = _internal.threadId;
+                      if (_internal?.resourceId) memoryHeaders['x-resource-id'] = _internal.resourceId;
+                      const merged = {
+                        ...memoryHeaders,
+                        ...modelHeaders,
+                        ...currentStep.modelSettings?.headers,
+                      };
+                      return Object.keys(merged).length > 0 ? merged : undefined;
+                    })(),
+                    methodType,
+                    generateId: _internal?.generateId,
+                    onResult: ({
+                      warnings: warningsFromStream,
+                      request: requestFromStream,
+                      rawResponse: rawResponseFromStream,
+                    }) => {
+                      warnings = warningsFromStream;
+                      request = requestFromStream || {};
+                      rawResponse = rawResponseFromStream;
 
-                    safeEnqueue(controller, {
-                      runId,
-                      from: ChunkFrom.AGENT,
-                      type: 'step-start',
-                      payload: {
+                      modelSpanTracker?.updateStep?.({
                         request: request || {},
+                        inputMessages,
                         warnings: warnings || [],
                         messageId: currentStep.messageId,
-                      },
-                    });
-                  },
-                  shouldThrowError: !isLastModel,
-                }),
-            });
+                      });
+
+                      safeEnqueue(controller, {
+                        runId,
+                        from: ChunkFrom.AGENT,
+                        type: 'step-start',
+                        payload: {
+                          request: request || {},
+                          warnings: warnings || [],
+                          messageId: currentStep.messageId,
+                        },
+                      });
+                    },
+                    shouldThrowError: !isLastModel,
+                  }),
+              });
+            } catch (error) {
+              endModelStep();
+              throw error;
+            }
           } else {
             throw new Error(
               `Unsupported model version: ${(currentStep.model as { specificationVersion?: string }).specificationVersion}. Supported versions: ${supportedLanguageModelSpecifications.join(', ')}`,
             );
           }
+
+          const tracedModelResult =
+            modelSpanTracker?.wrapStream?.(modelResult as ReadableStream<ChunkType<OUTPUT>>) ?? modelResult;
 
           const outputStream = new MastraModelOutput<OUTPUT>({
             model: {
@@ -834,7 +882,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               provider: currentStep.model.provider,
               version: currentStep.model.specificationVersion,
             },
-            stream: modelResult as ReadableStream<ChunkType<OUTPUT>>,
+            stream: tracedModelResult as ReadableStream<ChunkType<OUTPUT>>,
             messageList,
             messageId: currentStep.messageId,
             options: {
@@ -920,6 +968,19 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               });
 
               safeEnqueue(controller, { type: 'abort', runId, from: ChunkFrom.AGENT, payload: {} });
+              endModelStep({
+                messageId: outputStream.messageId,
+                text: outputStream._getImmediateText(),
+                usage: outputStream._getImmediateUsage() ?? inputData.output?.usage,
+                metadata: {
+                  providerMetadata: runState.state.providerOptions,
+                  ...runState.state.responseMetadata,
+                  ...rawResponse,
+                  modelMetadata: runState.state.modelMetadata,
+                  headers: rawResponse?.headers,
+                  request,
+                },
+              });
 
               return { callBail: true, outputStream, runState, stepTools: currentStep.tools };
             }
@@ -1025,6 +1086,19 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                 };
               }
 
+              endModelStep({
+                messageId: outputStream.messageId,
+                text: outputStream._getImmediateText(),
+                usage: outputStream._getImmediateUsage() ?? inputData.output?.usage,
+                metadata: {
+                  providerMetadata: runState.state.providerOptions,
+                  ...runState.state.responseMetadata,
+                  ...rawResponse,
+                  modelMetadata: runState.state.modelMetadata,
+                  headers: rawResponse?.headers,
+                  request,
+                },
+              });
               throw error;
             }
           }
@@ -1038,6 +1112,19 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             });
 
             safeEnqueue(controller, { type: 'abort', runId, from: ChunkFrom.AGENT, payload: {} });
+            endModelStep({
+              messageId: outputStream.messageId,
+              text: outputStream._getImmediateText(),
+              usage: outputStream._getImmediateUsage() ?? inputData.output?.usage,
+              metadata: {
+                providerMetadata: runState.state.providerOptions,
+                ...runState.state.responseMetadata,
+                ...rawResponse,
+                modelMetadata: runState.state.modelMetadata,
+                headers: rawResponse?.headers,
+                request,
+              },
+            });
 
             return { callBail: true, outputStream, runState, stepTools: currentStep.tools };
           }
@@ -1166,6 +1253,27 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           nonUser: [],
         };
 
+        modelSpanTracker?.endStep?.({
+          messageId: outputStream.messageId,
+          stepResult: {
+            reason: 'error' as any,
+            warnings,
+            isContinued: false,
+          },
+          output: {
+            text: outputStream._getImmediateText(),
+            toolCalls: [],
+            usage: outputStream._getImmediateUsage() ?? inputData.output?.usage,
+          },
+          metadata: {
+            providerMetadata: runState.state.providerOptions,
+            ...runState.state.responseMetadata,
+            modelMetadata: runState.state.modelMetadata,
+            headers: rawResponse?.headers,
+            request,
+          },
+        });
+
         return {
           messageId: outputStream.messageId,
           stepResult: {
@@ -1222,6 +1330,32 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           providerExecuted: inferProviderExecuted(chunk.payload.providerExecuted, tool),
         };
       });
+      const modelStepFinishReason = runState?.state?.stepResult?.reason ?? outputStream._getImmediateFinishReason();
+      const modelStepUsage = outputStream._getImmediateUsage() ?? inputData.output?.usage;
+      const modelStepObject = outputStream._getImmediateObject();
+
+      modelSpanTracker?.endStep?.({
+        messageId: outputStream.messageId,
+        stepResult: {
+          reason: modelStepFinishReason as any,
+          warnings,
+          isContinued: false,
+        },
+        output: {
+          text: outputStream._getImmediateText(),
+          toolCalls,
+          usage: modelStepUsage,
+          ...(modelStepObject ? { object: modelStepObject } : {}),
+        },
+        metadata: {
+          providerMetadata: runState.state.providerOptions,
+          ...runState.state.responseMetadata,
+          ...rawResponse,
+          modelMetadata: runState.state.modelMetadata,
+          headers: rawResponse?.headers,
+          request,
+        },
+      });
 
       // Call processOutputStep for processors (runs AFTER LLM response, BEFORE tool execution)
       // This allows processors to validate/modify the response and trigger retries if needed
@@ -1250,7 +1384,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           // Get current processor retry count from iteration data
           const currentRetryCount = inputData.processorRetryCount || 0;
 
-          // Use MODEL_STEP context so step processor spans are children of MODEL_STEP
+          // Output step processors run after the provider call, so they should not be
+          // children of the MODEL_STEP span that represents the provider call itself.
           const outputStepTracingContext = modelSpanTracker?.getTracingContext() ?? tracingContext;
 
           // Create a ProcessorStreamWriter from outputWriter if available.
@@ -1299,7 +1434,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       const usage = outputStream._getImmediateUsage();
       const responseMetadata = runState.state.responseMetadata;
       const text = outputStream._getImmediateText();
-      const object = outputStream._getImmediateObject();
+      const object = modelStepObject;
       // Check if tripwire was triggered (from stream processors or output step processors)
       const tripwireTriggered = outputStream.tripwire || processOutputStepTripwire !== null;
 

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -10,7 +10,7 @@ import { EntityType } from '@internal/core/storage';
 import type { MastraError } from '../../error';
 import type { Mastra } from '../../mastra';
 import type { RequestContext } from '../../request-context';
-import type { LanguageModelUsage, ProviderMetadata, StepStartPayload } from '../../stream/types';
+import type { LanguageModelUsage, ProviderMetadata, StepFinishPayload, StepStartPayload } from '../../stream/types';
 import type { WorkflowRunStatus, WorkflowStepStatus } from '../../workflows';
 import type {
   CustomSamplerOptions,
@@ -843,11 +843,12 @@ export interface IModelSpanTracker {
   wrapStream<T extends { pipeThrough: Function }>(stream: T): T;
   startStep(payload?: StepStartPayload): void;
   updateStep?(payload?: StepStartPayload): void;
+  endStep?(payload: StepFinishPayload): void;
 
   /**
    * Enable or disable deferred step closing for durable execution.
    * When enabled, step-finish chunks won't automatically close the step span.
-   * Use exportCurrentStep() to get the span data, then endDeferredStep() to close later.
+   * Use exportCurrentStep() to get the span data, then endStep() to close later.
    */
   setDeferStepClose(defer: boolean): void;
 


### PR DESCRIPTION
## Description

Fixes model step tracing so `MODEL_STEP` measures only the provider call instead of including input step processors, output step processors, or client-side tool execution. Updates durable execution and processor tracing expectations to match the new span hierarchy. Adds a focused regression test for the span boundary and a changeset for `@mastra/core` and `@mastra/observability`.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

Note: focused tests could not be run locally because this workspace is missing `node_modules` (`vitest`/`tsx` not found).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're timing how long it takes a chef to cook a meal. Right now, you're timing from when the chef starts preparing ingredients all the way until they plate the dish AND you get to eat it. This PR fixes the timing to measure only the actual cooking time, not the prep work before and the cleanup after. This way, you know exactly how fast the chef cooks, not how long the whole process takes.

## Overview

This PR refactors how `MODEL_STEP` spans are measured in tracing. Previously, the span encompassed the entire step lifecycle including input processors, output processors, and tool execution. Now, `MODEL_STEP` spans are scoped exclusively to provider calls, ensuring that LLM timing reflects only actual model execution.

## Changes

### Core Tracing Lifecycle Changes

**llm-execution-step.ts**: Reworked the `MODEL_STEP` tracing lifecycle by:
- Removing the unconditional `startStep()` call at the beginning
- Starting the span immediately before the provider `execute()` call
- Ending the span after the provider call completes but before output processors run
- Introducing a centralized `endModelStep` helper that handles span finalization across all control-flow paths (normal completion, errors, fallbacks, retries)

**loop.ts**: Removed wrapper logic that was keeping spans open across processors. Documentation clarifies that `MODEL_STEP` and `MODEL_CHUNK` spans are now handled entirely within `llm-execution-step`.

**durable/llm-execution.ts**: Replaced deferred step-closing behavior with explicit `endStep()` calls after streaming completes. Removed the export of `stepSpanData` and `stepFinishPayload` since the span is no longer kept open for tool execution.

### API Changes

**model-tracing.ts**: Exposed a new public `endStep<OUTPUT>()` method on `ModelSpanTracker` to allow external triggering of step completion (previously only internal via `#endStepSpan`).

**tracing.ts**: Updated the `IModelSpanTracker` interface to include an optional `endStep?(payload: StepFinishPayload)` hook for step completion reporting.

### Test Updates

**processor-tracing.test.ts**: Updated processor tracing test expectations to reflect the new span hierarchy:
- Input/output step processor spans are now asserted to be children of `MODEL_GENERATION` (not `MODEL_STEP`)
- Model chunk spans remain children of `MODEL_STEP`

**llm-execution-step.test.ts**: Added a focused regression test (`scopes MODEL_STEP tracing to the provider call only`) that validates the correct span boundaries and execution ordering, ensuring input/output processors and tool execution occur outside the `MODEL_STEP` span.

### Package Updates

**Changeset**: Bump @mastra/core and @mastra/observability with patch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->