### PR TITLE
docs(inngest): use /inngest/api so deployment guide works on core >=1.29 (#15743)

### DIFF
--- a/.changeset/inngest-deployment-non-api-path.md
+++ b/.changeset/inngest-deployment-non-api-path.md
@@ -2,15 +2,15 @@
 '@mastra/inngest': patch
 ---
 
-Updated JSDoc adapter examples to register Inngest at `/inngest/api` instead of `/api/inngest`. The Inngest deployment guide and the in-repo example projects use the same path.
+Updated the `serve` and `createServe` JSDoc adapter examples to register Inngest at `/inngest/api` instead of `/api/inngest`, matching the Inngest deployment guide and in-repo example projects.
 
 **Why**
 
-Mastra's server now rejects user-defined `apiRoutes[].path` values that start with the server's `apiPrefix` (default `/api`) because that prefix is reserved for built-in routes such as `/api/agents` and `/api/workflows`. Following the previous guide on a current `@mastra/core` caused the server to throw `Custom API route "/api/inngest" must not start with "/api"` at startup.
+Mastra reserves the `/api` prefix for built-in routes (agents, workflows, memory). Custom `apiRoutes[].path` values that start with the server's `apiPrefix` (default `/api`) are rejected at startup, so the previous JSDoc snippets threw `Custom API route "/api/inngest" must not start with "/api"` when copy-pasted into a current Mastra project.
 
 **Migration**
 
-If you registered Inngest with the previous guide:
+If you registered Inngest with the previous guide or JSDoc example:
 
 ```ts
 // Before
@@ -34,4 +34,4 @@ apiRoutes: [
 
 Update the dev server URL (`npx inngest-cli dev -u http://localhost:4111/inngest/api`) and, in production, set the **URL** field on your Inngest app to match.
 
-If you cannot change the path, set `server.apiPrefix` (for example `/_mastra`) to relocate Mastra's built-in routes and remember to update `server.auth.protected` and any `MastraClient` `apiPrefix` to match. See the [Inngest deployment guide](https://mastra.ai/guides/deployment/inngest) for the full walkthrough.
+If you cannot change the path, set `server.apiPrefix` (for example `/_mastra`) to relocate the built-in routes and remember to update `server.auth.protected` and any `MastraClient` `apiPrefix` to match. See the [Inngest deployment guide](https://mastra.ai/guides/deployment/inngest) for the full walkthrough.

--- a/.changeset/inngest-deployment-non-api-path.md
+++ b/.changeset/inngest-deployment-non-api-path.md
@@ -1,0 +1,37 @@
+---
+'@mastra/inngest': patch
+---
+
+Updated JSDoc adapter examples to register Inngest at `/inngest/api` instead of `/api/inngest`. The Inngest deployment guide and the in-repo example projects use the same path.
+
+**Why**
+
+Mastra's server now rejects user-defined `apiRoutes[].path` values that start with the server's `apiPrefix` (default `/api`) because that prefix is reserved for built-in routes such as `/api/agents` and `/api/workflows`. Following the previous guide on a current `@mastra/core` caused the server to throw `Custom API route "/api/inngest" must not start with "/api"` at startup.
+
+**Migration**
+
+If you registered Inngest with the previous guide:
+
+```ts
+// Before
+apiRoutes: [
+  {
+    path: '/api/inngest',
+    method: 'ALL',
+    createHandler: async ({ mastra }) => serve({ mastra, inngest }),
+  },
+]
+
+// After
+apiRoutes: [
+  {
+    path: '/inngest/api',
+    method: 'ALL',
+    createHandler: async ({ mastra }) => serve({ mastra, inngest }),
+  },
+]
+```
+
+Update the dev server URL (`npx inngest-cli dev -u http://localhost:4111/inngest/api`) and, in production, set the **URL** field on your Inngest app to match.
+
+If you cannot change the path, set `server.apiPrefix` (for example `/_mastra`) to relocate Mastra's built-in routes and remember to update `server.auth.protected` and any `MastraClient` `apiPrefix` to match. See the [Inngest deployment guide](https://mastra.ai/guides/deployment/inngest) for the full walkthrough.

--- a/docs/src/content/en/guides/deployment/inngest.mdx
+++ b/docs/src/content/en/guides/deployment/inngest.mdx
@@ -126,7 +126,7 @@ export const mastra = new Mastra({
     host: '0.0.0.0',
     apiRoutes: [
       {
-        path: '/api/inngest',
+        path: '/inngest/api',
         method: 'ALL',
         createHandler: async ({ mastra }) => {
           return serve({ mastra, inngest })
@@ -138,6 +138,10 @@ export const mastra = new Mastra({
 })
 ```
 
+:::note
+The path is `/inngest/api`, not `/api/inngest`. Mastra reserves the `/api` prefix for built-in routes (agents, workflows, memory). Custom `apiRoutes` paths that start with the server's `apiPrefix` (default `/api`) throw at startup. See [#15743](https://github.com/mastra-ai/mastra/pull/15743) for context, or skip to [Using a custom `apiPrefix`](#using-a-custom-apiprefix) if you need to keep `/api/inngest`.
+:::
+
 ## Running workflows
 
 ### Running locally
@@ -147,11 +151,11 @@ export const mastra = new Mastra({
 1. Start the Inngest Dev Server. In a new terminal, run:
 
    ```bash
-   npx inngest-cli@latest dev -u http://localhost:4111/api/inngest
+   npx inngest-cli@latest dev -u http://localhost:4111/inngest/api
    ```
 
    :::note
-   The URL after `-u` tells the Inngest dev server where to find your Mastra `/api/inngest` endpoint
+   The URL after `-u` tells the Inngest dev server where to find your Mastra `/inngest/api` endpoint
    :::
 
 1. Open the Inngest Dashboard at [http://localhost:8288](http://localhost:8288) and go to the **Apps** section in the sidebar to verify your Mastra workflow is registered
@@ -215,6 +219,10 @@ Before you begin, make sure you have:
    ```
 
 1. Sync with the [Inngest dashboard](https://app.inngest.com/env/production/apps) by selecting **Sync new app with Vercel** and following the instructions
+
+   :::warning
+   Inngest's auto-discover convention assumes `/api/inngest`. Because this guide uses `/inngest/api`, set the **URL** field on the Inngest app to your deployed origin plus `/inngest/api` (for example `https://your-app.vercel.app/inngest/api`). If you leave it on the default, the Inngest dashboard will not find your app's functions.
+   :::
 
 1. Invoke the workflow by going to **Functions**, selecting `workflow.increment-workflow`, selecting **All actions** > **Invoke**, and providing the following input:
 
@@ -281,7 +289,7 @@ export const mastra = new Mastra({
     host: '0.0.0.0',
     apiRoutes: [
       {
-        path: '/api/inngest',
+        path: '/inngest/api',
         method: 'ALL',
         createHandler: async ({ mastra }) => {
           return serve({
@@ -303,7 +311,7 @@ When you include custom functions:
 
 1. Mastra workflows are automatically converted to Inngest functions with IDs like `workflow.${workflowId}`
 1. Custom functions retain their specified IDs (e.g., `send-welcome-email`, `process-webhook`)
-1. All functions are served together on the same `/api/inngest` endpoint
+1. All functions are served together on the same `/inngest/api` endpoint
 
 This allows you to combine Mastra's workflow orchestration with your existing Inngest functions.
 
@@ -325,7 +333,7 @@ const app = express()
 app.use(express.json())
 
 const handler = createServe(expressAdapter)({ mastra, inngest })
-app.use('/api/inngest', handler)
+app.use('/inngest/api', handler)
 
 app.listen(3000)
 ```
@@ -345,7 +353,7 @@ const handler = createServe(fastifyAdapter)({ mastra, inngest })
 
 fastify.route({
   method: ['GET', 'POST', 'PUT'],
-  url: '/api/inngest',
+  url: '/inngest/api',
   handler,
 })
 
@@ -369,7 +377,7 @@ const router = new Router()
 app.use(bodyParser())
 
 const handler = createServe(koaAdapter)({ mastra, inngest })
-router.all('/api/inngest', handler)
+router.all('/inngest/api', handler)
 
 app.use(router.routes())
 app.use(router.allowedMethods())
@@ -379,7 +387,7 @@ app.listen(3000)
 
 ### Next.js
 
-```ts title="app/api/inngest/route.ts"
+```ts title="app/inngest/api/route.ts"
 import { createServe } from '@mastra/inngest'
 import { serve as nextAdapter } from 'inngest/next'
 import { mastra, inngest } from '@/mastra'
@@ -392,6 +400,34 @@ export { handler as GET, handler as POST, handler as PUT }
 ### Available adapters
 
 The `createServe` function works with any Inngest adapter. See the [Inngest serve documentation](https://www.inngest.com/docs/reference/serve) for a complete list of available adapters including AWS Lambda, Cloudflare Workers, and more.
+
+## Using a custom `apiPrefix`
+
+If you need to keep `/api/inngest` (for example to match Inngest's auto-discover convention without changing the dashboard URL), set `server.apiPrefix` to relocate Mastra's built-in routes:
+
+```ts title="src/mastra/index.ts" {6,9}
+import { Mastra } from '@mastra/core'
+import { serve } from '@mastra/inngest'
+
+export const mastra = new Mastra({
+  server: {
+    apiPrefix: '/_mastra',
+    apiRoutes: [
+      {
+        path: '/api/inngest',
+        method: 'ALL',
+        createHandler: async ({ mastra }) => serve({ mastra, inngest }),
+      },
+    ],
+  },
+})
+```
+
+Mastra's built-in routes now resolve under `/_mastra/agents`, `/_mastra/workflows`, and so on, freeing the `/api/inngest` path for your custom route.
+
+:::warning
+The default auth configuration protects `/api/*` and treats `/api`, `/api/auth/*` as public. When you change `apiPrefix`, those defaults no longer match and built-in routes fall outside the protected pattern. Update `server.auth.protected` and `server.auth.public` to reference the new prefix, and update any client code (including [`MastraClient`](/docs/server/mastra-client) `apiPrefix`) that hits `/api/*`.
+:::
 
 ## Flow control
 

--- a/docs/src/content/en/guides/deployment/inngest.mdx
+++ b/docs/src/content/en/guides/deployment/inngest.mdx
@@ -405,9 +405,10 @@ The `createServe` function works with any Inngest adapter. See the [Inngest serv
 
 If you need to keep `/api/inngest` (for example to match Inngest's auto-discover convention without changing the dashboard URL), set `server.apiPrefix` to relocate Mastra's built-in routes:
 
-```ts title="src/mastra/index.ts" {6,9}
+```ts title="src/mastra/index.ts" {7,10}
 import { Mastra } from '@mastra/core'
 import { serve } from '@mastra/inngest'
+import { inngest } from './inngest'
 
 export const mastra = new Mastra({
   server: {

--- a/examples/durable-agents/docker-compose.yaml
+++ b/examples/durable-agents/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
 
   inngest:
     image: inngest/inngest:v1.12.1
-    command: inngest dev -p 8288 -u http://host.docker.internal:4111/api/inngest --poll-interval=1
+    command: inngest dev -p 8288 -u http://host.docker.internal:4111/inngest/api --poll-interval=1
     ports:
       - '8288:8288'
     extra_hosts:

--- a/examples/durable-agents/package.json
+++ b/examples/durable-agents/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "mastra:dev": "mastra dev",
-    "start:inngest:server": "npx inngest-cli@latest dev -u http://localhost:3000/api/inngest"
+    "start:inngest:server": "npx inngest-cli@latest dev -u http://localhost:3000/inngest/api"
   },
   "keywords": [],
   "author": "",

--- a/examples/durable-agents/src/mastra/index.ts
+++ b/examples/durable-agents/src/mastra/index.ts
@@ -57,7 +57,7 @@ export const mastra = new Mastra({
     host: '0.0.0.0',
     apiRoutes: [
       {
-        path: '/api/inngest',
+        path: '/inngest/api',
         method: 'ALL',
         createHandler: async ({ mastra }) => inngestServe({ mastra, inngest }),
       },

--- a/examples/inngest/README.md
+++ b/examples/inngest/README.md
@@ -378,7 +378,7 @@ export const mastra = new Mastra({
     host: '0.0.0.0',
     apiRoutes: [
       {
-        path: '/api/inngest', // API endpoint for Inngest to send events to
+        path: '/inngest/api', // API endpoint for Inngest to send events to
         method: 'ALL',
         createHandler: async ({ mastra }) => inngestServe({ mastra, inngest }),
       },

--- a/examples/inngest/package.json
+++ b/examples/inngest/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "mastra:dev": "mastra dev",
-    "start:inngest:server": "npx inngest-cli@latest dev -u http://localhost:3000/api/inngest"
+    "start:inngest:server": "npx inngest-cli@latest dev -u http://localhost:3000/inngest/api"
   },
   "keywords": [],
   "author": "",

--- a/workflows/inngest/src/index.test.ts
+++ b/workflows/inngest/src/index.test.ts
@@ -13984,7 +13984,7 @@ describe('MastraInngestWorkflow', () => {
         server: {
           apiRoutes: [
             {
-              path: '/api/inngest',
+              path: '/inngest/api',
               method: 'ALL',
               createHandler: async ({ mastra }) =>
                 inngestServe({
@@ -14018,7 +14018,7 @@ describe('MastraInngestWorkflow', () => {
 
       try {
         // Make a request to the Inngest endpoint to get function introspection
-        const response = await fetch(`http://127.0.0.1:${port}/api/inngest`);
+        const response = await fetch(`http://127.0.0.1:${port}/inngest/api`);
         expect(response.ok).toBe(true);
 
         const introspectionData = await response.json();

--- a/workflows/inngest/src/serve.ts
+++ b/workflows/inngest/src/serve.ts
@@ -80,6 +80,7 @@ function prepareServeOptions({ mastra, inngest, functions: userFunctions = [], r
  *
  * @example Next.js
  * ```ts
+ * // app/inngest/api/route.ts — file path determines the route URL
  * import { createServe } from '@mastra/inngest';
  * import { serve } from 'inngest/next';
  *

--- a/workflows/inngest/src/serve.ts
+++ b/workflows/inngest/src/serve.ts
@@ -62,7 +62,7 @@ function prepareServeOptions({ mastra, inngest, functions: userFunctions = [], r
  * import { serve } from 'inngest/express';
  *
  * const serveExpress = createServe(serve);
- * app.use('/api/inngest', serveExpress({ mastra, inngest }));
+ * app.use('/inngest/api', serveExpress({ mastra, inngest }));
  * ```
  *
  * @example Fastify
@@ -74,7 +74,7 @@ function prepareServeOptions({ mastra, inngest, functions: userFunctions = [], r
  * fastify.route({
  *   method: ['GET', 'POST', 'PUT'],
  *   handler: serveFastify({ mastra, inngest }),
- *   url: '/api/inngest',
+ *   url: '/inngest/api',
  * });
  * ```
  *
@@ -105,7 +105,7 @@ export function createServe<THandler>(
  * ```ts
  * import { serve } from '@mastra/inngest';
  *
- * app.use('/api/inngest', async (c) => {
+ * app.use('/inngest/api', async (c) => {
  *   return serve({ mastra, inngest })(c);
  * });
  * ```


### PR DESCRIPTION
## Summary

Switches the Inngest deployment guide (and aligned in-repo references) from `/api/inngest` to `/inngest/api` so the guide works on `@mastra/core ≥ 1.29`.

After [#15743](https://github.com/mastra-ai/mastra/pull/15743), `MastraServer.validateCustomRoutePaths` rejects user-defined `apiRoutes[].path` values that start with the server's `apiPrefix` (default `/api`):

```ts
// packages/server/src/server/server-adapter/index.ts:528
protected validateCustomRoutePaths(routes: ApiRoute[]): void {
  const prefix = this.prefix ?? '';
  if (!prefix) return;
  for (const route of routes) {
    if (route._mastraInternal) continue;
    if (route.path.startsWith(`${prefix}/`) || route.path === prefix) {
      throw new Error(
        `Custom API route "${route.path}" must not start with "${prefix}" — ` +
          `that path is reserved for built-in Mastra routes. ` +
          `Choose a different path (e.g. "${route.path.replace(prefix, '/custom')}").`,
      );
    }
  }
}
```

The follow-up [#15952](https://github.com/mastra-ai/mastra/pull/15952) carved out *framework-generated channel-adapter webhook routes* (Slack and friends) via `route._mastraInternal`. It does **not** apply to user-supplied Inngest routes, so the deployment guide is the right place to fix this.

The previous guide caused module-init crashes in production. Concrete repro: `@mastra/core@1.31.0 + @mastra/inngest@1.3.0 + @mastra/deployer-vercel@1.1.24` on Vercel surfaces as `FUNCTION_INVOCATION_FAILED` with no log line above the validator stack trace (`MastraServer.validateCustomRoutePaths → MastraServer.buildCustomRouteHandler → MastraServer.registerCustomApiRoutes → createHonoServer`), invisible to `vercel inspect` and only retrievable via `vercel logs <preview-url>`.

## What changed

- **`docs/src/content/en/guides/deployment/inngest.mdx`** — every `apiRoutes` example uses `/inngest/api`. The Inngest CLI dev URL and the Express/Fastify/Koa/Next.js adapter examples are aligned for consistency. Added a `:::note` after the registration block linking to #15743 to pre-empt confused readers comparing this to upstream Inngest docs, and a `:::warning` in the production deploy steps reminding users to update the **URL** field on their Inngest app (Inngest's auto-discover convention assumes `/api/inngest`).
- **`Using a custom apiPrefix` subsection** — documents the supported escape hatch for users who must keep `/api/inngest` (set `server.apiPrefix: '/_mastra'`), with a `:::warning` covering the auth-defaults caveat (the default `protected: ['/api/*']` and `public: ['/api', '/api/auth/*']` patterns no longer match a custom prefix and need to be updated alongside any `MastraClient` `apiPrefix`).
- **`examples/durable-agents/`** — `src/mastra/index.ts`, `docker-compose.yaml`, and the `start:inngest:server` script in `package.json` all use the new path. The previous example was crashing on startup against the linked local `@mastra/core`.
- **`examples/inngest/`** — `README.md` apiRoutes example and the `start:inngest:server` script in `package.json`.
- **`workflows/inngest/src/serve.ts`** — JSDoc `@example` adapter snippets aligned with the docs. (These mount on the user's own framework so the validator never sees them, but consistency matters.)
- **`workflows/inngest/src/index.test.ts`** — `serve function with user-supplied functions` test fixture now uses `/inngest/api`. The test calls `createHonoServer(testMastra)`, which routes through `registerCustomApiRoutes → buildCustomRouteHandler → validateCustomRoutePaths` with the default `apiPrefix='/api'`, so the prior fixture would have hit the validator.
- **Changeset** — `@mastra/inngest` patch (the JSDoc text ships with the package).

The validator itself is **not** modified. No new framework carve-outs.

## Test plan

- [x] Sweep for residual `/api/inngest` references in `docs/`, `packages/`, `examples/`, `templates/`, and `workflows/inngest/src/` — only intentional mentions remain (inside admonitions explaining the change and inside the `apiPrefix` example showing how to keep the original path).
- [ ] Docs build / prose lint (`cd docs && pnpm run build && pnpm run lint:prose`) — couldn't run locally because docs `node_modules` aren't installed in this worktree; relying on CI.
- [ ] Run `examples/durable-agents` end-to-end with the new path on a current `@mastra/core` and confirm startup no longer throws `Custom API route "..." must not start with "/api"`.
- [ ] Run the targeted vitest in `workflows/inngest/src/index.test.ts` (`pnpm --filter @mastra/inngest test:workflow -t \"should merge user-supplied functions\"`) — couldn't run locally because the package's `vitest` binary isn't in `node_modules` here; this fixture would have been throwing post-#15743 and now exercises the validator-clean path.
- [ ] Smoke-test against the corrected guide: `npx inngest-cli@latest dev -u http://localhost:4111/inngest/api` reaches the app and discovers the workflow function.

## Reviewer notes

Tagging @wardpeet as the merger of #15743 — would value a sanity check on the path choice (`/inngest/api`) and the framing of the `apiPrefix` escape hatch, particularly the auth-defaults warning. Happy to drop the apiPrefix subsection entirely if it feels load-bearing or like it belongs on a dedicated config page.

🤖 _This PR was authored by Claude Code._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

Mastra moved the Inngest endpoint so it doesn't accidentally collide with Mastra's reserved /api routes. This PR replaces /api/inngest with /inngest/api across docs, examples, and tests so projects that use Mastra ≥1.29 start cleanly.

## Summary

This PR updates the Inngest deployment guide, in-repo examples, JSDoc snippets, tests, and a changeset to register Inngest at /inngest/api instead of /api/inngest. The change is required because @mastra/core ≥1.29 validates and rejects custom apiRoutes paths that start with the server's reserved apiPrefix (default /api). A documented escape hatch shows how to retain /api/inngest by moving Mastra’s built-in routes via server.apiPrefix (example: '/_mastra') and warns to update related auth and MastraClient apiPrefix settings.

### Changes by Area

- Documentation & Guides
  - docs/src/content/en/guides/deployment/inngest.mdx: all apiRoutes examples switched to /inngest/api; added note referencing #15743 and a warning to update the Inngest app URL; added "Using a custom apiPrefix" subsection showing how to keep /api/inngest by changing server.apiPrefix and warning to update auth/protected settings.
- Examples
  - examples/durable-agents/: updated src/mastra/index.ts, docker-compose.yaml, and start:inngest:server script to use /inngest/api.
  - examples/inngest/: updated README snippet and start:inngest:server script to use /inngest/api.
- Code & Tests
  - workflows/inngest/src/serve.ts: JSDoc/example snippets aligned with docs (/inngest/api).
  - workflows/inngest/src/index.test.ts: test fixture updated to /inngest/api so it no longer triggers the validator.
- Changeset
  - .changeset/inngest-deployment-non-api-path.md: documents the migration and rationale; JSDoc text scoped to @mastra/inngest.

Notes:
- The server-side validator was not changed; this is a docs/examples migration to match current validator behavior.
- Some historical occurrences remain (workflows/inngest/CHANGELOG.md contains past references to /api/inngest) and the docs intentionally show how to preserve /api/inngest via server.apiPrefix for users who need it.

Request from author: sanity check on the chosen /inngest/api path and the wording for the apiPrefix escape hatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->