### PR TITLE
fix prompt block version editor reset

### DIFF
--- a/.changeset/fix-prompt-version-editor.md
+++ b/.changeset/fix-prompt-version-editor.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed prompt block version selection so the editor and description field show the selected version's content.

--- a/packages/playground/e2e/tests/cms/prompts/edit/page.spec.ts
+++ b/packages/playground/e2e/tests/cms/prompts/edit/page.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { resetStorage } from '../../../__utils__/reset-storage';
+
+const PORT = process.env.E2E_PORT || '4111';
+const BASE_URL = `http://localhost:${PORT}`;
+
+type PromptBlockResponse = {
+  id: string;
+};
+
+type PromptBlockVersion = {
+  id: string;
+  versionNumber: number;
+};
+
+type PromptBlockVersionsResponse = {
+  versions: PromptBlockVersion[];
+};
+
+async function apiRequest<T>(path: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(`${BASE_URL}/api${path}`, {
+    ...options,
+    headers: {
+      'content-type': 'application/json',
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status} ${await response.text()}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+async function createPromptBlockVersions() {
+  const blockId = `version-switch-${Date.now().toString(36)}`;
+
+  const created = await apiRequest<PromptBlockResponse>('/stored/prompt-blocks', {
+    method: 'POST',
+    body: JSON.stringify({
+      id: blockId,
+      name: 'Version Switch Prompt',
+      description: 'Original prompt description',
+      content: 'Original prompt content',
+    }),
+  });
+
+  await apiRequest<PromptBlockResponse>(`/stored/prompt-blocks/${created.id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      name: 'Version Switch Prompt',
+      description: 'Latest prompt description',
+      content: 'Latest prompt content',
+    }),
+  });
+
+  const { versions } = await apiRequest<PromptBlockVersionsResponse>(
+    `/stored/prompt-blocks/${created.id}/versions?sortDirection=DESC`,
+  );
+
+  const originalVersion = versions.find(version => version.versionNumber === 1);
+  if (!originalVersion) {
+    throw new Error('Could not find original prompt block version');
+  }
+
+  return { blockId: created.id, originalVersion };
+}
+
+test.afterEach(async () => {
+  await resetStorage();
+});
+
+test.describe('Prompt Block Version Editing', () => {
+  test('shows selected version content in the editor and sidebar', async ({ page }) => {
+    /**
+     * FEATURE: Prompt block version browsing.
+     * USER STORY: As a Studio user, I want selecting an older prompt block version to show that version's saved data.
+     * BEHAVIOR UNDER TEST: Version selection changes both the main editor content and sidebar description values.
+     */
+    const { blockId, originalVersion } = await createPromptBlockVersions();
+
+    await page.goto(`/cms/prompts/${blockId}/edit`);
+
+    await expect(page.locator('#prompt-block-description')).toHaveValue('Latest prompt description');
+    await expect(page.locator('.cm-content')).toContainText('Latest prompt content');
+
+    await page.getByRole('combobox').first().click();
+    await page.getByRole('option', { name: /v1/ }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/cms/prompts/${blockId}/edit\\?versionId=${originalVersion.id}`));
+    await expect(page.getByText('This is a previous version')).toBeVisible();
+    await expect(page.locator('#prompt-block-description')).toHaveValue('Original prompt description');
+    await expect(page.locator('.cm-content')).toContainText('Original prompt content');
+    await expect(page.locator('.cm-content')).not.toContainText('Latest prompt content');
+
+    await page.reload();
+
+    await expect(page.locator('#prompt-block-description')).toHaveValue('Original prompt description');
+    await expect(page.locator('.cm-content')).toContainText('Original prompt content');
+  });
+});

--- a/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-main.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-main.tsx
@@ -8,9 +8,10 @@ import { DisplayConditionsDialog, SectionHeader } from '@/domains/cms';
 
 interface PromptBlockEditMainProps {
   form: UseFormReturn<PromptBlockFormValues>;
+  formResetKey?: number;
 }
 
-export function PromptBlockEditMain({ form }: PromptBlockEditMainProps) {
+export function PromptBlockEditMain({ form, formResetKey = 0 }: PromptBlockEditMainProps) {
   const { control, setValue } = form;
 
   const schema = useWatch({ control, name: 'variables' }) as JsonSchema | undefined;
@@ -40,6 +41,7 @@ export function PromptBlockEditMain({ form }: PromptBlockEditMainProps) {
         render={({ field }) => (
           <div className="flex-1 flex flex-col">
             <CodeEditor
+              key={formResetKey}
               value={field.value ?? ''}
               onChange={field.onChange}
               language="markdown"

--- a/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
+++ b/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
@@ -210,7 +210,7 @@ function CmsPromptBlocksEditForm({
         </Notice>
       )}
       <form className="h-full">
-        <PromptBlockEditMain form={form} />
+        <PromptBlockEditMain form={form} formResetKey={formResetKey} />
       </form>
     </AgentEditLayout>
   );

--- a/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
+++ b/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
@@ -93,7 +93,7 @@ function CmsPromptBlocksEditForm({
   const [formResetKey, setFormResetKey] = useState(0);
 
   useEffect(() => {
-    if (initialValues && !form.formState.isDirty) {
+    if (initialValues) {
       form.reset(initialValues);
       setFormResetKey(prev => prev + 1);
     }


### PR DESCRIPTION
## Description

Fixes prompt block version browsing in Studio so selecting an older version resets the edit form and updates both the CodeMirror editor and sidebar description. Adds an E2E regression that creates prompt block versions, selects the previous version from the dropdown, and verifies the selected content survives reload.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
