### PR TITLE
fix(memory): default observational memory config model

### DIFF
--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -33,7 +33,7 @@ export const agent = new Agent({
 })
 ```
 
-That's it. The agent now has humanlike long-term memory that persists across conversations. Setting `observationalMemory: true` uses `google/gemini-2.5-flash` by default. To use a different model or customize thresholds, pass a config object instead:
+That's it. The agent now has humanlike long-term memory that persists across conversations. Setting `observationalMemory: true` uses `google/gemini-2.5-flash` by default. Config objects also use this model unless you set a different one. To use a different model, pass it in the config object:
 
 ```typescript
 const memory = new Memory({
@@ -58,7 +58,7 @@ For an AI SDK example, see [Using Mastra Memory](/guides/build-your-ui/ai-sdk-ui
 :::note
 
 OM currently only supports `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb` storage adapters.
-It uses background agents for managing memory. When using `observationalMemory: true`, the default model is `google/gemini-2.5-flash`. When passing a config object, a `model` must be explicitly set.
+It uses background agents for managing memory. When no model is set, the default model is `google/gemini-2.5-flash`.
 
 :::
 
@@ -227,7 +227,7 @@ The progress bars update live while the agent is observing or reflecting, showin
 
 ## Models
 
-The Observer and Reflector run in the background. Any model that works with Mastra's [model routing](/models) (`provider/model`) can be used. When using `observationalMemory: true`, the default model is `google/gemini-2.5-flash`. When passing a config object, a `model` must be explicitly set.
+The Observer and Reflector run in the background. Any model that works with Mastra's [model routing](/models) (`provider/model`) can be used. When no model is set, the default model is `google/gemini-2.5-flash`.
 
 Generally speaking, we recommend using a model that has a large context window (128K+ tokens) and is fast enough to run in the background without slowing down your actions.
 

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -7308,7 +7308,7 @@ describe('Model Requirement', () => {
     ).toThrow('Please bump @mastra/core to a newer version');
   });
 
-  it('should throw when no model is provided at all', () => {
+  it('should use the default model when no model is provided', () => {
     expect(
       () =>
         new ObservationalMemory({
@@ -7317,19 +7317,7 @@ describe('Model Requirement', () => {
           observation: { messageTokens: 50000 },
           reflection: { observationTokens: 20000 },
         }),
-    ).toThrow('Observational Memory requires a model to be set');
-  });
-
-  it('should include docs link in model error', () => {
-    expect(
-      () =>
-        new ObservationalMemory({
-          storage: createInMemoryStorage(),
-          scope: 'thread',
-          observation: { messageTokens: 50000 },
-          reflection: { observationTokens: 20000 },
-        }),
-    ).toThrow('https://mastra.ai/docs/memory/observational-memory#models');
+    ).not.toThrow();
   });
 
   it('should accept a top-level model', () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { injectAnchorIds, parseAnchorId, stripEphemeralAnchorIds } from '../anchor-ids';
 import { BufferingCoordinator } from '../buffering-coordinator';
+import { OBSERVATIONAL_MEMORY_DEFAULTS } from '../constants';
 import {
   filterObservedMessages,
   getBufferedChunks,
@@ -7374,6 +7375,30 @@ describe('Model Requirement', () => {
           reflection: { observationTokens: 20000 },
         }),
     ).not.toThrow();
+  });
+
+  it('should resolve model: "default" using contextual observation and reflection defaults', () => {
+    const originalObservationModel = OBSERVATIONAL_MEMORY_DEFAULTS.observation.model;
+    const originalReflectionModel = OBSERVATIONAL_MEMORY_DEFAULTS.reflection.model;
+
+    try {
+      OBSERVATIONAL_MEMORY_DEFAULTS.observation.model = 'test/observer-default';
+      OBSERVATIONAL_MEMORY_DEFAULTS.reflection.model = 'test/reflector-default';
+
+      const om = new ObservationalMemory({
+        storage: createInMemoryStorage(),
+        scope: 'thread',
+        model: 'default',
+        observation: { messageTokens: 50000 },
+        reflection: { observationTokens: 20000 },
+      });
+
+      expect((om as any).observationConfig.model).toBe('test/observer-default');
+      expect((om as any).reflectionConfig.model).toBe('test/reflector-default');
+    } finally {
+      OBSERVATIONAL_MEMORY_DEFAULTS.observation.model = originalObservationModel;
+      OBSERVATIONAL_MEMORY_DEFAULTS.reflection.model = originalReflectionModel;
+    }
   });
 
   it('should not allow top-level model with observation.model', () => {

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -374,26 +374,21 @@ export class ObservationalMemory {
     this.onIndexObservations = config.onIndexObservations;
     this.mastra = config.mastra;
 
-    // Resolve "default" to the default model
+    // Resolve "default" to the default model.
     const resolveModel = (m: typeof config.model) =>
       m === 'default' ? OBSERVATIONAL_MEMORY_DEFAULTS.observation.model : m;
 
-    // Require an explicit model — no silent default.
-    // Resolution order: top-level model → sub-config model → the other sub-config model → error
+    // Resolution order: top-level model → sub-config model → the other sub-config model → default.
     const observationModel =
-      resolveModel(config.model) ?? resolveModel(config.observation?.model) ?? resolveModel(config.reflection?.model);
+      resolveModel(config.model) ??
+      resolveModel(config.observation?.model) ??
+      resolveModel(config.reflection?.model) ??
+      OBSERVATIONAL_MEMORY_DEFAULTS.observation.model;
     const reflectionModel =
-      resolveModel(config.model) ?? resolveModel(config.reflection?.model) ?? resolveModel(config.observation?.model);
-
-    if (!observationModel || !reflectionModel) {
-      throw new Error(
-        `Observational Memory requires a model to be set. Use \`observationalMemory: true\` for the default (google/gemini-2.5-flash), or set a model explicitly:\n\n` +
-          `  observationalMemory: {\n` +
-          `    model: "$provider/$model",\n` +
-          `  }\n\n` +
-          `See https://mastra.ai/docs/memory/observational-memory#models for model recommendations and alternatives.`,
-      );
-    }
+      resolveModel(config.model) ??
+      resolveModel(config.reflection?.model) ??
+      resolveModel(config.observation?.model) ??
+      OBSERVATIONAL_MEMORY_DEFAULTS.reflection.model;
 
     // Get base thresholds first (needed for shared budget calculation)
     const messageTokens = config.observation?.messageTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.messageTokens;

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -374,20 +374,20 @@ export class ObservationalMemory {
     this.onIndexObservations = config.onIndexObservations;
     this.mastra = config.mastra;
 
-    // Resolve "default" to the default model.
-    const resolveModel = (m: typeof config.model) =>
-      m === 'default' ? OBSERVATIONAL_MEMORY_DEFAULTS.observation.model : m;
+    // Resolve "default" to the model default for the agent being configured.
+    const resolveModel = (model: ObservationalMemoryModel | undefined, defaultModel: string) =>
+      model === 'default' ? defaultModel : model;
 
     // Resolution order: top-level model → sub-config model → the other sub-config model → default.
     const observationModel =
-      resolveModel(config.model) ??
-      resolveModel(config.observation?.model) ??
-      resolveModel(config.reflection?.model) ??
+      resolveModel(config.model, OBSERVATIONAL_MEMORY_DEFAULTS.observation.model) ??
+      resolveModel(config.observation?.model, OBSERVATIONAL_MEMORY_DEFAULTS.observation.model) ??
+      resolveModel(config.reflection?.model, OBSERVATIONAL_MEMORY_DEFAULTS.observation.model) ??
       OBSERVATIONAL_MEMORY_DEFAULTS.observation.model;
     const reflectionModel =
-      resolveModel(config.model) ??
-      resolveModel(config.reflection?.model) ??
-      resolveModel(config.observation?.model) ??
+      resolveModel(config.model, OBSERVATIONAL_MEMORY_DEFAULTS.reflection.model) ??
+      resolveModel(config.reflection?.model, OBSERVATIONAL_MEMORY_DEFAULTS.reflection.model) ??
+      resolveModel(config.observation?.model, OBSERVATIONAL_MEMORY_DEFAULTS.reflection.model) ??
       OBSERVATIONAL_MEMORY_DEFAULTS.reflection.model;
 
     // Get base thresholds first (needed for shared budget calculation)


### PR DESCRIPTION
## Summary
- Restore default model fallback for Observational Memory config objects that omit `model`
- Keep explicit top-level, observation, and reflection model overrides working
- Update Observational Memory docs and model requirement tests to match the non-breaking behavior

## Test plan
- `pnpm --filter ./packages/memory exec vitest run src/processors/observational-memory/__tests__/observational-memory.test.ts -t "Model Requirement" --reporter=dot`
- `pnpm --filter ./packages/memory check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR restores a safe default for Observational Memory so configs that omit a model no longer fail—OM now falls back to the documented default model (and supports a contextual "default" sentinel) while still allowing explicit overrides.

## Changes

**Code Changes** (`observational-memory.ts`):
- Restore non-breaking defaulting: constructor now computes observationModel and reflectionModel via a deterministic fallback chain that ultimately uses OBSERVATIONAL_MEMORY_DEFAULTS rather than throwing when a model is omitted.
- Support contextual "default" sentinel: the literal "default" value is resolved against the agent-specific observation or reflection default (so top-level, observation-level, and reflection-level overrides work correctly).
- Removed the prior error path that required explicit model resolution for both observer and reflector.

**Test Updates** (`observational-memory.test.ts`):
- "Model Requirement" test updated to expect successful construction without an explicit model (uses the default) instead of expecting a thrown error.
- New test added to verify that model: "default" resolves to the contextual observation/reflection default strings from OBSERVATIONAL_MEMORY_DEFAULTS (test temporarily overrides defaults via try/finally).
- Tests now affirm that threshold-only configs work without specifying a model.

**Documentation Updates** (`observational-memory.mdx`):
- Quickstart and Models sections clarified to state that enabling `observationalMemory: true` uses `google/gemini-2.5-flash` by default and that config objects inherit that default unless overridden.
- Removed language implying an explicit model is required; added a note that the default when no model is set is `google/gemini-2.5-flash`.

## Impact

Non-breaking restore of previous, user-friendly behavior: configs may omit model (threshold-only configs work), explicit model overrides remain supported at top-level, observation, and reflection levels, and the "default" sentinel now resolves contextually as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->