### PR TITLE
fix(server): tolerate older @mastra/core when using new 1.32 exports

### DIFF
--- a/.changeset/server-fix-fga-import-on-old-core.md
+++ b/.changeset/server-fix-fga-import-on-old-core.md
@@ -1,18 +1,7 @@
 ---
 '@mastra/server': patch
-'@mastra/deployer': patch
 ---
 
-Fix runtime import failures when `@mastra/server` is paired with an older `@mastra/core` than its own version.
+Fix a startup crash in `@mastra/server` when paired with an older `@mastra/core` (e.g. `1.31.0`) that does not export newer 1.32 names.
 
-In 1.32.0, `@mastra/server` added top-level value imports of names that only exist in `@mastra/core@1.32.0+` (`MastraFGAPermissions` from `@mastra/core/auth/ee`; `branchesFilterSchema`, `branchesOrderBySchema`, `getBranchArgsSchema`, `listBranchesResponseSchema`, `getBranchResponseSchema` from `@mastra/core/storage`; `computeNextFireAt` from `@mastra/core/workflows`). When a user's project pinned `@mastra/core@1.31.0` but transitively pulled `@mastra/server@1.32.0` through `mastra` / `@mastra/deployer`, the bundled output crashed at module link time:
-
-```
-SyntaxError: The requested module '@mastra/core/auth/ee' does not provide an export named 'MastraFGAPermissions'
-```
-
-The peer-dep range on `@mastra/server` (`>=1.13.2-0 <2.0.0-0`) accepted `@mastra/core@1.31.0` without warning, so the failure surfaced only at runtime, after `mastra build` had already succeeded.
-
-`@mastra/server` now imports these names through namespace-import shims with safe fallbacks. Modules load on any supported `@mastra/core` version; routes that depend on 1.32-only functionality continue to work on 1.32+, and on older `@mastra/core` they degrade in place (the request handler returns the same "not available" response it would on a project without that feature configured) instead of crashing the server at startup.
-
-`@mastra/deployer` is patch-bumped so that `mastra@1.7.x` (which pulls `@mastra/deployer` via `^1.31.0`) picks up a deployer that pins the patched `@mastra/server`.
+The server now starts successfully on those versions. Endpoints that depend on 1.32-only functionality degrade at request time instead of failing at module load.

--- a/.changeset/server-fix-fga-import-on-old-core.md
+++ b/.changeset/server-fix-fga-import-on-old-core.md
@@ -1,0 +1,18 @@
+---
+'@mastra/server': patch
+'@mastra/deployer': patch
+---
+
+Fix runtime import failures when `@mastra/server` is paired with an older `@mastra/core` than its own version.
+
+In 1.32.0, `@mastra/server` added top-level value imports of names that only exist in `@mastra/core@1.32.0+` (`MastraFGAPermissions` from `@mastra/core/auth/ee`; `branchesFilterSchema`, `branchesOrderBySchema`, `getBranchArgsSchema`, `listBranchesResponseSchema`, `getBranchResponseSchema` from `@mastra/core/storage`; `computeNextFireAt` from `@mastra/core/workflows`). When a user's project pinned `@mastra/core@1.31.0` but transitively pulled `@mastra/server@1.32.0` through `mastra` / `@mastra/deployer`, the bundled output crashed at module link time:
+
+```
+SyntaxError: The requested module '@mastra/core/auth/ee' does not provide an export named 'MastraFGAPermissions'
+```
+
+The peer-dep range on `@mastra/server` (`>=1.13.2-0 <2.0.0-0`) accepted `@mastra/core@1.31.0` without warning, so the failure surfaced only at runtime, after `mastra build` had already succeeded.
+
+`@mastra/server` now imports these names through namespace-import shims with safe fallbacks. Modules load on any supported `@mastra/core` version; routes that depend on 1.32-only functionality continue to work on 1.32+, and on older `@mastra/core` they degrade in place (the request handler returns the same "not available" response it would on a project without that feature configured) instead of crashing the server at startup.
+
+`@mastra/deployer` is patch-bumped so that `mastra@1.7.x` (which pulls `@mastra/deployer` via `^1.31.0`) picks up a deployer that pins the patched `@mastra/server`.

--- a/packages/server/src/server/fga-permissions.ts
+++ b/packages/server/src/server/fga-permissions.ts
@@ -10,19 +10,19 @@
  * entire user bundle down before any code runs.
  *
  * A namespace import tolerates missing names — `ns.MissingExport` is just
- * `undefined`, no link-time error. We then expose a permission map that
- * defaults to an empty object on older cores, so property access like
- * `MastraFGAPermissions.AGENTS_READ` yields `undefined` instead of throwing.
+ * `undefined`, no link-time error. We then expose the permission map.
  *
- * This is safe because:
- * - The permission constants are pure metadata used to label routes for
- *   FGA enforcement.
- * - All runtime FGA checks are gated behind `if (fgaProvider && user)`.
- *   A user on `@mastra/core < 1.32.0` cannot have a working FGA provider
- *   configured, so those branches never run.
- * - The route-config fields (`requiresPermission`, `fga`) did not exist
- *   on the route type in `@mastra/core < 1.32.0`, so nothing in that
- *   version reads them either.
+ * Fallback values:
+ * If the consuming `@mastra/core` does not export `MastraFGAPermissions`,
+ * we substitute a hardcoded map of the canonical permission strings used
+ * by routes in `@mastra/server`. This preserves the explicit RBAC
+ * permission overrides those routes already had as string literals in
+ * `@mastra/server@1.31.0` (e.g. `requiresPermission: "agents:execute"`
+ * on `/v1/responses`). Without this fallback, `requiresPermission` would
+ * be `undefined` on old core and the auth layer would derive the wrong
+ * permission from the route path (e.g. `v1:write` instead of
+ * `agents:execute`), breaking RBAC users who upgrade `@mastra/server`
+ * but stay on `@mastra/core@1.31.0`.
  *
  * Once the consuming `@mastra/core` is on `1.32.0+` the values are real
  * and behaviour is identical to a direct named import.
@@ -30,10 +30,31 @@
 
 import * as authEE from '@mastra/core/auth/ee';
 
+// Canonical strings for the FGA permission keys actually referenced by
+// `@mastra/server` source. Mirrors `MastraFGAPermissions` in
+// `@mastra/core@1.32.0+` for these specific keys, and matches the string
+// literals previously hardcoded on the same routes in `@mastra/server@1.31.0`.
+const FALLBACK_PERMISSIONS = {
+  AGENTS_CREATE: 'agents:create',
+  AGENTS_DELETE: 'agents:delete',
+  AGENTS_EXECUTE: 'agents:execute',
+  AGENTS_READ: 'agents:read',
+  MEMORY_DELETE: 'memory:delete',
+  MEMORY_READ: 'memory:read',
+  MEMORY_WRITE: 'memory:write',
+  TOOLS_EXECUTE: 'tools:execute',
+  TOOLS_READ: 'tools:read',
+  WORKFLOWS_EXECUTE: 'workflows:execute',
+  WORKFLOWS_READ: 'workflows:read',
+} as const;
+
+const realPermissions = (authEE as any).MastraFGAPermissions;
+
 // Typed as `any` on purpose: consumers of `@mastra/server` may run their
 // typecheck against a `@mastra/core` that doesn't export `MastraFGAPermissions`
 // (anything < 1.32.0). Pinning to the real type would push that name into the
 // emitted `.d.ts` and break downstream typecheck. `any` lets the property
 // accesses (`MastraFGAPermissions.AGENTS_READ`) flow through cleanly on every
 // supported core.
-export const MastraFGAPermissions: any = (authEE as any).MastraFGAPermissions ?? {};
+export const MastraFGAPermissions: any =
+  realPermissions && Object.keys(realPermissions).length > 0 ? realPermissions : FALLBACK_PERMISSIONS;

--- a/packages/server/src/server/fga-permissions.ts
+++ b/packages/server/src/server/fga-permissions.ts
@@ -1,0 +1,39 @@
+/**
+ * Safe re-export of `MastraFGAPermissions` from `@mastra/core/auth/ee`.
+ *
+ * Why this shim exists:
+ * `MastraFGAPermissions` was introduced in `@mastra/core@1.32.0`. Earlier
+ * versions of `@mastra/core` ship `@mastra/core/auth/ee` but do not export
+ * this constant. A direct named import (`import { MastraFGAPermissions }
+ * from '@mastra/core/auth/ee'`) fails at ESM link time when this version
+ * of `@mastra/server` is paired with `@mastra/core < 1.32.0`, taking the
+ * entire user bundle down before any code runs.
+ *
+ * A namespace import tolerates missing names — `ns.MissingExport` is just
+ * `undefined`, no link-time error. We then expose a permission map that
+ * defaults to an empty object on older cores, so property access like
+ * `MastraFGAPermissions.AGENTS_READ` yields `undefined` instead of throwing.
+ *
+ * This is safe because:
+ * - The permission constants are pure metadata used to label routes for
+ *   FGA enforcement.
+ * - All runtime FGA checks are gated behind `if (fgaProvider && user)`.
+ *   A user on `@mastra/core < 1.32.0` cannot have a working FGA provider
+ *   configured, so those branches never run.
+ * - The route-config fields (`requiresPermission`, `fga`) did not exist
+ *   on the route type in `@mastra/core < 1.32.0`, so nothing in that
+ *   version reads them either.
+ *
+ * Once the consuming `@mastra/core` is on `1.32.0+` the values are real
+ * and behaviour is identical to a direct named import.
+ */
+
+import * as authEE from '@mastra/core/auth/ee';
+
+// Typed as `any` on purpose: consumers of `@mastra/server` may run their
+// typecheck against a `@mastra/core` that doesn't export `MastraFGAPermissions`
+// (anything < 1.32.0). Pinning to the real type would push that name into the
+// emitted `.d.ts` and break downstream typecheck. `any` lets the property
+// accesses (`MastraFGAPermissions.AGENTS_READ`) flow through cleanly on every
+// supported core.
+export const MastraFGAPermissions: any = (authEE as any).MastraFGAPermissions ?? {};

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -1,7 +1,6 @@
 import { Agent, isDurableAgentLike } from '@mastra/core/agent';
 import type { AgentModelManagerConfig, DurableAgentLike } from '@mastra/core/agent';
 import { AGENT_STREAM_TOPIC } from '@mastra/core/agent/durable';
-import { MastraFGAPermissions } from '@mastra/core/auth/ee';
 import type { VersionOverrides } from '@mastra/core/di';
 import { mergeVersionOverrides, MASTRA_VERSIONS_KEY } from '@mastra/core/di';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
@@ -22,6 +21,7 @@ import { stringify } from 'superjson';
 import { z } from 'zod/v4';
 import { WORKSPACE_TOOLS, resolveToolConfig } from '../constants';
 import type { WorkspaceToolName } from '../constants';
+import { MastraFGAPermissions } from '../fga-permissions';
 
 import { HTTPException } from '../http-exception';
 import {

--- a/packages/server/src/server/handlers/conversations.ts
+++ b/packages/server/src/server/handlers/conversations.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { MastraFGAPermissions } from '@mastra/core/auth/ee';
+import { MastraFGAPermissions } from '../fga-permissions';
 import { HTTPException } from '../http-exception';
 import {
   conversationDeletedSchema,

--- a/packages/server/src/server/handlers/mcp.ts
+++ b/packages/server/src/server/handlers/mcp.ts
@@ -1,5 +1,5 @@
-import { MastraFGAPermissions } from '@mastra/core/auth/ee';
 import type { MCPServerBase as MastraMCPServerImplementation, ServerInfo } from '@mastra/core/mcp';
+import { MastraFGAPermissions } from '../fga-permissions';
 import { HTTPException } from '../http-exception';
 import {
   mcpServerDetailPathParams,

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -1,9 +1,9 @@
 import type { Agent, MastraDBMessage } from '@mastra/core/agent';
-import { MastraFGAPermissions } from '@mastra/core/auth/ee';
 import type { RequestContext } from '@mastra/core/di';
 import type { MastraMemory, StorageThreadType } from '@mastra/core/memory';
 import type { MastraStorage, MemoryStorage, StorageListThreadsOutput } from '@mastra/core/storage';
 import { generateEmptyFromSchema } from '@mastra/core/utils';
+import { MastraFGAPermissions } from '../fga-permissions';
 import { HTTPException } from '../http-exception';
 import {
   threadIdPathParams,

--- a/packages/server/src/server/handlers/observability-storage-schemas.ts
+++ b/packages/server/src/server/handlers/observability-storage-schemas.ts
@@ -1,0 +1,61 @@
+/**
+ * Safe re-export of branches-related Zod schemas from `@mastra/core/storage`.
+ *
+ * Why this shim exists:
+ * The `branches*` and `getBranch*` / `listBranches*` schemas (used to define
+ * `/observability/branches` and `/observability/traces/:traceId/branches/:spanId`
+ * routes) were introduced in `@mastra/core@1.32.0`. Earlier versions of
+ * `@mastra/core` ship `@mastra/core/storage` but do not export these names.
+ *
+ * A direct named import (`import { branchesFilterSchema } from
+ * '@mastra/core/storage'`) fails at ESM link time when this version of
+ * `@mastra/server` is paired with `@mastra/core < 1.32.0`, taking the entire
+ * user bundle down before any code runs.
+ *
+ * A namespace import tolerates missing names (`ns.MissingExport` is just
+ * `undefined`, no link-time error). We then fall back to a permissive empty
+ * `z.object({})` so the route definitions can still evaluate at module load
+ * time. On old core the branches routes will register but their handlers
+ * will fail at request time when the storage backend doesn't implement
+ * `listBranches` / `getBranch` — which is the correct degradation, since
+ * those storage methods don't exist on old core either.
+ *
+ * Once the consuming `@mastra/core` is on `1.32.0+` the schemas are real
+ * and behaviour is identical to a direct named import.
+ */
+
+import * as coreStorage from '@mastra/core/storage';
+import { z } from 'zod/v4';
+
+// Each export is typed as `any` on purpose: consumers of `@mastra/server` may
+// run their typecheck against a `@mastra/core` that doesn't export these names
+// (anything < 1.32.0). Pinning to the real types would push those names into
+// the emitted `.d.ts` and break downstream typecheck. `any` lets the schema
+// chains (`.extend(...)`, `.pick(...)`, `.partial()`) flow through cleanly on
+// every supported core.
+//
+// Runtime behaviour:
+//  - On `@mastra/core >= 1.32.0` the real Zod schemas are re-exported.
+//  - On older cores, fallbacks are used: `z.object({})` for object schemas
+//    (still supports `.extend`, `.pick`, `.partial`) and `z.unknown()` for
+//    response schemas. The branches/getBranch routes will register but their
+//    handlers will fail at request time when the storage backend doesn't
+//    implement `listBranches` / `getBranch` — the correct degradation, since
+//    those methods don't exist on old core either.
+const ns = coreStorage as Record<string, unknown>;
+const fallbackEmptyObject = z.object({});
+// `getBranchArgsSchema` is `.pick()`ed at module-eval time; the empty fallback
+// would crash because the picked keys aren't declared. Pre-declare them as
+// permissive `z.unknown()` so the route definitions evaluate cleanly.
+const fallbackBranchArgs = z.object({
+  traceId: z.unknown(),
+  spanId: z.unknown(),
+  depth: z.unknown(),
+});
+const fallbackSchema = z.unknown();
+
+export const branchesFilterSchema: any = ns.branchesFilterSchema ?? fallbackEmptyObject;
+export const branchesOrderBySchema: any = ns.branchesOrderBySchema ?? fallbackEmptyObject;
+export const getBranchArgsSchema: any = ns.getBranchArgsSchema ?? fallbackBranchArgs;
+export const listBranchesResponseSchema: any = ns.listBranchesResponseSchema ?? fallbackSchema;
+export const getBranchResponseSchema: any = ns.getBranchResponseSchema ?? fallbackSchema;

--- a/packages/server/src/server/handlers/observability.ts
+++ b/packages/server/src/server/handlers/observability.ts
@@ -16,17 +16,22 @@ import {
   getSpanArgsSchema,
   getSpanResponseSchema,
   dateRangeSchema,
-  branchesFilterSchema,
-  branchesOrderBySchema,
-  listBranchesResponseSchema,
-  getBranchArgsSchema,
-  getBranchResponseSchema,
 } from '@mastra/core/storage';
+// `branches*`, `listBranches*`, and `getBranch*` schemas are new in
+// @mastra/core@1.32.0; route them through a shim that tolerates older cores
+// (see ./observability-storage-schemas.ts for full rationale).
 import { z } from 'zod/v4';
 import { HTTPException } from '../http-exception';
 import { createRoute, pickParams, wrapSchemaForQueryParams } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
 import { getObservabilityStore, getStorage } from './observability-shared';
+import {
+  branchesFilterSchema,
+  branchesOrderBySchema,
+  listBranchesResponseSchema,
+  getBranchArgsSchema,
+  getBranchResponseSchema,
+} from './observability-storage-schemas';
 
 export * from './observability-new-endpoints';
 

--- a/packages/server/src/server/handlers/responses.ts
+++ b/packages/server/src/server/handlers/responses.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import type { Agent, MastraDBMessage } from '@mastra/core/agent';
-import { MastraFGAPermissions } from '@mastra/core/auth/ee';
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { MemoryStorage } from '@mastra/core/storage';
+import { MastraFGAPermissions } from '../fga-permissions';
 import { HTTPException } from '../http-exception';
 import {
   createResponseBodySchema,

--- a/packages/server/src/server/handlers/schedules-workflows-shim.ts
+++ b/packages/server/src/server/handlers/schedules-workflows-shim.ts
@@ -1,0 +1,32 @@
+/**
+ * Safe re-export of `computeNextFireAt` from `@mastra/core/workflows`.
+ *
+ * Why this shim exists:
+ * `computeNextFireAt` was introduced in `@mastra/core@1.32.0`. Earlier
+ * versions of `@mastra/core` ship `@mastra/core/workflows` but do not export
+ * this function. A direct named import fails at ESM link time when this
+ * version of `@mastra/server` is paired with `@mastra/core < 1.32.0`, taking
+ * the entire user bundle down before any code runs.
+ *
+ * A namespace import tolerates missing names. We expose the real function
+ * when available and fall back to a function that throws a clear error
+ * otherwise — schedules require new-core support anyway, so loud failure at
+ * the call site is far better than silent corruption.
+ *
+ * Typed as `any` on purpose (see ./observability-storage-schemas.ts for
+ * the same rationale): keeps the emitted `.d.ts` free of names that don't
+ * exist in older cores.
+ */
+
+import * as coreWorkflows from '@mastra/core/workflows';
+
+const exported = (coreWorkflows as Record<string, unknown>).computeNextFireAt;
+
+export const computeNextFireAt: any =
+  exported ??
+  (() => {
+    throw new Error(
+      '`computeNextFireAt` is not available in this version of @mastra/core. ' +
+        'Schedules require @mastra/core >= 1.32.0.',
+    );
+  });

--- a/packages/server/src/server/handlers/schedules.ts
+++ b/packages/server/src/server/handlers/schedules.ts
@@ -1,6 +1,7 @@
 import type { Mastra } from '@mastra/core';
-import { computeNextFireAt } from '@mastra/core/workflows';
 import type { WorkflowRunState } from '@mastra/core/workflows';
+// `computeNextFireAt` is new in @mastra/core@1.32.0; route it through a shim
+// that tolerates older cores (see ./schedules-workflows-shim.ts).
 import { HTTPException } from '../http-exception';
 import {
   listSchedulesQuerySchema,
@@ -11,6 +12,7 @@ import {
   listScheduleTriggersResponseSchema,
 } from '../schemas/schedules';
 import { createRoute } from '../server-adapter/routes/route-builder';
+import { computeNextFireAt } from './schedules-workflows-shim';
 
 type RunSummary = {
   status: WorkflowRunState['status'];

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -1,8 +1,8 @@
-import { MastraFGAPermissions } from '@mastra/core/auth/ee';
 import { isVercelTool, isProviderDefinedTool } from '@mastra/core/tools';
 import { toStandardSchema, standardSchemaToJSONSchema } from '@mastra/schema-compat/schema';
 import type { PublicSchema } from '@mastra/schema-compat/schema';
 import { stringify } from 'superjson';
+import { MastraFGAPermissions } from '../fga-permissions';
 import { HTTPException } from '../http-exception';
 import {
   executeToolContextBodySchema,

--- a/packages/server/src/server/handlers/utils.ts
+++ b/packages/server/src/server/handlers/utils.ts
@@ -1,8 +1,8 @@
-import { MastraFGAPermissions } from '@mastra/core/auth/ee';
 import type { MastraFGAPermissionInput } from '@mastra/core/auth/ee';
 import type { RequestContext } from '@mastra/core/di';
 import { MastraMemory } from '@mastra/core/memory';
 import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../constants';
+import { MastraFGAPermissions } from '../fga-permissions';
 import { HTTPException } from '../http-exception';
 
 // Validation helper

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -1,8 +1,8 @@
-import { MastraFGAPermissions } from '@mastra/core/auth/ee';
 import type { RequestContext } from '@mastra/core/di';
 import { createCachingTransformStream, createReplayStream } from '@mastra/core/stream';
 import type { WorkflowInfo, ChunkType, StreamEvent, WorkflowStateField } from '@mastra/core/workflows';
 import { z } from 'zod/v4';
+import { MastraFGAPermissions } from '../fga-permissions';
 import { HTTPException } from '../http-exception';
 import { streamResponseSchema } from '../schemas/agents';
 import { optionalRunIdSchema, runIdSchema } from '../schemas/common';


### PR DESCRIPTION
## Summary

`@mastra/server@1.32.0` added top-level value imports of names that only exist in `@mastra/core@1.32.0+`. Combined with the peer-dep range on `@mastra/server` (`>=1.13.2-0 <2.0.0-0`) and a caret on `@mastra/deployer` in `mastra@1.7.x`, fresh installs could land `@mastra/server@1.32.0` alongside `@mastra/core@1.31.0`. The bundled output then crashed at ESM link time:

```
SyntaxError: The requested module '@mastra/core/auth/ee' does not provide an export named 'MastraFGAPermissions'
    at .mastra/output/index.mjs:30
```

`mastra build` succeeded, so users only saw the failure when starting the deployed server.

## Root cause

Three new-in-1.32 imports were statically named-imported from `@mastra/core/*` subpaths in `@mastra/server`:

| Subpath | New names | Used in |
| --- | --- | --- |
| `@mastra/core/auth/ee` | `MastraFGAPermissions` | 8 handler files (route metadata) |
| `@mastra/core/storage` | `branchesFilterSchema`, `branchesOrderBySchema`, `getBranchArgsSchema`, `listBranchesResponseSchema`, `getBranchResponseSchema` | `handlers/observability.ts` |
| `@mastra/core/workflows` | `computeNextFireAt` | `handlers/schedules.ts` |

Static named ESM imports fail at link time when the export is missing. The peer-dep range did not enforce a 1.32 floor, so npm/pnpm accepted the mismatched install without warning.

## Fix

Each new import is routed through a small namespace-import shim with a safe fallback:

```ts
import * as authEE from '@mastra/core/auth/ee';
export const MastraFGAPermissions: any = (authEE as any).MastraFGAPermissions ?? {};
```

Namespace imports tolerate missing names (the property just resolves to `undefined`), so the module loads on any supported core. On `@mastra/core@1.32.0+`, behaviour is identical to a direct named import. On `@mastra/core@1.31.0`:

- **FGA permission constants** become an empty object. Route metadata gets `requiresPermission: undefined`. The FGA middleware's `if (fgaProvider && permission)` gate already short-circuits, and a project on 1.31 cannot configure a working FGA provider, so no behaviour changes.
- **Branch storage schemas** fall back to `z.object({})`. Routes register; the handler's existing "Storage is not available" path serves the response (same shape as a project without storage configured).
- **`computeNextFireAt`** falls back to a function that throws a clear "scheduler requires `@mastra/core@1.32.0+`" error if invoked. Scheduler is new in 1.32, so on 1.31 the fallback isn't reachable through any working code path.

`@mastra/deployer` is patch-bumped so `mastra@1.7.x` (which pulls `@mastra/deployer` via `^1.31.0`) picks up a deployer that pins the patched `@mastra/server@1.32.1`.

## Reach analysis

- `mastra@1.7.x` → `@mastra/deployer@^1.31.0` → resolves to `@mastra/deployer@1.32.1` (this PR) → pins `@mastra/server@1.32.1` (this PR). ✅
- No `mastra` or `@mastra/core` bump needed; neither carries the bug.
- Repo is in alpha prerelease mode, so the patch lands as `1.32.1-alpha.0` first.

## Trade-off acknowledged

Inside `@mastra/server`, the three shimmed identifiers are typed as `any`, so contributors editing FGA / observability / schedules handler code (~32 call sites across 10 files) lose autocomplete and typo detection on those specific names. Everything else stays fully typed: handler signatures, route configs, request/response types, public exports.

The alternative — typing the shims against the real `@mastra/core@1.32` types — pushes the new-in-1.32 type names into the emitted `.d.ts`, which then breaks downstream typecheck for any consumer on `@mastra/core@1.31.0` (the exact cohort this PR is fixing). Net-negative.

This is temporary scaffolding. When the next minor of `@mastra/server` raises its peer floor on `@mastra/core` to `>=1.32.0`, the shims delete and the handlers go back to direct named imports.

## Verification

- ✅ `pnpm build:server` and `pnpm test:server` (1154 tests) pass.
- ✅ Reproduced the original failure: fresh project with `mastra@1.8.0-alpha.4` + `@mastra/core@1.31.0`. Without this fix: `mastra build` succeeds, `node .mastra/output/index.mjs` crashes with the `MastraFGAPermissions` SyntaxError.
- ✅ With this fix overlaid: `node .mastra/output/index.mjs` starts cleanly. `GET /api/agents` returns `200`. `GET /api/observability/branches` returns the expected `500 Storage is not available` (handler-level, not link-level).
- ✅ Green-side regression check: same project upgraded to `@mastra/core@1.32.0` builds and serves identically — no regression on the matched-version path.

## Test plan

1. CI green on this branch.
2. After alpha publish, install `mastra@1.8.x-alpha.N` + `@mastra/core@1.31.0` in a fresh project, run `mastra build` and `mastra start`, confirm server boots and `GET /api/agents` responds.
3. Repeat with `@mastra/core@1.32.x` to confirm no regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation
The server tried to use new features from a newer core library and crashed when those features weren't there. This change adds safe "helpers" that use the new features when present, and sensible fallbacks when they're not, so the server runs with both old and new core versions.

## Changes Overview
Fixes a startup crash when @mastra/server@1.32.0 is used with @mastra/core@1.31.0 by replacing direct named ESM imports (which caused link-time failures if missing) with namespace-import shims that provide safe fallbacks. Handlers now degrade at runtime instead of failing to link.

## Root Cause
Server 1.32.0 added three new named imports from @mastra/core subpaths that do not exist in core < 1.32.0:
- MastraFGAPermissions (from @mastra/core/auth/ee)
- Branch storage schemas (from @mastra/core/storage)
- computeNextFireAt (from @mastra/core/workflows)

These static named imports caused ESM link-time crashes when an older @mastra/core was installed.

## Solution
Introduce local compatibility shims that import the full core namespace and export the needed symbols with typed-any fallbacks:

1. packages/server/src/server/fga-permissions.ts
   - Exports MastraFGAPermissions from core when present.
   - On older cores exports canonical permission-string mappings (not an empty object), preserving intended default permission values.

2. packages/server/src/server/handlers/observability-storage-schemas.ts
   - Exports five branch-related Zod schemas, falling back to permissive schemas (e.g., z.object({}), z.unknown()) so observability handlers continue to return existing "Storage is not available" behavior.

3. packages/server/src/server/handlers/schedules-workflows-shim.ts
   - Exports computeNextFireAt when present; otherwise exports a fallback that throws a clear runtime error indicating @mastra/core >= 1.32.0 is required if invoked.

All server modules that previously imported these symbols from @mastra/core now import from the local shims.

## Files Modified / Added
- Added: packages/server/src/server/fga-permissions.ts
- Added: packages/server/src/server/handlers/observability-storage-schemas.ts
- Added: packages/server/src/server/handlers/schedules-workflows-shim.ts
- Updated imports in:
  - packages/server/src/server/handlers/agents.ts
  - packages/server/src/server/handlers/conversations.ts
  - packages/server/src/server/handlers/mcp.ts
  - packages/server/src/server/handlers/memory.ts
  - packages/server/src/server/handlers/observability.ts
  - packages/server/src/server/handlers/responses.ts
  - packages/server/src/server/handlers/schedules.ts
  - packages/server/src/server/handlers/tools.ts
  - packages/server/src/server/handlers/utils.ts
  - packages/server/src/server/handlers/workflows.ts
- Changeset: .changeset/server-fix-fga-import-on-old-core.md

## Degradation Behavior
- FGA permissions now fall back to canonical permission strings (so route metadata retains intended defaults, e.g., MEMORY_READ), not an empty object.
- Branch storage schemas fall back to permissive validators letting handlers follow existing "storage unavailable" code paths.
- computeNextFireAt fallback throws a clear error only if the scheduler path is actually invoked.

## Packaging & Release
- @mastra/deployer patch-bumped so mastra@1.7.x pulls the patched @mastra/server@1.32.1 (published as 1.32.1-alpha.0 in the alpha prerelease flow).
- A previously redundant deployer changeset entry was removed because deployer is in the same fixed group and will be bumped automatically.

## Verification
- pnpm build:server and pnpm test:server passed (1154 tests).
- Reproduced the original crash on @mastra/core@1.31.0 and confirmed the shims prevent the crash.
- Verified no regressions when used with @mastra/core@1.32.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->