### PR TITLE
fix(core): drop orphan tool_use/tool_result blocks before LLM submission

### DIFF
--- a/.changeset/rich-rats-mix.md
+++ b/.changeset/rich-rats-mix.md
@@ -2,6 +2,6 @@
 '@mastra/core': patch
 ---
 
-Fixed agent crashing on Anthropic with `messages.N.content.0: unexpected tool_use_id` when SemanticRecall (or any recall window) returned a partial parallel tool-call group. The conversion path now drops orphan `tool_use` / `tool_result` blocks before sending to the LLM, so a recalled exchange that lost half its pair no longer poisons the next request.
+Fixed agent requests to Anthropic failing with `400 unexpected tool_use_id` when recalled history contained an incomplete `tool_use` / `tool_result` pair. This most commonly hit agents using parallel tool calls when an earlier run was interrupted before every tool finished — pulling that broken exchange into a new prompt no longer crashes the next request.
 
 Closes #16193

--- a/.changeset/rich-rats-mix.md
+++ b/.changeset/rich-rats-mix.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent crashing on Anthropic with `messages.N.content.0: unexpected tool_use_id` when SemanticRecall (or any recall window) returned a partial parallel tool-call group. The conversion path now drops orphan `tool_use` / `tool_result` blocks before sending to the LLM, so a recalled exchange that lost half its pair no longer poisons the next request.
+
+Closes #16193

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -7,7 +7,7 @@ import type { AdapterContext } from '../adapters';
 import { TypeDetector } from '../detection/TypeDetector';
 import type { MastraDBMessage, MessageSource } from '../state/types';
 import type { AIV5Type, AIV6Type } from '../types';
-import { ensureAnthropicCompatibleMessages } from '../utils/provider-compat';
+import { ensureAnthropicCompatibleMessages, sanitizeOrphanedToolPairs } from '../utils/provider-compat';
 import { getResponseProviderItemKey } from '../utils/response-item-metadata';
 
 /**
@@ -373,7 +373,9 @@ export function aiV5UIMessagesToAIV5ModelMessages(
   });
 
   // Add input field to tool-result parts for Anthropic API compatibility (fixes issue #11376)
-  return ensureAnthropicCompatibleMessages(withProviderOptions, dbMessages);
+  const anthropicCompat = ensureAnthropicCompatibleMessages(withProviderOptions, dbMessages);
+
+  return filterIncompleteToolCalls ? sanitizeOrphanedToolPairs(anthropicCompat) : anthropicCompat;
 }
 
 /**

--- a/packages/core/src/agent/message-list/index.ts
+++ b/packages/core/src/agent/message-list/index.ts
@@ -42,6 +42,7 @@ export type { AIV4AdapterContext, AIV5AdapterContext, AdapterContext } from './a
 export {
   ensureGeminiCompatibleMessages,
   ensureAnthropicCompatibleMessages,
+  sanitizeOrphanedToolPairs,
   hasOpenAIReasoningItemId,
   getOpenAIReasoningItemId,
   hasResponseProviderItemId,

--- a/packages/core/src/agent/message-list/utils/provider-compat.test.ts
+++ b/packages/core/src/agent/message-list/utils/provider-compat.test.ts
@@ -102,6 +102,27 @@ describe('sanitizeOrphanedToolPairs', () => {
     expect(sanitizeOrphanedToolPairs(messages)).toEqual([assistantWithToolCalls('A'), toolMessageWithResults('A')]);
   });
 
+  it('preserves a deferred provider-executed tool_use with no matching tool_result', () => {
+    // Anthropic non-deterministically defers server-side tools (e.g. web_search).
+    // The tool_use must survive in history so the provider can resume on the next call.
+    const assistant: ModelMessage = {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'srv-deferred',
+          toolName: 'web_search',
+          input: { query: 'x' },
+          providerExecuted: true,
+        } as any,
+      ],
+    };
+
+    const messages: ModelMessage[] = [assistant, { role: 'user', content: 'continue' }];
+
+    expect(sanitizeOrphanedToolPairs(messages)).toEqual(messages);
+  });
+
   it('preserves inline provider-executed tool_result on assistant content', () => {
     // For provider-executed tools (e.g. Anthropic web_search) tool_use and tool_result
     // live in the same assistant message; only tool_call parts on assistants are subject

--- a/packages/core/src/agent/message-list/utils/provider-compat.test.ts
+++ b/packages/core/src/agent/message-list/utils/provider-compat.test.ts
@@ -1,0 +1,161 @@
+import type { ModelMessage } from '@internal/ai-sdk-v5';
+import { describe, expect, it } from 'vitest';
+import { sanitizeOrphanedToolPairs } from './provider-compat';
+
+const assistantWithToolCalls = (...callIds: string[]): ModelMessage => ({
+  role: 'assistant',
+  content: callIds.map(toolCallId => ({
+    type: 'tool-call',
+    toolCallId,
+    toolName: 'fetch',
+    input: { url: `https://example.com/${toolCallId}` },
+  })),
+});
+
+const toolMessageWithResults = (...callIds: string[]): ModelMessage => ({
+  role: 'tool',
+  content: callIds.map(toolCallId => ({
+    type: 'tool-result',
+    toolCallId,
+    toolName: 'fetch',
+    output: { type: 'text', value: `result-${toolCallId}` },
+  })),
+});
+
+describe('sanitizeOrphanedToolPairs', () => {
+  it('returns empty input untouched', () => {
+    expect(sanitizeOrphanedToolPairs([])).toEqual([]);
+  });
+
+  it('passes through string-content messages unchanged', () => {
+    const messages: ModelMessage[] = [
+      { role: 'system', content: 'be helpful' },
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi there' },
+    ];
+
+    expect(sanitizeOrphanedToolPairs(messages)).toEqual(messages);
+  });
+
+  it('preserves a valid tool_use → tool_result pair', () => {
+    const messages: ModelMessage[] = [assistantWithToolCalls('A'), toolMessageWithResults('A')];
+
+    expect(sanitizeOrphanedToolPairs(messages)).toEqual(messages);
+  });
+
+  it('drops a tool_result with no preceding tool_use', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'hi' },
+      toolMessageWithResults('orphan-A'),
+      { role: 'assistant', content: 'ok' },
+    ];
+
+    expect(sanitizeOrphanedToolPairs(messages)).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'ok' },
+    ]);
+  });
+
+  it('drops a tool_result after a string-content assistant message', () => {
+    const messages: ModelMessage[] = [
+      { role: 'assistant', content: 'no tool call here' },
+      toolMessageWithResults('orphan-A'),
+      { role: 'user', content: 'next' },
+    ];
+
+    expect(sanitizeOrphanedToolPairs(messages)).toEqual([
+      { role: 'assistant', content: 'no tool call here' },
+      { role: 'user', content: 'next' },
+    ]);
+  });
+
+  it('drops an assistant message that contains only an orphan tool_use', () => {
+    const messages: ModelMessage[] = [assistantWithToolCalls('lonely-A'), { role: 'user', content: 'next question' }];
+
+    expect(sanitizeOrphanedToolPairs(messages)).toEqual([{ role: 'user', content: 'next question' }]);
+  });
+
+  it('keeps text on an assistant message after dropping its orphan tool_use', () => {
+    const assistant: ModelMessage = {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'thinking out loud' },
+        { type: 'tool-call', toolCallId: 'orphan', toolName: 'fetch', input: {} },
+      ],
+    };
+
+    expect(sanitizeOrphanedToolPairs([assistant, { role: 'user', content: 'next' }])).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: 'thinking out loud' }] },
+      { role: 'user', content: 'next' },
+    ]);
+  });
+
+  it('keeps the matched call and drops the orphan in a parallel tool group (missing result)', () => {
+    const messages: ModelMessage[] = [assistantWithToolCalls('A', 'B'), toolMessageWithResults('A')];
+
+    expect(sanitizeOrphanedToolPairs(messages)).toEqual([assistantWithToolCalls('A'), toolMessageWithResults('A')]);
+  });
+
+  it('drops orphan tool_results in a tool message that has a mix of valid and orphan ids', () => {
+    const messages: ModelMessage[] = [assistantWithToolCalls('A'), toolMessageWithResults('A', 'B')];
+
+    expect(sanitizeOrphanedToolPairs(messages)).toEqual([assistantWithToolCalls('A'), toolMessageWithResults('A')]);
+  });
+
+  it('preserves inline provider-executed tool_result on assistant content', () => {
+    // For provider-executed tools (e.g. Anthropic web_search) tool_use and tool_result
+    // live in the same assistant message; only tool_call parts on assistants are subject
+    // to the next-message pairing rule.
+    const assistant: ModelMessage = {
+      role: 'assistant',
+      content: [
+        { type: 'tool-call', toolCallId: 'srv-1', toolName: 'web_search', input: { q: 'x' } } as any,
+        { type: 'tool-result', toolCallId: 'srv-1', toolName: 'web_search', output: 'results' } as any,
+        { type: 'text', text: 'done' },
+      ],
+    };
+
+    expect(sanitizeOrphanedToolPairs([assistant, { role: 'user', content: 'next' }])).toEqual([
+      assistant,
+      { role: 'user', content: 'next' },
+    ]);
+  });
+
+  it('cleans multiple orphans across a long multi-turn chain', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'turn 1' },
+      assistantWithToolCalls('t1-A', 't1-B'),
+      toolMessageWithResults('t1-A'),
+      { role: 'user', content: 'turn 2' },
+      assistantWithToolCalls('t2-A'),
+      toolMessageWithResults('t2-A'),
+      { role: 'user', content: 'turn 3' },
+      toolMessageWithResults('stray'),
+      { role: 'assistant', content: 'final' },
+    ];
+
+    expect(sanitizeOrphanedToolPairs(messages)).toEqual([
+      { role: 'user', content: 'turn 1' },
+      assistantWithToolCalls('t1-A'),
+      toolMessageWithResults('t1-A'),
+      { role: 'user', content: 'turn 2' },
+      assistantWithToolCalls('t2-A'),
+      toolMessageWithResults('t2-A'),
+      { role: 'user', content: 'turn 3' },
+      { role: 'assistant', content: 'final' },
+    ]);
+  });
+
+  it('drops orphans across consecutive assistant messages with no tool message between them', () => {
+    const messages: ModelMessage[] = [
+      assistantWithToolCalls('orphan-1'),
+      { role: 'assistant', content: 'reconsidered' },
+      { role: 'user', content: 'continue' },
+    ];
+
+    expect(sanitizeOrphanedToolPairs(messages)).toEqual([
+      { role: 'assistant', content: 'reconsidered' },
+      { role: 'user', content: 'continue' },
+    ]);
+  });
+});

--- a/packages/core/src/agent/message-list/utils/provider-compat.ts
+++ b/packages/core/src/agent/message-list/utils/provider-compat.ts
@@ -85,6 +85,72 @@ export function ensureAnthropicCompatibleMessages(
 }
 
 /**
+ * Removes orphan tool_use / tool_result blocks. Anthropic requires every tool_result
+ * to be in the message immediately after its matching tool_use, and every tool_use
+ * to have a matching tool_result in the next message. Recall windows can slice
+ * through a parallel tool-call group and leave behind half a pair.
+ */
+export function sanitizeOrphanedToolPairs(messages: ModelMessage[]): ModelMessage[] {
+  const filteredContents = messages.map(m => (Array.isArray(m.content) ? [...m.content] : null));
+
+  for (let i = 0; i < messages.length; i++) {
+    const current = messages[i]!;
+
+    if (current.role === 'assistant' && Array.isArray(current.content)) {
+      const useIds = new Set<string>();
+      const inlineResultIds = new Set<string>();
+      for (const part of current.content) {
+        if (part.type === 'tool-call') useIds.add(part.toolCallId);
+        else if (part.type === 'tool-result') inlineResultIds.add(part.toolCallId);
+      }
+
+      const next = messages[i + 1];
+      const nextResultIds = new Set<string>();
+      if (next && next.role === 'tool' && Array.isArray(next.content)) {
+        for (const part of next.content) {
+          if (part.type === 'tool-result') nextResultIds.add(part.toolCallId);
+        }
+      }
+
+      const validPairs = new Set([...useIds].filter(id => inlineResultIds.has(id) || nextResultIds.has(id)));
+
+      filteredContents[i] = filteredContents[i]!.filter(
+        p => p.type !== 'tool-call' || validPairs.has((p as { toolCallId: string }).toolCallId),
+      );
+
+      if (next && next.role === 'tool' && Array.isArray(next.content)) {
+        filteredContents[i + 1] = filteredContents[i + 1]!.filter(
+          p => p.type !== 'tool-result' || validPairs.has((p as { toolCallId: string }).toolCallId),
+        );
+      }
+    } else if (current.role === 'tool' && Array.isArray(current.content)) {
+      const prev = messages[i - 1];
+      if (!prev || prev.role !== 'assistant' || !Array.isArray(prev.content)) {
+        filteredContents[i] = filteredContents[i]!.filter(p => p.type !== 'tool-result');
+      }
+    }
+  }
+
+  const result: ModelMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const original = messages[i]!;
+    const filtered = filteredContents[i];
+    if (filtered == null) {
+      result.push(original);
+      continue;
+    }
+    if (filtered.length === 0) continue;
+    if (Array.isArray(original.content) && filtered.length === original.content.length) {
+      result.push(original);
+      continue;
+    }
+    result.push({ ...original, content: filtered } as ModelMessage);
+  }
+
+  return result;
+}
+
+/**
  * Enriches a single message's tool-result parts with input field
  */
 function enrichToolResultsWithInput(message: ModelMessage, dbMessages: MastraDBMessage[]): ModelMessage {

--- a/packages/core/src/agent/message-list/utils/provider-compat.ts
+++ b/packages/core/src/agent/message-list/utils/provider-compat.ts
@@ -114,9 +114,13 @@ export function sanitizeOrphanedToolPairs(messages: ModelMessage[]): ModelMessag
 
       const validPairs = new Set([...useIds].filter(id => inlineResultIds.has(id) || nextResultIds.has(id)));
 
-      filteredContents[i] = filteredContents[i]!.filter(
-        p => p.type !== 'tool-call' || validPairs.has((p as { toolCallId: string }).toolCallId),
-      );
+      filteredContents[i] = filteredContents[i]!.filter(p => {
+        if (p.type !== 'tool-call') return true;
+        const tc = p as { toolCallId: string; providerExecuted?: boolean };
+        // Provider-executed tools may be deferred (e.g. Anthropic web_search): the tool_use
+        // can appear without a matching tool_result until the provider resumes on the next call.
+        return tc.providerExecuted === true || validPairs.has(tc.toolCallId);
+      });
 
       if (next && next.role === 'tool' && Array.isArray(next.content)) {
         filteredContents[i + 1] = filteredContents[i + 1]!.filter(


### PR DESCRIPTION
## Description

Anthropic returns `400 unexpected tool_use_id` when recalled history contains an incomplete `tool_use` / `tool_result` pair. This commonly hits agents that use parallel tool calls and got interrupted before every tool finished — the broken pair stays in the database and crashes future turns when recall pulls it back in.

**Fix:** a pairing sanitizer that drops orphan tool blocks before the request leaves for the LLM.

### What changed

- New `sanitizeOrphanedToolPairs` in `provider-compat.ts`. Drops unpaired `tool_use` / `tool_result`; preserves valid pairs, deferred provider-executed tools, and inline server tool results.
- Wired into `aiV5UIMessagesToAIV5ModelMessages`, gated on `filterIncompleteToolCalls` so only the LLM-submission path runs it. Inspection paths are untouched.
- 13 unit tests + verified end-to-end against the live Anthropic API: 8 orphan scenarios all returned `400` before the sanitizer and `200 stop_reason=end_turn` after.

## Related Issue(s)

Fixes #16193

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an AI agent recalls old conversations, it sometimes picks up incomplete tool instructions (like a "request to do X" without a "result of doing X", or vice versa). The AI provider (Anthropic) refuses these incomplete pairs and returns an error. This PR adds a cleanup function that removes these orphaned pieces before sending the message, so the AI doesn't reject it.

---

## Overview

Fixes Anthropic API `400 unexpected tool_use_id` errors that occur when semantic recall assembles messages containing orphaned `tool_use` or `tool_result` blocks. This commonly happens when agents run parallel tool calls and runs are interrupted, leaving incomplete tool-invocation pairs in the message history.

**Solution:** Implements `sanitizeOrphanedToolPairs()` — a utility function that removes unpaired tool-invocation parts before LLM submission while preserving valid tool pairs, provider-executed tools, and inline server-side tool results.

## Implementation Details

**New Function: `sanitizeOrphanedToolPairs`** (70 lines in `provider-compat.ts`)
- Filters message content arrays to remove mismatched `tool-call`/`tool-result` blocks
- For each assistant message, identifies "valid" `toolCallId`s that have a corresponding `tool-result` either inline in the same message or in the immediately following `tool` message
- Drops orphan `tool-call` parts unless marked `providerExecuted: true` (which are retained)
- Removes orphan `tool-result` parts whose `toolCallId` doesn't match any preceding `tool-call`
- Preserves original messages when no filtering is needed; omits any message whose filtered content becomes empty

**Integration Points:**
- Wired into `aiV5UIMessagesToAIV5ModelMessages` in `output-converter.ts`, gated by `filterIncompleteToolCalls` flag to only sanitize LLM-submission paths (inspection paths unchanged)
- Re-exported from `packages/core/src/agent/message-list/index.ts` for public use

## Testing & Verification

- **Unit test coverage** (182 lines in `provider-compat.test.ts`):
  - Empty input and passthrough scenarios
  - Valid assistant→tool result pairings (single and multi-tool)
  - Orphan `tool-result` removal (with and without preceding assistant messages)
  - Orphan `tool-call` removal with preserved assistant text content
  - Parallel tool groups and mixed result batches
  - Provider-executed tool preservation (deferred and inline cases)
  - Multi-turn chains and consecutive assistant messages
  
- **End-to-end verification against live Anthropic API**: Eight orphan scenarios that previously returned 400 errors now return 200 with `stop_reason=end_turn`

## Files Changed

| File | Lines | Change |
|------|-------|--------|
| `.changeset/rich-rats-mix.md` | +7 | Patch-level changelog entry |
| `provider-compat.ts` | +70 | New `sanitizeOrphanedToolPairs()` function |
| `provider-compat.test.ts` | +182 | Comprehensive test suite |
| `output-converter.ts` | +4/-2 | Integration into conversion pipeline |
| `index.ts` | +1 | Public re-export of sanitizer |

**Fixes:** #16193

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16201)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->