### PR TITLE
feat(playground-ui): add CodeBlock component

### DIFF
--- a/.changeset/every-buses-shave.md
+++ b/.changeset/every-buses-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added CodeBlock component with select/tabs switcher, optional shiki syntax highlighting, and Notion-style hover-only copy button (always visible on touch devices via media query).

--- a/.changeset/plenty-pens-call.md
+++ b/.changeset/plenty-pens-call.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Refactored the Mastra version dialog to use the new CodeBlock component and simplified the package versions copy button to an icon-only button with tooltip.

--- a/packages/playground-ui/src/ds/components/CodeBlock/code-block.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeBlock/code-block.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { TooltipProvider } from '../Tooltip';
+import { CodeBlock } from './code-block';
+
+const meta: Meta<typeof CodeBlock> = {
+  title: 'Composite/CodeBlock',
+  component: CodeBlock,
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <div className="w-full p-4">
+          <Story />
+        </div>
+      </TooltipProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CodeBlock>;
+
+const packageManagers = [
+  { label: 'pnpm', value: 'pnpm' },
+  { label: 'npm', value: 'npm' },
+  { label: 'yarn', value: 'yarn' },
+  { label: 'bun', value: 'bun' },
+];
+
+const commands: Record<string, string> = {
+  pnpm: 'pnpm add @mastra/core@latest @mastra/memory@latest mastra@latest',
+  npm: 'npm install @mastra/core@latest @mastra/memory@latest mastra@latest',
+  yarn: 'yarn add @mastra/core@latest @mastra/memory@latest mastra@latest',
+  bun: 'bun add @mastra/core@latest @mastra/memory@latest mastra@latest',
+};
+
+export const Default: Story = {
+  render: () => <CodeBlock code="pnpm dlx mastra@latest init" />,
+};
+
+export const WithSelect: Story = {
+  render: () => {
+    const [pm, setPm] = useState('pnpm');
+    return (
+      <CodeBlock
+        code={commands[pm]}
+        options={packageManagers}
+        value={pm}
+        onValueChange={setPm}
+        copyMessage="Copied update command!"
+      />
+    );
+  },
+};
+
+export const LongCommand: Story = {
+  render: () => {
+    const [pm, setPm] = useState('pnpm');
+    const long = `${pm} add @mastra/auth-workos@latest @mastra/client-js@latest @mastra/core@latest @mastra/duckdb@latest @mastra/editor@latest @mastra/libsql@latest @mastra/mcp@latest @mastra/memory@latest @mastra/observability@latest @mastra/slack@latest mastra@latest`;
+    return <CodeBlock code={long} options={packageManagers} value={pm} onValueChange={setPm} />;
+  },
+};
+
+export const WithFileName: Story = {
+  render: () => (
+    <CodeBlock
+      fileName="src/mastra/agents/index.ts"
+      lang="typescript"
+      code={`import { Agent } from '@mastra/core/agent';\nimport { openai } from '@ai-sdk/openai';\n\nexport const agent = new Agent({\n  name: 'assistant',\n  model: openai('gpt-4o-mini'),\n});`}
+    />
+  ),
+};
+
+export const WithTabs: Story = {
+  render: () => {
+    const [pm, setPm] = useState('pnpm');
+    return (
+      <CodeBlock
+        code={commands[pm]}
+        options={packageManagers}
+        value={pm}
+        onValueChange={setPm}
+        selector="tabs"
+        copyMessage="Copied update command!"
+      />
+    );
+  },
+};
+
+export const TabsWithCode: Story = {
+  render: () => {
+    const [provider, setProvider] = useState('anthropic');
+    const snippets: Record<string, string> = {
+      anthropic: `import { anthropic } from '@ai-sdk/anthropic';\n\nconst model = anthropic('claude-sonnet-4-5');`,
+      openai: `import { openai } from '@ai-sdk/openai';\n\nconst model = openai('gpt-4o-mini');`,
+      langchain: `import { ChatOpenAI } from '@langchain/openai';\n\nconst model = new ChatOpenAI({ model: 'gpt-4o-mini' });`,
+      mastra: `import { Agent } from '@mastra/core/agent';\n\nexport const agent = new Agent({ name: 'assistant', model });`,
+    };
+    return (
+      <CodeBlock
+        code={snippets[provider]}
+        lang="typescript"
+        selector="tabs"
+        options={[
+          { label: 'Anthropic', value: 'anthropic' },
+          { label: 'OpenAI', value: 'openai' },
+          { label: 'LangChain', value: 'langchain' },
+          { label: 'Mastra', value: 'mastra' },
+        ]}
+        value={provider}
+        onValueChange={setProvider}
+      />
+    );
+  },
+};
+
+export const Highlighted: Story = {
+  render: () => {
+    const [provider, setProvider] = useState('openai');
+    const snippets: Record<string, string> = {
+      openai: `import { openai } from '@ai-sdk/openai';\n\nconst model = openai('gpt-4o-mini');`,
+      anthropic: `import { anthropic } from '@ai-sdk/anthropic';\n\nconst model = anthropic('claude-sonnet-4-5');`,
+      mastra: `import { Agent } from '@mastra/core/agent';\n\nexport const agent = new Agent({ name: 'assistant', model });`,
+    };
+    return (
+      <CodeBlock
+        code={snippets[provider]}
+        lang="typescript"
+        options={[
+          { label: 'OpenAI', value: 'openai' },
+          { label: 'Anthropic', value: 'anthropic' },
+          { label: 'Mastra', value: 'mastra' },
+        ]}
+        value={provider}
+        onValueChange={setProvider}
+      />
+    );
+  },
+};

--- a/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
+++ b/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
@@ -117,10 +117,15 @@ function HighlightedCode({ code, lang }: HighlightedCodeProps) {
       setTokens(null);
       return;
     }
+    setTokens(null);
     let cancelled = false;
-    void highlight(code, lang).then(result => {
-      if (!cancelled && result) setTokens(result);
-    });
+    void highlight(code, lang)
+      .then(result => {
+        if (!cancelled && result) setTokens(result);
+      })
+      .catch(() => {
+        // Highlighting failed — plain-text fallback remains visible.
+      });
     return () => {
       cancelled = true;
     };
@@ -138,18 +143,14 @@ function HighlightedCode({ code, lang }: HighlightedCodeProps) {
         {tokens.map((line, lineIndex) => (
           <React.Fragment key={lineIndex}>
             <span>
-              {line.map((token, tokenIndex) => {
-                const style = typeof token.htmlStyle === 'string' ? undefined : token.htmlStyle;
-                return (
-                  <span
-                    key={tokenIndex}
-                    className="text-shiki-light bg-shiki-light-bg dark:text-shiki-dark dark:bg-shiki-dark-bg"
-                    style={style}
-                  >
-                    {token.content}
-                  </span>
-                );
-              })}
+              {line.map((token, tokenIndex) => (
+                <span
+                  key={tokenIndex}
+                  className="text-shiki-light bg-shiki-light-bg dark:text-shiki-dark dark:bg-shiki-dark-bg"
+                >
+                  {token.content}
+                </span>
+              ))}
             </span>
             {lineIndex !== tokens.length - 1 && '\n'}
           </React.Fragment>

--- a/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
+++ b/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { ThemedToken } from 'shiki';
 
 import { highlight } from '../CodeEditor';
 import { CopyButton } from '../CopyButton';
@@ -65,7 +66,7 @@ export function CodeBlock({
 
       {useSelect && options && (
         <div className="flex items-center border-b border-border2/40 px-2 py-1.5">
-          <Select value={value} onValueChange={onValueChange}>
+          <Select value={activeValue} onValueChange={onValueChange}>
             <SelectTrigger size="sm" variant="ghost">
               <SelectValue />
             </SelectTrigger>
@@ -109,7 +110,7 @@ interface HighlightedCodeProps {
 }
 
 function HighlightedCode({ code, lang }: HighlightedCodeProps) {
-  const [tokens, setTokens] = React.useState<any[] | null>(null);
+  const [tokens, setTokens] = React.useState<ThemedToken[][] | null>(null);
 
   React.useEffect(() => {
     if (!lang) {
@@ -137,7 +138,7 @@ function HighlightedCode({ code, lang }: HighlightedCodeProps) {
         {tokens.map((line, lineIndex) => (
           <React.Fragment key={lineIndex}>
             <span>
-              {line.map((token: any, tokenIndex: number) => {
+              {line.map((token, tokenIndex) => {
                 const style = typeof token.htmlStyle === 'string' ? undefined : token.htmlStyle;
                 return (
                   <span

--- a/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
+++ b/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
@@ -1,0 +1,159 @@
+import * as React from 'react';
+
+import { highlight } from '../CodeEditor';
+import { CopyButton } from '../CopyButton';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select';
+import { Tab, TabList, Tabs } from '../Tabs';
+import { transitions } from '@/ds/primitives/transitions';
+import { cn } from '@/lib/utils';
+
+export type CodeBlockSelector = 'select' | 'tabs';
+
+export interface CodeBlockOption {
+  label: string;
+  value: string;
+}
+
+export interface CodeBlockProps {
+  code: string;
+  options?: CodeBlockOption[];
+  value?: string;
+  onValueChange?: (value: string) => void;
+  selector?: CodeBlockSelector;
+  fileName?: string;
+  lang?: string;
+  copyMessage?: string;
+  copyTooltip?: string;
+  className?: string;
+}
+
+export function CodeBlock({
+  code,
+  options,
+  value,
+  onValueChange,
+  selector = 'select',
+  fileName,
+  lang,
+  copyMessage,
+  copyTooltip,
+  className,
+}: CodeBlockProps) {
+  const hasOptions = options && options.length > 0;
+  const useTabs = hasOptions && selector === 'tabs';
+  const useSelect = hasOptions && selector === 'select';
+  const activeValue = value ?? options?.[0]?.value;
+
+  return (
+    <figure
+      className={cn(
+        'group relative flex w-full flex-col overflow-hidden rounded-2xl border border-border2/40 bg-surface2',
+        className,
+      )}
+    >
+      {useTabs && options && (
+        <Tabs defaultTab={options[0].value} value={activeValue} onValueChange={onValueChange ?? (() => {})}>
+          <TabList>
+            {options.map(opt => (
+              <Tab key={opt.value} value={opt.value}>
+                {opt.label}
+              </Tab>
+            ))}
+          </TabList>
+        </Tabs>
+      )}
+
+      {useSelect && options && (
+        <div className="flex items-center border-b border-border2/40 px-2 py-1.5">
+          <Select value={value} onValueChange={onValueChange}>
+            <SelectTrigger size="sm" variant="ghost">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map(opt => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {!hasOptions && fileName && (
+        <div className="flex items-center border-b border-border2/40 px-4 py-2">
+          <figcaption className="font-mono text-ui-sm text-neutral4">{fileName}</figcaption>
+        </div>
+      )}
+
+      <div className="relative">
+        <HighlightedCode code={code} lang={lang} />
+        <CopyButton
+          content={code}
+          copyMessage={copyMessage}
+          tooltip={copyTooltip}
+          size="sm"
+          className={cn(
+            'absolute top-2 right-2 opacity-100 pointer-fine:opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
+            transitions.opacity,
+          )}
+        />
+      </div>
+    </figure>
+  );
+}
+
+interface HighlightedCodeProps {
+  code: string;
+  lang?: string;
+}
+
+function HighlightedCode({ code, lang }: HighlightedCodeProps) {
+  const [tokens, setTokens] = React.useState<any[] | null>(null);
+
+  React.useEffect(() => {
+    if (!lang) {
+      setTokens(null);
+      return;
+    }
+    let cancelled = false;
+    void highlight(code, lang).then(result => {
+      if (!cancelled && result) setTokens(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [code, lang]);
+
+  const preClass = 'px-4 py-3 font-mono text-ui-sm text-neutral5 whitespace-pre-wrap break-all';
+
+  if (!lang || !tokens) {
+    return <pre className={preClass}>{code}</pre>;
+  }
+
+  return (
+    <pre className={preClass}>
+      <code>
+        {tokens.map((line, lineIndex) => (
+          <React.Fragment key={lineIndex}>
+            <span>
+              {line.map((token: any, tokenIndex: number) => {
+                const style = typeof token.htmlStyle === 'string' ? undefined : token.htmlStyle;
+                return (
+                  <span
+                    key={tokenIndex}
+                    className="text-shiki-light bg-shiki-light-bg dark:text-shiki-dark dark:bg-shiki-dark-bg"
+                    style={style}
+                  >
+                    {token.content}
+                  </span>
+                );
+              })}
+            </span>
+            {lineIndex !== tokens.length - 1 && '\n'}
+          </React.Fragment>
+        ))}
+      </code>
+    </pre>
+  );
+}

--- a/packages/playground-ui/src/ds/components/CodeBlock/index.ts
+++ b/packages/playground-ui/src/ds/components/CodeBlock/index.ts
@@ -1,0 +1,1 @@
+export * from './code-block';

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -25,6 +25,7 @@ export * from './ds/components/Checkbox';
 export * from './ds/components/Collapsible';
 export * from './ds/components/Combobox';
 export * from './ds/components/Command';
+export * from './ds/components/CodeBlock';
 export * from './ds/components/CopyButton';
 export * from './ds/components/DashboardCard';
 export * from './ds/components/Dialog';

--- a/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
@@ -25,7 +25,11 @@ export interface MastraVersionFooterProps {
   collapsed?: boolean;
 }
 
-type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun';
+const PACKAGE_MANAGERS = ['pnpm', 'npm', 'yarn', 'bun'] as const;
+type PackageManager = (typeof PACKAGE_MANAGERS)[number];
+
+const isPackageManager = (value: string): value is PackageManager =>
+  (PACKAGE_MANAGERS as readonly string[]).includes(value);
 
 const packageManagerCommands: Record<PackageManager, string> = {
   pnpm: 'pnpm add',
@@ -277,7 +281,9 @@ const PackagesModalContent = ({
                 { label: 'bun', value: 'bun' },
               ]}
               value={packageManager}
-              onValueChange={value => onPackageManagerChange(value as PackageManager)}
+              onValueChange={value => {
+                if (isPackageManager(value)) onPackageManagerChange(value);
+              }}
               copyMessage="Copied update command!"
               copyTooltip="Copy command"
             />

--- a/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
@@ -1,11 +1,11 @@
 import {
-  SelectField,
+  CodeBlock,
+  CopyButton,
   Spinner,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
   Txt,
-  useCopyToClipboard,
   cn,
   Dialog,
   DialogContent,
@@ -15,7 +15,7 @@ import {
   DialogDescription,
   DialogBody,
 } from '@mastra/playground-ui';
-import { Copy, Check, MoveRight, Info, ExternalLink } from 'lucide-react';
+import { MoveRight, ExternalLink, Info } from 'lucide-react';
 import { useState } from 'react';
 import { useMastraPackages } from '../hooks/use-mastra-packages';
 import { usePackageUpdates } from '../hooks/use-package-updates';
@@ -168,14 +168,6 @@ const PackagesModalContent = ({
   const hasUpdates = outdatedCount > 0 || deprecatedCount > 0;
 
   const packagesText = packages.map(pkg => `${pkg.name}@${pkg.version}`).join('\n');
-  const { isCopied: isCopiedAll, handleCopy: handleCopyAll } = useCopyToClipboard({
-    text: packagesText,
-    copyMessage: 'Copied package versions!',
-  });
-  const { isCopied: isCopiedCommand, handleCopy: handleCopyCommand } = useCopyToClipboard({
-    text: updateCommand ?? '',
-    copyMessage: 'Copied update command!',
-  });
 
   return (
     <DialogContent className="max-w-2xl">
@@ -186,7 +178,7 @@ const PackagesModalContent = ({
 
       <DialogBody>
         {/* Status summary */}
-        <div className="text-sm text-neutral3 py-2">
+        <div className="flex items-center justify-between gap-3 text-sm text-neutral3 py-2">
           {isLoadingUpdates ? (
             <span className="text-neutral3">Checking for updates...</span>
           ) : !hasUpdates ? (
@@ -207,6 +199,12 @@ const PackagesModalContent = ({
               )}
             </div>
           )}
+          <CopyButton
+            content={packagesText}
+            copyMessage="Copied package versions!"
+            tooltip="Copy current versions"
+            size="sm"
+          />
         </div>
 
         {/* Package list */}
@@ -261,51 +259,28 @@ const PackagesModalContent = ({
           </div>
         </div>
 
-        {/* Copy current versions button - always visible */}
-        <button
-          onClick={handleCopyAll}
-          className="flex items-center justify-center gap-2 w-full py-2 px-3 rounded bg-surface2 hover:bg-surface3 text-neutral3 hover:text-neutral1 transition-colors"
-        >
-          {isCopiedAll ? <Check className="w-4 h-4 text-accent1" /> : <Copy className="w-4 h-4" />}
-          <Txt as="span" variant="ui-sm">
-            {isCopiedAll ? 'Copied!' : 'Copy current versions'}
-          </Txt>
-        </button>
-
         {/* Update command section */}
         {hasUpdates && updateCommand && (
-          <div className="space-y-3 pt-2 border-t border-border1">
-            <div className="flex items-center gap-2 text-sm text-neutral3 pt-3">
-              <Info className="w-4 h-4" />
-              <span>Use the command below to update your packages</span>
-            </div>
-
-            <div className="flex gap-2 items-center">
-              <SelectField
-                value={packageManager}
-                onValueChange={value => onPackageManagerChange(value as PackageManager)}
-                options={[
-                  { label: 'pnpm', value: 'pnpm' },
-                  { label: 'npm', value: 'npm' },
-                  { label: 'yarn', value: 'yarn' },
-                  { label: 'bun', value: 'bun' },
-                ]}
-              />
-
-              <pre className="flex-1 text-sm text-neutral3 bg-surface2 rounded-md px-3 py-1.5 overflow-x-auto whitespace-pre-wrap break-all">
-                {updateCommand}
-              </pre>
-            </div>
-
-            <button
-              onClick={handleCopyCommand}
-              className="flex items-center justify-center gap-2 w-full py-2 px-3 rounded bg-surface2 hover:bg-surface3 text-neutral3 hover:text-neutral1 transition-colors"
-            >
-              {isCopiedCommand ? <Check className="w-4 h-4 text-accent1" /> : <Copy className="w-4 h-4" />}
-              <Txt as="span" variant="ui-sm">
-                {isCopiedCommand ? 'Copied!' : 'Copy command'}
+          <div className="space-y-2 pt-2 border-t border-border1">
+            <div className="flex items-center gap-2 pt-3">
+              <Info className="w-4 h-4 text-neutral3" />
+              <Txt as="span" variant="ui-sm" className="text-neutral3">
+                Use the command below to update your packages
               </Txt>
-            </button>
+            </div>
+            <CodeBlock
+              code={updateCommand}
+              options={[
+                { label: 'pnpm', value: 'pnpm' },
+                { label: 'npm', value: 'npm' },
+                { label: 'yarn', value: 'yarn' },
+                { label: 'bun', value: 'bun' },
+              ]}
+              value={packageManager}
+              onValueChange={value => onPackageManagerChange(value as PackageManager)}
+              copyMessage="Copied update command!"
+              copyTooltip="Copy command"
+            />
           </div>
         )}
       </DialogBody>


### PR DESCRIPTION
## Summary
- New `CodeBlock` ds component with optional `select` or `tabs` switcher in the header, file-name caption, optional shiki syntax highlighting (via existing `highlight()` helper — no new deps), and a Notion-style copy button that hides on desktop until hover and stays visible on touch devices via `pointer-fine:` / `(hover: hover)` media queries.
- Refactored the Mastra version dialog (`mastra-version-footer.tsx`) to use `CodeBlock` for the update command and replaced the full-width "Copy current versions" button with an icon-only `CopyButton` on the status row.

<img width="947" height="756" alt="CleanShot 2026-05-05 at 11 52 48" src="https://github.com/user-attachments/assets/276d6fa4-1d27-4011-aba2-d9ff5c2807b3" />


## Test plan
- [ ] Open Storybook and review `Composite/CodeBlock` stories — `Default`, `WithSelect`, `WithTabs`, `TabsWithCode`, `WithFileName`, `Highlighted`, `LongCommand`
- [ ] Verify select changes the displayed code and tabs variant switches between provider snippets
- [ ] On desktop, copy button is hidden until hover; on touch (or mobile dev tools emulation), it stays visible
- [ ] In the playground dialog, switching package manager updates the command and the icon copy button next to the status copies all installed versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 - What's this PR about?

Adds a reusable code display component that can show different snippets (via dropdown or tabs), highlight code, and let you quickly copy the code; the Mastra packages dialog now uses this component so the UI is simpler and consistent.

---

## Changes

### New `CodeBlock` component
- Renders code with an optional variant selector (dropdown or tabs) to switch snippets (e.g., package managers or provider examples).
- Optional filename caption.
- Optional syntax highlighting via the existing highlight() helper (no new deps). Tokens are reset to null before each re-highlight and highlight() rejections are caught so the plain-text fallback remains visible and no unhandled promise rejections occur.
- Notion-style copy button: hidden on desktop until hover and remains visible on touch devices using pointer-fine / (hover: hover) media-query behavior.
- Supports configurable copy message/tooltip and controlled/uncontrolled value handling for the selector.

### Storybook
- Added stories demonstrating variants and behaviors: Default, WithSelect, LongCommand, WithFileName, WithTabs, TabsWithCode, Highlighted.

### Refactor: Mastra version dialog
- Replaced the dialog’s previous select + <pre> command block + copy button with the new `CodeBlock` for the update command (package-manager switching now drives CodeBlock via value/onValueChange).
- Replaced the full-width “Copy current versions” control with an icon-only `CopyButton` on the status row.
- Introduced PACKAGE_MANAGERS const, PackageManager union type, and isPackageManager guard for safer package-manager handling.
- Consolidated UI and clipboard handling into `CodeBlock`, simplifying the footer component.

### Exports & package surface
- Re-exported `CodeBlock` from packages/playground-ui/src/index.ts and added component index.ts.
- New exported types: `CodeBlockSelector`, `CodeBlockOption`, `CodeBlockProps`.

### Changesets / Versioning
- Minor bump for `@mastra/playground-ui` documenting the new component.
- Patch update for `mastra` recording the Mastra version dialog refactor.

### Notes for reviewers
- Verify select/tabs switching updates displayed code in Storybook.
- Confirm copy button visibility behavior (hidden until hover on desktop; visible on touch).
- In the playground dialog, confirm switching package manager updates the command and that the copy icon copies the expected text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->