### PR TITLE
fix(observability): resolve OpenRouter "vendor/model" ids in pricing lookup

### DIFF
--- a/.changeset/gentle-maps-rest.md
+++ b/.changeset/gentle-maps-rest.md
@@ -2,15 +2,4 @@
 '@mastra/observability': patch
 ---
 
-Fixed cost estimation for OpenRouter models. Token counts rendered in the observability **Model Usage & Cost** panel, but the cost column was empty for any model id reported in OpenRouter's `vendor/model` format (e.g. `openai/gpt-5-mini-2025-08-07`, `xiaomi/mimo-v2-pro-20260318`).
-
-**Why**
-
-OpenRouter routes calls under model ids that contain a `/` separator. The pricing registry's lookup variants previously normalized `.` to `-` and stripped date suffixes, but never handled `/`, so neither stored convention used in OpenRouter pricing data was reachable:
-
-- Some entries flatten the slash and keep the vendor prefix (`xiaomi/mimo-v2-pro` → `xiaomi-mimo-v2-pro`).
-- Some entries drop the vendor prefix entirely (`openai/gpt-5-mini` → `gpt-5-mini`).
-
-The registry now also tries the slash-flattened and prefix-dropped variants (with date stripping applied to each), covering both conventions. Native provider lookups (e.g. `openai` / `gpt-4o-mini-2024-07-18`) are unchanged.
-
-Follows up on the previous lookup fixes for dotted names and date suffixes.
+Fixed cost estimation for OpenRouter models. The **Model Usage & Cost** panel now shows costs for OpenRouter `vendor/model` ids (e.g. `openai/gpt-5-mini-2025-08-07`, `xiaomi/mimo-v2-pro-20260318`) that previously rendered an empty cost column.

--- a/.changeset/gentle-maps-rest.md
+++ b/.changeset/gentle-maps-rest.md
@@ -1,0 +1,16 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed cost estimation for OpenRouter models. Token counts rendered in the observability **Model Usage & Cost** panel, but the cost column was empty for any model id reported in OpenRouter's `vendor/model` format (e.g. `openai/gpt-5-mini-2025-08-07`, `xiaomi/mimo-v2-pro-20260318`).
+
+**Why**
+
+OpenRouter routes calls under model ids that contain a `/` separator. The pricing registry's lookup variants previously normalized `.` to `-` and stripped date suffixes, but never handled `/`, so neither stored convention used in OpenRouter pricing data was reachable:
+
+- Some entries flatten the slash and keep the vendor prefix (`xiaomi/mimo-v2-pro` → `xiaomi-mimo-v2-pro`).
+- Some entries drop the vendor prefix entirely (`openai/gpt-5-mini` → `gpt-5-mini`).
+
+The registry now also tries the slash-flattened and prefix-dropped variants (with date stripping applied to each), covering both conventions. Native provider lookups (e.g. `openai` / `gpt-4o-mini-2024-07-18`) are unchanged.
+
+Follows up on the previous lookup fixes for dotted names and date suffixes.

--- a/observability/mastra/src/metrics/__fixtures__/pricing-data-test.jsonl
+++ b/observability/mastra/src/metrics/__fixtures__/pricing-data-test.jsonl
@@ -1,3 +1,5 @@
 {"i":"openai-gpt-4o-mini","p":"openai","m":"gpt-4o-mini","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":7.5e-8},"it":{"c":1.5e-7},"ot":{"c":6e-7}}}]}}}
 {"i":"google-gemini-2-5-pro","p":"google","m":"gemini-2-5-pro","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":1.25e-7},"it":{"c":0.00000125},"ot":{"c":0.00001}}},{"w":[{"f":"tit","op":"gt","value":200000}],"r":{"icrt":{"c":2.5e-7},"it":{"c":0.0000025},"ot":{"c":0.000015}}}]}}}
 {"i":"anthropic-claude-sonnet-4-5","p":"anthropic","m":"claude-sonnet-4-5","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":3e-7},"icwt":{"c":0.00000375},"it":{"c":0.000003},"ot":{"c":0.000015}}}]}}}
+{"i":"openrouter-xiaomi-mimo-v2-pro","p":"openrouter","m":"xiaomi-mimo-v2-pro","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":2e-7},"it":{"c":1e-6},"ot":{"c":3e-6}}}]}}}
+{"i":"openrouter-gpt-5-mini","p":"openrouter","m":"gpt-5-mini","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":2.5e-8},"it":{"c":2.5e-7},"ot":{"c":2e-6}}}]}}}

--- a/observability/mastra/src/metrics/estimator.test.ts
+++ b/observability/mastra/src/metrics/estimator.test.ts
@@ -368,4 +368,58 @@ describe('estimateCosts', () => {
       error: 'no_matching_model',
     });
   });
+
+  it('resolves OpenRouter "vendor/model" ids when pricing data keeps the vendor prefix', () => {
+    // OpenRouter reports model ids with a slash separator, but pricing entries
+    // flatten them with a dash (e.g. "xiaomi/mimo-v2-pro" → "xiaomi-mimo-v2-pro").
+    const costs = estimateCosts(
+      {
+        provider: 'openrouter',
+        model: 'xiaomi/mimo-v2-pro-20260318',
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 100,
+        },
+      },
+      pricingRegistry,
+    );
+
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toEqual({
+      provider: 'openrouter',
+      model: 'xiaomi-mimo-v2-pro',
+      estimatedCost: 0.001,
+      costUnit: 'USD',
+      costMetadata: {
+        pricing_id: 'openrouter-xiaomi-mimo-v2-pro',
+        tier_index: 0,
+      },
+    });
+  });
+
+  it('resolves OpenRouter "vendor/model" ids when pricing data drops the vendor prefix', () => {
+    // Some OpenRouter pricing rows omit the vendor prefix entirely
+    // (e.g. "openai/gpt-5-mini" is stored as "gpt-5-mini").
+    const costs = estimateCosts(
+      {
+        provider: 'openrouter',
+        model: 'openai/gpt-5-mini-2025-08-07',
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 100,
+        },
+      },
+      pricingRegistry,
+    );
+
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toEqual({
+      provider: 'openrouter',
+      model: 'gpt-5-mini',
+      estimatedCost: 0.00025,
+      costUnit: 'USD',
+      costMetadata: {
+        pricing_id: 'openrouter-gpt-5-mini',
+        tier_index: 0,
+      },
+    });
+  });
 });

--- a/observability/mastra/src/metrics/pricing-registry.ts
+++ b/observability/mastra/src/metrics/pricing-registry.ts
@@ -191,14 +191,33 @@ function normalizeProvider(provider: string): string {
 
 /**
  * Generate model name variants to try during lookup, in priority order:
- * 1. Original model name
- * 2. Dots converted to dashes (e.g., "gpt-5.4" → "gpt-5-4")
- * 3. Date suffix stripped from original
- * 4. Date suffix stripped from dashed version
+ * 1. Original (and date-stripped original)
+ * 2. Dots → dashes, e.g. "gpt-5.4" → "gpt-5-4" (and date-stripped)
+ * 3. Dots and slashes → dashes, e.g. "xiaomi/mimo-v2-pro" → "xiaomi-mimo-v2-pro"
+ *    (covers OpenRouter entries that keep the vendor prefix flattened with a dash)
+ * 4. Vendor prefix dropped, e.g. "openai/gpt-5-mini" → "gpt-5-mini"
+ *    (covers OpenRouter entries stored without the vendor prefix)
+ *
+ * Each variant is also tried with its date suffix stripped.
+ * The Set dedupes so non-prefixed inputs do not pay for redundant lookups.
  */
 function getModelVariants(model: string): string[] {
-  const dashed = model.replace(/\./g, '-');
-  return [model, dashed, stripDateSuffix(model), stripDateSuffix(dashed)];
+  const variants = new Set<string>();
+  const add = (v: string) => {
+    variants.add(v);
+    variants.add(stripDateSuffix(v));
+  };
+
+  add(model);
+  add(model.replace(/\./g, '-'));
+  add(model.replace(/[./]/g, '-'));
+
+  const slashIndex = model.indexOf('/');
+  if (slashIndex !== -1) {
+    add(model.substring(slashIndex + 1));
+  }
+
+  return [...variants];
 }
 
 /**


### PR DESCRIPTION
## Description

Adds two more model-id variants to the pricing lookup so OpenRouter ids in `vendor/model` form resolve:

- slash-flattened (`xiaomi/mimo-v2-pro` → `xiaomi-mimo-v2-pro`)
- vendor-prefix-dropped (`openai/gpt-5-mini` → `gpt-5-mini`)

Date stripping is applied to each variant; the variant set is deduped so non-prefixed inputs don't pay for redundant lookups. Native provider lookups are unchanged.

Follows up on #14959 (dot-to-dash) and #15349 (date suffixes).

## Related Issue(s)

Closes #16205

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR fixes how the system finds prices for OpenRouter models that use names like "vendor/model" by trying additional name variants (like replacing "/" with "-" and dropping the vendor prefix) so the correct cost is found and shown.

## Changes

### Core Logic (observability/.../pricing-registry.ts)
- Rewrote getModelVariants to produce a prioritized, deduplicated set of lookup variants for a given model id.
- New variants generated:
  - Slash-to-dash normalization (e.g., `xiaomi/mimo-v2-pro` → `xiaomi-mimo-v2-pro`)
  - Vendor-prefix-dropped for slash-containing ids (e.g., `openai/gpt-5-mini` → `gpt-5-mini`)
  - Dot-to-dash normalization (existing behavior retained)
- Date-suffix stripping is applied to every variant.
- Variants are deduplicated to avoid redundant lookups.
- Doc comment expanded to explain variant strategy and ordering.
- Native provider lookups are unchanged.

### Tests (observability/.../estimator.test.ts)
- Added two Vitest cases to validate OpenRouter model normalization and pricing resolution:
  1. Resolves `xiaomi/mimo-v2-pro-...` to `xiaomi-mimo-v2-pro` when pricing keeps the vendor prefix.
  2. Resolves `openai/gpt-5-mini-...` to `gpt-5-mini` when pricing omits the vendor prefix.
- Ensures pricing_id/tier_index and cost calculations match expectations.

### Test Fixtures (observability/.../pricing-data-test.jsonl)
- Added JSONL fixture entries for OpenRouter models used in tests:
  - `openrouter-xiaomi-mimo-v2-pro` with USD pricing under model_pricing/v1
  - `openrouter-gpt-5-mini` with USD pricing under model_pricing/v1

### Changelog (.changeset/gentle-maps-rest.md)
- Patch entry for @mastra/observability documenting the fix: Model Usage & Cost now shows costs for OpenRouter IDs in `vendor/model` form that previously appeared empty.

## Impact
- Fixes observation/metrics cost lookup failures for OpenRouter models using `vendor/model` IDs by expanding normalization rules and applying date-stripping to all variants.
- Backward-compatible: native provider lookups unchanged.
- Tests and fixtures included; related issue closed: #16205
<!-- end of auto-generated comment: release notes by coderabbit.ai -->