### PR TITLE
feat(islo): add islo.dev sandbox provider for Mastra workspaces

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7415,6 +7415,49 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  workspaces/islo:
+    dependencies:
+      '@islo-labs/sdk':
+        specifier: ^0.0.16
+        version: 0.0.16
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@internal/workspace-test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.5(vitest@4.1.5)
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
+      eslint:
+        specifier: ^10.2.1
+        version: 10.2.1(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.57.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+
   workspaces/modal:
     dependencies:
       modal:
@@ -11492,6 +11535,10 @@ packages:
   '@isaacs/ttlcache@2.1.4':
     resolution: {integrity: sha512-7kMz0BJpMvgAMkyglums7B2vtrn5g0a0am77JY0GjkZZNetOBCFn7AG7gKCwT0QPiXyxW7YIQSgtARknUEOcxQ==}
     engines: {node: '>=12'}
+
+  '@islo-labs/sdk@0.0.16':
+    resolution: {integrity: sha512-Dr057VJA8rVdcS+1dbJ6VptrNcA6lGOVyfGZB4WeZDu+0bREYvLk+G/Qrs2MAo0/YF0Dtow/5QQ2PKv2jps1rg==}
+    engines: {node: '>=18.0.0'}
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -32492,6 +32539,8 @@ snapshots:
       minipass: 7.1.3
 
   '@isaacs/ttlcache@2.1.4': {}
+
+  '@islo-labs/sdk@0.0.16': {}
 
   '@jest/schemas@29.6.3':
     dependencies:

--- a/workspaces/islo/README.md
+++ b/workspaces/islo/README.md
@@ -1,0 +1,71 @@
+# @mastra/islo
+
+[islo.dev](https://islo.dev) sandbox provider for Mastra workspaces. Backed by [`@islo-labs/sdk`](https://www.npmjs.com/package/@islo-labs/sdk); commands stream stdout/stderr live by consuming the islo SSE exec endpoint directly.
+
+## Installation
+
+```bash
+npm install @mastra/islo
+```
+
+## Usage
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { Workspace } from '@mastra/core/workspace';
+import { IsloSandbox } from '@mastra/islo';
+
+const workspace = new Workspace({
+  sandbox: new IsloSandbox({
+    apiKey: process.env.ISLO_API_KEY, // also read from ISLO_API_KEY env var
+    image: 'docker.io/library/ubuntu:24.04',
+    workdir: 'my-project',
+    timeout: 60_000,
+  }),
+});
+
+const agent = new Agent({
+  name: 'my-agent',
+  model: 'anthropic/claude-opus-4-5',
+  workspace,
+});
+```
+
+`apiKey` falls back to the `ISLO_API_KEY` environment variable. `baseUrl` falls back to `ISLO_BASE_URL`, then `https://api.islo.dev`. The SDK exchanges the API key for a short-lived JWT and refreshes it automatically.
+
+## Lifecycle
+
+| WorkspaceSandbox method | islo SDK call |
+|---|---|
+| `start()` | `sandboxes.createSandbox` (or reconnects to an existing sandbox by name when one is already live) |
+| `stop()` | `sandboxes.stopSandbox` (paused; sandbox record retained) |
+| `destroy()` | `sandboxes.deleteSandbox` (only when this instance acquired the sandbox) |
+| `executeCommand()` | direct SSE consumer on `POST /sandboxes/{name}/exec/stream` |
+
+## Live streaming
+
+`@islo-labs/sdk`'s generated `execInSandboxStream` decodes the SSE response body through a JSON unmarshaler — by the time you see bytes, the command is finished. To deliver true line-by-line output, `IsloSandbox.executeCommand` bypasses that wrapper and consumes the `/exec/stream` endpoint directly. Auth still flows through the SDK's `TokenProvider`, so token refresh and base URL stay consistent.
+
+If the SDK later exposes a streaming iterator, the consumer in `src/sandbox/sse.ts` should be removed and the SDK call used instead.
+
+## Reconnection
+
+When you pass a `sandboxName` that already exists and is still live (not `deleted`/`failed`), `start()` reconnects to it instead of creating a new one. `destroy()` only deletes sandboxes the current instance acquired itself, so reconnecting to an existing sandbox does not destroy it on shutdown.
+
+## Configuration
+
+| Option | Description | Default |
+|---|---|---|
+| `sandboxName` | Sandbox name (path segment) | `mastra-<random>` |
+| `image` | Container image | islo tenant default |
+| `workdir` | Working directory relative to `/workspace` | islo image default |
+| `gatewayProfile` | Gateway profile name or id | tenant default |
+| `env` | Environment variables for sandbox creation | `{}` |
+| `apiKey` | islo API key (`ak_...`) | `ISLO_API_KEY` env var |
+| `baseUrl` | API base URL | `ISLO_BASE_URL` or `https://api.islo.dev` |
+| `timeout` | Default per-command timeout (ms) | `300000` |
+| `metadata` | Sandbox-create metadata | `{}` |
+
+## License
+
+Apache-2.0

--- a/workspaces/islo/eslint.config.js
+++ b/workspaces/islo/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/workspaces/islo/package.json
+++ b/workspaces/islo/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@mastra/islo",
+  "version": "0.0.1",
+  "description": "islo.dev sandbox provider for Mastra workspaces",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --silent --config tsup.config.ts",
+    "build:lib": "pnpm build",
+    "build:watch": "pnpm build --watch",
+    "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
+    "test:watch": "vitest watch",
+    "test": "vitest run ./src/**/*.integration.test.ts",
+    "test:cloud": "pnpm test",
+    "lint": "eslint ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@islo-labs/sdk": "^0.0.16"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@internal/workspace-test-utils": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.19.15",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "dotenv": "^17.3.1",
+    "eslint": "^10.2.1",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.12.0-0 <2.0.0-0"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "workspaces/islo"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/workspaces/islo/src/index.ts
+++ b/workspaces/islo/src/index.ts
@@ -1,0 +1,3 @@
+export { IsloSandbox, type IsloSandboxOptions } from './sandbox';
+export { isloSandboxProvider } from './provider';
+export { consumeIsloStream, type SSECallbacks, type SSEResult } from './sandbox/sse';

--- a/workspaces/islo/src/provider.ts
+++ b/workspaces/islo/src/provider.ts
@@ -1,0 +1,60 @@
+/**
+ * islo sandbox provider descriptor for MastraEditor.
+ *
+ * @example
+ * ```typescript
+ * import { isloSandboxProvider } from '@mastra/islo';
+ *
+ * const editor = new MastraEditor({
+ *   sandboxes: [isloSandboxProvider],
+ * });
+ * ```
+ */
+import type { SandboxProvider } from '@mastra/core/editor';
+
+import { IsloSandbox } from './sandbox';
+
+/**
+ * Serializable subset of `IsloSandboxOptions` for editor storage. Non-
+ * serializable options (callbacks) are excluded.
+ */
+interface IsloProviderConfig {
+  sandboxName?: string;
+  image?: string;
+  workdir?: string;
+  gatewayProfile?: string;
+  env?: Record<string, string>;
+  apiKey?: string;
+  baseUrl?: string;
+  timeout?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export const isloSandboxProvider: SandboxProvider<IsloProviderConfig> = {
+  id: 'islo',
+  name: 'islo Sandbox',
+  description: 'Cloud sandbox powered by islo.dev',
+  configSchema: {
+    type: 'object',
+    properties: {
+      sandboxName: { type: 'string', description: 'Sandbox name (path segment)' },
+      image: { type: 'string', description: 'Container image (e.g. docker.io/library/ubuntu:24.04)' },
+      workdir: { type: 'string', description: 'Working directory relative to /workspace' },
+      gatewayProfile: { type: 'string', description: 'Gateway profile name or id' },
+      env: {
+        type: 'object',
+        description: 'Environment variables for sandbox creation',
+        additionalProperties: { type: 'string' },
+      },
+      apiKey: { type: 'string', description: 'islo API key (falls back to ISLO_API_KEY)' },
+      baseUrl: { type: 'string', description: 'islo API base URL (falls back to ISLO_BASE_URL)' },
+      timeout: { type: 'number', description: 'Default per-command timeout in milliseconds', default: 300000 },
+      metadata: {
+        type: 'object',
+        description: 'Custom metadata',
+        additionalProperties: true,
+      },
+    },
+  },
+  createSandbox: (config) => new IsloSandbox(config),
+};

--- a/workspaces/islo/src/sandbox/index.integration.test.ts
+++ b/workspaces/islo/src/sandbox/index.integration.test.ts
@@ -1,0 +1,63 @@
+/**
+ * IsloSandbox integration tests.
+ *
+ * Run only when `ISLO_API_KEY` is set. Tests hit api.islo.dev and create real
+ * sandboxes which are torn down in `afterAll`.
+ */
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { IsloSandbox } from './index';
+
+const hasApiKey = !!process.env.ISLO_API_KEY;
+
+describe.skipIf(!hasApiKey)('IsloSandbox (live)', () => {
+  const sandbox = new IsloSandbox({
+    sandboxName: `mastra-it-${Date.now().toString(36)}`,
+    timeout: 60_000,
+  });
+
+  afterAll(async () => {
+    try {
+      await sandbox._destroy();
+    } catch {
+      // best-effort cleanup
+    }
+  }, 60_000);
+
+  it('creates a sandbox, runs a command, and streams output live', async () => {
+    await sandbox._start();
+    expect(sandbox.status).toBe('running');
+
+    const chunks: string[] = [];
+    const result = await sandbox.executeCommand!('echo', ['hello-from-mastra'], {
+      onStdout: (d) => chunks.push(d),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('hello-from-mastra');
+    expect(chunks.length).toBeGreaterThan(0);
+  }, 120_000);
+
+  it('streams output incrementally for a long-running command', async () => {
+    const chunks: string[] = [];
+    const start = Date.now();
+    const result = await sandbox.executeCommand!('bash', ['-lc', 'for i in 1 2 3; do echo $i; sleep 1; done'], {
+      onStdout: (d) => chunks.push(d),
+    });
+    const elapsed = Date.now() - start;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/1[\r\n]+2[\r\n]+3/);
+    // Three iterations sleep ≈3s; total should be around that, not buffered.
+    expect(elapsed).toBeGreaterThan(2_000);
+  }, 30_000);
+
+  it('propagates non-zero exit codes', async () => {
+    const result = await sandbox.executeCommand!('bash', ['-lc', 'echo oops >&2; exit 42']);
+    expect(result.exitCode).toBe(42);
+    expect(result.success).toBe(false);
+    expect(result.stderr).toContain('oops');
+  }, 60_000);
+});

--- a/workspaces/islo/src/sandbox/index.test.ts
+++ b/workspaces/islo/src/sandbox/index.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for IsloSandbox.
+ *
+ * The islo SDK + the global `fetch` are mocked so we can drive the lifecycle
+ * and exec paths without hitting api.islo.dev. Live integration coverage is
+ * in `index.integration.test.ts` and runs only when `ISLO_API_KEY` is set.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createSandboxMock = vi.fn();
+const getSandboxMock = vi.fn();
+const stopSandboxMock = vi.fn();
+const deleteSandboxMock = vi.fn();
+const getTokenMock = vi.fn();
+
+vi.mock('@islo-labs/sdk', () => {
+  function MockIslo(this: unknown) {
+    Object.assign(this as object, {
+      sandboxes: {
+        createSandbox: createSandboxMock,
+        getSandbox: getSandboxMock,
+        stopSandbox: stopSandboxMock,
+        deleteSandbox: deleteSandboxMock,
+      },
+    });
+  }
+  function MockTokenProvider(this: unknown) {
+    Object.assign(this as object, { getToken: getTokenMock });
+  }
+  return { Islo: MockIslo, TokenProvider: MockTokenProvider };
+});
+
+import { IsloSandbox } from './index';
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  process.env.ISLO_API_KEY = 'ak_test';
+  getTokenMock.mockResolvedValue('jwt-test');
+  createSandboxMock.mockResolvedValue({ name: 'mastra-test', status: 'running', created_at: '2026-05-05T00:00:00Z' });
+  // Default to "not found" so start() takes the create path.
+  getSandboxMock.mockRejectedValue({ statusCode: 404 });
+  stopSandboxMock.mockResolvedValue({});
+  deleteSandboxMock.mockResolvedValue({});
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  globalThis.fetch = realFetch;
+  delete process.env.ISLO_API_KEY;
+});
+
+function streamFromString(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+describe('IsloSandbox', () => {
+  describe('constructor', () => {
+    it('throws when ISLO_API_KEY is missing and no apiKey option is provided', () => {
+      delete process.env.ISLO_API_KEY;
+      expect(() => new IsloSandbox()).toThrow(/ISLO_API_KEY/);
+    });
+
+    it('uses an explicit apiKey option when env is unset', () => {
+      delete process.env.ISLO_API_KEY;
+      expect(() => new IsloSandbox({ apiKey: 'ak_inline' })).not.toThrow();
+    });
+
+    it('generates a sandbox name when none is supplied', () => {
+      const sb = new IsloSandbox();
+      expect(sb.name_).toMatch(/^mastra-/);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('start() creates a new sandbox when none exists', async () => {
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test', image: 'ubuntu:24.04' });
+      await sb._start();
+      expect(getSandboxMock).toHaveBeenCalledWith({ sandbox_name: 'mastra-test' });
+      expect(createSandboxMock).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'mastra-test', image: 'ubuntu:24.04' }),
+      );
+      expect(sb.status).toBe('running');
+    });
+
+    it('start() reconnects to an existing live sandbox by name', async () => {
+      getSandboxMock.mockResolvedValueOnce({
+        name: 'mastra-test',
+        status: 'running',
+        created_at: '2026-05-04T00:00:00Z',
+      });
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      await sb._start();
+      expect(createSandboxMock).not.toHaveBeenCalled();
+      expect(sb.status).toBe('running');
+    });
+
+    it('destroy() deletes only sandboxes acquired by this instance', async () => {
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      await sb._start();
+      await sb._destroy();
+      expect(deleteSandboxMock).toHaveBeenCalledWith({ sandbox_name: 'mastra-test' });
+    });
+
+    it('destroy() does not delete a sandbox the instance only reconnected to', async () => {
+      getSandboxMock.mockResolvedValueOnce({ name: 'mastra-keep', status: 'running' });
+      const sb = new IsloSandbox({ sandboxName: 'mastra-keep' });
+      await sb._start();
+      await sb._destroy();
+      expect(deleteSandboxMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('executeCommand', () => {
+    it('streams stdout/stderr deltas and propagates the exit code', async () => {
+      const sseBody = [
+        'event: stdout',
+        'data: hello',
+        '',
+        'event: stderr',
+        'data: warn',
+        '',
+        'event: exit',
+        'data: 0',
+        '',
+      ].join('\n');
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response(streamFromString(sseBody), {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+      ) as unknown as typeof fetch;
+
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      const stdoutChunks: string[] = [];
+      const stderrChunks: string[] = [];
+      const result = await sb.executeCommand!('echo', ['hello'], {
+        onStdout: (d) => stdoutChunks.push(d),
+        onStderr: (d) => stderrChunks.push(d),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.success).toBe(true);
+      expect(result.stdout).toBe('hello');
+      expect(result.stderr).toBe('warn');
+      expect(stdoutChunks).toEqual(['hello']);
+      expect(stderrChunks).toEqual(['warn']);
+
+      const fetchCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toContain('/sandboxes/mastra-test/exec/stream');
+      const init = fetchCall[1] as RequestInit;
+      expect(init.method).toBe('POST');
+      const headers = init.headers as Record<string, string>;
+      expect(headers.authorization).toBe('Bearer jwt-test');
+      expect(headers.accept).toBe('text/event-stream');
+    });
+
+    it('propagates a non-zero exit code', async () => {
+      const sseBody = 'event: stdout\ndata: nope\n\nevent: exit\ndata: 7\n\n';
+      globalThis.fetch = vi.fn().mockResolvedValue(new Response(streamFromString(sseBody))) as unknown as typeof fetch;
+
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      const result = await sb.executeCommand!('false');
+      expect(result.exitCode).toBe(7);
+      expect(result.success).toBe(false);
+    });
+
+    it('throws when the stream endpoint returns a non-2xx response', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response('boom', { status: 500, statusText: 'Internal Server Error' }),
+      ) as unknown as typeof fetch;
+
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test' });
+      await expect(sb.executeCommand!('echo', ['hi'])).rejects.toThrow(/500/);
+    });
+
+    it('marks the result as timedOut when the per-command timeout elapses', async () => {
+      // Hang fetch indefinitely by returning a body that never closes.
+      globalThis.fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+        return new Promise((_, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        });
+      }) as unknown as typeof fetch;
+
+      const sb = new IsloSandbox({ sandboxName: 'mastra-test', timeout: 25 });
+      const result = await sb.executeCommand!('sleep', ['10']);
+      expect(result.timedOut).toBe(true);
+      expect(result.exitCode).toBe(124);
+    });
+  });
+});

--- a/workspaces/islo/src/sandbox/index.ts
+++ b/workspaces/islo/src/sandbox/index.ts
@@ -1,0 +1,369 @@
+/**
+ * islo Sandbox Provider
+ *
+ * Wraps `@islo-labs/sdk` with the Mastra `WorkspaceSandbox` contract. Auth
+ * comes from `ISLO_API_KEY` (the SDK's `Islo` class handles API-key → JWT
+ * exchange and refresh). Lifecycle:
+ *
+ *  - start    → `sandboxes.createSandbox` (or reconnect to an existing
+ *               sandbox by name, idempotent)
+ *  - stop     → `sandboxes.stopSandbox` (record retained, sandbox paused)
+ *  - destroy  → `sandboxes.deleteSandbox` (sandbox marked for deletion)
+ *  - executeCommand → POST `/sandboxes/{name}/exec/stream`, parse SSE,
+ *                     dispatch stdout/stderr deltas to callbacks.
+ *
+ * The `executeCommand` path bypasses the SDK's generated stream wrapper
+ * (`execInSandboxStream`) because the wrapper buffers the SSE body through a
+ * JSON unmarshaler — useless for live output. Auth still comes from the
+ * SDK's `TokenProvider` so refresh stays consistent.
+ */
+
+import { Islo, TokenProvider } from '@islo-labs/sdk';
+import { MastraSandbox } from '@mastra/core/workspace';
+import type {
+  CommandResult,
+  ExecuteCommandOptions,
+  MastraSandboxOptions,
+  ProviderStatus,
+  SandboxInfo,
+} from '@mastra/core/workspace';
+
+import { consumeIsloStream } from './sse';
+
+const ENV_API_KEY = 'ISLO_API_KEY';
+const ENV_BASE_URL = 'ISLO_BASE_URL';
+const DEFAULT_BASE_URL = 'https://api.islo.dev';
+
+/**
+ * Configuration for an `IsloSandbox` instance.
+ */
+export interface IsloSandboxOptions extends MastraSandboxOptions {
+  /** Mastra-side instance ID. Auto-generated if omitted. */
+  id?: string;
+  /**
+   * islo sandbox name. Used as the path segment for sandbox API calls.
+   * If omitted, a fresh `mastra-<random>` name is generated. Reusing a name
+   * across runs reconnects to the existing sandbox if it is still live.
+   */
+  sandboxName?: string;
+  /** Container image (e.g. `docker.io/library/ubuntu:24.04`). */
+  image?: string;
+  /** Working directory relative to `/workspace` inside the sandbox. */
+  workdir?: string;
+  /** Gateway profile name or ID. Falls back to tenant default if omitted. */
+  gatewayProfile?: string;
+  /** Environment variables injected at sandbox-create time. */
+  env?: Record<string, string>;
+  /**
+   * islo API key (Descope access key). Falls back to `ISLO_API_KEY` env var.
+   */
+  apiKey?: string;
+  /**
+   * Base URL for the islo API. Falls back to `ISLO_BASE_URL` env var, then
+   * `https://api.islo.dev`.
+   */
+  baseUrl?: string;
+  /** Sandbox-create metadata. */
+  metadata?: Record<string, unknown>;
+  /** Default per-command timeout in milliseconds. */
+  timeout?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+export class IsloSandbox extends MastraSandbox {
+  readonly id: string;
+  readonly name = 'IsloSandbox';
+  readonly provider = 'islo';
+  status: ProviderStatus = 'pending';
+
+  private readonly client: Islo;
+  private readonly tokenProvider: TokenProvider;
+  private readonly baseUrl: string;
+  private readonly sandboxName: string;
+  private readonly image?: string;
+  private readonly workdir?: string;
+  private readonly gatewayProfile?: string;
+  private readonly env: Record<string, string>;
+  private readonly metadata: Record<string, unknown>;
+  private readonly defaultTimeoutMs: number;
+
+  private _createdAt: Date | null = null;
+  private _acquired = false;
+
+  constructor(options: IsloSandboxOptions = {}) {
+    super({ ...options, name: 'IsloSandbox' });
+
+    const apiKey = options.apiKey ?? process.env[ENV_API_KEY];
+    if (!apiKey) {
+      throw new Error(
+        `IsloSandbox: missing ${ENV_API_KEY}; set the env var or pass { apiKey } to the constructor`,
+      );
+    }
+    const baseUrl = (options.baseUrl ?? process.env[ENV_BASE_URL] ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+
+    this.id = options.id ?? generateIsloSandboxInstanceId();
+    this.sandboxName = options.sandboxName ?? generateSandboxName();
+    this.image = options.image;
+    this.workdir = options.workdir;
+    this.gatewayProfile = options.gatewayProfile;
+    this.env = options.env ?? {};
+    this.metadata = options.metadata ?? {};
+    this.defaultTimeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
+    this.baseUrl = baseUrl;
+
+    this.client = new Islo({ apiKey, baseUrl });
+    this.tokenProvider = new TokenProvider({ apiKey, baseUrl });
+  }
+
+  /**
+   * Direct access to the underlying `@islo-labs/sdk` `Islo` client for
+   * features not surfaced through the `WorkspaceSandbox` contract (e.g.
+   * snapshots, sessions, file transfer).
+   */
+  get islo(): Islo {
+    return this.client;
+  }
+
+  /** Sandbox name used in the islo API path. */
+  get name_(): string {
+    return this.sandboxName;
+  }
+
+  override async start(): Promise<void> {
+    // Reconnect to an existing live sandbox with this name if present.
+    const existing = await this.findExistingSandbox();
+    if (existing) {
+      this._createdAt = existing.createdAt;
+      this._acquired = false;
+      this.logger.debug(`reconnected to existing islo sandbox ${this.sandboxName}`);
+      return;
+    }
+
+    this.logger.debug(`creating islo sandbox ${this.sandboxName}`);
+    const created = await this.client.sandboxes.createSandbox({
+      name: this.sandboxName,
+      image: this.image,
+      workdir: this.workdir,
+      gateway_profile: this.gatewayProfile,
+      env: nullifyValues(this.env),
+    });
+    this._createdAt = created.created_at ? new Date(created.created_at) : new Date();
+    this._acquired = true;
+  }
+
+  override async stop(): Promise<void> {
+    try {
+      await this.client.sandboxes.stopSandbox({ sandbox_name: this.sandboxName });
+    } catch (err) {
+      // Stop is best-effort; log and continue. The destroy path will clean up.
+      this.logger.warn(`islo stop failed for ${this.sandboxName}`, { error: serializeError(err) });
+    }
+  }
+
+  override async destroy(): Promise<void> {
+    if (!this._acquired) {
+      // We didn't create this sandbox; don't delete it on the user's behalf.
+      return;
+    }
+    try {
+      await this.client.sandboxes.deleteSandbox({ sandbox_name: this.sandboxName });
+    } catch (err) {
+      this.logger.warn(`islo delete failed for ${this.sandboxName}`, { error: serializeError(err) });
+    }
+  }
+
+  override async getInfo(): Promise<SandboxInfo> {
+    const info: SandboxInfo = {
+      id: this.id,
+      name: this.name,
+      provider: this.provider,
+      status: this.status,
+      createdAt: this._createdAt ?? new Date(),
+      metadata: { sandboxName: this.sandboxName, ...this.metadata },
+    };
+    return info;
+  }
+
+  override async executeCommand(
+    command: string,
+    args: string[] = [],
+    options: ExecuteCommandOptions = {},
+  ): Promise<CommandResult> {
+    await this.ensureRunning();
+
+    const fullCommand = args.length > 0 ? [command, ...args] : [command];
+    const startTime = Date.now();
+    const timeoutMs = options.timeout ?? this.defaultTimeoutMs;
+    const cwd = options.cwd ?? this.workdir;
+    const envOverride = options.env ? mergeEnv(this.env, options.env) : this.env;
+
+    const url = `${this.baseUrl}/sandboxes/${encodeURIComponent(this.sandboxName)}/exec/stream`;
+    const token = await this.tokenProvider.getToken();
+
+    // Wire up timeout + caller's abort signal.
+    const controller = new AbortController();
+    const timeoutHandle =
+      timeoutMs > 0
+        ? setTimeout(() => controller.abort(new Error(`islo executeCommand timed out after ${timeoutMs}ms`)), timeoutMs)
+        : null;
+    const callerSignal = options.abortSignal;
+    const onCallerAbort = () => controller.abort(callerSignal?.reason);
+    if (callerSignal) {
+      if (callerSignal.aborted) {
+        controller.abort(callerSignal.reason);
+      } else {
+        callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+      }
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+          accept: 'text/event-stream',
+        },
+        body: JSON.stringify({
+          command: fullCommand,
+          workdir: cwd ?? null,
+          env: nullifyValues(envOverride),
+        }),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (callerSignal) callerSignal.removeEventListener('abort', onCallerAbort);
+      const aborted = (err as { name?: string })?.name === 'AbortError';
+      return {
+        success: false,
+        exitCode: aborted ? 124 : 1,
+        stdout: '',
+        stderr: aborted ? `command aborted: ${(err as Error).message}` : (err as Error).message,
+        executionTimeMs: Date.now() - startTime,
+        timedOut: aborted && !callerSignal?.aborted,
+        killed: aborted && !!callerSignal?.aborted,
+        command,
+        args,
+      };
+    }
+
+    if (!response.ok || !response.body) {
+      const text = await response.text().catch(() => '');
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (callerSignal) callerSignal.removeEventListener('abort', onCallerAbort);
+      throw new Error(
+        `islo exec stream ${response.status} ${response.statusText}: ${text.slice(0, 200)}`,
+      );
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let killed = false;
+    let exitCode = 0;
+
+    try {
+      const result = await consumeIsloStream(response.body, {
+        onStdout: (data) => {
+          stdout += data;
+          options.onStdout?.(data);
+        },
+        onStderr: (data) => {
+          stderr += data;
+          options.onStderr?.(data);
+        },
+      });
+      exitCode = result.exitCode;
+    } catch (err) {
+      const aborted = (err as { name?: string })?.name === 'AbortError';
+      if (aborted) {
+        timedOut = !callerSignal?.aborted;
+        killed = !!callerSignal?.aborted;
+        exitCode = 124;
+      } else {
+        throw err;
+      }
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (callerSignal) callerSignal.removeEventListener('abort', onCallerAbort);
+    }
+
+    return {
+      success: exitCode === 0,
+      exitCode,
+      stdout,
+      stderr,
+      executionTimeMs: Date.now() - startTime,
+      timedOut,
+      killed,
+      command,
+      args,
+    };
+  }
+
+  /**
+   * Look up an existing islo sandbox by name. Returns null if it doesn't
+   * exist, has been deleted, or the lookup raised a 404.
+   */
+  private async findExistingSandbox(): Promise<{ createdAt: Date } | null> {
+    try {
+      const sandbox = await this.client.sandboxes.getSandbox({ sandbox_name: this.sandboxName });
+      if (!sandbox || isDeletedStatus(sandbox.status)) {
+        return null;
+      }
+      return {
+        createdAt: sandbox.created_at ? new Date(sandbox.created_at) : new Date(),
+      };
+    } catch (err) {
+      if (isNotFoundError(err)) {
+        return null;
+      }
+      throw err;
+    }
+  }
+}
+
+function isDeletedStatus(status: string | undefined): boolean {
+  if (!status) return false;
+  return status === 'deleted' || status === 'failed';
+}
+
+function isNotFoundError(err: unknown): boolean {
+  const status = (err as { statusCode?: number; status?: number })?.statusCode ?? (err as { status?: number })?.status;
+  return status === 404;
+}
+
+function nullifyValues(record: Record<string, string>): Record<string, string | null> | undefined {
+  const keys = Object.keys(record);
+  if (keys.length === 0) return undefined;
+  const out: Record<string, string | null> = {};
+  for (const k of keys) {
+    out[k] = record[k] ?? null;
+  }
+  return out;
+}
+
+function mergeEnv(base: Record<string, string>, overlay: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = { ...base };
+  for (const [k, v] of Object.entries(overlay)) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return out;
+}
+
+function serializeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function generateIsloSandboxInstanceId(): string {
+  return `islo-sandbox-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function generateSandboxName(): string {
+  const random = Math.random().toString(36).slice(2, 10);
+  return `mastra-${random}`;
+}

--- a/workspaces/islo/src/sandbox/sse.test.ts
+++ b/workspaces/islo/src/sandbox/sse.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the islo SSE consumer.
+ *
+ * The wire format is verified against the live api.islo.dev `/exec/stream`
+ * endpoint and recorded here as fixtures so the parser can evolve without
+ * round-tripping to the API.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { consumeIsloStream } from './sse';
+
+function streamFromString(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) {
+        controller.enqueue(encoder.encode(c));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe('consumeIsloStream', () => {
+  it('routes stdout, stderr, and exit events', async () => {
+    const body = [
+      ': keepalive',
+      'event: stdout',
+      'data: hello',
+      'data: ',
+      '',
+      'event: stderr',
+      'data: warn-line',
+      '',
+      'event: exit',
+      'data: 7',
+      '',
+    ].join('\n');
+
+    let out = '';
+    let err = '';
+    const result = await consumeIsloStream(streamFromString(body), {
+      onStdout: (d) => {
+        out += d;
+      },
+      onStderr: (d) => {
+        err += d;
+      },
+    });
+
+    expect(result.exitCode).toBe(7);
+    // Multi-data lines join with '\n', so two lines `hello` + `` produce `hello\n`.
+    expect(out).toBe('hello\n');
+    expect(err).toBe('warn-line');
+  });
+
+  it('handles a chunked body where SSE events span chunk boundaries', async () => {
+    const body =
+      'event: stdout\ndata: line-1\n\nevent: stdout\ndata: line-2\n\nevent: exit\ndata: 0\n\n';
+    const split = [body.slice(0, 12), body.slice(12, 30), body.slice(30)];
+
+    const collected: string[] = [];
+    const result = await consumeIsloStream(streamFromChunks(split), {
+      onStdout: (d) => collected.push(d),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(collected).toEqual(['line-1', 'line-2']);
+  });
+
+  it('treats unknown event types as no-ops without throwing', async () => {
+    const body = 'event: heartbeat\ndata: tick\n\nevent: stdout\ndata: ok\n\n';
+    let out = '';
+    const result = await consumeIsloStream(streamFromString(body), {
+      onStdout: (d) => {
+        out += d;
+      },
+    });
+    expect(out).toBe('ok');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('handles CRLF line endings', async () => {
+    const body = 'event: stdout\r\ndata: hi\r\n\r\nevent: exit\r\ndata: 1\r\n\r\n';
+    let out = '';
+    const result = await consumeIsloStream(streamFromString(body), {
+      onStdout: (d) => {
+        out += d;
+      },
+    });
+    expect(out).toBe('hi');
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('handles a final event without a trailing blank line', async () => {
+    const body = 'event: stdout\ndata: trailing\n';
+    let out = '';
+    await consumeIsloStream(streamFromString(body), {
+      onStdout: (d) => {
+        out += d;
+      },
+    });
+    expect(out).toBe('trailing');
+  });
+});

--- a/workspaces/islo/src/sandbox/sse.ts
+++ b/workspaces/islo/src/sandbox/sse.ts
@@ -1,0 +1,128 @@
+/**
+ * SSE consumer for the islo `/sandboxes/{name}/exec/stream` endpoint.
+ *
+ * The TypeScript SDK's `execInSandboxStream` decodes the response body into
+ * `unknown` through the standard fetcher — by the time you see bytes the
+ * command is done. We bypass it here so callers see stdout/stderr deltas as
+ * they arrive.
+ *
+ * Wire format (verified against api.islo.dev): standard `text/event-stream`.
+ * Each event has an `event:` type line (`stdout`, `stderr`, or `exit`), one
+ * or more `data:` lines (joined with `\n`), and a blank-line terminator.
+ * `exit` carries the exit code as a decimal string.
+ */
+
+export interface SSECallbacks {
+  onStdout?: (data: string) => void;
+  onStderr?: (data: string) => void;
+}
+
+export interface SSEResult {
+  exitCode: number;
+}
+
+/**
+ * Consume the islo SSE stream and dispatch stdout/stderr deltas.
+ * Resolves when the response body ends; returns the exit code emitted by the
+ * final `exit` event (defaults to 0 if none was seen).
+ */
+export async function consumeIsloStream(
+  body: ReadableStream<Uint8Array>,
+  callbacks: SSECallbacks = {},
+): Promise<SSEResult> {
+  const decoder = new TextDecoder('utf-8');
+  const reader = body.getReader();
+  let buffer = '';
+  let exitCode = 0;
+  let event = '';
+  let dataLines: string[] = [];
+
+  const flush = () => {
+    if (event === '' && dataLines.length === 0) {
+      return;
+    }
+    const payload = dataLines.join('\n');
+    switch (event) {
+      case 'stdout':
+        callbacks.onStdout?.(payload);
+        break;
+      case 'stderr':
+        callbacks.onStderr?.(payload);
+        break;
+      case 'exit': {
+        const parsed = Number.parseInt(payload.trim(), 10);
+        if (Number.isFinite(parsed)) {
+          exitCode = parsed;
+        }
+        break;
+      }
+    }
+    event = '';
+    dataLines = [];
+  };
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buffer.indexOf('\n')) !== -1) {
+        // Strip CR if present (CRLF line endings).
+        let line = buffer.slice(0, nl);
+        if (line.endsWith('\r')) line = line.slice(0, -1);
+        buffer = buffer.slice(nl + 1);
+        processLine(line);
+      }
+    }
+    // Drain any remaining buffer as a final line.
+    buffer += decoder.decode();
+    if (buffer.length > 0) {
+      processLine(buffer);
+    }
+    flush();
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // Ignore release errors if reader is already done.
+    }
+  }
+
+  return { exitCode };
+
+  function processLine(line: string): void {
+    if (line === '') {
+      flush();
+      return;
+    }
+    if (line.startsWith(':')) {
+      // SSE comment / keepalive
+      return;
+    }
+    const colon = line.indexOf(':');
+    let field: string;
+    let value: string;
+    if (colon === -1) {
+      field = line;
+      value = '';
+    } else {
+      field = line.slice(0, colon);
+      value = line.slice(colon + 1);
+      // Per SSE spec, a single leading space after the colon is stripped.
+      if (value.startsWith(' ')) value = value.slice(1);
+    }
+    switch (field) {
+      case 'event':
+        event = value;
+        break;
+      case 'data':
+        dataLines.push(value);
+        break;
+      case 'id':
+      case 'retry':
+        // Ignored.
+        break;
+    }
+  }
+}

--- a/workspaces/islo/tsconfig.build.json
+++ b/workspaces/islo/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/islo/tsconfig.json
+++ b/workspaces/islo/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/islo/tsup.config.ts
+++ b/workspaces/islo/tsup.config.ts
@@ -1,0 +1,18 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  external: ['@mastra/core', '@islo-labs/sdk'],
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/workspaces/islo/vitest.config.ts
+++ b/workspaces/islo/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
+    setupFiles: ['dotenv/config'],
+    testTimeout: 60000,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
Adds @mastra/islo, a workspace sandbox provider backed by @islo-labs/sdk. Mirrors the @mastra/e2b shape so the existing test factory and editor provider descriptor patterns transfer 1:1.

Lifecycle:
- start    -> sandboxes.createSandbox (or reconnects to a live sandbox by
              name when one already exists)
- stop     -> sandboxes.stopSandbox (paused; record retained)
- destroy  -> sandboxes.deleteSandbox (only sandboxes this instance acquired)
- executeCommand -> direct SSE consumer on POST /sandboxes/{name}/exec/stream

The SDK's generated execInSandboxStream decodes the SSE body through a JSON unmarshaler, so by the time you see bytes the command is finished. To deliver true line-by-line output, executeCommand bypasses the wrapper and consumes the /exec/stream endpoint directly. Auth still flows through the SDK's TokenProvider so token refresh and base URL stay consistent.

Auth comes from ISLO_API_KEY (or apiKey option). Base URL from ISLO_BASE_URL or https://api.islo.dev. The SDK exchanges the API key for a short-lived JWT and refreshes it ~60s before expiry.

Tests:
- src/sandbox/sse.test.ts          - SSE parser unit tests
- src/sandbox/index.test.ts        - lifecycle + executeCommand mocks
- src/sandbox/index.integration.test.ts - live tests gated by ISLO_API_KEY

Live verification against api.islo.dev:
- creates a sandbox, runs `echo` and a 3-iteration sleep loop with live output, propagates a non-zero exit code, tears down on afterAll.
- 3/3 integration tests pass in ~10s.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a new sandbox provider called `@mastra/islo` that lets Mastra workspaces run code safely in ISLO's cloud environment. It's designed to work just like the existing E2B sandbox provider, so the same test patterns and configurations can be reused without any changes. The provider includes built-in SSE streaming for real-time command output and automatic JWT token management.

## Overview

This PR introduces the `@mastra/islo` package, a workspace sandbox provider that integrates the `@islo-labs/sdk` into Mastra's sandbox abstraction. The implementation mirrors the existing `@mastra/e2b` provider shape to ensure compatibility with existing editor configurations and test factories.

## Key Features

- **Sandbox Lifecycle Management**: Maps Mastra lifecycle methods to ISLO SDK operations:
  - `start()` → Creates or reconnects to an existing sandbox by name
  - `stop()` → Pauses sandbox while retaining the record
  - `destroy()` → Deletes sandbox only if created by this instance
  - `executeCommand()` → Streams live output via SSE to `/sandboxes/{name}/exec/stream`

- **Authentication & Configuration**: 
  - API key sourced from `ISLO_API_KEY` environment variable or explicit `apiKey` option
  - Base URL configurable via `ISLO_BASE_URL` or defaults to `https://api.islo.dev`
  - Automatic JWT token exchange and refresh (~60s before expiry) handled by SDK's `TokenProvider`

- **Live Streaming Output**: Bypasses the SDK's JSON-unmarshalling wrapper by consuming SSE directly, enabling true line-by-line output streaming with proper exit code propagation

## Implementation Details

**Core Files:**
- `src/sandbox/index.ts` - `IsloSandbox` class implementing the `WorkspaceSandbox` contract
- `src/sandbox/sse.ts` - SSE stream parser with callbacks for `onStdout`/`onStderr` and exit code extraction
- `src/provider.ts` - Editor provider descriptor (`isloSandboxProvider`) with JSON schema-based configuration
- `src/index.ts` - Public API exports

**Build & Configuration:**
- `package.json` - ESM package with dual ESM/CJS distribution via `tsup`
- `tsup.config.ts` - Build config with external dependency handling and type generation
- `vitest.config.ts` - Test environment setup with dotenv support
- `tsconfig.*.json` - TypeScript configurations for build and type checking
- `eslint.config.js` - ESLint configuration
- `README.md` - Installation and usage documentation

## Testing

**Unit Tests** (`src/sandbox/index.test.ts`):
- Constructor validation (missing API key, explicit `apiKey`, default sandbox name generation)
- Lifecycle behavior (create vs. reconnect, conditional deletion)
- Command execution with SSE streaming and proper error/timeout handling
- Timeout simulation via `AbortSignal`

**SSE Parser Tests** (`src/sandbox/sse.test.ts`):
- Event parsing and routing to callbacks
- Multi-chunk stream handling
- CRLF line ending support
- Unknown event type handling

**Integration Tests** (`src/sandbox/index.integration.test.ts`):
- Gated by `ISLO_API_KEY` environment variable
- End-to-end validation against live `api.islo.dev`
- Echo command execution with status verification
- Long-running command with incremental output assertion (~2s+ duration)
- Error handling with non-zero exit codes
- Automatic cleanup via `afterAll` hook

## Configuration Options

`IsloSandboxOptions` supports:
- `id` - Instance identifier (auto-generated if omitted)
- `sandboxName` - Sandbox name for reconnection (auto-generated if omitted)
- `image` - Base image for sandbox
- `workdir` - Working directory
- `gatewayProfile` - Gateway configuration
- `env` - Environment variables with override support
- `apiKey` - API key override
- `baseUrl` - Base URL override
- `timeout` - Command timeout
- `metadata` - Custom metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->