### PR TITLE
feat(playground-ui): align Badge variants with Notice/Toast palette

### DIFF
--- a/.changeset/good-paws-burn.md
+++ b/.changeset/good-paws-burn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Aligned Badge variant colors with the Notice and Toast palette so the design system uses one consistent set of semantic colors. Default badges keep their neutral surface, while success, error, info and warning variants now use the same notice tokens as Notices and Toasts. Icons inside badges are sized down to match the badge height. Storybook now covers every variant including warning, with and without icons.

--- a/.changeset/good-paws-burn.md
+++ b/.changeset/good-paws-burn.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Aligned Badge variant colors with the Notice and Toast palette so the design system uses one consistent set of semantic colors. Default badges keep their neutral surface, while success, error, info and warning variants now use the same notice tokens as Notices and Toasts. Icons inside badges are sized down to match the badge height. Storybook now covers every variant including warning, with and without icons.
+Aligned Badge variant colors with the Notice and Toast palette so the design system uses one consistent set of semantic colors. Default badges keep their neutral surface, while success, error, info and warning variants now use the same notice tokens as Notices and Toasts. Icons inside badges are sized down to match the badge height.

--- a/packages/playground-ui/src/ds/components/Badge/Badge.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/Badge.tsx
@@ -12,38 +12,26 @@ export interface BadgeProps {
 }
 
 const variantClasses = {
-  default: 'text-neutral3 bg-surface4',
-  success: 'text-accent1 bg-accent1Dark',
-  error: 'text-accent2 bg-accent2Dark',
-  info: 'text-accent5 bg-accent5Dark',
-  warning: 'text-accent6 bg-accent6Dark',
-};
-
-const iconClasses = {
-  default: 'text-neutral3',
-  success: 'text-accent1',
-  error: 'text-accent2',
-  info: 'text-accent5',
-  warning: 'text-accent6',
+  default: 'text-neutral3 bg-surface4 border-border1',
+  success: 'text-notice-success-fg bg-notice-success/20 border-notice-success/20',
+  error: 'text-notice-destructive-fg bg-notice-destructive/20 border-notice-destructive/20',
+  info: 'text-notice-info-fg bg-notice-info/20 border-notice-info/20',
+  warning: 'text-notice-warning-fg bg-notice-warning/20 border-notice-warning/20',
 };
 
 export const Badge = ({ icon, variant = 'default', className, children, ...props }: BadgeProps) => {
   return (
     <div
       className={cn(
-        'font-mono text-ui-sm gap-1 h-badge-default inline-flex items-center rounded-full border border-border1 shrink-0',
+        'font-mono text-ui-sm gap-1 h-badge-default inline-flex items-center rounded-full border shrink-0',
         transitions.colors,
         icon ? 'pl-2 pr-2.5' : 'px-2.5',
-        variant === 'default' && icon ? 'bg-surface4 text-neutral5' : variantClasses[variant],
+        variant === 'default' && icon ? 'bg-surface4 text-neutral5 border-border1' : variantClasses[variant],
         className,
       )}
       {...props}
     >
-      {icon && (
-        <span className={iconClasses[variant]}>
-          <Icon>{icon}</Icon>
-        </span>
-      )}
+      {icon && <Icon size="sm">{icon}</Icon>}
       {children}
     </div>
   );

--- a/packages/playground-ui/src/ds/components/Badge/Badge.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/Badge.tsx
@@ -12,7 +12,7 @@ export interface BadgeProps {
 }
 
 const variantClasses = {
-  default: 'text-neutral3 bg-surface4 border-border1',
+  default: 'text-neutral5 bg-surface4 border-border1',
   success: 'text-notice-success-fg bg-notice-success/20 border-notice-success/20',
   error: 'text-notice-destructive-fg bg-notice-destructive/20 border-notice-destructive/20',
   info: 'text-notice-info-fg bg-notice-info/20 border-notice-info/20',
@@ -26,7 +26,7 @@ export const Badge = ({ icon, variant = 'default', className, children, ...props
         'font-mono text-ui-sm gap-1 h-badge-default inline-flex items-center rounded-full border shrink-0',
         transitions.colors,
         icon ? 'pl-2 pr-2.5' : 'px-2.5',
-        variant === 'default' && icon ? 'bg-surface4 text-neutral5 border-border1' : variantClasses[variant],
+        variantClasses[variant],
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Badge/badge.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/badge.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Check, AlertCircle, Info as InfoIcon } from 'lucide-react';
+import { Check, AlertCircle, Info as InfoIcon, TriangleAlert, Tag } from 'lucide-react';
 import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {
@@ -8,68 +8,38 @@ const meta: Meta<typeof Badge> = {
   parameters: {
     layout: 'centered',
   },
-  argTypes: {
-    variant: {
-      control: { type: 'select' },
-      options: ['default', 'success', 'error', 'info'],
-    },
-  },
 };
 
 export default meta;
 type Story = StoryObj<typeof Badge>;
 
-export const Default: Story = {
-  args: {
-    children: 'Badge',
-    variant: 'default',
-  },
-};
-
-export const Success: Story = {
-  args: {
-    children: 'Success',
-    variant: 'success',
-  },
-};
-
-export const Error: Story = {
-  args: {
-    children: 'Error',
-    variant: 'error',
-  },
-};
-
-export const Info: Story = {
-  args: {
-    children: 'Info',
-    variant: 'info',
-  },
-};
-
-export const WithIcon: Story = {
-  args: {
-    children: 'Completed',
-    icon: <Check className="h-3 w-3" />,
-    variant: 'success',
-  },
-};
-
-export const WithErrorIcon: Story = {
-  args: {
-    children: 'Failed',
-    icon: <AlertCircle className="h-3 w-3" />,
-    variant: 'error',
-  },
-};
-
-export const AllVariants: Story = {
+export const Matrix: Story = {
   render: () => (
-    <div className="flex items-center gap-2">
-      <Badge variant="default">Default</Badge>
-      <Badge variant="success">Success</Badge>
-      <Badge variant="error">Error</Badge>
-      <Badge variant="info">Info</Badge>
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <Badge variant="default">Default</Badge>
+        <Badge variant="success">Success</Badge>
+        <Badge variant="error">Error</Badge>
+        <Badge variant="info">Info</Badge>
+        <Badge variant="warning">Warning</Badge>
+      </div>
+      <div className="flex items-center gap-2">
+        <Badge variant="default" icon={<Tag />}>
+          Default
+        </Badge>
+        <Badge variant="success" icon={<Check />}>
+          Success
+        </Badge>
+        <Badge variant="error" icon={<AlertCircle />}>
+          Error
+        </Badge>
+        <Badge variant="info" icon={<InfoIcon />}>
+          Info
+        </Badge>
+        <Badge variant="warning" icon={<TriangleAlert />}>
+          Warning
+        </Badge>
+      </div>
     </div>
   ),
 };


### PR DESCRIPTION
## Summary
- Remap Badge `success` / `error` / `info` / `warning` variants to the `notice-*` tokens already used by `Notice` and `Toast`, so all three components share one semantic palette.
- Drop the parallel `iconClasses` map — the icon now inherits `text-notice-*-fg` from the parent badge.
- Size the icon down to `icon-sm` (12px) so it fits the 28px badge height.
- Consolidate the stories to a single `Matrix` story showing every variant with and without an icon.

<img width="568" height="208" alt="image" src="https://github.com/user-attachments/assets/2f229274-b0da-4918-ac5d-369a78b3eef8" />

<img width="1136" height="416" alt="CleanShot 2026-05-05 at 16 55 19@2x" src="https://github.com/user-attachments/assets/a675ddeb-ff52-4339-9468-accb4a90376c" />


## Test plan
- [ ] `pnpm --filter @mastra/playground-ui build` passes
- [ ] Storybook `Elements/Badge → Matrix` renders all 5 variants in both rows
- [ ] Visual check in dark + light: badge tints match Notice/Toast tints for the same semantic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes Badge components use the same colors as Notice and Toast so they look consistent, makes badge icons smaller to fit better, and updates Storybook to show all badge styles in one place.

## Overview

The PR aligns the Badge component's design with the Notice and Toast components by consolidating their semantic color palettes. The changes include:

- **Color Token Alignment**: Badge success/error/info/warning variants are re-mapped to use notice-* tokens instead of custom badge-specific tokens, ensuring visual consistency with Notice and Toast components
- **Icon Styling Simplification**: Removed the parallel `iconClasses` map; badge icons now automatically inherit text-notice-*-fg colors from the parent badge element
- **Icon Size Reduction**: Badge icons are reduced to `icon-sm` (12px) to properly fit within the 28px badge height
- **Storybook Coverage**: Replaced individual variant stories with a single Matrix story that displays all 5 badge variants in two rows—one with text-only badges and another showing the same variants with icons
- **Default text color unification**: Default badge text now consistently uses neutral5 regardless of icon presence

## Changes

packages/playground-ui/src/ds/components/Badge/Badge.tsx
- Updated `variantClasses` map to include foreground, background, and border colors for success/error/info/warning variants (now using notice-* tokens)
- Removed hard-coded `border-border1` from base class; border color is now applied through variant classes
- Simplified icon rendering by removing the `span` wrapper and `iconClasses`, and rendering `<Icon size="sm">` directly

packages/playground-ui/src/ds/components/Badge/badge.stories.tsx
- Added imports for additional `lucide-react` icons (TriangleAlert, Tag)
- Replaced individual stories (Default, Success, Error, Info, WithIcon, WithErrorIcon, AllVariants) with a single `Matrix` story that shows all variants with and without icons
- Removed the `argTypes` configuration from meta (previously defined variant control)

.changeset/good-paws-burn.md
- Added a patch-level changeset documenting the design system alignment for Badge variants and the icon sizing change

## Testing

- Build: Run `pnpm --filter @mastra/playground-ui build` and confirm it passes
- Storybook: Open Elements/Badge → Matrix and verify all 5 variants render in both rows (text-only and with icons)
- Visual check: Confirm badge tints match Notice/Toast in both light and dark themes (screenshots included in PR)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->