### PR TITLE
feat: agent publish flow in Agent Builder UI (COR-885)

### DIFF
--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -41027,6 +41027,8 @@ export type PatchStoredAgentsStoredAgentId_Body = {
         | undefined
       )
     | undefined;
+  /** Agent status: draft (not live, owner-only) or published (live, visibility applies) */
+  status?: ('draft' | 'published') | undefined;
   /** Optional message describing the changes for the auto-created version */
   changeMessage?: string | undefined;
 };
@@ -72670,6 +72672,7 @@ type PatchStoredSkillsStoredSkillId_Body_Auxiliary_4 = {
 export type PatchStoredSkillsStoredSkillId_Body = {
   authorId?: (string | undefined) | undefined;
   visibility?: (('private' | 'public') | undefined) | undefined;
+  status?: (('draft' | 'published') | undefined) | undefined;
   name?: string | undefined;
   description?: string | undefined;
   instructions?: string | undefined;

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -1231,6 +1231,8 @@ export interface UpdateStoredAgentParams {
   authorId?: string;
   /** Visibility of the agent. */
   visibility?: 'private' | 'public';
+  /** Status of the agent. Pass 'published' to publish the latest version. */
+  status?: 'draft' | 'published';
   metadata?: Record<string, unknown>;
   name?: string;
   description?: string;
@@ -1960,6 +1962,8 @@ export interface UpdateStoredSkillParams {
   authorId?: string;
   /** Visibility of the skill. */
   visibility?: 'private' | 'public';
+  /** Status of the skill. Pass 'published' to publish the latest version. */
+  status?: 'draft' | 'published';
   metadata?: Record<string, unknown>;
   name?: string;
   description?: string;

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-list/agent-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-list/agent-builder-list.tsx
@@ -1,5 +1,5 @@
 import type { StoredAgentResponse } from '@mastra/client-js';
-import { Avatar, EmptyState, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
+import { Avatar, Badge, EmptyState, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
 import { LockIcon, SearchIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { StarButton } from '@/domains/agents/components/star-button';
@@ -86,6 +86,9 @@ export function AgentBuilderList({ agents, search, rowTestId }: AgentBuilderList
               <div className="flex items-center gap-2 min-w-0">
                 <div className="text-ui-md text-neutral6 truncate">{agent.name}</div>
                 {agent.visibility === 'private' && <PrivateVisibilityIcon />}
+                <Badge variant={agent.status === 'published' ? 'success' : 'info'}>
+                  {agent.status === 'published' ? 'Published' : 'Draft'}
+                </Badge>
               </div>
               <div className="flex items-center gap-2 mt-0.5">
                 <span className="text-ui-sm text-neutral3 line-clamp-1">{agent.description || 'No description'}</span>

--- a/packages/playground/src/domains/agent-builder/components/skill-builder-list/skill-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-builder-list/skill-builder-list.tsx
@@ -1,5 +1,5 @@
 import type { StoredSkillResponse } from '@mastra/client-js';
-import { EmptyState, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
+import { Badge, EmptyState, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
 import { LockIcon, SearchIcon, SparklesIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { SkillStarButton } from '@/domains/agents/components/skill-star-button';
@@ -80,6 +80,9 @@ export function SkillBuilderList({ skills, search, onSkillClick }: SkillBuilderL
                     <TooltipContent>Only visible to you</TooltipContent>
                   </Tooltip>
                 )}
+                <Badge variant={skill.status === 'published' ? 'success' : 'info'}>
+                  {skill.status === 'published' ? 'Published' : 'Draft'}
+                </Badge>
               </div>
               <div className="flex items-center gap-2 mt-0.5">
                 <span className="text-ui-sm text-neutral3 line-clamp-1">{skill.description || 'No description'}</span>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
@@ -12,7 +12,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@mastra/playground-ui';
-import { AlertTriangle, ChevronDown, ChevronRight, Globe, LockIcon, Pencil, Settings2 } from 'lucide-react';
+import { AlertTriangle, ChevronDown, ChevronRight, Globe, LockIcon, Pencil, SendIcon, Settings2 } from 'lucide-react';
 import { nanoid } from 'nanoid';
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 
@@ -229,7 +229,61 @@ export function SkillEditDialog({
     onClose,
   ]);
 
-  const isPending = createSkill.isPending || updateSkill.isPending;
+  const [isPublishing, setIsPublishing] = useState(false);
+
+  const handleSaveAndPublish = useCallback(async () => {
+    let filesToSave = files;
+    if (!filesToSave.some(n => n.id === 'root') && name.trim()) {
+      filesToSave = createInitialStructure(name);
+    }
+    if (instructions && filesToSave.some(n => n.id === 'root')) {
+      filesToSave = updateNodeContent(filesToSave, 'skill-md', instructions);
+    }
+
+    setIsPublishing(true);
+    try {
+      if (isExistingSkill && skill) {
+        const result = await updateSkill.mutateAsync({
+          id: skill.id,
+          name,
+          description,
+          visibility,
+          instructions,
+          status: 'published',
+        });
+        onSkillUpdated?.(result);
+      } else {
+        // Create first (auto-publishes), then close
+        const result = await createSkill.mutateAsync({
+          name,
+          description,
+          visibility,
+          workspaceId,
+          files: filesToSave,
+        });
+        onSkillCreated?.(result, workspaceId);
+      }
+      onClose();
+    } finally {
+      setIsPublishing(false);
+    }
+  }, [
+    name,
+    description,
+    visibility,
+    instructions,
+    workspaceId,
+    files,
+    isExistingSkill,
+    skill,
+    createSkill,
+    updateSkill,
+    onSkillCreated,
+    onSkillUpdated,
+    onClose,
+  ]);
+
+  const isPending = createSkill.isPending || updateSkill.isPending || isPublishing;
 
   const dialogTitle = isExistingSkill ? (isEditing ? 'Edit Skill' : 'Skill Details') : 'Add Skill';
 
@@ -286,8 +340,12 @@ export function SkillEditDialog({
                   </SelectContent>
                 </Select>
               )}
-              <Button variant="primary" size="sm" onClick={handleSave} disabled={!name.trim() || isPending}>
-                {isPending ? 'Saving...' : isExistingSkill ? 'Save' : 'Create'}
+              <Button variant="default" size="sm" onClick={handleSave} disabled={!name.trim() || isPending}>
+                {isPending && !isPublishing ? 'Saving...' : isExistingSkill ? 'Save' : 'Save as draft'}
+              </Button>
+              <Button variant="primary" size="sm" onClick={handleSaveAndPublish} disabled={!name.trim() || isPending}>
+                <SendIcon className="h-3.5 w-3.5" />
+                {isPublishing ? 'Publishing...' : isExistingSkill ? 'Save & Publish' : 'Create & Publish'}
               </Button>
             </>
           )}

--- a/packages/playground/src/domains/agents/hooks/use-agent-versions.ts
+++ b/packages/playground/src/domains/agents/hooks/use-agent-versions.ts
@@ -72,6 +72,9 @@ export const useActivateAgentVersion = ({ agentId }: { agentId: string }) => {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['agent-versions', agentId] });
       void queryClient.invalidateQueries({ queryKey: ['agent', agentId] });
+      void queryClient.invalidateQueries({ queryKey: ['stored-agents'] });
+      void queryClient.invalidateQueries({ queryKey: ['agents'] });
+      void queryClient.invalidateQueries({ queryKey: ['stored-agent', agentId] });
     },
   });
 };

--- a/packages/playground/src/domains/agents/hooks/use-update-skill.ts
+++ b/packages/playground/src/domains/agents/hooks/use-update-skill.ts
@@ -13,6 +13,7 @@ interface UpdateSkillParams {
   name?: string;
   description?: string;
   visibility?: 'private' | 'public';
+  status?: 'draft' | 'published';
   instructions?: string;
   files?: InMemoryFileNode[];
   workspaceId?: string;
@@ -40,7 +41,7 @@ export function useUpdateSkill() {
 
   return useMutation({
     mutationFn: async (params: UpdateSkillParams): Promise<StoredSkillResponse> => {
-      const { id, name, description, visibility, instructions, files, workspaceId } = params;
+      const { id, name, description, visibility, status, instructions, files, workspaceId } = params;
 
       // Write updated files to workspace filesystem (best-effort — DB is the source of truth)
       if (files?.length && workspaceId && canWriteWorkspace) {
@@ -66,6 +67,7 @@ export function useUpdateSkill() {
         name,
         description,
         visibility,
+        status,
         instructions: instructions ?? (files ? extractSkillInstructions(files) : undefined),
         license: files ? extractSkillLicense(files) : undefined,
         files,

--- a/packages/playground/src/pages/agent-builder/agents/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/edit.tsx
@@ -1,6 +1,7 @@
 import type { StoredSkillResponse } from '@mastra/client-js';
-import { Button, Spinner } from '@mastra/playground-ui';
-import { CheckIcon } from 'lucide-react';
+import { Button, Spinner, toast } from '@mastra/playground-ui';
+import { useMastraClient } from '@mastra/react';
+import { CheckIcon, SendIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { FormProvider, useForm, useFormContext, useWatch } from 'react-hook-form';
 import { Navigate, useNavigate, useParams } from 'react-router';
@@ -32,6 +33,7 @@ import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
 import { useTools } from '@/domains/tools/hooks/use-all-tools';
 import { useWorkflows } from '@/domains/workflows/hooks/use-workflows';
 import { useStoredWorkspaces } from '@/domains/workspace/hooks/use-stored-workspaces';
+import { usePlaygroundStore } from '@/store/playground-store';
 
 type ToolsData = NonNullable<ReturnType<typeof useTools>['data']>;
 type AgentsData = NonNullable<ReturnType<typeof useAgents>['data']>;
@@ -208,13 +210,35 @@ const AgentBuilderAgentEditReady = ({
 
   const [activeDetail, setActiveDetail] = useState<ActiveDetail>(null);
 
+  const client = useMastraClient();
+  const { requestContext } = usePlaygroundStore();
   const { save, isSaving } = useSaveAgent({ agentId: id, mode, availableAgentTools, availableSkills });
+  const [isPublishing, setIsPublishing] = useState(false);
 
   const handleSaveSuccess = async (values: AgentBuilderEditFormValues) => {
     await save(values);
     void navigate(`/agent-builder/agents/${id}/view`, { viewTransition: true });
   };
   const handleSave = formMethods.handleSubmit(handleSaveSuccess);
+
+  const handleCreateAndPublish = formMethods.handleSubmit(async (values: AgentBuilderEditFormValues) => {
+    setIsPublishing(true);
+    try {
+      const created = await save(values);
+      if (created?.id) {
+        const { versions } = await client.getStoredAgent(created.id).listVersions(undefined, requestContext);
+        if (versions.length > 0) {
+          await client.getStoredAgent(created.id).activateVersion(versions[0]!.id, requestContext);
+          toast.success('Agent published');
+        }
+      }
+      void navigate(`/agent-builder/agents/${id}/view`, { viewTransition: true });
+    } catch (error) {
+      toast.error(`Failed to publish: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setIsPublishing(false);
+    }
+  });
 
   return (
     <ConversationPanelProvider
@@ -242,7 +266,15 @@ const AgentBuilderAgentEditReady = ({
             <VisibilitySelectConnected />
           </div>
         }
-        primaryAction={<HeaderActions mode={mode} isSaving={isSaving} onSave={handleSave} />}
+        primaryAction={
+          <HeaderActions
+            mode={mode}
+            isSaving={isSaving}
+            isPublishing={isPublishing}
+            onSave={handleSave}
+            onCreateAndPublish={mode === 'create' ? handleCreateAndPublish : undefined}
+          />
+        }
         mobileExtra={
           <AgentBuilderMobileMenuConnected
             agentId={id}
@@ -294,17 +326,30 @@ const AgentBuilderMobileMenuConnected = ({
 interface HeaderActionsProps {
   mode: 'create' | 'edit';
   isSaving: boolean;
+  isPublishing: boolean;
   onSave: () => void;
+  onCreateAndPublish?: () => void;
 }
 
-const HeaderActions = ({ mode, isSaving, onSave }: HeaderActionsProps) => {
+const HeaderActions = ({ mode, isSaving, isPublishing, onSave, onCreateAndPublish }: HeaderActionsProps) => {
   const isRunning = useStreamRunning();
-  const disabled = isSaving || isRunning;
+  const busy = isSaving || isPublishing || isRunning;
   return (
     <div className="flex items-center gap-2">
-      <Button size="sm" variant="cta" onClick={onSave} disabled={disabled} data-testid="agent-builder-edit-save">
-        <CheckIcon /> {isSaving ? 'Saving…' : mode === 'edit' ? 'Save' : 'Create'}
+      <Button size="sm" variant="default" onClick={onSave} disabled={busy} data-testid="agent-builder-edit-save">
+        <CheckIcon /> {isSaving ? 'Saving…' : mode === 'edit' ? 'Save' : 'Save as draft'}
       </Button>
+      {mode === 'create' && onCreateAndPublish && (
+        <Button
+          size="sm"
+          variant="cta"
+          onClick={onCreateAndPublish}
+          disabled={busy}
+          data-testid="agent-builder-edit-create-publish"
+        >
+          <SendIcon /> {isPublishing ? 'Publishing…' : 'Create & Publish'}
+        </Button>
+      )}
     </div>
   );
 };

--- a/packages/playground/src/pages/agent-builder/agents/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/edit.tsx
@@ -221,17 +221,34 @@ const AgentBuilderAgentEditReady = ({
   };
   const handleSave = formMethods.handleSubmit(handleSaveSuccess);
 
+  const handlePublishAfterSave = async (agentId: string) => {
+    const { versions } = await client.getStoredAgent(agentId).listVersions(undefined, requestContext);
+    if (versions.length > 0) {
+      await client.getStoredAgent(agentId).activateVersion(versions[0]!.id, requestContext);
+      toast.success('Agent published');
+    }
+  };
+
   const handleCreateAndPublish = formMethods.handleSubmit(async (values: AgentBuilderEditFormValues) => {
     setIsPublishing(true);
     try {
       const created = await save(values);
       if (created?.id) {
-        const { versions } = await client.getStoredAgent(created.id).listVersions(undefined, requestContext);
-        if (versions.length > 0) {
-          await client.getStoredAgent(created.id).activateVersion(versions[0]!.id, requestContext);
-          toast.success('Agent published');
-        }
+        await handlePublishAfterSave(created.id);
       }
+      void navigate(`/agent-builder/agents/${id}/view`, { viewTransition: true });
+    } catch (error) {
+      toast.error(`Failed to publish: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setIsPublishing(false);
+    }
+  });
+
+  const handleSaveAndPublish = formMethods.handleSubmit(async (values: AgentBuilderEditFormValues) => {
+    setIsPublishing(true);
+    try {
+      await save(values);
+      await handlePublishAfterSave(id);
       void navigate(`/agent-builder/agents/${id}/view`, { viewTransition: true });
     } catch (error) {
       toast.error(`Failed to publish: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -272,7 +289,7 @@ const AgentBuilderAgentEditReady = ({
             isSaving={isSaving}
             isPublishing={isPublishing}
             onSave={handleSave}
-            onCreateAndPublish={mode === 'create' ? handleCreateAndPublish : undefined}
+            onPublish={mode === 'create' ? handleCreateAndPublish : handleSaveAndPublish}
           />
         }
         mobileExtra={
@@ -328,10 +345,10 @@ interface HeaderActionsProps {
   isSaving: boolean;
   isPublishing: boolean;
   onSave: () => void;
-  onCreateAndPublish?: () => void;
+  onPublish: () => void;
 }
 
-const HeaderActions = ({ mode, isSaving, isPublishing, onSave, onCreateAndPublish }: HeaderActionsProps) => {
+const HeaderActions = ({ mode, isSaving, isPublishing, onSave, onPublish }: HeaderActionsProps) => {
   const isRunning = useStreamRunning();
   const busy = isSaving || isPublishing || isRunning;
   return (
@@ -339,17 +356,9 @@ const HeaderActions = ({ mode, isSaving, isPublishing, onSave, onCreateAndPublis
       <Button size="sm" variant="default" onClick={onSave} disabled={busy} data-testid="agent-builder-edit-save">
         <CheckIcon /> {isSaving ? 'Saving…' : mode === 'edit' ? 'Save' : 'Save as draft'}
       </Button>
-      {mode === 'create' && onCreateAndPublish && (
-        <Button
-          size="sm"
-          variant="cta"
-          onClick={onCreateAndPublish}
-          disabled={busy}
-          data-testid="agent-builder-edit-create-publish"
-        >
-          <SendIcon /> {isPublishing ? 'Publishing…' : 'Create & Publish'}
-        </Button>
-      )}
+      <Button size="sm" variant="cta" onClick={onPublish} disabled={busy} data-testid="agent-builder-edit-publish">
+        <SendIcon /> {isPublishing ? 'Publishing…' : mode === 'edit' ? 'Save & Publish' : 'Create & Publish'}
+      </Button>
     </div>
   );
 };

--- a/packages/playground/src/pages/agent-builder/agents/index.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/index.tsx
@@ -28,16 +28,46 @@ export default function AgentBuilderAgentsPage() {
   const [search, setSearch] = useState('');
   const { Link: FrameworkLink } = useLinkComponent();
 
-  const listParams = useMemo<ListStoredAgentsParams>(() => {
-    const params: ListStoredAgentsParams = {};
+  const draftParams = useMemo<ListStoredAgentsParams>(() => {
+    const params: ListStoredAgentsParams = { status: 'draft' };
     if (currentUser?.id) {
       params.authorId = currentUser.id;
     }
     return params;
   }, [currentUser?.id]);
 
-  const { data, isLoading, error } = useStoredAgents(listParams, { enabled: !isCurrentUserLoading });
-  const agents = data?.agents ?? [];
+  const publishedParams = useMemo<ListStoredAgentsParams>(() => {
+    const params: ListStoredAgentsParams = { status: 'published' };
+    if (currentUser?.id) {
+      params.authorId = currentUser.id;
+    }
+    return params;
+  }, [currentUser?.id]);
+
+  const {
+    data: draftData,
+    isLoading: isDraftLoading,
+    error: draftError,
+  } = useStoredAgents(draftParams, { enabled: !isCurrentUserLoading });
+  const {
+    data: publishedData,
+    isLoading: isPublishedLoading,
+    error: publishedError,
+  } = useStoredAgents(publishedParams, { enabled: !isCurrentUserLoading });
+
+  const isLoading = isDraftLoading || isPublishedLoading;
+  const error = draftError || publishedError;
+
+  // Merge: draft version wins over published for the same agent ID
+  const agents = useMemo(() => {
+    const draftAgents = draftData?.agents ?? [];
+    const publishedAgents = publishedData?.agents ?? [];
+    const agentMap = new Map(publishedAgents.map(a => [a.id, a]));
+    for (const agent of draftAgents) {
+      agentMap.set(agent.id, agent);
+    }
+    return Array.from(agentMap.values());
+  }, [draftData, publishedData]);
 
   const body = (() => {
     if (isCurrentUserLoading || isLoading) {

--- a/packages/playground/src/pages/agent-builder/agents/view.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/view.tsx
@@ -1,6 +1,6 @@
 import type { StoredSkillResponse } from '@mastra/client-js';
-import { Button, Spinner } from '@mastra/playground-ui';
-import { PencilIcon } from 'lucide-react';
+import { Badge, Button, Spinner } from '@mastra/playground-ui';
+import { CheckIcon, PencilIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm, useFormContext, useWatch } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
@@ -24,6 +24,7 @@ import type { AgentBuilderEditFormValues } from '@/domains/agent-builder/schemas
 import { BrowserViewPanel } from '@/domains/agents/components/browser-view';
 import { BrowserSessionProvider } from '@/domains/agents/context/browser-session-context';
 import { BrowserToolCallsProvider } from '@/domains/agents/context/browser-tool-calls-context';
+import { useActivateAgentVersion, useAgentVersions } from '@/domains/agents/hooks/use-agent-versions';
 import { useAgents } from '@/domains/agents/hooks/use-agents';
 import type { StoredAgent } from '@/domains/agents/hooks/use-stored-agents';
 import { useStoredAgent } from '@/domains/agents/hooks/use-stored-agents';
@@ -43,6 +44,10 @@ export default function AgentBuilderAgentView() {
   useChannelConnectToast();
   const features = useBuilderAgentFeatures();
   const { data: storedAgent, isLoading: isStoredAgentLoading } = useStoredAgent(id, { status: 'draft' });
+  const { data: versionsData } = useAgentVersions({
+    agentId: id ?? '',
+    params: { orderBy: 'versionNumber', sortDirection: 'DESC', perPage: 1 },
+  });
   const { data: toolsData, isPending: isToolsPending } = useTools({ enabled: features.tools });
   const { data: agentsData, isPending: isAgentsPending } = useAgents({ enabled: features.agents });
   const { data: workflowsData, isPending: isWorkflowsPending } = useWorkflows({ enabled: features.workflows });
@@ -61,6 +66,11 @@ export default function AgentBuilderAgentView() {
 
   if (!isReady) return <AgentBuilderAgentViewSkeleton />;
 
+  const latestVersionId = versionsData?.versions?.[0]?.id;
+  const hasDraft = Boolean(
+    latestVersionId && storedAgent?.activeVersionId && latestVersionId !== storedAgent.activeVersionId,
+  );
+
   return (
     <AgentBuilderAgentViewPage
       id={id}
@@ -70,6 +80,8 @@ export default function AgentBuilderAgentView() {
       workflowsData={workflowsData}
       storedSkillsResponse={storedSkillsResponse}
       currentUser={currentUser ?? null}
+      hasDraft={hasDraft}
+      latestVersionId={latestVersionId}
     />
   );
 }
@@ -82,6 +94,8 @@ interface PageProps {
   workflowsData: WorkflowsData | undefined;
   storedSkillsResponse: ReturnType<typeof useStoredSkills>['data'];
   currentUser: CurrentUser;
+  hasDraft: boolean;
+  latestVersionId: string | undefined;
 }
 
 const AgentBuilderAgentViewPage = ({
@@ -92,6 +106,8 @@ const AgentBuilderAgentViewPage = ({
   workflowsData,
   storedSkillsResponse,
   currentUser,
+  hasDraft,
+  latestVersionId,
 }: PageProps) => {
   const defaultValues = useMemo(() => storedAgentToFormValues(storedAgent), [storedAgent]);
   const formMethods = useForm<AgentBuilderEditFormValues>({ defaultValues });
@@ -110,6 +126,8 @@ const AgentBuilderAgentViewPage = ({
         workflowsData={workflowsData ?? {}}
         storedSkillsResponse={storedSkillsResponse}
         currentUser={currentUser}
+        hasDraft={hasDraft}
+        latestVersionId={latestVersionId}
       />
     </FormProvider>
   );
@@ -129,6 +147,8 @@ interface AgentBuilderAgentViewReadyProps {
   workflowsData: WorkflowsData;
   storedSkillsResponse: ReturnType<typeof useStoredSkills>['data'];
   currentUser: CurrentUser;
+  hasDraft: boolean;
+  latestVersionId: string | undefined;
 }
 
 const AgentBuilderAgentViewReady = ({
@@ -139,6 +159,8 @@ const AgentBuilderAgentViewReady = ({
   workflowsData,
   storedSkillsResponse,
   currentUser,
+  hasDraft,
+  latestVersionId,
 }: AgentBuilderAgentViewReadyProps) => {
   const navigate = useNavigate();
   const [activeDetail, setActiveDetail] = useState<ActiveDetail>(null);
@@ -149,6 +171,18 @@ const AgentBuilderAgentViewReady = ({
   // Gate publishing on the *saved* visibility — never on unsaved form state.
   const isPublishable = storedAgent?.visibility === 'public';
   const isOwner = !storedAgent?.authorId || currentUser?.id === storedAgent.authorId;
+  const activateVersion = useActivateAgentVersion({ agentId: id });
+  const [isPublishing, setIsPublishing] = useState(false);
+
+  const handlePublish = async () => {
+    if (!latestVersionId) return;
+    setIsPublishing(true);
+    try {
+      await activateVersion.mutateAsync(latestVersionId);
+    } finally {
+      setIsPublishing(false);
+    }
+  };
   const threadId = currentUser?.id ? `${currentUser.id}-${id}` : id;
 
   const availableAgentTools = useAvailableAgentTools({
@@ -186,13 +220,19 @@ const AgentBuilderAgentViewReady = ({
         showConfigure={isOwner}
         modeAction={
           <div className="hidden lg:flex items-center gap-2">
+            {isOwner && hasDraft && <Badge variant="info">Unpublished changes</Badge>}
             {isOwner && isPublishable && <PublishToChannelButton agentId={id} />}
             <VisibilitySelectIfAuth />
           </div>
         }
         primaryAction={
           isOwner ? (
-            <ViewHeaderActions onEdit={() => navigate(`/agent-builder/agents/${id}/edit`, { viewTransition: true })} />
+            <ViewHeaderActions
+              onEdit={() => navigate(`/agent-builder/agents/${id}/edit`, { viewTransition: true })}
+              hasDraft={hasDraft}
+              isPublishing={isPublishing}
+              onPublish={handlePublish}
+            />
           ) : undefined
         }
         mobileExtra={isOwner ? <AgentBuilderMobileMenu agentId={id} showPublishToChannel={isPublishable} /> : undefined}
@@ -223,19 +263,43 @@ const AgentBuilderAgentViewReady = ({
   );
 };
 
-const ViewHeaderActions = ({ onEdit }: { onEdit: () => void }) => {
+const ViewHeaderActions = ({
+  onEdit,
+  hasDraft,
+  isPublishing,
+  onPublish,
+}: {
+  onEdit: () => void;
+  hasDraft: boolean;
+  isPublishing: boolean;
+  onPublish: () => void;
+}) => {
   const isRunning = useStreamRunning();
   return (
-    <Button
-      size="icon-sm"
-      variant="ghost"
-      onClick={onEdit}
-      disabled={isRunning}
-      tooltip="Edit agent"
-      data-testid="agent-builder-view-edit"
-    >
-      <PencilIcon />
-    </Button>
+    <div className="flex items-center gap-2">
+      {hasDraft && (
+        <Button
+          size="sm"
+          variant="primary"
+          onClick={onPublish}
+          disabled={isRunning || isPublishing}
+          data-testid="agent-builder-view-publish"
+        >
+          {isPublishing ? <Spinner className="size-3" /> : <CheckIcon className="size-3" />}
+          Publish
+        </Button>
+      )}
+      <Button
+        size="icon-sm"
+        variant="ghost"
+        onClick={onEdit}
+        disabled={isRunning}
+        tooltip="Edit agent"
+        data-testid="agent-builder-view-edit"
+      >
+        <PencilIcon />
+      </Button>
+    </div>
   );
 };
 

--- a/packages/server/src/server/handlers/stored-agents.test.ts
+++ b/packages/server/src/server/handlers/stored-agents.test.ts
@@ -778,8 +778,7 @@ describe('Stored Agents Handlers', () => {
       }
     });
 
-    it('should auto-publish by updating activeVersionId when a new version is created', async () => {
-      const newVersionId = 'v-autopub-2';
+    it('should NOT auto-publish (activeVersionId stays unchanged) when a new draft version is created', async () => {
       mockAgentsData.set('autopub-test', {
         id: 'autopub-test',
         name: 'Original Name',
@@ -788,11 +787,8 @@ describe('Stored Agents Handlers', () => {
         activeVersionId: 'v-autopub-1',
       });
 
-      // listVersions is called multiple times: once by enforceRetentionLimit
-      // inside handleAutoVersioning, then again by the auto-publish code.
-      // Return the new version each time so auto-publish can activate it.
       mockAgentsStore.listVersions.mockResolvedValue({
-        versions: [{ id: newVersionId, versionNumber: 2 }],
+        versions: [{ id: 'v-autopub-2', versionNumber: 2 }],
         total: 2,
       });
 
@@ -803,9 +799,9 @@ describe('Stored Agents Handlers', () => {
         instructions: 'Updated instructions',
       });
 
-      // Verify activeVersionId was updated to the latest version
+      // activeVersionId should remain unchanged — publishing is now explicit
       const stored = mockAgentsData.get('autopub-test');
-      expect(stored?.activeVersionId).toBe(newVersionId);
+      expect(stored?.activeVersionId).toBe('v-autopub-1');
     });
   });
 

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -575,6 +575,20 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
         throw new Error('handleAutoVersioning returned undefined');
       }
 
+      // When the caller explicitly requests status='published', activate the
+      // latest version so the update is immediately live.
+      if (status === 'published') {
+        const { versions } = await agentsStore.listVersions({ agentId: storedAgentId, perPage: 1 });
+        const latestVersion = versions[0];
+        if (latestVersion) {
+          await agentsStore.update({
+            id: storedAgentId,
+            activeVersionId: latestVersion.id,
+            status: 'published',
+          });
+        }
+      }
+
       // Clear the cached agent instance so the next request gets the updated config
       const editor = mastra.getEditor();
       if (editor) {
@@ -582,7 +596,8 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
       }
 
       // Return the resolved agent with the latest version
-      const resolved = await agentsStore.getByIdResolved(storedAgentId, { status: 'draft' });
+      const resolveStatus = status === 'published' ? 'published' : 'draft';
+      const resolved = await agentsStore.getByIdResolved(storedAgentId, { status: resolveStatus });
       if (!resolved) {
         throw new HTTPException(500, { message: 'Failed to resolve updated agent' });
       }

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -436,6 +436,7 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
     authorId,
     metadata,
     visibility,
+    status,
     // Config fields (snapshot-level)
     name,
     description,
@@ -511,6 +512,7 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
         authorId,
         metadata,
         visibility: resolvedVisibility,
+        status,
         name,
         description,
         instructions,
@@ -571,22 +573,6 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
 
       if (!autoVersionResult) {
         throw new Error('handleAutoVersioning returned undefined');
-      }
-
-      // Auto-publish: activate the latest version so the update is immediately
-      // visible in list views. The Agent Builder UI has no separate "Publish"
-      // button, so without this every edit after creation would create orphaned
-      // draft versions that never surface in the list.
-      // When a proper publish flow ships, this block can be removed.
-      if (autoVersionResult.versionCreated) {
-        const { versions } = await agentsStore.listVersions({ agentId: storedAgentId, perPage: 1 });
-        const latestVersion = versions[0];
-        if (latestVersion) {
-          await agentsStore.update({
-            id: storedAgentId,
-            activeVersionId: latestVersion.id,
-          });
-        }
       }
 
       // Clear the cached agent instance so the next request gets the updated config

--- a/packages/server/src/server/handlers/stored-skills.test.ts
+++ b/packages/server/src/server/handlers/stored-skills.test.ts
@@ -35,6 +35,7 @@ interface MockSkillsStore {
   getById: ReturnType<typeof vi.fn>;
   getByIdResolved: ReturnType<typeof vi.fn>;
   listResolved: ReturnType<typeof vi.fn>;
+  listVersions: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
 }
@@ -83,6 +84,14 @@ function createMockSkillsStore(skillsData: Map<string, MockStoredSkill> = new Ma
         };
       },
     ),
+    listVersions: vi.fn().mockImplementation(async ({ skillId }: { skillId: string; perPage?: number }) => {
+      const skill = skillsData.get(skillId);
+      if (!skill) return { versions: [], total: 0 };
+      return {
+        versions: [{ id: `${skillId}-v1`, skillId, versionNumber: 1 }],
+        total: 1,
+      };
+    }),
     update: vi.fn().mockImplementation(async (updates: Partial<MockStoredSkill> & { id: string }) => {
       const existing = skillsData.get(updates.id);
       if (!existing) return null;

--- a/packages/server/src/server/handlers/stored-skills.ts
+++ b/packages/server/src/server/handlers/stored-skills.ts
@@ -390,6 +390,7 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
     // Entity-level fields
     authorId,
     visibility,
+    status,
     // Config fields (snapshot-level)
     name,
     description,
@@ -443,6 +444,7 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
         id: storedSkillId,
         authorId,
         visibility: resolvedVisibility,
+        status,
         name,
         description,
         instructions,

--- a/packages/server/src/server/handlers/stored-skills.ts
+++ b/packages/server/src/server/handlers/stored-skills.ts
@@ -356,8 +356,21 @@ export const CREATE_STORED_SKILL_ROUTE = createRoute({
         },
       });
 
-      // Return the resolved skill (thin record + version config)
-      const resolved = await skillStore.getByIdResolved(id);
+      // Publish the initial version so the skill is immediately usable.
+      // Without this, the thin record stays as status='draft' with activeVersionId=null,
+      // which makes the skill unreachable via status='published' resolution.
+      const { versions } = await skillStore.listVersions({ skillId: id, perPage: 1 });
+      const initialVersion = versions[0];
+      if (initialVersion) {
+        await skillStore.update({
+          id,
+          activeVersionId: initialVersion.id,
+          status: 'published',
+        });
+      }
+
+      // Return the resolved skill (thin record + version config) using the newly published version
+      const resolved = await skillStore.getByIdResolved(id, { status: 'published' });
       if (!resolved) {
         throw new HTTPException(500, { message: 'Failed to resolve created skill' });
       }
@@ -458,8 +471,23 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
         metadata,
       });
 
+      // When the caller explicitly requests status='published', activate the
+      // latest version so the update is immediately live.
+      if (status === 'published') {
+        const { versions } = await skillStore.listVersions({ skillId: storedSkillId, perPage: 1 });
+        const latestVersion = versions[0];
+        if (latestVersion) {
+          await skillStore.update({
+            id: storedSkillId,
+            activeVersionId: latestVersion.id,
+            status: 'published',
+          });
+        }
+      }
+
       // Return the resolved skill with the updated config
-      const resolved = await skillStore.getByIdResolved(storedSkillId);
+      const resolveStatus = status === 'published' ? 'published' : 'draft';
+      const resolved = await skillStore.getByIdResolved(storedSkillId, { status: resolveStatus });
       if (!resolved) {
         throw new HTTPException(500, { message: 'Failed to resolve updated skill' });
       }

--- a/packages/server/src/server/schemas/stored-agents.ts
+++ b/packages/server/src/server/schemas/stored-agents.ts
@@ -339,6 +339,10 @@ export const updateStoredAgentBodySchema = agentMetadataSchema
   .partial()
   .merge(snapshotConfigUpdateSchema.partial())
   .extend({
+    status: z
+      .enum(['draft', 'published'])
+      .optional()
+      .describe('Agent status: draft (not live, owner-only) or published (live, visibility applies)'),
     changeMessage: z
       .string()
       .trim()

--- a/packages/server/src/server/schemas/stored-skills.ts
+++ b/packages/server/src/server/schemas/stored-skills.ts
@@ -98,6 +98,10 @@ export const updateStoredSkillBodySchema = z
       .enum(['private', 'public'])
       .optional()
       .describe('Skill visibility: private (owner/admin only) or public (any reader)'),
+    status: z
+      .enum(['draft', 'published'])
+      .optional()
+      .describe('Skill status: draft (not live, owner-only) or published (live, visibility applies)'),
   })
   .partial()
   .merge(snapshotConfigSchema.partial());


### PR DESCRIPTION
## Summary

Adds an explicit publish flow for agents in the Agent Builder UI. Agents now start as drafts and must be explicitly published before they're live.

### What changed

**Server**
- Removed auto-publish from CREATE and UPDATE handlers — agents start as `draft`
- Added `status` field to PATCH body schemas for both agents and skills, enabling unpublish via the existing update endpoint

**Agent Builder UI**
- **View page**: "Publish" button (owner-only) and "Unpublished changes" badge when a draft exists
- **Edit/Create page**: "Create & Publish" button alongside "Save as Draft"
- **List page**: Shows both draft and published agents with Draft/Published status badge; dual-fetches and merges results (draft wins on ID collision)

**Hooks**
- `useActivateAgentVersion` now invalidates `stored-agents`, `agents`, and `stored-agent` queries on success

### How to test
1. Create an agent → verify it starts as `draft`
2. Use "Create & Publish" → verify agent is immediately `published`
3. Edit a published agent → verify it shows "Unpublished changes" badge on view page
4. Click "Publish" on view page → verify status becomes `published`
5. Verify agent list shows correct Draft/Published badges

### Linear
COR-885