### PR TITLE
fix(e2b): pass region to s3fs and verify mount actually attached

### DIFF
--- a/.changeset/nice-rockets-arrive.md
+++ b/.changeset/nice-rockets-arrive.md
@@ -2,35 +2,6 @@
 '@mastra/e2b': patch
 ---
 
-Fixed silent S3 mount failures in E2B sandboxes.
+Fixed S3 mounts in E2B sandboxes by honoring the configured region and verifying that the FUSE mount attached successfully.
 
-The s3fs region option is now passed correctly so signature-version-4 requests match buckets outside `us-east-1` (Supabase, AWS S3 in non-default regions, etc). When s3fs daemonizes successfully but its FUSE init bucket check fails afterwards, Mastra now verifies the mountpoint and surfaces a clear error instead of reporting a successful mount.
-
-**Before**
-
-```ts
-new Workspace({
-  mounts: {
-    '/skills': new S3Filesystem({
-      bucket: 'skills',
-      region: 'ap-northeast-1', // ignored by s3fs — defaulted to us-east-1
-      endpoint: 'https://<project>.storage.supabase.co/storage/v1/s3',
-      accessKeyId,
-      secretAccessKey,
-    }),
-  },
-  sandbox: new E2BSandbox(),
-});
-// Logs: 'Mount successful' — but ls /skills is empty.
-```
-
-**After**
-
-The region flows to s3fs and the mount is verified post-attach. If verification fails the workspace surfaces:
-
-```
-s3fs returned exit 0 but /skills is not a mountpoint. The s3fs daemon
-likely failed during FUSE init (common causes: region mismatch, invalid
-credentials, or an S3-compatible endpoint that rejects the signature).
-Re-run inside the sandbox with '-f -o dbglevel=info' to see the underlying error.
-```
+Mount failures that previously appeared successful now surface a clear error, making region, credential, and endpoint compatibility problems easier to diagnose.

--- a/.changeset/nice-rockets-arrive.md
+++ b/.changeset/nice-rockets-arrive.md
@@ -1,0 +1,36 @@
+---
+'@mastra/e2b': patch
+---
+
+Fixed silent S3 mount failures in E2B sandboxes.
+
+The s3fs region option is now passed correctly so signature-version-4 requests match buckets outside `us-east-1` (Supabase, AWS S3 in non-default regions, etc). When s3fs daemonizes successfully but its FUSE init bucket check fails afterwards, Mastra now verifies the mountpoint and surfaces a clear error instead of reporting a successful mount.
+
+**Before**
+
+```ts
+new Workspace({
+  mounts: {
+    '/skills': new S3Filesystem({
+      bucket: 'skills',
+      region: 'ap-northeast-1', // ignored by s3fs — defaulted to us-east-1
+      endpoint: 'https://<project>.storage.supabase.co/storage/v1/s3',
+      accessKeyId,
+      secretAccessKey,
+    }),
+  },
+  sandbox: new E2BSandbox(),
+});
+// Logs: 'Mount successful' — but ls /skills is empty.
+```
+
+**After**
+
+The region flows to s3fs and the mount is verified post-attach. If verification fails the workspace surfaces:
+
+```
+s3fs returned exit 0 but /skills is not a mountpoint. The s3fs daemon
+likely failed during FUSE init (common causes: region mismatch, invalid
+credentials, or an S3-compatible endpoint that rejects the signature).
+Re-run inside the sandbox with '-f -o dbglevel=info' to see the underlying error.
+```

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -890,6 +890,11 @@ describe('E2BSandbox Mount Configuration', () => {
     const result = await sandbox.mount(mockFilesystem, '/data/s3-bad-region');
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/Invalid region/);
+    expect(
+      mockSandbox.commands.run.mock.calls.some(
+        (call: any[]) => call[0].includes('s3fs') && call[0].includes('/data/s3-bad-region'),
+      ),
+    ).toBe(false);
   });
 
   it('S3 mount rejects missing region (undefined) before invoking s3fs', async () => {
@@ -913,6 +918,11 @@ describe('E2BSandbox Mount Configuration', () => {
     const result = await sandbox.mount(mockFilesystem, '/data/s3-no-region');
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/Invalid region/);
+    expect(
+      mockSandbox.commands.run.mock.calls.some(
+        (call: any[]) => call[0].includes('s3fs') && call[0].includes('/data/s3-no-region'),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -891,6 +891,29 @@ describe('E2BSandbox Mount Configuration', () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/Invalid region/);
   });
+
+  it('S3 mount rejects missing region (undefined) before invoking s3fs', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-s3-no-region',
+      name: 'S3Filesystem',
+      provider: 's3',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 's3',
+        bucket: 'test-bucket',
+        region: undefined,
+        accessKeyId: 'key',
+        secretAccessKey: 'secret',
+      }),
+    } as any;
+
+    const result = await sandbox.mount(mockFilesystem, '/data/s3-no-region');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Invalid region/);
+  });
 });
 
 /**

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -798,6 +798,99 @@ describe('E2BSandbox Mount Configuration', () => {
       expect(s3fsMountCall[0]).not.toContain('test-bucket:/workspace/data/');
     }
   });
+
+  it('S3 mount passes region to s3fs as endpoint option', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-s3-region',
+      name: 'S3Filesystem',
+      provider: 's3',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 's3',
+        bucket: 'test-bucket',
+        region: 'ap-northeast-1',
+        endpoint: 'https://example.supabase.co/storage/v1/s3',
+        accessKeyId: 'key',
+        secretAccessKey: 'secret',
+      }),
+    } as any;
+
+    await sandbox.mount(mockFilesystem, '/data/s3-region');
+
+    const calls = mockSandbox.commands.run.mock.calls;
+    const s3fsMountCall = calls.find(
+      (call: any[]) => call[0].includes('s3fs') && call[0].includes('/data/s3-region') && !call[0].includes('which'),
+    );
+
+    expect(s3fsMountCall).toBeDefined();
+    if (s3fsMountCall) {
+      expect(s3fsMountCall[0]).toContain('endpoint=ap-northeast-1');
+    }
+  });
+
+  it('S3 mount throws when s3fs returns 0 but mountpoint check fails', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    // Override the default mock to make `mountpoint -q` fail (simulating
+    // s3fs daemon dying after fork — the parent returns 0 but no mount attached).
+    mockSandbox.commands.run.mockImplementation((cmd: string) => {
+      if (cmd.includes('which s3fs')) {
+        return Promise.resolve({ exitCode: 0, stdout: '/usr/bin/s3fs', stderr: '' });
+      }
+      if (cmd.includes('id -u')) {
+        return Promise.resolve({ exitCode: 0, stdout: '1000\n1000', stderr: '' });
+      }
+      if (cmd.startsWith('mountpoint -q')) {
+        return Promise.resolve({ exitCode: 32, stdout: '', stderr: '' });
+      }
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    const mockFilesystem = {
+      id: 'test-s3-silent-fail',
+      name: 'S3Filesystem',
+      provider: 's3',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 's3',
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        accessKeyId: 'key',
+        secretAccessKey: 'secret',
+      }),
+    } as any;
+
+    const result = await sandbox.mount(mockFilesystem, '/data/s3-silent');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not a mountpoint/);
+  });
+
+  it('S3 mount rejects invalid region before invoking s3fs', async () => {
+    const sandbox = new E2BSandbox();
+    await sandbox._start();
+
+    const mockFilesystem = {
+      id: 'test-s3-bad-region',
+      name: 'S3Filesystem',
+      provider: 's3',
+      status: 'ready',
+      getMountConfig: () => ({
+        type: 's3',
+        bucket: 'test-bucket',
+        region: 'us east 1; rm -rf /',
+        accessKeyId: 'key',
+        secretAccessKey: 'secret',
+      }),
+    } as any;
+
+    const result = await sandbox.mount(mockFilesystem, '/data/s3-bad-region');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Invalid region/);
+  });
 });
 
 /**

--- a/workspaces/e2b/src/sandbox/mounts/s3.ts
+++ b/workspaces/e2b/src/sandbox/mounts/s3.ts
@@ -1,7 +1,7 @@
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
 import { shellQuote } from '../../utils/shell-quote';
-import { LOG_PREFIX, validateBucketName, validateEndpoint, validatePrefix } from './types';
+import { LOG_PREFIX, validateBucketName, validateEndpoint, validatePrefix, validateRegion } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -41,6 +41,7 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
 
   // Validate inputs before interpolating into shell commands
   validateBucketName(config.bucket);
+  validateRegion(config.region);
   if (config.endpoint) {
     validateEndpoint(config.endpoint);
   }
@@ -124,6 +125,12 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
     mountOptions.push(`url=${endpoint}`, 'use_path_request_style', 'sigv4', 'nomultipart');
   }
 
+  // s3fs's `endpoint` option sets the AWS region used for sigv4 signing
+  // (confusingly named — distinct from the URL `endpoint` flag above).
+  // Default is us-east-1, which produces SignatureDoesNotMatch errors against
+  // buckets in other regions or S3-compatible services that validate the region.
+  mountOptions.push(`endpoint=${config.region}`);
+
   if (config.readOnly) {
     mountOptions.push('ro');
     logger.debug(`${LOG_PREFIX} Mounting as read-only`);
@@ -156,5 +163,19 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
     const stdout = errorObj.result?.stdout || '';
     logger.error(`${LOG_PREFIX} s3fs error:`, { stderr, stdout, error: String(error) });
     throw new Error(`Failed to mount S3 bucket: ${stderr || stdout || error}`);
+  }
+
+  // s3fs daemonizes before running its FUSE init, where the bucket check happens.
+  // If that check fails (wrong region, bad credentials, unsupported endpoint),
+  // the daemon exits but the parent has already returned exit code 0.
+  // Verify the mount actually attached.
+  const verify = await sandbox.commands.run(`mountpoint -q ${shellQuote(mountPath)}`);
+  if (verify.exitCode !== 0) {
+    throw new Error(
+      `s3fs returned exit 0 but ${mountPath} is not a mountpoint. ` +
+        `The s3fs daemon likely failed during FUSE init (common causes: region mismatch, ` +
+        `invalid credentials, or an S3-compatible endpoint that rejects the signature). ` +
+        `Re-run inside the sandbox with '-f -o dbglevel=info' to see the underlying error.`,
+    );
   }
 }

--- a/workspaces/e2b/src/sandbox/mounts/types.ts
+++ b/workspaces/e2b/src/sandbox/mounts/types.ts
@@ -62,6 +62,20 @@ export function validateEndpoint(endpoint: string): void {
 }
 
 /**
+ * Validate an AWS region (or R2's "auto") before interpolating into shell commands.
+ * Accepts standard AWS region codes like "us-east-1", "ap-northeast-1", and "auto".
+ */
+const SAFE_REGION = /^[a-z0-9-]{2,32}$/;
+
+export function validateRegion(region: string): void {
+  if (!SAFE_REGION.test(region)) {
+    throw new Error(
+      `Invalid region: "${region}". Region must be lowercase alphanumeric or hyphens (e.g., "us-east-1", "ap-northeast-1", "auto").`,
+    );
+  }
+}
+
+/**
  * Validate and normalize a mount prefix before interpolating into shell commands.
  * Returns the normalized prefix (no leading/trailing slashes).
  *

--- a/workspaces/e2b/src/sandbox/mounts/types.ts
+++ b/workspaces/e2b/src/sandbox/mounts/types.ts
@@ -67,10 +67,10 @@ export function validateEndpoint(endpoint: string): void {
  */
 const SAFE_REGION = /^[a-z0-9-]{2,32}$/;
 
-export function validateRegion(region: string): void {
-  if (!SAFE_REGION.test(region)) {
+export function validateRegion(region: unknown): asserts region is string {
+  if (typeof region !== 'string' || !SAFE_REGION.test(region)) {
     throw new Error(
-      `Invalid region: "${region}". Region must be lowercase alphanumeric or hyphens (e.g., "us-east-1", "ap-northeast-1", "auto").`,
+      `Invalid region: ${JSON.stringify(region)}. Region must be a string of lowercase alphanumeric or hyphens (e.g., "us-east-1", "ap-northeast-1", "auto").`,
     );
   }
 }


### PR DESCRIPTION
## Description

Fixes silent S3 mount failures in `@mastra/e2b` reported in #15144.

- Forward `config.region` to s3fs as `-o endpoint=<region>` (s3fs's name for the sigv4 signing region) — non-`us-east-1` buckets no longer fail with `SignatureDoesNotMatch`
- After s3fs returns, verify the mount actually attached with `mountpoint -q`; throw a clear, actionable error with debugging hints when it didn't (s3fs daemonizes before its FUSE init bucket check, so post-fork failures previously slipped past the parent's exit code)
- Add `validateRegion()` to safeguard shell interpolation of the new option
- 4 new unit tests covering region propagation, silent-failure detection, and region validation

Note: the mount itself still depends on s3fs being able to communicate with the chosen S3-compatible backend. Some providers (e.g. Supabase Storage) reject the specific request shape s3fs sends — those mounts will now produce a clear error instead of silently appearing to succeed. Today's workaround for those providers is AWS S3 / R2 / MinIO; broader compatibility (e.g. an rclone-based mount) is a separate follow-up.

## Related Issue(s)

Fixes #15144

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes S3 mounts in E2B sandboxes so buckets outside us-east-1 stop failing silently: it tells the s3fs tool which AWS region to use and then confirms the filesystem really mounted, producing clear errors when it didn't. It also adds stricter region validation and unit tests to prevent bad inputs.

---

## Overview

Ensure reliable, debuggable S3 mounts in @mastra/e2b by (1) passing the configured region to s3fs (as endpoint=<region> for sigv4 signing) and (2) verifying the FUSE mount attached with mountpoint -q, surfacing explicit errors when s3fs daemonizes but the mount never attaches.

## Changes

### Mount Configuration & Verification (workspaces/e2b/src/sandbox/mounts/s3.ts)
- Validate inputs (bucket, region, endpoint) before building shell commands.
- Add s3fs mount option endpoint=${config.region} so sigv4 signing uses the configured region (fixes SignatureDoesNotMatch for non-us-east-1 buckets).
- After invoking s3fs, run mountpoint -q to verify the mount actually attached; if verification fails, throw a detailed error with debugging hints.
- Keep existing behavior for endpoint/url, credentials handling, and public-bucket mode; note that backend compatibility with s3fs still affects mount success.

### Region Validation (workspaces/e2b/src/sandbox/mounts/types.ts)
- Add SAFE_REGION regex and exported validateRegion(region: unknown): asserts region is string which now rejects non-string inputs (undefined/null) and invalid region strings, improving shell-safety and preventing injection or accidental misuse.

### Tests (workspaces/e2b/src/sandbox/index.test.ts)
- Add four unit tests covering:
  - Region propagation to s3fs (ensures endpoint=<region> is included).
  - Detection of silent mount failures when s3fs returns exit 0 but mountpoint -q fails.
  - Validation rejects invalid region strings.
  - Validation rejects missing/undefined region and ensures s3fs is not invoked when validation fails (asserts no s3fs command executed).

### Changeset
- Bump @mastra/e2b patch and document the user-visible fix: region-aware s3fs mounts and explicit mount verification/errors.

## Notes
- Mount success still depends on the S3 backend accepting s3fs’s request shape; incompatible providers will now yield explicit errors (making incompatibilities visible). Broader alternatives (e.g., rclone) are out-of-scope follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->