### PR TITLE
test(inngest): force dev mode in vitest config

### DIFF
--- a/workflows/inngest/vitest.config.ts
+++ b/workflows/inngest/vitest.config.ts
@@ -9,5 +9,11 @@ export default defineConfig({
     hookTimeout: 30000, // Allow more time for beforeAll to setup Inngest
     fileParallelism: false,
     retry: 2, // Retry flaky tests up to 2 times (Inngest dev server can be flaky)
+    // Inngest SDK v4 defaults to "cloud" mode and requires an event key unless
+    // `isDev: true`, `INNGEST_DEV` env var, or an explicit dev URL is set.
+    // Tests use a local dev server; force dev mode for every Inngest client.
+    env: {
+      INNGEST_DEV: '1',
+    },
   },
 });


### PR DESCRIPTION
## Summary

Follow-up to #15377 (Inngest SDK v4 migration).

Inngest SDK v4 changed the default client mode from `dev` to `cloud`. Without `isDev: true`, the `INNGEST_DEV` env var, or an explicit dev URL, every `new Inngest()` call defaults to cloud mode and requires an event key. The test suite has 125 `new Inngest({ id, baseUrl })` callsites that all started failing with:

```
Failed to send event ... we couldn't find an event key to use to send events to Inngest.
To fix: Set the INNGEST_EVENT_KEY environment variable; Pass a key to the new Inngest() constructor using the eventKey option
```

This sets `INNGEST_DEV=1` at the vitest level so all Inngest clients in the suite stay in dev mode without touching every callsite.

## How discovered

Running `pnpm test:docker` locally against the merged v4 migration. The test suite isn't wired into CI (`workflows/inngest/vitest.config.ts` doesn't define a project name, so the `e2e:workflows/*` filter skips it), which is why this didn't fail on the original PR.

## ELI5

The Inngest v4 SDK assumes you're talking to production unless you tell it otherwise. The tests talk to a local dev server. Tell the SDK that explicitly with one env var instead of editing 125 places.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When Inngest SDK updated to version 4, it changed how it works by default—like switching a game from "practice mode" to "real mode." The test suite was still trying to use "practice mode" but didn't tell it to, so it failed. This PR simply tells the test system "Hey, use practice mode for all tests" so everything works without having to fix 125+ individual test calls.

## Changes

Modified `workflows/inngest/vitest.config.ts` to add `INNGEST_DEV: '1'` to the test environment configuration, ensuring all Inngest client instances in the test suite run in dev mode.

**File changes:**
- `workflows/inngest/vitest.config.ts`: Added `env: { INNGEST_DEV: '1' }` to the Vitest test configuration (+6 lines)

## Context

This follows the Inngest SDK v4 migration in #15377. The v4 upgrade changed the default client mode from "dev" to "cloud", requiring tests using `new Inngest({ id, baseUrl })` to either specify `isDev: true`, set the `INNGEST_DEV` environment variable, or use a dev URL. Rather than updating ~125 callsites across the test suite, setting the environment variable at the Vitest configuration level ensures all Inngest clients default to dev mode during testing.

The issue was discovered when running `pnpm test:docker` locally—tests were not failing in CI because the inngest Vitest config lacked a project name and was being skipped by existing `e2e:workflows/*` filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->