### PR TITLE
feat(core): add Agent signals

### DIFF
--- a/.changeset/rich-drinks-stay.md
+++ b/.changeset/rich-drinks-stay.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': minor
+'@mastra/server': minor
+'@mastra/client-js': minor
+---
+
+Added regular Agent APIs for sending signals to memory threads and subscribing to thread runs, plus signal conversion helpers and client/server routes.

--- a/.changeset/rich-drinks-stay.md
+++ b/.changeset/rich-drinks-stay.md
@@ -4,4 +4,22 @@
 '@mastra/client-js': minor
 ---
 
-Added regular Agent APIs for sending signals to memory threads and subscribing to thread runs, plus signal conversion helpers and client/server routes.
+Added Agent signals for sending contextual messages into agent thread loops and subscribing to thread activity.
+
+Call `agent.sendSignal()` to inject context into a running agent loop. When the thread is idle, that same signal becomes the prompt that starts the next loop.
+
+Use `agent.subscribeToThread()` to follow the raw stream chunks for a memory thread, observe signal echoes with stable IDs, and abort the active stream for that thread.
+
+```ts
+const subscription = await agent.subscribeToThread({ resourceId, threadId });
+
+void (async () => {
+  for await (const part of subscription.stream) {
+    if (part.type === 'finish') {
+      subscription.unsubscribe();
+    }
+  }
+})();
+
+agent.sendSignal({ type: 'user-message', contents: 'Use the latest answer' }, { resourceId, threadId });
+```

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -38,6 +38,8 @@ import type {
   AgentVersionResponse,
   ListAgentVersionsParams,
   ListAgentVersionsResponse,
+  SendAgentSignalParams,
+  SubscribeAgentThreadParams,
   CreateCodeAgentVersionParams,
   ActivateAgentVersionResponse,
   CompareVersionsResponse,
@@ -271,6 +273,21 @@ export class Agent extends BaseResource {
     return this.request(`/agents/${this.agentId}/instructions/enhance`, {
       method: 'POST',
       body: { instructions, comment },
+    });
+  }
+
+  sendSignal<OUTPUT = unknown>(params: SendAgentSignalParams<OUTPUT>): Promise<{ accepted: true; runId: string }> {
+    return this.request(`/agents/${this.agentId}/signals`, {
+      method: 'POST',
+      body: params,
+    });
+  }
+
+  subscribeToThread(params: SubscribeAgentThreadParams): Promise<Response> {
+    return this.request(`/agents/${this.agentId}/threads/subscribe`, {
+      method: 'POST',
+      body: params,
+      stream: true,
     });
   }
 

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -7,6 +7,7 @@ import type {
   ToolsInput,
   UIMessageWithMetadata,
   AgentInstructions,
+  AgentSignal,
 } from '@mastra/core/agent';
 import type { MessageListInput } from '@mastra/core/agent/message-list';
 import type { MastraScorerEntry, ScoreRowData } from '@mastra/core/evals';
@@ -108,6 +109,19 @@ export interface ClientOptions {
 }
 
 export type AgentVersionIdentifier = { versionId: string } | { status: 'draft' | 'published' };
+
+export interface SendAgentSignalParams<OUTPUT = unknown> {
+  signal: AgentSignal;
+  runId?: string;
+  resourceId?: string;
+  threadId?: string;
+  streamOptions?: Omit<AgentExecutionOptions<OUTPUT>, 'messages'>;
+}
+
+export interface SubscribeAgentThreadParams {
+  resourceId?: string;
+  threadId: string;
+}
 
 export interface RequestOptions {
   method?: string;

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -10,6 +10,7 @@ import {
   signalToDataPartFormat,
   signalToMastraDBMessage,
 } from '../signals';
+import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
 
 function createTextStreamModel(responseText: string) {
   return new MockLanguageModelV2({
@@ -34,6 +35,34 @@ function createTextStreamModel(responseText: string) {
 
 function nextTick() {
   return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function readNextRun(iterator: AsyncIterator<any>) {
+  let runId: string | undefined;
+  let text = '';
+
+  while (true) {
+    const next = await iterator.next();
+    if (next.done) return next;
+
+    const part = next.value;
+    runId ??= part.runId;
+    if (part.type === 'text-delta') {
+      text += part.payload.text;
+    }
+    if (part.type === 'finish' || part.type === 'error' || part.type === 'abort') {
+      return { value: { runId, text, part }, done: false };
+    }
+  }
+}
+
+async function waitForActiveRun(subscription: { activeRunId: () => string | null }) {
+  let runId = subscription.activeRunId();
+  while (!runId) {
+    await nextTick();
+    runId = subscription.activeRunId();
+  }
+  return runId;
 }
 
 describe('Agent signals', () => {
@@ -105,7 +134,7 @@ describe('Agent signals', () => {
       threadId: 'future-thread',
       resourceId: 'future-user',
     });
-    const nextRun = subscription.runs[Symbol.asyncIterator]().next();
+    const nextRun = readNextRun(subscription.stream[Symbol.asyncIterator]());
 
     const stream = await agent.stream('Hello', {
       memory: { thread: 'future-thread', resource: 'future-user' },
@@ -113,9 +142,9 @@ describe('Agent signals', () => {
 
     const subscribedRun = await nextRun;
     expect(subscribedRun.value.runId).toBe(stream.runId);
-    await expect(subscribedRun.value.output.text).resolves.toBe('future response');
+    expect(subscribedRun.value.text).toBe('future response');
 
-    subscription.cleanup();
+    subscription.unsubscribe();
   });
 
   it('starts an idle thread run when a user-message signal is sent', async () => {
@@ -130,18 +159,39 @@ describe('Agent signals', () => {
       threadId: 'idle-thread',
       resourceId: 'idle-user',
     });
-    const nextRun = subscription.runs[Symbol.asyncIterator]().next();
+    const nextRun = readNextRun(subscription.stream[Symbol.asyncIterator]());
 
     const signalResult = agent.sendSignal(
       { type: 'user-message', contents: 'Hello from signal' },
-      { resourceId: 'idle-user', threadId: 'idle-thread' },
+      {
+        resourceId: 'idle-user',
+        threadId: 'idle-thread',
+        ifIdle: { streamOptions: { memory: { resource: 'idle-user', thread: 'idle-thread' } } },
+      },
     );
 
     const subscribedRun = await nextRun;
-    expect(signalResult).toEqual({ accepted: true, runId: subscribedRun.value.runId });
-    await expect(subscribedRun.value.output.text).resolves.toBe('signal response');
+    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: subscribedRun.value.runId }));
+    expect(signalResult.signal.id).toBeDefined();
+    expect(subscribedRun.value.text).toBe('signal response');
 
-    subscription.cleanup();
+    subscription.unsubscribe();
+  });
+
+  it('requires ifIdle stream options before starting an idle thread run', () => {
+    const agent = new Agent({
+      id: 'idle-signal-without-options-agent',
+      name: 'Idle Signal Without Options Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('signal response'),
+    });
+
+    expect(() =>
+      agent.sendSignal(
+        { type: 'user-message', contents: 'Hello from signal' },
+        { resourceId: 'idle-user', threadId: 'idle-thread' },
+      ),
+    ).toThrow('No active agent run found for signal target');
   });
 
   it('supports cross-instance thread subscriptions through the Mastra runtime', async () => {
@@ -163,8 +213,8 @@ describe('Agent signals', () => {
       threadId: 'shared-thread',
       resourceId: 'shared-user',
     });
-    const iterator = subscription.runs[Symbol.asyncIterator]();
-    const firstRunPromise = iterator.next();
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+    const firstRunPromise = readNextRun(iterator);
 
     const stream = await runner.stream('Hello', {
       memory: { thread: 'shared-thread', resource: 'shared-user' },
@@ -172,30 +222,37 @@ describe('Agent signals', () => {
 
     const subscribedRun = await firstRunPromise;
     expect(subscribedRun.value.runId).toBe(stream.runId);
-    await expect(subscribedRun.value.output.text).resolves.toBe('shared response');
+    expect(subscribedRun.value.text).toBe('shared response');
 
-    const secondRunPromise = iterator.next();
+    const secondRunPromise = readNextRun(iterator);
     const signalResult = runner.sendSignal(
       { type: 'user-message', contents: 'Hello from shared signal' },
-      { resourceId: 'shared-user', threadId: 'shared-thread' },
+      {
+        resourceId: 'shared-user',
+        threadId: 'shared-thread',
+        ifIdle: { streamOptions: { memory: { resource: 'shared-user', thread: 'shared-thread' } } },
+      },
     );
     const signalRun = await secondRunPromise;
-    expect(signalResult).toEqual({ accepted: true, runId: signalRun.value.runId });
-    await expect(signalRun.value.output.text).resolves.toBe('shared response');
+    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: signalRun.value.runId }));
+    expect(signalResult.signal.id).toBeDefined();
+    expect(signalRun.value.text).toBe('shared response');
 
-    subscription.cleanup();
+    subscription.unsubscribe();
   });
 
-  it('queues a user-message signal while a thread run is active', async () => {
+  it('drains a user-message signal into the active same-agent thread run', async () => {
     let releaseFirst!: () => void;
     const firstFinished = new Promise<void>(resolve => {
       releaseFirst = resolve;
     });
     let streamCount = 0;
+    const prompts: any[][] = [];
 
     const model = new MockLanguageModelV2({
-      doStream: async () => {
+      doStream: async ({ prompt }) => {
         streamCount += 1;
+        prompts.push(prompt);
         const responseText = streamCount === 1 ? 'first response' : 'signal response';
 
         return {
@@ -239,28 +296,123 @@ describe('Agent signals', () => {
       threadId: 'active-thread',
       resourceId: 'active-user',
     });
-    const iterator = subscription.runs[Symbol.asyncIterator]();
-    const firstRunPromise = iterator.next();
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+    const firstRunPromise = readNextRun(iterator);
 
     const stream = await agent.stream('Hello', {
       memory: { thread: 'active-thread', resource: 'active-user' },
     });
-    const firstRun = await firstRunPromise;
+    await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
 
     const signalResult = agent.sendSignal(
       { type: 'user-message', contents: 'Hello while running' },
       { resourceId: 'active-user', threadId: 'active-thread' },
     );
-    expect(signalResult).toEqual({ accepted: true, runId: stream.runId });
+    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+    expect(signalResult.signal.id).toBeDefined();
 
     releaseFirst();
-    await expect(firstRun.value.output.text).resolves.toBe('first response');
+    const firstRun = await firstRunPromise;
+    expect(firstRun.value.text).toBe('first responsesignal response');
+    expect(streamCount).toBe(2);
+    expect(JSON.stringify(prompts[1])).toContain('Hello while running');
 
-    const secondRun = await iterator.next();
-    expect(secondRun.value.runId).not.toBe(stream.runId);
-    await expect(secondRun.value.output.text).resolves.toBe('signal response');
+    subscription.unsubscribe();
+  });
 
-    subscription.cleanup();
+  it('preserves active interjections sent immediately after repeated idle signal-started runs', async () => {
+    const releaseInitialCalls: Array<() => void> = [];
+    const prompts: any[][] = [];
+    let callCount = 0;
+
+    const model = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        callCount += 1;
+        const callIndex = callCount;
+        prompts.push(prompt);
+
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: new ReadableStream({
+            async start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+              controller.enqueue({
+                type: 'response-metadata',
+                id: `id-${callIndex}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              });
+              controller.enqueue({ type: 'text-start', id: 'text-1' });
+              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: `response ${callIndex}` });
+              controller.enqueue({ type: 'text-end', id: 'text-1' });
+              if (callIndex === 1 || callIndex === 2) {
+                await new Promise<void>(resolve => releaseInitialCalls.push(resolve));
+              }
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+              controller.close();
+            },
+          }),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'repeated-idle-signal-agent',
+      name: 'Repeated Idle Signal Agent',
+      instructions: 'Test',
+      model,
+    });
+
+    const subscription = await agent.subscribeToThread({
+      threadId: 'repeated-idle-thread',
+      resourceId: 'repeated-idle-user',
+    });
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+
+    const firstRunPromise = readNextRun(iterator);
+    const firstIdle = agent.sendSignal(
+      { type: 'user-message', contents: 'start first idle stream' },
+      {
+        resourceId: 'repeated-idle-user',
+        threadId: 'repeated-idle-thread',
+        ifIdle: { streamOptions: { memory: { resource: 'repeated-idle-user', thread: 'repeated-idle-thread' } } },
+      },
+    );
+    agent.sendSignal(
+      { type: 'user-message', contents: 'first active interjection' },
+      { runId: firstIdle.runId, resourceId: 'repeated-idle-user', threadId: 'repeated-idle-thread' },
+    );
+    while (releaseInitialCalls.length < 1) await nextTick();
+    releaseInitialCalls.shift()?.();
+    const firstRun = await firstRunPromise;
+    expect(firstRun.value.text).toBe('response 1');
+    expect(JSON.stringify(prompts[0])).toContain('first active interjection');
+
+    const secondRunPromise = readNextRun(iterator);
+    const secondIdle = agent.sendSignal(
+      { type: 'user-message', contents: 'start second idle stream' },
+      {
+        resourceId: 'repeated-idle-user',
+        threadId: 'repeated-idle-thread',
+        ifIdle: { streamOptions: { memory: { resource: 'repeated-idle-user', thread: 'repeated-idle-thread' } } },
+      },
+    );
+    agent.sendSignal(
+      { type: 'user-message', contents: 'second active interjection' },
+      { runId: secondIdle.runId, resourceId: 'repeated-idle-user', threadId: 'repeated-idle-thread' },
+    );
+    while (releaseInitialCalls.length < 1) await nextTick();
+    releaseInitialCalls.shift()?.();
+    const secondRun = await secondRunPromise;
+    expect(secondRun.value.text).toBe('response 2');
+    expect(JSON.stringify(prompts[1])).toContain('second active interjection');
+
+    subscription.unsubscribe();
   });
 
   it('queues a signal from another agent until the active thread run finishes', async () => {
@@ -338,34 +490,37 @@ describe('Agent signals', () => {
       threadId: 'cross-agent-thread',
       resourceId: 'cross-agent-user',
     });
-    const iterator = subscription.runs[Symbol.asyncIterator]();
-    const firstRunPromise = iterator.next();
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+    const firstRunPromise = readNextRun(iterator);
 
     const firstStream = await firstAgent.stream('Hello', {
       memory: { thread: 'cross-agent-thread', resource: 'cross-agent-user' },
     });
-    await firstRunPromise;
     const firstText = firstStream.text;
     await nextTick();
     expect(firstStarted).toBe(true);
 
-    const secondRunPromise = iterator.next();
     const signalResult = secondAgent.sendSignal(
       { type: 'user-message', contents: 'Hello from another agent' },
-      { resourceId: 'cross-agent-user', threadId: 'cross-agent-thread' },
+      {
+        resourceId: 'cross-agent-user',
+        threadId: 'cross-agent-thread',
+        ifIdle: { streamOptions: { memory: { resource: 'cross-agent-user', thread: 'cross-agent-thread' } } },
+      },
     );
     await nextTick();
     expect(secondStarted).toBe(false);
 
     releaseFirst();
     await expect(firstText).resolves.toBe('first response');
+    await expect(firstRunPromise).resolves.toMatchObject({ value: { runId: firstStream.runId }, done: false });
 
-    const secondRun = await secondRunPromise;
+    const secondRun = await readNextRun(iterator);
     expect(secondRun.value.runId).toBe(signalResult.runId);
-    await expect(secondRun.value.output.text).resolves.toBe('second response');
+    expect(secondRun.value.text).toBe('second response');
     expect(secondStarted).toBe(true);
 
-    subscription.cleanup();
+    subscription.unsubscribe();
   });
 
   it('cleans up a thread subscription and completes the iterator', async () => {
@@ -380,10 +535,32 @@ describe('Agent signals', () => {
       threadId: 'cleanup-thread',
       resourceId: 'cleanup-user',
     });
-    const iterator = subscription.runs[Symbol.asyncIterator]();
+    const iterator = subscription.stream[Symbol.asyncIterator]();
 
-    subscription.cleanup();
+    subscription.unsubscribe();
     await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it('allows a thread follower to abort the active run controller', () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const options = runtime.prepareRunOptions({
+      runId: 'abort-run',
+      memory: { thread: 'abort-thread', resource: 'abort-user' },
+    } as any);
+    const neverFinishes = new Promise<any>(() => {});
+
+    runtime.registerRun(
+      { id: 'abortable-agent' } as any,
+      {
+        runId: 'abort-run',
+        status: 'running',
+        getFullOutput: () => neverFinishes,
+      } as any,
+      options,
+    );
+
+    expect(runtime.abortThread({ threadId: 'abort-thread', resourceId: 'abort-user' })).toBe(true);
+    expect(options.abortSignal?.aborted).toBe(true);
   });
 
   it('delivers a future thread run to multiple subscribers', async () => {
@@ -402,8 +579,8 @@ describe('Agent signals', () => {
       threadId: 'multi-thread',
       resourceId: 'multi-user',
     });
-    const firstRunPromise = firstSubscription.runs[Symbol.asyncIterator]().next();
-    const secondRunPromise = secondSubscription.runs[Symbol.asyncIterator]().next();
+    const firstRunPromise = readNextRun(firstSubscription.stream[Symbol.asyncIterator]());
+    const secondRunPromise = readNextRun(secondSubscription.stream[Symbol.asyncIterator]());
 
     const stream = await agent.stream('Hello', {
       memory: { thread: 'multi-thread', resource: 'multi-user' },
@@ -412,8 +589,8 @@ describe('Agent signals', () => {
     await expect(firstRunPromise).resolves.toMatchObject({ value: { runId: stream.runId }, done: false });
     await expect(secondRunPromise).resolves.toMatchObject({ value: { runId: stream.runId }, done: false });
 
-    firstSubscription.cleanup();
-    secondSubscription.cleanup();
+    firstSubscription.unsubscribe();
+    secondSubscription.unsubscribe();
   });
 
   it('isolates subscriptions by resource and thread id', async () => {
@@ -437,9 +614,9 @@ describe('Agent signals', () => {
       resourceId: 'isolated-user',
     });
 
-    const targetNext = targetSubscription.runs[Symbol.asyncIterator]().next();
-    const otherResourceNext = otherResourceSubscription.runs[Symbol.asyncIterator]().next();
-    const otherThreadNext = otherThreadSubscription.runs[Symbol.asyncIterator]().next();
+    const targetNext = readNextRun(targetSubscription.stream[Symbol.asyncIterator]());
+    const otherResourceNext = readNextRun(otherResourceSubscription.stream[Symbol.asyncIterator]());
+    const otherThreadNext = readNextRun(otherThreadSubscription.stream[Symbol.asyncIterator]());
 
     const stream = await agent.stream('Hello', {
       memory: { thread: 'isolated-thread', resource: 'isolated-user' },
@@ -448,15 +625,15 @@ describe('Agent signals', () => {
     await expect(targetNext).resolves.toMatchObject({ value: { runId: stream.runId }, done: false });
     await nextTick();
 
-    otherResourceSubscription.cleanup();
-    otherThreadSubscription.cleanup();
+    otherResourceSubscription.unsubscribe();
+    otherThreadSubscription.unsubscribe();
     await expect(otherResourceNext).resolves.toEqual({ value: undefined, done: true });
     await expect(otherThreadNext).resolves.toEqual({ value: undefined, done: true });
 
-    targetSubscription.cleanup();
+    targetSubscription.unsubscribe();
   });
 
-  it('does not replay existing thread runs to late subscribers', async () => {
+  it('does not replay completed thread runs to late subscribers', async () => {
     const agent = new Agent({
       id: 'late-subscription-agent',
       name: 'Late Subscription Agent',
@@ -464,31 +641,34 @@ describe('Agent signals', () => {
       model: createTextStreamModel('late response'),
     });
 
-    await agent.stream('Hello', {
+    const stream = await agent.stream('Hello', {
       memory: { thread: 'late-thread', resource: 'late-user' },
     });
+    await stream.text;
     const subscription = await agent.subscribeToThread({
       threadId: 'late-thread',
       resourceId: 'late-user',
     });
-    const iterator = subscription.runs[Symbol.asyncIterator]();
+    const iterator = subscription.stream[Symbol.asyncIterator]();
 
-    const nextRun = iterator.next();
+    const nextRun = readNextRun(iterator);
     await nextTick();
-    subscription.cleanup();
+    subscription.unsubscribe();
     await expect(nextRun).resolves.toEqual({ value: undefined, done: true });
   });
 
-  it('queues a signal by active run id', async () => {
+  it('drains a signal by active run id into the active run', async () => {
     let releaseFirst!: () => void;
     const firstFinished = new Promise<void>(resolve => {
       releaseFirst = resolve;
     });
     let streamCount = 0;
+    const prompts: any[][] = [];
 
     const model = new MockLanguageModelV2({
-      doStream: async () => {
+      doStream: async ({ prompt }) => {
         streamCount += 1;
+        prompts.push(prompt);
         const responseText = streamCount === 1 ? 'run id first response' : 'run id signal response';
 
         return {
@@ -531,26 +711,28 @@ describe('Agent signals', () => {
       threadId: 'run-id-thread',
       resourceId: 'run-id-user',
     });
-    const iterator = subscription.runs[Symbol.asyncIterator]();
-    const firstRunPromise = iterator.next();
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+    const firstRunPromise = readNextRun(iterator);
 
     const stream = await agent.stream('Hello', {
       memory: { thread: 'run-id-thread', resource: 'run-id-user' },
     });
-    await firstRunPromise;
+    await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
 
-    expect(agent.sendSignal({ type: 'user-message', contents: 'Hello by run id' }, { runId: stream.runId })).toEqual({
-      accepted: true,
-      runId: stream.runId,
-    });
+    expect(agent.sendSignal({ type: 'user-message', contents: 'Hello by run id' }, { runId: stream.runId })).toEqual(
+      expect.objectContaining({
+        accepted: true,
+        runId: stream.runId,
+      }),
+    );
 
     releaseFirst();
-    await expect(iterator.next()).resolves.toMatchObject({
-      value: { threadId: 'run-id-thread', resourceId: 'run-id-user' },
-      done: false,
-    });
+    await firstRunPromise;
+    await expect(stream.text).resolves.toBe('run id first responserun id signal response');
+    expect(streamCount).toBe(2);
+    expect(JSON.stringify(prompts[1])).toContain('Hello by run id');
 
-    subscription.cleanup();
+    subscription.unsubscribe();
   });
 
   it('throws when sending a signal to an unknown run id without a thread target', () => {
@@ -599,7 +781,11 @@ describe('Agent signals', () => {
 
     const stream = agent.sendSignal(
       { type: 'system-reminder', contents: 'continue', attributes: { reminderType: 'test-reminder' } },
-      { resourceId: 'system-signal-user', threadId: 'system-signal-thread' },
+      {
+        resourceId: 'system-signal-user',
+        threadId: 'system-signal-thread',
+        ifIdle: { streamOptions: { memory: { resource: 'system-signal-user', thread: 'system-signal-thread' } } },
+      },
     );
 
     expect(stream.accepted).toBe(true);

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -103,7 +103,7 @@ describe('Agent signals', () => {
 
     expect(reminderSignal.toLLMMessage()).toEqual([
       {
-        role: 'system',
+        role: 'user',
         content:
           '<system-reminder type="dynamic-agents-md" path="/tmp/AGENTS.md" enabled="true">Use &lt;safe&gt; content &amp; continue</system-reminder>',
       },
@@ -120,6 +120,29 @@ describe('Agent signals', () => {
       enabled: true,
       ignored: null,
     });
+
+    const fileContents = {
+      role: 'user' as const,
+      content: [
+        { type: 'text' as const, text: 'Review this file' },
+        {
+          type: 'file' as const,
+          data: 'data:text/plain;base64,aGVsbG8=',
+          mediaType: 'text/plain',
+          filename: 'note.txt',
+        },
+      ],
+    };
+    const fileSignal = createSignal({
+      id: 'signal-3',
+      type: 'user-message',
+      contents: fileContents,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    expect(fileSignal.toLLMMessage()).toEqual(fileContents);
+    expect(fileSignal.toDataPart().data.contents).toEqual(fileContents);
+    expect(mastraDBMessageToSignal(fileSignal.toDBMessage()).contents).toEqual(fileContents);
   });
 
   it('subscribes to a future thread run', async () => {
@@ -748,7 +771,7 @@ describe('Agent signals', () => {
     );
   });
 
-  it('starts an idle thread run with a system-reminder signal as a system prompt message', async () => {
+  it('starts an idle thread run with a system-reminder signal as user-role XML context', async () => {
     let capturedPrompt: any[] | undefined;
     const model = new MockLanguageModelV2({
       doStream: async ({ prompt }) => {
@@ -789,12 +812,17 @@ describe('Agent signals', () => {
     );
 
     expect(stream.accepted).toBe(true);
-    await nextTick();
+    for (let i = 0; i < 10 && !capturedPrompt; i++) {
+      await nextTick();
+    }
     expect(
       capturedPrompt?.some(
         message =>
-          message.role === 'system' &&
-          message.content === '<system-reminder reminderType="test-reminder">continue</system-reminder>',
+          message.role === 'user' &&
+          Array.isArray(message.content) &&
+          message.content.some(
+            (part: any) => part.text === '<system-reminder reminderType="test-reminder">continue</system-reminder>',
+          ),
       ),
     ).toBe(true);
   });

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -1,0 +1,615 @@
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+
+import { Mastra } from '../../mastra';
+import { Agent } from '../agent';
+import {
+  createSignal,
+  dataPartToSignal,
+  mastraDBMessageToSignal,
+  signalToDataPartFormat,
+  signalToMastraDBMessage,
+} from '../signals';
+
+function createTextStreamModel(responseText: string) {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: responseText },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ]),
+    }),
+  });
+}
+
+function nextTick() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('Agent signals', () => {
+  it('converts signals between DB, LLM, and data part formats', () => {
+    const signal = createSignal({
+      id: 'signal-1',
+      type: 'user-message',
+      contents: 'Signal contents',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: { source: 'test' },
+    });
+
+    expect(signal.toLLMMessage()).toBe('Signal contents');
+    expect(signal.toDataPart()).toEqual({
+      type: 'data-user-message',
+      data: {
+        id: 'signal-1',
+        type: 'user-message',
+        contents: 'Signal contents',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        metadata: { source: 'test' },
+      },
+    });
+
+    const dbMessage = signal.toDBMessage({ threadId: 'thread-1', resourceId: 'resource-1' });
+    expect(dbMessage.role).toBe('signal');
+    expect(signalToMastraDBMessage(signal).role).toBe('signal');
+    expect(mastraDBMessageToSignal(dbMessage).contents).toBe('Signal contents');
+    expect(dataPartToSignal(signalToDataPartFormat(signal)).contents).toBe('Signal contents');
+
+    const reminderSignal = createSignal({
+      id: 'signal-2',
+      type: 'system-reminder',
+      contents: 'Use <safe> content & continue',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      attributes: { type: 'dynamic-agents-md', path: '/tmp/AGENTS.md', enabled: true, ignored: null },
+    });
+
+    expect(reminderSignal.toLLMMessage()).toEqual([
+      {
+        role: 'system',
+        content:
+          '<system-reminder type="dynamic-agents-md" path="/tmp/AGENTS.md" enabled="true">Use &lt;safe&gt; content &amp; continue</system-reminder>',
+      },
+    ]);
+    expect(reminderSignal.toDataPart().data.attributes).toEqual({
+      type: 'dynamic-agents-md',
+      path: '/tmp/AGENTS.md',
+      enabled: true,
+      ignored: null,
+    });
+    expect(mastraDBMessageToSignal(reminderSignal.toDBMessage()).attributes).toEqual({
+      type: 'dynamic-agents-md',
+      path: '/tmp/AGENTS.md',
+      enabled: true,
+      ignored: null,
+    });
+  });
+
+  it('subscribes to a future thread run', async () => {
+    const agent = new Agent({
+      id: 'future-thread-agent',
+      name: 'Future Thread Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('future response'),
+    });
+
+    const subscription = await agent.subscribeToThread({
+      threadId: 'future-thread',
+      resourceId: 'future-user',
+    });
+    const nextRun = subscription.runs[Symbol.asyncIterator]().next();
+
+    const stream = await agent.stream('Hello', {
+      memory: { thread: 'future-thread', resource: 'future-user' },
+    });
+
+    const subscribedRun = await nextRun;
+    expect(subscribedRun.value.runId).toBe(stream.runId);
+    await expect(subscribedRun.value.output.text).resolves.toBe('future response');
+
+    subscription.cleanup();
+  });
+
+  it('starts an idle thread run when a user-message signal is sent', async () => {
+    const agent = new Agent({
+      id: 'idle-signal-agent',
+      name: 'Idle Signal Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('signal response'),
+    });
+
+    const subscription = await agent.subscribeToThread({
+      threadId: 'idle-thread',
+      resourceId: 'idle-user',
+    });
+    const nextRun = subscription.runs[Symbol.asyncIterator]().next();
+
+    const signalResult = agent.sendSignal(
+      { type: 'user-message', contents: 'Hello from signal' },
+      { resourceId: 'idle-user', threadId: 'idle-thread' },
+    );
+
+    const subscribedRun = await nextRun;
+    expect(signalResult).toEqual({ accepted: true, runId: subscribedRun.value.runId });
+    await expect(subscribedRun.value.output.text).resolves.toBe('signal response');
+
+    subscription.cleanup();
+  });
+
+  it('supports cross-instance thread subscriptions through the Mastra runtime', async () => {
+    const runner = new Agent({
+      id: 'shared-agent',
+      name: 'Shared Runner Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('shared response'),
+    });
+    const observer = new Agent({
+      id: 'shared-agent',
+      name: 'Shared Observer Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('observer response'),
+    });
+    new Mastra({ agents: { runner, observer }, logger: false });
+
+    const subscription = await observer.subscribeToThread({
+      threadId: 'shared-thread',
+      resourceId: 'shared-user',
+    });
+    const iterator = subscription.runs[Symbol.asyncIterator]();
+    const firstRunPromise = iterator.next();
+
+    const stream = await runner.stream('Hello', {
+      memory: { thread: 'shared-thread', resource: 'shared-user' },
+    });
+
+    const subscribedRun = await firstRunPromise;
+    expect(subscribedRun.value.runId).toBe(stream.runId);
+    await expect(subscribedRun.value.output.text).resolves.toBe('shared response');
+
+    const secondRunPromise = iterator.next();
+    const signalResult = runner.sendSignal(
+      { type: 'user-message', contents: 'Hello from shared signal' },
+      { resourceId: 'shared-user', threadId: 'shared-thread' },
+    );
+    const signalRun = await secondRunPromise;
+    expect(signalResult).toEqual({ accepted: true, runId: signalRun.value.runId });
+    await expect(signalRun.value.output.text).resolves.toBe('shared response');
+
+    subscription.cleanup();
+  });
+
+  it('queues a user-message signal while a thread run is active', async () => {
+    let releaseFirst!: () => void;
+    const firstFinished = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    let streamCount = 0;
+
+    const model = new MockLanguageModelV2({
+      doStream: async () => {
+        streamCount += 1;
+        const responseText = streamCount === 1 ? 'first response' : 'signal response';
+
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: new ReadableStream({
+            async start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+              controller.enqueue({
+                type: 'response-metadata',
+                id: `id-${streamCount}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              });
+              controller.enqueue({ type: 'text-start', id: 'text-1' });
+              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: responseText });
+              controller.enqueue({ type: 'text-end', id: 'text-1' });
+              if (streamCount === 1) {
+                await firstFinished;
+              }
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+              controller.close();
+            },
+          }),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'active-signal-agent',
+      name: 'Active Signal Agent',
+      instructions: 'Test',
+      model,
+    });
+
+    const subscription = await agent.subscribeToThread({
+      threadId: 'active-thread',
+      resourceId: 'active-user',
+    });
+    const iterator = subscription.runs[Symbol.asyncIterator]();
+    const firstRunPromise = iterator.next();
+
+    const stream = await agent.stream('Hello', {
+      memory: { thread: 'active-thread', resource: 'active-user' },
+    });
+    const firstRun = await firstRunPromise;
+
+    const signalResult = agent.sendSignal(
+      { type: 'user-message', contents: 'Hello while running' },
+      { resourceId: 'active-user', threadId: 'active-thread' },
+    );
+    expect(signalResult).toEqual({ accepted: true, runId: stream.runId });
+
+    releaseFirst();
+    await expect(firstRun.value.output.text).resolves.toBe('first response');
+
+    const secondRun = await iterator.next();
+    expect(secondRun.value.runId).not.toBe(stream.runId);
+    await expect(secondRun.value.output.text).resolves.toBe('signal response');
+
+    subscription.cleanup();
+  });
+
+  it('queues a signal from another agent until the active thread run finishes', async () => {
+    let releaseFirst!: () => void;
+    const firstFinished = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    let firstStarted = false;
+    let secondStarted = false;
+
+    const firstAgent = new Agent({
+      id: 'cross-agent-a',
+      name: 'Cross Agent A',
+      instructions: 'Test',
+      model: new MockLanguageModelV2({
+        doStream: async () => {
+          firstStarted = true;
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'cross-a',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                });
+                controller.enqueue({ type: 'text-start', id: 'text-1' });
+                controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'first response' });
+                controller.enqueue({ type: 'text-end', id: 'text-1' });
+                await firstFinished;
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
+      }),
+    });
+    const secondAgent = new Agent({
+      id: 'cross-agent-b',
+      name: 'Cross Agent B',
+      instructions: 'Test',
+      model: new MockLanguageModelV2({
+        doStream: async () => {
+          secondStarted = true;
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'cross-b', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'second response' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              },
+            ]),
+          };
+        },
+      }),
+    });
+    new Mastra({ agents: { firstAgent, secondAgent }, logger: false });
+
+    const subscription = await firstAgent.subscribeToThread({
+      threadId: 'cross-agent-thread',
+      resourceId: 'cross-agent-user',
+    });
+    const iterator = subscription.runs[Symbol.asyncIterator]();
+    const firstRunPromise = iterator.next();
+
+    const firstStream = await firstAgent.stream('Hello', {
+      memory: { thread: 'cross-agent-thread', resource: 'cross-agent-user' },
+    });
+    await firstRunPromise;
+    const firstText = firstStream.text;
+    await nextTick();
+    expect(firstStarted).toBe(true);
+
+    const secondRunPromise = iterator.next();
+    const signalResult = secondAgent.sendSignal(
+      { type: 'user-message', contents: 'Hello from another agent' },
+      { resourceId: 'cross-agent-user', threadId: 'cross-agent-thread' },
+    );
+    await nextTick();
+    expect(secondStarted).toBe(false);
+
+    releaseFirst();
+    await expect(firstText).resolves.toBe('first response');
+
+    const secondRun = await secondRunPromise;
+    expect(secondRun.value.runId).toBe(signalResult.runId);
+    await expect(secondRun.value.output.text).resolves.toBe('second response');
+    expect(secondStarted).toBe(true);
+
+    subscription.cleanup();
+  });
+
+  it('cleans up a thread subscription and completes the iterator', async () => {
+    const agent = new Agent({
+      id: 'cleanup-signal-agent',
+      name: 'Cleanup Signal Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('cleanup response'),
+    });
+
+    const subscription = await agent.subscribeToThread({
+      threadId: 'cleanup-thread',
+      resourceId: 'cleanup-user',
+    });
+    const iterator = subscription.runs[Symbol.asyncIterator]();
+
+    subscription.cleanup();
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it('delivers a future thread run to multiple subscribers', async () => {
+    const agent = new Agent({
+      id: 'multiple-subscriber-agent',
+      name: 'Multiple Subscriber Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('multi response'),
+    });
+
+    const firstSubscription = await agent.subscribeToThread({
+      threadId: 'multi-thread',
+      resourceId: 'multi-user',
+    });
+    const secondSubscription = await agent.subscribeToThread({
+      threadId: 'multi-thread',
+      resourceId: 'multi-user',
+    });
+    const firstRunPromise = firstSubscription.runs[Symbol.asyncIterator]().next();
+    const secondRunPromise = secondSubscription.runs[Symbol.asyncIterator]().next();
+
+    const stream = await agent.stream('Hello', {
+      memory: { thread: 'multi-thread', resource: 'multi-user' },
+    });
+
+    await expect(firstRunPromise).resolves.toMatchObject({ value: { runId: stream.runId }, done: false });
+    await expect(secondRunPromise).resolves.toMatchObject({ value: { runId: stream.runId }, done: false });
+
+    firstSubscription.cleanup();
+    secondSubscription.cleanup();
+  });
+
+  it('isolates subscriptions by resource and thread id', async () => {
+    const agent = new Agent({
+      id: 'isolated-signal-agent',
+      name: 'Isolated Signal Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('isolated response'),
+    });
+
+    const targetSubscription = await agent.subscribeToThread({
+      threadId: 'isolated-thread',
+      resourceId: 'isolated-user',
+    });
+    const otherResourceSubscription = await agent.subscribeToThread({
+      threadId: 'isolated-thread',
+      resourceId: 'other-user',
+    });
+    const otherThreadSubscription = await agent.subscribeToThread({
+      threadId: 'other-thread',
+      resourceId: 'isolated-user',
+    });
+
+    const targetNext = targetSubscription.runs[Symbol.asyncIterator]().next();
+    const otherResourceNext = otherResourceSubscription.runs[Symbol.asyncIterator]().next();
+    const otherThreadNext = otherThreadSubscription.runs[Symbol.asyncIterator]().next();
+
+    const stream = await agent.stream('Hello', {
+      memory: { thread: 'isolated-thread', resource: 'isolated-user' },
+    });
+
+    await expect(targetNext).resolves.toMatchObject({ value: { runId: stream.runId }, done: false });
+    await nextTick();
+
+    otherResourceSubscription.cleanup();
+    otherThreadSubscription.cleanup();
+    await expect(otherResourceNext).resolves.toEqual({ value: undefined, done: true });
+    await expect(otherThreadNext).resolves.toEqual({ value: undefined, done: true });
+
+    targetSubscription.cleanup();
+  });
+
+  it('does not replay existing thread runs to late subscribers', async () => {
+    const agent = new Agent({
+      id: 'late-subscription-agent',
+      name: 'Late Subscription Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('late response'),
+    });
+
+    await agent.stream('Hello', {
+      memory: { thread: 'late-thread', resource: 'late-user' },
+    });
+    const subscription = await agent.subscribeToThread({
+      threadId: 'late-thread',
+      resourceId: 'late-user',
+    });
+    const iterator = subscription.runs[Symbol.asyncIterator]();
+
+    const nextRun = iterator.next();
+    await nextTick();
+    subscription.cleanup();
+    await expect(nextRun).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  it('queues a signal by active run id', async () => {
+    let releaseFirst!: () => void;
+    const firstFinished = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    let streamCount = 0;
+
+    const model = new MockLanguageModelV2({
+      doStream: async () => {
+        streamCount += 1;
+        const responseText = streamCount === 1 ? 'run id first response' : 'run id signal response';
+
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: new ReadableStream({
+            async start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+              controller.enqueue({
+                type: 'response-metadata',
+                id: `run-id-${streamCount}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              });
+              controller.enqueue({ type: 'text-start', id: 'text-1' });
+              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: responseText });
+              controller.enqueue({ type: 'text-end', id: 'text-1' });
+              if (streamCount === 1) {
+                await firstFinished;
+              }
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+              controller.close();
+            },
+          }),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'run-id-signal-agent',
+      name: 'Run Id Signal Agent',
+      instructions: 'Test',
+      model,
+    });
+    const subscription = await agent.subscribeToThread({
+      threadId: 'run-id-thread',
+      resourceId: 'run-id-user',
+    });
+    const iterator = subscription.runs[Symbol.asyncIterator]();
+    const firstRunPromise = iterator.next();
+
+    const stream = await agent.stream('Hello', {
+      memory: { thread: 'run-id-thread', resource: 'run-id-user' },
+    });
+    await firstRunPromise;
+
+    expect(agent.sendSignal({ type: 'user-message', contents: 'Hello by run id' }, { runId: stream.runId })).toEqual({
+      accepted: true,
+      runId: stream.runId,
+    });
+
+    releaseFirst();
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { threadId: 'run-id-thread', resourceId: 'run-id-user' },
+      done: false,
+    });
+
+    subscription.cleanup();
+  });
+
+  it('throws when sending a signal to an unknown run id without a thread target', () => {
+    const agent = new Agent({
+      id: 'missing-run-signal-agent',
+      name: 'Missing Run Signal Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('missing run response'),
+    });
+
+    expect(() => agent.sendSignal({ type: 'user-message', contents: 'Hello' }, { runId: 'missing-run-id' })).toThrow(
+      'No active agent run found for signal target',
+    );
+  });
+
+  it('starts an idle thread run with a system-reminder signal as a system prompt message', async () => {
+    let capturedPrompt: any[] | undefined;
+    const model = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        capturedPrompt = prompt;
+        return {
+          rawCall: { rawPrompt: prompt, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'system-signal-id', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'system signal response' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            },
+          ]),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'system-signal-agent',
+      name: 'System Signal Agent',
+      instructions: 'Test',
+      model,
+    });
+
+    const stream = agent.sendSignal(
+      { type: 'system-reminder', contents: 'continue', attributes: { reminderType: 'test-reminder' } },
+      { resourceId: 'system-signal-user', threadId: 'system-signal-thread' },
+    );
+
+    expect(stream.accepted).toBe(true);
+    await nextTick();
+    expect(
+      capturedPrompt?.some(
+        message =>
+          message.role === 'system' &&
+          message.content === '<system-reminder reminderType="test-reminder">continue</system-reminder>',
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -98,6 +98,7 @@ import type {
 import { MessageList } from './message-list';
 import type { MessageInput, MessageListInput, UIMessageWithMetadata, MastraDBMessage } from './message-list';
 import { SaveQueueManager } from './save-queue';
+import type { CreatedAgentSignal } from './signals';
 import { runStreamUntilIdle } from './stream-until-idle';
 import { AgentThreadStreamRuntime } from './thread-stream-runtime';
 import { TripWire } from './trip-wire';
@@ -5296,6 +5297,8 @@ export class Agent<
             agentBackgroundConfig: this.#backgroundTasks,
           }),
       skipBgTaskWait: options._skipBgTaskWait,
+      drainPendingSignals: this.#getThreadStreamRuntime().drainPendingSignals.bind(this.#getThreadStreamRuntime()),
+      initialSignalEchoes: options._initialSignalEchoes,
     });
 
     const run = await executionWorkflow.createRun();
@@ -5841,7 +5844,7 @@ export class Agent<
   sendSignal<OUTPUT = TOutput>(
     signal: AgentSignal,
     target: SendAgentSignalOptions<OUTPUT>,
-  ): { accepted: true; runId: string } {
+  ): { accepted: true; runId: string; signal: CreatedAgentSignal } {
     return this.#getThreadStreamRuntime().sendSignal(this as Agent<any, any, any, any>, signal, target);
   }
 
@@ -5930,8 +5933,16 @@ export class Agent<
 
     await this.#getThreadStreamRuntime().waitForCrossAgentThreadRun(this as Agent<any, any, any, any>, mergedOptions);
 
+    mergedOptions.runId ??=
+      this.#mastra?.generateId({
+        idType: 'run',
+        source: 'agent',
+        entityId: this.id,
+      }) ?? randomUUID();
+    const preparedOptions = this.#getThreadStreamRuntime().prepareRunOptions(mergedOptions);
+
     const executeOptions = {
-      ...mergedOptions,
+      ...preparedOptions,
       structuredOutput: mergedOptions.structuredOutput
         ? {
             ...mergedOptions.structuredOutput,
@@ -5971,7 +5982,7 @@ export class Agent<
     this.#getThreadStreamRuntime().registerRun(
       this as Agent<any, any, any, any>,
       result.result,
-      mergedOptions as AgentExecutionOptions<OUTPUT>,
+      preparedOptions as AgentExecutionOptions<OUTPUT>,
     );
 
     return result.result;

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5841,6 +5841,14 @@ export class Agent<
     return this.#getThreadStreamRuntime().subscribeToThread<OUTPUT>(this as Agent<any, any, any, any>, options);
   }
 
+  abortThreadStream(options: AgentSubscribeToThreadOptions): boolean {
+    return this.#getThreadStreamRuntime().abortThread(options);
+  }
+
+  abortRunStream(runId: string): boolean {
+    return this.#getThreadStreamRuntime().abortRun(runId);
+  }
+
   sendSignal<OUTPUT = TOutput>(
     signal: AgentSignal,
     target: SendAgentSignalOptions<OUTPUT>,
@@ -6144,9 +6152,12 @@ export class Agent<
 
     const runId = streamOptions?.runId ?? '';
     const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
+    const preparedOptions = this.#getThreadStreamRuntime().prepareRunOptions(
+      mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
+    );
 
     const result = await this.#execute({
-      ...mergedStreamOptions,
+      ...preparedOptions,
       structuredOutput: mergedStreamOptions.structuredOutput
         ? {
             ...mergedStreamOptions.structuredOutput,
@@ -6182,6 +6193,12 @@ export class Agent<
         text: 'An unknown error occurred while streaming',
       });
     }
+
+    this.#getThreadStreamRuntime().registerRun(
+      this as Agent<any, any, any, any>,
+      result.result as unknown as MastraModelOutput<OUTPUT>,
+      preparedOptions as AgentExecutionOptions<OUTPUT>,
+    );
 
     return result.result as unknown as MastraModelOutput<OUTPUT>;
   }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -99,6 +99,7 @@ import { MessageList } from './message-list';
 import type { MessageInput, MessageListInput, UIMessageWithMetadata, MastraDBMessage } from './message-list';
 import { SaveQueueManager } from './save-queue';
 import { runStreamUntilIdle } from './stream-until-idle';
+import { AgentThreadStreamRuntime } from './thread-stream-runtime';
 import { TripWire } from './trip-wire';
 import type {
   AgentConfig,
@@ -111,8 +112,12 @@ import type {
   AgentExecuteOnFinishOptions,
   AgentInstructions,
   AgentMethodType,
-  StructuredOutputOptions,
+  AgentSignal,
+  AgentSubscribeToThreadOptions,
+  AgentThreadSubscription,
   PublicStructuredOutputOptions,
+  SendAgentSignalOptions,
+  StructuredOutputOptions,
   ModelFallbackSettings,
   ModelWithRetries,
   ZodSchema,
@@ -272,6 +277,14 @@ export class Agent<
    * close if they're still the active one.
    */
   #activeStreamUntilIdle = new Map<string, () => void>();
+  /**
+   * Local fallback for standalone Agents that are not registered on a Mastra
+   * instance. Agents registered on the same Mastra instance coordinate through
+   * `mastra.agentThreadStreamRuntime` instead, so cross-agent thread locks and
+   * subscriptions are scoped to that Mastra runtime rather than process-global
+   * Agent state.
+   */
+  #threadStreamRuntime = new AgentThreadStreamRuntime();
   readonly #options?: AgentCreateOptions;
   #legacyHandler?: AgentLegacyHandler;
   #config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext>;
@@ -5815,6 +5828,23 @@ export class Agent<
     return fullOutput;
   }
 
+  #getThreadStreamRuntime() {
+    return this.#mastra?.agentThreadStreamRuntime ?? this.#threadStreamRuntime;
+  }
+
+  async subscribeToThread<OUTPUT = TOutput>(
+    options: AgentSubscribeToThreadOptions,
+  ): Promise<AgentThreadSubscription<OUTPUT>> {
+    return this.#getThreadStreamRuntime().subscribeToThread<OUTPUT>(this as Agent<any, any, any, any>, options);
+  }
+
+  sendSignal<OUTPUT = TOutput>(
+    signal: AgentSignal,
+    target: SendAgentSignalOptions<OUTPUT>,
+  ): { accepted: true; runId: string } {
+    return this.#getThreadStreamRuntime().sendSignal(this as Agent<any, any, any, any>, signal, target);
+  }
+
   async stream<
     OUTPUT extends StandardSchemaWithJSON<any, any>,
     T extends InferStandardSchemaOutput<OUTPUT> = InferStandardSchemaOutput<OUTPUT>,
@@ -5898,6 +5928,8 @@ export class Agent<
       });
     }
 
+    await this.#getThreadStreamRuntime().waitForCrossAgentThreadRun(this as Agent<any, any, any, any>, mergedOptions);
+
     const executeOptions = {
       ...mergedOptions,
       structuredOutput: mergedOptions.structuredOutput
@@ -5935,6 +5967,12 @@ export class Agent<
         text: 'An unknown error occurred while streaming',
       });
     }
+
+    this.#getThreadStreamRuntime().registerRun(
+      this as Agent<any, any, any, any>,
+      result.result,
+      mergedOptions as AgentExecutionOptions<OUTPUT>,
+    );
 
     return result.result;
   }

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -11,6 +11,7 @@ import type { ErrorProcessorOrWorkflow, InputProcessorOrWorkflow, OutputProcesso
 import type { RequestContext } from '../request-context';
 import type { OutputWriter } from '../workflows/types';
 import type { MessageListInput } from './message-list';
+import type { CreatedAgentSignal } from './signals';
 import type {
   AgentMemoryOption,
   ToolsetsInput,
@@ -630,6 +631,9 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
    * `agent.streamUntilIdle`, which drives continuation from outside the loop.
    */
   _skipBgTaskWait?: boolean;
+
+  /** @internal Signals that should be echoed to the stream but are already present in the initial messages. */
+  _initialSignalEchoes?: CreatedAgentSignal[];
 } & Partial<ObservabilityContext>;
 
 /**

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -2,6 +2,7 @@ export { TripWire } from './trip-wire';
 export { MessageList, convertMessages, aiV5ModelMessageToV2PromptMessage, TypeDetector } from './message-list';
 export type { OutputFormat } from './message-list';
 export * from './types';
+export * from './signals';
 export * from './agent';
 export * from './utils';
 

--- a/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
@@ -45,6 +45,34 @@ function filterEmptyTextParts(parts: MastraMessagePart[]): MastraMessagePart[] {
   });
 }
 
+function getSignalType(message: MastraDBMessage): string | undefined {
+  const signal = message.content.metadata?.signal;
+  if (signal && typeof signal === 'object' && !Array.isArray(signal)) {
+    const type = (signal as Record<string, unknown>).type;
+    return typeof type === 'string' ? type : message.type;
+  }
+
+  return message.type;
+}
+
+function toSignalDataPart(message: MastraDBMessage, contents: string): MastraMessagePart {
+  const metadata = { ...(message.content.metadata ?? {}) };
+  const signal =
+    metadata.signal && typeof metadata.signal === 'object' ? (metadata.signal as Record<string, unknown>) : {};
+  delete metadata.signal;
+
+  return {
+    type: `data-${getSignalType(message) ?? 'signal'}`,
+    data: {
+      id: typeof signal.id === 'string' ? signal.id : message.id,
+      type: getSignalType(message) ?? 'signal',
+      contents,
+      createdAt: typeof signal.createdAt === 'string' ? signal.createdAt : message.createdAt.toISOString(),
+      ...(Object.keys(metadata).length ? { metadata } : {}),
+    },
+  } as MastraMessagePart;
+}
+
 // Re-export for backward compatibility
 export type { UIMessageWithMetadata };
 
@@ -157,7 +185,11 @@ export class AIV4Adapter {
       parts.push({ type: 'text', text: '' });
     }
 
-    const v4Parts = preserveExtendedParts(parts);
+    const signalType = m.role === 'signal' ? getSignalType(m) : undefined;
+    const isUserMessageSignal = signalType === 'user-message';
+    const v4Parts = preserveExtendedParts(
+      m.role === 'signal' && !isUserMessageSignal ? [toSignalDataPart(m, m.content.content || contentString)] : parts,
+    );
 
     if (m.role === `user`) {
       const uiMessage: UIMessageWithMetadata = {
@@ -196,8 +228,8 @@ export class AIV4Adapter {
 
     const uiMessage: UIMessageWithMetadata = {
       id: m.id,
-      role: m.role,
-      content: m.content.content || contentString,
+      role: m.role === 'signal' ? (isUserMessageSignal ? 'user' : 'system') : m.role,
+      content: m.role === 'signal' && !isUserMessageSignal ? '' : m.content.content || contentString,
       createdAt: m.createdAt,
       parts: v4Parts,
       experimental_attachments: experimentalAttachments,

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
@@ -25,6 +25,41 @@ function filterEmptyTextParts(parts: MastraMessagePart[]): MastraMessagePart[] {
   });
 }
 
+function getSignalType(message: MastraDBMessage): string | undefined {
+  const signal = message.content.metadata?.signal;
+  if (signal && typeof signal === 'object' && !Array.isArray(signal)) {
+    const type = (signal as Record<string, unknown>).type;
+    return typeof type === 'string' ? type : message.type;
+  }
+
+  return message.type;
+}
+
+function getTextContent(message: MastraDBMessage): string {
+  return typeof message.content.content === 'string'
+    ? message.content.content
+    : (message.content.parts.find(part => part.type === 'text')?.text ?? '');
+}
+
+function toSignalDataPart(message: MastraDBMessage): AIV5Type.DataUIPart<AIV5.UIDataTypes> {
+  const metadata = { ...(message.content.metadata ?? {}) };
+  const signal =
+    metadata.signal && typeof metadata.signal === 'object' ? (metadata.signal as Record<string, unknown>) : {};
+  delete metadata.signal;
+
+  const type = getSignalType(message) ?? 'signal';
+  return {
+    type: `data-${type}`,
+    data: {
+      id: typeof signal.id === 'string' ? signal.id : message.id,
+      type,
+      contents: getTextContent(message),
+      createdAt: typeof signal.createdAt === 'string' ? signal.createdAt : message.createdAt.toISOString(),
+      ...(Object.keys(metadata).length ? { metadata } : {}),
+    },
+  } as AIV5Type.DataUIPart<AIV5.UIDataTypes>;
+}
+
 /**
  * Extract tool name from AI SDK v5 tool type string
  *
@@ -98,8 +133,14 @@ export class AIV5Adapter {
    * Direct conversion from MastraDBMessage to AIV5 UIMessage
    */
   static toUIMessage(dbMsg: MastraDBMessage): AIV5Type.UIMessage {
+    const signalType = dbMsg.role === 'signal' ? getSignalType(dbMsg) : undefined;
+    const isUserMessageSignal = signalType === 'user-message';
     const parts: AIV5Type.UIMessage['parts'] = [];
     const metadata: Record<string, unknown> = { ...(dbMsg.content.metadata || {}) };
+
+    if (dbMsg.role === 'signal' && !isUserMessageSignal) {
+      parts.push(toSignalDataPart(dbMsg));
+    }
 
     // Add Mastra-specific metadata
     if (dbMsg.createdAt) metadata.createdAt = dbMsg.createdAt;
@@ -109,6 +150,15 @@ export class AIV5Adapter {
     // Preserve message-level providerMetadata in metadata so it survives UI → Model conversion
     if (dbMsg.content.providerMetadata) {
       metadata.providerMetadata = dbMsg.content.providerMetadata;
+    }
+
+    if (dbMsg.role === 'signal' && !isUserMessageSignal) {
+      return {
+        id: dbMsg.id,
+        role: 'system',
+        metadata,
+        parts,
+      };
     }
 
     // 1. Handle tool invocations (only if not already in parts array)
@@ -373,7 +423,7 @@ export class AIV5Adapter {
 
     return {
       id: dbMsg.id,
-      role: dbMsg.role,
+      role: dbMsg.role === 'signal' ? (isUserMessageSignal ? 'user' : 'system') : dbMsg.role,
       metadata,
       parts,
     };

--- a/packages/core/src/agent/message-list/adapters/AIV6Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV6Adapter.ts
@@ -170,6 +170,15 @@ export class AIV6Adapter {
     const metadata = (v5Message.metadata || {}) as Record<string, unknown>;
     const parts: AIV6Type.UIMessage['parts'] = [];
 
+    if (dbMsg.role === 'signal' && v5Message.role !== 'user') {
+      return {
+        id: dbMsg.id,
+        role: 'system',
+        metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+        parts: v5Message.parts.map(part => AIV6Adapter.toUIPartFromV5(part)),
+      };
+    }
+
     const dbParts = dbMsg.content.parts || [];
     const hasToolInvocationParts = dbParts.some(part => part.type === 'tool-invocation');
     const hasReasoningParts = dbParts.some(part => part.type === 'reasoning');
@@ -211,7 +220,7 @@ export class AIV6Adapter {
 
     return {
       id: dbMsg.id,
-      role: dbMsg.role,
+      role: dbMsg.role === 'signal' ? v5Message.role : dbMsg.role,
       metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
       parts,
     };

--- a/packages/core/src/agent/message-list/adapters/agent-signal-ui-conversion.test.ts
+++ b/packages/core/src/agent/message-list/adapters/agent-signal-ui-conversion.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { signalToMastraDBMessage } from '../../signals';
+import { AIV4Adapter } from './AIV4Adapter';
+import { AIV5Adapter } from './AIV5Adapter';
+import { AIV6Adapter } from './AIV6Adapter';
+
+describe('agent signal UI conversion', () => {
+  it('converts user-message signals to user UI messages', () => {
+    const dbMessage = signalToMastraDBMessage({
+      id: 'signal-user-1',
+      type: 'user-message',
+      contents: 'Hello from the user',
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    });
+
+    expect(AIV4Adapter.toUIMessage(dbMessage)).toMatchObject({
+      id: 'signal-user-1',
+      role: 'user',
+      content: 'Hello from the user',
+      parts: [{ type: 'text', text: 'Hello from the user' }],
+    });
+    expect(AIV5Adapter.toUIMessage(dbMessage)).toMatchObject({
+      id: 'signal-user-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Hello from the user' }],
+    });
+    expect(AIV6Adapter.toUIMessage(dbMessage)).toMatchObject({
+      id: 'signal-user-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Hello from the user' }],
+    });
+  });
+
+  it('converts non-user signals to data parts instead of user text messages', () => {
+    const dbMessage = signalToMastraDBMessage({
+      id: 'signal-system-1',
+      type: 'system-reminder',
+      contents: 'continue',
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      metadata: { reminderType: 'anthropic-prefill-processor-retry' },
+    });
+
+    for (const uiMessage of [
+      AIV4Adapter.toUIMessage(dbMessage),
+      AIV5Adapter.toUIMessage(dbMessage),
+      AIV6Adapter.toUIMessage(dbMessage),
+    ]) {
+      expect(uiMessage.role).toBe('system');
+      expect(uiMessage.parts).toEqual([
+        {
+          type: 'data-system-reminder',
+          data: {
+            id: 'signal-system-1',
+            type: 'system-reminder',
+            contents: 'continue',
+            createdAt: '2024-01-01T00:00:00.000Z',
+            metadata: { reminderType: 'anthropic-prefill-processor-retry' },
+          },
+        },
+      ]);
+    }
+
+    expect(AIV4Adapter.toUIMessage(dbMessage).content).toBe('');
+  });
+});

--- a/packages/core/src/agent/message-list/state/types.ts
+++ b/packages/core/src/agent/message-list/state/types.ts
@@ -15,7 +15,7 @@ export type MemoryInfo = { threadId: string; resourceId?: string };
 
 type MastraMessageShared = {
   id: string;
-  role: 'user' | 'assistant' | 'system';
+  role: 'user' | 'assistant' | 'system' | 'signal';
   createdAt: Date;
   threadId?: string;
   resourceId?: string;
@@ -110,7 +110,7 @@ export type MastraDBMessage = MastraMessageShared & {
 export type MastraMessageV1 = {
   id: string;
   content: string | CoreMessageV4['content'];
-  role: 'system' | 'user' | 'assistant' | 'tool';
+  role: 'system' | 'user' | 'assistant' | 'tool' | 'signal';
   createdAt: Date;
   threadId?: string;
   resourceId?: string;

--- a/packages/core/src/agent/signals.ts
+++ b/packages/core/src/agent/signals.ts
@@ -1,0 +1,179 @@
+import type { CoreMessage } from '@internal/ai-sdk-v4';
+
+import type { MessageListInput } from './message-list';
+import type { MastraDBMessage } from './message-list/state/types';
+
+export type AgentSignalType = 'user-message' | 'system-reminder' | string;
+
+export interface AgentSignalInput {
+  id?: string;
+  type: AgentSignalType;
+  contents: string;
+  createdAt?: Date | string;
+  attributes?: Record<string, string | number | boolean | null | undefined>;
+  metadata?: Record<string, unknown>;
+}
+
+export type AgentSignalDataPart = {
+  type: `data-${string}`;
+  data: {
+    id: string;
+    type: AgentSignalType;
+    contents: string;
+    createdAt: string;
+    attributes?: Record<string, string | number | boolean | null | undefined>;
+    metadata?: Record<string, unknown>;
+  };
+};
+
+export type CreatedAgentSignal = AgentSignalInput & {
+  id: string;
+  createdAt: Date;
+  toDBMessage: (options?: { threadId?: string; resourceId?: string }) => MastraDBMessage;
+  toLLMMessage: () => MessageListInput;
+  toDataPart: () => AgentSignalDataPart;
+};
+
+export function isMastraSignalMessage(message: MastraDBMessage): message is MastraDBMessage & { role: 'signal' } {
+  return message.role === 'signal';
+}
+
+function normalizeSignal(signal: AgentSignalInput | CreatedAgentSignal) {
+  return {
+    ...signal,
+    id: signal.id ?? crypto.randomUUID(),
+    createdAt:
+      signal.createdAt instanceof Date ? signal.createdAt : signal.createdAt ? new Date(signal.createdAt) : new Date(),
+  };
+}
+
+function escapeXml(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXml(value).replaceAll('"', '&quot;');
+}
+
+function signalAttributesToXml(attributes?: AgentSignalInput['attributes']): string {
+  if (!attributes) {
+    return '';
+  }
+
+  const serialized = Object.entries(attributes)
+    .filter((entry): entry is [string, string | number | boolean] => entry[1] !== null && entry[1] !== undefined)
+    .map(([key, value]) => `${key}="${escapeXmlAttribute(String(value))}"`)
+    .join(' ');
+
+  return serialized ? ` ${serialized}` : '';
+}
+
+export function signalToXmlMarkup(signal: Pick<AgentSignalInput, 'type' | 'contents' | 'attributes'>): string {
+  return `<${signal.type}${signalAttributesToXml(signal.attributes)}>${escapeXml(signal.contents)}</${signal.type}>`;
+}
+
+function signalToLLMMessage(signal: Pick<AgentSignalInput, 'type' | 'contents' | 'attributes'>): MessageListInput {
+  if (signal.type === 'user-message') {
+    return signal.contents;
+  }
+
+  return [{ role: 'system', content: signalToXmlMarkup(signal) } as CoreMessage];
+}
+
+function signalToDataPart(signal: ReturnType<typeof normalizeSignal>): AgentSignalDataPart {
+  return {
+    type: `data-${signal.type}`,
+    data: {
+      id: signal.id,
+      type: signal.type,
+      contents: signal.contents,
+      createdAt: signal.createdAt.toISOString(),
+      ...(signal.attributes ? { attributes: signal.attributes } : {}),
+      ...(signal.metadata ? { metadata: signal.metadata } : {}),
+    },
+  };
+}
+
+function signalToDBMessage(
+  signal: ReturnType<typeof normalizeSignal>,
+  options?: { threadId?: string; resourceId?: string },
+): MastraDBMessage {
+  return {
+    id: signal.id,
+    role: 'signal',
+    createdAt: signal.createdAt,
+    threadId: options?.threadId,
+    resourceId: options?.resourceId,
+    type: signal.type,
+    content: {
+      format: 2,
+      content: signal.contents,
+      parts: [{ type: 'text', text: signal.contents }],
+      metadata: {
+        ...(signal.attributes ?? {}),
+        ...(signal.metadata ?? {}),
+        signal: {
+          id: signal.id,
+          type: signal.type,
+          createdAt: signal.createdAt.toISOString(),
+          ...(signal.attributes ? { attributes: signal.attributes } : {}),
+        },
+      },
+    },
+  };
+}
+
+export function createSignal(input: AgentSignalInput): CreatedAgentSignal {
+  const signal = normalizeSignal(input);
+
+  return {
+    ...signal,
+    toDBMessage: options => signalToDBMessage(signal, options),
+    toLLMMessage: () => signalToLLMMessage(signal),
+    toDataPart: () => signalToDataPart(signal),
+  };
+}
+
+export function signalToMessage(signal: AgentSignalInput | CreatedAgentSignal): MessageListInput {
+  return createSignal(signal).toLLMMessage();
+}
+
+export function signalToMastraDBMessage(
+  signal: AgentSignalInput | CreatedAgentSignal,
+  options?: { threadId?: string; resourceId?: string },
+): MastraDBMessage {
+  return createSignal(signal).toDBMessage(options);
+}
+
+export function signalToDataPartFormat(signal: AgentSignalInput | CreatedAgentSignal): AgentSignalDataPart {
+  return createSignal(signal).toDataPart();
+}
+
+export function mastraDBMessageToSignal(message: MastraDBMessage): CreatedAgentSignal {
+  const metadataSignal = message.content.metadata?.signal;
+  const signalMetadata =
+    metadataSignal && typeof metadataSignal === 'object' && !Array.isArray(metadataSignal)
+      ? (metadataSignal as Record<string, unknown>)
+      : undefined;
+
+  return createSignal({
+    id: typeof signalMetadata?.id === 'string' ? signalMetadata.id : message.id,
+    type: typeof signalMetadata?.type === 'string' ? signalMetadata.type : (message.type ?? 'user-message'),
+    contents:
+      typeof message.content.content === 'string'
+        ? message.content.content
+        : (message.content.parts.find(part => part.type === 'text')?.text ?? ''),
+    createdAt: typeof signalMetadata?.createdAt === 'string' ? signalMetadata.createdAt : message.createdAt,
+    attributes:
+      signalMetadata?.attributes &&
+      typeof signalMetadata.attributes === 'object' &&
+      !Array.isArray(signalMetadata.attributes)
+        ? (signalMetadata.attributes as AgentSignalInput['attributes'])
+        : undefined,
+    metadata: message.content.metadata,
+  });
+}
+
+export function dataPartToSignal(part: AgentSignalDataPart): CreatedAgentSignal {
+  return createSignal(part.data);
+}

--- a/packages/core/src/agent/signals.ts
+++ b/packages/core/src/agent/signals.ts
@@ -5,21 +5,33 @@ import type { MastraDBMessage } from './message-list/state/types';
 
 export type AgentSignalType = 'user-message' | 'system-reminder' | string;
 
-export interface AgentSignalInput {
+export type AgentSignalContents = MessageListInput;
+
+type AgentSignalInputBase = {
   id?: string;
-  type: AgentSignalType;
-  contents: string;
   createdAt?: Date | string;
   attributes?: Record<string, string | number | boolean | null | undefined>;
   metadata?: Record<string, unknown>;
-}
+};
+
+export type UserMessageAgentSignalInput = AgentSignalInputBase & {
+  type: 'user-message';
+  contents: AgentSignalContents;
+};
+
+export type ContextAgentSignalInput = AgentSignalInputBase & {
+  type: Exclude<AgentSignalType, 'user-message'>;
+  contents: string;
+};
+
+export type AgentSignalInput = UserMessageAgentSignalInput | ContextAgentSignalInput;
 
 export type AgentSignalDataPart = {
   type: `data-${string}`;
   data: {
     id: string;
     type: AgentSignalType;
-    contents: string;
+    contents: AgentSignalContents;
     createdAt: string;
     attributes?: Record<string, string | number | boolean | null | undefined>;
     metadata?: Record<string, unknown>;
@@ -69,7 +81,27 @@ function signalAttributesToXml(attributes?: AgentSignalInput['attributes']): str
 }
 
 export function signalToXmlMarkup(signal: Pick<AgentSignalInput, 'type' | 'contents' | 'attributes'>): string {
-  return `<${signal.type}${signalAttributesToXml(signal.attributes)}>${escapeXml(signal.contents)}</${signal.type}>`;
+  return `<${signal.type}${signalAttributesToXml(signal.attributes)}>${escapeXml(signalContentsToText(signal.contents))}</${signal.type}>`;
+}
+
+function signalContentsToText(contents: AgentSignalContents): string {
+  if (typeof contents === 'string') return contents;
+  if (Array.isArray(contents)) {
+    return contents.map(content => signalContentsToText(content as AgentSignalContents)).join('\n');
+  }
+  if (contents && typeof contents === 'object') {
+    const content = (contents as { content?: unknown }).content;
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+      return content
+        .map(part =>
+          part && typeof part === 'object' && 'text' in part ? String((part as { text: unknown }).text) : '',
+        )
+        .filter(Boolean)
+        .join('\n');
+    }
+  }
+  return '';
 }
 
 function signalToLLMMessage(signal: Pick<AgentSignalInput, 'type' | 'contents' | 'attributes'>): MessageListInput {
@@ -77,7 +109,13 @@ function signalToLLMMessage(signal: Pick<AgentSignalInput, 'type' | 'contents' |
     return signal.contents;
   }
 
-  return [{ role: 'system', content: signalToXmlMarkup(signal) } as CoreMessage];
+  return [
+    {
+      // user role for system messages because "system" role can not in any provider go contextually within conversation history, which is what signals need to do. Not assistant role because then the assistant will think it was the one who said that. User role is the only appropriate role. We wrap in xml tags to make it clearer to the LLM that this is system added context.
+      role: 'user',
+      content: signalToXmlMarkup({ ...signal, contents: signalContentsToText(signal.contents) }),
+    } as CoreMessage,
+  ];
 }
 
 function signalToDataPart(signal: ReturnType<typeof normalizeSignal>): AgentSignalDataPart {
@@ -107,8 +145,8 @@ function signalToDBMessage(
     type: signal.type,
     content: {
       format: 2,
-      content: signal.contents,
-      parts: [{ type: 'text', text: signal.contents }],
+      content: signalContentsToText(signal.contents),
+      parts: [{ type: 'text', text: signalContentsToText(signal.contents) }],
       metadata: {
         ...(signal.attributes ?? {}),
         ...(signal.metadata ?? {}),
@@ -116,6 +154,7 @@ function signalToDBMessage(
           id: signal.id,
           type: signal.type,
           createdAt: signal.createdAt.toISOString(),
+          contents: signal.contents,
           ...(signal.attributes ? { attributes: signal.attributes } : {}),
         },
       },
@@ -156,13 +195,15 @@ export function mastraDBMessageToSignal(message: MastraDBMessage): CreatedAgentS
       ? (metadataSignal as Record<string, unknown>)
       : undefined;
 
-  return createSignal({
-    id: typeof signalMetadata?.id === 'string' ? signalMetadata.id : message.id,
-    type: typeof signalMetadata?.type === 'string' ? signalMetadata.type : (message.type ?? 'user-message'),
-    contents:
-      typeof message.content.content === 'string'
+  const type = typeof signalMetadata?.type === 'string' ? signalMetadata.type : (message.type ?? 'user-message');
+  const contents =
+    signalMetadata && 'contents' in signalMetadata
+      ? (signalMetadata.contents as AgentSignalContents)
+      : typeof message.content.content === 'string'
         ? message.content.content
-        : (message.content.parts.find(part => part.type === 'text')?.text ?? ''),
+        : (message.content.parts.find(part => part.type === 'text')?.text ?? '');
+  const base = {
+    id: typeof signalMetadata?.id === 'string' ? signalMetadata.id : message.id,
     createdAt: typeof signalMetadata?.createdAt === 'string' ? signalMetadata.createdAt : message.createdAt,
     attributes:
       signalMetadata?.attributes &&
@@ -171,9 +212,17 @@ export function mastraDBMessageToSignal(message: MastraDBMessage): CreatedAgentS
         ? (signalMetadata.attributes as AgentSignalInput['attributes'])
         : undefined,
     metadata: message.content.metadata,
-  });
+  };
+
+  return createSignal(
+    type === 'user-message' ? { ...base, type, contents } : { ...base, type, contents: signalContentsToText(contents) },
+  );
 }
 
 export function dataPartToSignal(part: AgentSignalDataPart): CreatedAgentSignal {
-  return createSignal(part.data);
+  return createSignal(
+    part.data.type === 'user-message'
+      ? { ...part.data, type: 'user-message' }
+      : { ...part.data, contents: signalContentsToText(part.data.contents) },
+  );
 }

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -227,7 +227,7 @@ export class AgentThreadStreamRuntime {
       const runId = this.#activeThreadRunIds.get(key);
       if (!runId) return null;
       const record = this.#threadRunsById.get(runId);
-      if (!record) return runId;
+      if (!record) return null;
       return record.output.status === 'running' ? runId : null;
     };
 

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -1,0 +1,253 @@
+import { randomUUID } from 'node:crypto';
+
+import type { RequestContext } from '../request-context';
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context';
+import type { MastraModelOutput } from '../stream/base/output';
+import type { Agent } from './agent';
+import type { AgentExecutionOptions } from './agent.types';
+import { signalToMessage } from './signals';
+import type {
+  AgentSignal,
+  AgentSubscribeToThreadOptions,
+  AgentThreadRun,
+  AgentThreadSubscription,
+  SendAgentSignalOptions,
+} from './types';
+
+const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
+
+type AgentThreadRunRecord<OUTPUT = unknown> = {
+  agent: Agent<any, any, any, any>;
+  output: MastraModelOutput<OUTPUT>;
+  runId: string;
+  threadId: string;
+  resourceId?: string;
+  streamOptions: AgentExecutionOptions<OUTPUT>;
+};
+
+export class AgentThreadStreamRuntime {
+  #threadRunsById = new Map<string, AgentThreadRunRecord<any>>();
+  #activeThreadRunIds = new Map<string, string>();
+  #threadRunSubscribers = new Map<string, Set<(run: AgentThreadRunRecord<any>) => void>>();
+  #pendingSignalsByThread = new Map<string, AgentSignal[]>();
+  #watchedThreadRunIds = new Set<string>();
+
+  #threadKey(resourceId: string | undefined, threadId: string): string {
+    return [resourceId ?? '', threadId].join(AGENT_THREAD_KEY_SEPARATOR);
+  }
+
+  #getThreadTarget(options?: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext }) {
+    const thread = options?.memory?.thread;
+    const threadId =
+      (options?.requestContext?.get(MASTRA_THREAD_ID_KEY) as string | undefined) ||
+      (typeof thread === 'string' ? thread : thread?.id);
+    const resourceId =
+      (options?.requestContext?.get(MASTRA_RESOURCE_ID_KEY) as string | undefined) || options?.memory?.resource;
+
+    return { threadId, resourceId };
+  }
+
+  #toAgentThreadRun<OUTPUT>(record: AgentThreadRunRecord<OUTPUT>): AgentThreadRun<OUTPUT> {
+    return {
+      output: record.output,
+      get fullStream() {
+        return record.output.fullStream as ReadableStream<any>;
+      },
+      runId: record.runId,
+      threadId: record.threadId,
+      resourceId: record.resourceId,
+      cleanup: () => {},
+    };
+  }
+
+  #notifyThreadRun(record: AgentThreadRunRecord<any>) {
+    const key = this.#threadKey(record.resourceId, record.threadId);
+    this.#threadRunSubscribers.get(key)?.forEach(listener => listener(record));
+  }
+
+  registerRun<OUTPUT>(
+    agent: Agent<any, any, any, any>,
+    output: MastraModelOutput<OUTPUT>,
+    streamOptions: AgentExecutionOptions<OUTPUT>,
+  ) {
+    const { threadId, resourceId } = this.#getThreadTarget(streamOptions);
+    if (!threadId) return;
+
+    const key = this.#threadKey(resourceId, threadId);
+    const record: AgentThreadRunRecord<OUTPUT> = {
+      agent,
+      output,
+      runId: output.runId,
+      threadId,
+      resourceId,
+      streamOptions: streamOptions as AgentThreadRunRecord<OUTPUT>['streamOptions'],
+    };
+
+    this.#threadRunsById.set(output.runId, record);
+    this.#activeThreadRunIds.set(key, output.runId);
+    this.#notifyThreadRun(record);
+    this.#watchThreadRunCompletion(key, record);
+  }
+
+  #watchThreadRunCompletion(key: string, record: AgentThreadRunRecord<any>) {
+    if (this.#watchedThreadRunIds.has(record.runId)) return;
+    this.#watchedThreadRunIds.add(record.runId);
+
+    void record.output.getFullOutput().finally(() => {
+      this.#watchedThreadRunIds.delete(record.runId);
+      this.#threadRunsById.delete(record.runId);
+      if (this.#activeThreadRunIds.get(key) === record.runId) {
+        this.#activeThreadRunIds.delete(key);
+      }
+      void this.#drainPendingSignals(key, record);
+    });
+  }
+
+  async #drainPendingSignals(key: string, previousRun: AgentThreadRunRecord<any>) {
+    if (this.#activeThreadRunIds.has(key)) return;
+
+    const queue = this.#pendingSignalsByThread.get(key);
+    if (!queue) return;
+    const signal = queue.shift();
+    if (!signal) return;
+    if (queue.length === 0) {
+      this.#pendingSignalsByThread.delete(key);
+    }
+
+    const output = (await (previousRun.agent.stream as any)(signalToMessage(signal), {
+      ...previousRun.streamOptions,
+      runId: randomUUID(),
+      memory:
+        previousRun.streamOptions.memory ?? ({ resource: previousRun.resourceId, thread: previousRun.threadId } as any),
+    })) as MastraModelOutput<any>;
+
+    if (queue.length > 0) {
+      const nextRecord = this.#threadRunsById.get(output.runId);
+      if (nextRecord) {
+        this.#watchThreadRunCompletion(key, nextRecord);
+      }
+    }
+  }
+
+  async waitForCrossAgentThreadRun(
+    agent: Agent<any, any, any, any>,
+    options: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext },
+  ) {
+    const { threadId, resourceId } = this.#getThreadTarget(options);
+    if (!threadId) return;
+
+    const key = this.#threadKey(resourceId, threadId);
+    while (true) {
+      const activeRunId = this.#activeThreadRunIds.get(key);
+      const activeRecord = activeRunId ? this.#threadRunsById.get(activeRunId) : undefined;
+      if (!activeRecord || activeRecord.agent.id === agent.id || activeRecord.output.status !== 'running') return;
+      await activeRecord.output.getFullOutput().catch(() => {});
+    }
+  }
+
+  async subscribeToThread<OUTPUT = unknown>(
+    agent: Agent<any, any, any, any>,
+    options: AgentSubscribeToThreadOptions,
+  ): Promise<AgentThreadSubscription<OUTPUT>> {
+    void agent;
+    const key = this.#threadKey(options.resourceId, options.threadId);
+    const seenRunIds = new Set<string>();
+    const pendingRuns: AgentThreadRun<OUTPUT>[] = [];
+    const waiters: Array<() => void> = [];
+    let done = false;
+
+    const wake = () => {
+      while (waiters.length) waiters.shift()?.();
+    };
+
+    const enqueueRun = (record: AgentThreadRunRecord<any>) => {
+      if (done || seenRunIds.has(record.runId)) return;
+      seenRunIds.add(record.runId);
+      pendingRuns.push(this.#toAgentThreadRun(record) as AgentThreadRun<OUTPUT>);
+      wake();
+    };
+
+    const listeners = this.#threadRunSubscribers.get(key) ?? new Set<(run: AgentThreadRunRecord<any>) => void>();
+    listeners.add(enqueueRun);
+    this.#threadRunSubscribers.set(key, listeners);
+
+    const cleanup = () => {
+      if (done) return;
+      done = true;
+      listeners.delete(enqueueRun);
+      if (listeners.size === 0) {
+        this.#threadRunSubscribers.delete(key);
+      }
+      wake();
+    };
+
+    return {
+      cleanup,
+      runs: (async function* () {
+        try {
+          while (!done || pendingRuns.length > 0) {
+            if (pendingRuns.length === 0) {
+              await new Promise<void>(resolve => waiters.push(resolve));
+              continue;
+            }
+            yield pendingRuns.shift()!;
+          }
+        } finally {
+          cleanup();
+        }
+      })(),
+    };
+  }
+
+  sendSignal<OUTPUT = unknown>(
+    agent: Agent<any, any, any, any>,
+    signal: AgentSignal,
+    target: SendAgentSignalOptions<OUTPUT>,
+  ): { accepted: true; runId: string } {
+    let key: string | undefined;
+    let runId = target.runId;
+
+    let activeRecord: AgentThreadRunRecord<any> | undefined;
+    if (target.resourceId && target.threadId) {
+      key = this.#threadKey(target.resourceId, target.threadId);
+      const activeRunId = this.#activeThreadRunIds.get(key);
+      activeRecord = activeRunId ? this.#threadRunsById.get(activeRunId) : undefined;
+      if (activeRecord?.output.status !== 'running') {
+        this.#activeThreadRunIds.delete(key);
+        activeRecord = undefined;
+      }
+      if (activeRecord && activeRecord.agent.id === agent.id) {
+        runId = activeRecord.runId;
+      }
+    }
+
+    if (runId) {
+      activeRecord ??= this.#threadRunsById.get(runId);
+      if (activeRecord?.output.status === 'running') {
+        key ??= this.#threadKey(activeRecord.resourceId, activeRecord.threadId);
+        if (activeRecord.agent.id === agent.id) {
+          const queue = this.#pendingSignalsByThread.get(key) ?? [];
+          queue.push(signal);
+          this.#pendingSignalsByThread.set(key, queue);
+          this.#watchThreadRunCompletion(key, activeRecord);
+          return { accepted: true, runId };
+        }
+      }
+    }
+
+    const resourceId = target.resourceId ?? activeRecord?.resourceId;
+    const threadId = target.threadId ?? activeRecord?.threadId;
+    if (!threadId) {
+      throw new Error('No active agent run found for signal target');
+    }
+
+    runId = randomUUID();
+    void (agent.stream as any)(signalToMessage(signal), {
+      ...(target.streamOptions as AgentExecutionOptions<OUTPUT> | undefined),
+      runId,
+      memory: target.streamOptions?.memory ?? ({ resource: resourceId, thread: threadId } as any),
+    });
+
+    return { accepted: true, runId };
+  }
+}

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -5,11 +5,11 @@ import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context
 import type { MastraModelOutput } from '../stream/base/output';
 import type { Agent } from './agent';
 import type { AgentExecutionOptions } from './agent.types';
-import { signalToMessage } from './signals';
+import { createSignal, signalToMessage } from './signals';
+import type { CreatedAgentSignal } from './signals';
 import type {
   AgentSignal,
   AgentSubscribeToThreadOptions,
-  AgentThreadRun,
   AgentThreadSubscription,
   SendAgentSignalOptions,
 } from './types';
@@ -25,12 +25,20 @@ type AgentThreadRunRecord<OUTPUT = unknown> = {
   streamOptions: AgentExecutionOptions<OUTPUT>;
 };
 
+type PreparedThreadRun = {
+  abortController: AbortController;
+  cleanup: () => void;
+};
+
 export class AgentThreadStreamRuntime {
   #threadRunsById = new Map<string, AgentThreadRunRecord<any>>();
+  #threadKeysByRunId = new Map<string, string>();
   #activeThreadRunIds = new Map<string, string>();
   #threadRunSubscribers = new Map<string, Set<(run: AgentThreadRunRecord<any>) => void>>();
-  #pendingSignalsByThread = new Map<string, AgentSignal[]>();
+  #pendingSignalsByThread = new Map<string, CreatedAgentSignal[]>();
   #watchedThreadRunIds = new Set<string>();
+  #preparedRunsById = new Map<string, PreparedThreadRun>();
+  #abortedRunIds = new Set<string>();
 
   #threadKey(resourceId: string | undefined, threadId: string): string {
     return [resourceId ?? '', threadId].join(AGENT_THREAD_KEY_SEPARATOR);
@@ -47,17 +55,57 @@ export class AgentThreadStreamRuntime {
     return { threadId, resourceId };
   }
 
-  #toAgentThreadRun<OUTPUT>(record: AgentThreadRunRecord<OUTPUT>): AgentThreadRun<OUTPUT> {
+  prepareRunOptions<OUTPUT>(options: AgentExecutionOptions<OUTPUT>): AgentExecutionOptions<OUTPUT> {
+    const { threadId } = this.#getThreadTarget(options);
+    if (!threadId || !options.runId) return options;
+
+    const abortController = new AbortController();
+    const upstreamAbortSignal = options.abortSignal;
+    const abort = () => abortController.abort();
+    if (upstreamAbortSignal?.aborted) {
+      abort();
+    } else {
+      upstreamAbortSignal?.addEventListener('abort', abort, { once: true });
+    }
+
+    this.#preparedRunsById.set(options.runId, {
+      abortController,
+      cleanup: () => upstreamAbortSignal?.removeEventListener('abort', abort),
+    });
+
+    if (this.#abortedRunIds.has(options.runId)) {
+      abort();
+    }
+
     return {
-      output: record.output,
-      get fullStream() {
-        return record.output.fullStream as ReadableStream<any>;
-      },
-      runId: record.runId,
-      threadId: record.threadId,
-      resourceId: record.resourceId,
-      cleanup: () => {},
+      ...options,
+      abortSignal: abortController.signal,
     };
+  }
+
+  abortRun(runId: string): boolean {
+    const preparedRun = this.#preparedRunsById.get(runId);
+    if (!preparedRun) {
+      this.#abortedRunIds.add(runId);
+      return false;
+    }
+
+    preparedRun.abortController.abort();
+    this.#abortedRunIds.add(runId);
+    return true;
+  }
+
+  abortThread(options: AgentSubscribeToThreadOptions): boolean {
+    const key = this.#threadKey(options.resourceId, options.threadId);
+    const activeRunId = this.#activeThreadRunIds.get(key);
+    if (!activeRunId) return false;
+    return this.abortRun(activeRunId);
+  }
+
+  #cleanupPreparedRun(runId: string) {
+    this.#preparedRunsById.get(runId)?.cleanup();
+    this.#preparedRunsById.delete(runId);
+    this.#abortedRunIds.delete(runId);
   }
 
   #notifyThreadRun(record: AgentThreadRunRecord<any>) {
@@ -84,6 +132,7 @@ export class AgentThreadStreamRuntime {
     };
 
     this.#threadRunsById.set(output.runId, record);
+    this.#threadKeysByRunId.set(output.runId, key);
     this.#activeThreadRunIds.set(key, output.runId);
     this.#notifyThreadRun(record);
     this.#watchThreadRunCompletion(key, record);
@@ -96,6 +145,8 @@ export class AgentThreadStreamRuntime {
     void record.output.getFullOutput().finally(() => {
       this.#watchedThreadRunIds.delete(record.runId);
       this.#threadRunsById.delete(record.runId);
+      this.#threadKeysByRunId.delete(record.runId);
+      this.#cleanupPreparedRun(record.runId);
       if (this.#activeThreadRunIds.get(key) === record.runId) {
         this.#activeThreadRunIds.delete(key);
       }
@@ -129,6 +180,18 @@ export class AgentThreadStreamRuntime {
     }
   }
 
+  drainPendingSignals(runId: string) {
+    const record = this.#threadRunsById.get(runId);
+    const key = record ? this.#threadKey(record.resourceId, record.threadId) : this.#threadKeysByRunId.get(runId);
+    if (!key) return [];
+
+    const queue = this.#pendingSignalsByThread.get(key);
+    if (!queue || queue.length === 0) return [];
+
+    this.#pendingSignalsByThread.delete(key);
+    return queue;
+  }
+
   async waitForCrossAgentThreadRun(
     agent: Agent<any, any, any, any>,
     options: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext },
@@ -152,7 +215,7 @@ export class AgentThreadStreamRuntime {
     void agent;
     const key = this.#threadKey(options.resourceId, options.threadId);
     const seenRunIds = new Set<string>();
-    const pendingRuns: AgentThreadRun<OUTPUT>[] = [];
+    const pendingRuns: AgentThreadRunRecord<any>[] = [];
     const waiters: Array<() => void> = [];
     let done = false;
 
@@ -160,10 +223,18 @@ export class AgentThreadStreamRuntime {
       while (waiters.length) waiters.shift()?.();
     };
 
+    const activeRunId = () => {
+      const runId = this.#activeThreadRunIds.get(key);
+      if (!runId) return null;
+      const record = this.#threadRunsById.get(runId);
+      if (!record) return runId;
+      return record.output.status === 'running' ? runId : null;
+    };
+
     const enqueueRun = (record: AgentThreadRunRecord<any>) => {
       if (done || seenRunIds.has(record.runId)) return;
       seenRunIds.add(record.runId);
-      pendingRuns.push(this.#toAgentThreadRun(record) as AgentThreadRun<OUTPUT>);
+      pendingRuns.push(record);
       wake();
     };
 
@@ -171,7 +242,13 @@ export class AgentThreadStreamRuntime {
     listeners.add(enqueueRun);
     this.#threadRunSubscribers.set(key, listeners);
 
-    const cleanup = () => {
+    const currentRunId = activeRunId();
+    const currentRecord = currentRunId ? this.#threadRunsById.get(currentRunId) : undefined;
+    if (currentRecord) {
+      enqueueRun(currentRecord);
+    }
+
+    const unsubscribe = () => {
       if (done) return;
       done = true;
       listeners.delete(enqueueRun);
@@ -182,18 +259,24 @@ export class AgentThreadStreamRuntime {
     };
 
     return {
-      cleanup,
-      runs: (async function* () {
+      activeRunId,
+      abort: () => this.abortThread(options),
+      unsubscribe,
+      stream: (async function* () {
         try {
           while (!done || pendingRuns.length > 0) {
             if (pendingRuns.length === 0) {
               await new Promise<void>(resolve => waiters.push(resolve));
               continue;
             }
-            yield pendingRuns.shift()!;
+            const run = pendingRuns.shift()!;
+            for await (const part of run.output.fullStream) {
+              yield part as any;
+              if (done) break;
+            }
           }
         } finally {
-          cleanup();
+          unsubscribe();
         }
       })(),
     };
@@ -201,9 +284,10 @@ export class AgentThreadStreamRuntime {
 
   sendSignal<OUTPUT = unknown>(
     agent: Agent<any, any, any, any>,
-    signal: AgentSignal,
+    signalInput: AgentSignal,
     target: SendAgentSignalOptions<OUTPUT>,
-  ): { accepted: true; runId: string } {
+  ): { accepted: true; runId: string; signal: CreatedAgentSignal } {
+    const signal = createSignal(signalInput);
     let key: string | undefined;
     let runId = target.runId;
 
@@ -212,7 +296,7 @@ export class AgentThreadStreamRuntime {
       key = this.#threadKey(target.resourceId, target.threadId);
       const activeRunId = this.#activeThreadRunIds.get(key);
       activeRecord = activeRunId ? this.#threadRunsById.get(activeRunId) : undefined;
-      if (activeRecord?.output.status !== 'running') {
+      if (activeRecord && activeRecord.output.status !== 'running') {
         this.#activeThreadRunIds.delete(key);
         activeRecord = undefined;
       }
@@ -230,8 +314,15 @@ export class AgentThreadStreamRuntime {
           queue.push(signal);
           this.#pendingSignalsByThread.set(key, queue);
           this.#watchThreadRunCompletion(key, activeRecord);
-          return { accepted: true, runId };
+          return { accepted: true, runId, signal };
         }
+      }
+
+      if (key && this.#activeThreadRunIds.get(key) === runId) {
+        const queue = this.#pendingSignalsByThread.get(key) ?? [];
+        queue.push(signal);
+        this.#pendingSignalsByThread.set(key, queue);
+        return { accepted: true, runId, signal };
       }
     }
 
@@ -240,14 +331,28 @@ export class AgentThreadStreamRuntime {
     if (!threadId) {
       throw new Error('No active agent run found for signal target');
     }
+    if (!target.ifIdle) {
+      throw new Error('No active agent run found for signal target');
+    }
 
     runId = randomUUID();
+    key ??= this.#threadKey(resourceId, threadId);
+    if (!this.#activeThreadRunIds.has(key)) {
+      this.#activeThreadRunIds.set(key, runId);
+      this.#threadKeysByRunId.set(runId, key);
+    }
     void (agent.stream as any)(signalToMessage(signal), {
-      ...(target.streamOptions as AgentExecutionOptions<OUTPUT> | undefined),
+      ...target.ifIdle.streamOptions,
       runId,
-      memory: target.streamOptions?.memory ?? ({ resource: resourceId, thread: threadId } as any),
+      memory: target.ifIdle.streamOptions.memory ?? ({ resource: resourceId, thread: threadId } as any),
+      _initialSignalEchoes: [signal],
+    }).catch(() => {
+      this.#threadKeysByRunId.delete(runId);
+      if (this.#activeThreadRunIds.get(key) === runId) {
+        this.#activeThreadRunIds.delete(key);
+      }
     });
 
-    return { accepted: true, runId };
+    return { accepted: true, runId, signal };
   }
 }

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -41,7 +41,7 @@ import type {
 import type { RequestContext } from '../request-context';
 import type { PublicSchema, StandardSchemaWithJSON } from '../schema';
 import type { MastraModelOutput } from '../stream/base/output';
-import type { MastraOnFinishCallbackArgs, ModelManagerModelConfig } from '../stream/types';
+import type { AgentChunkType, MastraOnFinishCallbackArgs, ModelManagerModelConfig } from '../stream/types';
 import type { ToolAction, VercelTool, VercelToolV5 } from '../tools';
 import type { DynamicArgument } from '../types';
 import type { MastraVoice } from '../voice';
@@ -80,8 +80,18 @@ export type AgentInstructions = SystemMessage;
 export type { AgentSignalInput as AgentSignal, AgentSignalType, AgentSignalDataPart } from './signals';
 
 export type SendAgentSignalOptions<OUTPUT = unknown> =
-  | { runId: string; resourceId?: string; threadId?: string; streamOptions?: AgentExecutionOptions<OUTPUT> }
-  | { runId?: string; resourceId: string; threadId: string; streamOptions?: AgentExecutionOptions<OUTPUT> };
+  | {
+      runId: string;
+      resourceId?: string;
+      threadId?: string;
+      ifIdle?: { streamOptions: AgentExecutionOptions<OUTPUT> };
+    }
+  | {
+      runId?: string;
+      resourceId: string;
+      threadId: string;
+      ifIdle?: { streamOptions: AgentExecutionOptions<OUTPUT> };
+    };
 
 export interface AgentThreadRun<OUTPUT = unknown> {
   output: MastraModelOutput<OUTPUT>;
@@ -98,8 +108,10 @@ export interface AgentSubscribeToThreadOptions {
 }
 
 export interface AgentThreadSubscription<OUTPUT = unknown> {
-  runs: AsyncIterable<AgentThreadRun<OUTPUT>>;
-  cleanup: () => void;
+  stream: AsyncIterable<AgentChunkType<OUTPUT>>;
+  activeRunId: () => string | null;
+  abort: () => boolean;
+  unsubscribe: () => void;
 }
 
 export type ToolsetsInput = Record<string, ToolsInput>;

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -40,6 +40,7 @@ import type {
 } from '../processors/index';
 import type { RequestContext } from '../request-context';
 import type { PublicSchema, StandardSchemaWithJSON } from '../schema';
+import type { MastraModelOutput } from '../stream/base/output';
 import type { MastraOnFinishCallbackArgs, ModelManagerModelConfig } from '../stream/types';
 import type { ToolAction, VercelTool, VercelToolV5 } from '../tools';
 import type { DynamicArgument } from '../types';
@@ -75,6 +76,31 @@ export type ToolsInput = Record<
 >;
 
 export type AgentInstructions = SystemMessage;
+
+export type { AgentSignalInput as AgentSignal, AgentSignalType, AgentSignalDataPart } from './signals';
+
+export type SendAgentSignalOptions<OUTPUT = unknown> =
+  | { runId: string; resourceId?: string; threadId?: string; streamOptions?: AgentExecutionOptions<OUTPUT> }
+  | { runId?: string; resourceId: string; threadId: string; streamOptions?: AgentExecutionOptions<OUTPUT> };
+
+export interface AgentThreadRun<OUTPUT = unknown> {
+  output: MastraModelOutput<OUTPUT>;
+  readonly fullStream: ReadableStream<any>;
+  runId: string;
+  threadId: string;
+  resourceId?: string;
+  cleanup: () => void;
+}
+
+export interface AgentSubscribeToThreadOptions {
+  resourceId?: string;
+  threadId: string;
+}
+
+export interface AgentThreadSubscription<OUTPUT = unknown> {
+  runs: AsyncIterable<AgentThreadRun<OUTPUT>>;
+  cleanup: () => void;
+}
 
 export type ToolsetsInput = Record<string, ToolsInput>;
 

--- a/packages/core/src/agent/workflows/prepare-stream/index.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/index.ts
@@ -12,6 +12,7 @@ import { createWorkflow } from '../../../workflows';
 import type { Workspace } from '../../../workspace/workspace';
 import type { InnerAgentExecutionOptions } from '../../agent.types';
 import type { SaveQueueManager } from '../../save-queue';
+import type { CreatedAgentSignal } from '../../signals';
 import type { AgentMethodType } from '../../types';
 import { createMapResultsStep } from './map-results-step';
 import { createPrepareMemoryStep } from './prepare-memory-step';
@@ -51,6 +52,8 @@ interface CreatePrepareStreamWorkflowOptions<OUTPUT = undefined> {
    * drives continuation from outside the loop.
    */
   skipBgTaskWait?: boolean;
+  drainPendingSignals?: (runId: string) => CreatedAgentSignal[];
+  initialSignalEchoes?: CreatedAgentSignal[];
 }
 
 export function createPrepareStreamWorkflow<OUTPUT = undefined>({
@@ -77,6 +80,8 @@ export function createPrepareStreamWorkflow<OUTPUT = undefined>({
   backgroundTaskManager,
   agentBackgroundConfig,
   skipBgTaskWait,
+  drainPendingSignals,
+  initialSignalEchoes,
 }: CreatePrepareStreamWorkflowOptions<OUTPUT>) {
   const prepareToolsStep = createPrepareToolsStep({
     capabilities,
@@ -125,6 +130,8 @@ export function createPrepareStreamWorkflow<OUTPUT = undefined>({
     backgroundTaskManager,
     agentBackgroundConfig,
     skipBgTaskWait,
+    drainPendingSignals,
+    initialSignalEchoes,
   });
 
   const mapResultsStep = createMapResultsStep({

--- a/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
@@ -11,6 +11,7 @@ import { MastraModelOutput } from '../../../stream';
 import { createStep } from '../../../workflows';
 import type { Workspace } from '../../../workspace/workspace';
 import type { SaveQueueManager } from '../../save-queue';
+import type { CreatedAgentSignal } from '../../signals';
 import type { AgentMethodType } from '../../types';
 import type { AgentCapabilities } from './schema';
 
@@ -42,6 +43,8 @@ interface StreamStepOptions {
    * drives continuation from outside the loop.
    */
   skipBgTaskWait?: boolean;
+  drainPendingSignals?: (runId: string) => CreatedAgentSignal[];
+  initialSignalEchoes?: CreatedAgentSignal[];
 }
 
 export function createStreamStep<OUTPUT = undefined>({
@@ -64,6 +67,8 @@ export function createStreamStep<OUTPUT = undefined>({
   backgroundTaskManager,
   agentBackgroundConfig,
   skipBgTaskWait,
+  drainPendingSignals,
+  initialSignalEchoes,
 }: StreamStepOptions) {
   return createStep({
     id: 'stream-text-step',
@@ -104,6 +109,8 @@ export function createStreamStep<OUTPUT = undefined>({
           agentBackgroundConfig,
           backgroundTaskManagerConfig: backgroundTaskManager?.config,
           skipBgTaskWait,
+          drainPendingSignals,
+          initialSignalEchoes,
         },
         agentId,
         agentName,

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1561,7 +1561,7 @@ export class Harness<TState = {}> {
 
   private convertToHarnessMessage(msg: {
     id: string;
-    role: 'user' | 'assistant' | 'system';
+    role: 'user' | 'assistant' | 'system' | 'signal';
     createdAt: Date;
     content: {
       parts: Array<{
@@ -1616,7 +1616,7 @@ export class Harness<TState = {}> {
 
       return {
         id: msg.id,
-        role: msg.role,
+        role: msg.role === 'signal' ? 'user' : msg.role,
         content,
         createdAt: msg.createdAt,
       };
@@ -1763,7 +1763,7 @@ export class Harness<TState = {}> {
       }
     }
 
-    return { id: msg.id, role: msg.role, content, createdAt: msg.createdAt };
+    return { id: msg.id, role: msg.role === 'signal' ? 'user' : msg.role, content, createdAt: msg.createdAt };
   }
 
   /**

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -72,6 +72,8 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
     agentBackgroundConfig: _internal?.agentBackgroundConfig,
     backgroundTaskManagerConfig: _internal?.backgroundTaskManagerConfig,
     skipBgTaskWait: _internal?.skipBgTaskWait,
+    drainPendingSignals: _internal?.drainPendingSignals,
+    initialSignalEchoes: _internal?.initialSignalEchoes ? [..._internal.initialSignalEchoes] : undefined,
   };
 
   let startTimestamp = internalToUse.now?.();

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -11,6 +11,7 @@ import { z } from 'zod/v4';
 import type { IsTaskCompleteConfig, OnIterationCompleteHandler } from '../agent/agent.types';
 import type { MessageInput, MessageList } from '../agent/message-list';
 import type { SaveQueueManager } from '../agent/save-queue';
+import type { CreatedAgentSignal } from '../agent/signals';
 import type { StructuredOutputOptions } from '../agent/types';
 import type { AgentBackgroundConfig, BackgroundTaskManager, BackgroundTaskManagerConfig } from '../background-tasks';
 import type { ModelRouterModelId } from '../llm/model';
@@ -72,6 +73,8 @@ export type StreamInternal = {
   // running tasks to complete. Used by `agent.streamUntilIdle`, which handles
   // continuation from the outside — the inner loop shouldn't also wait.
   skipBgTaskWait?: boolean;
+  drainPendingSignals?: (runId: string) => CreatedAgentSignal[];
+  initialSignalEchoes?: CreatedAgentSignal[];
 };
 
 export type PrepareStepResult<TOOLS extends ToolSet = ToolSet> = {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -437,6 +437,17 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             messageList.addSystem(inputData.processorRetryFeedback, 'processor-retry-feedback');
           }
 
+          const initialSignalEchoes = _internal.initialSignalEchoes?.splice(0) ?? [];
+          for (const initialSignal of initialSignalEchoes) {
+            safeEnqueue(controller, initialSignal.toDataPart() as any);
+          }
+
+          const pendingSignals = _internal.drainPendingSignals?.(runId) ?? [];
+          for (const pendingSignal of pendingSignals) {
+            messageList.add(pendingSignal.toLLMMessage(), 'input');
+            safeEnqueue(controller, pendingSignal.toDataPart() as any);
+          }
+
           const currentStep: {
             messageId: string;
             model: MastraLanguageModel;

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -81,6 +81,17 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
       const typedInputData = inputData as LLMIterationData<Tools, OUTPUT>;
       let hasFinishedSteps = false;
 
+      const pendingSignals = _internal.drainPendingSignals?.(runId) ?? [];
+      if (pendingSignals.length > 0) {
+        for (const pendingSignal of pendingSignals) {
+          messageList.add(pendingSignal.toLLMMessage(), 'input');
+          safeEnqueue(controller, pendingSignal.toDataPart() as any);
+        }
+        if (typedInputData.stepResult) {
+          typedInputData.stepResult.isContinued = true;
+        }
+      }
+
       if (pendingFeedbackStop) {
         hasFinishedSteps = true;
         pendingFeedbackStop = false;

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { Agent } from '../agent';
+import { AgentThreadStreamRuntime } from '../agent/thread-stream-runtime';
 import type { DurableAgentLike } from '../agent/types';
 import { isDurableAgentLike } from '../agent/types';
 import { BackgroundTaskManager } from '../background-tasks';
@@ -515,6 +516,7 @@ export class Mastra<
   #bundler?: BundlerConfig;
   #idGenerator?: MastraIdGenerator;
   #pubsub: PubSub;
+  #agentThreadStreamRuntime = new AgentThreadStreamRuntime();
   #backgroundTaskConfig?: BackgroundTaskManagerConfig;
   #backgroundTaskManager?: BackgroundTaskManager;
   #schedulerConfig?: WorkflowSchedulerConfig;
@@ -550,6 +552,10 @@ export class Mastra<
 
   get pubsub() {
     return this.#pubsub;
+  }
+
+  get agentThreadStreamRuntime() {
+    return this.#agentThreadStreamRuntime;
   }
 
   get backgroundTaskManager() {

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -20,7 +20,7 @@ export type { MastraLanguageModel };
 export type MastraMessageV1 = {
   id: string;
   content: string | UserContent | AssistantContent | ToolContent;
-  role: 'system' | 'user' | 'assistant' | 'tool';
+  role: 'system' | 'user' | 'assistant' | 'tool' | 'signal';
   createdAt: Date;
   threadId?: string;
   resourceId?: string;

--- a/packages/core/src/processors/step-schema.ts
+++ b/packages/core/src/processors/step-schema.ts
@@ -78,7 +78,7 @@ type CoreMessageType = {
 
 export type ProcessorMessageType = {
   id: string;
-  role: 'user' | 'assistant' | 'system' | 'tool';
+  role: 'user' | 'assistant' | 'system' | 'tool' | 'signal';
   createdAt: Date;
   threadId?: string;
   resourceId?: string;
@@ -388,7 +388,7 @@ export const ProcessorMessageSchema: z.ZodType<ProcessorMessageType> = z
     /** Unique message identifier */
     id: z.string(),
     /** Message role */
-    role: z.enum(['user', 'assistant', 'system', 'tool']),
+    role: z.enum(['user', 'assistant', 'system', 'tool', 'signal']),
     /** When the message was created */
     createdAt: z.coerce.date(),
     /** Thread identifier for conversation grouping */

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -16,6 +16,8 @@ import {
   GENERATE_AGENT_ROUTE,
   STREAM_GENERATE_ROUTE,
   RESUME_STREAM_ROUTE,
+  SEND_AGENT_SIGNAL_ROUTE,
+  SUBSCRIBE_AGENT_THREAD_ROUTE,
   isProviderConnected,
   extractVersionOptions,
 } from './agents';
@@ -1020,6 +1022,145 @@ describe('Agent Routes Authorization', () => {
       } as any);
 
       expect(result).toBe(expectedStream);
+    });
+  });
+
+  describe('SIGNAL_ROUTES', () => {
+    it('should send a signal using context resource and thread values', async () => {
+      await mockMemory.createThread({
+        threadId: 'signal-thread-from-context',
+        resourceId: 'user-a',
+        title: 'Signal Thread',
+      });
+      const requestContext = createContextWithReservedKeys({
+        resourceId: 'user-a',
+        threadId: 'signal-thread-from-context',
+      });
+      let capturedSignal: any;
+      let capturedTarget: any;
+
+      vi.spyOn(mockAgent, 'sendSignal').mockImplementation((signal, target) => {
+        capturedSignal = signal;
+        capturedTarget = target;
+        return { accepted: true, runId: 'signal-run-id' };
+      });
+
+      const result = await SEND_AGENT_SIGNAL_ROUTE.handler({
+        mastra,
+        agentId: 'test-agent',
+        requestContext,
+        signal: { type: 'user-message', contents: 'hello' },
+        resourceId: 'user-b',
+        threadId: 'client-thread',
+      } as any);
+
+      expect(result).toEqual({ accepted: true, runId: 'signal-run-id' });
+      expect(capturedSignal).toEqual({ type: 'user-message', contents: 'hello' });
+      expect(capturedTarget).toMatchObject({
+        resourceId: 'user-a',
+        threadId: 'signal-thread-from-context',
+      });
+    });
+
+    it('should reject sending a signal to a thread owned by a different resource', async () => {
+      await mockMemory.createThread({
+        threadId: 'signal-thread-owned-by-b',
+        resourceId: 'user-b',
+        title: 'Thread B',
+      });
+      const requestContext = createContextWithReservedKeys({ resourceId: 'user-a' });
+
+      await expect(
+        SEND_AGENT_SIGNAL_ROUTE.handler({
+          mastra,
+          agentId: 'test-agent',
+          requestContext,
+          signal: { type: 'user-message', contents: 'hello' },
+          resourceId: 'user-a',
+          threadId: 'signal-thread-owned-by-b',
+        } as any),
+      ).rejects.toThrow(new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' }));
+    });
+
+    it('should subscribe to a thread and stream future run chunks', async () => {
+      await mockMemory.createThread({
+        threadId: 'subscribe-thread-from-context',
+        resourceId: 'user-a',
+        title: 'Subscribe Thread',
+      });
+      const requestContext = createContextWithReservedKeys({
+        resourceId: 'user-a',
+        threadId: 'subscribe-thread-from-context',
+      });
+      let capturedTarget: any;
+      const cleanup = vi.fn();
+      const chunk = { type: 'text-delta', id: 'text-1', delta: 'hello' };
+
+      vi.spyOn(mockAgent, 'subscribeToThread').mockImplementation(async target => {
+        capturedTarget = target;
+        return {
+          cleanup,
+          runs: (async function* () {
+            yield {
+              runId: 'subscribed-run-id',
+              threadId: target.threadId,
+              resourceId: target.resourceId,
+              fullStream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue(chunk);
+                  controller.close();
+                },
+              }),
+              output: {} as any,
+              cleanup: vi.fn(),
+            };
+          })(),
+        } as any;
+      });
+
+      const stream = (await SUBSCRIBE_AGENT_THREAD_ROUTE.handler({
+        mastra,
+        agentId: 'test-agent',
+        requestContext,
+        abortSignal: new AbortController().signal,
+        resourceId: 'user-b',
+        threadId: 'client-thread',
+      } as any)) as ReadableStream;
+
+      expect(capturedTarget).toEqual({ resourceId: 'user-a', threadId: 'subscribe-thread-from-context' });
+      const reader = stream.getReader();
+      await expect(reader.read()).resolves.toEqual({
+        value: {
+          type: 'run-started',
+          runId: 'subscribed-run-id',
+          threadId: 'subscribe-thread-from-context',
+          resourceId: 'user-a',
+        },
+        done: false,
+      });
+      await expect(reader.read()).resolves.toEqual({ value: chunk, done: false });
+      await reader.cancel();
+      expect(cleanup).toHaveBeenCalled();
+    });
+
+    it('should reject subscribing to a thread owned by a different resource', async () => {
+      await mockMemory.createThread({
+        threadId: 'subscribe-thread-owned-by-b',
+        resourceId: 'user-b',
+        title: 'Thread B',
+      });
+      const requestContext = createContextWithReservedKeys({ resourceId: 'user-a' });
+
+      await expect(
+        SUBSCRIBE_AGENT_THREAD_ROUTE.handler({
+          mastra,
+          agentId: 'test-agent',
+          requestContext,
+          abortSignal: new AbortController().signal,
+          resourceId: 'user-a',
+          threadId: 'subscribe-thread-owned-by-b',
+        } as any),
+      ).rejects.toThrow(new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' }));
     });
   });
 });

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -1093,27 +1093,22 @@ describe('Agent Routes Authorization', () => {
         threadId: 'subscribe-thread-from-context',
       });
       let capturedTarget: any;
-      const cleanup = vi.fn();
-      const chunk = { type: 'text-delta', id: 'text-1', delta: 'hello' };
+      const unsubscribe = vi.fn();
+      const chunk = {
+        type: 'text-delta',
+        runId: 'subscribed-run-id',
+        from: 'AGENT',
+        payload: { id: 'text-1', text: 'hello' },
+      };
 
       vi.spyOn(mockAgent, 'subscribeToThread').mockImplementation(async target => {
         capturedTarget = target;
         return {
-          cleanup,
-          runs: (async function* () {
-            yield {
-              runId: 'subscribed-run-id',
-              threadId: target.threadId,
-              resourceId: target.resourceId,
-              fullStream: new ReadableStream({
-                start(controller) {
-                  controller.enqueue(chunk);
-                  controller.close();
-                },
-              }),
-              output: {} as any,
-              cleanup: vi.fn(),
-            };
+          activeRunId: () => null,
+          abort: () => false,
+          unsubscribe,
+          stream: (async function* () {
+            yield chunk;
           })(),
         } as any;
       });
@@ -1129,18 +1124,9 @@ describe('Agent Routes Authorization', () => {
 
       expect(capturedTarget).toEqual({ resourceId: 'user-a', threadId: 'subscribe-thread-from-context' });
       const reader = stream.getReader();
-      await expect(reader.read()).resolves.toEqual({
-        value: {
-          type: 'run-started',
-          runId: 'subscribed-run-id',
-          threadId: 'subscribe-thread-from-context',
-          resourceId: 'user-a',
-        },
-        done: false,
-      });
       await expect(reader.read()).resolves.toEqual({ value: chunk, done: false });
       await reader.cancel();
-      expect(cleanup).toHaveBeenCalled();
+      expect(unsubscribe).toHaveBeenCalled();
     });
 
     it('should reject subscribing to a thread owned by a different resource', async () => {

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -49,6 +49,8 @@ import {
   declineNetworkToolCallBodySchema,
   observeAgentBodySchema,
   observeAgentResponseSchema,
+  sendAgentSignalBodySchema,
+  subscribeAgentThreadBodySchema,
   streamUntilIdleBodySchema,
   resumeStreamBodySchema,
 } from '../schemas/agents';
@@ -1553,6 +1555,148 @@ export const STREAM_GENERATE_ROUTE = createRoute({
       return streamResult.fullStream;
     } catch (error) {
       return handleError(error, 'error streaming agent response');
+    }
+  },
+});
+
+export const SEND_AGENT_SIGNAL_ROUTE = createRoute({
+  method: 'POST',
+  path: '/agents/:agentId/signals',
+  responseType: 'json' as const,
+  pathParamSchema: agentIdPathParams,
+  bodySchema: sendAgentSignalBodySchema,
+  responseSchema: z.object({ accepted: z.literal(true), runId: z.string() }),
+  summary: 'Send agent signal',
+  description: 'Sends a signal to an active agent run or starts a memory thread run when the thread is idle',
+  tags: ['Agents', 'Streaming'],
+  requiresAuth: true,
+  requiresPermission: 'agents:execute',
+  handler: async ({
+    mastra,
+    agentId,
+    requestContext: serverRequestContext,
+    signal,
+    runId,
+    resourceId,
+    threadId,
+    streamOptions,
+  }) => {
+    try {
+      const agent = await getAgentFromSystem({ mastra, agentId, requestContext: serverRequestContext });
+      const effectiveResourceId = getEffectiveResourceId(serverRequestContext, resourceId);
+      const effectiveThreadId = getEffectiveThreadId(serverRequestContext, threadId);
+      const streamOptionsWithContext: { streamOptions?: any } = streamOptions
+        ? { streamOptions: { ...streamOptions, requestContext: serverRequestContext } }
+        : {};
+
+      if (effectiveThreadId && effectiveResourceId) {
+        const memory = await agent.getMemory({ requestContext: serverRequestContext });
+        if (memory) {
+          const thread = await memory.getThreadById({ threadId: effectiveThreadId });
+          await validateThreadOwnership(thread, effectiveResourceId);
+        }
+      }
+
+      if (runId) {
+        return agent.sendSignal(signal, {
+          runId,
+          ...(effectiveResourceId ? { resourceId: effectiveResourceId } : {}),
+          ...(effectiveThreadId ? { threadId: effectiveThreadId } : {}),
+          ...streamOptionsWithContext,
+        });
+      }
+
+      if (!effectiveResourceId || !effectiveThreadId) {
+        throw new Error('resourceId and threadId are required when runId is not provided');
+      }
+
+      return agent.sendSignal(signal, {
+        resourceId: effectiveResourceId,
+        threadId: effectiveThreadId,
+        ...streamOptionsWithContext,
+      });
+    } catch (error) {
+      return handleError(error, 'error sending agent signal');
+    }
+  },
+});
+
+export const SUBSCRIBE_AGENT_THREAD_ROUTE = createRoute({
+  method: 'POST',
+  path: '/agents/:agentId/threads/subscribe',
+  responseType: 'stream' as const,
+  streamFormat: 'sse' as const,
+  pathParamSchema: agentIdPathParams,
+  bodySchema: subscribeAgentThreadBodySchema,
+  responseSchema: streamResponseSchema,
+  summary: 'Subscribe to agent thread runs',
+  description: 'Subscribes to future and active stream runs for a memory thread',
+  tags: ['Agents', 'Streaming'],
+  requiresAuth: true,
+  requiresPermission: 'agents:execute',
+  handler: async ({ mastra, agentId, resourceId, threadId, abortSignal, requestContext: serverRequestContext }) => {
+    try {
+      const agent = await getAgentFromSystem({ mastra, agentId, requestContext: serverRequestContext });
+      const effectiveResourceId = getEffectiveResourceId(serverRequestContext, resourceId);
+      const effectiveThreadId = getEffectiveThreadId(serverRequestContext, threadId);
+
+      if (!effectiveThreadId) {
+        throw new Error('threadId is required');
+      }
+
+      if (effectiveResourceId) {
+        const memory = await agent.getMemory({ requestContext: serverRequestContext });
+        if (memory) {
+          const thread = await memory.getThreadById({ threadId: effectiveThreadId });
+          await validateThreadOwnership(thread, effectiveResourceId);
+        }
+      }
+
+      const subscription = await agent.subscribeToThread({
+        resourceId: effectiveResourceId,
+        threadId: effectiveThreadId,
+      });
+
+      return new ReadableStream({
+        async start(controller) {
+          const cleanup = () => {
+            subscription.cleanup();
+            try {
+              controller.close();
+            } catch {}
+          };
+
+          abortSignal?.addEventListener('abort', cleanup, { once: true });
+
+          try {
+            for await (const run of subscription.runs) {
+              controller.enqueue({
+                type: 'run-started',
+                runId: run.runId,
+                threadId: run.threadId,
+                resourceId: run.resourceId,
+              });
+              const reader = run.fullStream.getReader();
+              try {
+                while (true) {
+                  const { value, done } = await reader.read();
+                  if (done) break;
+                  controller.enqueue(value);
+                }
+              } finally {
+                reader.releaseLock();
+              }
+            }
+          } catch (error) {
+            controller.error(error);
+          }
+        },
+        cancel() {
+          subscription.cleanup();
+        },
+      });
+    } catch (error) {
+      return handleError(error, 'error subscribing to agent thread');
     }
   },
 });

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -1585,8 +1585,8 @@ export const SEND_AGENT_SIGNAL_ROUTE = createRoute({
       const agent = await getAgentFromSystem({ mastra, agentId, requestContext: serverRequestContext });
       const effectiveResourceId = getEffectiveResourceId(serverRequestContext, resourceId);
       const effectiveThreadId = getEffectiveThreadId(serverRequestContext, threadId);
-      const streamOptionsWithContext: { streamOptions?: any } = streamOptions
-        ? { streamOptions: { ...streamOptions, requestContext: serverRequestContext } }
+      const ifIdleWithContext: { ifIdle?: { streamOptions: any } } = streamOptions
+        ? { ifIdle: { streamOptions: { ...streamOptions, requestContext: serverRequestContext } } }
         : {};
 
       if (effectiveThreadId && effectiveResourceId) {
@@ -1602,7 +1602,7 @@ export const SEND_AGENT_SIGNAL_ROUTE = createRoute({
           runId,
           ...(effectiveResourceId ? { resourceId: effectiveResourceId } : {}),
           ...(effectiveThreadId ? { threadId: effectiveThreadId } : {}),
-          ...streamOptionsWithContext,
+          ...ifIdleWithContext,
         });
       }
 
@@ -1613,7 +1613,7 @@ export const SEND_AGENT_SIGNAL_ROUTE = createRoute({
       return agent.sendSignal(signal, {
         resourceId: effectiveResourceId,
         threadId: effectiveThreadId,
-        ...streamOptionsWithContext,
+        ...ifIdleWithContext,
       });
     } catch (error) {
       return handleError(error, 'error sending agent signal');
@@ -1660,7 +1660,7 @@ export const SUBSCRIBE_AGENT_THREAD_ROUTE = createRoute({
       return new ReadableStream({
         async start(controller) {
           const cleanup = () => {
-            subscription.cleanup();
+            subscription.unsubscribe();
             try {
               controller.close();
             } catch {}
@@ -1669,30 +1669,15 @@ export const SUBSCRIBE_AGENT_THREAD_ROUTE = createRoute({
           abortSignal?.addEventListener('abort', cleanup, { once: true });
 
           try {
-            for await (const run of subscription.runs) {
-              controller.enqueue({
-                type: 'run-started',
-                runId: run.runId,
-                threadId: run.threadId,
-                resourceId: run.resourceId,
-              });
-              const reader = run.fullStream.getReader();
-              try {
-                while (true) {
-                  const { value, done } = await reader.read();
-                  if (done) break;
-                  controller.enqueue(value);
-                }
-              } finally {
-                reader.releaseLock();
-              }
+            for await (const part of subscription.stream) {
+              controller.enqueue(part);
             }
           } catch (error) {
             controller.error(error);
           }
         },
         cancel() {
-          subscription.cleanup();
+          subscription.unsubscribe();
         },
       });
     } catch (error) {

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -507,6 +507,25 @@ export const observeAgentBodySchema = z.object({
   offset: z.number().optional().describe('Resume from this event index (0-based). If omitted, replays all events.'),
 });
 
+export const sendAgentSignalBodySchema = z.object({
+  signal: z.object({
+    id: z.string().optional(),
+    type: z.string(),
+    contents: z.string(),
+    createdAt: z.union([z.string(), z.date()]).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  }),
+  runId: z.string().optional(),
+  resourceId: z.string().optional(),
+  threadId: z.string().optional(),
+  streamOptions: agentExecutionBodySchema.omit({ messages: true }).optional(),
+});
+
+export const subscribeAgentThreadBodySchema = z.object({
+  resourceId: z.string().optional(),
+  threadId: z.string(),
+});
+
 /**
  * Response schema for observe endpoint (streaming response)
  */

--- a/packages/server/src/server/schemas/processors.ts
+++ b/packages/server/src/server/schemas/processors.ts
@@ -69,7 +69,7 @@ const messageContentSchema = z
 const processorMessageSchema = z
   .object({
     id: z.string(),
-    role: z.enum(['user', 'assistant', 'system', 'tool']),
+    role: z.enum(['user', 'assistant', 'system', 'tool', 'signal']),
     createdAt: z.coerce.date().optional(),
     content: z.union([messageContentSchema, z.string()]),
   })

--- a/packages/server/src/server/server-adapter/routes/agents.ts
+++ b/packages/server/src/server/server-adapter/routes/agents.ts
@@ -8,6 +8,8 @@ import {
   STREAM_GENERATE_ROUTE,
   STREAM_GENERATE_VNEXT_DEPRECATED_ROUTE,
   OBSERVE_AGENT_STREAM_ROUTE,
+  SEND_AGENT_SIGNAL_ROUTE,
+  SUBSCRIBE_AGENT_THREAD_ROUTE,
   GET_PROVIDERS_ROUTE,
   APPROVE_TOOL_CALL_ROUTE,
   DECLINE_TOOL_CALL_ROUTE,
@@ -68,6 +70,8 @@ export const AGENTS_ROUTES: readonly ServerRoute[] = [
   // Resumable Stream Routes
   // ============================================================================
   OBSERVE_AGENT_STREAM_ROUTE,
+  SEND_AGENT_SIGNAL_ROUTE,
+  SUBSCRIBE_AGENT_THREAD_ROUTE,
 
   // ============================================================================
   // Tool Routes
@@ -142,6 +146,8 @@ export type AgentRoutes = readonly [
   typeof STREAM_GENERATE_ROUTE,
   typeof STREAM_UNTIL_IDLE_GENERATE_ROUTE,
   typeof STREAM_GENERATE_VNEXT_DEPRECATED_ROUTE,
+  typeof SEND_AGENT_SIGNAL_ROUTE,
+  typeof SUBSCRIBE_AGENT_THREAD_ROUTE,
   typeof EXECUTE_AGENT_TOOL_ROUTE,
   typeof APPROVE_TOOL_CALL_ROUTE,
   typeof DECLINE_TOOL_CALL_ROUTE,


### PR DESCRIPTION
## Description

Adds Agent signals as a first-class way to send contextual input into an agent thread. `agent.sendSignal()` can inject user messages into a running agent loop or start the thread when idle, and `agent.subscribeToThread()` exposes a thread-level stream subscription for consumers that need to follow output over time.

This also adds the supporting server/client routes and types, signal persistence/conversion helpers, stream runtime tracking scoped to Mastra instances, active-loop signal draining, stable signal echo data parts, and follower abort support.

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test Plan

- `pnpm --filter ./packages/core test src/agent/__tests__/agent-signals.test.ts --bail 1 --reporter=dot`
- `pnpm --filter ./packages/core check`
- Previously verified server agent signal route coverage with the focused server handlers test suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

This PR adds the ability to send messages to a running agent (like poking it with additional instructions) and to subscribe and watch what an agent is doing in real-time. Think of it like being able to give new instructions to a robot mid-task and also watching its work as it happens.

## Summary

This pull request introduces Agent signals as a first-class mechanism for contextual input into agent threads. It adds two main APIs:

1. **`agent.sendSignal()`** - Injects messages into a running agent loop or starts the thread when idle, with support for user messages (containing files/images) and contextual signals (string-based, delivered as XML)

2. **`agent.subscribeToThread()`** - Enables consumers to follow thread activity over time via a stream subscription that observes signal echoes with stable IDs

## Key Changes

**Core Agent Infrastructure:**
- New `AgentThreadStreamRuntime` class manages per-thread run lifecycle and cross-agent signaling, handling active run tracking, signal queuing/draining, and stream subscriptions
- Added signal-related methods to `Agent` class: `sendSignal()`, `subscribeToThread()`, `abortThreadStream()`, `abortRunStream()`
- Runtime is instantiated per-Mastra instance and exposed via `agentThreadStreamRuntime` getter

**Signal System:**
- New `signals.ts` module provides comprehensive signal handling: type definitions (`AgentSignal`, `AgentSignalInput`, `CreatedAgentSignal`), conversion helpers, and format adapters
- Supports bidirectional conversions between in-memory signals, LLM message formats, database message formats, and serialized data parts
- Implements XML markup escaping for system-like context passed to LLMs

**Message Handling & Adapters:**
- Extended message role types across the codebase to include `'signal'` role
- Updated `AIV4Adapter`, `AIV5Adapter`, and `AIV6Adapter` to handle signal messages with dedicated `data-*` UI data parts
- Signals are converted: user-message signals become `role: 'user'` messages, other signals become `role: 'system'` with signal metadata

**Stream & Execution Flow:**
- Signal callbacks (`drainPendingSignals`, `initialSignalEchoes`) integrated into prepare-stream workflow and stream step
- LLM execution step replays signal data at the start of each model execution
- Agentic loop drains pending signals at each iteration
- Loop module augmented to support signal context

**Server & Client APIs:**
- Added `POST /agents/{agentId}/signals` route for sending signals with ownership validation
- Added `POST /agents/{agentId}/threads/subscribe` route for SSE stream subscription to thread activity
- Extended client SDK with `Agent.sendSignal()` and `Agent.subscribeToThread()` methods
- New request body schemas for signal and subscription endpoints

**Validation & Processor Updates:**
- Extended processor message schema to accept `'signal'` role
- Harness message conversion handles signal role mapping to user

## Test Coverage

Comprehensive test suite (`agent-signals.test.ts`) validates:
- Signal conversions between LLM message, text, structured data parts, and DB representations
- XML/HTML escaping for system-reminder content
- Preservation of rich file message structures
- Agent runtime control flows: idle run startup, active run signal draining, signal queuing
- Cross-agent signaling and isolation by thread/resource
- Stream subscription and abort behaviors
- Signal echo stability and future run delivery to multiple subscribers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->