### PR TITLE
refactor(core): route system reminders through Agent signals

### DIFF
--- a/.changeset/soft-signals-smile.md
+++ b/.changeset/soft-signals-smile.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added processor `sendSignal` support and routed built-in system reminders through signal messages.

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { MastraDBMessage } from '../agent/message-list';
+import { createSignal, mastraDBMessageToSignal } from '../agent/signals';
 import type { ProcessInputArgs, ProcessInputStepArgs } from '../processors';
 import { RequestContext } from '../request-context';
 import { BrowserContextProcessor } from './processor';
@@ -15,7 +16,7 @@ describe('BrowserContextProcessor', () => {
     messageList: {} as any,
     requestContext: new RequestContext(),
     state: {},
-    abort: vi.fn(),
+    abort: vi.fn() as any,
     retryCount: 0,
     ...overrides,
   });
@@ -36,20 +37,30 @@ describe('BrowserContextProcessor', () => {
   };
 
   // Helper to create minimal args for processInputStep
-  const createInputStepArgs = (overrides: Partial<ProcessInputStepArgs> = {}): ProcessInputStepArgs => ({
-    messages: [],
-    systemMessages: [],
-    messageList: createMockMessageList() as any,
-    requestContext: new RequestContext(),
-    stepNumber: 0,
-    steps: [],
-    state: {},
-    model: undefined as any,
-    retryCount: 0,
-    abort: vi.fn(),
-    rotateResponseMessageId: vi.fn(),
-    ...overrides,
-  });
+  const createInputStepArgs = (overrides: Partial<ProcessInputStepArgs> = {}): ProcessInputStepArgs => {
+    const messageList = overrides.messageList ?? (createMockMessageList() as any);
+    const rotateResponseMessageId = overrides.rotateResponseMessageId ?? vi.fn();
+    return {
+      messages: [],
+      systemMessages: [],
+      messageList,
+      requestContext: new RequestContext(),
+      stepNumber: 0,
+      steps: [],
+      state: {},
+      model: undefined as any,
+      retryCount: 0,
+      abort: vi.fn() as any,
+      rotateResponseMessageId,
+      sendSignal: async signalInput => {
+        const signal = createSignal(signalInput);
+        rotateResponseMessageId?.();
+        messageList.add(signal.toDBMessage(), 'input');
+        return signal;
+      },
+      ...overrides,
+    };
+  };
 
   describe('processInput', () => {
     it('should return messageList unchanged when no browser context', () => {
@@ -95,13 +106,13 @@ describe('BrowserContextProcessor', () => {
   });
 
   describe('processInputStep', () => {
-    it('should return undefined when no browser context', () => {
-      const result = processor.processInputStep(createInputStepArgs());
+    it('should return undefined when no browser context', async () => {
+      const result = await processor.processInputStep(createInputStepArgs());
 
       expect(result).toBeUndefined();
     });
 
-    it('should return undefined when stepNumber is not 0', () => {
+    it('should return undefined when stepNumber is not 0', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -109,12 +120,12 @@ describe('BrowserContextProcessor', () => {
       };
       requestContext.set('browser', browserCtx);
 
-      const result = processor.processInputStep(createInputStepArgs({ requestContext, stepNumber: 1 }));
+      const result = await processor.processInputStep(createInputStepArgs({ requestContext, stepNumber: 1 }));
 
       expect(result).toBeUndefined();
     });
 
-    it('should add a new user message with system-reminder containing URL and title', () => {
+    it('should add a new user message with system-reminder containing URL and title', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -126,7 +137,7 @@ describe('BrowserContextProcessor', () => {
       const mockMessageList = createMockMessageList();
       const rotateResponseMessageId = vi.fn();
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -138,24 +149,25 @@ describe('BrowserContextProcessor', () => {
       expect(mockMessageList.add).toHaveBeenCalledTimes(1);
 
       const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
-      expect(addedMessage.role).toBe('user');
-      expect(addedMessage.content.metadata).toEqual({
-        systemReminder: {
+      expect(addedMessage.role).toBe('signal');
+      expect(addedMessage.type).toBe('system-reminder');
+      expect(addedMessage.content.metadata).toEqual(
+        expect.objectContaining({
           type: 'browser-context',
           url: 'https://example.com/page',
           title: 'Example Page',
-        },
-      });
+          signal: expect.objectContaining({ type: 'system-reminder' }),
+        }),
+      );
 
       const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
-      expect(textPart.text).toContain('<system-reminder type="browser-context">');
       expect(textPart.text).toContain('https://example.com/page');
       expect(textPart.text).toContain('Example Page');
 
       expect(rotateResponseMessageId).toHaveBeenCalled();
     });
 
-    it('should add system-reminder when only page title is available', () => {
+    it('should add system-reminder when only page title is available', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -165,7 +177,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList();
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -176,12 +188,12 @@ describe('BrowserContextProcessor', () => {
       expect(mockMessageList.add).toHaveBeenCalledTimes(1);
 
       const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
+      expect(addedMessage.role).toBe('signal');
       const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
-      expect(textPart.text).toContain('<system-reminder type="browser-context">');
       expect(textPart.text).toContain('Example Page');
     });
 
-    it('should return undefined when no per-request data available', () => {
+    it('should return undefined when no per-request data available', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -189,12 +201,12 @@ describe('BrowserContextProcessor', () => {
       };
       requestContext.set('browser', browserCtx);
 
-      const result = processor.processInputStep(createInputStepArgs({ requestContext }));
+      const result = await processor.processInputStep(createInputStepArgs({ requestContext }));
 
       expect(result).toBeUndefined();
     });
 
-    it('should not add duplicate reminder if same content already exists', () => {
+    it('should not add duplicate reminder if same content already exists', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -228,7 +240,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList([existingReminder]);
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -239,7 +251,7 @@ describe('BrowserContextProcessor', () => {
       expect(mockMessageList.add).not.toHaveBeenCalled();
     });
 
-    it('should add new reminder if URL changed from previous reminder', () => {
+    it('should add new reminder if URL changed from previous reminder', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -273,7 +285,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList([existingReminder]);
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -289,7 +301,7 @@ describe('BrowserContextProcessor', () => {
       expect(textPart.text).toContain('New Page');
     });
 
-    it('should add reminder for A→B→A navigation (trailing reminder B differs from current A)', () => {
+    it('should add reminder for A→B→A navigation (trailing reminder B differs from current A)', async () => {
       const requestContext = new RequestContext();
       // Current state: back on page A
       const browserCtx: BrowserContext = {
@@ -327,7 +339,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList([reminderA, reminderB]);
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -343,7 +355,7 @@ describe('BrowserContextProcessor', () => {
       expect(textPart.text).toContain('page-a');
     });
 
-    it('should add reminder when trailing message is not a browser reminder (user → reminder → assistant → user)', () => {
+    it('should add reminder when trailing message is not a browser reminder (user → reminder → assistant → user)', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -386,7 +398,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList([reminderA, assistantResponse, userMessage]);
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -398,7 +410,7 @@ describe('BrowserContextProcessor', () => {
       expect(mockMessageList.add).toHaveBeenCalledTimes(1);
     });
 
-    it('should escape XML special characters in URL and title', () => {
+    it('should escape XML special characters in URL and title', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -409,7 +421,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList();
 
-      processor.processInputStep(
+      await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -419,12 +431,18 @@ describe('BrowserContextProcessor', () => {
       const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
       const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
 
-      // Should escape &, <, > in the markup text
-      expect(textPart.text).toContain('&amp;');
-      expect(textPart.text).toContain('&lt;');
-      expect(textPart.text).toContain('&gt;');
-      expect(textPart.text).not.toContain('q=foo&bar'); // Should be escaped
-      expect(textPart.text).not.toContain('<Results>'); // Should be escaped
+      // DB signal content stays raw; XML escaping happens when converting to LLM markup.
+      expect(textPart.text).toContain('q=foo&bar');
+      expect(textPart.text).toContain('<Results>');
+
+      const llmMessage = mastraDBMessageToSignal(addedMessage).toLLMMessage();
+      expect(llmMessage).toEqual([
+        {
+          role: 'system',
+          content:
+            '<system-reminder type="browser-context">Current URL: https://example.com/search?q=foo&amp;bar=1 | Page title: Search &lt;Results&gt; &amp; More</system-reminder>',
+        },
+      ]);
     });
   });
 });

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -19,8 +19,7 @@
  * ```
  */
 
-import type { MessageList, MastraDBMessage } from '../agent/message-list';
-import type { MastraMessageContentV2 } from '../agent/message-list/state/types';
+import type { MastraDBMessage } from '../agent/message-list';
 import type { ProcessInputArgs, ProcessInputResult, ProcessInputStepArgs } from '../processors/index';
 
 const REMINDER_TYPE = 'browser-context';
@@ -86,7 +85,7 @@ export class BrowserContextProcessor {
     return { messages: args.messages, systemMessages };
   }
 
-  processInputStep(args: ProcessInputStepArgs): MessageList | undefined {
+  async processInputStep(args: ProcessInputStepArgs) {
     // Only inject per-request context at the first step
     if (args.stepNumber !== 0) return;
 
@@ -96,17 +95,16 @@ export class BrowserContextProcessor {
     const parts: string[] = [];
 
     if (ctx.currentUrl) {
-      parts.push(`Current URL: ${escapeXml(ctx.currentUrl)}`);
+      parts.push(`Current URL: ${ctx.currentUrl}`);
     }
 
     if (ctx.pageTitle) {
-      parts.push(`Page title: ${escapeXml(ctx.pageTitle)}`);
+      parts.push(`Page title: ${ctx.pageTitle}`);
     }
 
     if (parts.length === 0) return;
 
     const reminderText = parts.join(' | ');
-    const reminderMarkup = `<system-reminder type="${REMINDER_TYPE}">${reminderText}</system-reminder>`;
 
     // Only suppress if the trailing message is already the same browser reminder
     const existingMessages = args.messageList.get.all.db();
@@ -114,10 +112,17 @@ export class BrowserContextProcessor {
       return;
     }
 
-    // Add as a new user message at the end of history to preserve prompt cache
-    const reminderMessage = createBrowserReminderMessage(reminderMarkup, ctx.currentUrl, ctx.pageTitle);
-    args.messageList.add(reminderMessage, 'user');
-    args.rotateResponseMessageId?.();
+    await args.sendSignal?.({
+      type: 'system-reminder',
+      contents: reminderText,
+      attributes: {
+        type: REMINDER_TYPE,
+      },
+      metadata: {
+        url: ctx.currentUrl,
+        title: ctx.pageTitle,
+      },
+    });
 
     return args.messageList;
   }
@@ -127,41 +132,6 @@ interface BrowserReminderMetadata {
   type: typeof REMINDER_TYPE;
   url?: string;
   title?: string;
-}
-
-function createBrowserReminderMessage(
-  reminderMarkup: string,
-  url: string | undefined,
-  title: string | undefined,
-): MastraDBMessage {
-  const reminderMeta: BrowserReminderMetadata = {
-    type: REMINDER_TYPE,
-    url,
-    title,
-  };
-
-  const content: MastraMessageContentV2 = {
-    format: 2,
-    parts: [{ type: 'text', text: reminderMarkup }],
-    metadata: {
-      systemReminder: reminderMeta,
-    },
-  };
-
-  return {
-    id: crypto.randomUUID(),
-    role: 'user',
-    content,
-    createdAt: new Date(),
-  };
-}
-
-/**
- * Escape XML special characters in browser-derived values.
- * Prevents URLs or page titles containing <, &, or </system-reminder> from breaking the markup.
- */
-function escapeXml(value: string): string {
-  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
 }
 
 /**
@@ -175,13 +145,16 @@ function hasTrailingBrowserReminder(
   title: string | undefined,
 ): boolean {
   const msg = messages[messages.length - 1];
-  if (!msg || msg.role !== 'user') return false;
+  if (!msg || (msg.role !== 'user' && msg.role !== 'signal')) return false;
 
   const metadata = msg.content.metadata;
-  if (typeof metadata !== 'object' || metadata === null || !('systemReminder' in metadata)) {
+  if (typeof metadata !== 'object' || metadata === null) {
     return false;
   }
 
-  const reminder = (metadata as { systemReminder?: BrowserReminderMetadata }).systemReminder;
+  const reminder =
+    'systemReminder' in metadata
+      ? (metadata as { systemReminder?: BrowserReminderMetadata }).systemReminder
+      : (metadata as unknown as BrowserReminderMetadata);
   return reminder?.type === REMINDER_TYPE && reminder.url === url && reminder.title === title;
 }

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -2,6 +2,7 @@ import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
 import type { CallSettings, StepResult, ToolChoice } from '@internal/ai-sdk-v5';
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
+import type { AgentSignalInput, CreatedAgentSignal } from '../agent/signals';
 import type { TripWireOptions } from '../agent/trip-wire';
 import type { ModelRouterModelId } from '../llm/model';
 import type { MastraLanguageModel, OpenAICompatibleConfig, SharedProviderOptions } from '../llm/model/shared.types';
@@ -55,6 +56,11 @@ export interface ProcessorContext<TTripwireMetadata = unknown> extends Partial<O
   abort: (reason?: string, options?: TripWireOptions<TTripwireMetadata>) => never;
   /** Optional runtime context with execution metadata */
   requestContext?: RequestContext;
+  /**
+   * Add a signal to the message list, rotate the response message id when supported,
+   * and emit the signal as a data-* stream part when a writer is available.
+   */
+  sendSignal?: (signal: AgentSignalInput) => Promise<CreatedAgentSignal>;
   /**
    * Number of times processors have triggered retry for this generation.
    * Use this to implement retry limits within your processor.

--- a/packages/core/src/processors/prefill-error-handler.test.ts
+++ b/packages/core/src/processors/prefill-error-handler.test.ts
@@ -1,6 +1,7 @@
 import { APICallError } from '@internal/ai-sdk-v5';
 import { describe, expect, it } from 'vitest';
 import { MessageList } from '../agent/message-list';
+import { createSignal } from '../agent/signals';
 import { PrefillErrorHandler } from './prefill-error-handler';
 import type { ProcessAPIErrorArgs } from './index';
 
@@ -90,6 +91,11 @@ function makeArgs(overrides: Partial<ProcessAPIErrorArgs> = {}): ProcessAPIError
     abort: (() => {
       throw new Error('abort');
     }) as any,
+    sendSignal: async signalInput => {
+      const signal = createSignal(signalInput);
+      messageList.add(signal.toDBMessage(), 'input');
+      return signal;
+    },
     ...overrides,
   };
 }
@@ -115,18 +121,21 @@ describe('PrefillErrorHandler', () => {
     expect(messagesAfter.length).toBe(messageCountBefore + 1);
 
     const lastMessage = messagesAfter[messagesAfter.length - 1]!;
-    expect(lastMessage.role).toBe('user');
+    expect(lastMessage.role).toBe('signal');
+    expect(lastMessage.type).toBe('system-reminder');
     expect(lastMessage.content.parts).toEqual([
       expect.objectContaining({
         type: 'text',
-        text: '<system-reminder>continue</system-reminder>',
+        text: 'continue',
       }),
     ]);
-    expect(lastMessage.content.metadata).toEqual({
-      systemReminder: {
+    expect(lastMessage.content.metadata).toEqual(
+      expect.objectContaining({
         type: 'anthropic-prefill-processor-retry',
-      },
-    });
+        message: 'Continuing after prefill error',
+        signal: expect.objectContaining({ type: 'system-reminder' }),
+      }),
+    );
   });
 
   it('should return undefined for non-prefill errors', async () => {
@@ -164,7 +173,7 @@ describe('PrefillErrorHandler', () => {
 
     expect(result).toEqual({ retry: true });
     const lastMessage = args.messageList.get.all.db().at(-1);
-    expect(lastMessage?.role).toBe('user');
+    expect(lastMessage?.role).toBe('signal');
   });
 
   it('should return { retry: true } when qwen prefill string is only present in responseBody', async () => {

--- a/packages/core/src/processors/prefill-error-handler.ts
+++ b/packages/core/src/processors/prefill-error-handler.ts
@@ -1,17 +1,6 @@
-import { randomUUID } from 'node:crypto';
-
 import { APICallError } from '@internal/ai-sdk-v5';
 
-import type { DataChunkType } from '../stream/types';
 import type { Processor, ProcessAPIErrorArgs, ProcessAPIErrorResult } from './index';
-
-type SystemReminderChunk = DataChunkType & {
-  type: 'data-system-reminder';
-  data: {
-    message: string;
-    reminderType: string;
-  };
-};
 
 const PREFILL_ERROR_PATTERNS = [
   /does not support assistant message prefill/i,
@@ -66,56 +55,22 @@ export class PrefillErrorHandler implements Processor<'prefill-error-handler'> {
   readonly id = 'prefill-error-handler' as const;
   readonly name = 'Prefill Error Handler';
 
-  async processAPIError({
-    error,
-    messageList,
-    retryCount,
-    writer,
-    rotateResponseMessageId,
-  }: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
+  async processAPIError({ error, retryCount, sendSignal }: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
     // Only handle on first attempt — if it fails again after our fix, don't loop
     if (retryCount > 0) return;
 
     if (!isPrefillError(error)) return;
 
-    // Emit an ephemeral stream chunk so live UIs can show the retry is happening
-    if (writer) {
-      const chunk: SystemReminderChunk = {
-        type: 'data-system-reminder',
-        data: {
-          message: 'Continuing after prefill error',
-          reminderType: 'anthropic-prefill-processor-retry',
-        },
-        transient: true,
-      };
-      await writer.custom(chunk);
-    }
-
-    // Append a user message to break the trailing assistant pattern
-    messageList.add(
-      {
-        id: randomUUID(),
-        role: 'user' as const,
-        content: {
-          format: 2 as const,
-          parts: [
-            {
-              type: 'text' as const,
-              text: '<system-reminder>continue</system-reminder>',
-            },
-          ],
-          metadata: {
-            systemReminder: {
-              type: 'anthropic-prefill-processor-retry',
-            },
-          },
-        },
-        createdAt: new Date(),
+    await sendSignal?.({
+      type: 'system-reminder',
+      contents: 'continue',
+      attributes: {
+        type: 'anthropic-prefill-processor-retry',
       },
-      'input',
-    );
-
-    rotateResponseMessageId?.();
+      metadata: {
+        message: 'Continuing after prefill error',
+      },
+    });
 
     return { retry: true };
   }

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -2425,4 +2425,60 @@ describe('ProcessorRunner', () => {
       expect(mockLogger.error).toHaveBeenCalled();
     });
   });
+
+  describe('processor sendSignal', () => {
+    it('adds a signal message, rotates the response id, and writes a data part', async () => {
+      const rotateResponseMessageId = vi.fn(() => 'response-2');
+      const chunks: unknown[] = [];
+
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'signal-processor',
+            processInputStep: async ({ sendSignal }) => {
+              await sendSignal?.({
+                type: 'system-reminder',
+                contents: 'remember this',
+                metadata: { type: 'test-reminder' },
+              });
+            },
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await runner.runProcessInputStep({
+        messageList,
+        stepNumber: 0,
+        steps: [],
+        model: {} as any,
+        tools: {},
+        retryCount: 0,
+        messageId: 'response-1',
+        rotateResponseMessageId,
+        writer: {
+          custom: async chunk => {
+            chunks.push(chunk);
+          },
+        },
+      });
+
+      const signalMessage = messageList.get.all.db().at(-1);
+      expect(rotateResponseMessageId).toHaveBeenCalledTimes(1);
+      expect(signalMessage?.role).toBe('signal');
+      expect(signalMessage?.content.parts[0]).toEqual(expect.objectContaining({ type: 'text', text: 'remember this' }));
+      expect(chunks).toEqual([
+        expect.objectContaining({
+          type: 'data-system-reminder',
+          data: expect.objectContaining({
+            type: 'system-reminder',
+            contents: 'remember this',
+            metadata: { type: 'test-reminder' },
+          }),
+        }),
+      ]);
+    });
+  });
 });

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -1,6 +1,8 @@
 import type { StepResult } from '@internal/ai-sdk-v5';
 import type { MastraDBMessage, MessageInput } from '../agent/message-list';
 import { MessageList, messagesAreEqual } from '../agent/message-list';
+import { createSignal } from '../agent/signals';
+import type { AgentSignalInput, CreatedAgentSignal } from '../agent/signals';
 import { TripWire } from '../agent/trip-wire';
 import type { TripWireOptions } from '../agent/trip-wire';
 import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../agent/utils';
@@ -153,6 +155,20 @@ function areProcessorMessageArraysEqual(before: unknown[] | undefined, after: un
     before.length === after.length &&
     before.every((message, index) => messagesAreEqual(message as MessageInput, after[index] as MessageInput))
   );
+}
+
+function createProcessorSendSignal(args: {
+  messageList: MessageList;
+  writer?: ProcessorStreamWriter;
+  rotateResponseMessageId?: () => string;
+}): (signalInput: AgentSignalInput) => Promise<CreatedAgentSignal> {
+  return async signalInput => {
+    const signal = createSignal(signalInput);
+    args.rotateResponseMessageId?.();
+    args.messageList.add(signal.toDBMessage(), 'input');
+    await args.writer?.custom(signal.toDataPart());
+    return signal;
+  };
 }
 
 function buildProcessInputStepSpanInput(args: {
@@ -480,6 +496,7 @@ export class ProcessorRunner {
           requestContext,
           retryCount,
           writer,
+          sendSignal: createProcessorSendSignal({ messageList, writer }),
         });
 
         // Stop recording and get mutations for this processor
@@ -874,6 +891,7 @@ export class ProcessorRunner {
           messageList,
           requestContext,
           retryCount,
+          sendSignal: createProcessorSendSignal({ messageList }),
         });
 
         // Handle MessageList, MastraDBMessage[], or { messages, systemMessages } return types
@@ -1163,24 +1181,25 @@ export class ProcessorRunner {
           activeTools: inputData.activeTools,
         };
 
+        const rotateResponseMessageId = args.rotateResponseMessageId
+          ? () => {
+              const nextMessageId = args.rotateResponseMessageId!();
+              stepInput.messageId = nextMessageId;
+              return nextMessageId;
+            }
+          : undefined;
+
         const processMethodArgs = {
           messageList,
           ...inputData,
           state: processorState.customState,
           abort,
-          ...(args.rotateResponseMessageId
-            ? {
-                rotateResponseMessageId: () => {
-                  const nextMessageId = args.rotateResponseMessageId!();
-                  stepInput.messageId = nextMessageId;
-                  return nextMessageId;
-                },
-              }
-            : {}),
+          ...(rotateResponseMessageId ? { rotateResponseMessageId } : {}),
           ...createObservabilityContext({ currentSpan: processorSpan }),
           retryCount: args.retryCount ?? 0,
           writer,
           abortSignal: args.abortSignal,
+          sendSignal: createProcessorSendSignal({ messageList, writer, rotateResponseMessageId }),
         };
 
         const result = await ProcessorRunner.validateAndFormatProcessInputStepResult(
@@ -1401,6 +1420,7 @@ export class ProcessorRunner {
           requestContext,
           retryCount,
           writer,
+          sendSignal: createProcessorSendSignal({ messageList, writer }),
         });
 
         // Stop recording and get mutations for this processor
@@ -1559,6 +1579,14 @@ export class ProcessorRunner {
       const processorState = this.getProcessorState(processor.id);
 
       try {
+        const rotateResponseMessageId = args.rotateResponseMessageId
+          ? () => {
+              const nextMessageId = args.rotateResponseMessageId!();
+              messageIdAfter = nextMessageId;
+              return nextMessageId;
+            }
+          : undefined;
+
         const result = await processMethod({
           messages: processableMessages,
           messageList,
@@ -1573,15 +1601,8 @@ export class ProcessorRunner {
           writer,
           abortSignal,
           messageId: args.messageId,
-          ...(args.rotateResponseMessageId
-            ? {
-                rotateResponseMessageId: () => {
-                  const nextMessageId = args.rotateResponseMessageId!();
-                  messageIdAfter = nextMessageId;
-                  return nextMessageId;
-                },
-              }
-            : {}),
+          ...(rotateResponseMessageId ? { rotateResponseMessageId } : {}),
+          sendSignal: createProcessorSendSignal({ messageList, writer, rotateResponseMessageId }),
         });
 
         // Stop recording and get mutations for this processor

--- a/packages/core/src/processors/tool-result-reminder.test.ts
+++ b/packages/core/src/processors/tool-result-reminder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
+import { createSignal } from '../agent/signals';
 import { MastraLanguageModelV3Mock } from '../loop/test-utils/MastraLanguageModelV3Mock';
 import type { RequestContext } from '../request-context';
 import { AgentsMDInjector } from './tool-result-reminder';
@@ -156,15 +157,29 @@ function createProcessInputStepArgs(
     retryCount: 0,
     model: new MastraLanguageModelV3Mock({}),
     writer,
+    sendSignal: async signalInput => {
+      const signal = createSignal(signalInput);
+      rotateResponseMessageId?.();
+      messageList.add(signal.toDBMessage(), 'input');
+      await writer?.custom(signal.toDataPart());
+      return signal;
+    },
   } as ProcessInputStepArgs;
 }
 
 function extractReminderMarkup(messageList: TestMessageList): string[] {
-  return messageList.get.all
-    .db()
-    .filter(message => message.role === 'user')
-    .map(message => getMessageText(message))
-    .filter(text => text.includes('<system-reminder'));
+  return messageList.get.all.db().flatMap(message => {
+    if (message.role === 'signal' && message.content.metadata?.type === 'dynamic-agents-md') {
+      const path = message.content.metadata.path;
+      return typeof path === 'string'
+        ? [`<system-reminder type="dynamic-agents-md" path="${path}">${getMessageText(message)}</system-reminder>`]
+        : [];
+    }
+
+    if (message.role !== 'user') return [];
+    const text = getMessageText(message);
+    return text.includes('<system-reminder') ? [text] : [];
+  });
 }
 
 function getMessageText(message: MastraDBMessage): string {
@@ -206,12 +221,14 @@ describe('AgentsMDInjector', () => {
       `<system-reminder type="dynamic-agents-md" path="/repo/src/agents/nested/AGENTS.md"># Nested AGENTS\n\nUse the nested instructions when replying.</system-reminder>`,
     ]);
     const injectedReminder = messageList.get.all.db().at(-1);
-    expect(injectedReminder?.content.metadata).toEqual({
-      systemReminder: {
+    expect(injectedReminder?.role).toBe('signal');
+    expect(injectedReminder?.content.metadata).toEqual(
+      expect.objectContaining({
         path: '/repo/src/agents/nested/AGENTS.md',
         type: 'dynamic-agents-md',
-      },
-    });
+        signal: expect.objectContaining({ type: 'system-reminder' }),
+      }),
+    );
   });
 
   it('injects reminder for tool calls array format', async () => {
@@ -247,15 +264,17 @@ describe('AgentsMDInjector', () => {
     );
 
     expect(chunks).toEqual([
-      {
+      expect.objectContaining({
         type: 'data-system-reminder',
-        data: {
-          message: 'Project guidance from CLAUDE',
-          reminderType: 'dynamic-agents-md',
-          path: '/repo/CLAUDE.md',
-        },
-        transient: true,
-      },
+        data: expect.objectContaining({
+          type: 'system-reminder',
+          contents: 'Project guidance from CLAUDE',
+          metadata: {
+            path: '/repo/CLAUDE.md',
+            type: 'dynamic-agents-md',
+          },
+        }),
+      }),
     ]);
     expect(extractReminderMarkup(messageList)).toEqual([
       `<system-reminder type="dynamic-agents-md" path="/repo/CLAUDE.md">Project guidance from CLAUDE</system-reminder>`,

--- a/packages/core/src/processors/tool-result-reminder.ts
+++ b/packages/core/src/processors/tool-result-reminder.ts
@@ -2,8 +2,7 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, normalize, resolve } from 'node:path';
 import { estimateTokenCount } from 'tokenx';
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
-import type { MastraMessageContentV2 } from '../agent/message-list/state/types';
-import type { DataChunkType } from '../stream/types';
+import { signalToXmlMarkup } from '../agent/signals';
 import type { ProcessInputStepArgs, Processor, ToolCallInfo } from './index';
 
 const INSTRUCTION_FILE_NAMES = ['AGENTS.md', 'CLAUDE.md', 'CONTEXT.md'] as const;
@@ -19,16 +18,6 @@ type ReminderMetadataValue = {
 type ReminderMessageMetadata = {
   systemReminder?: ReminderMetadataValue;
   dynamicAgentsMdReminder?: ReminderMetadataValue;
-};
-
-type SystemReminderChunk = DataChunkType & {
-  type: 'data-system-reminder';
-  data: {
-    message: string;
-    reminderType: string;
-    path: string;
-  };
-  transient: true;
 };
 
 type TextPartLike = {
@@ -99,14 +88,6 @@ function findInstructionFileForPath(
   return undefined;
 }
 
-function escapeXml(value: string): string {
-  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-}
-
-function escapeXmlAttribute(value: string): string {
-  return escapeXml(value).replaceAll('"', '&quot;');
-}
-
 function getMessageText(message: MastraDBMessage): string {
   const parts = isRecord(message.content) ? message.content.parts : undefined;
   if (!Array.isArray(parts)) {
@@ -162,32 +143,19 @@ function extractReminderPathFromMetadata(message: MastraDBMessage): string | und
     ? metadata.systemReminder
     : isRecord(metadata[LEGACY_REMINDER_METADATA_KEY])
       ? metadata[LEGACY_REMINDER_METADATA_KEY]
-      : undefined;
-
-  if (!reminderMetadata) {
-    return undefined;
-  }
+      : isRecord(metadata.signal) && isRecord(metadata.signal.attributes)
+        ? metadata.signal.attributes
+        : metadata;
 
   return typeof reminderMetadata.path === 'string' ? reminderMetadata.path : undefined;
 }
 
-function createReminderMessage(reminderMarkup: string, instructionPath: string): MastraDBMessage {
-  const content: MastraMessageContentV2 = {
-    format: 2,
-    parts: [{ type: 'text', text: reminderMarkup }],
-    metadata: getReminderMetadata(instructionPath),
-  };
-
-  return {
-    id: crypto.randomUUID(),
-    role: 'user',
-    content,
-    createdAt: new Date(),
-  };
-}
-
 function getReminderMarkup(reminderText: string, instructionPath: string): string {
-  return `<system-reminder type="${REMINDER_TYPE}" path="${escapeXmlAttribute(instructionPath)}">${escapeXml(reminderText)}</system-reminder>`;
+  return signalToXmlMarkup({
+    type: 'system-reminder',
+    contents: reminderText,
+    attributes: { type: REMINDER_TYPE, path: instructionPath },
+  });
 }
 
 function truncateToTokenLimit(content: string, maxTokens: number): string {
@@ -292,7 +260,7 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
   }
 
   async processInputStep(args: ProcessInputStepArgs): Promise<MessageList | MastraDBMessage[]> {
-    const { messageList, rotateResponseMessageId } = args;
+    const { messageList } = args;
     const messages = messageList.get.all.db();
     const currentStepResponseMessages = getCurrentStepResponseMessages(messageList);
     const completedToolCalls = getCompletedToolCalls(currentStepResponseMessages);
@@ -312,21 +280,13 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
       return messageList;
     }
 
-    if (args.writer) {
-      const chunk: SystemReminderChunk = {
-        type: 'data-system-reminder',
-        data: {
-          message: reminderText,
-          reminderType: REMINDER_TYPE,
-          path: instructionPath,
-        },
-        transient: true,
-      };
-      await args.writer.custom(chunk);
-    }
+    await args.sendSignal?.({
+      type: 'system-reminder',
+      contents: reminderText,
+      attributes: { type: REMINDER_TYPE, path: instructionPath },
+      metadata: getReminderMetadata(instructionPath).systemReminder,
+    });
 
-    messageList.add(createReminderMessage(reminderMarkup, instructionPath), 'user');
-    rotateResponseMessageId?.();
     return messageList;
   }
 
@@ -393,7 +353,7 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
     const reminderPath = extractReminderPath(reminderMarkup);
 
     return messages.some(message => {
-      if (message.role !== 'user') {
+      if (message.role !== 'user' && message.role !== 'signal') {
         return false;
       }
 


### PR DESCRIPTION
## Description

Routes system reminder processors through the new Agent signal path instead of appending reminder markup directly. Browser reminders, tool-result reminders, and prefill-error reminders now send structured signal metadata that is converted into the appropriate stream data part, persisted message, and LLM-facing XML context.

This keeps reminder injection consistent with the Agent signal runtime while preserving the existing reminder behavior for agent context.

Stacked on #16227.

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test Plan

- Focused processor/reminder tests for browser, prefill-error, runner, and tool-result reminder processors
- `pnpm --filter ./packages/core check`
