### PR TITLE
refactor(core): route system reminders through Agent signals

### DIFF
--- a/.changeset/soft-signals-smile.md
+++ b/.changeset/soft-signals-smile.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added processor `sendSignal` support and routed built-in system reminders through signal messages.

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -304,6 +304,10 @@ export class Agent extends BaseResource {
       }) => Promise<void>;
     };
 
+    if (!streamResponse.body) {
+      throw new Error('No response body');
+    }
+
     streamResponse.processDataStream = async ({
       onChunk,
     }: {

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -5400,242 +5400,52 @@ type PostAgentsAgentIdSignals_Body_Auxiliary_2 =
       [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
     };
 
-export type PostAgentsAgentIdSignals_Body = {
-  signal:
-    | {
-        id?: string | undefined;
-        createdAt?: (string | Date) | undefined;
-        metadata?:
-          | {
-              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-            }
-          | undefined;
-        attributes?:
-          | {
-              [key: string]: string | number | boolean | null | undefined;
-            }
-          | undefined;
-        type: 'user-message';
-        contents:
-          | string
-          | string[]
-          | (
+export type PostAgentsAgentIdSignals_Body =
+  | {
+      signal:
+        | {
+            id?: string | undefined;
+            createdAt?: (string | Date) | undefined;
+            metadata?:
               | {
-                  id?: string | undefined;
-                  name?: string | undefined;
-                  metadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  providerMetadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  providerOptions?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  experimental_providerMetadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  role: 'system' | 'user' | 'assistant' | 'tool';
-                  content:
-                    | string
-                    | (
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'text';
-                            text: string;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'image';
-                            image:
-                              | string
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                };
-                            mediaType?: string | undefined;
-                            mimeType?: string | undefined;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'file';
-                            data?:
-                              | (
-                                  | string
-                                  | {
-                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                    }
-                                )
-                              | undefined;
-                            file?:
-                              | (
-                                  | string
-                                  | {
-                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                    }
-                                )
-                              | undefined;
-                            url?: string | undefined;
-                            mediaType?: string | undefined;
-                            mimeType?: string | undefined;
-                            filename?: string | undefined;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'tool-call';
-                            toolCallId: string;
-                            toolName: string;
-                            args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                            input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'tool-result';
-                            toolCallId: string;
-                            toolName?: string | undefined;
-                            result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                            output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                          }
-                      )[];
+                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
                 }
+              | undefined;
+            attributes?:
               | {
-                  id?: string | undefined;
-                  name?: string | undefined;
-                  metadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  providerMetadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  providerOptions?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  experimental_providerMetadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  role: 'system' | 'user' | 'assistant' | 'tool' | 'data';
-                  content?:
-                    | (
+                  [key: string]: string | number | boolean | null | undefined;
+                }
+              | undefined;
+            type: 'user-message';
+            contents:
+              | string
+              | string[]
+              | (
+                  | {
+                      id?: string | undefined;
+                      name?: string | undefined;
+                      metadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      experimental_providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      role: 'system' | 'user' | 'assistant' | 'tool';
+                      content:
                         | string
                         | (
                             | {
@@ -5799,601 +5609,201 @@ export type PostAgentsAgentIdSignals_Body = {
                                 result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
                                 output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
                               }
-                          )[]
-                      )
-                    | undefined;
-                  parts?:
-                    | (
+                          )[];
+                    }
+                  | {
+                      id?: string | undefined;
+                      name?: string | undefined;
+                      metadata?:
                         | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'text';
-                            text: string;
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
                           }
+                        | undefined;
+                      providerMetadata?:
                         | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'image';
-                            image:
-                              | string
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                };
-                            mediaType?: string | undefined;
-                            mimeType?: string | undefined;
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
                           }
+                        | undefined;
+                      providerOptions?:
                         | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'file';
-                            data?:
-                              | (
-                                  | string
-                                  | {
-                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                    }
-                                )
-                              | undefined;
-                            file?:
-                              | (
-                                  | string
-                                  | {
-                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                    }
-                                )
-                              | undefined;
-                            url?: string | undefined;
-                            mediaType?: string | undefined;
-                            mimeType?: string | undefined;
-                            filename?: string | undefined;
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
                           }
+                        | undefined;
+                      experimental_providerMetadata?:
                         | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'tool-call';
-                            toolCallId: string;
-                            toolName: string;
-                            args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                            input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
                           }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'tool-result';
-                            toolCallId: string;
-                            toolName?: string | undefined;
-                            result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                            output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                          }
-                      )[]
-                    | undefined;
-                  createdAt?: (string | Date) | undefined;
-                }
-              | {
-                  id: string;
-                  role: 'system' | 'user' | 'assistant' | 'signal';
-                  createdAt: string | Date;
-                  threadId?: string | undefined;
-                  resourceId?: string | undefined;
-                  type?: string | undefined;
-                  content: {
-                    format: 2;
-                    parts: {
-                      type: string;
-                      [x: string]: unknown;
-                    }[];
-                    content?:
-                      | (
-                          | string
-                          | (
-                              | {
-                                  id?: string | undefined;
-                                  name?: string | undefined;
-                                  metadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerOptions?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  experimental_providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  type: 'text';
-                                  text: string;
-                                }
-                              | {
-                                  id?: string | undefined;
-                                  name?: string | undefined;
-                                  metadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerOptions?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  experimental_providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  type: 'image';
-                                  image:
-                                    | string
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      };
-                                  mediaType?: string | undefined;
-                                  mimeType?: string | undefined;
-                                }
-                              | {
-                                  id?: string | undefined;
-                                  name?: string | undefined;
-                                  metadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerOptions?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  experimental_providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  type: 'file';
-                                  data?:
-                                    | (
-                                        | string
-                                        | {
-                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                          }
-                                      )
-                                    | undefined;
-                                  file?:
-                                    | (
-                                        | string
-                                        | {
-                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                          }
-                                      )
-                                    | undefined;
-                                  url?: string | undefined;
-                                  mediaType?: string | undefined;
-                                  mimeType?: string | undefined;
-                                  filename?: string | undefined;
-                                }
-                              | {
-                                  id?: string | undefined;
-                                  name?: string | undefined;
-                                  metadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerOptions?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  experimental_providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  type: 'tool-call';
-                                  toolCallId: string;
-                                  toolName: string;
-                                  args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                                  input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                                }
-                              | {
-                                  id?: string | undefined;
-                                  name?: string | undefined;
-                                  metadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerOptions?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  experimental_providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  type: 'tool-result';
-                                  toolCallId: string;
-                                  toolName?: string | undefined;
-                                  result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                                  output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                                }
-                            )[]
-                        )
-                      | undefined;
-                    experimental_attachments?:
-                      | {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        }[]
-                      | undefined;
-                    toolInvocations?:
-                      | {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        }[]
-                      | undefined;
-                    reasoning?: string | undefined;
-                    annotations?: PostAgentsAgentIdSignals_Body_Auxiliary_2[] | undefined;
-                    metadata?:
-                      | {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        }
-                      | undefined;
-                    providerMetadata?:
-                      | {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        }
-                      | undefined;
-                    [x: string]: unknown;
-                  };
-                }
-            )
-          | (
-              | {
-                  id?: string | undefined;
-                  name?: string | undefined;
-                  metadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  providerMetadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  providerOptions?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  experimental_providerMetadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  role: 'system' | 'user' | 'assistant' | 'tool';
-                  content:
-                    | string
-                    | (
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'text';
-                            text: string;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'image';
-                            image:
-                              | string
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                };
-                            mediaType?: string | undefined;
-                            mimeType?: string | undefined;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'file';
-                            data?:
-                              | (
-                                  | string
-                                  | {
-                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                    }
-                                )
-                              | undefined;
-                            file?:
-                              | (
-                                  | string
-                                  | {
-                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                    }
-                                )
-                              | undefined;
-                            url?: string | undefined;
-                            mediaType?: string | undefined;
-                            mimeType?: string | undefined;
-                            filename?: string | undefined;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'tool-call';
-                            toolCallId: string;
-                            toolName: string;
-                            args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                            input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'tool-result';
-                            toolCallId: string;
-                            toolName?: string | undefined;
-                            result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                            output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                          }
-                      )[];
-                }
-              | {
-                  id?: string | undefined;
-                  name?: string | undefined;
-                  metadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  providerMetadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  providerOptions?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  experimental_providerMetadata?:
-                    | {
-                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                      }
-                    | undefined;
-                  role: 'system' | 'user' | 'assistant' | 'tool' | 'data';
-                  content?:
-                    | (
-                        | string
+                        | undefined;
+                      role: 'system' | 'user' | 'assistant' | 'tool' | 'data';
+                      content?:
+                        | (
+                            | string
+                            | (
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'text';
+                                    text: string;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'image';
+                                    image:
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        };
+                                    mediaType?: string | undefined;
+                                    mimeType?: string | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'file';
+                                    data?:
+                                      | (
+                                          | string
+                                          | {
+                                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                            }
+                                        )
+                                      | undefined;
+                                    file?:
+                                      | (
+                                          | string
+                                          | {
+                                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                            }
+                                        )
+                                      | undefined;
+                                    url?: string | undefined;
+                                    mediaType?: string | undefined;
+                                    mimeType?: string | undefined;
+                                    filename?: string | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'tool-call';
+                                    toolCallId: string;
+                                    toolName: string;
+                                    args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'tool-result';
+                                    toolCallId: string;
+                                    toolName?: string | undefined;
+                                    result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                  }
+                              )[]
+                          )
+                        | undefined;
+                      parts?:
                         | (
                             | {
                                 id?: string | undefined;
@@ -6557,540 +5967,2686 @@ export type PostAgentsAgentIdSignals_Body = {
                                 output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
                               }
                           )[]
-                      )
-                    | undefined;
-                  parts?:
-                    | (
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'text';
-                            text: string;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'image';
-                            image:
-                              | string
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                };
-                            mediaType?: string | undefined;
-                            mimeType?: string | undefined;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'file';
-                            data?:
-                              | (
-                                  | string
-                                  | {
-                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                    }
-                                )
-                              | undefined;
-                            file?:
-                              | (
-                                  | string
-                                  | {
-                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                    }
-                                )
-                              | undefined;
-                            url?: string | undefined;
-                            mediaType?: string | undefined;
-                            mimeType?: string | undefined;
-                            filename?: string | undefined;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'tool-call';
-                            toolCallId: string;
-                            toolName: string;
-                            args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                            input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                          }
-                        | {
-                            id?: string | undefined;
-                            name?: string | undefined;
-                            metadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            providerOptions?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            experimental_providerMetadata?:
-                              | {
-                                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                }
-                              | undefined;
-                            type: 'tool-result';
-                            toolCallId: string;
-                            toolName?: string | undefined;
-                            result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                            output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                          }
-                      )[]
-                    | undefined;
-                  createdAt?: (string | Date) | undefined;
-                }
-              | {
-                  id: string;
-                  role: 'system' | 'user' | 'assistant' | 'signal';
-                  createdAt: string | Date;
-                  threadId?: string | undefined;
-                  resourceId?: string | undefined;
-                  type?: string | undefined;
-                  content: {
-                    format: 2;
-                    parts: {
-                      type: string;
-                      [x: string]: unknown;
-                    }[];
-                    content?:
-                      | (
-                          | string
+                        | undefined;
+                      createdAt?: (string | Date) | undefined;
+                    }
+                  | {
+                      id: string;
+                      role: 'system' | 'user' | 'assistant' | 'signal';
+                      createdAt: string | Date;
+                      threadId?: string | undefined;
+                      resourceId?: string | undefined;
+                      type?: string | undefined;
+                      content: {
+                        format: 2;
+                        parts: {
+                          type: string;
+                          [x: string]: unknown;
+                        }[];
+                        content?:
                           | (
-                              | {
-                                  id?: string | undefined;
-                                  name?: string | undefined;
-                                  metadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerOptions?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  experimental_providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  type: 'text';
-                                  text: string;
-                                }
-                              | {
-                                  id?: string | undefined;
-                                  name?: string | undefined;
-                                  metadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerOptions?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  experimental_providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  type: 'image';
-                                  image:
-                                    | string
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      };
-                                  mediaType?: string | undefined;
-                                  mimeType?: string | undefined;
-                                }
-                              | {
-                                  id?: string | undefined;
-                                  name?: string | undefined;
-                                  metadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerOptions?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  experimental_providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  type: 'file';
-                                  data?:
-                                    | (
-                                        | string
+                              | string
+                              | (
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
                                         | {
                                             [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
                                           }
-                                      )
-                                    | undefined;
-                                  file?:
-                                    | (
-                                        | string
+                                        | undefined;
+                                      providerMetadata?:
                                         | {
                                             [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
                                           }
-                                      )
-                                    | undefined;
-                                  url?: string | undefined;
-                                  mediaType?: string | undefined;
-                                  mimeType?: string | undefined;
-                                  filename?: string | undefined;
-                                }
-                              | {
-                                  id?: string | undefined;
-                                  name?: string | undefined;
-                                  metadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerOptions?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  experimental_providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  type: 'tool-call';
-                                  toolCallId: string;
-                                  toolName: string;
-                                  args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                                  input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                                }
-                              | {
-                                  id?: string | undefined;
-                                  name?: string | undefined;
-                                  metadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  providerOptions?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  experimental_providerMetadata?:
-                                    | {
-                                        [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                                      }
-                                    | undefined;
-                                  type: 'tool-result';
-                                  toolCallId: string;
-                                  toolName?: string | undefined;
-                                  result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                                  output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
-                                }
-                            )[]
-                        )
-                      | undefined;
-                    experimental_attachments?:
-                      | {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        }[]
-                      | undefined;
-                    toolInvocations?:
-                      | {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        }[]
-                      | undefined;
-                    reasoning?: string | undefined;
-                    annotations?: PostAgentsAgentIdSignals_Body_Auxiliary_2[] | undefined;
-                    metadata?:
-                      | {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        }
-                      | undefined;
-                    providerMetadata?:
-                      | {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        }
-                      | undefined;
-                    [x: string]: unknown;
-                  };
-                }
-            )[];
-      }
-    | {
-        id?: string | undefined;
-        createdAt?: (string | Date) | undefined;
-        metadata?:
-          | {
-              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-            }
-          | undefined;
-        attributes?:
-          | {
-              [key: string]: string | number | boolean | null | undefined;
-            }
-          | undefined;
-        type: string;
-        contents: string;
-      };
-  runId?: string | undefined;
-  resourceId?: string | undefined;
-  threadId?: string | undefined;
-  streamOptions?:
-    | {
-        instructions?: (string | string[] | any | any[]) | undefined;
-        system?: (string | string[] | any | any[]) | undefined;
-        context?: any[] | undefined;
-        memory?:
-          | {
-              thread:
-                | string
-                | {
-                    id: string;
-                    [x: string]: unknown;
-                  };
-              resource: string;
-              options?:
-                | {
-                    [key: string]: any;
-                  }
-                | undefined;
-              readOnly?: boolean | undefined;
-            }
-          | undefined;
-        runId?: string | undefined;
-        savePerStep?: boolean | undefined;
-        requestContext?:
-          | {
-              [key: string]: any;
-            }
-          | undefined;
-        versions?:
-          | {
-              agents?:
-                | {
-                    [key: string]:
-                      | {
-                          versionId: string;
-                        }
-                      | {
-                          status: 'draft' | 'published';
-                        };
-                  }
-                | undefined;
-            }
-          | undefined;
-        maxSteps?: number | undefined;
-        stopWhen?: any | undefined;
-        providerOptions?:
-          | {
-              anthropic?:
-                | {
-                    [key: string]: any;
-                  }
-                | undefined;
-              google?:
-                | {
-                    [key: string]: any;
-                  }
-                | undefined;
-              openai?:
-                | {
-                    [key: string]: any;
-                  }
-                | undefined;
-              xai?:
-                | {
-                    [key: string]: any;
-                  }
-                | undefined;
-            }
-          | undefined;
-        modelSettings?: any | undefined;
-        activeTools?: string[] | undefined;
-        toolsets?:
-          | {
-              [key: string]: any;
-            }
-          | undefined;
-        clientTools?:
-          | {
-              [key: string]: any;
-            }
-          | undefined;
-        toolChoice?:
-          | (
-              | ('auto' | 'none' | 'required')
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'text';
+                                      text: string;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'image';
+                                      image:
+                                        | string
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          };
+                                      mediaType?: string | undefined;
+                                      mimeType?: string | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'file';
+                                      data?:
+                                        | (
+                                            | string
+                                            | {
+                                                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                              }
+                                          )
+                                        | undefined;
+                                      file?:
+                                        | (
+                                            | string
+                                            | {
+                                                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                              }
+                                          )
+                                        | undefined;
+                                      url?: string | undefined;
+                                      mediaType?: string | undefined;
+                                      mimeType?: string | undefined;
+                                      filename?: string | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'tool-call';
+                                      toolCallId: string;
+                                      toolName: string;
+                                      args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                      input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'tool-result';
+                                      toolCallId: string;
+                                      toolName?: string | undefined;
+                                      result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                      output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    }
+                                )[]
+                            )
+                          | undefined;
+                        experimental_attachments?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }[]
+                          | undefined;
+                        toolInvocations?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }[]
+                          | undefined;
+                        reasoning?: string | undefined;
+                        annotations?: PostAgentsAgentIdSignals_Body_Auxiliary_2[] | undefined;
+                        metadata?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }
+                          | undefined;
+                        providerMetadata?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }
+                          | undefined;
+                        [x: string]: unknown;
+                      };
+                    }
+                )
+              | (
+                  | {
+                      id?: string | undefined;
+                      name?: string | undefined;
+                      metadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      experimental_providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      role: 'system' | 'user' | 'assistant' | 'tool';
+                      content:
+                        | string
+                        | (
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'text';
+                                text: string;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'image';
+                                image:
+                                  | string
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    };
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'file';
+                                data?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                file?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                url?: string | undefined;
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                                filename?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-call';
+                                toolCallId: string;
+                                toolName: string;
+                                args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-result';
+                                toolCallId: string;
+                                toolName?: string | undefined;
+                                result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                          )[];
+                    }
+                  | {
+                      id?: string | undefined;
+                      name?: string | undefined;
+                      metadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      experimental_providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      role: 'system' | 'user' | 'assistant' | 'tool' | 'data';
+                      content?:
+                        | (
+                            | string
+                            | (
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'text';
+                                    text: string;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'image';
+                                    image:
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        };
+                                    mediaType?: string | undefined;
+                                    mimeType?: string | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'file';
+                                    data?:
+                                      | (
+                                          | string
+                                          | {
+                                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                            }
+                                        )
+                                      | undefined;
+                                    file?:
+                                      | (
+                                          | string
+                                          | {
+                                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                            }
+                                        )
+                                      | undefined;
+                                    url?: string | undefined;
+                                    mediaType?: string | undefined;
+                                    mimeType?: string | undefined;
+                                    filename?: string | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'tool-call';
+                                    toolCallId: string;
+                                    toolName: string;
+                                    args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'tool-result';
+                                    toolCallId: string;
+                                    toolName?: string | undefined;
+                                    result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                  }
+                              )[]
+                          )
+                        | undefined;
+                      parts?:
+                        | (
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'text';
+                                text: string;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'image';
+                                image:
+                                  | string
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    };
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'file';
+                                data?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                file?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                url?: string | undefined;
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                                filename?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-call';
+                                toolCallId: string;
+                                toolName: string;
+                                args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-result';
+                                toolCallId: string;
+                                toolName?: string | undefined;
+                                result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                          )[]
+                        | undefined;
+                      createdAt?: (string | Date) | undefined;
+                    }
+                  | {
+                      id: string;
+                      role: 'system' | 'user' | 'assistant' | 'signal';
+                      createdAt: string | Date;
+                      threadId?: string | undefined;
+                      resourceId?: string | undefined;
+                      type?: string | undefined;
+                      content: {
+                        format: 2;
+                        parts: {
+                          type: string;
+                          [x: string]: unknown;
+                        }[];
+                        content?:
+                          | (
+                              | string
+                              | (
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'text';
+                                      text: string;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'image';
+                                      image:
+                                        | string
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          };
+                                      mediaType?: string | undefined;
+                                      mimeType?: string | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'file';
+                                      data?:
+                                        | (
+                                            | string
+                                            | {
+                                                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                              }
+                                          )
+                                        | undefined;
+                                      file?:
+                                        | (
+                                            | string
+                                            | {
+                                                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                              }
+                                          )
+                                        | undefined;
+                                      url?: string | undefined;
+                                      mediaType?: string | undefined;
+                                      mimeType?: string | undefined;
+                                      filename?: string | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'tool-call';
+                                      toolCallId: string;
+                                      toolName: string;
+                                      args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                      input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'tool-result';
+                                      toolCallId: string;
+                                      toolName?: string | undefined;
+                                      result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                      output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    }
+                                )[]
+                            )
+                          | undefined;
+                        experimental_attachments?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }[]
+                          | undefined;
+                        toolInvocations?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }[]
+                          | undefined;
+                        reasoning?: string | undefined;
+                        annotations?: PostAgentsAgentIdSignals_Body_Auxiliary_2[] | undefined;
+                        metadata?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }
+                          | undefined;
+                        providerMetadata?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }
+                          | undefined;
+                        [x: string]: unknown;
+                      };
+                    }
+                )[];
+          }
+        | {
+            id?: string | undefined;
+            createdAt?: (string | Date) | undefined;
+            metadata?:
               | {
-                  type: 'tool';
-                  toolName: string;
+                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
                 }
-            )
-          | undefined;
-        requireToolApproval?: boolean | undefined;
-        scorers?:
-          | (
+              | undefined;
+            attributes?:
+              | {
+                  [key: string]: string | number | boolean | null | undefined;
+                }
+              | undefined;
+            type: string;
+            contents: string;
+          };
+      runId: string;
+      resourceId?: string | undefined;
+      threadId?: string | undefined;
+      streamOptions?: undefined | undefined;
+    }
+  | {
+      signal:
+        | {
+            id?: string | undefined;
+            createdAt?: (string | Date) | undefined;
+            metadata?:
+              | {
+                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                }
+              | undefined;
+            attributes?:
+              | {
+                  [key: string]: string | number | boolean | null | undefined;
+                }
+              | undefined;
+            type: 'user-message';
+            contents:
+              | string
+              | string[]
+              | (
+                  | {
+                      id?: string | undefined;
+                      name?: string | undefined;
+                      metadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      experimental_providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      role: 'system' | 'user' | 'assistant' | 'tool';
+                      content:
+                        | string
+                        | (
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'text';
+                                text: string;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'image';
+                                image:
+                                  | string
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    };
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'file';
+                                data?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                file?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                url?: string | undefined;
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                                filename?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-call';
+                                toolCallId: string;
+                                toolName: string;
+                                args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-result';
+                                toolCallId: string;
+                                toolName?: string | undefined;
+                                result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                          )[];
+                    }
+                  | {
+                      id?: string | undefined;
+                      name?: string | undefined;
+                      metadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      experimental_providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      role: 'system' | 'user' | 'assistant' | 'tool' | 'data';
+                      content?:
+                        | (
+                            | string
+                            | (
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'text';
+                                    text: string;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'image';
+                                    image:
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        };
+                                    mediaType?: string | undefined;
+                                    mimeType?: string | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'file';
+                                    data?:
+                                      | (
+                                          | string
+                                          | {
+                                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                            }
+                                        )
+                                      | undefined;
+                                    file?:
+                                      | (
+                                          | string
+                                          | {
+                                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                            }
+                                        )
+                                      | undefined;
+                                    url?: string | undefined;
+                                    mediaType?: string | undefined;
+                                    mimeType?: string | undefined;
+                                    filename?: string | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'tool-call';
+                                    toolCallId: string;
+                                    toolName: string;
+                                    args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'tool-result';
+                                    toolCallId: string;
+                                    toolName?: string | undefined;
+                                    result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                  }
+                              )[]
+                          )
+                        | undefined;
+                      parts?:
+                        | (
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'text';
+                                text: string;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'image';
+                                image:
+                                  | string
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    };
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'file';
+                                data?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                file?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                url?: string | undefined;
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                                filename?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-call';
+                                toolCallId: string;
+                                toolName: string;
+                                args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-result';
+                                toolCallId: string;
+                                toolName?: string | undefined;
+                                result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                          )[]
+                        | undefined;
+                      createdAt?: (string | Date) | undefined;
+                    }
+                  | {
+                      id: string;
+                      role: 'system' | 'user' | 'assistant' | 'signal';
+                      createdAt: string | Date;
+                      threadId?: string | undefined;
+                      resourceId?: string | undefined;
+                      type?: string | undefined;
+                      content: {
+                        format: 2;
+                        parts: {
+                          type: string;
+                          [x: string]: unknown;
+                        }[];
+                        content?:
+                          | (
+                              | string
+                              | (
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'text';
+                                      text: string;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'image';
+                                      image:
+                                        | string
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          };
+                                      mediaType?: string | undefined;
+                                      mimeType?: string | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'file';
+                                      data?:
+                                        | (
+                                            | string
+                                            | {
+                                                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                              }
+                                          )
+                                        | undefined;
+                                      file?:
+                                        | (
+                                            | string
+                                            | {
+                                                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                              }
+                                          )
+                                        | undefined;
+                                      url?: string | undefined;
+                                      mediaType?: string | undefined;
+                                      mimeType?: string | undefined;
+                                      filename?: string | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'tool-call';
+                                      toolCallId: string;
+                                      toolName: string;
+                                      args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                      input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'tool-result';
+                                      toolCallId: string;
+                                      toolName?: string | undefined;
+                                      result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                      output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    }
+                                )[]
+                            )
+                          | undefined;
+                        experimental_attachments?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }[]
+                          | undefined;
+                        toolInvocations?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }[]
+                          | undefined;
+                        reasoning?: string | undefined;
+                        annotations?: PostAgentsAgentIdSignals_Body_Auxiliary_2[] | undefined;
+                        metadata?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }
+                          | undefined;
+                        providerMetadata?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }
+                          | undefined;
+                        [x: string]: unknown;
+                      };
+                    }
+                )
+              | (
+                  | {
+                      id?: string | undefined;
+                      name?: string | undefined;
+                      metadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      experimental_providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      role: 'system' | 'user' | 'assistant' | 'tool';
+                      content:
+                        | string
+                        | (
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'text';
+                                text: string;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'image';
+                                image:
+                                  | string
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    };
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'file';
+                                data?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                file?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                url?: string | undefined;
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                                filename?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-call';
+                                toolCallId: string;
+                                toolName: string;
+                                args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-result';
+                                toolCallId: string;
+                                toolName?: string | undefined;
+                                result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                          )[];
+                    }
+                  | {
+                      id?: string | undefined;
+                      name?: string | undefined;
+                      metadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      experimental_providerMetadata?:
+                        | {
+                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                          }
+                        | undefined;
+                      role: 'system' | 'user' | 'assistant' | 'tool' | 'data';
+                      content?:
+                        | (
+                            | string
+                            | (
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'text';
+                                    text: string;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'image';
+                                    image:
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        };
+                                    mediaType?: string | undefined;
+                                    mimeType?: string | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'file';
+                                    data?:
+                                      | (
+                                          | string
+                                          | {
+                                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                            }
+                                        )
+                                      | undefined;
+                                    file?:
+                                      | (
+                                          | string
+                                          | {
+                                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                            }
+                                        )
+                                      | undefined;
+                                    url?: string | undefined;
+                                    mediaType?: string | undefined;
+                                    mimeType?: string | undefined;
+                                    filename?: string | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'tool-call';
+                                    toolCallId: string;
+                                    toolName: string;
+                                    args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                  }
+                                | {
+                                    id?: string | undefined;
+                                    name?: string | undefined;
+                                    metadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    providerOptions?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    experimental_providerMetadata?:
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                      | undefined;
+                                    type: 'tool-result';
+                                    toolCallId: string;
+                                    toolName?: string | undefined;
+                                    result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                  }
+                              )[]
+                          )
+                        | undefined;
+                      parts?:
+                        | (
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'text';
+                                text: string;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'image';
+                                image:
+                                  | string
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    };
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'file';
+                                data?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                file?:
+                                  | (
+                                      | string
+                                      | {
+                                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                        }
+                                    )
+                                  | undefined;
+                                url?: string | undefined;
+                                mediaType?: string | undefined;
+                                mimeType?: string | undefined;
+                                filename?: string | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-call';
+                                toolCallId: string;
+                                toolName: string;
+                                args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                            | {
+                                id?: string | undefined;
+                                name?: string | undefined;
+                                metadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                providerOptions?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                experimental_providerMetadata?:
+                                  | {
+                                      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                    }
+                                  | undefined;
+                                type: 'tool-result';
+                                toolCallId: string;
+                                toolName?: string | undefined;
+                                result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                              }
+                          )[]
+                        | undefined;
+                      createdAt?: (string | Date) | undefined;
+                    }
+                  | {
+                      id: string;
+                      role: 'system' | 'user' | 'assistant' | 'signal';
+                      createdAt: string | Date;
+                      threadId?: string | undefined;
+                      resourceId?: string | undefined;
+                      type?: string | undefined;
+                      content: {
+                        format: 2;
+                        parts: {
+                          type: string;
+                          [x: string]: unknown;
+                        }[];
+                        content?:
+                          | (
+                              | string
+                              | (
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'text';
+                                      text: string;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'image';
+                                      image:
+                                        | string
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          };
+                                      mediaType?: string | undefined;
+                                      mimeType?: string | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'file';
+                                      data?:
+                                        | (
+                                            | string
+                                            | {
+                                                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                              }
+                                          )
+                                        | undefined;
+                                      file?:
+                                        | (
+                                            | string
+                                            | {
+                                                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                              }
+                                          )
+                                        | undefined;
+                                      url?: string | undefined;
+                                      mediaType?: string | undefined;
+                                      mimeType?: string | undefined;
+                                      filename?: string | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'tool-call';
+                                      toolCallId: string;
+                                      toolName: string;
+                                      args?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                      input?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    }
+                                  | {
+                                      id?: string | undefined;
+                                      name?: string | undefined;
+                                      metadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      providerOptions?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      experimental_providerMetadata?:
+                                        | {
+                                            [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                                          }
+                                        | undefined;
+                                      type: 'tool-result';
+                                      toolCallId: string;
+                                      toolName?: string | undefined;
+                                      result?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                      output?: PostAgentsAgentIdSignals_Body_Auxiliary_2 | undefined;
+                                    }
+                                )[]
+                            )
+                          | undefined;
+                        experimental_attachments?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }[]
+                          | undefined;
+                        toolInvocations?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }[]
+                          | undefined;
+                        reasoning?: string | undefined;
+                        annotations?: PostAgentsAgentIdSignals_Body_Auxiliary_2[] | undefined;
+                        metadata?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }
+                          | undefined;
+                        providerMetadata?:
+                          | {
+                              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                            }
+                          | undefined;
+                        [x: string]: unknown;
+                      };
+                    }
+                )[];
+          }
+        | {
+            id?: string | undefined;
+            createdAt?: (string | Date) | undefined;
+            metadata?:
+              | {
+                  [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+                }
+              | undefined;
+            attributes?:
+              | {
+                  [key: string]: string | number | boolean | null | undefined;
+                }
+              | undefined;
+            type: string;
+            contents: string;
+          };
+      runId?: string | undefined;
+      resourceId: string;
+      threadId: string;
+      streamOptions?:
+        | {
+            instructions?: (string | string[] | any | any[]) | undefined;
+            system?: (string | string[] | any | any[]) | undefined;
+            context?: any[] | undefined;
+            memory?:
+              | {
+                  thread:
+                    | string
+                    | {
+                        id: string;
+                        [x: string]: unknown;
+                      };
+                  resource: string;
+                  options?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                  readOnly?: boolean | undefined;
+                }
+              | undefined;
+            runId?: string | undefined;
+            savePerStep?: boolean | undefined;
+            requestContext?:
               | {
                   [key: string]: any;
                 }
+              | undefined;
+            versions?:
               | {
-                  [key: string]: {
-                    scorer: string;
-                    sampling?: any | undefined;
-                  };
+                  agents?:
+                    | {
+                        [key: string]:
+                          | {
+                              versionId: string;
+                            }
+                          | {
+                              status: 'draft' | 'published';
+                            };
+                      }
+                    | undefined;
                 }
-            )
-          | undefined;
-        returnScorerData?: boolean | undefined;
-        tracingOptions?:
-          | {
-              metadata?:
-                | {
-                    [key: string]: unknown;
-                  }
-                | undefined;
-              requestContextKeys?: string[] | undefined;
-              traceId?: string | undefined;
-              parentSpanId?: string | undefined;
-              tags?: string[] | undefined;
-              hideInput?: boolean | undefined;
-              hideOutput?: boolean | undefined;
-            }
-          | undefined;
-        output?: any | undefined;
-        structuredOutput?:
-          | {
-              schema: {
-                [x: string]: unknown;
-              };
-              model?: (string | any) | undefined;
-              instructions?: string | undefined;
-              jsonPromptInjection?: boolean | undefined;
-              errorStrategy?: ('strict' | 'warn' | 'fallback') | undefined;
-              fallbackValue?: any | undefined;
-            }
-          | undefined;
-        [x: string]: unknown;
-      }
-    | undefined;
-};
+              | undefined;
+            maxSteps?: number | undefined;
+            stopWhen?: any | undefined;
+            providerOptions?:
+              | {
+                  anthropic?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                  google?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                  openai?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                  xai?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                }
+              | undefined;
+            modelSettings?: any | undefined;
+            activeTools?: string[] | undefined;
+            toolsets?:
+              | {
+                  [key: string]: any;
+                }
+              | undefined;
+            clientTools?:
+              | {
+                  [key: string]: any;
+                }
+              | undefined;
+            toolChoice?:
+              | (
+                  | ('auto' | 'none' | 'required')
+                  | {
+                      type: 'tool';
+                      toolName: string;
+                    }
+                )
+              | undefined;
+            requireToolApproval?: boolean | undefined;
+            scorers?:
+              | (
+                  | {
+                      [key: string]: any;
+                    }
+                  | {
+                      [key: string]: {
+                        scorer: string;
+                        sampling?: any | undefined;
+                      };
+                    }
+                )
+              | undefined;
+            returnScorerData?: boolean | undefined;
+            tracingOptions?:
+              | {
+                  metadata?:
+                    | {
+                        [key: string]: unknown;
+                      }
+                    | undefined;
+                  requestContextKeys?: string[] | undefined;
+                  traceId?: string | undefined;
+                  parentSpanId?: string | undefined;
+                  tags?: string[] | undefined;
+                  hideInput?: boolean | undefined;
+                  hideOutput?: boolean | undefined;
+                }
+              | undefined;
+            output?: any | undefined;
+            structuredOutput?:
+              | {
+                  schema: {
+                    [x: string]: unknown;
+                  };
+                  model?: (string | any) | undefined;
+                  instructions?: string | undefined;
+                  jsonPromptInjection?: boolean | undefined;
+                  errorStrategy?: ('strict' | 'warn' | 'fallback') | undefined;
+                  fallbackValue?: any | undefined;
+                }
+              | undefined;
+            [x: string]: unknown;
+          }
+        | undefined;
+    };
 
 export type PostAgentsAgentIdSignals_Response = {
   accepted: true;

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -110,13 +110,21 @@ export interface ClientOptions {
 
 export type AgentVersionIdentifier = { versionId: string } | { status: 'draft' | 'published' };
 
-export interface SendAgentSignalParams<OUTPUT = unknown> {
-  signal: AgentSignal;
-  runId?: string;
-  resourceId?: string;
-  threadId?: string;
-  streamOptions?: Omit<AgentExecutionOptions<OUTPUT>, 'messages'>;
-}
+export type SendAgentSignalParams<OUTPUT = unknown> =
+  | {
+      signal: AgentSignal;
+      runId: string;
+      resourceId?: string;
+      threadId?: string;
+      streamOptions?: never;
+    }
+  | {
+      signal: AgentSignal;
+      runId?: string;
+      resourceId: string;
+      threadId: string;
+      streamOptions?: Omit<AgentExecutionOptions<OUTPUT>, 'messages'>;
+    };
 
 export interface SubscribeAgentThreadParams {
   resourceId?: string;

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -18,7 +18,7 @@ You can use individual [`Processor`](/reference/processors/processor-interface) 
 
 Some processors implement both input and output logic and can be used in either array depending on where the transformation should occur.
 
-Some built-in processors also persist hidden system reminder messages using `<system-reminder>...</system-reminder>` text plus `metadata.systemReminder`. These reminders stay available in raw memory history and retry/prompt reconstruction paths, but standard UI-facing message conversions and default memory recall hide them unless you explicitly opt in.
+Some built-in processors also send hidden system reminder signals. These signals are persisted in raw memory history and converted to `<system-reminder>...</system-reminder>` context before the next model call, but standard UI-facing message conversions and default memory recall hide them unless you explicitly opt in.
 
 ## When to use processors
 

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -108,6 +108,143 @@ export const agent = new Agent({
 })
 ```
 
+## Thread signals
+
+Use Agent signals to send additional context into a memory thread. Signals are useful when a user adds follow-up context while an agent is already streaming, or when another process needs to add structured context to the thread.
+
+A `user-message` signal represents user input. When the target thread is running, Mastra queues the signal and drains it at a stream boundary so the agent can respond to the new input. When the thread is idle, `ifIdle.streamOptions` can start the next stream with the signal as the input.
+
+```typescript title="src/mastra/signals.ts"
+const subscription = await agent.subscribeToThread({
+  resourceId: 'user-123',
+  threadId: 'thread-abc',
+})
+
+void (async () => {
+  for await (const chunk of subscription.stream) {
+    console.log(chunk)
+  }
+})()
+
+await agent.sendSignal(
+  { type: 'user-message', contents: 'Use the latest customer note too.' },
+  {
+    resourceId: 'user-123',
+    threadId: 'thread-abc',
+    ifIdle: {
+      streamOptions: {
+        memory: {
+          resource: 'user-123',
+          thread: 'thread-abc',
+        },
+      },
+    },
+  },
+)
+```
+
+Use a custom signal type for contextual messages that should reach the model as XML-wrapped context instead of normal user input:
+
+```typescript
+await agent.sendSignal(
+  {
+    type: 'system-reminder',
+    contents: 'Continue from the previous tool result.',
+    attributes: { reminderType: 'tool-result' },
+  },
+  { resourceId: 'user-123', threadId: 'thread-abc' },
+)
+```
+
+### `sendSignal(signal, options)`
+
+Sends a signal to an active run or memory thread.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'signal',
+    type: "{ type: 'user-message'; contents: MessageListInput } | { type: string; contents: string }",
+    description:
+      '`user-message` signals are treated as user input. Other signal types are converted to XML context before the next model call.',
+  },
+  {
+    name: 'options.runId',
+    type: 'string',
+    isOptional: true,
+    description: 'Run ID to target directly. Use this when you already know the active run ID.',
+  },
+  {
+    name: 'options.resourceId',
+    type: 'string',
+    isOptional: true,
+    description: 'Resource ID for the memory thread. Required with `threadId` for thread-targeted signals.',
+  },
+  {
+    name: 'options.threadId',
+    type: 'string',
+    isOptional: true,
+    description: 'Thread ID to target. Required with `resourceId` for thread-targeted signals.',
+  },
+  {
+    name: 'options.ifIdle',
+    type: '{ streamOptions: AgentExecutionOptions }',
+    isOptional: true,
+    description:
+      'Starts a stream when the target thread is idle. Only available when `resourceId` and `threadId` are provided.',
+  },
+]}
+/>
+
+Returns `{ accepted: true, runId: string }`.
+
+### `subscribeToThread(options)`
+
+Subscribes to raw stream chunks for a memory thread. Use this before calling `sendSignal()` when you need to render stream output, observe signal echoes, or abort the active run.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'options.resourceId',
+    type: 'string',
+    isOptional: true,
+    description: 'Resource ID for the memory thread.',
+  },
+  {
+    name: 'options.threadId',
+    type: 'string',
+    description: 'Thread ID to subscribe to.',
+  },
+]}
+/>
+
+Returns an `AgentThreadSubscription` object with these members:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'stream',
+    type: 'AsyncIterable<AgentChunkType>',
+    description: 'Raw agent stream chunks for the subscribed thread.',
+  },
+  {
+    name: 'activeRunId',
+    type: '() => string | null',
+    description: 'Returns the active run ID for the thread, or `null` when no run is active.',
+  },
+  {
+    name: 'abort',
+    type: '() => boolean',
+    description: 'Aborts the active run for the thread. Returns `true` when a run was aborted.',
+  },
+  {
+    name: 'unsubscribe',
+    type: '() => void',
+    description: 'Stops the subscription without aborting the active run.',
+  },
+]}
+/>
+
 ## Constructor parameters
 
 <PropertiesTable

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -160,6 +160,115 @@ for await (const part of uiMessageStream) {
 }
 ```
 
+### `sendSignal()`
+
+Send a signal to an active agent run or memory thread. Use this with `subscribeToThread()` when a client needs to send follow-up context while a thread is already streaming.
+
+```typescript
+const agent = mastraClient.getAgent('support-agent')
+
+const result = await agent.sendSignal({
+  signal: {
+    type: 'user-message',
+    contents: 'Also consider the customer note I just added.',
+  },
+  resourceId: 'user-123',
+  threadId: 'thread-abc',
+})
+
+console.log(result.runId)
+```
+
+Pass `streamOptions` to start the thread when it is idle:
+
+```typescript
+await agent.sendSignal({
+  signal: { type: 'user-message', contents: 'Start from this follow-up.' },
+  resourceId: 'user-123',
+  threadId: 'thread-abc',
+  streamOptions: {
+    memory: {
+      resource: 'user-123',
+      thread: 'thread-abc',
+    },
+  },
+})
+```
+
+Returns `{ accepted: true, runId: string }`.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'signal',
+    type: "{ type: 'user-message'; contents: MessageListInput } | { type: string; contents: string }",
+    description:
+      '`user-message` signals are treated as user input. Other signal types are converted to contextual XML before the next model call.',
+  },
+  {
+    name: 'runId',
+    type: 'string',
+    isOptional: true,
+    description: 'Run ID to target directly.',
+  },
+  {
+    name: 'resourceId',
+    type: 'string',
+    isOptional: true,
+    description: 'Resource ID for the memory thread. Use with `threadId` for thread-targeted signals.',
+  },
+  {
+    name: 'threadId',
+    type: 'string',
+    isOptional: true,
+    description: 'Thread ID to target. Use with `resourceId` for thread-targeted signals.',
+  },
+  {
+    name: 'streamOptions',
+    type: "Omit<AgentExecutionOptions, 'messages'>",
+    isOptional: true,
+    description: 'Stream options used when the thread is idle and the signal starts a new run.',
+  },
+]}
+/>
+
+### `subscribeToThread()`
+
+Subscribe to raw stream chunks for a memory thread. Use this to render output from a thread that may be started or continued by `sendSignal()`.
+
+```typescript
+const agent = mastraClient.getAgent('support-agent')
+
+const subscription = await agent.subscribeToThread({
+  resourceId: 'user-123',
+  threadId: 'thread-abc',
+})
+
+await subscription.processDataStream({
+  onChunk: async chunk => {
+    console.log(chunk)
+  },
+})
+```
+
+`subscribeToThread()` returns the underlying `Response` plus a `processDataStream()` helper. The helper reads the subscription stream until the connection closes or the request is aborted.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'resourceId',
+    type: 'string',
+    isOptional: true,
+    description: 'Resource ID for the memory thread.',
+  },
+  {
+    name: 'threadId',
+    type: 'string',
+    description: 'Thread ID to subscribe to.',
+  },
+]}
+/>
+
 ### `streamUntilIdle()`
 
 Stream a response and keep the stream open until every [background task](/docs/agents/background-tasks) dispatched during the run completes. The server re-enters the agentic loop on each task completion so the LLM can react to results in the same call. Requires background tasks to be [enabled on the Mastra instance](/reference/configuration#backgroundtasks) and a memory thread; otherwise the call falls through to a plain `stream()`.

--- a/docs/src/content/en/reference/processors/prefill-error-handler.mdx
+++ b/docs/src/content/en/reference/processors/prefill-error-handler.mdx
@@ -9,7 +9,7 @@ packages:
 
 The `PrefillErrorHandler` is an **error processor** that handles assistant-response prefill errors. This error occurs when a conversation ends with an assistant message and the model rejects the request because it interprets it as prefilling the assistant response.
 
-When the error is detected, the processor appends a hidden `<system-reminder>continue</system-reminder>` user message to the conversation and signals a retry. The reminder is persisted with `metadata.systemReminder = { type: 'anthropic-prefill-processor-retry' }`, which keeps it available for retry reconstruction and raw history while standard UI-facing message conversions hide it.
+When the error is detected, the processor sends a hidden `system-reminder` signal with `continue` as its contents and signals a retry. The reminder is persisted as signal metadata, which keeps it available for retry reconstruction and raw history while standard UI-facing message conversions hide it.
 
 Add this processor to `errorProcessors` when you want Mastra to recover from assistant prefill rejections (for example Anthropic's "assistant message prefill" and Qwen/llama.cpp's "assistant response prefill is incompatible with `enable_thinking`" errors).
 
@@ -17,7 +17,7 @@ Add this processor to `errorProcessors` when you want Mastra to recover from ass
 
 1. The LLM API call fails with a known assistant-prefill rejection message
 1. `PrefillErrorHandler` checks that this is the first retry attempt
-1. It appends a hidden `<system-reminder>continue</system-reminder>` user message to the `messageList`
+1. It sends a hidden `system-reminder` signal with `continue` as its contents
 1. It returns `{ retry: true }` to signal the LLM call should be retried with the modified messages
 
 The processor now reacts to the API rejection itself instead of re-checking whether the conversation currently ends with an assistant message. This makes it resilient to cases where the provider rejects the request for prefill semantics even if the trailing message shape has already been transformed upstream.
@@ -83,7 +83,7 @@ The `PrefillErrorHandler` takes no constructor parameters.
     name: 'processAPIError',
     type: '(args: ProcessAPIErrorArgs) => ProcessAPIErrorResult | void',
     description:
-      'Handles known assistant-prefill errors by appending a hidden system reminder continue message and signaling retry. Only triggers on the first retry attempt.',
+      'Handles known assistant-prefill errors by sending a hidden system reminder signal and signaling retry. Only triggers on the first retry attempt.',
     isOptional: false,
   },
 ]}

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -38,12 +38,22 @@ type PreparedThreadRun = {
   cleanup: () => void;
 };
 
+type PendingIdleSignal<OUTPUT = unknown> = {
+  agent: Agent<any, any, any, any>;
+  signal: CreatedAgentSignal;
+  runId: string;
+  resourceId: string;
+  threadId: string;
+  streamOptions: AgentExecutionOptions<OUTPUT>;
+};
+
 export class AgentThreadStreamRuntime {
   #threadRunsById = new Map<string, AgentThreadRunRecord<any>>();
   #threadKeysByRunId = new Map<string, string>();
   #activeThreadRunIds = new Map<string, string>();
   #threadRunSubscribers = new Map<string, Set<(run: AgentThreadRunRecord<any>) => void>>();
   #pendingSignalsByThread = new Map<string, CreatedAgentSignal[]>();
+  #pendingIdleSignalsByThread = new Map<string, PendingIdleSignal<any>[]>();
   #watchedThreadRunIds = new Set<string>();
   #preparedRunsById = new Map<string, PreparedThreadRun>();
   #abortedRunIds = new Set<string>();
@@ -168,31 +178,60 @@ export class AgentThreadStreamRuntime {
     }
 
     const queue = this.#pendingSignalsByThread.get(key);
-    if (!queue) {
+    const signal = queue?.shift();
+    if (signal && queue) {
+      if (queue.length === 0) {
+        this.#pendingSignalsByThread.delete(key);
+      }
+
+      const output = await previousRun.agent.stream(signal, {
+        ...(previousRun.streamOptions as any),
+        runId: randomUUID(),
+        memory: withThreadMemory(
+          previousRun.streamOptions.memory,
+          previousRun.resourceId ?? '',
+          previousRun.threadId ?? '',
+        ),
+      });
+
+      if (queue.length > 0) {
+        const nextRecord = this.#threadRunsById.get(output.runId);
+        if (nextRecord) {
+          this.#watchThreadRunCompletion(key, nextRecord);
+        }
+      }
       return;
     }
-    const signal = queue.shift();
-    if (!signal) {
+
+    const idleQueue = this.#pendingIdleSignalsByThread.get(key);
+    const pendingIdle = idleQueue?.shift();
+    if (!pendingIdle || !idleQueue) {
       return;
     }
-    if (queue.length === 0) {
-      this.#pendingSignalsByThread.delete(key);
+    if (idleQueue.length === 0) {
+      this.#pendingIdleSignalsByThread.delete(key);
     }
 
-    const output = await previousRun.agent.stream(signal, {
-      ...(previousRun.streamOptions as any),
-      runId: randomUUID(),
-      memory: withThreadMemory(
-        previousRun.streamOptions.memory,
-        previousRun.resourceId ?? '',
-        previousRun.threadId ?? '',
-      ),
-    });
+    this.#activeThreadRunIds.set(key, pendingIdle.runId);
+    this.#threadKeysByRunId.set(pendingIdle.runId, key);
+    try {
+      const output = await pendingIdle.agent.stream(pendingIdle.signal, {
+        ...(pendingIdle.streamOptions as any),
+        runId: pendingIdle.runId,
+        memory: withThreadMemory(pendingIdle.streamOptions.memory, pendingIdle.resourceId, pendingIdle.threadId),
+      });
 
-    if (queue.length > 0) {
-      const nextRecord = this.#threadRunsById.get(output.runId);
-      if (nextRecord) {
-        this.#watchThreadRunCompletion(key, nextRecord);
+      if ((idleQueue?.length ?? 0) > 0) {
+        const nextRecord = this.#threadRunsById.get(output.runId);
+        if (nextRecord) {
+          this.#watchThreadRunCompletion(key, nextRecord);
+        }
+      }
+    } catch {
+      this.#threadKeysByRunId.delete(pendingIdle.runId);
+      this.#cleanupPreparedRun(pendingIdle.runId);
+      if (this.#activeThreadRunIds.get(key) === pendingIdle.runId) {
+        this.#activeThreadRunIds.delete(key);
       }
     }
   }
@@ -379,12 +418,22 @@ export class AgentThreadStreamRuntime {
 
     runId = randomUUID();
     key ??= this.#threadKey(resourceId, threadId);
-    if (!this.#activeThreadRunIds.has(key)) {
-      // No active same-agent run accepted the signal. Reserve the thread before starting
-      // the idle stream so concurrent callers do not launch duplicate runs.
-      this.#activeThreadRunIds.set(key, runId);
-      this.#threadKeysByRunId.set(runId, key);
+    if (this.#activeThreadRunIds.has(key)) {
+      // Another run owns the thread. Queue this idle-start request and let the watcher
+      // launch it only after the active run clears the thread reservation.
+      const idleQueue = this.#pendingIdleSignalsByThread.get(key) ?? [];
+      idleQueue.push({ agent, signal, runId, resourceId, threadId, streamOptions: target.ifIdle.streamOptions });
+      this.#pendingIdleSignalsByThread.set(key, idleQueue);
+      if (activeRecord) {
+        this.#watchThreadRunCompletion(key, activeRecord);
+      }
+      return { accepted: true, runId, signal };
     }
+
+    // No active same-agent run accepted the signal. Reserve the thread before starting
+    // the idle stream so concurrent callers do not launch duplicate runs.
+    this.#activeThreadRunIds.set(key, runId);
+    this.#threadKeysByRunId.set(runId, key);
     void agent
       .stream(signal, {
         ...(target.ifIdle.streamOptions as any),

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { MastraDBMessage } from '../agent/message-list';
+import { createSignal, mastraDBMessageToSignal } from '../agent/signals';
 import type { ProcessInputArgs, ProcessInputStepArgs } from '../processors';
 import { RequestContext } from '../request-context';
 import { BrowserContextProcessor } from './processor';
@@ -15,7 +16,7 @@ describe('BrowserContextProcessor', () => {
     messageList: {} as any,
     requestContext: new RequestContext(),
     state: {},
-    abort: vi.fn(),
+    abort: vi.fn() as any,
     retryCount: 0,
     ...overrides,
   });
@@ -36,20 +37,30 @@ describe('BrowserContextProcessor', () => {
   };
 
   // Helper to create minimal args for processInputStep
-  const createInputStepArgs = (overrides: Partial<ProcessInputStepArgs> = {}): ProcessInputStepArgs => ({
-    messages: [],
-    systemMessages: [],
-    messageList: createMockMessageList() as any,
-    requestContext: new RequestContext(),
-    stepNumber: 0,
-    steps: [],
-    state: {},
-    model: undefined as any,
-    retryCount: 0,
-    abort: vi.fn(),
-    rotateResponseMessageId: vi.fn(),
-    ...overrides,
-  });
+  const createInputStepArgs = (overrides: Partial<ProcessInputStepArgs> = {}): ProcessInputStepArgs => {
+    const messageList = overrides.messageList ?? (createMockMessageList() as any);
+    const rotateResponseMessageId = overrides.rotateResponseMessageId ?? vi.fn();
+    return {
+      messages: [],
+      systemMessages: [],
+      messageList,
+      requestContext: new RequestContext(),
+      stepNumber: 0,
+      steps: [],
+      state: {},
+      model: undefined as any,
+      retryCount: 0,
+      abort: vi.fn() as any,
+      rotateResponseMessageId,
+      sendSignal: async signalInput => {
+        const signal = createSignal(signalInput);
+        rotateResponseMessageId?.();
+        messageList.add(signal.toDBMessage(), 'input');
+        return signal;
+      },
+      ...overrides,
+    };
+  };
 
   describe('processInput', () => {
     it('should return messageList unchanged when no browser context', () => {
@@ -95,13 +106,13 @@ describe('BrowserContextProcessor', () => {
   });
 
   describe('processInputStep', () => {
-    it('should return undefined when no browser context', () => {
-      const result = processor.processInputStep(createInputStepArgs());
+    it('should return undefined when no browser context', async () => {
+      const result = await processor.processInputStep(createInputStepArgs());
 
       expect(result).toBeUndefined();
     });
 
-    it('should return undefined when stepNumber is not 0', () => {
+    it('should return undefined when stepNumber is not 0', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -109,12 +120,12 @@ describe('BrowserContextProcessor', () => {
       };
       requestContext.set('browser', browserCtx);
 
-      const result = processor.processInputStep(createInputStepArgs({ requestContext, stepNumber: 1 }));
+      const result = await processor.processInputStep(createInputStepArgs({ requestContext, stepNumber: 1 }));
 
       expect(result).toBeUndefined();
     });
 
-    it('should add a new user message with system-reminder containing URL and title', () => {
+    it('should add a new user message with system-reminder containing URL and title', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -126,7 +137,7 @@ describe('BrowserContextProcessor', () => {
       const mockMessageList = createMockMessageList();
       const rotateResponseMessageId = vi.fn();
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -138,24 +149,25 @@ describe('BrowserContextProcessor', () => {
       expect(mockMessageList.add).toHaveBeenCalledTimes(1);
 
       const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
-      expect(addedMessage.role).toBe('user');
-      expect(addedMessage.content.metadata).toEqual({
-        systemReminder: {
+      expect(addedMessage.role).toBe('signal');
+      expect(addedMessage.type).toBe('system-reminder');
+      expect(addedMessage.content.metadata).toEqual(
+        expect.objectContaining({
           type: 'browser-context',
           url: 'https://example.com/page',
           title: 'Example Page',
-        },
-      });
+          signal: expect.objectContaining({ type: 'system-reminder' }),
+        }),
+      );
 
       const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
-      expect(textPart.text).toContain('<system-reminder type="browser-context">');
       expect(textPart.text).toContain('https://example.com/page');
       expect(textPart.text).toContain('Example Page');
 
       expect(rotateResponseMessageId).toHaveBeenCalled();
     });
 
-    it('should add system-reminder when only page title is available', () => {
+    it('should add system-reminder when only page title is available', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -165,7 +177,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList();
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -176,12 +188,12 @@ describe('BrowserContextProcessor', () => {
       expect(mockMessageList.add).toHaveBeenCalledTimes(1);
 
       const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
+      expect(addedMessage.role).toBe('signal');
       const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
-      expect(textPart.text).toContain('<system-reminder type="browser-context">');
       expect(textPart.text).toContain('Example Page');
     });
 
-    it('should return undefined when no per-request data available', () => {
+    it('should return undefined when no per-request data available', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -189,12 +201,12 @@ describe('BrowserContextProcessor', () => {
       };
       requestContext.set('browser', browserCtx);
 
-      const result = processor.processInputStep(createInputStepArgs({ requestContext }));
+      const result = await processor.processInputStep(createInputStepArgs({ requestContext }));
 
       expect(result).toBeUndefined();
     });
 
-    it('should not add duplicate reminder if same content already exists', () => {
+    it('should not add duplicate reminder if same content already exists', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -228,7 +240,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList([existingReminder]);
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -239,7 +251,7 @@ describe('BrowserContextProcessor', () => {
       expect(mockMessageList.add).not.toHaveBeenCalled();
     });
 
-    it('should add new reminder if URL changed from previous reminder', () => {
+    it('should add new reminder if URL changed from previous reminder', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -273,7 +285,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList([existingReminder]);
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -289,7 +301,7 @@ describe('BrowserContextProcessor', () => {
       expect(textPart.text).toContain('New Page');
     });
 
-    it('should add reminder for A→B→A navigation (trailing reminder B differs from current A)', () => {
+    it('should add reminder for A→B→A navigation (trailing reminder B differs from current A)', async () => {
       const requestContext = new RequestContext();
       // Current state: back on page A
       const browserCtx: BrowserContext = {
@@ -327,7 +339,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList([reminderA, reminderB]);
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -343,7 +355,7 @@ describe('BrowserContextProcessor', () => {
       expect(textPart.text).toContain('page-a');
     });
 
-    it('should add reminder when trailing message is not a browser reminder (user → reminder → assistant → user)', () => {
+    it('should add reminder when trailing message is not a browser reminder (user → reminder → assistant → user)', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -386,7 +398,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList([reminderA, assistantResponse, userMessage]);
 
-      const result = processor.processInputStep(
+      const result = await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -398,7 +410,7 @@ describe('BrowserContextProcessor', () => {
       expect(mockMessageList.add).toHaveBeenCalledTimes(1);
     });
 
-    it('should escape XML special characters in URL and title', () => {
+    it('should escape XML special characters in URL and title', async () => {
       const requestContext = new RequestContext();
       const browserCtx: BrowserContext = {
         provider: 'agent-browser',
@@ -409,7 +421,7 @@ describe('BrowserContextProcessor', () => {
 
       const mockMessageList = createMockMessageList();
 
-      processor.processInputStep(
+      await processor.processInputStep(
         createInputStepArgs({
           requestContext,
           messageList: mockMessageList as any,
@@ -419,12 +431,18 @@ describe('BrowserContextProcessor', () => {
       const addedMessage = mockMessageList.add.mock.calls[0][0] as MastraDBMessage;
       const textPart = addedMessage.content.parts?.[0] as { type: 'text'; text: string };
 
-      // Should escape &, <, > in the markup text
-      expect(textPart.text).toContain('&amp;');
-      expect(textPart.text).toContain('&lt;');
-      expect(textPart.text).toContain('&gt;');
-      expect(textPart.text).not.toContain('q=foo&bar'); // Should be escaped
-      expect(textPart.text).not.toContain('<Results>'); // Should be escaped
+      // DB signal content stays raw; XML escaping happens when converting to LLM markup.
+      expect(textPart.text).toContain('q=foo&bar');
+      expect(textPart.text).toContain('<Results>');
+
+      const llmMessage = mastraDBMessageToSignal(addedMessage).toLLMMessage();
+      expect(llmMessage).toEqual([
+        {
+          role: 'system',
+          content:
+            '<system-reminder type="browser-context">Current URL: https://example.com/search?q=foo&amp;bar=1 | Page title: Search &lt;Results&gt; &amp; More</system-reminder>',
+        },
+      ]);
     });
   });
 });

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -19,8 +19,7 @@
  * ```
  */
 
-import type { MessageList, MastraDBMessage } from '../agent/message-list';
-import type { MastraMessageContentV2 } from '../agent/message-list/state/types';
+import type { MastraDBMessage } from '../agent/message-list';
 import type { ProcessInputArgs, ProcessInputResult, ProcessInputStepArgs } from '../processors/index';
 
 const REMINDER_TYPE = 'browser-context';
@@ -86,7 +85,7 @@ export class BrowserContextProcessor {
     return { messages: args.messages, systemMessages };
   }
 
-  processInputStep(args: ProcessInputStepArgs): MessageList | undefined {
+  async processInputStep(args: ProcessInputStepArgs) {
     // Only inject per-request context at the first step
     if (args.stepNumber !== 0) return;
 
@@ -96,17 +95,16 @@ export class BrowserContextProcessor {
     const parts: string[] = [];
 
     if (ctx.currentUrl) {
-      parts.push(`Current URL: ${escapeXml(ctx.currentUrl)}`);
+      parts.push(`Current URL: ${ctx.currentUrl}`);
     }
 
     if (ctx.pageTitle) {
-      parts.push(`Page title: ${escapeXml(ctx.pageTitle)}`);
+      parts.push(`Page title: ${ctx.pageTitle}`);
     }
 
     if (parts.length === 0) return;
 
     const reminderText = parts.join(' | ');
-    const reminderMarkup = `<system-reminder type="${REMINDER_TYPE}">${reminderText}</system-reminder>`;
 
     // Only suppress if the trailing message is already the same browser reminder
     const existingMessages = args.messageList.get.all.db();
@@ -114,10 +112,17 @@ export class BrowserContextProcessor {
       return;
     }
 
-    // Add as a new user message at the end of history to preserve prompt cache
-    const reminderMessage = createBrowserReminderMessage(reminderMarkup, ctx.currentUrl, ctx.pageTitle);
-    args.messageList.add(reminderMessage, 'user');
-    args.rotateResponseMessageId?.();
+    await args.sendSignal?.({
+      type: 'system-reminder',
+      contents: reminderText,
+      attributes: {
+        type: REMINDER_TYPE,
+      },
+      metadata: {
+        url: ctx.currentUrl,
+        title: ctx.pageTitle,
+      },
+    });
 
     return args.messageList;
   }
@@ -127,41 +132,6 @@ interface BrowserReminderMetadata {
   type: typeof REMINDER_TYPE;
   url?: string;
   title?: string;
-}
-
-function createBrowserReminderMessage(
-  reminderMarkup: string,
-  url: string | undefined,
-  title: string | undefined,
-): MastraDBMessage {
-  const reminderMeta: BrowserReminderMetadata = {
-    type: REMINDER_TYPE,
-    url,
-    title,
-  };
-
-  const content: MastraMessageContentV2 = {
-    format: 2,
-    parts: [{ type: 'text', text: reminderMarkup }],
-    metadata: {
-      systemReminder: reminderMeta,
-    },
-  };
-
-  return {
-    id: crypto.randomUUID(),
-    role: 'user',
-    content,
-    createdAt: new Date(),
-  };
-}
-
-/**
- * Escape XML special characters in browser-derived values.
- * Prevents URLs or page titles containing <, &, or </system-reminder> from breaking the markup.
- */
-function escapeXml(value: string): string {
-  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
 }
 
 /**
@@ -175,13 +145,16 @@ function hasTrailingBrowserReminder(
   title: string | undefined,
 ): boolean {
   const msg = messages[messages.length - 1];
-  if (!msg || msg.role !== 'user') return false;
+  if (!msg || (msg.role !== 'user' && msg.role !== 'signal')) return false;
 
   const metadata = msg.content.metadata;
-  if (typeof metadata !== 'object' || metadata === null || !('systemReminder' in metadata)) {
+  if (typeof metadata !== 'object' || metadata === null) {
     return false;
   }
 
-  const reminder = (metadata as { systemReminder?: BrowserReminderMetadata }).systemReminder;
+  const reminder =
+    'systemReminder' in metadata
+      ? (metadata as { systemReminder?: BrowserReminderMetadata }).systemReminder
+      : (metadata as unknown as BrowserReminderMetadata);
   return reminder?.type === REMINDER_TYPE && reminder.url === url && reminder.title === title;
 }

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -2,6 +2,7 @@ import type { LanguageModelV2, LanguageModelV2Prompt } from '@ai-sdk/provider-v5
 import type { CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
 import type { CallSettings, StepResult, ToolChoice } from '@internal/ai-sdk-v5';
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
+import type { AgentSignalInput, CreatedAgentSignal } from '../agent/signals';
 import type { TripWireOptions } from '../agent/trip-wire';
 import type { ModelRouterModelId } from '../llm/model';
 import type { MastraLanguageModel, OpenAICompatibleConfig, SharedProviderOptions } from '../llm/model/shared.types';
@@ -55,6 +56,11 @@ export interface ProcessorContext<TTripwireMetadata = unknown> extends Partial<O
   abort: (reason?: string, options?: TripWireOptions<TTripwireMetadata>) => never;
   /** Optional runtime context with execution metadata */
   requestContext?: RequestContext;
+  /**
+   * Add a signal to the message list, rotate the response message id when supported,
+   * and emit the signal as a data-* stream part when a writer is available.
+   */
+  sendSignal?: (signal: AgentSignalInput) => Promise<CreatedAgentSignal>;
   /**
    * Number of times processors have triggered retry for this generation.
    * Use this to implement retry limits within your processor.

--- a/packages/core/src/processors/prefill-error-handler.test.ts
+++ b/packages/core/src/processors/prefill-error-handler.test.ts
@@ -1,6 +1,7 @@
 import { APICallError } from '@internal/ai-sdk-v5';
 import { describe, expect, it } from 'vitest';
 import { MessageList } from '../agent/message-list';
+import { createSignal } from '../agent/signals';
 import { PrefillErrorHandler } from './prefill-error-handler';
 import type { ProcessAPIErrorArgs } from './index';
 
@@ -90,6 +91,11 @@ function makeArgs(overrides: Partial<ProcessAPIErrorArgs> = {}): ProcessAPIError
     abort: (() => {
       throw new Error('abort');
     }) as any,
+    sendSignal: async signalInput => {
+      const signal = createSignal(signalInput);
+      messageList.add(signal.toDBMessage(), 'input');
+      return signal;
+    },
     ...overrides,
   };
 }
@@ -115,18 +121,21 @@ describe('PrefillErrorHandler', () => {
     expect(messagesAfter.length).toBe(messageCountBefore + 1);
 
     const lastMessage = messagesAfter[messagesAfter.length - 1]!;
-    expect(lastMessage.role).toBe('user');
+    expect(lastMessage.role).toBe('signal');
+    expect(lastMessage.type).toBe('system-reminder');
     expect(lastMessage.content.parts).toEqual([
       expect.objectContaining({
         type: 'text',
-        text: '<system-reminder>continue</system-reminder>',
+        text: 'continue',
       }),
     ]);
-    expect(lastMessage.content.metadata).toEqual({
-      systemReminder: {
+    expect(lastMessage.content.metadata).toEqual(
+      expect.objectContaining({
         type: 'anthropic-prefill-processor-retry',
-      },
-    });
+        message: 'Continuing after prefill error',
+        signal: expect.objectContaining({ type: 'system-reminder' }),
+      }),
+    );
   });
 
   it('should return undefined for non-prefill errors', async () => {
@@ -164,7 +173,7 @@ describe('PrefillErrorHandler', () => {
 
     expect(result).toEqual({ retry: true });
     const lastMessage = args.messageList.get.all.db().at(-1);
-    expect(lastMessage?.role).toBe('user');
+    expect(lastMessage?.role).toBe('signal');
   });
 
   it('should return { retry: true } when qwen prefill string is only present in responseBody', async () => {

--- a/packages/core/src/processors/prefill-error-handler.ts
+++ b/packages/core/src/processors/prefill-error-handler.ts
@@ -1,17 +1,6 @@
-import { randomUUID } from 'node:crypto';
-
 import { APICallError } from '@internal/ai-sdk-v5';
 
-import type { DataChunkType } from '../stream/types';
 import type { Processor, ProcessAPIErrorArgs, ProcessAPIErrorResult } from './index';
-
-type SystemReminderChunk = DataChunkType & {
-  type: 'data-system-reminder';
-  data: {
-    message: string;
-    reminderType: string;
-  };
-};
 
 const PREFILL_ERROR_PATTERNS = [
   /does not support assistant message prefill/i,
@@ -66,56 +55,22 @@ export class PrefillErrorHandler implements Processor<'prefill-error-handler'> {
   readonly id = 'prefill-error-handler' as const;
   readonly name = 'Prefill Error Handler';
 
-  async processAPIError({
-    error,
-    messageList,
-    retryCount,
-    writer,
-    rotateResponseMessageId,
-  }: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
+  async processAPIError({ error, retryCount, sendSignal }: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
     // Only handle on first attempt — if it fails again after our fix, don't loop
     if (retryCount > 0) return;
 
     if (!isPrefillError(error)) return;
 
-    // Emit an ephemeral stream chunk so live UIs can show the retry is happening
-    if (writer) {
-      const chunk: SystemReminderChunk = {
-        type: 'data-system-reminder',
-        data: {
-          message: 'Continuing after prefill error',
-          reminderType: 'anthropic-prefill-processor-retry',
-        },
-        transient: true,
-      };
-      await writer.custom(chunk);
-    }
-
-    // Append a user message to break the trailing assistant pattern
-    messageList.add(
-      {
-        id: randomUUID(),
-        role: 'user' as const,
-        content: {
-          format: 2 as const,
-          parts: [
-            {
-              type: 'text' as const,
-              text: '<system-reminder>continue</system-reminder>',
-            },
-          ],
-          metadata: {
-            systemReminder: {
-              type: 'anthropic-prefill-processor-retry',
-            },
-          },
-        },
-        createdAt: new Date(),
+    await sendSignal?.({
+      type: 'system-reminder',
+      contents: 'continue',
+      attributes: {
+        type: 'anthropic-prefill-processor-retry',
       },
-      'input',
-    );
-
-    rotateResponseMessageId?.();
+      metadata: {
+        message: 'Continuing after prefill error',
+      },
+    });
 
     return { retry: true };
   }

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -2425,4 +2425,60 @@ describe('ProcessorRunner', () => {
       expect(mockLogger.error).toHaveBeenCalled();
     });
   });
+
+  describe('processor sendSignal', () => {
+    it('adds a signal message, rotates the response id, and writes a data part', async () => {
+      const rotateResponseMessageId = vi.fn(() => 'response-2');
+      const chunks: unknown[] = [];
+
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'signal-processor',
+            processInputStep: async ({ sendSignal }) => {
+              await sendSignal?.({
+                type: 'system-reminder',
+                contents: 'remember this',
+                metadata: { type: 'test-reminder' },
+              });
+            },
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await runner.runProcessInputStep({
+        messageList,
+        stepNumber: 0,
+        steps: [],
+        model: {} as any,
+        tools: {},
+        retryCount: 0,
+        messageId: 'response-1',
+        rotateResponseMessageId,
+        writer: {
+          custom: async chunk => {
+            chunks.push(chunk);
+          },
+        },
+      });
+
+      const signalMessage = messageList.get.all.db().at(-1);
+      expect(rotateResponseMessageId).toHaveBeenCalledTimes(1);
+      expect(signalMessage?.role).toBe('signal');
+      expect(signalMessage?.content.parts[0]).toEqual(expect.objectContaining({ type: 'text', text: 'remember this' }));
+      expect(chunks).toEqual([
+        expect.objectContaining({
+          type: 'data-system-reminder',
+          data: expect.objectContaining({
+            type: 'system-reminder',
+            contents: 'remember this',
+            metadata: { type: 'test-reminder' },
+          }),
+        }),
+      ]);
+    });
+  });
 });

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -2,6 +2,8 @@ import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import type { StepResult } from '@internal/ai-sdk-v5';
 import type { MastraDBMessage, MessageInput } from '../agent/message-list';
 import { MessageList, messagesAreEqual } from '../agent/message-list';
+import { createSignal } from '../agent/signals';
+import type { AgentSignalInput, CreatedAgentSignal } from '../agent/signals';
 import { TripWire } from '../agent/trip-wire';
 import type { TripWireOptions } from '../agent/trip-wire';
 import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../agent/utils';
@@ -155,6 +157,20 @@ function areProcessorMessageArraysEqual(before: unknown[] | undefined, after: un
     before.length === after.length &&
     before.every((message, index) => messagesAreEqual(message as MessageInput, after[index] as MessageInput))
   );
+}
+
+function createProcessorSendSignal(args: {
+  messageList: MessageList;
+  writer?: ProcessorStreamWriter;
+  rotateResponseMessageId?: () => string;
+}): (signalInput: AgentSignalInput) => Promise<CreatedAgentSignal> {
+  return async signalInput => {
+    const signal = createSignal(signalInput);
+    args.rotateResponseMessageId?.();
+    args.messageList.add(signal.toDBMessage(), 'input');
+    await args.writer?.custom(signal.toDataPart());
+    return signal;
+  };
 }
 
 function buildProcessInputStepSpanInput(args: {
@@ -482,6 +498,7 @@ export class ProcessorRunner {
           requestContext,
           retryCount,
           writer,
+          sendSignal: createProcessorSendSignal({ messageList, writer }),
         });
 
         // Stop recording and get mutations for this processor
@@ -876,6 +893,7 @@ export class ProcessorRunner {
           messageList,
           requestContext,
           retryCount,
+          sendSignal: createProcessorSendSignal({ messageList }),
         });
 
         // Handle MessageList, MastraDBMessage[], or { messages, systemMessages } return types
@@ -1165,24 +1183,25 @@ export class ProcessorRunner {
           activeTools: inputData.activeTools,
         };
 
+        const rotateResponseMessageId = args.rotateResponseMessageId
+          ? () => {
+              const nextMessageId = args.rotateResponseMessageId!();
+              stepInput.messageId = nextMessageId;
+              return nextMessageId;
+            }
+          : undefined;
+
         const processMethodArgs = {
           messageList,
           ...inputData,
           state: processorState.customState,
           abort,
-          ...(args.rotateResponseMessageId
-            ? {
-                rotateResponseMessageId: () => {
-                  const nextMessageId = args.rotateResponseMessageId!();
-                  stepInput.messageId = nextMessageId;
-                  return nextMessageId;
-                },
-              }
-            : {}),
+          ...(rotateResponseMessageId ? { rotateResponseMessageId } : {}),
           ...createObservabilityContext({ currentSpan: processorSpan }),
           retryCount: args.retryCount ?? 0,
           writer,
           abortSignal: args.abortSignal,
+          sendSignal: createProcessorSendSignal({ messageList, writer, rotateResponseMessageId }),
         };
 
         const result = await ProcessorRunner.validateAndFormatProcessInputStepResult(
@@ -1472,6 +1491,7 @@ export class ProcessorRunner {
           requestContext,
           retryCount,
           writer,
+          sendSignal: createProcessorSendSignal({ messageList, writer }),
         });
 
         // Stop recording and get mutations for this processor
@@ -1630,6 +1650,14 @@ export class ProcessorRunner {
       const processorState = this.getProcessorState(processor.id);
 
       try {
+        const rotateResponseMessageId = args.rotateResponseMessageId
+          ? () => {
+              const nextMessageId = args.rotateResponseMessageId!();
+              messageIdAfter = nextMessageId;
+              return nextMessageId;
+            }
+          : undefined;
+
         const result = await processMethod({
           messages: processableMessages,
           messageList,
@@ -1644,15 +1672,8 @@ export class ProcessorRunner {
           writer,
           abortSignal,
           messageId: args.messageId,
-          ...(args.rotateResponseMessageId
-            ? {
-                rotateResponseMessageId: () => {
-                  const nextMessageId = args.rotateResponseMessageId!();
-                  messageIdAfter = nextMessageId;
-                  return nextMessageId;
-                },
-              }
-            : {}),
+          ...(rotateResponseMessageId ? { rotateResponseMessageId } : {}),
+          sendSignal: createProcessorSendSignal({ messageList, writer, rotateResponseMessageId }),
         });
 
         // Stop recording and get mutations for this processor

--- a/packages/core/src/processors/tool-result-reminder.test.ts
+++ b/packages/core/src/processors/tool-result-reminder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
+import { createSignal } from '../agent/signals';
 import { MastraLanguageModelV3Mock } from '../loop/test-utils/MastraLanguageModelV3Mock';
 import type { RequestContext } from '../request-context';
 import { AgentsMDInjector } from './tool-result-reminder';
@@ -156,15 +157,29 @@ function createProcessInputStepArgs(
     retryCount: 0,
     model: new MastraLanguageModelV3Mock({}),
     writer,
+    sendSignal: async signalInput => {
+      const signal = createSignal(signalInput);
+      rotateResponseMessageId?.();
+      messageList.add(signal.toDBMessage(), 'input');
+      await writer?.custom(signal.toDataPart());
+      return signal;
+    },
   } as ProcessInputStepArgs;
 }
 
 function extractReminderMarkup(messageList: TestMessageList): string[] {
-  return messageList.get.all
-    .db()
-    .filter(message => message.role === 'user')
-    .map(message => getMessageText(message))
-    .filter(text => text.includes('<system-reminder'));
+  return messageList.get.all.db().flatMap(message => {
+    if (message.role === 'signal' && message.content.metadata?.type === 'dynamic-agents-md') {
+      const path = message.content.metadata.path;
+      return typeof path === 'string'
+        ? [`<system-reminder type="dynamic-agents-md" path="${path}">${getMessageText(message)}</system-reminder>`]
+        : [];
+    }
+
+    if (message.role !== 'user') return [];
+    const text = getMessageText(message);
+    return text.includes('<system-reminder') ? [text] : [];
+  });
 }
 
 function getMessageText(message: MastraDBMessage): string {
@@ -206,12 +221,14 @@ describe('AgentsMDInjector', () => {
       `<system-reminder type="dynamic-agents-md" path="/repo/src/agents/nested/AGENTS.md"># Nested AGENTS\n\nUse the nested instructions when replying.</system-reminder>`,
     ]);
     const injectedReminder = messageList.get.all.db().at(-1);
-    expect(injectedReminder?.content.metadata).toEqual({
-      systemReminder: {
+    expect(injectedReminder?.role).toBe('signal');
+    expect(injectedReminder?.content.metadata).toEqual(
+      expect.objectContaining({
         path: '/repo/src/agents/nested/AGENTS.md',
         type: 'dynamic-agents-md',
-      },
-    });
+        signal: expect.objectContaining({ type: 'system-reminder' }),
+      }),
+    );
   });
 
   it('injects reminder for tool calls array format', async () => {
@@ -247,15 +264,17 @@ describe('AgentsMDInjector', () => {
     );
 
     expect(chunks).toEqual([
-      {
+      expect.objectContaining({
         type: 'data-system-reminder',
-        data: {
-          message: 'Project guidance from CLAUDE',
-          reminderType: 'dynamic-agents-md',
-          path: '/repo/CLAUDE.md',
-        },
-        transient: true,
-      },
+        data: expect.objectContaining({
+          type: 'system-reminder',
+          contents: 'Project guidance from CLAUDE',
+          metadata: {
+            path: '/repo/CLAUDE.md',
+            type: 'dynamic-agents-md',
+          },
+        }),
+      }),
     ]);
     expect(extractReminderMarkup(messageList)).toEqual([
       `<system-reminder type="dynamic-agents-md" path="/repo/CLAUDE.md">Project guidance from CLAUDE</system-reminder>`,

--- a/packages/core/src/processors/tool-result-reminder.ts
+++ b/packages/core/src/processors/tool-result-reminder.ts
@@ -2,8 +2,7 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, normalize, resolve } from 'node:path';
 import { estimateTokenCount } from 'tokenx';
 import type { MessageList, MastraDBMessage } from '../agent/message-list';
-import type { MastraMessageContentV2 } from '../agent/message-list/state/types';
-import type { DataChunkType } from '../stream/types';
+import { signalToXmlMarkup } from '../agent/signals';
 import type { ProcessInputStepArgs, Processor, ToolCallInfo } from './index';
 
 const INSTRUCTION_FILE_NAMES = ['AGENTS.md', 'CLAUDE.md', 'CONTEXT.md'] as const;
@@ -19,16 +18,6 @@ type ReminderMetadataValue = {
 type ReminderMessageMetadata = {
   systemReminder?: ReminderMetadataValue;
   dynamicAgentsMdReminder?: ReminderMetadataValue;
-};
-
-type SystemReminderChunk = DataChunkType & {
-  type: 'data-system-reminder';
-  data: {
-    message: string;
-    reminderType: string;
-    path: string;
-  };
-  transient: true;
 };
 
 type TextPartLike = {
@@ -99,14 +88,6 @@ function findInstructionFileForPath(
   return undefined;
 }
 
-function escapeXml(value: string): string {
-  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-}
-
-function escapeXmlAttribute(value: string): string {
-  return escapeXml(value).replaceAll('"', '&quot;');
-}
-
 function getMessageText(message: MastraDBMessage): string {
   const parts = isRecord(message.content) ? message.content.parts : undefined;
   if (!Array.isArray(parts)) {
@@ -162,32 +143,19 @@ function extractReminderPathFromMetadata(message: MastraDBMessage): string | und
     ? metadata.systemReminder
     : isRecord(metadata[LEGACY_REMINDER_METADATA_KEY])
       ? metadata[LEGACY_REMINDER_METADATA_KEY]
-      : undefined;
-
-  if (!reminderMetadata) {
-    return undefined;
-  }
+      : isRecord(metadata.signal) && isRecord(metadata.signal.attributes)
+        ? metadata.signal.attributes
+        : metadata;
 
   return typeof reminderMetadata.path === 'string' ? reminderMetadata.path : undefined;
 }
 
-function createReminderMessage(reminderMarkup: string, instructionPath: string): MastraDBMessage {
-  const content: MastraMessageContentV2 = {
-    format: 2,
-    parts: [{ type: 'text', text: reminderMarkup }],
-    metadata: getReminderMetadata(instructionPath),
-  };
-
-  return {
-    id: crypto.randomUUID(),
-    role: 'user',
-    content,
-    createdAt: new Date(),
-  };
-}
-
 function getReminderMarkup(reminderText: string, instructionPath: string): string {
-  return `<system-reminder type="${REMINDER_TYPE}" path="${escapeXmlAttribute(instructionPath)}">${escapeXml(reminderText)}</system-reminder>`;
+  return signalToXmlMarkup({
+    type: 'system-reminder',
+    contents: reminderText,
+    attributes: { type: REMINDER_TYPE, path: instructionPath },
+  });
 }
 
 function truncateToTokenLimit(content: string, maxTokens: number): string {
@@ -292,7 +260,7 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
   }
 
   async processInputStep(args: ProcessInputStepArgs): Promise<MessageList | MastraDBMessage[]> {
-    const { messageList, rotateResponseMessageId } = args;
+    const { messageList } = args;
     const messages = messageList.get.all.db();
     const currentStepResponseMessages = getCurrentStepResponseMessages(messageList);
     const completedToolCalls = getCompletedToolCalls(currentStepResponseMessages);
@@ -312,21 +280,13 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
       return messageList;
     }
 
-    if (args.writer) {
-      const chunk: SystemReminderChunk = {
-        type: 'data-system-reminder',
-        data: {
-          message: reminderText,
-          reminderType: REMINDER_TYPE,
-          path: instructionPath,
-        },
-        transient: true,
-      };
-      await args.writer.custom(chunk);
-    }
+    await args.sendSignal?.({
+      type: 'system-reminder',
+      contents: reminderText,
+      attributes: { type: REMINDER_TYPE, path: instructionPath },
+      metadata: getReminderMetadata(instructionPath).systemReminder,
+    });
 
-    messageList.add(createReminderMessage(reminderMarkup, instructionPath), 'user');
-    rotateResponseMessageId?.();
     return messageList;
   }
 
@@ -393,7 +353,7 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
     const reminderPath = extractReminderPath(reminderMarkup);
 
     return messages.some(message => {
-      if (message.role !== 'user') {
+      if (message.role !== 'user' && message.role !== 'signal') {
         return false;
       }
 

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -661,13 +661,24 @@ export const observeAgentBodySchema = z.object({
   offset: z.number().optional().describe('Resume from this event index (0-based). If omitted, replays all events.'),
 });
 
-export const sendAgentSignalBodySchema = z.object({
+const sendAgentSignalBaseBodySchema = z.object({
   signal: agentSignalSchema,
-  runId: z.string().optional(),
-  resourceId: z.string().optional(),
-  threadId: z.string().optional(),
-  streamOptions: agentExecutionBodySchema.omit({ messages: true }).optional(),
 });
+
+export const sendAgentSignalBodySchema = z.union([
+  sendAgentSignalBaseBodySchema.extend({
+    runId: z.string(),
+    resourceId: z.string().optional(),
+    threadId: z.string().optional(),
+    streamOptions: z.undefined().optional(),
+  }),
+  sendAgentSignalBaseBodySchema.extend({
+    runId: z.string().optional(),
+    resourceId: z.string(),
+    threadId: z.string(),
+    streamOptions: agentExecutionBodySchema.omit({ messages: true }).optional(),
+  }),
+]);
 
 export const subscribeAgentThreadBodySchema = z.object({
   resourceId: z.string().optional(),


### PR DESCRIPTION
## Summary

Routes system reminders through Agent signals instead of injecting reminder markup directly in each processor.

Processors now send structured signal context:

```ts
sendSignal({
  type: 'system-reminder',
  contents: reminderText,
  attributes: { reminderType: 'tool-result' },
});
```

The signal layer handles the stream data part, persisted message, and LLM-facing XML context consistently. This keeps browser reminders, tool-result reminders, and prefill-error reminders on the same contextual thread-input path.

## Stack

Previous PR: #16229 — Core Agent signal runtime, server routes, and client-js API

This is PR 2 of the Agent signals stack:

1. #16229 — Core Agent signal runtime, server routes, and client-js API
2. #16230 — Route system reminders through Agent signals
3. #16231 — Use Agent signals for MastraCode follow-up chat
4. #16338 — Use Agent signals for Studio/playground follow-up chat

## What changed

- Replaced direct system-reminder message injection with structured signal emission.
- Preserved existing reminder semantics while routing persistence and stream echo behavior through the signal layer.
- Updated processor tests for reminder signal behavior.

## Test plan

- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core exec vitest run src/agent/__tests__/agent-signals.test.ts --bail 1 --reporter=dot`
