### PR TITLE
fix(core): pass writer to durable output processors

### DIFF
--- a/.changeset/kind-donkeys-sell.md
+++ b/.changeset/kind-donkeys-sell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed DurableAgent output processors so custom chunks stream and processed final text is used.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
@@ -10,6 +10,7 @@ import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { z } from 'zod';
 import { EventEmitterPubSub } from '../../../events/event-emitter';
+import type { OutputProcessor } from '../../../processors';
 import { createTool } from '../../../tools';
 import { Agent } from '../../agent';
 import { AGENT_STREAM_TOPIC, AgentStreamEventTypes } from '../constants';
@@ -228,6 +229,55 @@ describe('DurableAgent streaming execution', () => {
       // Cleanup should remove from registry
       cleanup();
       expect(durableAgent.runRegistry.has(runId)).toBe(false);
+    });
+
+    it('should stream custom chunks emitted by output processors before finish', async () => {
+      let writerWasProvided = false;
+      const outputProcessor: OutputProcessor = {
+        id: 'durable-output-writer',
+        name: 'Durable Output Writer',
+        processOutputResult: async ({ messages, writer }) => {
+          writerWasProvided = !!writer;
+          const lastAssistantMessage = [...messages].reverse().find(message => message.role === 'assistant');
+          const textPart = lastAssistantMessage?.content.parts.find(part => part.type === 'text');
+
+          if (textPart && 'text' in textPart) {
+            textPart.text = 'processed response';
+          }
+
+          await writer?.custom({
+            type: 'data-durable-output',
+            data: { status: 'processed' },
+          });
+
+          return messages;
+        },
+      };
+
+      const baseAgent = new Agent({
+        id: 'output-writer-agent',
+        name: 'Output Writer Agent',
+        instructions: 'Test durable output writer',
+        model: createTextStreamModel('draft response') as LanguageModelV2,
+        outputProcessors: [outputProcessor],
+      });
+
+      const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+      const { output, cleanup } = await durableAgent.stream('Test');
+      const chunks: any[] = [];
+
+      for await (const chunk of output.fullStream) {
+        chunks.push(chunk);
+      }
+
+      cleanup();
+
+      const finishChunk = chunks.find(chunk => chunk.type === 'finish');
+
+      expect(writerWasProvided).toBe(true);
+      expect(chunks.some(chunk => chunk.type === 'data-durable-output')).toBe(true);
+      expect(finishChunk?.payload.output.text).toBe('processed response');
+      await expect(output.text).resolves.toBe('processed response');
     });
   });
 

--- a/packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
@@ -272,12 +272,24 @@ describe('DurableAgent streaming execution', () => {
 
       cleanup();
 
+      const dataIndex = chunks.findIndex(chunk => chunk.type === 'data-durable-output');
+      const finishIndex = chunks.findIndex(chunk => chunk.type === 'finish');
+      const dataChunk = chunks[dataIndex];
       const finishChunk = chunks.find(chunk => chunk.type === 'finish');
 
       expect(writerWasProvided).toBe(true);
-      expect(chunks.some(chunk => chunk.type === 'data-durable-output')).toBe(true);
+      expect(dataChunk).toBeDefined();
+      expect(finishChunk).toBeDefined();
+      expect(dataIndex).toBeLessThan(finishIndex);
       expect(finishChunk?.payload.output.text).toBe('processed response');
       await expect(output.text).resolves.toBe('processed response');
+
+      const steps = await output.steps;
+      const fullOutput = await output.getFullOutput();
+
+      expect(steps.at(-1)?.text).toBe('processed response');
+      expect(fullOutput.text).toBe('processed response');
+      expect(fullOutput.steps.at(-1)?.text).toBe('processed response');
     });
   });
 

--- a/packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
@@ -279,6 +279,7 @@ describe('DurableAgent streaming execution', () => {
 
       expect(writerWasProvided).toBe(true);
       expect(dataChunk).toBeDefined();
+      expect(dataChunk.data).toEqual({ status: 'processed' });
       expect(finishChunk).toBeDefined();
       expect(dataIndex).toBeLessThan(finishIndex);
       expect(finishChunk?.payload.output.text).toBe('processed response');

--- a/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
+++ b/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
@@ -272,7 +272,7 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
                 : undefined;
               const processedMessageList = await runner.runOutputProcessors(
                 outputMessageList,
-                {} as any,
+                createObservabilityContext((params as any).tracingContext),
                 requestContext ?? new RequestContext(),
                 0,
                 outputProcessorWriter,
@@ -293,7 +293,7 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
                 .map(part => part.text)
                 .join('');
 
-              if (processedText) {
+              if (processedText !== undefined) {
                 finalText = processedText;
               }
             } catch (error) {

--- a/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
+++ b/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
@@ -10,7 +10,7 @@ import { PUBSUB_SYMBOL } from '../../../workflows/constants';
 import { MessageList } from '../../message-list';
 import { DurableStepIds, DurableAgentDefaults } from '../constants';
 import { globalRunRegistry } from '../run-registry';
-import { emitFinishEvent } from '../stream-adapter';
+import { emitChunkEvent, emitFinishEvent } from '../stream-adapter';
 import type {
   DurableToolCallInput,
   DurableAgenticWorkflowInput,
@@ -246,7 +246,7 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
 
           // Extract final text from last step
           const lastStep = state.accumulatedSteps[state.accumulatedSteps.length - 1];
-          const finalText = lastStep?.text;
+          let finalText = lastStep?.text;
 
           // Run output processors (processOutputResult) if available
           const registryEntry = globalRunRegistry.get(state.runId);
@@ -263,7 +263,39 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
               });
               const outputMessageList = new MessageList();
               outputMessageList.deserialize(state.messageListState);
-              await runner.runOutputProcessors(outputMessageList, {} as any, requestContext ?? new RequestContext(), 0);
+              const outputProcessorWriter = pubsub
+                ? {
+                    custom: async (data: { type: string }) => {
+                      await emitChunkEvent(pubsub, state.runId, data as any);
+                    },
+                  }
+                : undefined;
+              const processedMessageList = await runner.runOutputProcessors(
+                outputMessageList,
+                {} as any,
+                requestContext ?? new RequestContext(),
+                0,
+                outputProcessorWriter,
+                {
+                  text: finalText ?? '',
+                  usage: state.accumulatedUsage,
+                  finishReason: state.lastStepResult?.reason ?? 'unknown',
+                  steps: state.accumulatedSteps,
+                },
+              );
+              state.messageListState = processedMessageList.serialize();
+
+              const lastAssistantMessage = [...processedMessageList.get.response.db()]
+                .reverse()
+                .find(message => message.role === 'assistant');
+              const processedText = lastAssistantMessage?.content.parts
+                .filter(part => part.type === 'text')
+                .map(part => part.text)
+                .join('');
+
+              if (processedText) {
+                finalText = processedText;
+              }
             } catch (error) {
               logger?.warn?.(`[DurableAgent] Error running output processors: ${error}`);
             }

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -882,9 +882,21 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   // Cast needed because chunk.payload.response is typed with default OUTPUT=undefined
                   (chunk.payload as { response?: LLMStepResult<OUTPUT>['response'] }).response = response;
                 } else if (!self.#options.isLLMExecutionStep) {
-                  // No processor runner, not in LLM execution step - resolve with buffered text
+                  const finishOutput = chunk.payload.output as { steps?: LLMStepResult<OUTPUT>[]; text?: string };
+                  const finalText = finishOutput.text ?? self.#bufferedText.join('');
+                  if (finishOutput.steps?.length) {
+                    self.#bufferedSteps = finishOutput.steps;
+                  }
+                  const lastStep = self.#bufferedSteps[self.#bufferedSteps.length - 1];
+
+                  self.#bufferedText = [finalText];
+                  if (lastStep) {
+                    lastStep.text = finalText;
+                  }
+
+                  // No processor runner, not in LLM execution step - resolve with durable finish text when available
                   this.resolvePromises({
-                    text: (chunk.payload.output as { text?: string }).text ?? self.#bufferedText.join(''),
+                    text: finalText,
                     finishReason: self.#finishReason,
                   });
                 }

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -883,11 +883,11 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   (chunk.payload as { response?: LLMStepResult<OUTPUT>['response'] }).response = response;
                 } else if (!self.#options.isLLMExecutionStep) {
                   const finishOutput = chunk.payload.output as { steps?: LLMStepResult<OUTPUT>[]; text?: string };
-                  const finalText = finishOutput.text ?? self.#bufferedText.join('');
                   if (finishOutput.steps?.length) {
                     self.#bufferedSteps = finishOutput.steps;
                   }
                   const lastStep = self.#bufferedSteps[self.#bufferedSteps.length - 1];
+                  const finalText = finishOutput.text ?? lastStep?.text ?? self.#bufferedText.join('');
 
                   self.#bufferedText = [finalText];
                   if (lastStep) {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -884,7 +884,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 } else if (!self.#options.isLLMExecutionStep) {
                   // No processor runner, not in LLM execution step - resolve with buffered text
                   this.resolvePromises({
-                    text: self.#bufferedText.join(''),
+                    text: (chunk.payload.output as { text?: string }).text ?? self.#bufferedText.join(''),
                     finishReason: self.#finishReason,
                   });
                 }


### PR DESCRIPTION
## Description

Fixes DurableAgent output processors so they can write custom stream chunks and update the final response text correctly.
Durable input processors already received a stream writer, but output processors did not. This meant `writer.custom(...)` calls from `processOutputResult` never reached the client stream.


## Related Issue(s)

Fixes #16221 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Durable agents couldn't send small custom streamed messages or the final processed assistant text from output processors to clients; this change gives output processors a stream writer and wires their emitted chunks back into the durable agent stream so those custom chunks and the final processed message reach the client.

## Changes Overview

Fixes issue #16221 by passing a stream writer into DurableAgent output processors and re-emitting processor-emitted chunks into the durable PubSub stream so OM-related chunks, processor custom chunks, and the final assistant message are delivered through the client stream while preserving resumable stream semantics. Marked as a breaking change.

### Key Changes

- packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
  - Import emitChunkEvent and emitFinishEvent.
  - Make finalText mutable and update it from processed output when processors modify the last assistant message.
  - Dynamically import and run ProcessorRunner at workflow finish, constructing a MessageList from persisted state.
  - Provide an outputProcessorWriter that forwards processor.custom(...) events to PubSub via emitChunkEvent.
  - Serialize updated MessageList back to state and derive processed final text; on processor failure, log a warning and continue.
  - Ensure finish events use the possibly updated final output.

- packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
  - Add OutputProcessor import and a new integration test verifying an OutputProcessor receives a writer, can emit a data-durable-output event before finish, mutate the last assistant text to "processed response", and that the durable stream's finish payload and output (text/fullOutput/steps) reflect the processed text. Confirms event ordering (processor chunk before finish).

- packages/core/src/stream/base/output.ts
  - In the non-processor / non-LLM-execution finish path, prefer chunk.payload.output.text (when present) to resolve final text; reconcile buffered steps/text with that final text and update last step text and buffered text accordingly.

- .changeset/kind-donkeys-sell.md
  - Add changeset (patch) noting the fix and marking the change as breaking.

## Tests & Docs

- Tests: Added an integration test covering output-processor streaming and final-text processing.
- Changeset/Docs: Changeset added; docs/notes updated to reflect the breaking change.

## Impact

Restores expected streaming behavior for DurableAgent-based routes: output processors can emit custom stream chunks to clients and update the final assistant message that is streamed to clients (fixes the resumable-stream regressions). This is a breaking change in output processing/stream emission semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->