### PR TITLE
perf(duckdb): batch observability schema init

### DIFF
--- a/.changeset/beige-flies-kick.md
+++ b/.changeset/beige-flies-kick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/duckdb': patch
+---
+
+Improved DuckDB observability initialization by batching schema setup statements on one connection while preserving migration order.

--- a/stores/duckdb/src/storage/db/index.test.ts
+++ b/stores/duckdb/src/storage/db/index.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DuckDBConnection } from './index';
+
+describe('DuckDBConnection', () => {
+  describe('executeBatch', () => {
+    it('executes multiple statements with one DuckDB connection', async () => {
+      const db = new DuckDBConnection({ path: ':memory:' });
+      const getConnectionSpy = vi.spyOn(db, 'getConnection');
+
+      try {
+        await db.executeBatch([
+          'CREATE TABLE batch_a (id INTEGER)',
+          'CREATE TABLE batch_b (id INTEGER)',
+          'INSERT INTO batch_a VALUES (1)',
+          'INSERT INTO batch_b VALUES (2)',
+        ]);
+
+        expect(getConnectionSpy).toHaveBeenCalledTimes(1);
+
+        const rows = await db.query<{ total: number }>(`
+          SELECT
+            (SELECT COUNT(*) FROM batch_a) + (SELECT COUNT(*) FROM batch_b) AS total
+        `);
+
+        expect(rows).toEqual([{ total: 2 }]);
+      } finally {
+        await db.close();
+      }
+    });
+
+    it('handles statements ending in line comments', async () => {
+      const db = new DuckDBConnection({ path: ':memory:' });
+
+      try {
+        await db.executeBatch([
+          `
+            CREATE TABLE batch_comment_a (
+              id INTEGER
+            )
+            -- no trailing semicolon
+          `,
+          'CREATE TABLE batch_comment_b (id INTEGER)',
+        ]);
+
+        const rows = await db.query<{ table_name: string }>(`
+          SELECT table_name
+          FROM information_schema.tables
+          WHERE table_name IN ('batch_comment_a', 'batch_comment_b')
+          ORDER BY table_name
+        `);
+
+        expect(rows).toEqual([{ table_name: 'batch_comment_a' }, { table_name: 'batch_comment_b' }]);
+      } finally {
+        await db.close();
+      }
+    });
+
+    it('handles statements with trailing semicolons and string literal semicolons', async () => {
+      const db = new DuckDBConnection({ path: ':memory:' });
+
+      try {
+        await db.executeBatch([
+          'CREATE TABLE batch_semicolon_text (value TEXT);',
+          "INSERT INTO batch_semicolon_text VALUES ('a;b;c');",
+        ]);
+
+        const rows = await db.query<{ value: string }>('SELECT value FROM batch_semicolon_text');
+
+        expect(rows).toEqual([{ value: 'a;b;c' }]);
+      } finally {
+        await db.close();
+      }
+    });
+
+    it('closes the DuckDB connection when a batch statement fails', async () => {
+      const db = new DuckDBConnection({ path: ':memory:' });
+      const closeConnectionSpy = vi.spyOn(
+        db as unknown as { closeConnection(connection: unknown): void },
+        'closeConnection',
+      );
+
+      try {
+        await expect(
+          db.executeBatch([
+            'CREATE TABLE batch_failure_a (id INTEGER)',
+            'SELECT * FROM missing_batch_table',
+            'CREATE TABLE batch_failure_b (id INTEGER)',
+          ]),
+        ).rejects.toThrow(/missing_batch_table/);
+
+        expect(closeConnectionSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        await db.close();
+      }
+    });
+
+    it('skips empty batches without opening a DuckDB connection', async () => {
+      const db = new DuckDBConnection({ path: ':memory:' });
+      const getConnectionSpy = vi.spyOn(db, 'getConnection');
+
+      try {
+        await db.executeBatch(['', '   ']);
+
+        expect(getConnectionSpy).not.toHaveBeenCalled();
+      } finally {
+        await db.close();
+      }
+    });
+  });
+});

--- a/stores/duckdb/src/storage/db/index.ts
+++ b/stores/duckdb/src/storage/db/index.ts
@@ -195,6 +195,29 @@ export class DuckDBConnection extends MastraBase {
   }
 
   /**
+   * Execute multiple SQL statements in order using a single DuckDB connection.
+   *
+   * This is intended for schema setup/migrations where statements have no
+   * parameters and must remain ordered, but opening a connection per statement
+   * would dominate initialization cost. Blank statements are skipped. Like
+   * calling execute() repeatedly, this does not wrap statements in a transaction,
+   * so prior statements can remain applied if a later statement fails.
+   */
+  async executeBatch(sqlStatements: readonly string[]): Promise<void> {
+    const statements = sqlStatements.map(statement => statement.trim()).filter(Boolean);
+    if (statements.length === 0) return;
+
+    const connection = await this.getConnection();
+    try {
+      const sql =
+        statements.map((statement, i) => `-- executeBatch statement ${i + 1}\n${statement}`).join('\n;\n') + '\n;';
+      await connection.run(sql);
+    } finally {
+      this.closeConnection(connection);
+    }
+  }
+
+  /**
    * Escape a value for safe inline SQL use.
    * DuckDB prepared statements can't handle NULL for parameters typed as ANY,
    * so for complex INSERT/UPDATE operations we inline values safely.

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -1,7 +1,10 @@
 import { EntityType, SpanType } from '@mastra/core/observability';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DuckDBConnection } from '../../db/index';
 import { DuckDBStore } from '../../index';
+import { ALL_DDL, ALL_MIGRATIONS } from './ddl';
 import type { ObservabilityStorageDuckDB } from './index';
+import { ObservabilityStorageDuckDB as ConcreteObservabilityStorageDuckDB } from './index';
 
 async function setupLegacyStore(): Promise<DuckDBStore> {
   const legacyStore = new DuckDBStore({ path: ':memory:' });
@@ -71,6 +74,22 @@ describe('ObservabilityStorageDuckDB', () => {
       preferred: 'event-sourced',
       supported: ['event-sourced'],
     });
+  });
+
+  it('batches schema DDL and migrations during initialization', async () => {
+    const db = {
+      // Empty migration-status query results mean no legacy signal tables need migrating.
+      query: vi.fn().mockResolvedValue([]),
+      execute: vi.fn(),
+      executeBatch: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DuckDBConnection;
+    const storage = new ConcreteObservabilityStorageDuckDB({ db });
+
+    await storage.init();
+
+    expect(db.executeBatch).toHaveBeenCalledTimes(1);
+    expect(db.executeBatch).toHaveBeenCalledWith([...ALL_DDL, ...ALL_MIGRATIONS]);
+    expect(db.execute).not.toHaveBeenCalled();
   });
 
   // ==========================================================================

--- a/stores/duckdb/src/storage/domains/observability/index.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.ts
@@ -145,13 +145,7 @@ export class ObservabilityStorageDuckDB extends ObservabilityStorage {
       });
     }
 
-    for (const ddl of ALL_DDL) {
-      await this.db.execute(ddl);
-    }
-
-    for (const migration of ALL_MIGRATIONS) {
-      await this.db.execute(migration);
-    }
+    await this.db.executeBatch([...ALL_DDL, ...ALL_MIGRATIONS]);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add `DuckDBConnection.executeBatch()` for ordered no-parameter schema setup statements on one DuckDB connection.
- Use it from DuckDB observability `init()` for `ALL_DDL` followed by `ALL_MIGRATIONS`, preserving existing order and non-transactional behavior.
- Add focused coverage for batching, line comments, trailing/embedded semicolons, failure cleanup, empty batches, and observability init wiring.

Fixes #16238

## Why this shape
The reported performance issue is real, but `Promise.all()` is not the right fix for schema setup. Observability DDL and migrations should remain deterministic and ordered; batching through one connection removes repeated connection/run/close overhead without parallelizing schema mutations.

## Measurement
Local in-memory benchmark comparing old sequential init against the batched path showed roughly 1.3x faster observability initialization for this schema setup path.

## Validation
- `pnpm --filter ./stores/duckdb test src/storage/db/index.test.ts src/storage/domains/observability/index.test.ts`
- `pnpm --filter ./stores/duckdb typecheck`
- `pnpm --filter ./stores/duckdb lint`
- `pnpm --filter ./stores/duckdb build:lib`
- `git diff --check HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Instead of opening and closing a database connection many times to run SQL setup statements (like opening a door, saying something, and closing it each time), this PR lets you run all of them at once through a single open door, which is much faster and simpler.

## Overview

This PR optimizes DuckDB observability initialization by introducing a batch execution helper method that runs multiple SQL statements through a single connection, eliminating repeated connection overhead. The change maintains deterministic ordering and non-transactional semantics while improving performance.

## Changes

### New Features
- **DuckDBConnection.executeBatch()**: A new public method that executes multiple SQL statements in a single, non-transactional batch. The method:
  - Accepts a readonly array of SQL statements
  - Trims and filters empty statements
  - Prefixes each statement with a comment header
  - Concatenates all statements with semicolon separators
  - Executes via a single connection.run() call
  - Ensures connection cleanup in a finally block

### Modified Behaviors
- **ObservabilityStorageDuckDB.init()**: Refactored to use `executeBatch([...ALL_DDL, ...ALL_MIGRATIONS])` instead of sequentially looping over DDL and migrations with individual execute() calls. This reduces the number of connection open/close cycles while preserving ordering and migration dependencies.

### Testing
- **DuckDBConnection.executeBatch() tests**: Comprehensive test coverage including:
  - Successful multi-statement batch execution
  - Line-comment handling within statements
  - Trailing and embedded semicolon handling
  - Proper connection closure on failures with cleanup
  - Empty batch entry skipping without connection overhead
  
- **ObservabilityDuckDB initialization test**: Validates that observability init batches all DDL and migrations via executeBatch with no direct execute() calls

### Documentation
- Added changeset entry for @mastra/duckdb patch describing the observability initialization optimization

## Impact
- Performance improvement (~1.3× faster observability initialization in local benchmarking for the schema setup path)
- Simplified connection lifecycle management during schema initialization
- No changes to observability behavior or public APIs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->