### PR TITLE
fix(evals): allow TRAJECTORY and STEP entityType in score schema

### DIFF
--- a/.changeset/light-forks-joke.md
+++ b/.changeset/light-forks-joke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `runEvals` failing to persist trajectory and step scorer results. The internal score validation schema rejected the `entityType` values `TRAJECTORY` and `STEP` that the runner emits, so scores were computed but silently dropped before reaching storage. Trajectory and step scorer results now persist correctly and appear in Studio's observability section.

--- a/.changeset/light-forks-joke.md
+++ b/.changeset/light-forks-joke.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed `runEvals` failing to persist trajectory and step scorer results. The internal score validation schema rejected the `entityType` values `TRAJECTORY` and `STEP` that the runner emits, so scores were computed but silently dropped before reaching storage. Trajectory and step scorer results now persist correctly and appear in Studio's observability section.
+Fixed an issue where trajectory and step scorer results from `runEvals` were not saved to storage. These scores now persist correctly and appear alongside agent and workflow scores in Studio's observability section.

--- a/packages/core/src/evals/types.test.ts
+++ b/packages/core/src/evals/types.test.ts
@@ -770,6 +770,10 @@ describe('saveScorePayloadSchema', () => {
     expect(() => saveScorePayloadSchema.parse(buildPayload(entityType))).not.toThrow();
   });
 
+  it('accepts SpanType values forwarded from observability', () => {
+    expect(() => saveScorePayloadSchema.parse(buildPayload(SpanType.AGENT_RUN))).not.toThrow();
+  });
+
   it('rejects entityType values outside the allowed set', () => {
     expect(() => saveScorePayloadSchema.parse(buildPayload('NOT_A_REAL_TYPE'))).toThrow();
   });

--- a/packages/core/src/evals/types.test.ts
+++ b/packages/core/src/evals/types.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { SpanType } from '../observability';
 import type { SpanRecord } from '../storage';
-import { extractTrajectoryFromTrace } from './types';
+import { extractTrajectoryFromTrace, saveScorePayloadSchema } from './types';
 
 function createSpan(overrides: Partial<SpanRecord> & { spanId: string; spanType: SpanRecord['spanType'] }): SpanRecord {
   return {
@@ -750,5 +750,27 @@ describe('extractTrajectoryFromTrace', () => {
       expect(step.toolResult).toEqual({ results: [] });
       expect(step.success).toBe(true);
     }
+  });
+});
+
+describe('saveScorePayloadSchema', () => {
+  const buildPayload = (entityType: string) => ({
+    scorerId: 'test-scorer',
+    entityId: 'test-entity',
+    runId: 'run-1',
+    output: { result: 'ok' },
+    score: 0.85,
+    scorer: { id: 'test-scorer', name: 'test-scorer' },
+    source: 'TEST' as const,
+    entity: { id: 'test-entity' },
+    entityType,
+  });
+
+  it.each(['AGENT', 'WORKFLOW', 'TRAJECTORY', 'STEP'])('accepts entityType %s emitted by runEvals', entityType => {
+    expect(() => saveScorePayloadSchema.parse(buildPayload(entityType))).not.toThrow();
+  });
+
+  it('rejects entityType values outside the allowed set', () => {
+    expect(() => saveScorePayloadSchema.parse(buildPayload('NOT_A_REAL_TYPE'))).toThrow();
   });
 });

--- a/packages/core/src/evals/types.ts
+++ b/packages/core/src/evals/types.ts
@@ -21,11 +21,13 @@ export const scoringSourceSchema = z.enum(['LIVE', 'TEST']);
 
 export type ScoringSource = z.infer<typeof scoringSourceSchema>;
 
-export const scoringEntityTypeSchema = z.enum(['AGENT', 'WORKFLOW', ...Object.values(SpanType)] as [
-  string,
-  string,
-  ...string[],
-]);
+export const scoringEntityTypeSchema = z.enum([
+  'AGENT',
+  'WORKFLOW',
+  'TRAJECTORY',
+  'STEP',
+  ...Object.values(SpanType),
+] as [string, string, ...string[]]);
 
 export type ScoringEntityType = z.infer<typeof scoringEntityTypeSchema>;
 


### PR DESCRIPTION
## Description

`runEvals` was silently dropping trajectory and step scorer results because `scoringEntityTypeSchema` did not list the `entityType` values the runner emits. `saveScorePayloadSchema.parse()` rejected the payload, the error was swallowed as a warning, and scores never reached storage.

- Added `'TRAJECTORY'` and `'STEP'` to the explicit list in `scoringEntityTypeSchema` (`packages/core/src/evals/types.ts`) so the schema accepts every value `runEvals` emits in `packages/core/src/evals/run/index.ts`.
- Added a focused `saveScorePayloadSchema` test block in `packages/core/src/evals/types.test.ts` that parametrizes over all four runner-emitted entity types (`AGENT`, `WORKFLOW`, `TRAJECTORY`, `STEP`) plus a negative case for unknown values.
- Verified zero impact on existing call sites: production code (`mastra/hooks.ts`, `server/handlers/scores.ts`, Studio UI in `playground`) keeps comparing the same string literals; stored data, public REST API, and Studio filters are unchanged. Studio's previously-broken trajectory score panel now receives data.
- Patch changeset for `@mastra/core` describing the bug fix from the customer perspective.

## Related Issue(s)

Fixes #16243

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)
The system was calculating scores for "trajectory" and "step" runs but wasn't saving them because the validator didn't recognize those types. This PR tells the validator that TRAJECTORY and STEP are valid so those scores get saved and show up in Studio.

## Changes

### Schema updates
- Added 'TRAJECTORY' and 'STEP' to scoringEntityTypeSchema in packages/core/src/evals/types.ts so saveScorePayloadSchema accepts payloads emitted by runEvals.

### Test coverage
- Added a focused test suite in packages/core/src/evals/types.test.ts for saveScorePayloadSchema that parametrizes accepted entity types (AGENT, WORKFLOW, TRAJECTORY, STEP) and includes a negative test for unknown values.

### Changeset
- Added a patch changeset for @mastra/core describing the user-facing bug fix (trajectory and step scorer results from runEvals are now persisted and visible in Studio).

## Impact
- Trajectory and step scorer results are now persisted to storage and visible in Studio's observability alongside agent and workflow scores.
- No changes to existing call sites, stored data format, public REST API, or Studio filters; verification showed zero impact beyond fixing persistence of trajectory/step scores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->