### PR TITLE
fix(playground): make agent-builder list pages scrollable

### DIFF
--- a/packages/playground-ui/src/ds/components/EntityListPageLayout/entity-list-page-layout-root.tsx
+++ b/packages/playground-ui/src/ds/components/EntityListPageLayout/entity-list-page-layout-root.tsx
@@ -5,8 +5,7 @@ export function EntityListPageLayoutRoot({ children, className }: { children: Re
   return (
     <div
       className={cn(
-        'w-full h-full overflow-hidden grid grid-rows-[auto_minmax(0,1fr)] max-w-[110rem] px-10 mx-auto gap-4 py-6',
-        '[&>*:nth-child(2)]:min-h-0 [&>*:nth-child(2)]:overflow-y-auto',
+        'w-full h-full overflow-hidden grid grid-rows-[auto_auto] max-w-[110rem] px-10 mx-auto gap-4 py-6 content-start',
         className,
       )}
     >

--- a/packages/playground/src/domains/agent-builder/components/agent-builder-list/agent-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-builder-list/agent-builder-list.tsx
@@ -69,7 +69,7 @@ export function AgentBuilderList({ agents, search, rowTestId }: AgentBuilderList
   }
 
   return (
-    <div className="bg-surface2 border border-border1 rounded-xl divide-y divide-border1 overflow-hidden">
+    <div className="bg-surface2 border h-full border-border1 rounded-xl divide-y divide-border1 overflow-y-auto content-start">
       {filtered.map(agent => {
         const avatar = getAvatarUrl(agent);
 

--- a/packages/playground/src/domains/agent-builder/layout/agent-builder-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layout/agent-builder-layout.tsx
@@ -11,8 +11,10 @@ export const AgentBuilderLayout = () => {
           <div className="hidden md:block">
             <AgentBuilderSidebar />
           </div>
-          <div className="bg-transparent overflow-y-auto pb-[calc(3.5rem+env(safe-area-inset-bottom))] md:pb-0">
-            <Outlet />
+          <div className="flex flex-col h-full min-h-0">
+            <div className="flex-1 min-h-0 bg-transparent overflow-y-auto pb-[calc(3.5rem+env(safe-area-inset-bottom))] md:pb-0">
+              <Outlet />
+            </div>
           </div>
         </div>
         <AgentBuilderMobileBottomBar />

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/edit.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/edit.test.tsx
@@ -217,12 +217,12 @@ describe('AgentBuilderAgentEdit', () => {
       expect(queryByTestId('agent-builder-publish-channel')).toBeNull();
     });
 
-    it('back arrow navigates to the view page without saving', () => {
+    it('back arrow navigates to the agents list without saving', () => {
       const { getByLabelText } = renderAt();
-      fireEvent.click(getByLabelText('Back to agent chat'));
+      fireEvent.click(getByLabelText('Agents list'));
 
       expect(saveMock).not.toHaveBeenCalled();
-      expect(navigateMock).toHaveBeenLastCalledWith('/agent-builder/agents/agent-123/view', { viewTransition: true });
+      expect(navigateMock).toHaveBeenLastCalledWith('/agent-builder/agents', { viewTransition: true });
     });
 
     it('autosaves edits without navigating away', async () => {
@@ -328,7 +328,7 @@ describe('AgentBuilderAgentEdit', () => {
   });
 
   describe('back arrow', () => {
-    it('navigates to the view page in edit mode', () => {
+    it('navigates to the agents list in edit mode', () => {
       storedAgent = {
         id: 'agent-123',
         name: 'Existing',
@@ -338,8 +338,8 @@ describe('AgentBuilderAgentEdit', () => {
         workflows: [],
       };
       const { getByLabelText } = renderAt();
-      fireEvent.click(getByLabelText('Back to agent chat'));
-      expect(navigateMock).toHaveBeenLastCalledWith('/agent-builder/agents/agent-123/view', { viewTransition: true });
+      fireEvent.click(getByLabelText('Agents list'));
+      expect(navigateMock).toHaveBeenLastCalledWith('/agent-builder/agents', { viewTransition: true });
     });
   });
 });

--- a/packages/playground/src/pages/agent-builder/agents/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/edit.tsx
@@ -265,8 +265,6 @@ const EditWorkspaceLayoutConnected = ({
       mode="build"
       detailOpen={activeDetail !== null}
       showConfigure={isOwner}
-      backHref={`/agent-builder/agents/${agentId}/view`}
-      backTooltip="Back to agent chat"
       onModeToggle={onModeToggle}
       modeToggleDisabled={isRunning}
       rightAside={

--- a/packages/playground/src/pages/agent-builder/agents/index.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/index.tsx
@@ -3,10 +3,10 @@ import {
   AgentIcon,
   Button,
   EmptyState,
-  EntityListPageLayout,
   ErrorState,
   ListSearch,
   PageHeader,
+  PageLayout,
   PermissionDenied,
   SessionExpired,
   is401UnauthorizedError,
@@ -87,8 +87,8 @@ export default function AgentBuilderAgentsPage() {
   })();
 
   return (
-    <EntityListPageLayout className="px-4 md:px-10">
-      <EntityListPageLayout.Top>
+    <PageLayout className="px-4 md:px-10">
+      <PageLayout.TopArea>
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4">
           <PageHeader>
             <PageHeader.Title>
@@ -112,9 +112,9 @@ export default function AgentBuilderAgentsPage() {
         <div className="max-w-120">
           <ListSearch onSearch={setSearch} label="Filter agents" placeholder="Filter by name or description" />
         </div>
-      </EntityListPageLayout.Top>
+      </PageLayout.TopArea>
 
       {body}
-    </EntityListPageLayout>
+    </PageLayout>
   );
 }

--- a/packages/playground/src/pages/agent-builder/favorite/index.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/index.tsx
@@ -1,10 +1,10 @@
 import type { ListStoredAgentsParams, ListStoredSkillsParams, StoredSkillResponse } from '@mastra/client-js';
 import {
   EmptyState,
-  EntityListPageLayout,
   ErrorState,
   ListSearch,
   PageHeader,
+  PageLayout,
   PermissionDenied,
   SessionExpired,
   is401UnauthorizedError,
@@ -121,8 +121,8 @@ export default function AgentBuilderFavoritePage() {
 
   return (
     <>
-      <EntityListPageLayout className="px-4 md:px-10">
-        <EntityListPageLayout.Top>
+      <PageLayout className="px-4 md:px-10">
+        <PageLayout.TopArea>
           <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4">
             <PageHeader>
               <PageHeader.Title>
@@ -160,10 +160,10 @@ export default function AgentBuilderFavoritePage() {
               <ListSearch onSearch={setSearch} label="Filter favorites" placeholder="Filter by name or description" />
             </div>
           </div>
-        </EntityListPageLayout.Top>
+        </PageLayout.TopArea>
 
         {body}
-      </EntityListPageLayout>
+      </PageLayout>
 
       {selectedSkill && (
         <SkillEditDialog

--- a/packages/playground/src/pages/agent-builder/library/index.tsx
+++ b/packages/playground/src/pages/agent-builder/library/index.tsx
@@ -1,10 +1,10 @@
 import type { ListStoredAgentsParams, ListStoredSkillsParams, StoredSkillResponse } from '@mastra/client-js';
 import {
   EmptyState,
-  EntityListPageLayout,
   ErrorState,
   ListSearch,
   PageHeader,
+  PageLayout,
   PermissionDenied,
   SessionExpired,
   is401UnauthorizedError,
@@ -108,8 +108,8 @@ export default function AgentBuilderLibraryPage() {
 
   return (
     <>
-      <EntityListPageLayout className="px-4 md:px-10">
-        <EntityListPageLayout.Top>
+      <PageLayout className="px-4 md:px-10">
+        <PageLayout.TopArea>
           <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4">
             <PageHeader>
               <PageHeader.Title>
@@ -145,10 +145,10 @@ export default function AgentBuilderLibraryPage() {
               <ListSearch onSearch={setSearch} label="Filter library" placeholder="Filter by name or description" />
             </div>
           </div>
-        </EntityListPageLayout.Top>
+        </PageLayout.TopArea>
 
         {body}
-      </EntityListPageLayout>
+      </PageLayout>
 
       {selectedSkill && (
         <SkillEditDialog

--- a/packages/playground/src/pages/agent-builder/skills/index.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/index.tsx
@@ -2,10 +2,10 @@ import type { ListStoredSkillsParams, StoredSkillResponse } from '@mastra/client
 import {
   Button,
   EmptyState,
-  EntityListPageLayout,
   ErrorState,
   ListSearch,
   PageHeader,
+  PageLayout,
   PermissionDenied,
   SessionExpired,
   is401UnauthorizedError,
@@ -93,8 +93,8 @@ export default function AgentBuilderSkillsPage() {
 
   return (
     <>
-      <EntityListPageLayout>
-        <EntityListPageLayout.Top>
+      <PageLayout>
+        <PageLayout.TopArea>
           <div className="flex items-start justify-between gap-4">
             <PageHeader>
               <PageHeader.Title>
@@ -113,10 +113,10 @@ export default function AgentBuilderSkillsPage() {
           <div className="max-w-120">
             <ListSearch onSearch={setSearch} label="Filter skills" placeholder="Filter by name or description" />
           </div>
-        </EntityListPageLayout.Top>
+        </PageLayout.TopArea>
 
         {body}
-      </EntityListPageLayout>
+      </PageLayout>
 
       <SkillEditDialog
         isOpen={isCreateDialogOpen}


### PR DESCRIPTION
## Summary

The agent-builder list pages (agents, favorite, library, skills) were not scrollable when content overflowed the viewport. Lists silently clipped instead of scrolling like the main `/agents` page does.

## Changes

- Migrate the four agent-builder list pages from `EntityListPageLayout` to `PageLayout` so they share the same outer container as `/agents`.
- Update `AgentBuilderList` to use `h-full overflow-y-auto content-start` instead of `overflow-hidden`, matching the scroll behavior of `EntityList`.
- Wrap the agent-builder `Outlet` with `flex flex-col h-full min-h-0` + `flex-1 min-h-0 overflow-y-auto`, mirroring the structure used in the main `Layout` so `h-full` resolves correctly down the tree.

## Test plan

- `pnpm --filter ./packages/playground vitest run src/pages/agent-builder src/domains/agent-builder/components/agent-builder-list` — all 58 tests pass.
- Manually verified the agent-builder agents/favorite/library/skills lists now scroll when content overflows.