### PR TITLE
Fix double-encoded JSON in Datadog LLM span input/output

### DIFF
--- a/.changeset/legal-bars-glow.md
+++ b/.changeset/legal-bars-glow.md
@@ -2,4 +2,4 @@
 '@mastra/datadog': patch
 ---
 
-Fixed double-encoded JSON on `llm: <model_name>` span input in Datadog. Mastra wraps MODEL_GENERATION input as `{ messages, schema? }`; the exporter now unwraps that (and Gemini's `{ contents }` request body) into a proper Datadog `{role, content}[]` message array instead of stringifying the whole wrapper into a single user message. Also avoids the same problem on tool-call-only outputs by summarizing tool calls instead of stringifying the full `{text, object, toolCalls, ...}` AI SDK output.
+Fixed double-encoded JSON on span input in Datadog.

--- a/.changeset/legal-bars-glow.md
+++ b/.changeset/legal-bars-glow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': patch
+---
+
+Fixed double-encoded JSON on `llm: <model_name>` span input in Datadog. Mastra wraps MODEL_GENERATION input as `{ messages, schema? }`; the exporter now unwraps that (and Gemini's `{ contents }` request body) into a proper Datadog `{role, content}[]` message array instead of stringifying the whole wrapper into a single user message. Also avoids the same problem on tool-call-only outputs by summarizing tool calls instead of stringifying the full `{text, object, toolCalls, ...}` AI SDK output.

--- a/observability/datadog/src/utils.test.ts
+++ b/observability/datadog/src/utils.test.ts
@@ -158,6 +158,45 @@ describe('formatInput', () => {
       ]);
     });
 
+    it('unwraps Mastra { messages, schema } input wrapper', () => {
+      const input = {
+        messages: [
+          { role: 'system', content: 'You are helpful' },
+          { role: 'user', content: 'Hello' },
+        ],
+        schema: { type: 'object' },
+      };
+      const result = formatInput(input, SpanType.MODEL_GENERATION);
+      expect(result).toEqual([
+        { role: 'system', content: 'You are helpful' },
+        { role: 'user', content: 'Hello' },
+      ]);
+    });
+
+    it('unwraps { messages } wrapper for MODEL_STEP spans too', () => {
+      const input = {
+        messages: [{ role: 'user', content: 'Hi' }],
+      };
+      const result = formatInput(input, SpanType.MODEL_STEP);
+      expect(result).toEqual([{ role: 'user', content: 'Hi' }]);
+    });
+
+    it('unwraps Gemini { contents } request body shape', () => {
+      const input = {
+        contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+      };
+      const result = formatInput(input, SpanType.MODEL_GENERATION);
+      expect(result).toEqual([{ role: 'user', content: 'Hello' }]);
+    });
+
+    it('stringifies multimodal content arrays into the message content field', () => {
+      const input = {
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      };
+      const result = formatInput(input, SpanType.MODEL_GENERATION);
+      expect(result).toEqual([{ role: 'user', content: '[{"type":"text","text":"hi"}]' }]);
+    });
+
     it('redacts binary data and summarizes tool calls in Gemini parts', () => {
       const contents = [
         {
@@ -220,6 +259,22 @@ describe('formatOutput', () => {
     it('stringifies object output without text property', () => {
       const result = formatOutput({ result: 'success' }, SpanType.MODEL_GENERATION);
       expect(result).toEqual([{ role: 'assistant', content: '{"result":"success"}' }]);
+    });
+
+    it('summarizes tool-call-only outputs without burying them as escaped JSON', () => {
+      const result = formatOutput(
+        {
+          text: '',
+          toolCalls: [{ toolName: 'search', args: { q: 'mastra' } }, { toolName: 'fetch' }],
+        },
+        SpanType.MODEL_GENERATION,
+      );
+      expect(result).toEqual([{ role: 'assistant', content: '[tool: search][tool: fetch]' }]);
+    });
+
+    it('uses object payload when text is empty and an object result is present', () => {
+      const result = formatOutput({ text: '', object: { ok: true } }, SpanType.MODEL_GENERATION);
+      expect(result).toEqual([{ role: 'assistant', content: '{"ok":true}' }]);
     });
   });
 

--- a/observability/datadog/src/utils.ts
+++ b/observability/datadog/src/utils.ts
@@ -123,6 +123,17 @@ function isGeminiContentArray(data: any): data is Array<{ role: string; parts: a
 }
 
 /**
+ * Maps a {role, content}[] message array into the Datadog message shape,
+ * stringifying any non-string content (e.g. multimodal part arrays).
+ */
+function toDatadogMessages(messages: Array<{ role: string; content: any }>): Array<{ role: string; content: string }> {
+  return messages.map(m => ({
+    role: m.role,
+    content: typeof m.content === 'string' ? m.content : safeStringify(m.content),
+  }));
+}
+
+/**
  * Converts a Gemini content item to Datadog message format.
  * Extracts text from parts, skips binary data to avoid bloating traces.
  */
@@ -148,14 +159,25 @@ export function formatInput(input: any, spanType: SpanType): any {
   if (spanType === SpanType.MODEL_GENERATION || spanType === SpanType.MODEL_STEP) {
     // Already in message format
     if (isMessageArray(input)) {
-      return input.map(m => ({
-        role: m.role,
-        content: typeof m.content === 'string' ? m.content : safeStringify(m.content),
-      }));
+      return toDatadogMessages(input);
     }
     // Gemini format: {role, parts} → normalize to {role, content}
     if (isGeminiContentArray(input)) {
       return input.map(geminiContentToMessage);
+    }
+    // Mastra wraps MODEL_GENERATION input as { messages, schema? } and Gemini
+    // request bodies use { contents }. Unwrap so we don't bury the message array
+    // inside a single stringified user-message content (double-encoded JSON).
+    if (input && typeof input === 'object' && !Array.isArray(input)) {
+      if (isMessageArray((input as any).messages)) {
+        return toDatadogMessages((input as any).messages);
+      }
+      if (isGeminiContentArray((input as any).messages)) {
+        return (input as any).messages.map(geminiContentToMessage);
+      }
+      if (isGeminiContentArray((input as any).contents)) {
+        return (input as any).contents.map(geminiContentToMessage);
+      }
     }
     // String input becomes user message
     if (typeof input === 'string') {
@@ -179,18 +201,26 @@ export function formatOutput(output: any, spanType: SpanType): any {
   if (spanType === SpanType.MODEL_GENERATION || spanType === SpanType.MODEL_STEP) {
     // Already in message format
     if (isMessageArray(output)) {
-      return output.map(m => ({
-        role: m.role,
-        content: typeof m.content === 'string' ? m.content : safeStringify(m.content),
-      }));
+      return toDatadogMessages(output);
     }
     // String output becomes assistant message
     if (typeof output === 'string') {
       return [{ role: 'assistant', content: output }];
     }
-    // Object with text property (common AI SDK format)
-    if (output?.text) {
-      return [{ role: 'assistant', content: output.text }];
+    // AI SDK shape: { text, object, reasoning, toolCalls, ... }.
+    // Prefer text, then object, then a structured tool-call summary so we don't
+    // bury the whole object as escaped JSON inside a single assistant content.
+    if (output && typeof output === 'object') {
+      if (typeof output.text === 'string' && output.text.length > 0) {
+        return [{ role: 'assistant', content: output.text }];
+      }
+      if (output.object !== undefined) {
+        return [{ role: 'assistant', content: safeStringify(output.object) }];
+      }
+      if (Array.isArray(output.toolCalls) && output.toolCalls.length > 0) {
+        const summary = output.toolCalls.map((c: any) => `[tool: ${c?.toolName ?? c?.name ?? 'unknown'}]`).join('');
+        return [{ role: 'assistant', content: summary }];
+      }
     }
     // Other objects get stringified as assistant message
     return [{ role: 'assistant', content: safeStringify(output) }];


### PR DESCRIPTION
## Description

Fixed double-encoded JSON in Datadog `llm: <model_name>` spans by properly unwrapping input and output wrapper objects instead of stringifying them as single messages.

**Input handling:** Mastra wraps MODEL_GENERATION input as `{ messages, schema? }` and Gemini request bodies use `{ contents }`. The exporter now unwraps these structures to extract the actual message array, preventing the entire wrapper from being stringified into a single user message (which resulted in double-encoded JSON).

**Output handling:** For tool-call-only outputs, the exporter now generates a structured summary (e.g., `[tool: search][tool: fetch]`) instead of stringifying the full AI SDK output object `{text, object, toolCalls, ...}` as escaped JSON. Also added logic to prefer the `object` field when `text` is empty.

## Changes

- Added `toDatadogMessages()` helper to normalize message arrays with proper content stringification
- Enhanced `formatInput()` to unwrap `{ messages, schema }` and `{ contents }` wrapper objects
- Enhanced `formatOutput()` to handle tool-call-only outputs with a summary format and prefer `object` field when text is empty
- Added comprehensive test coverage for all new unwrapping and formatting scenarios

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Test Plan

Added 5 new unit tests covering:
- Unwrapping Mastra `{ messages, schema }` input wrapper
- Unwrapping `{ messages }` wrapper for MODEL_STEP spans
- Unwrapping Gemini `{ contents }` request body shape
- Stringifying multimodal content arrays
- Summarizing tool-call-only outputs
- Using object payload when text is empty

All existing tests continue to pass.

https://claude.ai/code/session_019e8tPUFHwPXhy367bjSvSM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Datadog is a monitoring tool that Mastra uses to track what happens when AI models run. When Mastra was sending information about what the model was asked and what it answered to Datadog, it was accidentally wrapping the data in extra layers, like putting a box inside a box inside a box. This PR unwraps those extra layers so Datadog receives clean, readable data instead.

## Changes

**Input Handling**
- Added logic to unwrap input wrapper objects before sending to Datadog
- Extracts the actual message array from Mastra's `{ messages, schema? }` structure
- Handles Gemini request bodies with `{ contents }` format
- Stringifies multimodal content arrays into properly formatted message content

**Output Handling**
- For tool-call-only outputs, now generates a simple structured summary (e.g., "[tool: search][tool: fetch]") instead of stringifying the entire complex AI SDK output object
- When text output is empty, prefers using the `object` field if available

**Implementation**
- Added `toDatadogMessages()` helper function to normalize message arrays with proper content stringification
- Enhanced `formatInput()` to implement unwrapping and extraction logic
- Enhanced `formatOutput()` to handle tool-call summarization and object preference logic
- Added comprehensive unit tests covering:
  - Unwrapping Mastra input wrappers for MODEL_GENERATION spans
  - Unwrapping message wrapper structures for MODEL_STEP spans
  - Unwrapping Gemini content arrays
  - Tool-call-only output formatting without JSON escaping
  - Object payload usage when text is empty

**Files Modified**
- `.changeset/legal-bars-glow.md` - Added changeset entry
- `observability/datadog/src/utils.ts` - Core implementation (+41/-11 lines)
- `observability/datadog/src/utils.test.ts` - Test coverage (+55 new lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->