### PR TITLE
Traces list virtualization

### DIFF
--- a/.changeset/data-list-virtualization.md
+++ b/.changeset/data-list-virtualization.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved Studio's Traces page to scale smoothly to many traces. The list now renders only the visible window, so scrolling stays responsive and memory usage stays bounded regardless of how many traces are loaded.

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -88,6 +88,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-visually-hidden": "^1.2.4",
+    "@tanstack/react-virtual": "^3.13.22",
     "@uiw/codemirror-theme-dracula": "^4.25.9",
     "@uiw/react-codemirror": "^4.25.9",
     "cmdk": "^1.1.1",

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useMemo, useRef } from 'react';
+import type { ReactNode } from 'react';
 import { groupTracesByThread } from '../utils/group-traces-by-thread';
 import { getInputPreview } from '../utils/span-utils';
 import { DataListSkeleton, TracesDataList } from '@/ds/components/DataList';
@@ -28,6 +30,13 @@ export type TracesListViewTrace = {
 
 const COLUMNS = 'auto auto auto auto minmax(5rem,1fr) auto auto';
 
+const ROW_HEIGHT = 36;
+const OVERSCAN = 8;
+
+type ListItem =
+  | { kind: 'subheader'; key: string; node: ReactNode }
+  | { kind: 'row'; key: string; trace: TracesListViewTrace };
+
 export type TracesListViewProps = {
   traces: TracesListViewTrace[];
   isLoading?: boolean;
@@ -44,8 +53,9 @@ export type TracesListViewProps = {
 };
 
 /**
- * Pure presentational list. Renders the TracesDataList primitive with rows, optional thread grouping,
- * empty state, and infinite-paging loader. Owns no state.
+ * Virtualized presentational list. Flattens optional thread groups into a single
+ * indexed item array, renders only the visible window via TanStack Virtual, and
+ * uses DataList primitives for layout (CSS Grid with subgrid rows).
  */
 export function TracesListView({
   traces,
@@ -59,36 +69,69 @@ export function TracesListView({
   groupByThread,
   threadTitles,
 }: TracesListViewProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const items = useMemo<ListItem[]>(() => {
+    if (traces.length === 0) return [];
+    if (!groupByThread) {
+      return traces.map(trace => ({ kind: 'row', key: trace.traceId, trace }));
+    }
+    const { groups, ungrouped } = groupTracesByThread(traces);
+    const result: ListItem[] = [];
+    for (const group of groups) {
+      result.push({
+        kind: 'subheader',
+        key: `header-${group.threadId}`,
+        node: (
+          <TracesDataList.SubHeading className="flex gap-2">
+            <span className="uppercase">Thread</span>
+            {threadTitles?.[group.threadId] && <b>'{threadTitles[group.threadId]}'</b>}
+            <b># {group.threadId}</b>
+            <span className="text-neutral2">({group.traces.length})</span>
+          </TracesDataList.SubHeading>
+        ),
+      });
+      for (const trace of group.traces) {
+        result.push({ kind: 'row', key: trace.traceId, trace });
+      }
+    }
+    if (ungrouped.length > 0) {
+      result.push({
+        kind: 'subheader',
+        key: 'header-ungrouped',
+        node: (
+          <TracesDataList.SubHeading className="flex gap-2 uppercase">
+            <span>No thread</span>
+            <span className="text-neutral2">({ungrouped.length})</span>
+          </TracesDataList.SubHeading>
+        ),
+      });
+      for (const trace of ungrouped) {
+        result.push({ kind: 'row', key: trace.traceId, trace });
+      }
+    }
+    return result;
+  }, [traces, groupByThread, threadTitles]);
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: OVERSCAN,
+  });
+
   if (isLoading) {
     return <DataListSkeleton columns={COLUMNS} />;
   }
 
-  const renderRows = (rows: TracesListViewTrace[]) =>
-    rows.map(trace => {
-      const isFeatured = trace.traceId === featuredTraceId;
-      const displayDate = trace.startedAt ?? trace.createdAt;
-      const entityName =
-        trace.entityName || trace.entityId || trace.attributes?.agentId || trace.attributes?.workflowId;
-
-      return (
-        <TracesDataList.RowButton
-          key={trace.traceId}
-          onClick={() => onTraceClick(trace)}
-          className={cn(isFeatured && 'bg-surface4')}
-        >
-          <TracesDataList.IdCell traceId={trace.traceId} />
-          <TracesDataList.DateCell timestamp={displayDate} />
-          <TracesDataList.TimeCell timestamp={displayDate} />
-          <TracesDataList.NameCell name={trace.name} />
-          <TracesDataList.InputCell input={getInputPreview(trace.input)} />
-          <TracesDataList.EntityCell entityType={trace.entityType} entityName={entityName} />
-          <TracesDataList.StatusCell status={trace.attributes?.status} />
-        </TracesDataList.RowButton>
-      );
-    });
+  const virtualItems = virtualizer.getVirtualItems();
+  const totalSize = virtualizer.getTotalSize();
+  const paddingTop = virtualItems[0]?.start ?? 0;
+  const paddingBottom =
+    virtualItems.length > 0 ? Math.max(0, totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0)) : 0;
 
   return (
-    <TracesDataList columns={COLUMNS} className="min-w-0">
+    <TracesDataList columns={COLUMNS} scrollRef={scrollRef} className="min-w-0">
       <TracesDataList.Top>
         <TracesDataList.TopCell>ID</TracesDataList.TopCell>
         <TracesDataList.TopCell>Date</TracesDataList.TopCell>
@@ -99,51 +142,56 @@ export function TracesListView({
         <TracesDataList.TopCell>Status</TracesDataList.TopCell>
       </TracesDataList.Top>
 
-      {traces.length === 0 ? (
+      {items.length === 0 ? (
         <TracesDataList.NoMatch
           message={filtersApplied ? 'No traces found for applied filters' : 'No traces found yet'}
         />
-      ) : groupByThread ? (
-        (() => {
-          const { groups, ungrouped } = groupTracesByThread(traces);
-          return (
-            <>
-              {groups.map(group => (
-                <React.Fragment key={group.threadId}>
-                  <TracesDataList.Subheader>
-                    <TracesDataList.SubHeading className="flex gap-2">
-                      <span className="uppercase">Thread</span>
-                      {threadTitles?.[group.threadId] && <b>'{threadTitles[group.threadId]}'</b>}
-                      <b># {group.threadId}</b>
-                      <span className="text-neutral2">({group.traces.length})</span>
-                    </TracesDataList.SubHeading>
-                  </TracesDataList.Subheader>
-                  {renderRows(group.traces)}
-                </React.Fragment>
-              ))}
-              {ungrouped.length > 0 && (
-                <>
-                  <TracesDataList.Subheader>
-                    <TracesDataList.SubHeading className="flex gap-2 uppercase">
-                      <span>No thread</span>
-                      <span className="text-neutral2">({ungrouped.length})</span>
-                    </TracesDataList.SubHeading>
-                  </TracesDataList.Subheader>
-                  {renderRows(ungrouped)}
-                </>
-              )}
-            </>
-          );
-        })()
       ) : (
-        renderRows(traces)
-      )}
-      {traces.length > 0 && (
-        <TracesDataList.NextPageLoading
-          isLoading={isFetchingNextPage}
-          hasMore={hasNextPage}
-          setEndOfListElement={setEndOfListElement}
-        />
+        <>
+          <TracesDataList.Spacer height={paddingTop} />
+          {virtualItems.map(vi => {
+            const item = items[vi.index];
+            if (!item) return null;
+
+            if (item.kind === 'subheader') {
+              return (
+                <TracesDataList.Subheader key={item.key} ref={virtualizer.measureElement} data-index={vi.index}>
+                  {item.node}
+                </TracesDataList.Subheader>
+              );
+            }
+
+            const trace = item.trace;
+            const isFeatured = trace.traceId === featuredTraceId;
+            const displayDate = trace.startedAt ?? trace.createdAt;
+            const entityName =
+              trace.entityName || trace.entityId || trace.attributes?.agentId || trace.attributes?.workflowId;
+
+            return (
+              <TracesDataList.RowButton
+                key={trace.traceId}
+                ref={virtualizer.measureElement}
+                data-index={vi.index}
+                onClick={() => onTraceClick(trace)}
+                className={cn(isFeatured && 'bg-surface4')}
+              >
+                <TracesDataList.IdCell traceId={trace.traceId} />
+                <TracesDataList.DateCell timestamp={displayDate} />
+                <TracesDataList.TimeCell timestamp={displayDate} />
+                <TracesDataList.NameCell name={trace.name} />
+                <TracesDataList.InputCell input={getInputPreview(trace.input)} />
+                <TracesDataList.EntityCell entityType={trace.entityType} entityName={entityName} />
+                <TracesDataList.StatusCell status={trace.attributes?.status} />
+              </TracesDataList.RowButton>
+            );
+          })}
+          <TracesDataList.Spacer height={paddingBottom} />
+          <TracesDataList.NextPageLoading
+            isLoading={isFetchingNextPage}
+            hasMore={hasNextPage}
+            setEndOfListElement={setEndOfListElement}
+          />
+        </>
       )}
     </TracesDataList>
   );

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
@@ -3,6 +3,7 @@ import { DataListNextPageLoading } from '../data-list-next-page-loading';
 import { DataListNoMatch } from '../data-list-no-match';
 import { DataListRoot } from '../data-list-root';
 import { DataListRowButton } from '../data-list-row-button';
+import { DataListSpacer } from '../data-list-spacer';
 import { DataListSubheader } from '../data-list-subheader';
 import { DataListSubHeading } from '../data-list-subheading';
 import { DataListTop } from '../data-list-top';
@@ -28,6 +29,7 @@ export const TracesDataList = Object.assign(TracesDataListRoot, {
   NoMatch: DataListNoMatch,
   Subheader: DataListSubheader,
   SubHeading: DataListSubHeading,
+  Spacer: DataListSpacer,
   IdCell: TracesDataListIdCell,
   DateCell: TracesDataListDateCell,
   TimeCell: TracesDataListTimeCell,

--- a/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-root.tsx
@@ -1,15 +1,22 @@
-import type { ReactNode } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import { cn } from '@/lib/utils';
 
 export type DataListRootProps = {
   children: ReactNode;
   columns: string;
   className?: string;
+  /**
+   * Ref to the scroll container — pass this to TanStack Virtual's
+   * `getScrollElement` when virtualizing. Without it, the list behaves as a
+   * normal scrollable grid.
+   */
+  scrollRef?: RefObject<HTMLDivElement | null>;
 };
 
-export function DataListRoot({ children, columns, className }: DataListRootProps) {
+export function DataListRoot({ children, columns, className, scrollRef }: DataListRootProps) {
   return (
     <div
+      ref={scrollRef}
       className={cn(
         'grid bg-surface2 border max-h-full border-border1 rounded-xl overflow-y-auto content-start',
         className,

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
@@ -1,17 +1,22 @@
-import type { ReactNode } from 'react';
+import { forwardRef } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 import { dataListRowStyles } from './shared';
 import { cn } from '@/lib/utils';
 
-export type DataListRowButtonProps = {
-  children: ReactNode;
-  onClick?: () => void;
-  className?: string;
-};
+export type DataListRowButtonProps = ComponentPropsWithoutRef<'button'>;
 
-export function DataListRowButton({ children, onClick, className }: DataListRowButtonProps) {
-  return (
-    <button type="button" onClick={onClick} className={cn(...dataListRowStyles, 'text-left', className)}>
-      {children}
-    </button>
-  );
-}
+/**
+ * Forwarded ref + spread props so virtualizers (`useVirtualizer.measureElement`)
+ * can attach a ref and `data-index` to each rendered row.
+ */
+export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButtonProps>(
+  ({ children, className, type = 'button', ...rest }, ref) => {
+    return (
+      <button ref={ref} type={type} className={cn(...dataListRowStyles, 'text-left', className)} {...rest}>
+        {children}
+      </button>
+    );
+  },
+);
+
+DataListRowButton.displayName = 'DataListRowButton';

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row.tsx
@@ -1,12 +1,20 @@
-import type { ReactNode } from 'react';
+import { forwardRef } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 import { dataListRowStyles } from './shared';
 import { cn } from '@/lib/utils';
 
-export type DataListRowProps = {
-  children: ReactNode;
-  className?: string;
-};
+export type DataListRowProps = ComponentPropsWithoutRef<'div'>;
 
-export function DataListRow({ children, className }: DataListRowProps) {
-  return <div className={cn(...dataListRowStyles, className)}>{children}</div>;
-}
+/**
+ * Forwarded ref + spread props so virtualizers (`useVirtualizer.measureElement`)
+ * can attach a ref and `data-index` to each rendered row.
+ */
+export const DataListRow = forwardRef<HTMLDivElement, DataListRowProps>(({ children, className, ...rest }, ref) => {
+  return (
+    <div ref={ref} className={cn(...dataListRowStyles, className)} {...rest}>
+      {children}
+    </div>
+  );
+});
+
+DataListRow.displayName = 'DataListRow';

--- a/packages/playground-ui/src/ds/components/DataList/data-list-spacer.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-spacer.tsx
@@ -1,0 +1,14 @@
+export type DataListSpacerProps = {
+  /** Pixel height of the spacer. Pass 0 to render nothing. */
+  height: number;
+};
+
+/**
+ * Pads top/bottom of the visible window when virtualizing — preserves the
+ * grid's total scroll height for the rows that aren't currently rendered.
+ * Spans the full grid width so it doesn't disturb column layout.
+ */
+export function DataListSpacer({ height }: DataListSpacerProps) {
+  if (height <= 0) return null;
+  return <div className="col-span-full" style={{ height }} />;
+}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-subheader.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-subheader.tsx
@@ -1,21 +1,25 @@
-import type { ReactNode } from 'react';
+import { forwardRef } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 import { cn } from '@/lib/utils';
 
-export type DataListSubheaderProps = {
-  children: ReactNode;
-  className?: string;
-};
+export type DataListSubheaderProps = ComponentPropsWithoutRef<'div'>;
 
-export function DataListSubheader({ children, className }: DataListSubheaderProps) {
-  return (
-    <div
-      className={cn(
-        'data-list-subheader relative isolate col-span-full px-4 py-3 border-none text-ui-md text-neutral4 font-medium mx-1',
-        'before:absolute before:inset-x-0 before:inset-y-1 before:bg-surface4 before:rounded-md before:-z-1',
-        className,
-      )}
-    >
-      {children}
-    </div>
-  );
-}
+export const DataListSubheader = forwardRef<HTMLDivElement, DataListSubheaderProps>(
+  ({ children, className, ...rest }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'data-list-subheader relative isolate col-span-full px-4 py-3 border-none text-ui-md text-neutral4 font-medium mx-1',
+          'before:absolute before:inset-x-0 before:inset-y-1 before:bg-surface4 before:rounded-md before:-z-1',
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+DataListSubheader.displayName = 'DataListSubheader';

--- a/packages/playground-ui/src/ds/components/DataList/data-list.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.tsx
@@ -6,6 +6,7 @@ import { DataListRoot } from './data-list-root';
 import { DataListRow } from './data-list-row';
 import { DataListRowButton } from './data-list-row-button';
 import { DataListRowLink } from './data-list-row-link';
+import { DataListSpacer } from './data-list-spacer';
 import { DataListSubheader } from './data-list-subheader';
 import { DataListSubHeading } from './data-list-subheading';
 import { DataListTop } from './data-list-top';
@@ -26,6 +27,7 @@ export const DataList = Object.assign(DataListRoot, {
   NoMatch: DataListNoMatch,
   Subheader: DataListSubheader,
   SubHeading: DataListSubHeading,
+  Spacer: DataListSpacer,
   NextPageLoading: DataListNextPageLoading,
   Pagination: DataListPagination,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4360,6 +4360,9 @@ importers:
       '@radix-ui/react-visually-hidden':
         specifier: ^1.2.4
         version: 1.2.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.22
+        version: 3.13.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@uiw/codemirror-theme-dracula':
         specifier: ^4.25.9
         version: 4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.0)
@@ -37832,6 +37835,12 @@ snapshots:
       '@tanstack/virtual-core': 3.13.23
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/react-virtual@3.13.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.23
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   '@tanstack/table-core@8.21.3': {}
 


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Added virtualization to Traces list. 

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the Traces page faster and more memory-efficient by using a technique called "virtualization"—instead of rendering every single trace in the list at once (which can be slow and use lots of memory), it only renders the traces that are currently visible on your screen, plus a bit extra. As you scroll, new traces appear and old ones are removed from memory.

---

## Overview

This PR implements virtualization for the Traces list in the Studio's Traces page. The implementation uses TanStack's React Virtual library to render only the visible window of traces, improving scrolling responsiveness and keeping memory usage bounded when many traces are loaded.

---

## Key Changes

### Dependencies
- Added `@tanstack/react-virtual` (^3.13.22) for virtualizer functionality

### Core Virtualization Implementation
- **TracesListView Component** (`traces-list-view.tsx`): 
  - Integrated TanStack Virtualizer to render only visible items
  - Created internal flattening logic that combines subheaders and trace rows into a single virtualizable list
  - Added spacer elements for top/bottom padding to maintain correct scroll height
  - Refactored rendering to map over virtualized items instead of directly rendering rows

### DataList Component Refactoring
To support virtualization and improve component flexibility, several core DataList components were refactored to use `forwardRef` and accept native HTML element props:

- **DataListRow**: Converted to `forwardRef<HTMLDivElement>`, now accepts `ComponentPropsWithoutRef<'div'>` instead of explicit children/className props
- **DataListRowButton**: Converted to `forwardRef<HTMLButtonElement>`, now accepts `ComponentPropsWithoutRef<'button'>` for full button prop support
- **DataListSubheader**: Converted to `forwardRef<HTMLDivElement>`, now accepts `ComponentPropsWithoutRef<'div'>`
- **DataListRoot**: Added optional `scrollRef` prop to accept a scroll container reference for virtualization integration

### New Components
- **DataListSpacer** (`data-list-spacer.tsx`): New component that renders padding divs to preserve total scroll height during virtualization; exposed as `DataList.Spacer` and `TracesDataList.Spacer`

---

## Impact

These changes maintain backward compatibility for the public API while enabling virtualization support across the traces list. The refactoring to use `forwardRef` and native HTML props makes the DataList components more flexible and reusable in virtualization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->