### PR TITLE
Logs list virtualization

### DIFF
--- a/.changeset/logs-virtualization.md
+++ b/.changeset/logs-virtualization.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved Studio's Logs page to scale smoothly to many log records. The list now renders only the visible window, so scrolling stays responsive and memory usage stays bounded regardless of how many logs are loaded.

--- a/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
@@ -1,8 +1,13 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useRef } from 'react';
 import type { LogRecord } from '../types';
 import { LogsDataList, LogsDataListSkeleton } from '@/ds/components/LogsDataList';
 import { cn } from '@/lib/utils';
 
 const COLUMNS = 'auto auto auto auto minmax(5rem,1fr) minmax(5rem,1fr)';
+
+const ROW_HEIGHT = 36;
+const OVERSCAN = 8;
 
 export interface LogsListViewProps {
   logs: LogRecord[];
@@ -20,8 +25,9 @@ export interface LogsListViewProps {
 }
 
 /**
- * Pure presentational list. Renders the LogsDataList primitive with rows, empty state, and
- * infinite-paging loader. Owns no state and fetches no data.
+ * Virtualized presentational list. Renders only the visible window of logs via
+ * TanStack Virtual, sandwiched between top/bottom Spacers that preserve total
+ * scroll height. Owns no state and fetches no data.
  */
 export function LogsListView({
   logs,
@@ -33,12 +39,27 @@ export function LogsListView({
   featuredLogId,
   onLogClick,
 }: LogsListViewProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const virtualizer = useVirtualizer({
+    count: logs.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: OVERSCAN,
+  });
+
   if (isLoading) {
     return <LogsDataListSkeleton columns={COLUMNS} />;
   }
 
+  const virtualItems = virtualizer.getVirtualItems();
+  const totalSize = virtualizer.getTotalSize();
+  const paddingTop = virtualItems[0]?.start ?? 0;
+  const paddingBottom =
+    virtualItems.length > 0 ? Math.max(0, totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0)) : 0;
+
   return (
-    <LogsDataList columns={COLUMNS} className="min-w-0">
+    <LogsDataList columns={COLUMNS} scrollRef={scrollRef} className="min-w-0">
       <LogsDataList.Top>
         <LogsDataList.TopCell>Date</LogsDataList.TopCell>
         <LogsDataList.TopCell>Time</LogsDataList.TopCell>
@@ -51,29 +72,37 @@ export function LogsListView({
       {logs.length === 0 ? (
         <LogsDataList.NoMatch message="No logs match your search" />
       ) : (
-        logs.map(log => {
-          const id = logIdMap.get(log);
-          // Defensive: consumer is expected to build `logIdMap` from the same `logs` list
-          // (via `useLogsListNavigation`), but if they drift we'd rather drop the row than
-          // ship a missing-key warning and broken selection highlighting.
-          if (!id) return null;
-          const isFeatured = id === featuredLogId;
+        <>
+          <LogsDataList.Spacer height={paddingTop} />
+          {virtualItems.map(vi => {
+            const log = logs[vi.index];
+            if (!log) return null;
+            const id = logIdMap.get(log);
+            // Defensive: consumer is expected to build `logIdMap` from the same `logs` list
+            // (via `useLogsListNavigation`), but if they drift we'd rather drop the row than
+            // ship a missing-key warning and broken selection highlighting.
+            if (!id) return null;
+            const isFeatured = id === featuredLogId;
 
-          return (
-            <LogsDataList.RowButton
-              key={id}
-              onClick={() => onLogClick(log)}
-              className={cn(isFeatured && 'bg-surface4')}
-            >
-              <LogsDataList.DateCell timestamp={log.timestamp} />
-              <LogsDataList.TimeCell timestamp={log.timestamp} />
-              <LogsDataList.LevelCell level={log.level} />
-              <LogsDataList.EntityCell entityType={log.entityType} entityName={log.entityName} />
-              <LogsDataList.MessageCell message={log.message} />
-              <LogsDataList.DataCell data={log.data} />
-            </LogsDataList.RowButton>
-          );
-        })
+            return (
+              <LogsDataList.RowButton
+                key={id}
+                ref={virtualizer.measureElement}
+                data-index={vi.index}
+                onClick={() => onLogClick(log)}
+                className={cn(isFeatured && 'bg-surface4')}
+              >
+                <LogsDataList.DateCell timestamp={log.timestamp} />
+                <LogsDataList.TimeCell timestamp={log.timestamp} />
+                <LogsDataList.LevelCell level={log.level} />
+                <LogsDataList.EntityCell entityType={log.entityType} entityName={log.entityName} />
+                <LogsDataList.MessageCell message={log.message} />
+                <LogsDataList.DataCell data={log.data} />
+              </LogsDataList.RowButton>
+            );
+          })}
+          <LogsDataList.Spacer height={paddingBottom} />
+        </>
       )}
       <LogsDataList.NextPageLoading
         isLoading={isFetchingNextPage}

--- a/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list.tsx
+++ b/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list.tsx
@@ -4,6 +4,7 @@ import { DataListRoot } from '../DataList/data-list-root';
 import { DataListRow } from '../DataList/data-list-row';
 import { DataListRowButton } from '../DataList/data-list-row-button';
 import { DataListRowLink } from '../DataList/data-list-row-link';
+import { DataListSpacer } from '../DataList/data-list-spacer';
 import { DataListTop } from '../DataList/data-list-top';
 import { DataListTopCell, DataListTopCellWithTooltip, DataListTopCellSmart } from '../DataList/data-list-top-cell';
 import {
@@ -23,6 +24,7 @@ export const LogsDataList = Object.assign(DataListRoot, {
   Row: DataListRow,
   RowButton: DataListRowButton,
   RowLink: DataListRowLink,
+  Spacer: DataListSpacer,
   NoMatch: DataListNoMatch,
   DateCell: LogsDataListDateCell,
   TimeCell: LogsDataListTimeCell,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Added virtualization to Logs list.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

Instead of trying to show all the log entries at once (which makes the page slow and uses lots of memory), this PR makes the Logs page only show the logs you can actually see on your screen, plus a few extra ones above and below. When you scroll, it quickly swaps out the hidden logs with new ones, keeping everything fast and smooth no matter how many logs you have.

---

## Changes Overview

This PR introduces virtual scrolling to the Studio's Logs page using TanStack Virtual, enabling the list to handle large numbers of log records efficiently.

### Core Implementation

**LogsListView Component** (`packages/playground-ui/src/domains/logs/components/logs-list-view.tsx`)
- Refactored to implement virtualization using `@tanstack/react-virtual`
- Uses `useVirtualizer` hook configured with:
  - `ROW_HEIGHT` of 36px for accurate item sizing
  - `OVERSCAN` of 8 rows to pre-render items near viewport edges
- Renders only visible virtual items between calculated top/bottom spacers
- Maintains all existing behavior including:
  - Loading and empty states
  - Featured log highlighting via `featuredLogId`
  - Click event handling for log selection
  - End-of-list pagination detection
- Public API remains unchanged

**LogsDataList Component** (`packages/playground-ui/src/ds/components/LogsDataList/logs-data-list.tsx`)
- Exposed `Spacer` component (previously internal) to support virtualization spacing
- Allows proper padding calculation between virtual item groups

### Performance Improvements

- Only visible log rows are rendered in the DOM, drastically reducing memory footprint
- Scrolling remains responsive regardless of total log count
- Efficient height calculations through TanStack Virtual's measurement system
- Overscan buffer prevents empty space during scroll operations

---

## Manifest Changes

- **@mastra/playground-ui**: Patch version bump
- **Files modified**: 3 files affected
- **Total lines changed**: +61/-25

<!-- end of auto-generated comment: release notes by coderabbit.ai -->