### PR TITLE
chore(agent-builder example): enable avatarUpload feature flag

### DIFF
--- a/examples/agent-builder/src/mastra/index.ts
+++ b/examples/agent-builder/src/mastra/index.ts
@@ -85,6 +85,7 @@ export const mastra = new Mastra({
           stars: true,
           model: true,
           browser: true,
+          avatarUpload: true,
         },
       },
       configuration: {


### PR DESCRIPTION
## Summary

Enables the `avatarUpload` feature flag in the `examples/agent-builder` Mastra config so the agent avatar upload UI is exposed when running the example. With the flag on, the configure panel renders the interactive upload trigger; without it, the avatar shows as a non-interactive display.

## Why

The avatar upload flow already exists end-to-end (configure panel → form state → \`metadata.avatarUrl\` → \`PATCH /stored/agents/:id\` with server-side data-URL validation), but the example was not opting into it, making the feature invisible when smoke-testing against the example app.

## Test Plan

- Run \`pnpm --filter ./examples/agent-builder dev\`, open the agent builder, and confirm the avatar trigger is present and accepts an image upload.

🤖 Generated with [Mastra Code](https://mastra.ai)