### PR TITLE
feat(core): extend Responses WebSocket transport to Azure

### DIFF
--- a/.changeset/fruity-roses-hear.md
+++ b/.changeset/fruity-roses-hear.md
@@ -1,0 +1,20 @@
+---
+'@mastra/core': minor
+---
+
+Added Azure OpenAI Responses WebSocket transport support for streaming agent and tool loops.
+
+Configure the Azure gateway with `useResponsesAPI: true`, then opt into WebSocket streaming per request:
+
+```ts
+const stream = await agent.stream('Review this task', {
+  providerOptions: {
+    azure: {
+      transport: 'websocket',
+      websocket: { closeOnFinish: false },
+    },
+  },
+});
+```
+
+Responses WebSocket streams now preserve transport handles through agent loops, reuse explicit API-key router connections safely, clean up cancelled streams, and reject overlapping `previous_response_id` continuations on the same connection.

--- a/docs/src/content/en/models/gateways/azure-openai.mdx
+++ b/docs/src/content/en/models/gateways/azure-openai.mdx
@@ -182,6 +182,45 @@ Use `apiVersion: "v1"` for the GA `v1` route. Microsoft currently exposes previe
 
 The same API key and Microsoft Entra ID authentication modes work with the `v1` route.
 
+### Azure Responses WebSocket transport
+
+Azure OpenAI also supports WebSocket mode on the Responses API. Use it for agent or tool loops with many model-tool round trips. Keep the standard HTTP transport for single-shot requests and short conversations.
+
+WebSocket transport requires `useResponsesAPI: true`, because Azure exposes it on the `v1` Responses path. Then opt in per stream request with `providerOptions.azure.transport: "websocket"`.
+
+```typescript
+import { Agent } from "@mastra/core/agent";
+
+const agent = new Agent({
+  id: "azure-ws-agent",
+  name: "Azure WebSocket Agent",
+  instructions: "Use tools when they are useful.",
+  model: "azure-openai/my-gpt-5-4-deployment",
+});
+
+const stream = await agent.stream("Find and improve the slow function.", {
+  providerOptions: {
+    azure: {
+      transport: "websocket",
+      store: false,
+      websocket: {
+        closeOnFinish: false,
+      },
+    },
+  },
+});
+
+for await (const chunk of stream.textStream) {
+  process.stdout.write(chunk);
+}
+
+stream.transport?.close();
+```
+
+Set `closeOnFinish: false` when you want to keep the socket open across follow-up turns. Azure keeps one response chain in connection-local memory, so continuing from the most recent `previous_response_id` can reduce continuation latency. The connection runs one response at a time and does not multiplex parallel runs.
+
+Do not send overlapping follow-up requests with `previous_response_id` on the same WebSocket transport. Mastra rejects overlapping continuation requests because Azure only keeps one in-flight response per connection. Wait for the active stream to finish before continuing the response chain.
+
 ## Configuration Reference
 
 | Option | Type | Required | Description |

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -995,9 +995,9 @@ await agent.stream('message for agent', {
 })
 ```
 
-## OpenAI WebSocket transport
+## Responses WebSocket transport
 
-Opt into OpenAI Responses WebSocket streaming via `providerOptions.openai.transport`. This only applies to streaming calls and is currently supported for direct OpenAI models (for example, `openai/gpt-5.4`). If WebSocket streaming is unavailable, Mastra falls back to HTTP streaming. By default, Mastra closes the WebSocket when the stream finishes.
+Opt into Responses WebSocket streaming with provider options. This only applies to streaming calls and is supported for direct OpenAI models and Azure OpenAI Responses deployments. If WebSocket streaming is unavailable, Mastra falls back to HTTP streaming. By default, Mastra closes the WebSocket when the stream finishes.
 
 ```ts title="index.ts"
 const stream = await agent.stream('Hello', {
@@ -1008,6 +1008,20 @@ const stream = await agent.stream('Hello', {
         url: 'wss://api.openai.com/v1/responses',
         closeOnFinish: true, // default
       },
+    },
+  },
+})
+```
+
+For Azure OpenAI, configure the gateway with `useResponsesAPI: true`, then use `providerOptions.azure.transport`.
+
+```ts title="index.ts"
+const stream = await agent.stream('Hello', {
+  providerOptions: {
+    azure: {
+      transport: 'websocket',
+      store: false,
+      websocket: { closeOnFinish: true },
     },
   },
 })
@@ -1028,6 +1042,8 @@ const stream = await agent.stream('Hello', {
 // Later, when you're done with the connection:
 stream.transport?.close()
 ```
+
+Responses WebSocket connections run one response at a time. Mastra rejects overlapping continuation requests that include `previous_response_id` on the same WebSocket transport. Wait for the active stream to finish before sending the next turn in the response chain.
 
 ## Related
 

--- a/packages/core/src/llm/model/gateways/azure.test.ts
+++ b/packages/core/src/llm/model/gateways/azure.test.ts
@@ -2,6 +2,17 @@ import { createAzure } from '@ai-sdk/azure';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { AzureOpenAIGateway } from './azure';
 import type { AzureOpenAIGatewayConfig } from './azure';
+import { MASTRA_GATEWAY_STREAM_TRANSPORT } from './base';
+
+const { wsFetch, wsClose } = vi.hoisted(() => {
+  const wsClose = vi.fn();
+  const wsFetch = Object.assign(
+    vi.fn(async () => new Response('')),
+    { close: wsClose },
+  );
+
+  return { wsFetch, wsClose };
+});
 
 vi.mock('@ai-sdk/azure', () => ({
   createAzure: vi.fn((options: Record<string, unknown>) => {
@@ -17,6 +28,12 @@ vi.mock('@ai-sdk/azure', () => ({
   }),
 }));
 
+vi.mock('../openai-websocket-fetch.js', () => ({
+  createOpenAIWebSocketFetch: vi.fn(() => wsFetch),
+}));
+
+const { createOpenAIWebSocketFetch } = await import('../openai-websocket-fetch.js');
+
 const mockFetch = vi.fn();
 global.fetch = mockFetch as any;
 
@@ -24,6 +41,8 @@ describe('AzureOpenAIGateway', () => {
   afterEach(() => {
     vi.clearAllMocks();
     mockFetch.mockClear();
+    wsFetch.mockClear();
+    wsClose.mockClear();
   });
 
   describe('Configuration Validation', () => {
@@ -725,6 +744,112 @@ describe('AzureOpenAIGateway', () => {
           useDeploymentBasedUrls: false,
         }),
       );
+    });
+
+    it('should use Azure Responses WebSocket fetch when requested', async () => {
+      const gateway = new AzureOpenAIGateway({
+        resourceName: 'test-resource',
+        apiKey: 'test-key',
+        useResponsesAPI: true,
+        deployments: ['gpt-5-4-deployment'],
+      });
+
+      const model = (await gateway.resolveLanguageModel({
+        modelId: 'gpt-5-4-deployment',
+        providerId: 'azure-openai',
+        apiKey: 'test-key',
+        transport: 'websocket',
+        responsesWebSocket: {
+          headers: { 'x-ms-client-request-id': 'request-1' },
+        },
+      })) as any;
+
+      expect(model.api).toBe('responses');
+      expect(createOpenAIWebSocketFetch).toHaveBeenLastCalledWith({
+        url: 'wss://test-resource.openai.azure.com/openai/v1/responses',
+        headers: { 'x-ms-client-request-id': 'request-1' },
+        apiKeyQueryParam: 'api-key',
+        betaHeader: false,
+      });
+      expect(createAzure).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fetch: wsFetch,
+          apiVersion: 'v1',
+          useDeploymentBasedUrls: false,
+        }),
+      );
+      expect(model[MASTRA_GATEWAY_STREAM_TRANSPORT].close).toBe(wsClose);
+    });
+
+    it('should use a custom Azure Responses WebSocket URL when provided', async () => {
+      const gateway = new AzureOpenAIGateway({
+        resourceName: 'test-resource',
+        apiKey: 'test-key',
+        useResponsesAPI: true,
+        deployments: ['gpt-5-4-deployment'],
+      });
+
+      await gateway.resolveLanguageModel({
+        modelId: 'gpt-5-4-deployment',
+        providerId: 'azure-openai',
+        apiKey: 'test-key',
+        transport: 'websocket',
+        responsesWebSocket: {
+          url: 'wss://proxy.example.com/openai/v1/responses',
+        },
+      });
+
+      expect(createOpenAIWebSocketFetch).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          url: 'wss://proxy.example.com/openai/v1/responses',
+        }),
+      );
+    });
+
+    it('should route Azure Responses WebSocket Entra ID auth through the token fetch wrapper', async () => {
+      const credential = {
+        getToken: vi.fn().mockResolvedValue({
+          token: 'entra-token',
+          expiresOnTimestamp: Date.now() + 3600_000,
+        }),
+      };
+
+      const gateway = new AzureOpenAIGateway({
+        resourceName: 'test-resource',
+        authentication: {
+          type: 'entraId',
+          credential,
+        },
+        useResponsesAPI: true,
+        deployments: ['gpt-5-4-deployment'],
+      });
+
+      const model = (await gateway.resolveLanguageModel({
+        modelId: 'gpt-5-4-deployment',
+        providerId: 'azure-openai',
+        apiKey: await gateway.getApiKey('gpt-5-4-deployment'),
+        transport: 'websocket',
+      })) as any;
+
+      expect(createOpenAIWebSocketFetch).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          apiKeyQueryParam: false,
+          betaHeader: false,
+        }),
+      );
+
+      await model.options.fetch('https://test-resource.openai.azure.com/openai/v1/responses', {
+        method: 'POST',
+        headers: {
+          'api-key': '',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ stream: true, model: 'gpt-5-4-deployment', input: 'hello' }),
+      });
+
+      const fetchHeaders = wsFetch.mock.calls.at(-1)?.[1].headers as Headers;
+      expect(fetchHeaders.get('Authorization')).toBe('Bearer entra-token');
+      expect(fetchHeaders.has('api-key')).toBe(false);
     });
 
     it('should mirror Azure Responses item IDs only inside Azure Responses model calls', async () => {

--- a/packages/core/src/llm/model/gateways/azure.ts
+++ b/packages/core/src/llm/model/gateways/azure.ts
@@ -2,7 +2,9 @@ import { createAzure } from '@ai-sdk/azure';
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import { InMemoryServerCache } from '../../../cache/inmemory.js';
 import { MastraError } from '../../../error/index.js';
-import { MastraModelGateway } from './base.js';
+import { createOpenAIWebSocketFetch } from '../openai-websocket-fetch.js';
+import type { OpenAITransport, ResponsesWebSocketOptions } from '../provider-options.js';
+import { MASTRA_GATEWAY_STREAM_TRANSPORT, MastraModelGateway } from './base.js';
 import type { ProviderConfig } from './base.js';
 import { MASTRA_USER_AGENT } from './constants.js';
 
@@ -537,15 +539,38 @@ export class AzureOpenAIGateway extends MastraModelGateway {
     };
   }
 
+  private createAzureResponsesWebSocketFetch({
+    useEntraId,
+    responsesWebSocket,
+  }: {
+    useEntraId: boolean;
+    responsesWebSocket?: ResponsesWebSocketOptions;
+  }): typeof globalThis.fetch & { close(): void } {
+    const websocketFetch = createOpenAIWebSocketFetch({
+      url: responsesWebSocket?.url ?? `wss://${this.config.resourceName}.openai.azure.com/openai/v1/responses`,
+      headers: responsesWebSocket?.headers,
+      apiKeyQueryParam: useEntraId ? false : 'api-key',
+      betaHeader: false,
+    });
+
+    return useEntraId
+      ? Object.assign(this.createEntraIdFetch(websocketFetch), { close: websocketFetch.close })
+      : websocketFetch;
+  }
+
   async resolveLanguageModel({
     modelId,
     apiKey,
     headers,
+    transport,
+    responsesWebSocket,
   }: {
     modelId: string;
     providerId: string;
     apiKey: string;
     headers?: Record<string, string>;
+    transport?: OpenAITransport;
+    responsesWebSocket?: ResponsesWebSocketOptions;
   }): Promise<LanguageModelV2> {
     const useResponsesAPI = this.config.useResponsesAPI ?? false;
     const apiVersion =
@@ -553,6 +578,13 @@ export class AzureOpenAIGateway extends MastraModelGateway {
       (useResponsesAPI || this.config.useDeploymentBasedUrls === false ? 'v1' : '2024-04-01-preview');
     const useDeploymentBasedUrls = this.config.useDeploymentBasedUrls ?? (useResponsesAPI ? false : true);
     const useEntraId = this.config.authentication?.type === 'entraId';
+    const useWebSocket = useResponsesAPI && transport === 'websocket';
+    const websocketFetch = useWebSocket
+      ? this.createAzureResponsesWebSocketFetch({
+          useEntraId,
+          responsesWebSocket,
+        })
+      : undefined;
     const azureConfig = {
       resourceName: this.config.resourceName,
       apiKey: useEntraId ? '' : apiKey,
@@ -562,19 +594,31 @@ export class AzureOpenAIGateway extends MastraModelGateway {
       // to use the newer Azure OpenAI v1 route.
       useDeploymentBasedUrls,
       headers: { 'User-Agent': MASTRA_USER_AGENT, ...headers },
+      ...(websocketFetch && !useEntraId ? { fetch: websocketFetch } : {}),
     };
 
     const azureProvider = createAzure(
       useEntraId
         ? {
             ...azureConfig,
-            fetch: this.createEntraIdFetch(),
+            fetch: websocketFetch ?? this.createEntraIdFetch(),
           }
         : azureConfig,
     );
 
     if (useResponsesAPI) {
-      return withAzureResponsesInputCompatibility(azureProvider.responses(modelId));
+      const model = withAzureResponsesInputCompatibility(azureProvider.responses(modelId));
+      if (websocketFetch) {
+        Object.defineProperty(model, MASTRA_GATEWAY_STREAM_TRANSPORT, {
+          configurable: true,
+          value: {
+            type: 'openai-websocket',
+            close: websocketFetch.close,
+          },
+        });
+      }
+
+      return model;
     }
 
     return azureProvider(modelId);

--- a/packages/core/src/llm/model/gateways/base.ts
+++ b/packages/core/src/llm/model/gateways/base.ts
@@ -5,6 +5,8 @@
 
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import type { LanguageModelV3 } from '@ai-sdk/provider-v6';
+import type { StreamTransport } from '../../../stream/types';
+import type { OpenAITransport, ResponsesWebSocketOptions } from '../provider-options.js';
 
 export interface ProviderConfig {
   url?: string;
@@ -22,6 +24,14 @@ export interface ProviderConfig {
  * Supports both AI SDK v5 (LanguageModelV2) and v6 (LanguageModelV3).
  */
 export type GatewayLanguageModel = LanguageModelV2 | LanguageModelV3;
+export type GatewayStreamTransportHandle = Pick<StreamTransport, 'type' | 'close'>;
+
+/** @internal Stream transport handle attached by gateways that own custom streaming transports. */
+export const MASTRA_GATEWAY_STREAM_TRANSPORT = Symbol.for('@mastra/core.gatewayStreamTransport');
+
+export type GatewayLanguageModelWithStreamTransport = GatewayLanguageModel & {
+  [MASTRA_GATEWAY_STREAM_TRANSPORT]?: GatewayStreamTransportHandle;
+};
 
 export abstract class MastraModelGateway {
   /**
@@ -76,6 +86,8 @@ export abstract class MastraModelGateway {
     providerId: string;
     apiKey: string;
     headers?: Record<string, string>;
+    transport?: OpenAITransport;
+    responsesWebSocket?: ResponsesWebSocketOptions;
   }): Promise<GatewayLanguageModel> | GatewayLanguageModel;
 
   /**

--- a/packages/core/src/llm/model/openai-websocket-fetch.test.ts
+++ b/packages/core/src/llm/model/openai-websocket-fetch.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { sockets, nextServerEvents } = vi.hoisted(() => ({
+  sockets: [] as Array<{
+    url: string;
+    options: { headers: Record<string, string> };
+    sent: Array<Record<string, unknown>>;
+    close: () => void;
+  }>,
+  nextServerEvents: [] as Array<Record<string, unknown> | string>,
+}));
+
+vi.mock('ws', async () => {
+  const { EventEmitter } = await import('node:events');
+
+  class MockWebSocket extends EventEmitter {
+    static OPEN = 1;
+    readyState = MockWebSocket.OPEN;
+    url: string;
+    options: { headers: Record<string, string> };
+    sent: Array<Record<string, unknown>> = [];
+
+    constructor(url: string, options: { headers: Record<string, string> }) {
+      super();
+      this.url = url;
+      this.options = options;
+      sockets.push(this);
+      queueMicrotask(() => this.emit('open'));
+    }
+
+    send(message: string) {
+      this.sent.push(JSON.parse(message));
+      const events = nextServerEvents.length > 0 ? nextServerEvents.splice(0) : [{ type: 'response.completed' }];
+      queueMicrotask(() => {
+        for (const event of events) {
+          this.emit('message', typeof event === 'string' ? event : JSON.stringify(event));
+        }
+      });
+    }
+
+    close() {
+      this.readyState = 3;
+      this.emit('close');
+    }
+  }
+
+  return { default: MockWebSocket };
+});
+
+const { createOpenAIWebSocketFetch } = await import('./openai-websocket-fetch.js');
+
+describe('createOpenAIWebSocketFetch', () => {
+  beforeEach(() => {
+    sockets.length = 0;
+    nextServerEvents.length = 0;
+  });
+
+  it('can move API key headers to the WebSocket URL without sending OpenAI beta headers', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch({
+      url: 'wss://test-resource.openai.azure.com/openai/v1/responses',
+      headers: { 'x-ms-client-request-id': 'request-1' },
+      apiKeyQueryParam: 'api-key',
+      betaHeader: false,
+    });
+
+    const response = await websocketFetch('https://test-resource.openai.azure.com/openai/v1/responses', {
+      method: 'POST',
+      headers: {
+        'api-key': 'azure-key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ stream: true, model: 'gpt-5-4-deployment', input: 'hello' }),
+    });
+
+    await response.text();
+
+    expect(sockets[0]).toMatchObject({
+      url: 'wss://test-resource.openai.azure.com/openai/v1/responses?api-key=azure-key',
+      options: {
+        headers: expect.objectContaining({
+          'x-ms-client-request-id': 'request-1',
+        }),
+      },
+    });
+    expect(sockets[0].options.headers).not.toHaveProperty('Authorization');
+    expect(sockets[0].options.headers).not.toHaveProperty('api-key');
+    expect(sockets[0].options.headers).not.toHaveProperty('OpenAI-Beta');
+  });
+
+  it('keeps API key headers as headers when query auth is not configured', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch({
+      url: 'wss://api.openai.com/v1/responses',
+      betaHeader: false,
+    });
+
+    const response = await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'api-key': 'openai-key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'hello' }),
+    });
+
+    await response.text();
+
+    expect(sockets[0].options.headers).toMatchObject({
+      'api-key': 'openai-key',
+    });
+    expect(sockets[0].options.headers).not.toHaveProperty('Authorization');
+  });
+
+  it('sends the OpenAI beta header by default', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch({
+      url: 'wss://api.openai.com/v1/responses',
+    });
+
+    const response = await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer openai-key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'hello' }),
+    });
+
+    await response.text();
+
+    expect(sockets[0].options.headers).toMatchObject({
+      Authorization: 'Bearer openai-key',
+      'OpenAI-Beta': 'responses_websockets=2026-02-06',
+    });
+  });
+
+  it('preserves explicit Authorization headers', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch({
+      url: 'wss://api.openai.com/v1/responses',
+      betaHeader: false,
+    });
+
+    const response = await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer explicit-key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'hello' }),
+    });
+
+    await response.text();
+
+    expect(sockets[0].options.headers).toMatchObject({
+      Authorization: 'Bearer explicit-key',
+    });
+  });
+
+  it('routes Responses URLs with query parameters through the WebSocket transport', async () => {
+    const httpFetch = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Unexpected HTTP fallback'));
+    const websocketFetch = createOpenAIWebSocketFetch({
+      url: 'wss://test-resource.openai.azure.com/openai/v1/responses',
+      apiKeyQueryParam: 'api-key',
+      betaHeader: false,
+    });
+
+    const response = await websocketFetch('https://test-resource.openai.azure.com/openai/v1/responses?api-version=v1', {
+      method: 'POST',
+      headers: {
+        'api-key': 'azure-key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ stream: true, model: 'gpt-5-4-deployment', input: 'hello' }),
+    });
+
+    await response.text();
+
+    expect(httpFetch).not.toHaveBeenCalled();
+    expect(sockets[0].sent[0]).toMatchObject({
+      type: 'response.create',
+      model: 'gpt-5-4-deployment',
+    });
+    httpFetch.mockRestore();
+  });
+
+  it('opens a new query-auth socket when the API key changes', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch({
+      url: 'wss://test-resource.openai.azure.com/openai/v1/responses',
+      apiKeyQueryParam: 'api-key',
+      betaHeader: false,
+    });
+
+    const firstResponse = await websocketFetch('https://test-resource.openai.azure.com/openai/v1/responses', {
+      method: 'POST',
+      headers: {
+        'api-key': 'first-key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ stream: true, model: 'gpt-5-4-deployment', input: 'hello' }),
+    });
+    await firstResponse.text();
+
+    const secondResponse = await websocketFetch('https://test-resource.openai.azure.com/openai/v1/responses', {
+      method: 'POST',
+      headers: {
+        'api-key': 'second-key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ stream: true, model: 'gpt-5-4-deployment', input: 'again' }),
+    });
+    await secondResponse.text();
+
+    expect(sockets).toHaveLength(2);
+    expect(sockets[0].readyState).toBe(3);
+    expect(sockets[1].url).toBe('wss://test-resource.openai.azure.com/openai/v1/responses?api-key=second-key');
+  });
+
+  it('strips HTTP-only Responses fields before sending response.create', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch();
+
+    const response = await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer openai-key' },
+      body: JSON.stringify({ stream: true, background: true, model: 'gpt-5.5', input: 'hello' }),
+    });
+
+    await response.text();
+
+    expect(sockets[0].sent[0]).toMatchObject({
+      type: 'response.create',
+      model: 'gpt-5.5',
+      input: 'hello',
+    });
+    expect(sockets[0].sent[0]).not.toHaveProperty('stream');
+    expect(sockets[0].sent[0]).not.toHaveProperty('background');
+  });
+
+  it('terminates the SSE stream for failed and incomplete response events', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch();
+    nextServerEvents.push({ type: 'response.failed', response: { id: 'resp_failed' } });
+
+    const failedResponse = await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer openai-key' },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'hello' }),
+    });
+
+    await expect(failedResponse.text()).resolves.toContain('data: [DONE]');
+
+    nextServerEvents.push({ type: 'response.incomplete', response: { id: 'resp_incomplete' } });
+    const incompleteResponse = await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer openai-key' },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'again' }),
+    });
+
+    await expect(incompleteResponse.text()).resolves.toContain('data: [DONE]');
+  });
+
+  it('formats multiline WebSocket frames as valid SSE data lines', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch();
+    nextServerEvents.push(
+      `{
+  "type": "error",
+  "status": 400,
+  "error": {
+    "code": "invalid_request_error"
+  }
+}`,
+    );
+
+    const response = await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer openai-key' },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'hello' }),
+    });
+
+    await expect(response.text()).resolves.toContain('data:   "type": "error",');
+  });
+
+  it('closes the socket when the service reports the WebSocket connection limit', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch();
+    nextServerEvents.push({
+      type: 'error',
+      status: 400,
+      error: { code: 'websocket_connection_limit_reached' },
+    });
+
+    const response = await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer openai-key' },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'hello' }),
+    });
+
+    await response.text();
+
+    expect(sockets[0].readyState).toBe(3);
+  });
+
+  it('does not silently fall back to HTTP for overlapping non-persisted continuations', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch();
+    nextServerEvents.push({ type: 'response.output_text.delta', delta: 'still running' });
+
+    await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer openai-key' },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'hello' }),
+    });
+
+    await expect(
+      websocketFetch('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer openai-key' },
+        body: JSON.stringify({
+          stream: true,
+          store: false,
+          previous_response_id: 'resp_previous',
+          model: 'gpt-5.5',
+          input: 'continue',
+        }),
+      }),
+    ).rejects.toThrow('Cannot start an overlapping WebSocket Responses continuation');
+
+    websocketFetch.close();
+  });
+
+  it('does not silently fall back to HTTP for any overlapping continuation', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch();
+    nextServerEvents.push({ type: 'response.output_text.delta', delta: 'still running' });
+
+    await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer openai-key' },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'hello' }),
+    });
+
+    await expect(
+      websocketFetch('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer openai-key' },
+        body: JSON.stringify({
+          stream: true,
+          store: true,
+          previous_response_id: 'resp_previous',
+          model: 'gpt-5.5',
+          input: 'continue',
+        }),
+      }),
+    ).rejects.toThrow('Cannot start an overlapping WebSocket Responses continuation');
+
+    websocketFetch.close();
+  });
+
+  it('cleans up listeners and busy state when the response stream is cancelled', async () => {
+    const websocketFetch = createOpenAIWebSocketFetch();
+    nextServerEvents.push({ type: 'response.output_text.delta', delta: 'still running' });
+
+    const response = await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer openai-key' },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'hello' }),
+    });
+
+    await response.body?.cancel();
+
+    const nextResponse = await websocketFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer openai-key' },
+      body: JSON.stringify({ stream: true, model: 'gpt-5.5', input: 'again' }),
+    });
+
+    await expect(nextResponse.text()).resolves.toContain('data: [DONE]');
+    expect(sockets[0].readyState).toBe(3);
+    expect(sockets).toHaveLength(2);
+  });
+});

--- a/packages/core/src/llm/model/openai-websocket-fetch.ts
+++ b/packages/core/src/llm/model/openai-websocket-fetch.ts
@@ -11,11 +11,29 @@ export interface CreateOpenAIWebSocketFetchOptions {
    * Authorization and OpenAI-Beta are managed internally.
    */
   headers?: Record<string, string>;
+  /**
+   * Convert an `api-key` request header into `Authorization: Bearer ...` for
+   * providers whose WebSocket endpoint authenticates API keys as bearer tokens.
+   */
+  apiKeyAsBearer?: boolean;
+  /**
+   * Move an `api-key` request header into the WebSocket URL query string for
+   * providers whose WebSocket endpoint authenticates API keys through a query
+   * parameter. Entra ID and OpenAI bearer-token auth should leave this disabled.
+   */
+  apiKeyQueryParam?: string | false;
+  /**
+   * Optional beta header sent when establishing the WebSocket connection.
+   * @default 'responses_websockets=2026-02-06'
+   */
+  betaHeader?: string | false;
 }
 
 export type OpenAIWebSocketFetch = ((input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) & {
   close(): void;
 };
+
+const TERMINAL_RESPONSE_EVENTS = new Set(['response.completed', 'response.failed', 'response.incomplete', 'error']);
 
 /**
  * Creates a `fetch` function that routes OpenAI Responses API streaming
@@ -23,17 +41,45 @@ export type OpenAIWebSocketFetch = ((input: RequestInfo | URL, init?: RequestIni
  */
 export function createOpenAIWebSocketFetch(options?: CreateOpenAIWebSocketFetchOptions): OpenAIWebSocketFetch {
   const wsUrl = options?.url ?? 'wss://api.openai.com/v1/responses';
+  const betaHeader = options?.betaHeader === undefined ? 'responses_websockets=2026-02-06' : options.betaHeader;
+  const apiKeyQueryParam = options?.apiKeyQueryParam ?? false;
 
   let ws: WebSocket | null = null;
   let connecting: Promise<WebSocket> | null = null;
   let connectionKey: string | null = null;
+  let nextQueryCredentialId = 0;
+  const queryCredentialIds = new Map<string, string>();
   let busy = false;
 
-  function getConnection(authorization: string, headers: Record<string, string>): Promise<WebSocket> {
+  function getQueryCredentialCacheId(value?: string): string {
+    if (!value) return '';
+
+    const existing = queryCredentialIds.get(value);
+    if (existing) return existing;
+
+    const id = String(++nextQueryCredentialId);
+    queryCredentialIds.set(value, id);
+    return id;
+  }
+
+  function getConnection(
+    authorization: string,
+    headers: Record<string, string>,
+    signal?: AbortSignal | null,
+  ): Promise<WebSocket> {
+    if (signal?.aborted) {
+      return Promise.reject(getAbortError(signal));
+    }
+
     const normalizedHeaders = { ...normalizeHeaders(options?.headers), ...headers };
+    const apiKey = normalizedHeaders['api-key'];
     delete normalizedHeaders['authorization'];
     delete normalizedHeaders['openai-beta'];
-    const nextConnectionKey = buildConnectionKey(authorization, normalizedHeaders);
+    if (options?.apiKeyAsBearer || apiKeyQueryParam) {
+      delete normalizedHeaders['api-key'];
+    }
+    const queryCredential = apiKeyQueryParam ? `${apiKeyQueryParam}:${getQueryCredentialCacheId(apiKey)}` : '';
+    const nextConnectionKey = buildConnectionKey(authorization, normalizedHeaders, queryCredential);
 
     if (ws?.readyState === WebSocket.OPEN && connectionKey === nextConnectionKey) {
       return Promise.resolve(ws);
@@ -50,26 +96,54 @@ export function createOpenAIWebSocketFetch(options?: CreateOpenAIWebSocketFetchO
     connectionKey = nextConnectionKey;
 
     connecting = new Promise<WebSocket>((resolve, reject) => {
-      const socket = new WebSocket(wsUrl, {
+      let settled = false;
+      const socket = new WebSocket(getWebSocketUrl(wsUrl, apiKeyQueryParam, apiKey), {
         headers: {
           ...normalizedHeaders,
-          Authorization: authorization,
-          'OpenAI-Beta': 'responses_websockets=2026-02-06',
+          ...(authorization ? { Authorization: authorization } : {}),
+          ...(betaHeader ? { 'OpenAI-Beta': betaHeader } : {}),
         },
       });
 
+      function cleanupAbortListener() {
+        signal?.removeEventListener('abort', onAbort);
+      }
+
+      function rejectConnection(err: unknown, closeSocket = true) {
+        if (settled) return;
+        settled = true;
+        connecting = null;
+        connectionKey = null;
+        cleanupAbortListener();
+        if (closeSocket) socket.close();
+        reject(err);
+      }
+
+      function onAbort() {
+        rejectConnection(getAbortError(signal));
+      }
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+
       socket.on('open', () => {
+        if (signal?.aborted) {
+          rejectConnection(getAbortError(signal));
+          return;
+        }
+        settled = true;
         ws = socket;
         connecting = null;
+        cleanupAbortListener();
         resolve(socket);
       });
 
       socket.on('error', err => {
-        if (connecting) {
-          connecting = null;
-          connectionKey = null;
-          reject(err);
-        }
+        rejectConnection(err, false);
+      });
+
+      socket.on('close', () => {
+        if (settled) return;
+        rejectConnection(new Error('WebSocket closed before the connection opened'), false);
       });
 
       socket.on('close', () => {
@@ -84,7 +158,7 @@ export function createOpenAIWebSocketFetch(options?: CreateOpenAIWebSocketFetchO
   async function websocketFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     const url = input instanceof URL ? input.toString() : typeof input === 'string' ? input : input.url;
 
-    if (init?.method !== 'POST' || !url.endsWith('/responses')) {
+    if (init?.method !== 'POST' || !isResponsesUrl(url)) {
       return globalThis.fetch(input, init);
     }
 
@@ -100,33 +174,50 @@ export function createOpenAIWebSocketFetch(options?: CreateOpenAIWebSocketFetchO
     }
 
     // Prevent concurrent streams from sharing one WebSocket transport instance.
-    // In that case, fall back to HTTP streaming for the overlapping request.
+    // Only fall back to HTTP when the request does not depend on the socket's
+    // connection-local previous_response_id cache.
     if (busy) {
+      if (body.previous_response_id) {
+        throw new Error(
+          'Cannot start an overlapping WebSocket Responses continuation. Wait for the active stream to finish before sending previous_response_id.',
+        );
+      }
       return globalThis.fetch(input, init);
     }
 
     const headers = normalizeHeaders(init.headers);
-    const authorization = headers['authorization'] ?? '';
+    const authorization =
+      headers['authorization'] ?? (options?.apiKeyAsBearer && headers['api-key'] ? `Bearer ${headers['api-key']}` : '');
 
     // Acquire the busy lock before awaiting to prevent races
     busy = true;
     let connection: WebSocket;
     try {
-      connection = await getConnection(authorization, headers);
+      connection = await getConnection(authorization, headers, init?.signal);
     } catch (err) {
       busy = false;
       throw err;
     }
 
-    const { stream: _stream, ...requestBody } = body;
+    const { stream: _stream, background: _background, ...requestBody } = body;
     const encoder = new TextEncoder();
 
+    let cleanupActiveStream: ((options?: { closeSocket?: boolean }) => void) | undefined;
     const responseStream = new ReadableStream<Uint8Array>({
       start(controller) {
+        let cleanedUp = false;
+        let abortHandler: (() => void) | undefined;
+
         function cleanup({ closeSocket = false }: { closeSocket?: boolean } = {}) {
+          if (cleanedUp) return;
+          cleanedUp = true;
           connection.off('message', onMessage);
           connection.off('error', onError);
           connection.off('close', onClose);
+          if (abortHandler) {
+            init?.signal?.removeEventListener('abort', abortHandler);
+            abortHandler = undefined;
+          }
 
           if (closeSocket && ws === connection) {
             connection.close();
@@ -135,17 +226,20 @@ export function createOpenAIWebSocketFetch(options?: CreateOpenAIWebSocketFetchO
           }
 
           busy = false;
+          cleanupActiveStream = undefined;
         }
+
+        cleanupActiveStream = cleanup;
 
         function onMessage(data: WebSocket.RawData) {
           const text = data.toString();
-          controller.enqueue(encoder.encode(`data: ${text}\n\n`));
+          controller.enqueue(encoder.encode(formatSSEData(text)));
 
           try {
             const event = JSON.parse(text);
-            if (event.type === 'response.completed' || event.type === 'error') {
+            if (isTerminalWebSocketEvent(event)) {
               controller.enqueue(encoder.encode('data: [DONE]\n\n'));
-              cleanup();
+              cleanup({ closeSocket: shouldReconnectAfterEvent(event) });
               controller.close();
             }
           } catch {
@@ -178,21 +272,21 @@ export function createOpenAIWebSocketFetch(options?: CreateOpenAIWebSocketFetchO
             controller.error(signal.reason ?? new DOMException('Aborted', 'AbortError'));
             return;
           }
-          signal.addEventListener(
-            'abort',
-            () => {
-              cleanup({ closeSocket: true });
-              try {
-                controller.error(signal.reason ?? new DOMException('Aborted', 'AbortError'));
-              } catch {
-                // already closed
-              }
-            },
-            { once: true },
-          );
+          abortHandler = () => {
+            cleanup({ closeSocket: true });
+            try {
+              controller.error(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+            } catch {
+              // already closed
+            }
+          };
+          signal.addEventListener('abort', abortHandler, { once: true });
         }
 
         connection.send(JSON.stringify({ type: 'response.create', ...requestBody }));
+      },
+      cancel() {
+        cleanupActiveStream?.({ closeSocket: true });
       },
     });
 
@@ -215,11 +309,60 @@ export function createOpenAIWebSocketFetch(options?: CreateOpenAIWebSocketFetchO
   });
 }
 
-function buildConnectionKey(authorization: string, headers: Record<string, string>): string {
+function isResponsesUrl(url: string): boolean {
+  try {
+    return new URL(url).pathname.endsWith('/responses');
+  } catch {
+    return url.split('?')[0]?.endsWith('/responses') ?? false;
+  }
+}
+
+function getWebSocketUrl(url: string, apiKeyQueryParam: string | false, apiKey?: string): string {
+  if (!apiKeyQueryParam || !apiKey) return url;
+
+  const parsedUrl = new URL(url);
+  parsedUrl.searchParams.set(apiKeyQueryParam, apiKey);
+  return parsedUrl.toString();
+}
+
+function formatSSEData(text: string): string {
+  return `${text
+    .split(/\r?\n/)
+    .map(line => `data: ${line}`)
+    .join('\n')}\n\n`;
+}
+
+function buildConnectionKey(authorization: string, headers: Record<string, string>, queryCredential = ''): string {
   return JSON.stringify({
     authorization,
+    queryCredential,
     headers: Object.entries(headers).sort(([a], [b]) => a.localeCompare(b)),
   });
+}
+
+function isTerminalWebSocketEvent(event: unknown): event is { type: string } {
+  return (
+    typeof event === 'object' &&
+    event !== null &&
+    'type' in event &&
+    typeof event.type === 'string' &&
+    TERMINAL_RESPONSE_EVENTS.has(event.type)
+  );
+}
+
+function shouldReconnectAfterEvent(event: unknown): boolean {
+  if (typeof event !== 'object' || event === null || !('error' in event)) return false;
+  const error = event.error;
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'websocket_connection_limit_reached'
+  );
+}
+
+function getAbortError(signal?: AbortSignal | null): unknown {
+  return signal?.reason ?? new DOMException('Aborted', 'AbortError');
 }
 
 function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {

--- a/packages/core/src/llm/model/provider-options.test-d.ts
+++ b/packages/core/src/llm/model/provider-options.test-d.ts
@@ -2,14 +2,22 @@ import { describe, expectTypeOf, it } from 'vitest';
 import type { ProviderOptions } from './provider-options';
 
 describe('ProviderOptions type tests', () => {
-  it('accepts Azure Responses continuation options', () => {
+  it('accepts Azure Responses WebSocket options with Responses continuation options', () => {
     const options: ProviderOptions = {
       azure: {
+        transport: 'websocket',
+        websocket: {
+          url: 'wss://example-resource.openai.azure.com/openai/v1/responses',
+          headers: { 'x-ms-client-request-id': 'request-1' },
+          closeOnFinish: false,
+        },
         store: false,
         previousResponseId: 'resp_123',
       },
     };
 
+    expectTypeOf(options.azure?.transport).toEqualTypeOf<'auto' | 'websocket' | 'fetch' | undefined>();
+    expectTypeOf(options.azure?.websocket?.closeOnFinish).toEqualTypeOf<boolean | undefined>();
     expectTypeOf(options.azure?.previousResponseId).toEqualTypeOf<string | null | undefined>();
   });
 });

--- a/packages/core/src/llm/model/provider-options.ts
+++ b/packages/core/src/llm/model/provider-options.ts
@@ -26,7 +26,7 @@ export type {
 // Alias for consistency
 export type GoogleProviderOptions = GoogleGenerativeAIProviderOptions;
 export type OpenAITransport = 'auto' | 'websocket' | 'fetch';
-export type OpenAIWebSocketOptions = {
+export type ResponsesWebSocketOptions = {
   /**
    * WebSocket endpoint URL.
    * @default 'wss://api.openai.com/v1/responses'
@@ -43,6 +43,7 @@ export type OpenAIWebSocketOptions = {
    */
   closeOnFinish?: boolean;
 };
+export type OpenAIWebSocketOptions = ResponsesWebSocketOptions;
 export type OpenAIProviderOptions = OpenAIResponsesProviderOptions & {
   /**
    * Select the transport used for streaming responses.
@@ -56,7 +57,26 @@ export type OpenAIProviderOptions = OpenAIResponsesProviderOptions & {
    */
   websocket?: OpenAIWebSocketOptions;
 };
-export type AzureProviderOptions = OpenAIResponsesProviderOptions;
+export type AzureWebSocketOptions = Omit<ResponsesWebSocketOptions, 'url'> & {
+  /**
+   * WebSocket endpoint URL.
+   * @default resource-specific Azure OpenAI Responses URL
+   */
+  url?: string;
+};
+export type AzureProviderOptions = OpenAIResponsesProviderOptions & {
+  /**
+   * Select the transport used for streaming responses.
+   * - `fetch` uses HTTP streaming.
+   * - `websocket` uses the Azure OpenAI Responses WebSocket API when supported.
+   * - `auto` chooses WebSocket when supported, otherwise falls back to fetch.
+   */
+  transport?: OpenAITransport;
+  /**
+   * WebSocket-specific configuration for Azure OpenAI Responses streaming.
+   */
+  websocket?: AzureWebSocketOptions;
+};
 export type DeepSeekProviderOptions = DeepSeekChatOptions;
 
 /**

--- a/packages/core/src/llm/model/router-openai-websocket.test.ts
+++ b/packages/core/src/llm/model/router-openai-websocket.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Agent } from '../../agent/index.js';
+import { execute } from '../../stream/aisdk/v5/execute.js';
+import { readModelStreamTransport } from '../../stream/types.js';
 import { createMockModel } from '../../test-utils/llm-mock.js';
+import { MASTRA_GATEWAY_STREAM_TRANSPORT, MastraModelGateway } from './gateways/base.js';
+import type { GatewayLanguageModel, ProviderConfig } from './gateways/base.js';
 import { ModelRouterLanguageModel } from './router.js';
 
 const { closeSpy, wsFetch } = vi.hoisted(() => {
@@ -26,12 +30,12 @@ vi.mock('./openai-websocket-fetch.js', async () => {
 });
 
 const { createOpenAI } = await import('@ai-sdk/openai-v6');
+const { createOpenAIWebSocketFetch } = await import('./openai-websocket-fetch.js');
 
 describe('ModelRouter - OpenAI WebSocket transport', () => {
   beforeEach(() => {
     process.env.OPENAI_API_KEY = 'test-openai-key';
-    (ModelRouterLanguageModel as any).modelInstances = new Map();
-    (ModelRouterLanguageModel as any).webSocketFetches = new Map();
+    (ModelRouterLanguageModel as any)._clearCachesForTests();
     closeSpy.mockClear();
 
     vi.mocked(createOpenAI).mockImplementation(() => {
@@ -109,6 +113,39 @@ describe('ModelRouter - OpenAI WebSocket transport', () => {
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('reuses per-router WebSocket models when an explicit API key is configured', async () => {
+    vi.mocked(createOpenAI).mockClear();
+    vi.mocked(createOpenAIWebSocketFetch).mockClear();
+
+    const router = new ModelRouterLanguageModel({
+      id: 'openai/gpt-4o',
+      apiKey: 'explicit-openai-key',
+    });
+    const streamOptions = {
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      providerOptions: {
+        openai: {
+          transport: 'websocket',
+          websocket: { closeOnFinish: false },
+        },
+      },
+    } as any;
+
+    const firstResult = await router.doStream(streamOptions);
+    const secondResult = await router.doStream(streamOptions);
+
+    expect(vi.mocked(createOpenAI)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createOpenAIWebSocketFetch)).toHaveBeenCalledTimes(1);
+    expect(readModelStreamTransport(firstResult)).toMatchObject({
+      type: 'openai-websocket',
+      closeOnFinish: false,
+    });
+    expect(readModelStreamTransport(secondResult)).toMatchObject({
+      type: 'openai-websocket',
+      closeOnFinish: false,
+    });
+  });
+
   it('uses HTTP fetch by default', async () => {
     const agent = new Agent({
       id: 'test-agent',
@@ -130,5 +167,212 @@ describe('ModelRouter - OpenAI WebSocket transport', () => {
     const hasWebSocketFetch = calls.some(([args]) => typeof args.fetch === 'function');
 
     expect(hasWebSocketFetch).toBe(false);
+  });
+
+  it('passes Azure WebSocket transport options through prefixed gateways', async () => {
+    const azureCloseSpy = vi.fn();
+    const calls: Array<Record<string, unknown>> = [];
+    class TestAzureGateway extends MastraModelGateway {
+      readonly id = 'azure-openai';
+      readonly name = 'azure-openai';
+
+      fetchProviders(): Promise<Record<string, ProviderConfig>> {
+        return Promise.resolve({
+          'azure-openai': {
+            name: 'Azure OpenAI',
+            models: ['gpt-5-4-deployment'],
+            apiKeyEnvVar: [],
+            gateway: 'azure-openai',
+          },
+        });
+      }
+
+      buildUrl(): undefined {
+        return undefined;
+      }
+
+      getApiKey(): Promise<string> {
+        return Promise.resolve('test-azure-key');
+      }
+
+      resolveLanguageModel(args: Record<string, unknown>): GatewayLanguageModel {
+        calls.push(args);
+        const model = createMockModel({ mockText: 'Hello from Azure!' }) as GatewayLanguageModel;
+        Object.defineProperty(model, MASTRA_GATEWAY_STREAM_TRANSPORT, {
+          configurable: true,
+          value: {
+            type: 'openai-websocket',
+            close: azureCloseSpy,
+          },
+        });
+        return model;
+      }
+    }
+
+    const router = new ModelRouterLanguageModel('azure-openai/gpt-5-4-deployment', [new TestAzureGateway()]);
+
+    await router.doStream({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      providerOptions: {
+        azure: {
+          transport: 'websocket',
+          websocket: { closeOnFinish: false },
+        },
+      },
+    } as any);
+
+    expect(calls[0]).toMatchObject({
+      providerId: 'azure-openai',
+      modelId: 'gpt-5-4-deployment',
+      transport: 'websocket',
+      responsesWebSocket: { closeOnFinish: false },
+    });
+    expect(router._getStreamTransport()).toMatchObject({
+      type: 'openai-websocket',
+      closeOnFinish: false,
+    });
+    router._getStreamTransport()?.close();
+    expect(azureCloseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('scopes Azure WebSocket model cache entries by gateway instance', async () => {
+    class TestAzureGateway extends MastraModelGateway {
+      readonly id = 'azure-openai';
+      readonly name = 'azure-openai';
+
+      constructor(
+        private close: () => void,
+        private calls: Array<Record<string, unknown>>,
+      ) {
+        super();
+      }
+
+      fetchProviders(): Promise<Record<string, ProviderConfig>> {
+        return Promise.resolve({
+          'azure-openai': {
+            name: 'Azure OpenAI',
+            models: ['gpt-5-4-deployment'],
+            apiKeyEnvVar: [],
+            gateway: 'azure-openai',
+          },
+        });
+      }
+
+      buildUrl(): undefined {
+        return undefined;
+      }
+
+      getApiKey(): Promise<string> {
+        return Promise.resolve('test-azure-key');
+      }
+
+      resolveLanguageModel(args: Record<string, unknown>): GatewayLanguageModel {
+        this.calls.push(args);
+        const model = createMockModel({ mockText: 'Hello from Azure!' }) as GatewayLanguageModel;
+        Object.defineProperty(model, MASTRA_GATEWAY_STREAM_TRANSPORT, {
+          configurable: true,
+          value: {
+            type: 'openai-websocket',
+            close: this.close,
+          },
+        });
+        return model;
+      }
+    }
+
+    const firstClose = vi.fn();
+    const secondClose = vi.fn();
+    const firstCalls: Array<Record<string, unknown>> = [];
+    const secondCalls: Array<Record<string, unknown>> = [];
+    const firstRouter = new ModelRouterLanguageModel('azure-openai/gpt-5-4-deployment', [
+      new TestAzureGateway(firstClose, firstCalls),
+    ]);
+    const secondRouter = new ModelRouterLanguageModel('azure-openai/gpt-5-4-deployment', [
+      new TestAzureGateway(secondClose, secondCalls),
+    ]);
+    const streamOptions = {
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      providerOptions: {
+        azure: {
+          transport: 'websocket',
+          websocket: { closeOnFinish: false },
+        },
+      },
+    } as any;
+
+    await firstRouter.doStream(streamOptions);
+    await secondRouter.doStream(streamOptions);
+
+    expect(firstCalls).toHaveLength(1);
+    expect(secondCalls).toHaveLength(1);
+    secondRouter._getStreamTransport()?.close();
+    expect(firstClose).not.toHaveBeenCalled();
+    expect(secondClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves router stream transport handles through the execute stream wrapper', async () => {
+    const close = vi.fn();
+    class TestAzureGateway extends MastraModelGateway {
+      readonly id = 'azure-openai';
+      readonly name = 'azure-openai';
+
+      fetchProviders(): Promise<Record<string, ProviderConfig>> {
+        return Promise.resolve({
+          'azure-openai': {
+            name: 'Azure OpenAI',
+            models: ['gpt-5-4-deployment'],
+            apiKeyEnvVar: [],
+            gateway: 'azure-openai',
+          },
+        });
+      }
+
+      buildUrl(): undefined {
+        return undefined;
+      }
+
+      getApiKey(): Promise<string> {
+        return Promise.resolve('test-azure-key');
+      }
+
+      resolveLanguageModel(): GatewayLanguageModel {
+        const model = createMockModel({ mockText: 'response' }) as GatewayLanguageModel;
+        Object.defineProperty(model, MASTRA_GATEWAY_STREAM_TRANSPORT, {
+          configurable: true,
+          value: {
+            type: 'openai-websocket',
+            close,
+          },
+        });
+        return model;
+      }
+    }
+
+    const router = new ModelRouterLanguageModel('azure-openai/gpt-5-4-deployment', [new TestAzureGateway()]);
+    const outputStream = execute({
+      runId: 'run-1',
+      model: router,
+      inputMessages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      providerOptions: {
+        azure: {
+          transport: 'websocket',
+          websocket: { closeOnFinish: false },
+        },
+      },
+      onResult: vi.fn(),
+      methodType: 'stream',
+    });
+
+    const reader = outputStream.getReader();
+    await reader.read();
+
+    const transport = readModelStreamTransport(outputStream);
+    expect(transport).toMatchObject({
+      type: 'openai-websocket',
+      closeOnFinish: false,
+    });
+    transport?.close();
+    expect(close).toHaveBeenCalledTimes(1);
+    await reader.cancel();
   });
 });

--- a/packages/core/src/llm/model/router-provider-tools.test.ts
+++ b/packages/core/src/llm/model/router-provider-tools.test.ts
@@ -94,10 +94,7 @@ describe('ModelRouterLanguageModel with V3 gateway and provider tools (#13667)',
 
   beforeEach(() => {
     // Clear cached model instances between tests
-    // @ts-expect-error accessing private static field for test cleanup
-    ModelRouterLanguageModel.modelInstances = new Map();
-    // @ts-expect-error accessing private static field for test cleanup
-    ModelRouterLanguageModel.webSocketFetches = new Map();
+    (ModelRouterLanguageModel as any)._clearCachesForTests();
 
     mockV3Model = createMockV3Model();
     gateway = new V3Gateway(mockV3Model);

--- a/packages/core/src/llm/model/router-supported-urls.test.ts
+++ b/packages/core/src/llm/model/router-supported-urls.test.ts
@@ -43,7 +43,7 @@ describe('ModelRouterLanguageModel - supportedUrls propagation (Issue #12152)', 
 
   beforeEach(() => {
     // Clear any cached model instances
-    (ModelRouterLanguageModel as any).modelInstances?.clear?.();
+    (ModelRouterLanguageModel as any)._clearCachesForTests();
 
     // Mock findGatewayForModel to return our mock gateway
     vi.spyOn(gatewaysModule, 'findGatewayForModel').mockReturnValue(mockGateway as any);

--- a/packages/core/src/llm/model/router.ts
+++ b/packages/core/src/llm/model/router.ts
@@ -3,11 +3,18 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5';
 import { createOpenAI } from '@ai-sdk/openai-v6';
 import type { LanguageModelV2, LanguageModelV2CallOptions, LanguageModelV2StreamPart } from '@ai-sdk/provider-v5';
 import type { LanguageModelV3 } from '@ai-sdk/provider-v6';
+import { attachModelStreamTransport } from '../../stream/types';
 import type { StreamTransport } from '../../stream/types';
 import { AISDKV5LanguageModel } from './aisdk/v5/model';
 import { AISDKV6LanguageModel } from './aisdk/v6/model';
 import { parseModelRouterId } from './gateway-resolver.js';
-import type { GatewayLanguageModel, MastraModelGateway } from './gateways/base.js';
+import { MASTRA_GATEWAY_STREAM_TRANSPORT } from './gateways/base.js';
+import type {
+  GatewayLanguageModel,
+  GatewayLanguageModelWithStreamTransport,
+  GatewayStreamTransportHandle,
+  MastraModelGateway,
+} from './gateways/base.js';
 import { findGatewayForModel } from './gateways/index.js';
 
 import { MastraGateway } from './gateways/mastra.js';
@@ -15,7 +22,7 @@ import { ModelsDevGateway } from './gateways/models-dev.js';
 import { NetlifyGateway } from './gateways/netlify.js';
 import { createOpenAIWebSocketFetch } from './openai-websocket-fetch.js';
 import type { OpenAIWebSocketFetch } from './openai-websocket-fetch.js';
-import type { OpenAITransport, OpenAIWebSocketOptions, ProviderOptions } from './provider-options.js';
+import type { OpenAITransport, ProviderOptions, ResponsesWebSocketOptions } from './provider-options.js';
 import type { ModelRouterModelId } from './provider-registry.js';
 import { PROVIDER_REGISTRY } from './provider-registry.js';
 import type { MastraLanguageModelV2, OpenAICompatibleConfig } from './shared.types';
@@ -30,20 +37,37 @@ function isLanguageModelV3(model: GatewayLanguageModel): model is LanguageModelV
 const OPENAI_WS_ALLOWLIST = new Set(['openai']);
 const OPENAI_API_HOST = 'api.openai.com';
 
-function getOpenAITransport(providerOptions?: ProviderOptions): {
+type GatewayModelCache = {
+  modelInstances: Map<string, GatewayLanguageModel>;
+  webSocketFetches: Map<string, OpenAIWebSocketFetch>;
+  gatewayStreamTransports: Map<string, GatewayStreamTransportHandle>;
+};
+
+function createGatewayModelCache(): GatewayModelCache {
+  return {
+    modelInstances: new Map(),
+    webSocketFetches: new Map(),
+    gatewayStreamTransports: new Map(),
+  };
+}
+
+function getOpenAITransport(
+  providerOptions?: ProviderOptions,
+  providerId?: string,
+): {
   transport: OpenAITransport;
-  websocket?: OpenAIWebSocketOptions;
+  websocket?: ResponsesWebSocketOptions;
 } {
-  const openaiOptions = providerOptions?.openai as
+  const transportOptions = (providerId === 'azure-openai' ? providerOptions?.azure : providerOptions?.openai) as
     | {
         transport?: OpenAITransport;
-        websocket?: OpenAIWebSocketOptions;
+        websocket?: ResponsesWebSocketOptions;
       }
     | undefined;
 
   return {
-    transport: openaiOptions?.transport ?? 'fetch',
-    websocket: openaiOptions?.websocket,
+    transport: transportOptions?.transport ?? 'fetch',
+    websocket: transportOptions?.websocket,
   };
 }
 
@@ -103,6 +127,7 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
   private config: OpenAICompatibleConfig & { routerId: string };
   private gateway: MastraModelGateway;
   private _supportedUrlsPromise: Promise<Record<string, RegExp[]>> | null = null;
+  private readonly instanceGatewayCache = createGatewayModelCache();
   #lastStreamTransport: StreamTransport | undefined;
 
   constructor(config: ModelRouterModelId | OpenAICompatibleConfig, customGateways?: MastraModelGateway[]) {
@@ -264,31 +289,59 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     };
   }
 
-  private setStreamTransport({
+  private getGatewayCache(): GatewayModelCache {
+    let cache = ModelRouterLanguageModel.gatewayCaches.get(this.gateway);
+
+    if (!cache) {
+      cache = createGatewayModelCache();
+      ModelRouterLanguageModel.gatewayCaches.set(this.gateway, cache);
+    }
+
+    return cache;
+  }
+
+  private setStreamTransportHandle({
     resolvedTransport,
-    key,
-    openaiWebSocket,
+    transport,
+    responsesWebSocket,
   }: {
     resolvedTransport: OpenAITransport;
-    key: string;
-    openaiWebSocket?: OpenAIWebSocketOptions;
+    transport?: GatewayStreamTransportHandle;
+    responsesWebSocket?: ResponsesWebSocketOptions;
   }) {
     if (resolvedTransport !== 'websocket') {
       this.#lastStreamTransport = undefined;
       return;
     }
 
-    const wsFetch = ModelRouterLanguageModel.webSocketFetches.get(key);
-    if (!wsFetch) {
+    if (!transport) {
       this.#lastStreamTransport = undefined;
       return;
     }
 
     this.#lastStreamTransport = {
-      type: 'openai-websocket',
-      close: () => wsFetch.close(),
-      closeOnFinish: openaiWebSocket?.closeOnFinish ?? true,
+      type: transport.type,
+      close: transport.close,
+      closeOnFinish: responsesWebSocket?.closeOnFinish ?? true,
     };
+  }
+
+  private setStreamTransportFromCache({
+    cache,
+    resolvedTransport,
+    key,
+    responsesWebSocket,
+  }: {
+    cache: GatewayModelCache;
+    resolvedTransport: OpenAITransport;
+    key: string;
+    responsesWebSocket?: ResponsesWebSocketOptions;
+  }) {
+    const wsFetch = cache.webSocketFetches.get(key);
+    const gatewayTransport = cache.gatewayStreamTransports.get(key);
+    const transport = wsFetch ? { type: 'openai-websocket' as const, close: () => wsFetch.close() } : gatewayTransport;
+
+    this.setStreamTransportHandle({ resolvedTransport, transport, responsesWebSocket });
   }
 
   async doGenerate(options: LanguageModelV2CallOptions): Promise<StreamResult> {
@@ -360,31 +413,40 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     }
 
     const gatewayPrefix = this.gateway.id === 'models.dev' ? undefined : this.gateway.id;
-    const { transport, websocket } = getOpenAITransport(options.providerOptions as ProviderOptions | undefined);
+    const parsedModelId = parseModelRouterId(this.config.routerId, gatewayPrefix);
+    const { transport, websocket } = getOpenAITransport(
+      options.providerOptions as ProviderOptions | undefined,
+      parsedModelId.providerId,
+    );
     const requestedTransport: OpenAITransport = transport === 'auto' ? 'websocket' : transport;
     const allowWebSocket =
       requestedTransport === 'websocket' &&
-      OPENAI_WS_ALLOWLIST.has(this.provider) &&
       !this.config.url &&
-      this.gateway.id === 'models.dev';
+      ((this.gateway.id === 'models.dev' && OPENAI_WS_ALLOWLIST.has(this.provider)) ||
+        this.gateway.id === 'azure-openai');
     const resolvedTransport: OpenAITransport = allowWebSocket ? 'websocket' : 'fetch';
 
     const model = await this.resolveLanguageModel({
       apiKey,
       headers: this.config.headers,
       transport: resolvedTransport,
-      openaiWebSocket: websocket,
-      ...parseModelRouterId(this.config.routerId, gatewayPrefix),
+      responsesWebSocket: websocket,
+      ...parsedModelId,
     });
 
     // Handle both V2 and V3 models
+    const streamTransport = this.#lastStreamTransport;
     if (isLanguageModelV3(model)) {
       const aiSDKV6Model = new AISDKV6LanguageModel(model);
       // Cast V3 stream result to V2 format - the stream contents are compatible at runtime
-      return aiSDKV6Model.doStream(options as any) as unknown as Promise<StreamResult>;
+      const streamResult = (await aiSDKV6Model.doStream(options as any)) as unknown as StreamResult;
+      attachModelStreamTransport(streamResult, streamTransport);
+      return streamResult;
     }
     const aiSDKV5Model = new AISDKV5LanguageModel(model);
-    return aiSDKV5Model.doStream(options);
+    const streamResult = await aiSDKV5Model.doStream(options);
+    attachModelStreamTransport(streamResult, streamTransport);
+    return streamResult;
   }
 
   private async resolveLanguageModel({
@@ -393,35 +455,38 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     apiKey,
     headers,
     transport,
-    openaiWebSocket,
+    responsesWebSocket,
   }: {
     modelId: string;
     providerId: string;
     apiKey: string;
     headers?: Record<string, string>;
     transport?: OpenAITransport;
-    openaiWebSocket?: OpenAIWebSocketOptions;
+    responsesWebSocket?: ResponsesWebSocketOptions;
   }): Promise<GatewayLanguageModel> {
     const resolvedTransport: OpenAITransport = transport ?? 'fetch';
     const websocketKey =
       resolvedTransport === 'websocket'
-        ? `${openaiWebSocket?.url ?? ''}:${stableHeaderKey(openaiWebSocket?.headers)}`
+        ? `${responsesWebSocket?.url ?? ''}:${stableHeaderKey(responsesWebSocket?.headers)}`
         : '';
+    const usesExplicitApiKey = this.config.apiKey !== undefined;
+    const cache = usesExplicitApiKey ? this.instanceGatewayCache : this.getGatewayCache();
     const key = createHash('sha256')
       .update(
-        this.gateway.id +
-          modelId +
-          providerId +
-          apiKey +
-          (this.config.url || '') +
-          stableHeaderKey(headers) +
-          resolvedTransport +
+        JSON.stringify([
+          this.gateway.id,
+          modelId,
+          providerId,
+          this.config.url || '',
+          stableHeaderKey(headers),
+          resolvedTransport,
           websocketKey,
+        ]),
       )
       .digest('hex');
-    if (ModelRouterLanguageModel.modelInstances.has(key)) {
-      this.setStreamTransport({ resolvedTransport, key, openaiWebSocket });
-      return ModelRouterLanguageModel.modelInstances.get(key)!;
+    if (cache.modelInstances.has(key)) {
+      this.setStreamTransportFromCache({ cache, resolvedTransport, key, responsesWebSocket });
+      return cache.modelInstances.get(key)!;
     }
 
     // If custom URL is provided, use it directly with openai-compatible
@@ -433,8 +498,8 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
         headers: this.config.headers,
         supportsStructuredOutputs: true,
       }).chatModel(modelId);
-      ModelRouterLanguageModel.modelInstances.set(key, modelInstance);
-      this.setStreamTransport({ resolvedTransport, key, openaiWebSocket });
+      cache.modelInstances.set(key, modelInstance);
+      this.setStreamTransportHandle({ resolvedTransport, responsesWebSocket });
       return modelInstance;
     }
 
@@ -447,18 +512,29 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
           apiKey,
           baseURL,
           headers,
-          openaiWebSocket,
+          responsesWebSocket,
         });
-        ModelRouterLanguageModel.modelInstances.set(key, modelInstance);
-        ModelRouterLanguageModel.webSocketFetches.set(key, wsFetch);
-        this.setStreamTransport({ resolvedTransport, key, openaiWebSocket });
+        cache.modelInstances.set(key, modelInstance);
+        cache.webSocketFetches.set(key, wsFetch);
+        this.setStreamTransportFromCache({ cache, resolvedTransport, key, responsesWebSocket });
         return modelInstance;
       }
     }
 
-    const modelInstance = await this.gateway.resolveLanguageModel({ modelId, providerId, apiKey, headers });
-    ModelRouterLanguageModel.modelInstances.set(key, modelInstance);
-    this.setStreamTransport({ resolvedTransport, key, openaiWebSocket });
+    const modelInstance = await this.gateway.resolveLanguageModel({
+      modelId,
+      providerId,
+      apiKey,
+      headers,
+      transport: resolvedTransport,
+      responsesWebSocket,
+    });
+    const gatewayTransport = readGatewayStreamTransport(modelInstance);
+    cache.modelInstances.set(key, modelInstance);
+    if (gatewayTransport) {
+      cache.gatewayStreamTransports.set(key, gatewayTransport);
+    }
+    this.setStreamTransportHandle({ resolvedTransport, transport: gatewayTransport, responsesWebSocket });
     return modelInstance;
   }
 
@@ -467,17 +543,17 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     apiKey,
     baseURL,
     headers,
-    openaiWebSocket,
+    responsesWebSocket,
   }: {
     modelId: string;
     apiKey: string;
     baseURL?: string;
     headers?: Record<string, string>;
-    openaiWebSocket?: OpenAIWebSocketOptions;
+    responsesWebSocket?: ResponsesWebSocketOptions;
   }): { modelInstance: GatewayLanguageModel; wsFetch: OpenAIWebSocketFetch } {
     const wsFetch = createOpenAIWebSocketFetch({
-      url: openaiWebSocket?.url,
-      headers: openaiWebSocket?.headers,
+      url: responsesWebSocket?.url,
+      headers: responsesWebSocket?.headers,
     });
 
     const modelInstance = createOpenAI({
@@ -488,6 +564,13 @@ export class ModelRouterLanguageModel implements MastraLanguageModelV2 {
     }).responses(modelId);
     return { modelInstance, wsFetch };
   }
-  private static modelInstances = new Map<string, GatewayLanguageModel>();
-  private static webSocketFetches = new Map<string, OpenAIWebSocketFetch>();
+  private static _clearCachesForTests() {
+    ModelRouterLanguageModel.gatewayCaches = new WeakMap();
+  }
+
+  private static gatewayCaches = new WeakMap<MastraModelGateway, GatewayModelCache>();
+}
+
+function readGatewayStreamTransport(model: GatewayLanguageModel): GatewayStreamTransportHandle | undefined {
+  return (model as GatewayLanguageModelWithStreamTransport)[MASTRA_GATEWAY_STREAM_TRANSPORT];
 }

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -31,7 +31,7 @@ import type {
   StreamTransport,
   StreamTransportRef,
 } from '../../../stream/types';
-import { ChunkFrom } from '../../../stream/types';
+import { ChunkFrom, readModelStreamTransport } from '../../../stream/types';
 import { findProviderToolByName, inferProviderExecuted } from '../../../tools/provider-tool-utils';
 import type { ToolToConvert } from '../../../tools/tool-builder/builder';
 import { isMastraTool } from '../../../tools/toolchecks';
@@ -390,7 +390,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       // Start the MODEL_STEP span at the beginning of LLM execution
       modelSpanTracker?.startStep();
 
-      let modelResult;
+      let modelResult: ReturnType<typeof execute> | undefined;
       let warnings: any;
       let request: any;
       let rawResponse: any;
@@ -853,7 +853,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           let transportResolver: (() => StreamTransport | undefined) | undefined;
           if (currentStep.model instanceof ModelRouterLanguageModel) {
             const routerModel = currentStep.model;
-            transportResolver = () => routerModel._getStreamTransport();
+            transportResolver = () => readModelStreamTransport(modelResult) ?? routerModel._getStreamTransport();
           }
 
           try {

--- a/packages/core/src/stream/base/input.ts
+++ b/packages/core/src/stream/base/input.ts
@@ -1,5 +1,6 @@
 import type { LanguageModelV2StreamPart } from '@ai-sdk/provider-v5';
 import { MastraBase } from '../../base';
+import { attachModelStreamTransport, readModelStreamTransport } from '../types';
 import type { ChunkType, CreateStream, OnResult } from '../types';
 
 /**
@@ -59,10 +60,12 @@ export abstract class MastraModelInput extends MastraBase {
   initialize({ runId, createStream, onResult }: { createStream: CreateStream; runId: string; onResult: OnResult }) {
     const self = this;
 
-    const stream = new ReadableStream<ChunkType>({
+    let outputStream: ReadableStream<ChunkType>;
+    outputStream = new ReadableStream<ChunkType>({
       async start(controller) {
         try {
           const stream = await createStream();
+          attachModelStreamTransport(outputStream, readModelStreamTransport(stream));
 
           onResult({
             warnings: stream.warnings,
@@ -83,6 +86,6 @@ export abstract class MastraModelInput extends MastraBase {
       },
     });
 
-    return stream;
+    return outputStream;
   }
 }

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -61,6 +61,24 @@ export type StreamTransport = {
   closeOnFinish: boolean;
 };
 
+export const MASTRA_MODEL_STREAM_TRANSPORT = Symbol.for('@mastra/core.modelStreamTransport');
+
+export type StreamTransportCarrier = {
+  [key: symbol]: StreamTransport | undefined;
+};
+
+export function attachModelStreamTransport(target: object, transport?: StreamTransport): void {
+  if (!transport) return;
+  Object.defineProperty(target, MASTRA_MODEL_STREAM_TRANSPORT, {
+    configurable: true,
+    value: transport,
+  });
+}
+
+export function readModelStreamTransport(target: unknown): StreamTransport | undefined {
+  return (target as StreamTransportCarrier | undefined)?.[MASTRA_MODEL_STREAM_TRANSPORT];
+}
+
 export type StreamTransportRef = {
   current?: StreamTransport;
 };


### PR DESCRIPTION
Stacked on #16246.

OpenAI Responses WebSocket transport already exists in the base branch. This PR extends that existing Responses WebSocket transport to Azure OpenAI Responses and hardens the shared WebSocket fetch used by both paths.

The transport-specific pieces split out per maintainer feedback are:

- Azure gateway WebSocket routing for `useResponsesAPI: true`.
- Provider-neutral router/gateway stream transport plumbing.
- Shared WebSocket fetch hardening for auth/header handling, abort cleanup, terminal SSE formatting, and overlapping continuation rejection.
- Docs for direct OpenAI and Azure Responses WebSocket usage.
- Focused OpenAI/Azure WebSocket tests.

Usage for Azure:

```ts
const stream = await agent.stream("Run the tool loop", {
  providerOptions: {
    azure: {
      transport: "websocket",
      store: false,
      websocket: { closeOnFinish: false },
    },
  },
});
```

Direct OpenAI continues to use the existing provider option shape:

```ts
const stream = await agent.stream("Run the tool loop", {
  providerOptions: {
    openai: {
      transport: "websocket",
      websocket: { closeOnFinish: false },
    },
  },
});
```

Live Azure benchmark from the combined branch against a real Azure `gpt-5.4` deployment, 3 measured iterations per route after one warmup:

| Scenario | HTTP Responses avg | HTTP Responses p50 | WebSocket Responses avg | WebSocket Responses p50 | Completion |
|---|---:|---:|---:|---:|---|
| Cold single text | 775ms | 739ms | 1225ms | 1235ms | 3/3 each route |
| Warm single text reuse | 842ms | 839ms | 1344ms | 558ms | 3/3 each route |
| Warm 3-tool agent loop | 3851ms | 3600ms | 2683ms | 2585ms | 3/3 each route, 3 tools avg |
| Warm 5-tool agent loop | 4510ms | 4084ms | 2460ms | 2446ms | 3/3 each route, 5 tools avg |

Interpretation: single-shot text was not faster over WebSocket in this sample. Warm multi-tool agent loops completed on both routes and showed a WebSocket latency gain on the tested Azure deployment.

Validation:

- Focused `@mastra/core` WebSocket/Azure tests passed: 3 files, 64 tests.
- `@mastra/core` typecheck passed.
- Docs frontmatter/sidebar validation passed.
- Prettier passed on touched files.
- `git diff --check` passed.

Not claimed:

- No broad performance win for single-shot text calls.
- No live Entra ID WebSocket benchmark was run; Entra ID behavior is covered by unit tests.