### PR TITLE
fix(memory): keep best OM reflection after max compression

### DIFF
--- a/.changeset/lemon-birds-go.md
+++ b/.changeset/lemon-birds-go.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory reflection so it keeps the smallest compressed result after all retry levels are exhausted.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -2210,6 +2210,56 @@ describe('Observer Agent Helpers', () => {
     });
   });
 
+  describe('Reflector compression retries', () => {
+    it('returns the smallest non-degenerate reflection after exhausting compression levels', async () => {
+      const om = new ObservationalMemory({
+        storage: createInMemoryStorage(),
+        observation: {
+          model: 'openai/gpt-4o-mini',
+          messageTokens: 1,
+          bufferTokens: false,
+        },
+        reflection: {
+          model: 'openai/gpt-4o-mini',
+          observationTokens: 1,
+        },
+      });
+
+      const outputs = [
+        `<observations>\n- ${'large '.repeat(200)}\n</observations>`,
+        `<observations>\n- smallest candidate\n</observations>`,
+        `<observations>\n- ${'medium '.repeat(40)}\n</observations>`,
+        `<observations>\n- ${'largest '.repeat(300)}\n</observations>`,
+      ];
+      let callCount = 0;
+
+      vi.spyOn((om as any).reflector, 'createAgent').mockReturnValue({
+        stream: async () => {
+          const text = outputs[callCount++]!;
+          return {
+            getFullOutput: async () => ({
+              text,
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            }),
+          };
+        },
+      } as any);
+
+      const result = await (om as any).reflector.call(
+        '- source observations',
+        undefined,
+        undefined,
+        0,
+        undefined,
+        undefined,
+        1,
+      );
+
+      expect(callCount).toBe(4);
+      expect(result.observations).toBe('- smallest candidate');
+    });
+  });
+
   describe('buildObserverHistoryMessage', () => {
     it('should preserve placeholders and attachments in order', () => {
       const msg = createTestMessage('ignored', 'user');

--- a/packages/memory/src/processors/observational-memory/reflector-runner.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-runner.ts
@@ -267,6 +267,9 @@ export class ReflectorRunner {
     let parsed: ReturnType<typeof parseReflectorOutput> = { observations: '', suggestedContinuation: undefined };
     let reflectedTokens = 0;
     let attemptNumber = 0;
+    let bestParsed: ReturnType<typeof parseReflectorOutput> | undefined;
+    let bestReflectedTokens = Number.POSITIVE_INFINITY;
+    let exhaustedCompressionRetries = false;
 
     while (currentLevel <= maxLevel) {
       attemptNumber++;
@@ -358,17 +361,24 @@ export class ReflectorRunner {
         reflectedTokens = originalTokens;
       } else {
         reflectedTokens = this.tokenCounter.countObservations(parsed.observations);
+        if (reflectedTokens < bestReflectedTokens) {
+          bestParsed = parsed;
+          bestReflectedTokens = reflectedTokens;
+        }
       }
       omDebug(
         `[OM:callReflector] attempt #${attemptNumber} parsed: reflectedTokens=${reflectedTokens}, targetThreshold=${targetThreshold}, compressionValid=${validateCompression(reflectedTokens, targetThreshold)}, parsedObsLen=${parsed.observations?.length}, degenerate=${parsed.degenerate ?? false}`,
       );
 
       if (!parsed.degenerate && (validateCompression(reflectedTokens, targetThreshold) || currentLevel >= maxLevel)) {
+        exhaustedCompressionRetries =
+          !validateCompression(reflectedTokens, targetThreshold) && currentLevel >= maxLevel;
         break;
       }
 
       if (parsed.degenerate && currentLevel >= maxLevel) {
         omDebug(`[OM:callReflector] degenerate output persists at maxLevel=${maxLevel}, breaking`);
+        exhaustedCompressionRetries = true;
         break;
       }
 
@@ -406,6 +416,13 @@ export class ReflectorRunner {
       }
 
       currentLevel = Math.min(currentLevel + 1, maxLevel) as CompressionLevel;
+    }
+
+    if (exhaustedCompressionRetries && bestParsed && bestParsed !== parsed) {
+      omDebug(
+        `[OM:callReflector] exhausted compression retries; returning smallest candidate with tokens=${bestReflectedTokens} instead of final attempt tokens=${reflectedTokens}`,
+      );
+      parsed = bestParsed;
     }
 
     return {


### PR DESCRIPTION
## Description

Fixes observational memory reflection so when compression retries are exhausted, the reflector returns the smallest non-degenerate candidate produced instead of the final attempt. This prevents repeated reflection loops when even max compression cannot get below the configured threshold.

## Related Issue(s)

Fixes #15062

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

Imagine you have a box that's too full, so you keep squeezing things to make them fit. The old system would squeeze and squeeze forever, never giving up—even if it was never going to fit. This PR fixes it so that instead of getting stuck, the system remembers the best squeeze it did so far and says "okay, that's good enough" when it realizes it can't squeeze any harder.

## Changes

### Core Fix: Reflector Runner (`packages/memory/src/processors/observational-memory/reflector-runner.ts`)

The `ReflectorRunner.call()` method now tracks the best (smallest) non-degenerate reflector output across all compression retry attempts. When compression retries are exhausted—either because the maximum compression level is reached or all attempts remain above the target threshold—the system returns the smallest successful candidate found during the attempts instead of the final attempt's result.

Key logic additions:
- Maintains state tracking (`bestParsed`, `bestReflectedTokens`) to store the lowest-token candidate across compression levels
- Sets an `exhaustedCompressionRetries` flag when breaking due to max-level exhaustion
- Conditionally swaps the final `parsed` result to the recorded best candidate if the final attempt isn't optimal

This prevents infinite retry loops when even maximum compression cannot reduce content below the configured threshold.

### Test Coverage (`packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts`)

Added a new test suite titled "Reflector compression retries" that validates the fix by:
- Verifying that when reflector outputs remain above the target threshold across multiple compression attempts, the system performs the expected number of calls
- Confirming that the smallest non-degenerate reflection is returned after exhausting all compression levels

### Release Notes (`.changeset/lemon-birds-go.md`)

Patch-level changeset for `@mastra/memory` documenting the fix.

## Impact

This addresses the edge case described in issue #15062 where observational memory could retry indefinitely when observations exceed the threshold even at maximum compression levels, improving system stability without losing useful memory data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->