### PR TITLE
Fix CLI next.config lint parsing

### DIFF
--- a/.changeset/fine-oranges-switch.md
+++ b/.changeset/fine-oranges-switch.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed CLI linting of Next.js config so it reads serverExternalPackages without running project code.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,6 +69,7 @@
     "serve-handler": "^6.1.7",
     "shell-quote": "^1.8.3",
     "strip-json-comments": "^5.0.3",
+    "typescript": "catalog:",
     "yocto-spinner": "^1.1.0"
   },
   "devDependencies": {
@@ -90,7 +91,6 @@
     "rollup": "^4.59.0",
     "tsup": "^8.5.1",
     "type-fest": "^5.4.4",
-    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/packages/cli/src/commands/lint/rules/nextConfigRule.test.ts
+++ b/packages/cli/src/commands/lint/rules/nextConfigRule.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { nextConfigRule } from './nextConfigRule.js';
+import type { LintContext } from './types.js';
+
+vi.mock('../../../utils/logger.js', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const evalMarker = 'MASTRA_NEXT_CONFIG_RULE_EVAL_MARKER';
+
+function createContext(rootDir: string): LintContext {
+  return {
+    rootDir,
+    mastraDir: join(rootDir, 'src', 'mastra'),
+    outputDirectory: join(rootDir, '.mastra'),
+    discoveredTools: [],
+    packageJson: {},
+    mastraPackages: [{ name: '@mastra/core', version: '1.0.0', isAlpha: false }],
+  };
+}
+
+function createProject(nextConfigContent: string): string {
+  const rootDir = mkdtempSync(join(tmpdir(), 'mastra-next-config-rule-'));
+  writeFileSync(join(rootDir, 'next.config.js'), nextConfigContent);
+  return rootDir;
+}
+
+describe('nextConfigRule', () => {
+  const projectDirs: string[] = [];
+
+  afterEach(() => {
+    delete process.env[evalMarker];
+
+    for (const projectDir of projectDirs.splice(0)) {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads serverExternalPackages from a nextConfig object literal', async () => {
+    const rootDir = createProject(`
+      const nextConfig = {
+        serverExternalPackages: ["@mastra/*"],
+      };
+      module.exports = nextConfig;
+    `);
+    projectDirs.push(rootDir);
+
+    await expect(nextConfigRule.run(createContext(rootDir))).resolves.toBe(true);
+  });
+
+  it('reads serverExternalPackages from module.exports object literal', async () => {
+    const rootDir = createProject(`
+      module.exports = {
+        serverExternalPackages: ["@mastra/core"],
+      };
+    `);
+    projectDirs.push(rootDir);
+
+    await expect(nextConfigRule.run(createContext(rootDir))).resolves.toBe(true);
+  });
+
+  it('reads serverExternalPackages from export default object literal', async () => {
+    const rootDir = createProject(`
+      export default {
+        serverExternalPackages: ["@mastra/memory"],
+      };
+    `);
+    projectDirs.push(rootDir);
+
+    await expect(nextConfigRule.run(createContext(rootDir))).resolves.toBe(true);
+  });
+
+  it('does not execute dynamic code in next.config.js', async () => {
+    const rootDir = createProject(`
+      const nextConfig = {
+        serverExternalPackages: (() => {
+          process.env.${evalMarker} = "executed";
+          return ["@mastra/*"];
+        })(),
+      };
+      module.exports = nextConfig;
+    `);
+    projectDirs.push(rootDir);
+
+    await expect(nextConfigRule.run(createContext(rootDir))).resolves.toBe(false);
+    expect(process.env[evalMarker]).toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/lint/rules/nextConfigRule.ts
+++ b/packages/cli/src/commands/lint/rules/nextConfigRule.ts
@@ -1,18 +1,124 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import ts from 'typescript';
 import { logger } from '../../../utils/logger.js';
 import type { LintContext, LintRule } from './types.js';
 
-function readNextConfig(dir: string) {
+interface NextConfig {
+  serverExternalPackages?: string[];
+}
+
+function getPropertyNameText(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+
+  return null;
+}
+
+function readStaticStringArray(expression: ts.Expression): string[] | null {
+  if (!ts.isArrayLiteralExpression(expression)) {
+    return null;
+  }
+
+  const values: string[] = [];
+  for (const element of expression.elements) {
+    if (!ts.isStringLiteral(element) && !ts.isNoSubstitutionTemplateLiteral(element)) {
+      return null;
+    }
+
+    values.push(element.text);
+  }
+
+  return values;
+}
+
+function readConfigObject(configObject: ts.ObjectLiteralExpression): NextConfig {
+  const config: NextConfig = {};
+
+  for (const property of configObject.properties) {
+    if (!ts.isPropertyAssignment(property) || getPropertyNameText(property.name) !== 'serverExternalPackages') {
+      continue;
+    }
+
+    const serverExternalPackages = readStaticStringArray(property.initializer);
+    if (serverExternalPackages) {
+      config.serverExternalPackages = serverExternalPackages;
+    } else {
+      delete config.serverExternalPackages;
+    }
+  }
+
+  return config;
+}
+
+function isModuleExports(expression: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    expression.name.text === 'exports' &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === 'module'
+  );
+}
+
+function findNextConfigObject(sourceFile: ts.SourceFile): ts.ObjectLiteralExpression | null {
+  let configObject: ts.ObjectLiteralExpression | null = null;
+
+  sourceFile.forEachChild(node => {
+    if (configObject) {
+      return;
+    }
+
+    if (ts.isVariableStatement(node)) {
+      for (const declaration of node.declarationList.declarations) {
+        if (
+          ts.isIdentifier(declaration.name) &&
+          declaration.name.text === 'nextConfig' &&
+          declaration.initializer &&
+          ts.isObjectLiteralExpression(declaration.initializer)
+        ) {
+          configObject = declaration.initializer;
+          return;
+        }
+      }
+    }
+
+    if (
+      ts.isExpressionStatement(node) &&
+      ts.isBinaryExpression(node.expression) &&
+      node.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      isModuleExports(node.expression.left) &&
+      ts.isObjectLiteralExpression(node.expression.right)
+    ) {
+      configObject = node.expression.right;
+      return;
+    }
+
+    if (ts.isExportAssignment(node) && ts.isObjectLiteralExpression(node.expression)) {
+      configObject = node.expression;
+    }
+  });
+
+  return configObject;
+}
+
+function readNextConfig(dir: string): NextConfig | null {
   const nextConfigPath = join(dir, 'next.config.js');
   try {
     const nextConfigContent = readFileSync(nextConfigPath, 'utf-8');
-    const configMatch = nextConfigContent.match(/const nextConfig = ({[\s\S]*?});/);
-    if (!configMatch?.[1]) {
+    const sourceFile = ts.createSourceFile(
+      nextConfigPath,
+      nextConfigContent,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.JS,
+    );
+    const configObject = findNextConfigObject(sourceFile);
+    if (!configObject) {
       return null;
     }
-    const configStr = configMatch[1].replace(/\n/g, '').replace(/\s+/g, ' ');
-    return eval(`(${configStr})`);
+
+    return readConfigObject(configObject);
   } catch {
     return null;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2978,6 +2978,9 @@ importers:
       strip-json-comments:
         specifier: ^5.0.3
         version: 5.0.3
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
       yocto-spinner:
         specifier: ^1.1.0
         version: 1.1.0
@@ -3039,9 +3042,6 @@ importers:
       type-fest:
         specifier: ^5.4.4
         version: 5.6.0
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.12.13(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))


### PR DESCRIPTION
## Description

Fixes the CLI Next.js lint rule so it statically parses `next.config.js` and reads literal `serverExternalPackages` values without executing project code. Adds regression coverage for supported literal config shapes and for dynamic code that must not run during linting.

## Related Issue(s)

Fixes #16180

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a security issue in the Mastra CLI where it was using dangerous `eval()` code to read Next.js configuration files, which could execute any code embedded in those files. The fix replaces that with safe static code analysis (reading the file structure without running it), so configuration can still be read properly but no hidden code gets executed.

---

## Overview

The PR replaces unsafe `eval()`-based parsing with TypeScript AST (Abstract Syntax Tree) parsing in the Next.js config lint rule, eliminating the risk of executing arbitrary code from `next.config.js` during linting while preserving all lint functionality.

---

## Changes Made

### Core Implementation (`packages/cli/src/commands/lint/rules/nextConfigRule.ts`)

Refactored the config parsing logic to use TypeScript's AST parser instead of regex extraction and `eval()`:

- **New helper functions**:
  - `readStaticStringArray()`: Safely extracts string arrays from AST nodes, returning `null` for any non-literal expressions
  - `readConfigObject()`: Extracts `serverExternalPackages` from an object literal AST node
  - `findNextConfigObject()`: Locates the config object in three supported literal patterns:
    - `const nextConfig = { ... }; module.exports = nextConfig;`
    - `module.exports = { ... };`
    - `export default { ... };`
  - `isModuleExports()`: Checks if an expression is `module.exports`
  - `getPropertyNameText()`: Safely reads property names from AST nodes

- **Behavior**: Parses `next.config.js` using `ts.createSourceFile()`, locates a literal object config, and extracts only statically-determinable string arrays for `serverExternalPackages`. Dynamic expressions (IIFE, function calls, variables) are rejected, causing the rule to fail if no valid static config is found.

### Test Coverage (`packages/cli/src/commands/lint/rules/nextConfigRule.test.ts`)

Added comprehensive regression tests:

- **Literal config support**: Validates all three supported config patterns correctly read `serverExternalPackages`
- **Security regression test**: Proves that dynamic code (a self-executing function that sets an environment variable) is **not executed** during linting, with assertion that the env variable remains undefined

Test infrastructure:
- Creates isolated temporary project directories with synthetic `next.config.js` files
- Mocks the logger module to avoid side effects
- Cleans up temp directories and environment state after each test

### Dependency Update (`packages/cli/package.json`)

Added TypeScript as a dependency (`"typescript": "catalog:"`) to enable AST parsing capabilities.

### Changeset Entry

Added `.changeset/fine-oranges-switch.md` documenting the patch fix: "Fixed CLI linting of Next.js config so it reads serverExternalPackages without running project code."

---

## Security Impact

- **Before**: Executing arbitrary code in `next.config.js` during linting
- **After**: Static analysis only; no code execution regardless of what's in the config file

---

## Testing

- 4 test cases covering all supported literal config shapes and security regression
- Dynamic code rejection validated with IIFE mutation test

<!-- end of auto-generated comment: release notes by coderabbit.ai -->