### PR TITLE
fix(playground): keep stable layout wrapper across auth states

### DIFF
--- a/.changeset/fix-scorer-form-remount.md
+++ b/.changeset/fix-scorer-form-remount.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed a regression where the Studio Layout swapped its DOM tree once auth capabilities finished loading, which unmounted and remounted the active page. On the Create Scorer page this wiped the Name and Description inputs and reset the form, so submitting failed with "Name is required". The Layout now keeps a single stable wrapper across auth states.

--- a/.changeset/regen-client-js-route-types.md
+++ b/.changeset/regen-client-js-route-types.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Regenerate route types to include `TRAJECTORY` and `STEP` entityType variants on the score response (follow-up to #16249).

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -12536,6 +12536,8 @@ export type GetObservabilityTracesTraceIdSpanIdScores_Response = {
       | (
           | 'AGENT'
           | 'WORKFLOW'
+          | 'TRAJECTORY'
+          | 'STEP'
           | 'agent_run'
           | 'scorer_run'
           | 'scorer_step'

--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -47,20 +47,16 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
       <NavigationCommand />
       <div className={cn('h-full', shouldShowSidebar && 'lg:grid lg:grid-cols-[auto_1fr] lg:grid-rows-[1fr]')}>
         {shouldShowSidebar && <AppSidebar />}
-        {shouldShowSidebar ? (
-          <div className="flex flex-col h-full min-h-0">
-            <MobileNavbar />
-            <div className="flex-1 min-h-0 bg-transparent overflow-y-auto">{content}</div>
-          </div>
-        ) : (
+        <div className="flex flex-col h-full min-h-0">
+          {shouldShowSidebar && <MobileNavbar />}
           <div
-            className={cn('bg-transparent overflow-y-auto', {
-              'h-[calc(100%-1.5rem)]': shouldHideSidebar,
+            className={cn('flex-1 min-h-0 bg-transparent overflow-y-auto', {
+              'h-[calc(100%-1.5rem)]': !shouldShowSidebar && shouldHideSidebar,
             })}
           >
             {content}
           </div>
-        )}
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
The Studio layout was rendering the active route inside two different JSX subtrees depending on whether `useAuthCapabilities()` had finished fetching. When that query resolved, React swapped subtrees and unmounted/remounted the page underneath.

On the Create Scorer page this wiped the Name and Description `<input>` values and reset `useForm()` to empty defaults, so clicking Create failed client-side validation with "Name is required" and never hit the API. This is what was timing out kitchen-sink shard 2 (`e2e/tests/cms/scorers/edit/page.spec.ts`).

Before:

```tsx
{shouldShowSidebar ? (
  <div><MobileNavbar /><div>{content}</div></div>
) : (
  <div>{content}</div>
)}
```

After:

```tsx
<div>
  {shouldShowSidebar && <MobileNavbar />}
  <div>{content}</div>
</div>
```

Verified locally: `e2e/tests/cms/scorers/edit/page.spec.ts` 19/19 pass on first run (was 3 failed + 15 flaky), and `create/page.spec.ts` 13/13 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes a bug that made the Create Scorer form forget what you typed: the layout used two different DOM trees while auth was loading, causing React to unmount and remount the page and clear inputs. The layout now keeps a single stable wrapper so the form state is preserved.

## Summary

- Root cause: packages/playground/src/components/layout.tsx rendered the active route inside two different JSX subtrees depending on useAuthCapabilities() loading state. When that query finished, React swapped subtrees and unmounted/remounted the page, resetting useForm() state (clearing Name/Description) and breaking the Create Scorer flow and related e2e tests.
- Fix: refactor layout to use one stable outer wrapper and render MobileNavbar conditionally as a sibling rather than swapping entire subtrees. Example change: replaced
  {shouldShowSidebar ? (<div><MobileNavbar /><div>{content}</div></div>) : (<div>{content}</div>)} 
  with
  <div>{shouldShowSidebar && <MobileNavbar />}<div>{content}</div></div>
  ensuring the content container stays in the same DOM position across auth-state transitions.
- Verification: locally re-ran affected tests — e2e/tests/cms/scorers/edit/page.spec.ts passed 19/19 (previously failing/flaky) and create/page.spec.ts passed 13/13.

## Files changed (high level)

- packages/playground/src/components/layout.tsx
  - Reworked responsive layout to a single consistent wrapper; MobileNavbar is conditionally rendered and content container kept stable. (~+5/-9 lines)
- client-sdks/client-js/src/route-types.generated.ts
  - Regenerated route types: added TRAJECTORY and STEP string literals to the generated route union.
- .changeset/*.md
  - Added changeset entries documenting the layout fix and the client-js route-types regeneration.

## API / public surface

- No handwritten public API or exported signature changes. Only the generated client-js route-types union was expanded to include TRAJECTORY and STEP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->