### PR TITLE
fix(observability): recover Anthropic non-cache tokens from providerMetadata (#16261)

### DIFF
--- a/.changeset/anthropic-non-cache-token-fallback.md
+++ b/.changeset/anthropic-non-cache-token-fallback.md
@@ -1,0 +1,7 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed Anthropic generation spans showing `0` input and output tokens in Langfuse and other OTel-based dashboards. The Anthropic Vercel AI SDK adapter sometimes reports the non-cache token counts only on `providerMetadata.anthropic`, leaving the top-level `usage` empty; Mastra now falls back to those values so the dashboards stay accurate end-to-end.
+
+Fixes #16261.

--- a/observability/mastra/src/usage.test.ts
+++ b/observability/mastra/src/usage.test.ts
@@ -522,4 +522,108 @@ describe('extractUsageMetrics', () => {
       expect(result.outputDetails).toEqual({ text: 50 });
     });
   });
+
+  // Regression for #16261. The Anthropic Vercel AI SDK adapter sometimes
+  // reports `inputTokens` / `outputTokens` only on `providerMetadata.anthropic`,
+  // not on the top-level `usage` object — which left Langfuse's
+  // generation-span usage reading 0 for all Anthropic spans. PR #13914
+  // established the providerMetadata fallback for cache tokens; this group
+  // pins the same fallback for the non-cache input/output counts.
+  describe('Anthropic non-cache token fallback (#16261)', () => {
+    it('falls back to providerMetadata.anthropic.inputTokens when usage.inputTokens is undefined', () => {
+      const usage = { outputTokens: 50 } as LanguageModelUsage;
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: { inputTokens: 100 } as Record<string, number>,
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(100);
+      expect(result.outputTokens).toBe(50);
+      expect(result.inputDetails?.text).toBe(100);
+    });
+
+    it('falls back to providerMetadata.anthropic.outputTokens when usage.outputTokens is undefined', () => {
+      const usage = { inputTokens: 100 } as LanguageModelUsage;
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: { outputTokens: 50 } as Record<string, number>,
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(100);
+      expect(result.outputTokens).toBe(50);
+      expect(result.outputDetails?.text).toBe(50);
+    });
+
+    it('falls back when both usage tokens are missing — the canonical #16261 shape', () => {
+      // The exact shape from the issue: AI SDK Anthropic finish chunk for a
+      // streaming call where token counts only land on providerMetadata.
+      const usage = {} as LanguageModelUsage;
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          inputTokens: 1234,
+          outputTokens: 567,
+        } as Record<string, number>,
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(1234);
+      expect(result.outputTokens).toBe(567);
+      expect(result.inputDetails?.text).toBe(1234);
+      expect(result.outputDetails?.text).toBe(567);
+    });
+
+    it('still combines the recovered base input with anthropic cache tokens', () => {
+      // Same fallback, but also exercises the existing cache-summing path
+      // so we confirm the two recoveries compose: base from providerMetadata,
+      // plus cache tokens from providerMetadata.
+      const usage = {} as LanguageModelUsage;
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadInputTokens: 800,
+          cacheCreationInputTokens: 200,
+        } as Record<string, number>,
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(1100); // 100 + 800 + 200
+      expect(result.outputTokens).toBe(50);
+      expect(result.inputDetails?.text).toBe(100);
+      expect(result.inputDetails?.cacheRead).toBe(800);
+      expect(result.inputDetails?.cacheWrite).toBe(200);
+    });
+
+    it('prefers usage.inputTokens / outputTokens over providerMetadata when both are present (no regression)', () => {
+      const usage: LanguageModelUsage = { inputTokens: 999, outputTokens: 888 };
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: { inputTokens: 1, outputTokens: 1 } as Record<string, number>,
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(999);
+      expect(result.outputTokens).toBe(888);
+    });
+
+    it('does not invent tokens when neither usage nor providerMetadata has them', () => {
+      const usage = { outputTokens: 0 } as LanguageModelUsage;
+
+      const providerMetadata: ProviderMetadata = { anthropic: {} as Record<string, number> };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBeUndefined();
+      expect(result.outputTokens).toBe(0);
+    });
+  });
 });

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -12,6 +12,16 @@ import type { LanguageModelUsage, ProviderMetadata } from '@mastra/core/stream';
 interface AnthropicMetadata {
   cacheReadInputTokens?: number;
   cacheCreationInputTokens?: number;
+  /**
+   * Non-cache input/output token counts. Anthropic's Vercel AI SDK adapter
+   * sometimes reports these on `providerMetadata.anthropic` only, with no
+   * `usage.inputTokens` / `usage.outputTokens` populated — see #16261.
+   * `extractUsageMetrics` falls back to these when the top-level usage
+   * fields are absent so Langfuse generation spans don't read 0 tokens
+   * for Anthropic-only spans.
+   */
+  inputTokens?: number;
+  outputTokens?: number;
 }
 
 interface GoogleUsageMetadata {
@@ -83,7 +93,7 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
   const outputDetails: OutputTokenDetails = {};
 
   let inputTokens = usage.inputTokens;
-  const outputTokens = usage.outputTokens;
+  let outputTokens = usage.outputTokens;
 
   // ===== AI SDK aggregated format (inputTokenDetails) =====
   // In multi-step runs, providerMetadata only reflects the LAST step.
@@ -112,11 +122,25 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
   }
 
   // ===== Anthropic =====
-  // Cache tokens are in providerMetadata.anthropic
-  // inputTokens does NOT include cache tokens - need to sum them
+  // Cache tokens are in providerMetadata.anthropic.
+  // inputTokens does NOT include cache tokens - need to sum them.
+  // Per #16261, the Anthropic adapter sometimes also reports the non-cache
+  // `inputTokens` / `outputTokens` here when the top-level `usage` is empty
+  // (the streaming finish-chunk shape that left Langfuse spans reading 0).
   const anthropic = providerMetadata?.anthropic as AnthropicMetadata | undefined;
 
   if (anthropic) {
+    // Recover base tokens from providerMetadata when the top-level usage is
+    // missing them. Same fallback shape that PR #13914 introduced for cache
+    // tokens, extended to non-cache counts. We capture the recovered base
+    // so the cache-summing path below adds to it instead of to zero.
+    if (!isDefined(inputTokens) && isDefined(anthropic.inputTokens)) {
+      inputTokens = anthropic.inputTokens;
+    }
+    if (!isDefined(outputTokens) && isDefined(anthropic.outputTokens)) {
+      outputTokens = anthropic.outputTokens;
+    }
+
     const rawV3InputUsage = isV3RawUsage(usage.raw) ? usage.raw.inputTokens : undefined;
     const hasV3CachedTotals =
       rawV3InputUsage?.total !== undefined &&
@@ -136,7 +160,7 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
       (isDefined(usage.cacheCreationInputTokens) && usage.cacheCreationInputTokens > 0);
 
     if (!inputAlreadyIncludesCache && (isDefined(inputDetails.cacheRead) || isDefined(inputDetails.cacheWrite))) {
-      inputTokens = (usage.inputTokens ?? 0) + (inputDetails.cacheRead ?? 0) + (inputDetails.cacheWrite ?? 0);
+      inputTokens = (inputTokens ?? 0) + (inputDetails.cacheRead ?? 0) + (inputDetails.cacheWrite ?? 0);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #16261.

`@mastra/observability`'s `extractUsageMetrics` reads `usage.inputTokens` / `usage.outputTokens` from the AI SDK response. Anthropic's Vercel AI SDK adapter sometimes reports those counts only on `providerMetadata.anthropic` for streaming finish chunks — leaving Langfuse generation spans (and any other OTel-based dashboard) reading **0 tokens for every Anthropic-only span**. Reproduced by the issue reporter against `@mastra/core@1.31.0` + `@mastra/langfuse@1.2.5` against a self-hosted Langfuse v3 stack.

The reporter cited three prior closed-without-fix issues (#8162, #13848, #15962) for the same class of problem. PR #13914 established the providerMetadata fallback for cache tokens; this PR extends the same fallback shape to the non-cache input/output counts.

## What changed

[`observability/mastra/src/usage.ts`](https://github.com/mastra-ai/mastra/blob/main/observability/mastra/src/usage.ts):

- `AnthropicMetadata` interface gains optional `inputTokens` / `outputTokens` fields, fully documented as the streaming-finish-chunk fallback with a reference to #16261.
- Inside `extractUsageMetrics`'s Anthropic branch, recover `inputTokens` / `outputTokens` from `providerMetadata.anthropic` when the top-level `usage` doesn't carry them. Done **before** the existing cache-summing path so the two recoveries compose: base from providerMetadata + cache from providerMetadata.
- The cache adjustment formula now starts from the recovered base (`inputTokens ?? 0`) instead of `usage.inputTokens ?? 0`, so cache tokens add to the right number even when the base came from the fallback.

The non-Anthropic paths (OpenAI, Google, OpenRouter) and the existing Mastra-aggregated multi-step path are completely untouched.

## Test plan

Added an `Anthropic non-cache token fallback (#16261)` describe block in [`observability/mastra/src/usage.test.ts`](https://github.com/mastra-ai/mastra/pull/16289/files) with **6 cases**:

- [x] Falls back to `providerMetadata.anthropic.inputTokens` when `usage.inputTokens` is undefined
- [x] Falls back to `providerMetadata.anthropic.outputTokens` when `usage.outputTokens` is undefined
- [x] Falls back when **both** are missing — the canonical #16261 shape
- [x] Composes with cache tokens (base from providerMetadata + cache from providerMetadata)
- [x] **No-regression**: prefers `usage.{input,output}Tokens` over providerMetadata when both present
- [x] **No-regression**: doesn't invent tokens when neither side has them

**Verified**:
- Pre-fix: **4 of 6 fail** with assertions like `expected undefined to be 1234` — bug reproduces in pure-unit form (no Anthropic SDK, no Langfuse server, no OTel collector needed).
- Post-fix: all 6 pass plus the 26 existing `extractUsageMetrics` tests stay green (**32/32 in the file**).
- Full `@mastra/observability` package: **704/706 tests pass** across 27 files (2 skipped, 0 failed).

```bash
pnpm --filter @mastra/observability test -t "Anthropic non-cache token fallback"
pnpm --filter @mastra/observability test
```

## Backwards compatibility

The fallback only fires when `usage.{input,output}Tokens` is `undefined` (not when it's explicitly `0`). Every existing call path that already populated those fields — including OpenAI, OpenRouter, Google/Gemini, and the multi-step Mastra-aggregated path — keeps the exact same behaviour. The `AnthropicMetadata` shape change is additive (two new optional fields).

## Related

- #8162 — original report (closed 2025-09 without a linked fix PR)
- #13848 / PR #13914 — cache-token fallback (established the pattern this PR extends)
- #15962 — non-spec attribute names on `@mastra/otel-exporter` (closed 2026-04-30)

The reporter ([@danielnc](https://github.com/danielnc)) currently routes through LiteLLM as a workaround. After this PR they should be able to drop that and read Anthropic tokens directly off the parent agent span in Langfuse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When Anthropic's AI SDK adapter sends token count information, it sometimes puts the numbers in a backup location instead of the main location. This PR teaches the observability system to check that backup location when the main one is empty, so monitoring dashboards (like Langfuse) show the correct token counts instead of zero.

## Overview

Fixes Anthropic generation spans reporting 0 input/output tokens in Langfuse and other OpenTelemetry dashboards when using the Vercel AI SDK adapter. The Anthropic adapter occasionally reports non-cache token counts only on `providerMetadata.anthropic` instead of the top-level `usage.inputTokens` / `usage.outputTokens` fields, causing Langfuse spans to read zero tokens.

## Changes

**Interface Updates** (`observability/mastra/src/usage.ts`):
- Extended `AnthropicMetadata` with two optional fields:
  - `inputTokens?: number` — non-cache input token counts
  - `outputTokens?: number` — non-cache output token counts
- Added documentation referencing the streaming-finish-chunk fallback behavior and issue #16261

**Core Logic** (`extractUsageMetrics` function):
- Refactored `inputTokens` and `outputTokens` from const to mutable variables to enable fallback behavior
- Added recovery logic that populates base tokens from `providerMetadata.anthropic` when top-level `usage` fields are undefined
- Positioned recovery before the existing cache-summing path so base and cache tokens compose correctly (e.g., 100 base + 800 cache read + 200 cache write = 1100 total input tokens)
- Cache adjustment now uses the recovered base (`inputTokens ?? 0`) instead of always using `usage.inputTokens ?? 0`, preventing zero-padding when cache tokens should add to recovered values

**Test Coverage** (6 new test cases in `observability/mastra/src/usage.test.ts`):
- Input-only fallback: recovers `inputTokens` from providerMetadata when missing from usage
- Output-only fallback: recovers `outputTokens` from providerMetadata when missing from usage
- Both-missing fallback: the canonical #16261 shape (empty usage, tokens on providerMetadata)
- Cache composition: verifies recovered base tokens combine correctly with cache tokens (e.g., 100 + 800 + 200 = 1100)
- Precedence: confirms top-level `usage` takes priority over `providerMetadata` when both present (no regression)
- No spurious recovery: does not invent tokens when neither source provides them

All 6 new tests pass; existing 32 test cases in the file remain green. Package test run: 704/706 passing (2 skipped).

## Backwards Compatibility

- Fallback logic only activates when `usage.inputTokens` or `usage.outputTokens` are `undefined`; existing behavior unchanged when top-level usage is present
- `AnthropicMetadata` additions are optional fields; no breaking changes to interface consumers
- No changes to public API signatures or exported entity declarations

## Changeset

Patch-level entry added to `@mastra/observability` with description: "Fixed Anthropic generation spans showing `0` input and output tokens in Langfuse and other OTel-based dashboards." References issue #16261.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->