### PR TITLE
fix(deployer): protect bundled Studio refresh routes

### DIFF
--- a/.changeset/proud-bars-report.md
+++ b/.changeset/proud-bars-report.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed bundled Studio refresh endpoints to require configured server authentication.

--- a/packages/deployer/src/server/__tests__/node-server-host.test.ts
+++ b/packages/deployer/src/server/__tests__/node-server-host.test.ts
@@ -43,6 +43,8 @@ vi.mock('../handlers/health', () => ({
 
 vi.mock('../handlers/client', () => ({
   handleClientsRefresh: vi.fn(ctx => ctx.json({ refresh: true })),
+  handleClientsRefreshRequest: vi.fn(() => new Response(JSON.stringify({ refresh: true }))),
+  getTriggerClientsRefreshPayload: vi.fn(() => ({ triggered: true })),
   handleTriggerClientsRefresh: vi.fn(ctx => ctx.json({ triggered: true })),
   isHotReloadDisabled: vi.fn(() => false),
 }));

--- a/packages/deployer/src/server/__tests__/option-studio-base.test.ts
+++ b/packages/deployer/src/server/__tests__/option-studio-base.test.ts
@@ -6,6 +6,7 @@
 
 import { readFile } from 'node:fs/promises';
 import type { Mastra } from '@mastra/core/mastra';
+import { SimpleAuth } from '@mastra/core/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHonoServer } from '../index';
 
@@ -47,6 +48,8 @@ vi.mock('../handlers/health', () => ({
 
 vi.mock('../handlers/client', () => ({
   handleClientsRefresh: vi.fn(ctx => ctx.json({ refresh: true })),
+  handleClientsRefreshRequest: vi.fn(() => new Response(JSON.stringify({ refresh: true }))),
+  getTriggerClientsRefreshPayload: vi.fn(() => ({ triggered: true })),
   handleTriggerClientsRefresh: vi.fn(ctx => ctx.json({ triggered: true })),
   isHotReloadDisabled: vi.fn(() => false),
 }));
@@ -169,6 +172,45 @@ describe('Mastra Studio "studioBase" functionality', () => {
 
       const response = await app.request('/studio/__hot-reload-status');
       expect([200, 404]).toContain(response.status);
+    });
+  });
+
+  describe('studio route auth', () => {
+    const auth = new SimpleAuth({
+      tokens: {
+        'test-token': {
+          id: 'user-1',
+          email: 'admin@example.com',
+          name: 'Admin User',
+        },
+      },
+    });
+
+    it.each([
+      { route: '/studio/refresh-events', method: 'GET' },
+      { route: '/studio/__refresh', method: 'POST' },
+      { route: '/studio/__hot-reload-status', method: 'GET' },
+    ])('should require auth for $method $route when server auth is configured', async ({ route, method }) => {
+      vi.mocked(mockMastra.getServer).mockReturnValue({ studioBase: '/studio', auth });
+      const app = await createHonoServer(mockMastra, { tools: {}, studio: true });
+
+      const response = await app.request(route, { method });
+      expect(response.status).toBe(401);
+    });
+
+    it.each([
+      { route: '/studio/refresh-events', method: 'GET' },
+      { route: '/studio/__refresh', method: 'POST' },
+      { route: '/studio/__hot-reload-status', method: 'GET' },
+    ])('should allow $method $route with valid auth when server auth is configured', async ({ route, method }) => {
+      vi.mocked(mockMastra.getServer).mockReturnValue({ studioBase: '/studio', auth });
+      const app = await createHonoServer(mockMastra, { tools: {}, studio: true });
+
+      const response = await app.request(route, {
+        method,
+        headers: { Authorization: 'Bearer test-token' },
+      });
+      expect(response.status).toBe(200);
     });
   });
 

--- a/packages/deployer/src/server/__tests__/swagger-openapi-warning.test.ts
+++ b/packages/deployer/src/server/__tests__/swagger-openapi-warning.test.ts
@@ -46,6 +46,8 @@ vi.mock('../handlers/health', () => ({
 
 vi.mock('../handlers/client', () => ({
   handleClientsRefresh: vi.fn(ctx => ctx.json({ refresh: true })),
+  handleClientsRefreshRequest: vi.fn(() => new Response(JSON.stringify({ refresh: true }))),
+  getTriggerClientsRefreshPayload: vi.fn(() => ({ triggered: true })),
   handleTriggerClientsRefresh: vi.fn(ctx => ctx.json({ triggered: true })),
   isHotReloadDisabled: vi.fn(() => false),
 }));

--- a/packages/deployer/src/server/handlers/client.ts
+++ b/packages/deployer/src/server/handlers/client.ts
@@ -4,12 +4,16 @@ const clients = new Set<ReadableStreamDefaultController>();
 let hotReloadDisabled = false;
 
 export function handleClientsRefresh(c: Context): Response {
+  return handleClientsRefreshRequest(c.req.raw);
+}
+
+export function handleClientsRefreshRequest(request: Request): Response {
   const stream = new ReadableStream({
     start(controller) {
       clients.add(controller);
       controller.enqueue('data: connected\n\n');
 
-      c.req.raw.signal.addEventListener('abort', () => {
+      request.signal.addEventListener('abort', () => {
         clients.delete(controller);
       });
     },
@@ -25,7 +29,7 @@ export function handleClientsRefresh(c: Context): Response {
   });
 }
 
-export function handleTriggerClientsRefresh(c: Context) {
+export function getTriggerClientsRefreshPayload() {
   clients.forEach(controller => {
     try {
       controller.enqueue('data: refresh\n\n');
@@ -33,7 +37,11 @@ export function handleTriggerClientsRefresh(c: Context) {
       clients.delete(controller);
     }
   });
-  return c.json({ success: true, clients: clients.size });
+  return { success: true, clients: clients.size };
+}
+
+export function handleTriggerClientsRefresh(c: Context) {
+  return c.json(getTriggerClientsRefreshPayload());
 }
 
 // Functions to control hot reload during template installation

--- a/packages/deployer/src/server/handlers/client.ts
+++ b/packages/deployer/src/server/handlers/client.ts
@@ -4,16 +4,16 @@ const clients = new Set<ReadableStreamDefaultController>();
 let hotReloadDisabled = false;
 
 export function handleClientsRefresh(c: Context): Response {
-  return handleClientsRefreshRequest(c.req.raw);
+  return handleClientsRefreshRequest(c.req.raw.signal);
 }
 
-export function handleClientsRefreshRequest(request: Request): Response {
+export function handleClientsRefreshRequest(abortSignal: AbortSignal): Response {
   const stream = new ReadableStream({
     start(controller) {
       clients.add(controller);
       controller.enqueue('data: connected\n\n');
 
-      request.signal.addEventListener('abort', () => {
+      abortSignal.addEventListener('abort', () => {
         clients.delete(controller);
       });
     },

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -10,7 +10,7 @@ import { Tool } from '@mastra/core/tools';
 import { MastraServer, setupBrowserStream } from '@mastra/hono';
 import type { HonoBindings, HonoVariables } from '@mastra/hono';
 import { InMemoryTaskStore } from '@mastra/server/a2a/store';
-import type { Context } from 'hono';
+import type { ServerRoute } from '@mastra/server/server-adapter';
 import { Hono } from 'hono';
 import { compress } from 'hono/compress';
 import { cors } from 'hono/cors';
@@ -18,7 +18,7 @@ import { logger } from 'hono/logger';
 import { timeout } from 'hono/timeout';
 import { describeRoute } from 'hono-openapi';
 import { injectStudioHtmlConfig, normalizeStudioBase } from '../build/utils';
-import { handleClientsRefresh, handleTriggerClientsRefresh, isHotReloadDisabled } from './handlers/client';
+import { getTriggerClientsRefreshPayload, handleClientsRefreshRequest, isHotReloadDisabled } from './handlers/client';
 import { errorHandler } from './handlers/error';
 import { healthHandler } from './handlers/health';
 import { restartAllActiveWorkflowRunsHandler } from './handlers/restart-active-runs';
@@ -316,37 +316,34 @@ export async function createHonoServer(
   const studioBasePath = normalizeStudioBase(serverOptions?.studioBase ?? '/');
 
   if (options?.studio) {
-    // SSE endpoint for refresh notifications
-    app.get(
-      `${studioBasePath}/refresh-events`,
-      describeRoute({
-        hide: true,
-      }),
-      handleClientsRefresh,
-    );
-
-    // Trigger refresh for all clients
-    app.post(
-      `${studioBasePath}/__refresh`,
-      describeRoute({
-        hide: true,
-      }),
-      handleTriggerClientsRefresh,
-    );
-
-    // Check hot reload status
-    app.get(
-      `${studioBasePath}/__hot-reload-status`,
-      describeRoute({
-        hide: true,
-      }),
-      (c: Context) => {
-        return c.json({
+    const studioControlRoutes: ServerRoute[] = [
+      {
+        method: 'GET',
+        path: '/refresh-events',
+        responseType: 'datastream-response',
+        handler: async ({ request }) => handleClientsRefreshRequest(request as Request),
+      },
+      {
+        method: 'POST',
+        path: '/__refresh',
+        responseType: 'json',
+        handler: async () => getTriggerClientsRefreshPayload(),
+      },
+      {
+        method: 'GET',
+        path: '/__hot-reload-status',
+        responseType: 'json',
+        handler: async () => ({
           disabled: isHotReloadDisabled(),
           timestamp: new Date().toISOString(),
-        });
+        }),
       },
-    );
+    ];
+
+    for (const route of studioControlRoutes) {
+      customRouteAuthConfig.set(`${route.method}:${studioBasePath}${route.path}`, true);
+      await honoServerAdapter.registerRoute(app, route, { prefix: studioBasePath });
+    }
 
     // Enable gzip/deflate compression for studio static assets only
     app.use(`${studioBasePath}/assets/*`, compress());

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -321,7 +321,7 @@ export async function createHonoServer(
         method: 'GET',
         path: '/refresh-events',
         responseType: 'datastream-response',
-        handler: async ({ request }) => handleClientsRefreshRequest(request as Request),
+        handler: async ({ abortSignal }) => handleClientsRefreshRequest(abortSignal),
       },
       {
         method: 'POST',


### PR DESCRIPTION

## Description

Require configured server auth for bundled Studio refresh, hot-reload status, and refresh-trigger endpoints so they do not bypass the API auth boundary.


## Related Issue(s)

Fixes #16232 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)
Some Studio control endpoints were accidentally left open like an unlocked door. This PR locks those Studio hot-reload and refresh endpoints so they require the same server authentication as the API.

## Changes

### Security: Require server auth for bundled Studio control endpoints
- Protects bundled Studio control endpoints with configured server authentication so they no longer bypass server.auth or expose Access-Control-Allow-Origin: * when auth is configured:
  - GET /refresh-events (SSE)
  - POST /__refresh (trigger refresh)
  - GET /__hot-reload-status

### Handler refactor
- packages/deployer/src/server/handlers/client.ts
  - handleClientsRefresh now delegates to handleClientsRefreshRequest(abortSignal: AbortSignal) which creates the SSE ReadableStream and ties controller cleanup to the provided abort signal.
  - Added getTriggerClientsRefreshPayload() to broadcast SSE refresh events to connected clients and return { success: true, clients: number }.
  - handleTriggerClientsRefresh now returns c.json(getTriggerClientsRefreshPayload()) (payload construction moved into helper).

### Route registration / auth wiring
- packages/deployer/src/server/index.ts
  - Consolidated Studio control endpoints into a data-driven studioControlRoutes array and register them via honoServerAdapter.registerRoute with explicit per-route auth entries recorded in customRouteAuthConfig (keys like `${method}:${studioBasePath}${path}`).
  - Routes now call the new request/abort-signal–based helpers: refresh-events uses handleClientsRefreshRequest(abortSignal), __refresh returns getTriggerClientsRefreshPayload(), and __hot-reload-status remains functionally equivalent but is registered via the route array.

### Tests
- packages/deployer/src/server/__tests__/option-studio-base.test.ts
  - Adds "studio route auth" suite using SimpleAuth to verify that when server.auth is configured:
    - requests to /studio/refresh-events, /studio/__refresh, and /studio/__hot-reload-status return 401 without credentials
    - the same routes return 200 with a valid Bearer token
- packages/deployer/src/server/__tests__/node-server-host.test.ts and swagger-openapi-warning.test.ts
  - Update mocks to expose handleClientsRefreshRequest and getTriggerClientsRefreshPayload helpers.

### Release notes / changeset
- .changeset/proud-bars-report.md: patch for @mastra/deployer noting bundled Studio refresh endpoints now require configured server authentication.

## Impact
- Fixes security gap from issue #16232: bundled Studio SSE and control routes are no longer publicly reachable when the API server requires authentication; they are now protected by the configured server auth or the documented Studio auth/session mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->