### PR TITLE
Fix Codex OAuth callback port fallback

### DIFF
--- a/.changeset/shiny-eagles-poke.md
+++ b/.changeset/shiny-eagles-poke.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed OpenAI Codex login when the default callback port is already in use. The login flow now falls back to the Codex-supported fallback port and shows a clear warning when both supported callback ports are unavailable.

--- a/mastracode/src/auth/providers/openai-codex.test.ts
+++ b/mastracode/src/auth/providers/openai-codex.test.ts
@@ -1,0 +1,95 @@
+import http from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const blockers: http.Server[] = [];
+
+async function getFreePort(): Promise<number> {
+  const server = http.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  await closeServer(server);
+  if (!address || typeof address === 'string') throw new Error('Failed to allocate a test port');
+  return address.port;
+}
+
+async function getTestPorts(): Promise<{ defaultPort: number; fallbackPort: number }> {
+  return {
+    defaultPort: await getFreePort(),
+    fallbackPort: await getFreePort(),
+  };
+}
+
+async function blockPort(port: number): Promise<void> {
+  const server = http.createServer((_, res) => {
+    res.statusCode = 200;
+    res.end('blocked');
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', resolve);
+  });
+  blockers.push(server);
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  await new Promise<void>(resolve => server.close(() => resolve()));
+}
+
+describe('OpenAI Codex OAuth callback port selection', () => {
+  afterEach(async () => {
+    while (blockers.length > 0) {
+      const server = blockers.pop();
+      if (server) await closeServer(server);
+    }
+  });
+
+  it('uses the Codex default callback port first', async () => {
+    const ports = await getTestPorts();
+    const { __testing } = await import('./openai-codex.js');
+
+    const server = await __testing.startLocalOAuthServer('state', ports);
+    try {
+      expect(server.redirectUri).toBe(`http://localhost:${ports.defaultPort}/auth/callback`);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('falls back to the Codex fallback port when the default is busy', async () => {
+    const ports = await getTestPorts();
+    await blockPort(ports.defaultPort);
+    const { __testing } = await import('./openai-codex.js');
+
+    const server = await __testing.startLocalOAuthServer('state', ports);
+    try {
+      expect(server.redirectUri).toBe(`http://localhost:${ports.fallbackPort}/auth/callback`);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('does not scan arbitrary callback ports after the Codex ports are busy', async () => {
+    const ports = await getTestPorts();
+    await blockPort(ports.defaultPort);
+    await blockPort(ports.fallbackPort);
+    const { __testing } = await import('./openai-codex.js');
+
+    const server = await __testing.startLocalOAuthServer('state', ports);
+    try {
+      expect(server.redirectUri).toBe(`http://localhost:${ports.fallbackPort}/auth/callback`);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('uses the selected callback port in the authorization URL', async () => {
+    const { __testing } = await import('./openai-codex.js');
+
+    const { url } = await __testing.createAuthorizationFlow('http://localhost:1457/auth/callback', 'state');
+
+    expect(new URL(url).searchParams.get('redirect_uri')).toBe('http://localhost:1457/auth/callback');
+  });
+});

--- a/mastracode/src/auth/providers/openai-codex.ts
+++ b/mastracode/src/auth/providers/openai-codex.ts
@@ -11,13 +11,22 @@
 // NEVER convert to top-level imports - breaks browser/Vite builds (web-ui)
 let _randomBytes: ((size: number) => Buffer) | null = null;
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+let _httpPromise: Promise<typeof import('node:http')> | null = null;
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 let _http: typeof import('node:http') | null = null;
+type HttpServer = {
+  off: (event: 'error' | 'listening', listener: (...args: any[]) => void) => HttpServer;
+  once: (event: 'error' | 'listening', listener: (...args: any[]) => void) => HttpServer;
+  listen: (port: number, hostname: string) => HttpServer;
+  close: () => void;
+};
 if (typeof process !== 'undefined' && (process.versions?.node || process.versions?.bun)) {
   import('node:crypto').then(m => {
     _randomBytes = m.randomBytes;
   });
-  import('node:http').then(m => {
+  _httpPromise = import('node:http').then(m => {
     _http = m;
+    return m;
   });
 }
 
@@ -27,7 +36,8 @@ import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderI
 const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize';
 const TOKEN_URL = 'https://auth.openai.com/oauth/token';
-const REDIRECT_URI = 'http://localhost:1455/auth/callback';
+const DEFAULT_CALLBACK_PORT = 1455;
+const FALLBACK_CALLBACK_PORT = 1457;
 const SCOPE = 'openid profile email offline_access';
 const JWT_CLAIM_PATH = 'https://api.openai.com/auth';
 
@@ -111,11 +121,7 @@ function decodeJwt(token: string): JwtPayload | null {
   }
 }
 
-async function exchangeAuthorizationCode(
-  code: string,
-  verifier: string,
-  redirectUri: string = REDIRECT_URI,
-): Promise<TokenResult> {
+async function exchangeAuthorizationCode(code: string, verifier: string, redirectUri: string): Promise<TokenResult> {
   const response = await fetch(TOKEN_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -195,15 +201,16 @@ async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
 }
 
 async function createAuthorizationFlow(
+  redirectUri: string,
+  state: string,
   originator: string = 'pi',
-): Promise<{ verifier: string; state: string; url: string }> {
+): Promise<{ verifier: string; url: string }> {
   const { verifier, challenge } = await generatePKCE();
-  const state = createState();
 
   const url = new URL(AUTHORIZE_URL);
   url.searchParams.set('response_type', 'code');
   url.searchParams.set('client_id', CLIENT_ID);
-  url.searchParams.set('redirect_uri', REDIRECT_URI);
+  url.searchParams.set('redirect_uri', redirectUri);
   url.searchParams.set('scope', SCOPE);
   url.searchParams.set('code_challenge', challenge);
   url.searchParams.set('code_challenge_method', 'S256');
@@ -212,24 +219,86 @@ async function createAuthorizationFlow(
   url.searchParams.set('codex_cli_simplified_flow', 'true');
   url.searchParams.set('originator', originator);
 
-  return { verifier, state, url: url.toString() };
+  return { verifier, url: url.toString() };
 }
 
 type OAuthServerInfo = {
+  redirectUri: string;
+  warning?: string;
   close: () => void;
   cancelWait: () => void;
   waitForCode: () => Promise<{ code: string } | null>;
 };
 
-function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
+type CallbackPorts = {
+  defaultPort: number;
+  fallbackPort: number;
+};
+
+const CODEX_CALLBACK_PORTS: CallbackPorts = {
+  defaultPort: DEFAULT_CALLBACK_PORT,
+  fallbackPort: FALLBACK_CALLBACK_PORT,
+};
+
+async function requestCancel(port: number): Promise<void> {
+  try {
+    await fetch(`http://127.0.0.1:${port}/cancel`, { signal: AbortSignal.timeout(200) });
+  } catch {
+    // The existing listener might not be a Codex auth server.
+  }
+}
+
+function listen(server: HttpServer, port: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const onError = () => {
+      server.off('listening', onListening);
+      resolve(false);
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolve(true);
+    };
+
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+async function bindOAuthServer(server: HttpServer, ports: CallbackPorts): Promise<number | null> {
+  await requestCancel(ports.defaultPort);
+  if (await listen(server, ports.defaultPort)) return ports.defaultPort;
+  if (await listen(server, ports.fallbackPort)) return ports.fallbackPort;
+
+  return null;
+}
+
+async function getHttpModule() {
+  if (!_http && _httpPromise) {
+    _http = await _httpPromise;
+  }
   if (!_http) {
     throw new Error('OpenAI Codex OAuth is only available in Node.js environments');
   }
+  return _http;
+}
+
+async function startLocalOAuthServer(
+  state: string,
+  ports: CallbackPorts = CODEX_CALLBACK_PORTS,
+): Promise<OAuthServerInfo> {
+  const http = await getHttpModule();
   let lastCode: string | null = null;
   let cancelled = false;
-  const server = _http.createServer((req, res) => {
+  const server = http.createServer((req, res) => {
     try {
       const url = new URL(req.url || '', 'http://localhost');
+      if (url.pathname === '/cancel') {
+        cancelled = true;
+        res.statusCode = 200;
+        res.end('Cancelled');
+        return;
+      }
       if (url.pathname !== '/auth/callback') {
         res.statusCode = 404;
         res.end('Not found');
@@ -257,31 +326,11 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
   });
 
   return new Promise(resolve => {
-    server
-      .listen(1455, '127.0.0.1', () => {
+    bindOAuthServer(server, ports).then(port => {
+      if (!port) {
         resolve({
-          close: () => server.close(),
-          cancelWait: () => {
-            cancelled = true;
-          },
-          waitForCode: async () => {
-            const sleep = () => new Promise(r => setTimeout(r, 100));
-            for (let i = 0; i < 600; i += 1) {
-              if (lastCode) return { code: lastCode };
-              if (cancelled) return null;
-              await sleep();
-            }
-            return null;
-          },
-        });
-      })
-      .on('error', (err: NodeJS.ErrnoException) => {
-        console.error(
-          '[openai-codex] Failed to bind http://127.0.0.1:1455 (',
-          err.code,
-          ') Falling back to manual paste.',
-        );
-        resolve({
+          redirectUri: `http://localhost:${ports.fallbackPort}/auth/callback`,
+          warning: `OpenAI Codex OAuth requires localhost port ${ports.defaultPort} or ${ports.fallbackPort}, but both are in use. Automatic browser callback will not work until one is freed.`,
           close: () => {
             try {
               server.close();
@@ -292,7 +341,26 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
           cancelWait: () => {},
           waitForCode: async () => null,
         });
+        return;
+      }
+
+      resolve({
+        redirectUri: `http://localhost:${port}/auth/callback`,
+        close: () => server.close(),
+        cancelWait: () => {
+          cancelled = true;
+        },
+        waitForCode: async () => {
+          const sleep = () => new Promise(r => setTimeout(r, 100));
+          for (let i = 0; i < 600; i += 1) {
+            if (lastCode) return { code: lastCode };
+            if (cancelled) return null;
+            await sleep();
+          }
+          return null;
+        },
       });
+    });
   });
 }
 
@@ -321,12 +389,18 @@ export async function loginOpenAICodex(options: {
   onManualCodeInput?: () => Promise<string>;
   originator?: string;
 }): Promise<OAuthCredentials> {
-  const { verifier, state, url } = await createAuthorizationFlow(options.originator);
+  const state = createState();
   const server = await startLocalOAuthServer(state);
+  if (server.warning) {
+    options.onProgress?.(server.warning);
+  }
+  const { verifier, url } = await createAuthorizationFlow(server.redirectUri, state, options.originator);
 
   options.onAuth({
     url,
-    instructions: 'A browser window should open. Complete login to finish.',
+    instructions: server.warning
+      ? `${server.warning} You can still paste the authorization code or full redirect URL manually.`
+      : 'A browser window should open. Complete login to finish.',
   });
 
   let code: string | undefined;
@@ -403,7 +477,7 @@ export async function loginOpenAICodex(options: {
       throw new Error('Missing authorization code');
     }
 
-    const tokenResult = await exchangeAuthorizationCode(code, verifier);
+    const tokenResult = await exchangeAuthorizationCode(code, verifier, server.redirectUri);
     if (tokenResult.type !== 'success') {
       throw new Error('Token exchange failed');
     }
@@ -423,6 +497,11 @@ export async function loginOpenAICodex(options: {
     server.close();
   }
 }
+
+export const __testing = {
+  createAuthorizationFlow,
+  startLocalOAuthServer,
+};
 
 /**
  * Refresh OpenAI Codex OAuth token


### PR DESCRIPTION
## Summary
- match Codex OAuth callback behavior by trying localhost port 1455 before falling back to 1457
- use the selected callback port in the OAuth redirect URI and token exchange
- show a visible MastraCode warning when both supported callback ports are unavailable
- add unit coverage for default, fallback, no arbitrary scanning, and auth URL redirect behavior

## Test plan
- pnpm --filter ./mastracode exec tsc --noEmit
- pnpm --filter ./mastracode exec eslint src/auth/providers/openai-codex.ts src/auth/providers/openai-codex.test.ts
- pnpm --filter ./mastracode test run src/auth/providers/openai-codex.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes how OpenAI Codex login works on your computer. Instead of always trying to use the same port (which might already be in use by another program), it now tries port 1455 first, and if that's busy, it falls back to port 1457. If both ports are busy, it shows you a warning so you know to free up a port. It's like having a backup parking spot when your favorite one is full!

## Changes

### Changeset Documentation
Added release notes documenting the fix to the OpenAI Codex login flow, describing the port fallback behavior and warning system.

### Test Suite (`mastracode/src/auth/providers/openai-codex.test.ts`)
Introduced a comprehensive test suite with integration-style tests that verify OAuth callback port selection:
- Helper utilities to allocate free local TCP ports and temporarily block ports via HTTP servers
- Tests validating that the code uses the default callback port (1455) first
- Tests confirming fallback to the alternate port (1457) when the default is unavailable
- Tests ensuring the system doesn't attempt to scan arbitrary ports once both Codex ports are in use
- Verification that the chosen callback port is reflected in the authorization URL's `redirect_uri` parameter

### Core Implementation (`mastracode/src/auth/providers/openai-codex.ts`)
Refactored to support dynamic local callback ports:
- Added Node-only lazy-loading for `crypto` and `http` modules via cached promises
- Introduced `startLocalOAuthServer(state, ports)` function that attempts to bind to `DEFAULT_CALLBACK_PORT` (1455) first, then `FALLBACK_CALLBACK_PORT` (1457)
- Function returns `OAuthServerInfo` with the selected `redirectUri` and server lifecycle controls
- Updated `createAuthorizationFlow()` to accept an explicit `redirectUri` parameter instead of using a hardcoded constant
- Modified `exchangeAuthorizationCode()` to require the redirect URI as a parameter (no longer has a default)
- Updated `loginOpenAICodex()` flow to create state, start the local server, receive the warning/selected redirect URI, and use that URI throughout the authorization and token exchange process
- Exported `__testing` object exposing `createAuthorizationFlow` and `startLocalOAuthServer` for test access

### Function Signature Changes
- `exchangeAuthorizationCode(code: string, verifier: string, redirectUri: string)` — now requires explicit redirect URI
- `createAuthorizationFlow(redirectUri: string, state: string, originator?: string)` — now requires explicit redirect URI parameter
- New export: `__testing = { createAuthorizationFlow, startLocalOAuthServer }`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->