### PR TITLE
Fix WorkOS FGA example initialization

### DIFF
--- a/examples/agent/src/mastra/auth/workos.ts
+++ b/examples/agent/src/mastra/auth/workos.ts
@@ -10,6 +10,7 @@ export async function initWorkOS(): Promise<AuthResult> {
 
   const mastraAuth = new MastraAuthWorkos({
     redirectUri: process.env.WORKOS_REDIRECT_URI || 'http://localhost:4111/api/auth/callback',
+    fetchMemberships: true,
   });
 
   const rbacProvider = new MastraRBACWorkos({
@@ -28,13 +29,8 @@ export async function initWorkOS(): Promise<AuthResult> {
     },
   });
 
-  const organizationId = process.env.WORKOS_ORGANIZATION_ID;
-  if (!organizationId) {
-    throw new Error('WORKOS_ORGANIZATION_ID is required to enable WorkOS FGA');
-  }
-
   const fgaProvider = new MastraFGAWorkos({
-    organizationId,
+    organizationId: process.env.WORKOS_ORGANIZATION_ID,
     resourceMapping: {
       // Per-resource filtering: agent ID maps directly to WorkOS resource external ID
       agent: { fgaResourceType: 'agent' },


### PR DESCRIPTION
## Description

Fixes the WorkOS agent example so WorkOS FGA is initialized only when `server.fga` is configured. This prevents `WORKOS_ORGANIZATION_ID` from being required for WorkOS auth or RBAC-only setups.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR tweaks the WorkOS example so the WorkOS auth client always fetches group/membership data, and the FGA (Fine-Grained Authorization) provider is constructed unconditionally using the ORGANIZATION_ID environment variable (which may be undefined) instead of being gated by an explicit presence check.

## Changes

### WorkOS Authentication Initialization

**File: `examples/agent/src/mastra/auth/workos.ts`**

- initWorkOS():
  - Enables fetchMemberships: true when constructing MastraAuthWorkos.
  - Constructs MastraFGAWorkos unconditionally and passes process.env.WORKOS_ORGANIZATION_ID as organizationId (no longer checks for or throws when the env var is missing).
  - resourceMapping configured for:
    - agent → fgaResourceType: 'agent'
    - workflow → fgaResourceType: 'workflow'
    - tool → fgaResourceType: 'tool'
    - memory → fgaResourceType: 'user', deriveId: ctx => ctx.user.userId
  - permissionMapping set to an empty object (permission slugs fall through to original strings).
  - Returns { mastraAuth, rbacProvider, fgaProvider } as before.

## Notes / Observations

- Signature and exported API unchanged.
- The code now always constructs an FGA provider (potentially with organizationId undefined).
- The deriveId uses ctx in a scope where ctx is not defined in this function (potential runtime/reference issue).
- Type of change: Bug fix (non-breaking)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->