### PR TITLE
fix(core): handle special tokens in TokenLimiterProcessor

### DIFF
--- a/.changeset/purple-lizards-stop.md
+++ b/.changeset/purple-lizards-stop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed TokenLimiterProcessor crashing when counting text that contains special token strings.

--- a/packages/core/src/processors/processors/token-limiter.test.ts
+++ b/packages/core/src/processors/processors/token-limiter.test.ts
@@ -256,6 +256,40 @@ describe('TokenLimiterProcessor', () => {
       expect(result).toEqual(part);
     });
 
+    it('should handle text-delta chunks containing special token strings', async () => {
+      processor = new TokenLimiterProcessor({ limit: 10 });
+
+      const part: ChunkType = {
+        type: 'text-delta',
+        payload: { text: 'Hello <|endoftext|>', id: 'test-id' },
+        runId: 'test-run-id',
+        from: ChunkFrom.AGENT,
+      };
+
+      await expect(
+        processor.processOutputStream({ part, streamParts: [], state: {}, abort: mockAbort }),
+      ).resolves.toEqual(part);
+    });
+
+    it('should handle tool-result chunks containing special token strings', async () => {
+      processor = new TokenLimiterProcessor({ limit: 10 });
+
+      const part: ChunkType = {
+        type: 'tool-result' as const,
+        payload: {
+          toolCallId: 'call_1',
+          toolName: 'leakyTool',
+          result: 'raw model output <|endoftext|>',
+        },
+        runId: 'test-run-id',
+        from: ChunkFrom.AGENT,
+      };
+
+      await expect(
+        processor.processOutputStream({ part, streamParts: [], state: {}, abort: mockAbort }),
+      ).resolves.toEqual(part);
+    });
+
     it('should handle object chunks', async () => {
       processor = new TokenLimiterProcessor({ limit: 50 });
 
@@ -459,6 +493,18 @@ describe('TokenLimiterProcessor', () => {
   });
 
   describe('processOutputResult', () => {
+    it('should handle text content containing special token strings', async () => {
+      processor = new TokenLimiterProcessor({ limit: 50 });
+
+      const originalText = 'Final answer <|endoftext|>';
+      const messages = [createTestMessage(originalText)];
+
+      const result = await processor.processOutputResult({ messages, abort: mockAbort });
+
+      expect(result).toHaveLength(1);
+      expect((result[0].content.parts[0] as TextPart).text).toBe(originalText);
+    });
+
     it('should truncate text content that exceeds token limit', async () => {
       processor = new TokenLimiterProcessor({ limit: 10 });
 
@@ -591,6 +637,77 @@ describe('TokenLimiterProcessor', () => {
         doGenerate: async () => ({}),
         doStream: async () => ({}),
       }) as any;
+
+    it('should count system messages containing special token strings', async () => {
+      const processor = new TokenLimiterProcessor({ limit: 1000 });
+      const messageList = new MessageList();
+
+      messageList.add(
+        {
+          id: 'user-1',
+          role: 'user',
+          content: { format: 2, content: 'Hello', parts: [{ type: 'text', text: 'Hello' }] },
+          createdAt: new Date('2023-01-01T00:00:00Z'),
+        },
+        'input',
+      );
+
+      await expect(
+        processor.processInputStep({
+          messageList,
+          stepNumber: 1,
+          model: createMockModel(),
+          steps: [],
+          systemMessages: [{ role: 'system', content: 'System text <|endoftext|>' }],
+          state: {},
+          retryCount: 0,
+          abort: mockAbort,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should count tool results containing special token strings', async () => {
+      const processor = new TokenLimiterProcessor({ limit: 1000 });
+      const messageList = new MessageList();
+
+      messageList.add(
+        {
+          id: 'tool-result',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  state: 'result',
+                  toolCallId: 'call_1',
+                  toolName: 'leakyTool',
+                  args: {},
+                  result: 'raw model output <|endoftext|>',
+                },
+              },
+            ],
+          },
+          createdAt: new Date('2023-01-01T00:00:00Z'),
+        },
+        'response',
+      );
+
+      await expect(
+        processor.processInputStep({
+          messageList,
+          stepNumber: 1,
+          model: createMockModel(),
+          steps: [],
+          systemMessages: [],
+          state: {},
+          retryCount: 0,
+          abort: mockAbort,
+        }),
+      ).resolves.toBeUndefined();
+    });
 
     it('should prune old messages at each step to stay within token limit', async () => {
       const processor = new TokenLimiterProcessor({ limit: 50 });

--- a/packages/core/src/processors/processors/token-limiter.ts
+++ b/packages/core/src/processors/processors/token-limiter.ts
@@ -93,6 +93,10 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
     return this.encoderPromise;
   }
 
+  private countTokens(encoder: Tiktoken, text: string): number {
+    return encoder.encode(text, 'all').length;
+  }
+
   /**
    * Process input messages at each step of the agentic loop, before they are sent to the LLM.
    * Runs at every step (including tool call continuations), preventing the conversation history
@@ -195,7 +199,7 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
     const encoder = await this.getEncoder();
     const tokenString = message.role + message.content;
 
-    return encoder.encode(tokenString).length + TokenLimiterProcessor.TOKENS_PER_MESSAGE;
+    return this.countTokens(encoder, tokenString) + TokenLimiterProcessor.TOKENS_PER_MESSAGE;
   }
 
   /**
@@ -266,7 +270,7 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
       overhead += toolResultCount * TokenLimiterProcessor.TOKENS_PER_MESSAGE;
     }
 
-    const tokenCount = encoder.encode(tokenString).length;
+    const tokenCount = this.countTokens(encoder, tokenString);
     const total = tokenCount + overhead;
     return total;
   }
@@ -326,12 +330,12 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
     const encoder = await this.getEncoder();
     if (part.type === 'text-delta') {
       // For text chunks, count the text content directly
-      return encoder.encode(part.payload.text).length;
+      return this.countTokens(encoder, part.payload.text);
     } else if (part.type === 'object') {
       // For object chunks, count the JSON representation
       // This is similar to how the memory processor handles object content
       const objectString = JSON.stringify(part.object);
-      return encoder.encode(objectString).length;
+      return this.countTokens(encoder, objectString);
     } else if (part.type === 'tool-call') {
       // For tool-call chunks, count tool name and args
       let tokenString = part.payload.toolName;
@@ -342,7 +346,7 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
           tokenString += JSON.stringify(part.payload.args);
         }
       }
-      return encoder.encode(tokenString).length;
+      return this.countTokens(encoder, tokenString);
     } else if (part.type === 'tool-result') {
       // For tool-result chunks, count the result
       let tokenString = '';
@@ -353,10 +357,10 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
           tokenString += JSON.stringify(part.payload.result);
         }
       }
-      return encoder.encode(tokenString).length;
+      return this.countTokens(encoder, tokenString);
     } else {
       // For other part types, count the JSON representation
-      return encoder.encode(JSON.stringify(part)).length;
+      return this.countTokens(encoder, JSON.stringify(part));
     }
   }
 
@@ -384,7 +388,7 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
       const processedParts = message.content.parts.map(part => {
         if (part.type === 'text') {
           const textContent = part.text;
-          const tokens = encoder.encode(textContent).length;
+          const tokens = this.countTokens(encoder, textContent);
 
           // Check if adding this part's tokens would exceed the cumulative limit
           if (cumulativeTokens + tokens <= limit) {
@@ -408,7 +412,7 @@ export class TokenLimiterProcessor implements Processor<'token-limiter', TokenLi
               while (left <= right) {
                 const mid = Math.floor((left + right) / 2);
                 const testText = textContent.slice(0, mid);
-                const testTokens = encoder.encode(testText).length;
+                const testTokens = this.countTokens(encoder, testText);
 
                 if (testTokens <= remainingTokens) {
                   // This length fits, try to find a longer one


### PR DESCRIPTION
## Description

Fixed `TokenLimiterProcessor` crashing when input or output text contains tiktoken
special-token strings (e.g. `<|endoftext|>`). The processor now passes `'all'` to
`encoder.encode`, which treats those sequences as ordinary text instead of raising.

- Added a `countTokens` helper on `TokenLimiterProcessor` that wraps `encoder.encode(text,
  'all').length`
- Replaced every direct `encoder.encode(...).length` call (input-step counting,
  output-result counting, and stream-chunk counting) with the helper
- Added tests for text-delta and tool-result chunks, output result text, system messages,
  and tool results that contain special token strings

## Related Issue(s)

Fixes #16301

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The TokenLimiterProcessor is a tool that counts the length of conversations to prevent them from getting too long. When AI models generate responses, they sometimes include special marker sequences (like `<|endoftext|>`) that were causing the processor to crash. This fix tells the token counter to treat these special markers as regular text instead of rejecting them, so conversations with AI-generated content can be measured without errors.

## Overview

This PR fixes a bug in `TokenLimiterProcessor` where the component would crash when processing text containing tiktoken special-token strings such as `<|endoftext|>`. The root cause was that token counting calls to `encoder.encode()` were rejecting these special tokens by default. The solution centralizes token counting through a new helper function that calls `encoder.encode(text, 'all')`, which treats special-token sequences as ordinary text for counting purposes.

## Changes

**Implementation (`token-limiter.ts`):**
- Added a `countTokens()` helper function that wraps `encoder.encode(text, 'all').length` to safely count tokens in any text, including special-token strings
- Refactored all token-counting calls throughout the processor to use this helper:
  - System message token accounting
  - Input message content token accounting (across various content types and tool handling paths)
  - Streaming chunk token counting (text deltas, object chunks, tool-call results, tool-result chunks)
  - Output truncation calculations (non-streaming text parts and binary-search truncation loop)

**Tests (`token-limiter.test.ts`):**
- Added test coverage for text-delta chunks containing `"<|endoftext|>"` to verify they are processed without truncation
- Added test coverage for tool-result chunks containing special token strings
- Added test coverage for final output text containing special token strings (ensuring no unintended truncation)
- Added test scenarios for system messages and tool-result messages with special-token strings to verify successful processing

**Metadata:**
- Added changeset entry for a patch release of `@mastra/core`

## Impact

The processor now gracefully handles AI-generated content that includes special-token sequences, preventing crashes during token counting while maintaining the intended behavior of tracking token budgets across conversations and managing output truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->