### PR TITLE
Unify empty state of Traces and Logs pages

### DIFF
--- a/.changeset/eighty-readers-lose.md
+++ b/.changeset/eighty-readers-lose.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added `NoTracesInfo` component that informs the user there are no traces for the active date range.

--- a/packages/playground-ui/src/domains/traces/components/index.ts
+++ b/packages/playground-ui/src/domains/traces/components/index.ts
@@ -20,3 +20,4 @@ export { TraceDetailsView, type TraceDetailsViewProps } from './trace-details-vi
 export { TracesLayout, type TracesLayoutProps } from './traces-layout';
 export { TracesListView, type TracesListViewProps, type TracesListViewTrace } from './traces-list-view';
 export { TracesErrorContent, type TracesErrorContentProps } from './traces-error-content';
+export { NoTracesInfo, type NoTracesInfoProps } from './no-traces-info';

--- a/packages/playground-ui/src/domains/traces/components/no-traces-info.tsx
+++ b/packages/playground-ui/src/domains/traces/components/no-traces-info.tsx
@@ -1,0 +1,72 @@
+import { format } from 'date-fns';
+import { CircleSlashIcon, ExternalLinkIcon } from 'lucide-react';
+import type { TraceDatePreset } from '../types';
+import { Button } from '@/ds/components/Button';
+import { EmptyState } from '@/ds/components/EmptyState';
+
+const PRESET_LABELS: Record<Exclude<TraceDatePreset, 'all' | 'custom'>, string> = {
+  'last-24h': 'the last 24 hours',
+  'last-3d': 'the last 3 days',
+  'last-7d': 'the last 7 days',
+  'last-14d': 'the last 14 days',
+  'last-30d': 'the last 30 days',
+};
+
+export interface NoTracesInfoProps {
+  datePreset?: TraceDatePreset;
+  dateFrom?: Date;
+  dateTo?: Date;
+}
+
+const DATE_FORMAT = 'MMM d, yyyy HH:mm';
+
+const RANGE_TIP = 'Pick a wider time range — older traces may fall outside the current window.';
+
+function describeRange({ datePreset, dateFrom, dateTo }: NoTracesInfoProps): { title: string; description: string } {
+  if (datePreset && datePreset !== 'all' && datePreset !== 'custom') {
+    return {
+      title: `No traces for ${PRESET_LABELS[datePreset]}`,
+      description: RANGE_TIP,
+    };
+  }
+  if (dateFrom && dateTo) {
+    return {
+      title: `No traces between ${format(dateFrom, DATE_FORMAT)} and ${format(dateTo, DATE_FORMAT)}`,
+      description: RANGE_TIP,
+    };
+  }
+  if (dateFrom) {
+    return {
+      title: `No traces since ${format(dateFrom, DATE_FORMAT)}`,
+      description: RANGE_TIP,
+    };
+  }
+  return {
+    title: 'No traces yet',
+    description: 'Traces will appear here once agents, workflows, or tools are executed.',
+  };
+}
+
+export const NoTracesInfo = ({ datePreset, dateFrom, dateTo }: NoTracesInfoProps = {}) => {
+  const { title, description } = describeRange({ datePreset, dateFrom, dateTo });
+  return (
+    <div className="flex h-full items-center justify-center">
+      <EmptyState
+        iconSlot={<CircleSlashIcon />}
+        titleSlot={title}
+        descriptionSlot={description}
+        actionSlot={
+          <Button
+            variant="ghost"
+            as="a"
+            href="https://mastra.ai/en/docs/observability/tracing/overview"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Tracing Documentation <ExternalLinkIcon />
+          </Button>
+        }
+      />
+    </div>
+  );
+};

--- a/packages/playground/src/pages/logs/index.tsx
+++ b/packages/playground/src/pages/logs/index.tsx
@@ -191,7 +191,9 @@ export default function LogsPage() {
     );
   }
 
-  if (logs.length === 0 && !isLoadingLogs && url.filterTokens.length === 0) {
+  const contentFiltersApplied = !!url.selectedEntityOption || url.filterTokens.length > 0;
+
+  if (logs.length === 0 && !isLoadingLogs && !contentFiltersApplied) {
     return (
       <PageLayout width="wide" height="full">
         {pageTopArea}

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -2,7 +2,7 @@ import { EntityType } from '@mastra/core/observability';
 import {
   ButtonWithTooltip,
   DateTimeRangePicker,
-  NoDataPageLayout,
+  NoTracesInfo,
   PageHeader,
   PageLayout,
   PropertyFilterCreator,
@@ -169,14 +169,6 @@ export default function TracesPage() {
     url.handleSpanTabChange('scoring');
   }, [lightSpans, url]);
 
-  if (tracesError) {
-    return (
-      <NoDataPageLayout title="Traces" icon={<EyeIcon />}>
-        <TracesErrorContent error={tracesError} resource="traces" errorTitle="Failed to load traces" />
-      </NoDataPageLayout>
-    );
-  }
-
   const filtersApplied =
     !!url.selectedEntityOption ||
     !!url.selectedStatus ||
@@ -184,68 +176,96 @@ export default function TracesPage() {
     url.datePreset !== 'last-24h' ||
     !!url.selectedDateTo;
 
+  const pageTopArea = (
+    <PageLayout.TopArea>
+      <PageLayout.Row>
+        <PageLayout.Column>
+          <PageHeader>
+            <PageHeader.Title isLoading={isTracesLoading}>
+              <EyeIcon /> Traces
+            </PageHeader.Title>
+          </PageHeader>
+        </PageLayout.Column>
+        <PageLayout.Column className="flex justify-end items-center gap-2">
+          <DateTimeRangePicker
+            preset={url.datePreset}
+            onPresetChange={url.handleDatePresetChange}
+            dateFrom={url.selectedDateFrom}
+            dateTo={url.selectedDateTo}
+            onDateChange={url.handleDateChange}
+            disabled={isTracesLoading}
+            presets={['last-24h', 'last-3d', 'last-7d', 'last-14d', 'last-30d', 'custom']}
+          />
+          <PropertyFilterCreator
+            fields={filterFields}
+            tokens={url.filterTokens}
+            onTokensChange={url.handleFilterTokensChange}
+            disabled={isTracesLoading}
+            onStartTextFilter={setAutoFocusFilterFieldId}
+          />
+          <ButtonWithTooltip
+            disabled={isTracesLoading}
+            aria-pressed={groupByThread}
+            aria-label={groupByThread ? 'Ungroup traces' : 'Group traces by thread'}
+            tooltipContent={groupByThread ? 'Ungroup traces' : 'Group traces by thread'}
+            onClick={() => setGroupByThread(prev => !prev)}
+          >
+            {groupByThread ? <ListIcon /> : <ListTreeIcon />}
+          </ButtonWithTooltip>
+          <ButtonWithTooltip
+            as="a"
+            href="https://mastra.ai/en/docs/observability/tracing/overview"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Traces documentation"
+            tooltipContent="Go to Traces documentation"
+          >
+            <BookIcon />
+          </ButtonWithTooltip>
+        </PageLayout.Column>
+      </PageLayout.Row>
+
+      <TracesToolbar
+        isLoading={isTracesLoading}
+        filterFields={filterFields}
+        filterTokens={url.filterTokens}
+        onFilterTokensChange={url.handleFilterTokensChange}
+        onClear={handleClear}
+        onRemoveAll={url.handleRemoveAll}
+        onSave={persistence.handleSave}
+        onRemoveSaved={persistence.hasSavedFilters ? persistence.handleRemoveSaved : undefined}
+        autoFocusFilterFieldId={autoFocusFilterFieldId}
+      />
+    </PageLayout.TopArea>
+  );
+
+  if (tracesError) {
+    return (
+      <PageLayout width="wide" height="full">
+        {pageTopArea}
+        <PageLayout.MainArea isCentered>
+          <TracesErrorContent error={tracesError} resource="traces" errorTitle="Failed to load traces" />
+        </PageLayout.MainArea>
+      </PageLayout>
+    );
+  }
+
+  const contentFiltersApplied = !!url.selectedEntityOption || !!url.selectedStatus || url.filterTokens.length > 0;
+
+  if (traces.length === 0 && !isTracesLoading && !contentFiltersApplied) {
+    return (
+      <PageLayout width="wide" height="full">
+        {pageTopArea}
+        <PageLayout.MainArea isCentered>
+          <NoTracesInfo datePreset={url.datePreset} dateFrom={url.selectedDateFrom} dateTo={url.selectedDateTo} />
+        </PageLayout.MainArea>
+      </PageLayout>
+    );
+  }
+
   return (
     <PageLayout width="wide" height="full">
-      <PageLayout.TopArea>
-        <PageLayout.Row>
-          <PageLayout.Column>
-            <PageHeader>
-              <PageHeader.Title isLoading={isTracesLoading}>
-                <EyeIcon /> Traces
-              </PageHeader.Title>
-            </PageHeader>
-          </PageLayout.Column>
-          <PageLayout.Column className="flex justify-end items-center gap-2">
-            <DateTimeRangePicker
-              preset={url.datePreset}
-              onPresetChange={url.handleDatePresetChange}
-              dateFrom={url.selectedDateFrom}
-              dateTo={url.selectedDateTo}
-              onDateChange={url.handleDateChange}
-              disabled={isTracesLoading}
-              presets={['last-24h', 'last-3d', 'last-7d', 'last-14d', 'last-30d', 'custom']}
-            />
-            <PropertyFilterCreator
-              fields={filterFields}
-              tokens={url.filterTokens}
-              onTokensChange={url.handleFilterTokensChange}
-              disabled={isTracesLoading}
-              onStartTextFilter={setAutoFocusFilterFieldId}
-            />
-            <ButtonWithTooltip
-              disabled={isTracesLoading}
-              aria-pressed={groupByThread}
-              aria-label={groupByThread ? 'Ungroup traces' : 'Group traces by thread'}
-              tooltipContent={groupByThread ? 'Ungroup traces' : 'Group traces by thread'}
-              onClick={() => setGroupByThread(prev => !prev)}
-            >
-              {groupByThread ? <ListIcon /> : <ListTreeIcon />}
-            </ButtonWithTooltip>
-            <ButtonWithTooltip
-              as="a"
-              href="https://mastra.ai/en/docs/observability/tracing/overview"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Traces documentation"
-              tooltipContent="Go to Traces documentation"
-            >
-              <BookIcon />
-            </ButtonWithTooltip>
-          </PageLayout.Column>
-        </PageLayout.Row>
-
-        <TracesToolbar
-          isLoading={isTracesLoading}
-          filterFields={filterFields}
-          filterTokens={url.filterTokens}
-          onFilterTokensChange={url.handleFilterTokensChange}
-          onClear={handleClear}
-          onRemoveAll={url.handleRemoveAll}
-          onSave={persistence.handleSave}
-          onRemoveSaved={persistence.hasSavedFilters ? persistence.handleRemoveSaved : undefined}
-          autoFocusFilterFieldId={autoFocusFilterFieldId}
-        />
-      </PageLayout.TopArea>
+      {pageTopArea}
 
       <TracesLayout
         traceCollapsed={traceCollapsed}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the "no data" screens on the Traces and Logs pages look and behave the same way. It adds a new component that tells users there are no traces to show and updates the logic that decides when to display these empty states, so they appear consistently across both pages.

## Changes

### New Components
- **NoTracesInfo**: A new React component that displays when there are no traces. It shows a helpful message and a link to documentation. The message adapts based on the selected date range (e.g., "No traces for the last 24 hours" vs. "No traces yet").

### Traces Page Refactoring
- Refactored the page layout to use a `pageTopArea` variable that centralizes the header and toolbar, reducing duplication.
- Updated empty state condition to check for both token filters and content filters (`contentFiltersApplied` constant).
- Modified error handling to use full-width `PageLayout` instead of `NoDataPageLayout`, ensuring consistent styling with the header and toolbar.
- Improved code organization and filter application logic.

### Logs Page Updates
- Updated the empty logs condition to account for selected entity filters in addition to token filters, so `NoLogsInfo` only displays when no content filters are applied.

### Package Updates
- Added changeset entry for `@mastra/playground-ui` patch release to reflect the new `NoTracesInfo` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->