### PR TITLE
[Fix] Traces and Logs lists update

### DIFF
--- a/.changeset/eighty-guests-arrive.md
+++ b/.changeset/eighty-guests-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed two issues on the virtualized Logs and Traces lists: column widths no longer shift while scrolling, and Logs no longer break after loading multiple pages (`selectLogs` now deduplicates rows that offset-based pagination produces at page boundaries).

--- a/.changeset/eighty-guests-arrive.md
+++ b/.changeset/eighty-guests-arrive.md
@@ -2,4 +2,8 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed two issues on the virtualized Logs and Traces lists: column widths no longer shift while scrolling, and Logs no longer break after loading multiple pages (`selectLogs` now deduplicates rows that offset-based pagination produces at page boundaries).
+Fixed three issues on the Logs and Traces pages:
+
+- Column widths now stay stable while scrolling — they no longer jump as different rows scroll into view.
+- Scrolling far down the Logs list no longer scrambles rows (duplicates, gaps, or empty rows after additional pages load).
+- Changing a filter or the date range now scrolls the list back to the top, instead of leaving an empty band above the new data until you nudge the scroll. Logs and Traces now behave the same way on filter changes.

--- a/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
@@ -4,7 +4,8 @@ import type { LogRecord } from '../types';
 import { LogsDataList, LogsDataListSkeleton } from '@/ds/components/LogsDataList';
 import { cn } from '@/lib/utils';
 
-const COLUMNS = 'auto auto auto auto minmax(5rem,1fr) minmax(5rem,1fr)';
+// Fixed widths on non-flex columns prevent track shifts as the virtualizer swaps rows in/out.
+const COLUMNS = '6rem 9rem 5rem 10rem minmax(8rem,1fr) minmax(8rem,1fr)';
 
 const ROW_HEIGHT = 36;
 const OVERSCAN = 8;

--- a/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import type { LogRecord } from '../types';
 import { LogsDataList, LogsDataListSkeleton } from '@/ds/components/LogsDataList';
 import { cn } from '@/lib/utils';
@@ -48,6 +48,24 @@ export function LogsListView({
     estimateSize: () => ROW_HEIGHT,
     overscan: OVERSCAN,
   });
+
+  // Reset scroll to top whenever a fresh query resolves (filter / date range change).
+  // `isLoading` only flips on initial fetches — `fetchNextPage` keeps it `false`, so this
+  // effect doesn't fire during pagination.
+  //
+  // Why the manual scroll event: when the skeleton-vs-list branch swaps in the new scroll
+  // container, it mounts at `scrollTop = 0`. The virtualizer rebinds its listener but
+  // doesn't re-read `scrollTop`, so it keeps the stale `scrollOffset` from the previous
+  // element. `scrollToOffset(0)` no-ops because the new element is already at 0 (no scroll
+  // event fires). Dispatching a synthetic `scroll` forces the virtualizer's handler to
+  // read the fresh `scrollTop` and recompute `virtualItems` with `paddingTop = 0`.
+  const wasLoadingRef = useRef(isLoading);
+  useEffect(() => {
+    if (wasLoadingRef.current && !isLoading) {
+      scrollRef.current?.dispatchEvent(new Event('scroll'));
+    }
+    wasLoadingRef.current = isLoading;
+  }, [isLoading]);
 
   if (isLoading) {
     return <LogsDataListSkeleton columns={COLUMNS} />;

--- a/packages/playground-ui/src/domains/logs/hooks/use-logs.ts
+++ b/packages/playground-ui/src/domains/logs/hooks/use-logs.ts
@@ -17,8 +17,22 @@ function getNextPageParam(lastPage: ListLogsResponse | undefined, _allPages: unk
   return undefined;
 }
 
+/** Deduplicates logs across loaded pages. Offset-based pagination duplicates rows at the page
+ *  boundary whenever new logs are inserted between sequential `fetchNextPage` calls — without
+ *  this filter the duplicates produce duplicate React keys and chaotic virtualizer offsets. */
 function selectLogs(data: { pages: ListLogsResponse[] }) {
-  return data.pages.flatMap(page => page.logs ?? []);
+  const seen = new Set<string>();
+  const result = [];
+  for (const page of data.pages) {
+    for (const log of page.logs ?? []) {
+      const ts = log.timestamp instanceof Date ? log.timestamp.toISOString() : log.timestamp;
+      const key = log.logId ?? `${ts}|${log.message ?? ''}|${log.data ? JSON.stringify(log.data) : ''}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(log);
+    }
+  }
+  return result;
 }
 
 export const useLogs = ({ filters }: LogsFilters = {}) => {

--- a/packages/playground-ui/src/domains/logs/hooks/use-logs.ts
+++ b/packages/playground-ui/src/domains/logs/hooks/use-logs.ts
@@ -51,7 +51,7 @@ export const useLogs = ({ filters }: LogsFilters = {}) => {
     getNextPageParam,
     select: selectLogs,
     retry: false,
-    refetchInterval: 3000,
+    refetchInterval: 10000,
   });
 
   const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;

--- a/packages/playground-ui/src/domains/logs/hooks/use-logs.ts
+++ b/packages/playground-ui/src/domains/logs/hooks/use-logs.ts
@@ -19,14 +19,15 @@ function getNextPageParam(lastPage: ListLogsResponse | undefined, _allPages: unk
 
 /** Deduplicates logs across loaded pages. Offset-based pagination duplicates rows at the page
  *  boundary whenever new logs are inserted between sequential `fetchNextPage` calls — without
- *  this filter the duplicates produce duplicate React keys and chaotic virtualizer offsets. */
+ *  this filter the duplicates produce duplicate React keys and chaotic virtualizer offsets.
+ *  Falls back to the full serialized record when `logId` is absent so logs that happen to
+ *  share `(timestamp, message, data)` but differ in other fields aren't collapsed. */
 function selectLogs(data: { pages: ListLogsResponse[] }) {
   const seen = new Set<string>();
   const result = [];
   for (const page of data.pages) {
     for (const log of page.logs ?? []) {
-      const ts = log.timestamp instanceof Date ? log.timestamp.toISOString() : log.timestamp;
-      const key = log.logId ?? `${ts}|${log.message ?? ''}|${log.data ? JSON.stringify(log.data) : ''}`;
+      const key = log.logId ?? JSON.stringify(log);
       if (seen.has(key)) continue;
       seen.add(key);
       result.push(log);

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -28,7 +28,8 @@ export type TracesListViewTrace = {
   threadId?: string | null;
 };
 
-const COLUMNS = 'auto auto auto auto minmax(5rem,1fr) auto auto';
+// Fixed widths on non-flex columns prevent track shifts as the virtualizer swaps rows in/out.
+const COLUMNS = '7rem 6rem 9rem 14rem minmax(8rem,1fr) 14rem 6rem';
 
 const ROW_HEIGHT = 36;
 const OVERSCAN = 8;

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { groupTracesByThread } from '../utils/group-traces-by-thread';
 import { getInputPreview } from '../utils/span-utils';
@@ -120,6 +120,24 @@ export function TracesListView({
     estimateSize: () => ROW_HEIGHT,
     overscan: OVERSCAN,
   });
+
+  // Reset scroll to top whenever a fresh query resolves (filter / date range change).
+  // `isLoading` only flips on initial fetches — `fetchNextPage` keeps it `false`, so this
+  // effect doesn't fire during pagination.
+  //
+  // Why the manual scroll event: when the skeleton-vs-list branch swaps in the new scroll
+  // container, it mounts at `scrollTop = 0`. The virtualizer rebinds its listener but
+  // doesn't re-read `scrollTop`, so it keeps the stale `scrollOffset` from the previous
+  // element. `scrollToOffset(0)` no-ops because the new element is already at 0 (no scroll
+  // event fires). Dispatching a synthetic `scroll` forces the virtualizer's handler to
+  // read the fresh `scrollTop` and recompute `virtualItems` with `paddingTop = 0`.
+  const wasLoadingRef = useRef(isLoading);
+  useEffect(() => {
+    if (wasLoadingRef.current && !isLoading) {
+      scrollRef.current?.dispatchEvent(new Event('scroll'));
+    }
+    wasLoadingRef.current = isLoading;
+  }, [isLoading]);
 
   if (isLoading) {
     return <DataListSkeleton columns={COLUMNS} />;

--- a/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
@@ -1,6 +1,6 @@
 import type { ListBranchesArgs, ListBranchesResponse, ListTracesArgs, ListTracesResponse } from '@mastra/core/storage';
 import { useMastraClient } from '@mastra/react';
-import { useInfiniteQuery, keepPreviousData } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import type { TraceListMode } from '../trace-filters';
 import { useInView } from '@/hooks/use-in-view';
@@ -98,7 +98,6 @@ export const useTraces = ({ filters, listMode = 'traces' }: TracesFilters) => {
     initialPageParam: 0,
     getNextPageParam: getTracesNextPageParam,
     select: selectUniqueTraces,
-    placeholderData: keepPreviousData,
     retry: false,
     // Disable polling on 403 to prevent flickering
     refetchInterval: query => (is403ForbiddenError(query.state.error) ? false : 10000),


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

- use defined value as list column widths, instead of `auto` to prevent column changes when scrolling
- fix next pages loading in virtualized Logs list

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

When you scroll the Logs or Traces lists the columns no longer jump around and the lists stop showing duplicate or scrambled rows when more data loads; changing filters/date range also reliably resets the list to the top.

## Changes

### Column width & virtualization stability
- LogsListView and TracesListView: replace `auto` column templates with fixed/minmax column widths to prevent grid "track shifts" while TanStack Virtual swaps rows.
- Both components add an effect that detects when `isLoading` transitions from true → false and dispatches a synthetic `scroll` event on the list's scroll container. This forces the virtualizer to reread `scrollTop` after the skeleton ↔ list branch swap so paddings/offsets are recomputed correctly.
- Applies to both the real lists and their skeleton loaders.

### Logs pagination / duplicate prevention
- use-logs.ts: `select` for the infinite query now deduplicates logs across loaded pages by tracking seen keys (prefers `log.logId`, falls back to `JSON.stringify(log)`), preventing duplicate React keys and virtualizer offset issues at page boundaries.
- Increased `refetchInterval` from 3000ms to 10000ms.

### Traces pagination / dedup + minor query import change
- use-traces.tsx: `select` (selectUniqueTraces) deduplicates trace/branch rows by `traceId:spanId` across pages and merges `threadTitles` from pages for grouping.
- Adjusted react-query usage/imports (removed keepPreviousData usage and explicitly imports `useInfiniteQuery`).

### UX tweak: reset scroll on filter/date changes
- Both Logs and Traces lists reset their scroll/paddings to the top when a fresh query resolves (filter or date-range change), avoiding an empty top band until the user nudges the scroll.

### Metadata
- Patch release to `@mastra/playground-ui`.
- No public API/exports or component signatures changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->