### PR TITLE
fix(fastify): clean up streams on disconnect

### DIFF
--- a/.changeset/new-squids-matter.md
+++ b/.changeset/new-squids-matter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/fastify': patch
+---
+
+Fixed Fastify stream cleanup and route abort signals when clients disconnect before streamed responses finish.

--- a/server-adapters/fastify/src/__tests__/stream-disconnect.test.ts
+++ b/server-adapters/fastify/src/__tests__/stream-disconnect.test.ts
@@ -1,0 +1,414 @@
+import { EventEmitter } from 'node:events';
+import type { ServerRoute } from '@mastra/server/server-adapter';
+import Fastify from 'fastify';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { describe, expect, it, vi } from 'vitest';
+import { MastraServer } from '../index';
+
+class MockRawReply extends EventEmitter {
+  writes = 0;
+  ended = false;
+  destroyed = false;
+  writableEnded = false;
+
+  writeHead(): void {}
+
+  write(): boolean {
+    this.writes += 1;
+    return true;
+  }
+
+  end(): void {
+    this.ended = true;
+    this.writableEnded = true;
+  }
+}
+
+class MockRawRequest extends EventEmitter {
+  complete = false;
+  aborted = true;
+  readableAborted = true;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(assertion: () => boolean, timeout = 500): Promise<void> {
+  const start = Date.now();
+  while (!assertion()) {
+    if (Date.now() - start > timeout) {
+      throw new Error('Timed out waiting for assertion');
+    }
+    await sleep(1);
+  }
+}
+
+describe('stream disconnect handling', () => {
+  function createAdapter(app: unknown = {}) {
+    return new MastraServer({
+      app: app as any,
+      mastra: {
+        getLogger: () => ({
+          error: vi.fn(),
+        }),
+        getServer: () => undefined,
+        setMastraServer: vi.fn(),
+      } as any,
+    });
+  }
+
+  async function createRequestWithAbortSignal(requestRaw: MockRawRequest, replyRaw: MockRawReply) {
+    const adapter = createAdapter();
+    const request = {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: {},
+      raw: requestRaw,
+    } as unknown as FastifyRequest;
+    const reply = {
+      raw: replyRaw,
+    } as unknown as FastifyReply;
+
+    await adapter.createContextMiddleware()(request, reply, vi.fn());
+    return request;
+  }
+
+  it('aborts the route abortSignal when a completed request reports an aborted close', async () => {
+    const requestRaw = new MockRawRequest();
+    requestRaw.complete = true;
+    requestRaw.aborted = true;
+    requestRaw.readableAborted = true;
+    const replyRaw = new MockRawReply();
+    const request = await createRequestWithAbortSignal(requestRaw, replyRaw);
+
+    requestRaw.emit('close');
+
+    expect(request.abortSignal.aborted).toBe(true);
+  });
+
+  it('does not abort the route abortSignal when a completed request body closes normally', async () => {
+    const requestRaw = new MockRawRequest();
+    requestRaw.complete = true;
+    requestRaw.aborted = false;
+    requestRaw.readableAborted = false;
+    const replyRaw = new MockRawReply();
+    const request = await createRequestWithAbortSignal(requestRaw, replyRaw);
+
+    requestRaw.emit('close');
+
+    expect(request.abortSignal.aborted).toBe(false);
+  });
+
+  it('aborts the route abortSignal when the response closes before finishing', async () => {
+    const requestRaw = new MockRawRequest();
+    requestRaw.complete = true;
+    requestRaw.aborted = false;
+    requestRaw.readableAborted = false;
+    const replyRaw = new MockRawReply();
+    const request = await createRequestWithAbortSignal(requestRaw, replyRaw);
+
+    replyRaw.emit('close');
+
+    expect(request.abortSignal.aborted).toBe(true);
+  });
+
+  it('cancels a hijacked stream when the request closes without a response close event', async () => {
+    const adapter = createAdapter();
+
+    const rawReply = new MockRawReply();
+    const requestRaw = new MockRawRequest();
+    const reply = {
+      getHeaders: () => ({}),
+      hijack: vi.fn(),
+      raw: rawReply,
+    } as unknown as FastifyReply;
+    const request = {
+      raw: requestRaw,
+    } as unknown as FastifyRequest;
+    const route = {
+      method: 'GET',
+      path: '/stream',
+      responseType: 'stream',
+      streamFormat: 'sse',
+      handler: vi.fn(),
+    } as unknown as ServerRoute;
+
+    let resolveCanceled!: (reason: unknown) => void;
+    const canceled = new Promise<unknown>(resolve => {
+      resolveCanceled = resolve;
+    });
+    const stream = new ReadableStream({
+      async pull(controller) {
+        controller.enqueue({ type: 'chunk' });
+        await sleep(5);
+      },
+      cancel(reason) {
+        resolveCanceled(reason);
+      },
+    });
+
+    const streamPromise = adapter.stream(route, reply, { fullStream: stream }, request);
+
+    await waitFor(() => rawReply.writes > 0);
+
+    requestRaw.emit('close');
+
+    const canceledByRequestClose = await Promise.race([canceled.then(() => true), sleep(100).then(() => false)]);
+    if (!canceledByRequestClose) {
+      rawReply.emit('close');
+    }
+
+    await streamPromise;
+
+    expect(canceledByRequestClose).toBe(true);
+    await expect(canceled).resolves.toBe('request aborted');
+    expect(reply.hijack).toHaveBeenCalledOnce();
+    expect(rawReply.ended).toBe(true);
+  });
+
+  it('does not cancel a hijacked stream when a completed request body closes normally', async () => {
+    const adapter = createAdapter();
+
+    const rawReply = new MockRawReply();
+    const requestRaw = new MockRawRequest();
+    requestRaw.complete = true;
+    requestRaw.aborted = false;
+    requestRaw.readableAborted = false;
+    const reply = {
+      getHeaders: () => ({}),
+      hijack: vi.fn(),
+      raw: rawReply,
+    } as unknown as FastifyReply;
+    const request = {
+      raw: requestRaw,
+    } as unknown as FastifyRequest;
+    const route = {
+      method: 'POST',
+      path: '/stream',
+      responseType: 'stream',
+      streamFormat: 'sse',
+      handler: vi.fn(),
+    } as unknown as ServerRoute;
+
+    const cancel = vi.fn();
+    let pulls = 0;
+    const stream = new ReadableStream({
+      async pull(controller) {
+        pulls += 1;
+        controller.enqueue({ type: 'chunk', pulls });
+        await sleep(5);
+        if (pulls >= 3) {
+          controller.close();
+        }
+      },
+      cancel,
+    });
+
+    const streamPromise = adapter.stream(route, reply, { fullStream: stream }, request);
+
+    await waitFor(() => rawReply.writes > 0);
+
+    requestRaw.emit('close');
+    await streamPromise;
+
+    expect(cancel).not.toHaveBeenCalled();
+    expect(rawReply.writes).toBe(3);
+    expect(rawReply.ended).toBe(true);
+  });
+
+  it('keeps a real Fastify POST stream open when the request body closes normally', async () => {
+    const app = Fastify();
+    const adapter = createAdapter(app);
+    const cancel = vi.fn();
+    const route = {
+      method: 'POST',
+      path: '/stream',
+      responseType: 'stream',
+      streamFormat: 'sse',
+      handler: vi.fn(),
+    } as unknown as ServerRoute;
+
+    app.post('/stream', async (request, reply) => {
+      let pulls = 0;
+      const stream = new ReadableStream({
+        async pull(controller) {
+          pulls += 1;
+          controller.enqueue({ type: 'chunk', pulls });
+          await sleep(5);
+          if (pulls >= 3) {
+            controller.close();
+          }
+        },
+        cancel,
+      });
+
+      await adapter.stream(route, reply, { fullStream: stream }, request);
+    });
+
+    try {
+      const address = await app.listen({ port: 0 });
+      const response = await fetch(`${address}/stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hello: 'world' }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.text();
+
+      expect(cancel).not.toHaveBeenCalled();
+      expect(body).toContain('"pulls":1');
+      expect(body).toContain('"pulls":2');
+      expect(body).toContain('"pulls":3');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('cancels a real Fastify stream when the client cancels the response body', async () => {
+    const app = Fastify();
+    const adapter = createAdapter(app);
+    const route = {
+      method: 'GET',
+      path: '/stream',
+      responseType: 'stream',
+      streamFormat: 'sse',
+      handler: vi.fn(),
+    } as unknown as ServerRoute;
+    let resolveCanceled!: (reason: unknown) => void;
+    const canceled = new Promise<unknown>(resolve => {
+      resolveCanceled = resolve;
+    });
+
+    app.get('/stream', async (request, reply) => {
+      const stream = new ReadableStream({
+        async pull(controller) {
+          controller.enqueue({ type: 'chunk' });
+          await sleep(5);
+        },
+        cancel(reason) {
+          resolveCanceled(reason);
+        },
+      });
+
+      await adapter.stream(route, reply, { fullStream: stream }, request);
+    });
+
+    try {
+      const address = await app.listen({ port: 0 });
+      const response = await fetch(`${address}/stream`);
+      const reader = response.body?.getReader();
+      expect(reader).toBeDefined();
+
+      await reader!.read();
+      await reader!.cancel();
+
+      await expect(Promise.race([canceled, sleep(500).then(() => 'timed out')])).resolves.toBe('request aborted');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('cancels a datastream response when the request closes without a response close event', async () => {
+    const adapter = createAdapter();
+
+    const rawReply = new MockRawReply();
+    const requestRaw = new MockRawRequest();
+    const reply = {
+      header: vi.fn(),
+      status: vi.fn(),
+      raw: rawReply,
+    } as unknown as FastifyReply;
+    const request = {
+      raw: requestRaw,
+    } as unknown as FastifyRequest;
+    const route = {
+      method: 'GET',
+      path: '/datastream',
+      responseType: 'datastream-response',
+      handler: vi.fn(),
+    } as unknown as ServerRoute;
+
+    let resolveCanceled!: (reason: unknown) => void;
+    const canceled = new Promise<unknown>(resolve => {
+      resolveCanceled = resolve;
+    });
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        controller.enqueue(new TextEncoder().encode('data\n'));
+        await sleep(5);
+      },
+      cancel(reason) {
+        resolveCanceled(reason);
+      },
+    });
+
+    const streamPromise = adapter.sendResponse(route, reply, new Response(stream), request);
+
+    await waitFor(() => rawReply.writes > 0);
+
+    requestRaw.emit('close');
+
+    const canceledByRequestClose = await Promise.race([canceled.then(() => true), sleep(100).then(() => false)]);
+    if (!canceledByRequestClose) {
+      rawReply.emit('error', new Error('cleanup'));
+    }
+
+    await streamPromise;
+
+    expect(canceledByRequestClose).toBe(true);
+    await expect(canceled).resolves.toBe('request aborted');
+    expect(reply.status).toHaveBeenCalledWith(200);
+    expect(rawReply.ended).toBe(true);
+  });
+
+  it('does not cancel a datastream response when a completed request body closes normally', async () => {
+    const adapter = createAdapter();
+
+    const rawReply = new MockRawReply();
+    const requestRaw = new MockRawRequest();
+    requestRaw.complete = true;
+    requestRaw.aborted = false;
+    requestRaw.readableAborted = false;
+    const reply = {
+      header: vi.fn(),
+      status: vi.fn(),
+      raw: rawReply,
+    } as unknown as FastifyReply;
+    const request = {
+      raw: requestRaw,
+    } as unknown as FastifyRequest;
+    const route = {
+      method: 'POST',
+      path: '/datastream',
+      responseType: 'datastream-response',
+      handler: vi.fn(),
+    } as unknown as ServerRoute;
+
+    const cancel = vi.fn();
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        pulls += 1;
+        controller.enqueue(new TextEncoder().encode(`data-${pulls}\n`));
+        await sleep(5);
+        if (pulls >= 3) {
+          controller.close();
+        }
+      },
+      cancel,
+    });
+
+    const streamPromise = adapter.sendResponse(route, reply, new Response(stream), request);
+
+    await waitFor(() => rawReply.writes > 0);
+
+    requestRaw.emit('close');
+    await streamPromise;
+
+    expect(cancel).not.toHaveBeenCalled();
+    expect(rawReply.writes).toBe(3);
+    expect(rawReply.ended).toBe(true);
+  });
+});

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -57,6 +57,13 @@ function toWebRequest(request: FastifyRequest): globalThis.Request {
   });
 }
 
+function isRequestAborted(rawRequest: FastifyRequest['raw']): boolean {
+  // Fastify can emit request close after a POST body is fully consumed while
+  // the response stream is still active, so only treat it as disconnect when
+  // the request itself reports an abort or never completed.
+  return rawRequest.aborted || rawRequest.readableAborted || !rawRequest.complete;
+}
+
 // Extend Fastify types to include Mastra context
 declare module 'fastify' {
   interface FastifyRequest {
@@ -71,7 +78,7 @@ declare module 'fastify' {
 
 export class MastraServer extends MastraServerBase<FastifyInstance, FastifyRequest, FastifyReply> {
   createContextMiddleware(): preHandlerHookHandler {
-    return async (request: FastifyRequest, _reply: FastifyReply) => {
+    return async (request: FastifyRequest, reply: FastifyReply) => {
       // Parse request context from request body and add to context
       let bodyRequestContext: Record<string, any> | undefined;
       let paramsRequestContext: Record<string, any> | undefined;
@@ -125,8 +132,14 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
       // Create abort controller for request cancellation
       const controller = new AbortController();
       request.raw.on('close', () => {
-        // Only abort if the response wasn't successfully completed
-        if (!request.raw.complete) {
+        if (isRequestAborted(request.raw)) {
+          controller.abort();
+        }
+      });
+      reply.raw.on('close', () => {
+        // Response close fires for normal completion too; only abort if the
+        // response did not finish successfully.
+        if (!reply.raw.writableEnded) {
           controller.abort();
         }
       });
@@ -134,7 +147,12 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
     };
   }
 
-  async stream(route: ServerRoute, reply: FastifyReply, result: { fullStream: ReadableStream }): Promise<void> {
+  async stream(
+    route: ServerRoute,
+    reply: FastifyReply,
+    result: { fullStream: ReadableStream },
+    request?: FastifyRequest,
+  ): Promise<void> {
     // Capture headers set by plugins (e.g., @fastify/cors) BEFORE hijacking
     // reply.hijack() bypasses Fastify's response handling, so we need to preserve
     // any headers that were set by hooks/plugins and manually include them
@@ -178,9 +196,20 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
     const readableStream = result instanceof ReadableStream ? result : result.fullStream;
     const reader = readableStream.getReader();
 
-    reply.raw.on('close', () => {
-      void reader.cancel('request aborted');
-    });
+    let readerCanceled = false;
+    const cancelReader = (reason: string) => {
+      if (readerCanceled) return;
+      readerCanceled = true;
+      void reader.cancel(reason);
+    };
+    const cancelReaderOnResponseClose = () => cancelReader('request aborted');
+    const cancelReaderOnRequestClose = () => {
+      if (request && isRequestAborted(request.raw)) {
+        cancelReader('request aborted');
+      }
+    };
+    reply.raw.on('close', cancelReaderOnResponseClose);
+    request?.raw.on('close', cancelReaderOnRequestClose);
 
     try {
       while (true) {
@@ -203,7 +232,11 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
       });
     } finally {
-      reply.raw.end();
+      reply.raw.off('close', cancelReaderOnResponseClose);
+      request?.raw.off('close', cancelReaderOnRequestClose);
+      if (!reply.raw.writableEnded && !reply.raw.destroyed) {
+        reply.raw.end();
+      }
     }
   }
 
@@ -326,7 +359,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
     if (route.responseType === 'json') {
       await reply.send(result);
     } else if (route.responseType === 'stream') {
-      await this.stream(route, reply, result as { fullStream: ReadableStream });
+      await this.stream(route, reply, result as { fullStream: ReadableStream }, request);
     } else if (route.responseType === 'datastream-response') {
       // Handle AI SDK Response objects - pipe Response.body to Fastify response
       const fetchResponse = result as globalThis.Response;
@@ -334,14 +367,30 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
       reply.status(fetchResponse.status);
       if (fetchResponse.body) {
         const reader = fetchResponse.body.getReader();
+        let readerCanceled = false;
+
+        const cancelReader = (reason: string) => {
+          if (readerCanceled) return;
+          readerCanceled = true;
+          void reader.cancel(reason);
+        };
+
+        const cancelReaderOnResponseClose = () => cancelReader('request aborted');
+        const cancelReaderOnRequestClose = () => {
+          if (request && isRequestAborted(request.raw)) {
+            cancelReader('request aborted');
+          }
+        };
 
         const onResError = (err: unknown) => {
           this.mastra.getLogger()?.error('Error writing datastream response', {
             error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
           });
-          void reader.cancel('response write error');
+          cancelReader('response write error');
         };
         reply.raw.once('error', onResError);
+        reply.raw.on('close', cancelReaderOnResponseClose);
+        request?.raw.on('close', cancelReaderOnRequestClose);
 
         try {
           while (true) {
@@ -355,7 +404,11 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
           });
         } finally {
           reply.raw.off('error', onResError);
-          reply.raw.end();
+          reply.raw.off('close', cancelReaderOnResponseClose);
+          request?.raw.off('close', cancelReaderOnRequestClose);
+          if (!reply.raw.writableEnded && !reply.raw.destroyed) {
+            reply.raw.end();
+          }
         }
       } else {
         reply.raw.end();


### PR DESCRIPTION
This fixes Fastify stream cleanup when a client disconnects before a built-in streamed response finishes.

Before this change, the adapter only canceled hijacked streams from `reply.raw.close`. Bun can miss that response close event, so long-running streams could keep producing chunks after the client was gone. The route `abortSignal` also only watched the request side, which meant upstream work could keep running when the response closed early.

After this change, built-in `stream` and `datastream-response` readers cancel from response close, and from request close when the request reports an aborted or incomplete close. Completed POST body close is explicitly guarded so normal POST streams are not canceled just because Fastify finished reading the body.

I also added focused coverage for aborted request closes, response closes, normal completed POST body closes, real Fastify client cancellation, and datastream cleanup.

Follow-up issue for the remaining Bun/Fastify raw streaming gaps: #16307.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR fixes a bug where Fastify streams keep sending data to clients even after they disconnect. When a client closes the connection, the server now properly detects this and stops sending data, preventing wasted resources. It also makes sure that normal, completed data transfers aren't mistaken for unexpected disconnects.

---

## Changes

### Changeset
- Added a new Changeset entry for `@mastra/fastify` with a `patch` version bump documenting the fix for stream cleanup and route abort signal handling on client disconnect.

### Test Coverage
- Added comprehensive test suite (`stream-disconnect.test.ts`) with 8 test cases covering:
  - Route-level `abortSignal` cancellation when a completed request emits an aborted close
  - Prevention of abort when a completed request body closes normally
  - Route abort behavior when response closes before stream completion
  - Hijacked `ReadableStream` cancellation and cleanup when request closes
  - Prevention of hijacked stream cancellation on normal request close
  - Real Fastify POST stream behavior (ensuring normal completion isn't treated as cancellation)
  - Client cancellation of response body triggering stream cancellation
  - Analogous behavior for `datastream-response` reader cancellation with status and raw reply handling

### Core Logic Updates
The Fastify adapter now:
- Introduces an `isRequestAborted` helper to explicitly detect real disconnect scenarios, distinguishing them from normal POST body completion
- Aborts the per-request `AbortController` only for genuine disconnect cases
- Implements centralized reader-cancellation logic where readers are canceled on both response close and request close (conditionally)
- Removes event listeners and ends the raw response properly for hijacked streaming responses instead of relying solely on `reply.raw.close` events
- Applies the same mirrored cancellation handling to `datastream-response` with cleanup for listeners and conditional response termination
- Explicitly guards completed POST body close events so normal POST streams are not canceled when Fastify finishes reading the body

<!-- end of auto-generated comment: release notes by coderabbit.ai -->