### PR TITLE
fix(playground): clear mcpClients in e2e reset handler

### DIFF
--- a/packages/playground/e2e/kitchen-sink/src/mastra/index.ts
+++ b/packages/playground/e2e/kitchen-sink/src/mastra/index.ts
@@ -74,6 +74,11 @@ export const mastra = new Mastra({
             clearTasks.push(datasetsStore.dangerouslyClearAll());
           }
 
+          const mcpClientsStore = await storage.getStore('mcpClients');
+          if (mcpClientsStore) {
+            clearTasks.push(mcpClientsStore.dangerouslyClearAll());
+          }
+
           // Reset schedule pause state + drop trigger history between tests.
           // Schedules are declarative config registered at boot, so we
           // snapshot the current rows, clear, then re-create them with a


### PR DESCRIPTION
The `/e2e/reset-storage` handler in the kitchen-sink fixture was clearing 8 stores but missed `mcpClients`. When a test using `Test MCP Client` had to retry, the second attempt hit a 409 from `POST /api/stored/mcp-clients`, the create form silently failed via a toast, and the redirect-based assertion in `e2e/tests/cms/agents/create/page.spec.ts` timed out.

Now the reset clears `mcpClients` too, matching how every other store in that handler is treated.

```ts
const mcpClientsStore = await storage.getStore('mcpClients');
if (mcpClientsStore) {
  clearTasks.push(mcpClientsStore.dangerouslyClearAll());
}
```

Verified the previously flaky `persists selected MCP client tools` passes 5/5 with `--repeat-each=5` and the full `create/page.spec.ts` passes 48/48 with `--repeat-each=2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When tests in the playground tool create MCP clients (special connectors to external services), they need to clean up after themselves so the next test run starts fresh. The code was forgetting to clean up the MCP clients, causing tests to fail when they tried again because the old ones were still there. This fix adds the missing cleanup step.

## Summary

This PR fixes flaky e2e tests in the playground by ensuring the `/e2e/reset-storage` handler properly clears the `mcpClients` store during test cleanup.

### Problem

The reset-storage handler was clearing eight stores (workflows, memory, scores, observability, agents, scorerDefinitions, and datasets) but omitting `mcpClients`. When tests retried, subsequent attempts to create an MCP client with the same name resulted in a 409 Conflict error from `POST /api/stored/mcp-clients`, causing the test to fail silently and assertions to time out.

### Solution

Added logic to fetch the `mcpClients` store and call `dangerouslyClearAll()` on it if present, ensuring it's included in the aggregated cleanup tasks.

### Verification

- The previously flaky test "persists selected MCP client tools" passed 5/5 with `--repeat-each=5`
- Full `create/page.spec.ts` test suite passed 48/48 with `--repeat-each=2`

### Changes

- **packages/playground/e2e/kitchen-sink/src/mastra/index.ts**: Updated the `/e2e/reset-storage` POST handler to clear the `mcpClients` store (+5 lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->