### PR TITLE
feat(cli): pre-deploy validation for studio and server deploy

### DIFF
--- a/.changeset/deploy-preflight-validation.md
+++ b/.changeset/deploy-preflight-validation.md
@@ -1,0 +1,16 @@
+---
+'mastra': patch
+---
+
+Add pre-deploy validation (preflight) to `mastra studio deploy` and `mastra server deploy` that inspects the built bundle before upload and surfaces likely deployment failures locally.
+
+**What it checks**
+
+- **Missing env vars** (warning) — `process.env.FOO` references in the bundle that aren't satisfied by the resolved `.env`/`.env.local` (or `--env-file`). Common platform/runtime/tooling vars (`PORT`, `NODE_ENV`, `MASTRA_*`, `OTEL_*`, `DEBUG`, etc.) are allowlisted.
+- **Local storage paths** (error) — SQLite/file URLs (`file:./mastra.db`, `sqlite://...`) and `localhost`/`127.0.0.1` connection strings that won't survive on a remote container.
+
+**How it runs**
+
+- Runs after the local build (or after `--skip-build` when `.mastra/output/index.mjs` already exists), before zipping/uploading.
+- Errors always block the deploy. Warnings prompt for confirmation in interactive mode and pass through silently in `--yes` / headless mode.
+- Opt out entirely with `--skip-preflight` or `MASTRA_SKIP_PREFLIGHT=1`.

--- a/.changeset/deploy-preflight-validation.md
+++ b/.changeset/deploy-preflight-validation.md
@@ -12,5 +12,5 @@ Add pre-deploy validation (preflight) to `mastra studio deploy` and `mastra serv
 **How it runs**
 
 - Runs after the local build (or after `--skip-build` when `.mastra/output/index.mjs` already exists), before zipping/uploading.
-- Errors always block the deploy. Warnings prompt for confirmation in interactive mode and pass through silently in `--yes` / headless mode.
+- Errors always block the deploy and exit non-zero (so CI surfaces them as a real failure). Warnings prompt for confirmation in interactive mode and pass through silently in `--yes` / headless mode; declining the prompt cancels with exit code 0.
 - Opt out entirely with `--skip-preflight` or `MASTRA_SKIP_PREFLIGHT=1`.

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -1,0 +1,184 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+import { preflightBuildOutput, printPreflightIssues } from './deploy-preflight.js';
+import type { PreflightIssue } from './deploy-preflight.js';
+
+vi.mock('@clack/prompts', () => ({
+  log: { warn: vi.fn(), error: vi.fn() },
+  confirm: vi.fn(),
+  isCancel: (v: unknown) => v === Symbol.for('clack.cancel'),
+}));
+
+describe('preflightBuildOutput', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mastra-preflight-test-'));
+    mkdirSync(join(tmpDir, '.mastra', 'output'), { recursive: true });
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ name: 'test', dependencies: {} }));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeBundle(content: string) {
+    writeFileSync(join(tmpDir, '.mastra', 'output', 'index.mjs'), content);
+  }
+
+  function writePackageJson(pkg: Record<string, unknown>) {
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify(pkg));
+  }
+
+  it('returns no issues when build output is missing', async () => {
+    rmSync(join(tmpDir, '.mastra'), { recursive: true, force: true });
+    const issues = await preflightBuildOutput(tmpDir, {});
+    expect(issues).toEqual([]);
+  });
+
+  it('returns no issues for a clean bundle', async () => {
+    writeBundle(`import { Mastra } from 'mastra';\nconst port = process.env.PORT;\nexport default new Mastra({});`);
+    writePackageJson({ name: 'test', dependencies: { mastra: '*' } });
+
+    const issues = await preflightBuildOutput(tmpDir, {});
+    expect(issues).toEqual([]);
+  });
+
+  describe('MISSING_ENV_VAR', () => {
+    it('flags env vars referenced in code but missing from env file', async () => {
+      writeBundle(`const k = process.env.ANTHROPIC_API_KEY;\nconst u = process.env.DATABASE_URL;`);
+
+      const issues = await preflightBuildOutput(tmpDir, {});
+      const missing = issues.find(i => i.code === 'MISSING_ENV_VAR');
+      expect(missing).toBeDefined();
+      expect(missing?.severity).toBe('warning');
+      expect(missing?.message).toContain('ANTHROPIC_API_KEY');
+      expect(missing?.message).toContain('DATABASE_URL');
+    });
+
+    it('does not flag env vars present in the env file', async () => {
+      writeBundle(`const k = process.env.ANTHROPIC_API_KEY;`);
+      const issues = await preflightBuildOutput(tmpDir, { ANTHROPIC_API_KEY: 'sk-x' });
+      expect(issues.find(i => i.code === 'MISSING_ENV_VAR')).toBeUndefined();
+    });
+
+    it('does not flag platform-set env vars (PORT, NODE_ENV, MASTRA_*)', async () => {
+      writeBundle(`
+        const port = process.env.PORT;
+        const env = process.env.NODE_ENV;
+        const mst = process.env.MASTRA_API_TOKEN;
+        const otel = process.env.OTEL_SERVICE_NAME;
+      `);
+      const issues = await preflightBuildOutput(tmpDir, {});
+      expect(issues.find(i => i.code === 'MISSING_ENV_VAR')).toBeUndefined();
+    });
+
+    it('does not flag framework-internal sentinel env vars from bundled deps', async () => {
+      writeBundle(`
+        const dbg = process.env.DEBUG;
+        const fd = process.env.DEBUG_FD;
+        const exp = process.env.EXPERIMENTAL_FEATURES;
+        const om = process.env.OM_DEBUG;
+        const omRepro = process.env.OM_REPRO_CAPTURE;
+        const skills = process.env.SKILLS_BASE_DIR;
+        const noColor = process.env.NO_COLOR;
+        const force = process.env.FORCE_COLOR;
+      `);
+      const issues = await preflightBuildOutput(tmpDir, {});
+      expect(issues.find(i => i.code === 'MISSING_ENV_VAR')).toBeUndefined();
+    });
+
+    it('detects bracket-notation references', async () => {
+      writeBundle(`const k = process.env['STRIPE_KEY'];`);
+      const issues = await preflightBuildOutput(tmpDir, {});
+      const missing = issues.find(i => i.code === 'MISSING_ENV_VAR');
+      expect(missing?.message).toContain('STRIPE_KEY');
+    });
+  });
+
+  describe('LOCAL_STORAGE_PATH', () => {
+    it('flags file:./*.db LibSQL paths as errors', async () => {
+      writeBundle(`const url = 'file:./mastra.db';`);
+      const issues = await preflightBuildOutput(tmpDir, {});
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue).toBeDefined();
+      expect(issue?.severity).toBe('error');
+      expect(issue?.message).toContain('file:./mastra.db');
+    });
+
+    it('flags localhost in connection strings', async () => {
+      writeBundle(`const pg = 'postgresql://user:pass@localhost:5432/db';`);
+      const issues = await preflightBuildOutput(tmpDir, {});
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue).toBeDefined();
+      expect(issue?.severity).toBe('error');
+    });
+
+    it('flags 127.0.0.1 in connection strings', async () => {
+      writeBundle(`const r = 'redis://127.0.0.1:6379';`);
+      const issues = await preflightBuildOutput(tmpDir, {});
+      expect(issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeDefined();
+    });
+
+    it('does not flag hosted libsql:// URLs', async () => {
+      writeBundle(`const url = 'libsql://my-db-acme.turso.io';`);
+      const issues = await preflightBuildOutput(tmpDir, {});
+      expect(issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeUndefined();
+    });
+
+    it('does not flag the word "localhost" in unrelated strings', async () => {
+      writeBundle(`const msg = 'You can run this on localhost too';`);
+      const issues = await preflightBuildOutput(tmpDir, {});
+      expect(issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeUndefined();
+    });
+  });
+
+  it('scans nested .mjs files in the output directory', async () => {
+    writeBundle(`export {};`);
+    const subDir = join(tmpDir, '.mastra', 'output', 'chunks');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(join(subDir, 'chunk-1.mjs'), `const k = process.env.SECRET_KEY;`);
+
+    const issues = await preflightBuildOutput(tmpDir, {});
+    const missing = issues.find(i => i.code === 'MISSING_ENV_VAR');
+    expect(missing?.message).toContain('SECRET_KEY');
+  });
+});
+
+describe('printPreflightIssues', () => {
+  const errorIssue: PreflightIssue = {
+    code: 'LOCAL_STORAGE_PATH',
+    severity: 'error',
+    message: 'local sqlite path',
+    fix: 'use a hosted url',
+  };
+  const warningIssue: PreflightIssue = {
+    code: 'MISSING_ENV_VAR',
+    severity: 'warning',
+    message: 'missing FOO',
+    fix: 'add it to .env',
+  };
+
+  it('returns true when there are no issues', async () => {
+    const result = await printPreflightIssues([], { autoAccept: true });
+    expect(result).toBe(true);
+  });
+
+  it('blocks deploy on errors even with autoAccept (--yes)', async () => {
+    const result = await printPreflightIssues([errorIssue], { autoAccept: true });
+    expect(result).toBe(false);
+  });
+
+  it('blocks deploy on errors mixed with warnings under autoAccept', async () => {
+    const result = await printPreflightIssues([errorIssue, warningIssue], { autoAccept: true });
+    expect(result).toBe(false);
+  });
+
+  it('passes through warnings-only under autoAccept', async () => {
+    const result = await printPreflightIssues([warningIssue], { autoAccept: true });
+    expect(result).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -162,23 +162,23 @@ describe('printPreflightIssues', () => {
     fix: 'add it to .env',
   };
 
-  it('returns true when there are no issues', async () => {
+  it('returns ok when there are no issues', async () => {
     const result = await printPreflightIssues([], { autoAccept: true });
-    expect(result).toBe(true);
+    expect(result).toBe('ok');
   });
 
-  it('blocks deploy on errors even with autoAccept (--yes)', async () => {
+  it('returns blocked on errors even with autoAccept (--yes)', async () => {
     const result = await printPreflightIssues([errorIssue], { autoAccept: true });
-    expect(result).toBe(false);
+    expect(result).toBe('blocked');
   });
 
-  it('blocks deploy on errors mixed with warnings under autoAccept', async () => {
+  it('returns blocked on errors mixed with warnings under autoAccept', async () => {
     const result = await printPreflightIssues([errorIssue, warningIssue], { autoAccept: true });
-    expect(result).toBe(false);
+    expect(result).toBe('blocked');
   });
 
-  it('passes through warnings-only under autoAccept', async () => {
+  it('returns ok for warnings-only under autoAccept', async () => {
     const result = await printPreflightIssues([warningIssue], { autoAccept: true });
-    expect(result).toBe(true);
+    expect(result).toBe('ok');
   });
 });

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -1,0 +1,284 @@
+import type { Dirent } from 'node:fs';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                             */
+/* ------------------------------------------------------------------ */
+
+export type PreflightIssueCode = 'MISSING_ENV_VAR' | 'LOCAL_STORAGE_PATH';
+
+export interface PreflightIssue {
+  code: PreflightIssueCode;
+  severity: 'error' | 'warning';
+  message: string;
+  fix: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Config                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Env vars the runtime/platform sets automatically — referencing these in
+ * user code is fine even when not present in the user's `.env` file.
+ */
+const ENV_VAR_ALLOWLIST_EXACT = new Set([
+  'PORT',
+  'HOST',
+  'HOSTNAME',
+  'NODE_ENV',
+  'NODE_OPTIONS',
+  'PWD',
+  'HOME',
+  'USER',
+  'PATH',
+  'TZ',
+  'LANG',
+  'CI',
+  // Framework/tooling sentinel flags read by bundled dependencies (debug,
+  // pino, @mastra/* internals). Referencing these from the bundle is
+  // expected and shouldn't be surfaced as a missing-env-var warning.
+  'DEBUG',
+  'DEBUG_FD',
+  'DEBUG_COLORS',
+  'DEBUG_DEPTH',
+  'DEBUG_HIDE_DATE',
+  'NO_COLOR',
+  'FORCE_COLOR',
+  'EXPERIMENTAL_FEATURES',
+  'SKILLS_BASE_DIR',
+]);
+
+/**
+ * Prefixes for env vars set by the platform, runtime, or tooling.
+ */
+const ENV_VAR_ALLOWLIST_PREFIXES = [
+  'MASTRA_',
+  'npm_',
+  'OTEL_',
+  'NEXT_',
+  'VERCEL_',
+  'AWS_LAMBDA_',
+  // Observational memory internal flags
+  'OM_',
+];
+
+/**
+ * Connection-string-shaped patterns that resolve to the build host and will
+ * never work inside the deploy container.
+ */
+const LOCAL_HOST_PATTERNS: Array<{ pattern: RegExp; hint: string }> = [
+  {
+    pattern: /\bfile:\.{1,2}\/[^\s'"`]+\.(?:db|sqlite)\b/i,
+    hint: 'LibSQL/SQLite file path relative to the build host',
+  },
+  {
+    pattern: /\b(?:postgres(?:ql)?|mysql|mongodb|redis|libsql):\/\/[^/\s'"`]*localhost\b/i,
+    hint: 'localhost in a connection string',
+  },
+  {
+    pattern: /\b(?:postgres(?:ql)?|mysql|mongodb|redis|libsql):\/\/[^/\s'"`]*127\.0\.0\.1\b/,
+    hint: '127.0.0.1 in a connection string',
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/*  Public API                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Inspect a built `.mastra/output` directory plus the env vars about to be
+ * uploaded and return a list of issues that are likely to cause the deploy
+ * to fail with a USER-attributable error.
+ *
+ * Returns an empty array when no build output is found — the caller is
+ * responsible for surfacing the missing-output error.
+ */
+export async function preflightBuildOutput(
+  targetDir: string,
+  envVars: Record<string, string>,
+): Promise<PreflightIssue[]> {
+  const outputDir = join(targetDir, '.mastra', 'output');
+  const entryPath = join(outputDir, 'index.mjs');
+
+  // If there's no build output yet, there's nothing to check. The deploy
+  // command verifies the entry exists separately.
+  try {
+    await stat(entryPath);
+  } catch {
+    return [];
+  }
+
+  const bundleSources = await readBundleSources(outputDir);
+  const combinedSource = bundleSources.join('\n');
+
+  const issues: PreflightIssue[] = [];
+
+  issues.push(...checkMissingEnvVars(combinedSource, envVars));
+  issues.push(...checkLocalStoragePaths(combinedSource));
+
+  return issues;
+}
+
+/**
+ * Print preflight issues. Returns `true` when the deploy should proceed,
+ * `false` when the user cancelled or errors are present.
+ *
+ * - No issues: returns true silently.
+ * - Warnings only: prints them; in interactive mode prompts to confirm,
+ *   in `autoAccept` mode passes through.
+ * - One or more errors: prints them and returns false. Errors always block
+ *   the deploy regardless of `--yes` / headless mode — opt out with
+ *   `--skip-preflight` if a check is genuinely a false positive.
+ */
+export async function printPreflightIssues(
+  issues: PreflightIssue[],
+  options: { autoAccept: boolean },
+): Promise<boolean> {
+  if (issues.length === 0) return true;
+
+  const errors = issues.filter(i => i.severity === 'error');
+  const warnings = issues.filter(i => i.severity === 'warning');
+
+  for (const issue of warnings) {
+    p.log.warn(`${pc.yellow(`[${issue.code}]`)} ${issue.message}\n  ${pc.dim('→')} ${issue.fix}`);
+  }
+
+  for (const issue of errors) {
+    p.log.error(`${pc.red(`[${issue.code}]`)} ${issue.message}\n  ${pc.dim('→')} ${issue.fix}`);
+  }
+
+  if (errors.length > 0) {
+    p.log.error(
+      `Deploy blocked by ${errors.length} preflight error(s). ` +
+        `Fix the issues above, or pass --skip-preflight to override.`,
+    );
+    return false;
+  }
+
+  // Warnings only.
+  if (options.autoAccept) return true;
+
+  const confirmed = await p.confirm({
+    message: `Found ${warnings.length} preflight warning(s). Deploy anyway?`,
+    initialValue: true,
+  });
+
+  if (p.isCancel(confirmed) || !confirmed) {
+    return false;
+  }
+
+  return true;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Bundle reading                                                    */
+/* ------------------------------------------------------------------ */
+
+async function readBundleSources(outputDir: string): Promise<string[]> {
+  const files = await collectMjsFiles(outputDir);
+  const contents = await Promise.all(files.map(f => readFile(f, 'utf-8').catch(() => '')));
+  return contents;
+}
+
+async function collectMjsFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  let entries: Array<Dirent | string>;
+  try {
+    entries = (await readdir(dir, { withFileTypes: true })) as Array<Dirent | string>;
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    // Tests sometimes mock readdir with plain string arrays — fall back to stat
+    const name = typeof entry === 'string' ? entry : entry.name;
+    if (name === 'node_modules') continue;
+    const full = join(dir, name);
+    const isDir = typeof entry === 'string' ? false : entry.isDirectory?.() === true;
+    const isFile = typeof entry === 'string' ? true : entry.isFile?.() === true;
+    if (isDir) {
+      out.push(...(await collectMjsFiles(full)));
+    } else if (isFile && (name.endsWith('.mjs') || name.endsWith('.js'))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Check 1 — missing env vars                                        */
+/* ------------------------------------------------------------------ */
+
+const PROCESS_ENV_REGEX = /\bprocess\.env\.([A-Z_][A-Z0-9_]*)\b/g;
+const PROCESS_ENV_BRACKET_REGEX = /\bprocess\.env\[['"]([A-Z_][A-Z0-9_]*)['"]\]/g;
+
+function checkMissingEnvVars(source: string, envVars: Record<string, string>): PreflightIssue[] {
+  const referenced = new Set<string>();
+  for (const match of source.matchAll(PROCESS_ENV_REGEX)) {
+    referenced.add(match[1]!);
+  }
+  for (const match of source.matchAll(PROCESS_ENV_BRACKET_REGEX)) {
+    referenced.add(match[1]!);
+  }
+
+  const provided = new Set(Object.keys(envVars));
+  const missing: string[] = [];
+
+  for (const name of referenced) {
+    if (provided.has(name)) continue;
+    if (ENV_VAR_ALLOWLIST_EXACT.has(name)) continue;
+    if (ENV_VAR_ALLOWLIST_PREFIXES.some(prefix => name.startsWith(prefix))) continue;
+    missing.push(name);
+  }
+
+  if (missing.length === 0) return [];
+
+  missing.sort();
+  return [
+    {
+      code: 'MISSING_ENV_VAR',
+      severity: 'warning',
+      message: `Build references ${missing.length} env var(s) not in the env file being deployed: ${missing.join(', ')}`,
+      fix: `Add them to your env file, or confirm your code provides a fallback (e.g. \`process.env.X ?? 'default'\`).`,
+    },
+  ];
+}
+
+/* ------------------------------------------------------------------ */
+/*  Check 2 — local storage paths                                     */
+/* ------------------------------------------------------------------ */
+
+function checkLocalStoragePaths(source: string): PreflightIssue[] {
+  const issues: PreflightIssue[] = [];
+  const seen = new Set<string>();
+
+  for (const { pattern, hint } of LOCAL_HOST_PATTERNS) {
+    const globalPattern = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g');
+    for (const match of source.matchAll(globalPattern)) {
+      const value = match[0];
+      const key = `${hint}::${value}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      issues.push({
+        code: 'LOCAL_STORAGE_PATH',
+        severity: 'error',
+        message: `Build contains a host-local storage URL: ${truncate(value, 80)} (${hint})`,
+        fix: `Replace it with a hosted URL (e.g. a Turso \`libsql://...\` URL or a public Postgres connection string) and store it in your env file.`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -123,22 +123,27 @@ export async function preflightBuildOutput(
   return issues;
 }
 
+export type PreflightOutcome = 'ok' | 'blocked' | 'cancelled';
+
 /**
- * Print preflight issues. Returns `true` when the deploy should proceed,
- * `false` when the user cancelled or errors are present.
+ * Print preflight issues and decide whether the deploy should proceed.
  *
- * - No issues: returns true silently.
- * - Warnings only: prints them; in interactive mode prompts to confirm,
- *   in `autoAccept` mode passes through.
- * - One or more errors: prints them and returns false. Errors always block
- *   the deploy regardless of `--yes` / headless mode — opt out with
- *   `--skip-preflight` if a check is genuinely a false positive.
+ * Returns:
+ * - `'ok'`     — no issues, or warnings the caller has accepted.
+ * - `'blocked'`— at least one error-severity issue. Errors always block,
+ *                regardless of `autoAccept` / headless mode. Caller should
+ *                exit non-zero so CI surfaces the failure.
+ * - `'cancelled'` — warnings only, but the user explicitly declined the
+ *                confirmation prompt. Caller should exit zero (normal
+ *                user-initiated cancel).
+ *
+ * `--skip-preflight` is the escape hatch when a check is a false positive.
  */
 export async function printPreflightIssues(
   issues: PreflightIssue[],
   options: { autoAccept: boolean },
-): Promise<boolean> {
-  if (issues.length === 0) return true;
+): Promise<PreflightOutcome> {
+  if (issues.length === 0) return 'ok';
 
   const errors = issues.filter(i => i.severity === 'error');
   const warnings = issues.filter(i => i.severity === 'warning');
@@ -156,11 +161,11 @@ export async function printPreflightIssues(
       `Deploy blocked by ${errors.length} preflight error(s). ` +
         `Fix the issues above, or pass --skip-preflight to override.`,
     );
-    return false;
+    return 'blocked';
   }
 
   // Warnings only.
-  if (options.autoAccept) return true;
+  if (options.autoAccept) return 'ok';
 
   const confirmed = await p.confirm({
     message: `Found ${warnings.length} preflight warning(s). Deploy anyway?`,
@@ -168,10 +173,10 @@ export async function printPreflightIssues(
   });
 
   if (p.isCancel(confirmed) || !confirmed) {
-    return false;
+    return 'cancelled';
   }
 
-  return true;
+  return 'ok';
 }
 
 /* ------------------------------------------------------------------ */

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -9,6 +9,7 @@ import { runBuild } from '../../utils/run-build.js';
 import { fetchOrgs } from '../auth/api.js';
 import { MASTRA_STUDIO_URL } from '../auth/client.js';
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
+import { preflightBuildOutput, printPreflightIssues } from '../deploy-preflight.js';
 import { getProjectConfigToSave, loadProjectConfig, saveProjectConfig } from '../studio/project-config.js';
 import { fetchServerProjects, createServerProject, uploadServerDeploy, pollServerDeploy } from './platform-api.js';
 
@@ -260,6 +261,7 @@ export async function serverDeployAction(
     yes?: boolean;
     config?: string;
     skipBuild?: boolean;
+    skipPreflight?: boolean;
     debug?: boolean;
     envFile?: string;
   },
@@ -267,6 +269,7 @@ export async function serverDeployAction(
   const targetDir = resolve(dir || process.cwd());
   const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);
   const autoAccept = opts.yes ?? isHeadless;
+  const skipPreflight = opts.skipPreflight || process.env.MASTRA_SKIP_PREFLIGHT === '1';
 
   p.intro('mastra server deploy');
 
@@ -365,6 +368,16 @@ export async function serverDeployAction(
     p.log.step(`Found ${envCount} env var(s)`);
   } else {
     p.log.step('No env vars found in selected env file');
+  }
+
+  // Pre-upload validation — catch USER-attributable errors before shipping.
+  if (!skipPreflight) {
+    const issues = await preflightBuildOutput(targetDir, envVars);
+    const proceed = await printPreflightIssues(issues, { autoAccept });
+    if (!proceed) {
+      p.cancel('Deploy cancelled.');
+      process.exit(0);
+    }
   }
 
   s.start('Uploading...');

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -355,13 +355,6 @@ export async function serverDeployAction(
     throw new Error('.mastra/output/index.mjs not found — did the build succeed?');
   }
 
-  s.start('Zipping build artifact...');
-  const zipPath = await zipOutput(targetDir);
-  const zipStat = await stat(zipPath);
-  const sizeKB = zipStat.size / 1024;
-  const sizeLabel = sizeKB > 1024 ? `${(sizeKB / 1024).toFixed(1)}MB` : `${sizeKB.toFixed(1)}KB`;
-  s.stop(`Created ${sizeLabel} archive`);
-
   const envVars = await readEnvVars(targetDir, { autoAccept, envFile: opts.envFile });
   const envCount = Object.keys(envVars).length;
   if (envCount > 0) {
@@ -370,15 +363,26 @@ export async function serverDeployAction(
     p.log.step('No env vars found in selected env file');
   }
 
-  // Pre-upload validation — catch USER-attributable errors before shipping.
+  // Pre-upload validation — catch USER-attributable errors before zipping/shipping.
   if (!skipPreflight) {
     const issues = await preflightBuildOutput(targetDir, envVars);
-    const proceed = await printPreflightIssues(issues, { autoAccept });
-    if (!proceed) {
+    const outcome = await printPreflightIssues(issues, { autoAccept });
+    if (outcome === 'blocked') {
+      p.cancel('Deploy blocked by preflight errors.');
+      process.exit(1);
+    }
+    if (outcome === 'cancelled') {
       p.cancel('Deploy cancelled.');
       process.exit(0);
     }
   }
+
+  s.start('Zipping build artifact...');
+  const zipPath = await zipOutput(targetDir);
+  const zipStat = await stat(zipPath);
+  const sizeKB = zipStat.size / 1024;
+  const sizeLabel = sizeKB > 1024 ? `${(sizeKB / 1024).toFixed(1)}MB` : `${sizeKB.toFixed(1)}KB`;
+  s.stop(`Created ${sizeLabel} archive`);
 
   s.start('Uploading...');
   const zipBuffer = await readFile(zipPath);

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -434,14 +434,6 @@ export async function deployAction(
     throw new Error('.mastra/output/index.mjs not found — did the build succeed?');
   }
 
-  t = performance.now();
-  s.start('Zipping build artifact...');
-  const zipPath = await zipOutput(targetDir);
-  const zipStat = await stat(zipPath);
-  const sizeKB = zipStat.size / 1024;
-  const sizeLabel = sizeKB > 1024 ? `${(sizeKB / 1024).toFixed(1)}MB` : `${sizeKB.toFixed(1)}KB`;
-  s.stop(`Created ${sizeLabel} archive (${elapsed(performance.now() - t)})`);
-
   const envVars = await readEnvVars(targetDir, { autoAccept, envFile: opts.envFile });
   const envCount = Object.keys(envVars).length;
   if (envCount > 0) {
@@ -450,15 +442,27 @@ export async function deployAction(
     p.log.step('No env vars found in selected env file');
   }
 
-  // Pre-upload validation — catch USER-attributable errors before shipping.
+  // Pre-upload validation — catch USER-attributable errors before zipping/shipping.
   if (!skipPreflight) {
     const issues = await preflightBuildOutput(targetDir, envVars);
-    const proceed = await printPreflightIssues(issues, { autoAccept });
-    if (!proceed) {
+    const outcome = await printPreflightIssues(issues, { autoAccept });
+    if (outcome === 'blocked') {
+      p.cancel('Deploy blocked by preflight errors.');
+      process.exit(1);
+    }
+    if (outcome === 'cancelled') {
       p.cancel('Deploy cancelled.');
       process.exit(0);
     }
   }
+
+  t = performance.now();
+  s.start('Zipping build artifact...');
+  const zipPath = await zipOutput(targetDir);
+  const zipStat = await stat(zipPath);
+  const sizeKB = zipStat.size / 1024;
+  const sizeLabel = sizeKB > 1024 ? `${(sizeKB / 1024).toFixed(1)}MB` : `${sizeKB.toFixed(1)}KB`;
+  s.stop(`Created ${sizeLabel} archive (${elapsed(performance.now() - t)})`);
 
   t = performance.now();
   s.start('Uploading...');

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -10,6 +10,7 @@ import { runBuild } from '../../utils/run-build.js';
 import { fetchOrgs } from '../auth/api.js';
 import { MASTRA_STUDIO_URL } from '../auth/client.js';
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
+import { preflightBuildOutput, printPreflightIssues } from '../deploy-preflight.js';
 import { fetchProjects, createProject, uploadDeploy, pollDeploy } from './platform-api.js';
 import { getProjectConfigToSave, loadProjectConfig, saveProjectConfig } from './project-config.js';
 
@@ -296,6 +297,7 @@ export async function deployAction(
     yes?: boolean;
     config?: string;
     skipBuild?: boolean;
+    skipPreflight?: boolean;
     debug?: boolean;
     envFile?: string;
   },
@@ -306,6 +308,7 @@ export async function deployAction(
     throw new Error('MASTRA_ORG_ID and MASTRA_PROJECT_ID are required when MASTRA_API_TOKEN is set');
   }
   const autoAccept = opts.yes ?? isHeadless;
+  const skipPreflight = opts.skipPreflight || process.env.MASTRA_SKIP_PREFLIGHT === '1';
 
   p.intro('mastra studio deploy');
 
@@ -445,6 +448,16 @@ export async function deployAction(
     p.log.step(`Found ${envCount} env var(s)`);
   } else {
     p.log.step('No env vars found in selected env file');
+  }
+
+  // Pre-upload validation — catch USER-attributable errors before shipping.
+  if (!skipPreflight) {
+    const issues = await preflightBuildOutput(targetDir, envVars);
+    const proceed = await printPreflightIssues(issues, { autoAccept });
+    if (!proceed) {
+      p.cancel('Deploy cancelled.');
+      process.exit(0);
+    }
   }
 
   t = performance.now();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -197,6 +197,7 @@ const deployCommand = studioCommand
   .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
   .option('--env-file <file>', 'Env file to deploy (for example: .env.production)')
   .option('--skip-build', 'Skip the build step and use existing .mastra/output')
+  .option('--skip-preflight', 'Skip the pre-deploy build/env validation')
   .option('--debug', 'Enable debug logs', false)
   .action(wrapAction(deployAction));
 
@@ -282,6 +283,7 @@ const serverDeployCommand = serverCommand
   .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
   .option('--env-file <file>', 'Env file to deploy (for example: .env.production)')
   .option('--skip-build', 'Skip the build step and deploy the existing .mastra/output directory')
+  .option('--skip-preflight', 'Skip the pre-deploy build/env validation')
   .option('--debug', 'Enable debug logs', false)
   .action(wrapAction(serverDeployAction));
 


### PR DESCRIPTION
Adds a pre-deploy validation step that runs after `mastra build` and before upload, catching the two most common deploy failures locally instead of after a full Cloud Build cycle.

Two checks run today:

- `MISSING_ENV_VAR` (warning) — `process.env.X` references in the bundle that aren't covered by the resolved env file. Common platform/runtime/tooling vars (`PORT`, `NODE_ENV`, `MASTRA_*`, `OTEL_*`, `DEBUG`, `OM_*`, etc.) are allowlisted so users only see vars they actually need to set.
- `LOCAL_STORAGE_PATH` (error) — `file:./*.db` SQLite paths and `localhost`/`127.0.0.1` connection strings that won't survive in a remote container.

Errors block the deploy even under `--yes`/headless. Warnings prompt for confirmation interactively and pass through with `--yes`. The whole check can be skipped with `--skip-preflight` or `MASTRA_SKIP_PREFLIGHT=1`.

Example output against a project with a missing env var and a local SQLite path:

\`\`\`
▲  [MISSING_ENV_VAR] Build references 1 env var(s) not in the env file being deployed: MY_REQUIRED_SECRET
   → Add them to your env file, or confirm your code provides a fallback (e.g. \`process.env.X ?? 'default'\`).
■  [LOCAL_STORAGE_PATH] Build contains a host-local storage URL: file:./mastra.db (LibSQL/SQLite file path relative to the build host)
   → Replace it with a hosted URL (e.g. a Turso \`libsql://...\` URL or a public Postgres connection string) and store it in your env file.
■  Deploy blocked by 1 preflight error(s). Fix the issues above, or pass --skip-preflight to override.
└  Deploy cancelled.
\`\`\`

Verified end-to-end against a fresh Mastra project deploying to the live platform: errors block before upload, warnings pass under \`--yes\`, and \`--skip-preflight\` correctly bypasses the check. 17 unit tests cover the detection logic and printer behavior; full CLI suite (344 tests) and \`pnpm --filter ./packages/cli typecheck\` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Before uploading your Mastra app, this PR adds a quick local check that warns about missing config and blocks deploys that rely on files or localhost-only databases so you don't accidentally break the remote deploy.

## Overview

Adds a pre-deploy "preflight" validation for `mastra studio deploy` and `mastra server deploy` that runs after the local build (or uses existing bundle with `--skip-build`) and before zipping/uploading. It inspects the built bundle for two classes of issues:

- MISSING_ENV_VAR (warning): Detects references like `process.env.X` in the bundle that are not present in the resolved env file (including `.env`, `.env.local`, or `--env-file`). Common platform/runtime/tooling vars are allowlisted (e.g., PORT, NODE_ENV, MASTRA_*, OTEL_*, DEBUG, OM_*). Warnings are printed interactively and can be accepted with `--yes` (autoAccept); declining cancels the deploy with exit code 0.
- LOCAL_STORAGE_PATH (error): Detects host-local storage usages that won't work inside the remote container (e.g., `file:./*.db` SQLite/libsql file paths and connection strings containing `localhost` or `127.0.0.1`). Errors always block the deploy (non-zero exit), including in headless/`--yes` mode.

The preflight can be skipped with `--skip-preflight` or `MASTRA_SKIP_PREFLIGHT=1`. The flow was reordered so the preflight runs before creating the zip output to avoid leaking temporary zip files when checks block or the user cancels.

## Changes

- New module: packages/cli/src/commands/deploy-preflight.ts
  - Exports types: PreflightIssueCode ('MISSING_ENV_VAR' | 'LOCAL_STORAGE_PATH'), PreflightIssue, PreflightOutcome ('ok' | 'blocked' | 'cancelled').
  - New functions:
    - preflightBuildOutput(targetDir, envVars): Scans .mastra/output (.mjs/.js files) for missing env var references and local-storage patterns; returns deduplicated issues.
    - printPreflightIssues(issues, { autoAccept }): Prints issues, prompts for confirmation on warnings, and returns an explicit outcome ('ok' | 'blocked' | 'cancelled'). Errors always return 'blocked'; cancelled prompts return 'cancelled' so callers can exit 0.
  - Allowlist and detection heuristics for platform env vars and local-host patterns; robust bundle file collection and partial-read tolerance.

- Tests: packages/cli/src/commands/deploy-preflight.test.ts
  - 17 Vitest tests covering detection of dot and bracket notation env references, allowlist behavior, nested .mjs scanning, local storage patterns, and printPreflightIssues outcome behavior (including autoAccept semantics).
  - Mocks @clack/prompts to validate logging and prompt behavior.

- CLI integration:
  - packages/cli/src/commands/studio/deploy.ts and packages/cli/src/commands/server/deploy.ts
    - Added skipPreflight option (derived from --skip-preflight or MASTRA_SKIP_PREFLIGHT=1).
    - Preflight runs after build/env loading but before creating the zip/upload; blocked or cancelled outcomes cause early exit (blocked => non-zero, cancelled => zero).
  - packages/cli/src/index.ts
    - Registers --skip-preflight for both studio and server deploy commands.

- Changelog: .changeset/deploy-preflight-validation.md

## Testing & Validation

- Unit tests (17) for detection and printer behavior; full CLI suite (344 tests) and TypeScript checks pass.
- E2E verification on a fresh Mastra project: errors block before upload, warnings pass under `--yes`, and `--skip-preflight` bypasses checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->