### PR TITLE
fix: keep goal commands and user choices intact

### DIFF
--- a/.mastracode/commands/pr-triage.md
+++ b/.mastracode/commands/pr-triage.md
@@ -21,7 +21,8 @@ Do this:
    Within each reviewer bucket, sort so easy merges or easy closes appear first.
 6. After the full tracking file is ready, present the best first candidates and pair-review them with me one at a time, updating the list as we go through to add status/notes, until the list is empty.
 7. For each PR in the pair-review sequence, start with a concise TL;DR that explains the issue/change, whether it needs more work or looks close to done, and any other short helpful context for deciding what to do next.
-8. When pair-reviewing the first PR, ask whether I want you to open each PR in my browser with the GitHub CLI (`gh pr view <number> --web`). Ask this preference only once, then respect the answer for each PR in the pair-review sequence.
+8. After the TL;DR for each PR, stop and ask me what action to take. Do not submit a review, request changes, approve, merge, close, comment, or mark a GitHub action as taken until I explicitly choose that action.
+9. When pair-reviewing the first PR, ask whether I want you to open each PR in my browser with the GitHub CLI (`gh pr view <number> --web`). Ask this preference only once, then respect the answer for each PR in the pair-review sequence.
 
 If I provide extra guidance, use it as additional selection criteria:
 

--- a/mastracode/src/tui/__tests__/goal-manager.test.ts
+++ b/mastracode/src/tui/__tests__/goal-manager.test.ts
@@ -194,54 +194,6 @@ describe('GoalManager', () => {
     ]);
   });
 
-  it('answers goal-mode questions with the judge using exact option labels', async () => {
-    mocks.stream.mockResolvedValue({
-      consumeStream: vi.fn().mockResolvedValue(undefined),
-      getFullOutput: vi.fn().mockResolvedValue({ object: { answer: 'Verified' } }),
-    });
-    mocks.agentConstructor.mockImplementation(function () {
-      return { stream: mocks.stream };
-    });
-
-    const manager = new GoalManager();
-    manager.setGoal('tell whale facts and wait for judge verification', 'openai/gpt-5.4-mini');
-
-    const answer = await manager.answerQuestion(createState(), 'Is this a whale fact?', [
-      { label: 'Verified', description: 'This is a whale fact.' },
-      { label: 'Reject', description: 'This is not a whale fact.' },
-    ]);
-
-    expect(answer).toBe('Verified');
-    expect(mocks.stream).toHaveBeenCalledWith(
-      expect.stringContaining('verify it yourself unless the goal explicitly requires human/user verification'),
-      expect.objectContaining({ structuredOutput: { schema: expect.any(Object) } }),
-    );
-  });
-
-  it('rejects goal-mode question answers outside the provided option labels', async () => {
-    mocks.stream.mockResolvedValue({
-      consumeStream: vi.fn().mockResolvedValue(undefined),
-      getFullOutput: vi.fn().mockResolvedValue({ object: { answer: 'Looks good' } }),
-    });
-    mocks.agentConstructor.mockImplementation(function () {
-      return { stream: mocks.stream };
-    });
-
-    const manager = new GoalManager();
-    manager.setGoal('tell whale facts and wait for judge verification', 'openai/gpt-5.4-mini');
-
-    const answer = await manager.answerQuestion(createState(), 'Is this a whale fact?', [
-      { label: 'Verified', description: 'This is a whale fact.' },
-      { label: 'Reject', description: 'This is not a whale fact.' },
-    ]);
-
-    expect(answer).toBe('(judge could not answer: returned "Looks good" outside available answers.)');
-    expect(mocks.stream).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({ structuredOutput: { schema: expect.any(Object) } }),
-    );
-  });
-
   it('does not auto-continue when the judge says the assistant is waiting on the user', async () => {
     mocks.stream.mockResolvedValue({
       consumeStream: vi.fn().mockResolvedValue(undefined),

--- a/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -22,7 +22,7 @@ vi.mock('../display.js', () => ({
 }));
 
 import { GOAL_JUDGE_INPUT_LOCK_MESSAGE } from '../goal-input-lock.js';
-import { handleAgentEnd } from '../handlers/agent-lifecycle.js';
+import { handleAgentAborted, handleAgentEnd } from '../handlers/agent-lifecycle.js';
 import type { EventHandlerContext } from '../handlers/types.js';
 import { MastraTUI, consumePendingImages, syncInitialThreadState } from '../mastra-tui.js';
 import type { TUIState } from '../state.js';
@@ -345,6 +345,26 @@ describe('MastraTUI queueing', () => {
     });
   });
 
+  it('does not pause an active goal when a user-initiated abort ends the agent turn', () => {
+    const goalManager = {
+      isActive: vi.fn(() => true),
+      pause: vi.fn(),
+      saveToThread: vi.fn(),
+    };
+    const state = createQueueState({
+      userInitiatedAbort: true,
+      goalManager: goalManager as any,
+    });
+    const ctx = createQueueContext(state);
+
+    handleAgentAborted(ctx);
+
+    expect(goalManager.pause).not.toHaveBeenCalled();
+    expect(goalManager.saveToThread).not.toHaveBeenCalled();
+    expect(state.userInitiatedAbort).toBe(false);
+    expect(mocks.showInfo).not.toHaveBeenCalledWith(state, 'Goal paused (interrupted). Use /goal resume to continue.');
+  });
+
   it('waits for harness-level follow-ups to finish before draining the local queue', () => {
     const state = createQueueState({
       harness: { getFollowUpCount: vi.fn(() => 1) } as any,
@@ -362,11 +382,11 @@ describe('MastraTUI queueing', () => {
 });
 
 describe('syncInitialThreadState', () => {
-  it('loads persisted goal metadata for the initially selected thread', async () => {
+  it('reconnects active goal metadata for the initially selected thread without prompting the agent', async () => {
     const persistedGoal = {
       id: 'goal-1',
       objective: 'finish pr triage',
-      status: 'paused' as const,
+      status: 'active' as const,
       turnsUsed: 1,
       maxTurns: 50,
       judgeModelId: 'openai/gpt-5.5',
@@ -378,6 +398,7 @@ describe('syncInitialThreadState', () => {
           { id: 'thread-1', title: 'PR triage', metadata: { goal: persistedGoal } },
           { id: 'thread-2', title: 'Other thread', metadata: {} },
         ]),
+        sendMessage: vi.fn(),
       },
       goalManager: { loadFromThreadMetadata: vi.fn() },
       currentThreadTitle: undefined,
@@ -387,6 +408,7 @@ describe('syncInitialThreadState', () => {
 
     expect(state.currentThreadTitle).toBe('PR triage');
     expect(state.goalManager.loadFromThreadMetadata).toHaveBeenCalledWith({ goal: persistedGoal });
+    expect(state.harness.sendMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
+++ b/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
@@ -103,6 +103,26 @@ describe('Parallel interactive tool calls (issue #13642)', () => {
       await p2;
     });
 
+    it('leaves ask_user choices for the user while a goal is active', async () => {
+      const answerQuestion = vi.fn();
+      state.goalManager = {
+        getGoal: vi.fn(() => ({ status: 'active', judgeModelId: 'openai/gpt-5.5' })),
+        answerQuestion,
+      } as any;
+
+      const prompt = handleAskQuestion(ctx, 'q1', 'Choose a review action?', [
+        { label: 'Request changes', description: 'Submit a blocking review.' },
+        { label: 'Skip', description: 'Move to the next PR.' },
+      ]);
+
+      expect(state.activeInlineQuestion).toBeDefined();
+      expect(answerQuestion).not.toHaveBeenCalled();
+      expect(state.harness.respondToQuestion).not.toHaveBeenCalled();
+
+      state.activeInlineQuestion!.handleInput('\r');
+      await prompt;
+    });
+
     it('should allow answering all parallel questions sequentially', async () => {
       const respondToQuestion = state.harness.respondToQuestion as ReturnType<typeof vi.fn>;
 

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -81,6 +81,11 @@ function createState(isRunning: boolean) {
     allSystemReminderComponents: [],
     allShellComponents: [],
     ui: { requestRender: vi.fn(), start: vi.fn(), stop: vi.fn() },
+    goalManager: {
+      isActive: vi.fn(() => false),
+      pause: vi.fn(),
+      saveToThread: vi.fn(),
+    },
   } as any;
 
   return { state, editor, actions };
@@ -175,6 +180,25 @@ describe('setupKeyboardShortcuts', () => {
     expect(editor.setText).not.toHaveBeenCalled();
     expect(queueFollowUpMessage).not.toHaveBeenCalled();
     expect(showInfo).toHaveBeenCalledWith(state, GOAL_JUDGE_INPUT_LOCK_MESSAGE);
+    expect(state.ui.requestRender).toHaveBeenCalled();
+  });
+
+  it('does not pause an active goal when clearing empty idle input', () => {
+    const { state, editor, actions } = createState(false);
+    editor.getText.mockReturnValue('');
+    state.goalManager.isActive.mockReturnValue(true);
+
+    setupKeyboardShortcuts(state, {
+      stop: vi.fn(),
+      doubleCtrlCMs: 500,
+      queueFollowUpMessage: vi.fn(),
+    });
+
+    actions.get('clear')?.();
+
+    expect(state.goalManager.pause).not.toHaveBeenCalled();
+    expect(state.goalManager.saveToThread).not.toHaveBeenCalled();
+    expect(showInfo).not.toHaveBeenCalledWith(state, 'Goal paused (interrupted). Use /goal resume to continue.');
     expect(state.ui.requestRender).toHaveBeenCalled();
   });
 

--- a/mastracode/src/tui/components/__tests__/custom-editor.test.ts
+++ b/mastracode/src/tui/components/__tests__/custom-editor.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   superHandleInput: vi.fn(),
   superRender: vi.fn(() => ['────', 'hello', '────']),
+  editorSetText: vi.fn(),
   getClipboardImage: vi.fn(),
   getClipboardText: vi.fn(),
   matchesKey: vi.fn((_data: string, _key: string) => false),
@@ -32,6 +33,10 @@ vi.mock('@mariozechner/pi-tui', () => {
 
     getText(): string {
       return '';
+    }
+
+    setText(text: string): void {
+      mocks.editorSetText(text);
     }
 
     isShowingAutocomplete(): boolean {
@@ -102,6 +107,22 @@ describe('CustomEditor image paste handling', () => {
     editor.handleInput('\r');
 
     expect(mocks.superHandleInput).toHaveBeenCalledWith('\t');
+    expect(followUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the slash before submitting a slash autocomplete selection that inserts without one', () => {
+    mocks.matchesKey.mockImplementation((_data: string, key: string) => key === 'enter');
+
+    const editor = new CustomEditor({} as any, {} as any);
+    const followUp = vi.fn(() => true);
+    editor.onAction('followUp', followUp);
+    editor.getText = vi.fn().mockReturnValueOnce('/goal/pr').mockReturnValue('goal/pr-triage ');
+    editor.isShowingAutocomplete = vi.fn(() => true);
+
+    editor.handleInput('\r');
+
+    expect(mocks.superHandleInput).toHaveBeenCalledWith('\t');
+    expect(mocks.editorSetText).toHaveBeenCalledWith('/goal/pr-triage ');
     expect(followUp).toHaveBeenCalledTimes(1);
   });
 

--- a/mastracode/src/tui/components/custom-editor.ts
+++ b/mastracode/src/tui/components/custom-editor.ts
@@ -551,8 +551,13 @@ export class CustomEditor extends Editor {
       const handler = this.actionHandlers.get('followUp');
       if (handler) {
         if (this.isShowingAutocomplete()) {
+          const wasSlashCommand = this.getText().trimStart().startsWith('/');
           super.handleInput('\t');
-          if (this.getText().trimStart().startsWith('/') && handler() !== false) {
+          const completedText = this.getText();
+          if (wasSlashCommand && !completedText.trimStart().startsWith('/')) {
+            this.setText(`/${completedText.trimStart()}`);
+          }
+          if (wasSlashCommand && handler() !== false) {
             return;
           }
           return;

--- a/mastracode/src/tui/goal-manager.ts
+++ b/mastracode/src/tui/goal-manager.ts
@@ -70,12 +70,6 @@ const judgeSchema = z.object({
   reason: z.string().describe('Brief explanation of what was accomplished or what remains to be done'),
 });
 
-const questionAnswerSchema = z.object({
-  answer: z
-    .string()
-    .describe('The answer to give the assistant. If choices are provided, use exactly one choice label.'),
-});
-
 // =============================================================================
 // GoalManager
 // =============================================================================
@@ -182,19 +176,6 @@ export class GoalManager {
    * Called after each agent turn completes. Evaluates whether to continue.
    * Returns a GoalEvaluationResult with continuation prompt and judge result.
    */
-  async answerQuestion(
-    state: TUIState,
-    question: string,
-    options?: Array<{ label: string; description?: string }>,
-  ): Promise<string> {
-    if (!this.goal || this.goal.status !== 'active') {
-      return '(skipped)';
-    }
-
-    const result = await this.callJudgeForQuestion(state, question, options);
-    return result.answer;
-  }
-
   async evaluateAfterTurn(state: TUIState): Promise<GoalEvaluationResult> {
     if (!this.goal || this.goal.status !== 'active') {
       return { continuation: null, judgeResult: null };
@@ -302,57 +283,6 @@ export class GoalManager {
         .join('\n');
     }
     return String(content ?? '');
-  }
-
-  private async callJudgeForQuestion(
-    state: TUIState,
-    question: string,
-    options?: Array<{ label: string; description?: string }>,
-  ): Promise<{ answer: string }> {
-    try {
-      const memory = await this.getJudgeMemory(state);
-      const judgeAgent = this.createJudgeAgent(memory);
-      if (!judgeAgent) {
-        return { answer: '(judge could not answer: Judge model could not be initialized.)' };
-      }
-
-      const optionLabels = options?.map(option => option.label) ?? [];
-      const optionsText = optionLabels.length
-        ? `\n\nAvailable answers (choose exactly one label):\n${options!
-            .map(option => `- ${option.label}${option.description ? `: ${option.description}` : ''}`)
-            .join('\n')}`
-        : '';
-      const answerSchema = optionLabels.length
-        ? z.object({
-            answer: z
-              .enum(optionLabels as [string, ...string[]])
-              .describe('Exactly one label from the available answers.'),
-          })
-        : questionAnswerSchema;
-      const stream = await judgeAgent.stream(
-        `Goal: ${this.goal!.objective}\n\nThe assistant asked a question while goal mode is active. Answer it as the goal judge so the assistant can continue without waiting for the human user. If the question asks for verification, verify it yourself unless the goal explicitly requires human/user verification.\n\nQuestion:\n${question}${optionsText}`,
-        {
-          ...(memory
-            ? { memory: { thread: this.getJudgeThreadId(state), resource: state.harness.getResourceId() } }
-            : {}),
-          structuredOutput: {
-            schema: answerSchema,
-          },
-        },
-      );
-
-      await stream.consumeStream();
-      const output = (await stream.getFullOutput()).object as z.infer<typeof questionAnswerSchema> | undefined;
-      if (!output?.answer) {
-        return { answer: '(judge could not answer: no structured answer returned.)' };
-      }
-      if (optionLabels.length && !optionLabels.includes(output.answer)) {
-        return { answer: `(judge could not answer: returned "${output.answer}" outside available answers.)` };
-      }
-      return { answer: output.answer };
-    } catch (error) {
-      return { answer: `(judge could not answer: ${formatError(error)})` };
-    }
   }
 
   private async callJudge(

--- a/mastracode/src/tui/handlers/__tests__/prompts.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/prompts.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest';
-import { AssistantMessageComponent } from '../../components/assistant-message.js';
 import type { TUIState } from '../../state.js';
 import { handleAskQuestion, handlePlanApproval } from '../prompts.js';
 import type { EventHandlerContext } from '../types.js';
@@ -11,16 +10,22 @@ function createCtx() {
       getGoal: vi.fn(() => ({ status: 'active', judgeModelId: 'openai/gpt-5.5' })),
       answerQuestion,
     },
+    options: { inlineQuestions: true },
     harness: {
       respondToQuestion: vi.fn(),
       getDisplayState: vi.fn(() => ({ isRunning: false })),
     },
+    pendingInlineQuestions: [],
     gradientAnimator: {
       start: vi.fn(),
       stop: vi.fn(),
     },
     ui: {
       requestRender: vi.fn(),
+    },
+    chatContainer: {
+      addChild: vi.fn(),
+      invalidate: vi.fn(),
     },
     hideThinkingBlock: false,
   } as unknown as TUIState;
@@ -36,35 +41,20 @@ function createCtx() {
 }
 
 describe('handleAskQuestion goal mode', () => {
-  it('answers ask_user prompts with the active goal judge instead of showing the user prompt', async () => {
+  it('shows ask_user prompts to the user instead of answering with the goal judge', async () => {
     const { ctx, state, answerQuestion } = createCtx();
     const options = [{ label: 'Verified', description: 'This is a whale fact.' }];
 
-    await handleAskQuestion(ctx, 'q1', 'Is this a whale fact?', options);
+    const promise = handleAskQuestion(ctx, 'q1', 'Is this a whale fact?', options);
 
-    expect(answerQuestion).toHaveBeenCalledWith(state, 'Is this a whale fact?', options);
-    expect(ctx.addChildBeforeFollowUps).toHaveBeenCalledTimes(2);
-    const rendered = (ctx.addChildBeforeFollowUps as any).mock.calls[0][0].render(80).join('\n');
-    expect(rendered).toContain('Question');
-    expect(rendered).toContain('Is this a whale fact?');
-    expect(rendered).toContain('Verified');
-    expect(state.harness.respondToQuestion).toHaveBeenCalledWith({ questionId: 'q1', answer: 'Verified' });
-    expect(ctx.notify).not.toHaveBeenCalled();
+    expect(answerQuestion).not.toHaveBeenCalled();
+    expect(state.activeInlineQuestion).toBeDefined();
+    expect(state.harness.respondToQuestion).not.toHaveBeenCalled();
+    expect(ctx.addChildBeforeFollowUps).not.toHaveBeenCalled();
     expect(state.activeGoalJudge).toBeUndefined();
-  });
 
-  it('creates a fresh assistant component after the auto-answered question', async () => {
-    const { ctx, state } = createCtx();
-    const preQuestionStream = new AssistantMessageComponent();
-    state.streamingComponent = preQuestionStream;
-
-    await handleAskQuestion(ctx, 'q1', 'Continue?', [{ label: 'Yes' }]);
-
-    expect(ctx.addChildBeforeFollowUps).toHaveBeenCalledTimes(2);
-    expect((ctx.addChildBeforeFollowUps as any).mock.calls[0][0]).not.toBeInstanceOf(AssistantMessageComponent);
-    expect((ctx.addChildBeforeFollowUps as any).mock.calls[1][0]).toBeInstanceOf(AssistantMessageComponent);
-    expect(state.streamingComponent).toBe((ctx.addChildBeforeFollowUps as any).mock.calls[1][0]);
-    expect(state.streamingComponent).not.toBe(preQuestionStream);
+    state.activeInlineQuestion!.handleInput('\r');
+    await promise;
   });
 });
 

--- a/mastracode/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/src/tui/handlers/agent-lifecycle.ts
@@ -120,13 +120,6 @@ export function handleAgentAborted(ctx: EventHandlerContext): void {
     state.gradientAnimator.fadeOut();
   }
 
-  // Pause the goal loop on user-initiated abort
-  if (state.userInitiatedAbort && state.goalManager.isActive()) {
-    state.goalManager.pause();
-    state.goalManager.saveToThread(state).catch(() => {});
-    showInfo(state, 'Goal paused (interrupted). Use /goal resume to continue.');
-  }
-
   // Update streaming message to show it was interrupted
   if (state.streamingComponent && state.streamingMessage) {
     state.streamingMessage.stopReason = 'aborted';

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -5,11 +5,10 @@
 import { savePlanToDisk } from '../../utils/plans.js';
 import { AskQuestionDialogComponent } from '../components/ask-question-dialog.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
-import { AssistantMessageComponent } from '../components/assistant-message.js';
 import { PlanApprovalInlineComponent } from '../components/plan-approval-inline.js';
 import { showModalOverlay } from '../overlay.js';
 import type { TUIState } from '../state.js';
-import { getMarkdownTheme, theme } from '../theme.js';
+import { theme } from '../theme.js';
 
 import type { EventHandlerContext } from './types.js';
 
@@ -38,38 +37,6 @@ export async function handleAskQuestion(
   options?: Array<{ label: string; description?: string }>,
 ): Promise<void> {
   const { state } = ctx;
-  const activeGoal = state.goalManager?.getGoal();
-  if (activeGoal?.status === 'active') {
-    state.activeGoalJudge = { modelId: activeGoal.judgeModelId };
-    state.gradientAnimator?.start();
-    ctx.updateStatusLine();
-    try {
-      const answer = await state.goalManager.answerQuestion(state, question, options);
-      const questionComponent = new AskQuestionInlineComponent(
-        {
-          question,
-          options,
-          multiline: true,
-          onSubmit: () => {},
-          onCancel: () => {},
-        },
-        state.ui,
-      );
-      questionComponent.answer(Array.isArray(answer) ? answer.join(', ') : answer);
-      ctx.addChildBeforeFollowUps(questionComponent);
-      state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
-      ctx.addChildBeforeFollowUps(state.streamingComponent);
-      state.ui.requestRender();
-      state.harness.respondToQuestion({ questionId, answer });
-    } finally {
-      state.activeGoalJudge = undefined;
-      if (!state.harness.getDisplayState().isRunning) {
-        state.gradientAnimator?.stop();
-      }
-      ctx.updateStatusLine();
-    }
-    return;
-  }
 
   return new Promise(resolve => {
     if (state.options.inlineQuestions) {

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -61,11 +61,6 @@ export function setupKeyboardShortcuts(
       if (current.length > 0) {
         state.lastClearedText = current;
         state.editor.setText('');
-      } else if (state.goalManager.isActive()) {
-        // Input already empty and goal is active — pause the goal
-        state.goalManager.pause();
-        state.goalManager.saveToThread(state).catch(() => {});
-        showInfo(state, 'Goal paused (interrupted). Use /goal resume to continue.');
       }
       state.ui.requestRender();
     }


### PR DESCRIPTION
This fixes a couple of goal-mode control issues from the follow-up testing.

Slash autocomplete now preserves the leading slash before submit:

```txt
before: goal/pr-triage
 after: /goal/pr-triage
```

The goal judge no longer answers `ask_user` prompts for the user, and Esc/Ctrl-C no longer pause active goals implicitly. If a goal should pause, the user still does that explicitly:

```txt
/goal pause
```

I also tightened the `pr-triage` command wording so opening a GitHub review stays user-approved, not judge-driven.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you're typing a command that starts with "/" in the chat interface, the autocomplete helper was accidentally removing the "/" before submitting it, which broke the command. This PR fixes that by keeping the "/" intact. It also changes how the AI behaves when running goals—it stops trying to automatically answer questions (leaving that to you) and stops pausing the goal when you press Escape (you now have to explicitly tell it to pause).

## Overview

This PR addresses two interconnected issues:
1. **Slash-command autocomplete bug**: Fixed an edge case where slash-command autocomplete (e.g., `/goal/pr-triage`) would lose its leading slash upon submission, causing the command to run as a normal prompt instead of dispatching correctly.
2. **Goal control behavior**: Adjusted how goals interact with user input and interrupts—removed the goal judge's ability to auto-answer `ask_user` prompts and changed interrupt behavior so Escape/Ctrl-C no longer implicitly pause active goals.

## Changes by File

**mastracode/src/tui/components/custom-editor.ts**
- Modified the `handleInput` enter/autocomplete flow to detect if the original input started with a slash, force tab completion, then restore the leading slash if it was removed during completion.

**mastracode/src/tui/components/__tests__/custom-editor.test.ts**
- Added a regression test verifying that Enter submission of slash-autocomplete selections preserves the leading `/` before text submission.

**mastracode/src/tui/goal-manager.ts**
- Removed `answerQuestion()` method that allowed the goal judge to automatically answer `ask_user` prompts while a goal is active.
- Removed `callJudgeForQuestion()` helper and its associated Zod schema.

**mastracode/src/tui/handlers/prompts.ts**
- Removed the special-case branch in `handleAskQuestion` that used goal-judge auto-answering when a goal was active.
- All `ask_user` prompts now flow through the inline-question queue/modal-dialog path, requiring explicit user input.

**mastracode/src/tui/handlers/agent-lifecycle.ts**
- Modified `handleAgentAborted` to no longer pause the goal loop on user-initiated abort while a goal is active.

**mastracode/src/tui/setup.ts**
- Changed the Ctrl+C/Escape "clear" action to only pause a goal if the editor text is empty (previously would pause regardless).

**mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts**
- Updated tests to reflect that user-initiated abort no longer pauses active goals.
- Adjusted `syncInitialThreadState` test to expect active goal status instead of paused.

**mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts**
- Added test ensuring `handleAskQuestion` does not trigger goal auto-answering; instead sets `activeInlineQuestion` and waits for user input.

**mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts**
- Added test verifying that clearing empty idle input does not pause an active goal.

**mastracode/src/tui/__tests__/goal-manager.test.ts**
- Removed two test cases related to goal-judge auto-answering of `ask_user` prompts.

**mastracode/src/tui/handlers/__tests__/prompts.test.ts**
- Updated `handleAskQuestion` test to verify inline-question flow instead of goal-judge auto-answer path.

**.mastracode/commands/pr-triage.md**
- Updated instruction numbering and added guidance to wait for user approval before opening GitHub reviews.

## Testing

Added focused regression tests covering:
- Slash-command autocomplete preservation during submit
- User-initiated interrupt behavior with active goals
- Inline question handling when goals are active
- Goal pause behavior with keyboard shortcuts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->