### PR TITLE
fix(client-js): send orderBy as object on paginated list methods

### DIFF
--- a/.changeset/sdk-orderby-shape.md
+++ b/.changeset/sdk-orderby-shape.md
@@ -1,0 +1,33 @@
+---
+'@mastra/client-js': patch
+'@internal/playground': patch
+---
+
+Fix `orderBy` shape mismatch for paginated list methods.
+
+The server expects `orderBy` as a structured object (`{ field, direction }`),
+but several SDK methods were sending `orderBy` and `sortDirection` as flat
+strings, which caused server-side schema validation to fail.
+
+Affected methods:
+
+- `MastraClient.listMemoryThreads`
+- `Agent.listVersions`
+- `StoredAgent.listVersions`
+- `StoredPromptBlock.listVersions`
+- `StoredScorer.listVersions`
+
+Before:
+
+```ts
+client.listMemoryThreads({ orderBy: 'createdAt', sortDirection: 'DESC' });
+```
+
+After:
+
+```ts
+client.listMemoryThreads({ orderBy: { field: 'createdAt', direction: 'DESC' } });
+```
+
+The flat `sortDirection` parameter has been removed from the affected param
+types in favor of the nested `orderBy.direction` field.

--- a/.changeset/sdk-orderby-shape.md
+++ b/.changeset/sdk-orderby-shape.md
@@ -1,6 +1,5 @@
 ---
-'@mastra/client-js': patch
-'@internal/playground': patch
+'@mastra/client-js': minor
 ---
 
 Fix `orderBy` shape mismatch for paginated list methods.

--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -260,8 +260,14 @@ export class MastraClient extends BaseResource {
     if (params.agentId) queryParams.set('agentId', params.agentId);
     if (params.page !== undefined) queryParams.set('page', params.page.toString());
     if (params.perPage !== undefined) queryParams.set('perPage', params.perPage.toString());
-    if (params.orderBy) queryParams.set('orderBy', params.orderBy);
-    if (params.sortDirection) queryParams.set('sortDirection', params.sortDirection);
+    if (params.orderBy) {
+      if (params.orderBy.field) {
+        queryParams.set('orderBy[field]', params.orderBy.field);
+      }
+      if (params.orderBy.direction) {
+        queryParams.set('orderBy[direction]', params.orderBy.direction);
+      }
+    }
 
     const queryString = queryParams.toString();
     const response: ListMemoryThreadsResponse | ListMemoryThreadsResponse['threads'] = await this.request(

--- a/client-sdks/client-js/src/resources/agent.test.ts
+++ b/client-sdks/client-js/src/resources/agent.test.ts
@@ -529,13 +529,12 @@ describe('Agent Client Methods', () => {
     const result = await agent.listVersions({
       page: 0,
       perPage: 10,
-      orderBy: 'createdAt',
-      sortDirection: 'DESC',
+      orderBy: { field: 'createdAt', direction: 'DESC' },
     });
 
     expect(result).toEqual(mockResponse);
     expect(global.fetch).toHaveBeenCalledWith(
-      `${clientOptions.baseUrl}/api/stored/agents/test-agent/versions?page=0&perPage=10&orderBy=createdAt&sortDirection=DESC`,
+      `${clientOptions.baseUrl}/api/stored/agents/test-agent/versions?page=0&perPage=10&orderBy%5Bfield%5D=createdAt&orderBy%5Bdirection%5D=DESC`,
       expect.objectContaining({
         headers: expect.objectContaining(clientOptions.headers),
       }),

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -303,8 +303,14 @@ export class Agent extends BaseResource {
     const queryParams = new URLSearchParams();
     if (params?.page !== undefined) queryParams.set('page', String(params.page));
     if (params?.perPage !== undefined) queryParams.set('perPage', String(params.perPage));
-    if (params?.orderBy) queryParams.set('orderBy', params.orderBy);
-    if (params?.sortDirection) queryParams.set('sortDirection', params.sortDirection);
+    if (params?.orderBy) {
+      if (params.orderBy.field) {
+        queryParams.set('orderBy[field]', params.orderBy.field);
+      }
+      if (params.orderBy.direction) {
+        queryParams.set('orderBy[direction]', params.orderBy.direction);
+      }
+    }
 
     const queryString = queryParams.toString();
     const contextString = requestContextQueryString(requestContext);

--- a/client-sdks/client-js/src/resources/stored-agent.test.ts
+++ b/client-sdks/client-js/src/resources/stored-agent.test.ts
@@ -305,12 +305,11 @@ describe('StoredAgent Resource', () => {
         const result = await storedAgent.listVersions({
           page: 1,
           perPage: 5,
-          orderBy: 'createdAt',
-          sortDirection: 'DESC',
+          orderBy: { field: 'createdAt', direction: 'DESC' },
         });
         expect(result).toEqual(mockResponse);
         expect(global.fetch).toHaveBeenCalledWith(
-          `${clientOptions.baseUrl}/api/stored/agents/${storedAgentId}/versions?page=1&perPage=5&orderBy=createdAt&sortDirection=DESC`,
+          `${clientOptions.baseUrl}/api/stored/agents/${storedAgentId}/versions?page=1&perPage=5&orderBy%5Bfield%5D=createdAt&orderBy%5Bdirection%5D=DESC`,
           expect.objectContaining({
             headers: expect.objectContaining(clientOptions.headers),
           }),

--- a/client-sdks/client-js/src/resources/stored-agent.ts
+++ b/client-sdks/client-js/src/resources/stored-agent.ts
@@ -94,8 +94,14 @@ export class StoredAgent extends BaseResource {
     const queryParams = new URLSearchParams();
     if (params?.page !== undefined) queryParams.set('page', String(params.page));
     if (params?.perPage !== undefined) queryParams.set('perPage', String(params.perPage));
-    if (params?.orderBy) queryParams.set('orderBy', params.orderBy);
-    if (params?.sortDirection) queryParams.set('sortDirection', params.sortDirection);
+    if (params?.orderBy) {
+      if (params.orderBy.field) {
+        queryParams.set('orderBy[field]', params.orderBy.field);
+      }
+      if (params.orderBy.direction) {
+        queryParams.set('orderBy[direction]', params.orderBy.direction);
+      }
+    }
 
     const queryString = queryParams.toString();
     const contextString = requestContextQueryString(requestContext);

--- a/client-sdks/client-js/src/resources/stored-prompt-block.ts
+++ b/client-sdks/client-js/src/resources/stored-prompt-block.ts
@@ -94,8 +94,14 @@ export class StoredPromptBlock extends BaseResource {
     const queryParams = new URLSearchParams();
     if (params?.page !== undefined) queryParams.set('page', String(params.page));
     if (params?.perPage !== undefined) queryParams.set('perPage', String(params.perPage));
-    if (params?.orderBy) queryParams.set('orderBy', params.orderBy);
-    if (params?.sortDirection) queryParams.set('sortDirection', params.sortDirection);
+    if (params?.orderBy) {
+      if (params.orderBy.field) {
+        queryParams.set('orderBy[field]', params.orderBy.field);
+      }
+      if (params.orderBy.direction) {
+        queryParams.set('orderBy[direction]', params.orderBy.direction);
+      }
+    }
 
     const queryString = queryParams.toString();
     const contextString = requestContextQueryString(requestContext, queryString ? '&' : '?');

--- a/client-sdks/client-js/src/resources/stored-scorer.ts
+++ b/client-sdks/client-js/src/resources/stored-scorer.ts
@@ -95,8 +95,14 @@ export class StoredScorer extends BaseResource {
     const queryParams = new URLSearchParams();
     if (params?.page !== undefined) queryParams.set('page', String(params.page));
     if (params?.perPage !== undefined) queryParams.set('perPage', String(params.perPage));
-    if (params?.orderBy) queryParams.set('orderBy', params.orderBy);
-    if (params?.sortDirection) queryParams.set('sortDirection', params.sortDirection);
+    if (params?.orderBy) {
+      if (params.orderBy.field) {
+        queryParams.set('orderBy[field]', params.orderBy.field);
+      }
+      if (params.orderBy.direction) {
+        queryParams.set('orderBy[direction]', params.orderBy.direction);
+      }
+    }
 
     const queryString = queryParams.toString();
     const contextString = requestContextQueryString(requestContext);

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -609,8 +609,10 @@ export interface ListMemoryThreadsParams {
   agentId?: string;
   page?: number;
   perPage?: number;
-  orderBy?: 'createdAt' | 'updatedAt';
-  sortDirection?: 'ASC' | 'DESC';
+  orderBy?: {
+    field?: 'createdAt' | 'updatedAt';
+    direction?: 'ASC' | 'DESC';
+  };
   requestContext?: RequestContext | Record<string, any>;
 }
 
@@ -1469,8 +1471,10 @@ export interface AgentVersionResponse {
 export interface ListAgentVersionsParams {
   page?: number;
   perPage?: number;
-  orderBy?: 'versionNumber' | 'createdAt';
-  sortDirection?: 'ASC' | 'DESC';
+  orderBy?: {
+    field?: 'versionNumber' | 'createdAt';
+    direction?: 'ASC' | 'DESC';
+  };
 }
 
 export interface ListAgentVersionsResponse {
@@ -1558,8 +1562,10 @@ export interface ScorerVersionResponse {
 export interface ListScorerVersionsParams {
   page?: number;
   perPage?: number;
-  orderBy?: 'versionNumber' | 'createdAt';
-  sortDirection?: 'ASC' | 'DESC';
+  orderBy?: {
+    field?: 'versionNumber' | 'createdAt';
+    direction?: 'ASC' | 'DESC';
+  };
 }
 
 export interface ListScorerVersionsResponse {
@@ -2487,8 +2493,10 @@ export interface PromptBlockVersionResponse {
 export interface ListPromptBlockVersionsParams {
   page?: number;
   perPage?: number;
-  orderBy?: 'versionNumber' | 'createdAt';
-  sortDirection?: 'ASC' | 'DESC';
+  orderBy?: {
+    field?: 'versionNumber' | 'createdAt';
+    direction?: 'ASC' | 'DESC';
+  };
 }
 
 export interface ListPromptBlockVersionsResponse {

--- a/packages/playground/src/domains/agents/hooks/use-agent-cms-form.ts
+++ b/packages/playground/src/domains/agents/hooks/use-agent-cms-form.ts
@@ -317,7 +317,7 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
             // Now activate the first version
             const versionsResponse = await client
               .getStoredAgent(options.agentId)
-              .listVersions({ sortDirection: 'DESC', perPage: 1 });
+              .listVersions({ orderBy: { direction: 'DESC' }, perPage: 1 });
             const latestVersion = versionsResponse.versions[0];
             if (latestVersion) {
               await client.getStoredAgent(options.agentId).activateVersion(latestVersion.id);
@@ -326,7 +326,7 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
             // Check if there's an unpublished draft version to activate
             const [agentDetails, versionsResponse] = await Promise.all([
               client.getStoredAgent(options.agentId).details(),
-              client.getStoredAgent(options.agentId).listVersions({ sortDirection: 'DESC', perPage: 1 }),
+              client.getStoredAgent(options.agentId).listVersions({ orderBy: { direction: 'DESC' }, perPage: 1 }),
             ]);
 
             const latestVersion = versionsResponse.versions[0];

--- a/packages/playground/src/domains/agents/hooks/use-agent-cms-form.ts
+++ b/packages/playground/src/domains/agents/hooks/use-agent-cms-form.ts
@@ -317,7 +317,7 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
             // Now activate the first version
             const versionsResponse = await client
               .getStoredAgent(options.agentId)
-              .listVersions({ orderBy: { direction: 'DESC' }, perPage: 1 });
+              .listVersions({ orderBy: { field: 'createdAt', direction: 'DESC' }, perPage: 1 });
             const latestVersion = versionsResponse.versions[0];
             if (latestVersion) {
               await client.getStoredAgent(options.agentId).activateVersion(latestVersion.id);
@@ -326,7 +326,9 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
             // Check if there's an unpublished draft version to activate
             const [agentDetails, versionsResponse] = await Promise.all([
               client.getStoredAgent(options.agentId).details(),
-              client.getStoredAgent(options.agentId).listVersions({ orderBy: { direction: 'DESC' }, perPage: 1 }),
+              client
+                .getStoredAgent(options.agentId)
+                .listVersions({ orderBy: { field: 'createdAt', direction: 'DESC' }, perPage: 1 }),
             ]);
 
             const latestVersion = versionsResponse.versions[0];


### PR DESCRIPTION
## Summary

Five SDK list methods were sending `orderBy` and `sortDirection` as flat query string params, but the server expects `orderBy` as a structured object (`{ field, direction }`) and parses bracket-notation params (`orderBy[field]=...&orderBy[direction]=...`) back into an object before Zod validation. The flat-string shape failed server-side schema validation.

This PR aligns the SDK with the server contract.

## Affected methods

- \`MastraClient.listMemoryThreads\`
- \`Agent.listVersions\`
- \`StoredAgent.listVersions\`
- \`StoredPromptBlock.listVersions\`
- \`StoredScorer.listVersions\`

## Before

\`\`\`ts
client.listMemoryThreads({ orderBy: 'createdAt', sortDirection: 'DESC' });
// → GET /api/memory/threads?orderBy=createdAt&sortDirection=DESC  (rejected by server)
\`\`\`

## After

\`\`\`ts
client.listMemoryThreads({ orderBy: { field: 'createdAt', direction: 'DESC' } });
// → GET /api/memory/threads?orderBy[field]=createdAt&orderBy[direction]=DESC
\`\`\`

## Changes

- Param types in \`types.ts\` updated to nested \`orderBy\` object; flat \`sortDirection\` field removed
- Resource methods serialize bracket-notation query params
- Playground callers in \`use-agent-cms-form.ts\` migrated
- Existing unit tests updated to assert the new query-string shape

## Test plan

- \`pnpm --filter @mastra/client-js exec vitest run src/resources/agent.test.ts src/resources/stored-agent.test.ts src/client.test.ts\` — passing (1 pre-existing vNext stream failure unrelated)
- \`pnpm --filter @internal/playground exec tsc --noEmit\` — clean
- \`pnpm --filter @mastra/client-js lint\` — clean
- Internal contract-audit script: 5 \`orderBy\` drift cases drop out of the report

## Related

Part of the @mastra/client-js ↔ server contract drift cleanup tracked in #16292.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The SDK was sending sorting options to the server in the wrong shape. Instead of sending the sort field and direction together, it sent them separately — the server wants them bundled as an object in bracketed query params. This PR updates five list methods to send the correct bundled format.

---

## Summary

Fixes a contract mismatch between the client-js SDK and the server for paginated list endpoints: the server expects ordering as a structured `orderBy` object (`{ field, direction }`) encoded via bracket-notation query params, but the SDK was sending flat `orderBy` and `sortDirection` query params which failed server-side validation. The PR updates types, request serialization, a playground caller, and tests to align with the server contract.

### Affected methods
- MastraClient.listMemoryThreads
- Agent.listVersions
- StoredAgent.listVersions
- StoredPromptBlock.listVersions
- StoredScorer.listVersions

### Key changes
- Types: Replace flat `orderBy: string` + `sortDirection` with `orderBy?: { field?: ..., direction?: ... }` for relevant List*Params in client-sdks/client-js/src/types.ts.
- Request serialization: Resource methods now serialize `orderBy` into bracket-notation query params (`orderBy[field]=...&orderBy[direction]=...`) instead of `orderBy=...&sortDirection=...` (client.ts, agent.ts, stored-agent.ts, stored-prompt-block.ts, stored-scorer.ts).
- Playground: Updated use-agent-cms-form to pass `{ orderBy: { field: 'createdAt', direction: 'DESC' } }` when fetching the latest version in publish flows.
- Tests: Updated expectations in agent.test.ts and stored-agent.test.ts to assert the new bracketed query-string shape.
- Changeset/commits: Added a changeset to bump @mastra/client-js (minor) and adjusted a playground lookup to be deterministic; noted public-source-level breaking change (removal of top-level sortDirection).

### Before / After example
Before (rejected by server):
client.listMemoryThreads({ orderBy: 'createdAt', sortDirection: 'DESC' })
→ GET ...?orderBy=createdAt&sortDirection=DESC

After (accepted by server):
client.listMemoryThreads({ orderBy: { field: 'createdAt', direction: 'DESC' } })
→ GET ...?orderBy[field]=createdAt&orderBy[direction]=DESC

### Tests & validation
- Vitest unit tests updated and run (one unrelated, pre-existing failure remains).
- Playground TypeScript build clean.
- Client lint clean.
- Internal contract audit reports five orderBy drift cases resolved.

Related: part of broader client-js ↔ server contract drift cleanup tracked in #16292.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->