### PR TITLE
Fix Postgres observability discovery for Studio

### DIFF
--- a/.changeset/hot-files-draw.md
+++ b/.changeset/hot-files-draw.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed Postgres observability discovery endpoints so Studio can load span entity filters without unsupported storage errors.

--- a/stores/pg/src/storage/domains/observability/discovery.test.ts
+++ b/stores/pg/src/storage/domains/observability/discovery.test.ts
@@ -1,6 +1,7 @@
+import { MastraError } from '@mastra/core/error';
 import { EntityType, SpanType } from '@mastra/core/observability';
 import { Pool } from 'pg';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { connectionString } from '../../test-utils';
 import { ObservabilityPG } from './index';
@@ -96,5 +97,42 @@ describe('ObservabilityPG discovery', () => {
     await expect(storage.getTags({})).resolves.toEqual({
       tags: ['agent', 'chef', 'tool', 'weather'],
     });
+  });
+
+  it('normalizes database errors from discovery queries', async () => {
+    const cause = new Error('database unavailable');
+    const storageWithFailingClient = new ObservabilityPG({
+      client: {
+        manyOrNone: vi.fn().mockRejectedValue(cause),
+      } as any,
+    });
+
+    const cases: Array<[string, () => Promise<unknown>, string]> = [
+      ['entity types', () => storageWithFailingClient.getEntityTypes({}), 'Failed to fetch entityTypes from storage'],
+      [
+        'entity names',
+        () => storageWithFailingClient.getEntityNames({ entityType: EntityType.AGENT }),
+        'Failed to fetch entityNames from storage',
+      ],
+      [
+        'service names',
+        () => storageWithFailingClient.getServiceNames({}),
+        'Failed to fetch serviceNames from storage',
+      ],
+      ['environments', () => storageWithFailingClient.getEnvironments({}), 'Failed to fetch environments from storage'],
+      [
+        'tags',
+        () => storageWithFailingClient.getTags({ entityType: EntityType.AGENT }),
+        'Failed to fetch tags from storage',
+      ],
+    ];
+
+    for (const [_name, callDiscoveryMethod, message] of cases) {
+      await expect(callDiscoveryMethod()).rejects.toMatchObject({
+        message,
+        cause: expect.objectContaining({ message: cause.message }),
+      });
+      await expect(callDiscoveryMethod()).rejects.toBeInstanceOf(MastraError);
+    }
   });
 });

--- a/stores/pg/src/storage/domains/observability/discovery.test.ts
+++ b/stores/pg/src/storage/domains/observability/discovery.test.ts
@@ -1,0 +1,100 @@
+import { EntityType, SpanType } from '@mastra/core/observability';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { connectionString } from '../../test-utils';
+import { ObservabilityPG } from './index';
+
+describe('ObservabilityPG discovery', () => {
+  let pool: Pool;
+  let storage: ObservabilityPG;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString });
+    storage = new ObservabilityPG({ pool });
+    await storage.init();
+  });
+
+  beforeEach(async () => {
+    await storage.dangerouslyClearAll();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('returns distinct entity names filtered by entity type', async () => {
+    const startedAt = new Date('2026-01-01T00:00:00.000Z');
+
+    await storage.createSpan({
+      span: {
+        traceId: 'trace-1',
+        spanId: 'span-1',
+        name: 'agent span',
+        spanType: SpanType.AGENT_RUN,
+        isEvent: false,
+        startedAt,
+        entityType: EntityType.AGENT,
+        entityId: 'agent-1',
+        entityName: 'Chef Agent',
+        serviceName: 'agent-service',
+        environment: 'production',
+        tags: ['agent', 'chef'],
+      },
+    });
+    await storage.createSpan({
+      span: {
+        traceId: 'trace-2',
+        spanId: 'span-2',
+        name: 'duplicate agent span',
+        spanType: SpanType.AGENT_RUN,
+        isEvent: false,
+        startedAt,
+        entityType: EntityType.AGENT,
+        entityId: 'agent-2',
+        entityName: 'Chef Agent',
+        serviceName: 'agent-service',
+        environment: 'production',
+        tags: ['agent'],
+      },
+    });
+    await storage.createSpan({
+      span: {
+        traceId: 'trace-3',
+        spanId: 'span-3',
+        name: 'tool span',
+        spanType: SpanType.TOOL_CALL,
+        isEvent: false,
+        startedAt,
+        entityType: EntityType.TOOL,
+        entityId: 'tool-1',
+        entityName: 'Weather Tool',
+        serviceName: 'tool-service',
+        environment: 'staging',
+        tags: ['tool', 'weather'],
+      },
+    });
+
+    await expect(storage.getEntityTypes({})).resolves.toEqual({
+      entityTypes: [EntityType.AGENT, EntityType.TOOL],
+    });
+    await expect(storage.getEntityNames({ entityType: EntityType.AGENT })).resolves.toEqual({
+      names: ['Chef Agent'],
+    });
+    await expect(storage.getEntityNames({})).resolves.toEqual({
+      names: ['Chef Agent', 'Weather Tool'],
+    });
+    await expect(storage.getServiceNames({})).resolves.toEqual({
+      serviceNames: ['agent-service', 'tool-service'],
+    });
+    await expect(storage.getEnvironments({})).resolves.toEqual({
+      environments: ['production', 'staging'],
+    });
+    await expect(storage.getTags({ entityType: EntityType.AGENT })).resolves.toEqual({
+      tags: ['agent', 'chef'],
+    });
+    await expect(storage.getTags({})).resolves.toEqual({
+      tags: ['agent', 'chef', 'tool', 'weather'],
+    });
+  });
+});

--- a/stores/pg/src/storage/domains/observability/index.ts
+++ b/stores/pg/src/storage/domains/observability/index.ts
@@ -250,89 +250,151 @@ export class ObservabilityPG extends ObservabilityStorage {
   }
 
   async getEntityTypes(_args: GetEntityTypesArgs): Promise<GetEntityTypesResponse> {
-    const tableName = getTableName({
-      indexName: TABLE_SPANS,
-      schemaName: getSchemaName(this.#schema),
-    });
-    const rows = await this.#db.client.manyOrNone<{ entityType: string }>(
-      `SELECT DISTINCT "entityType" FROM ${tableName} WHERE "entityType" IS NOT NULL ORDER BY "entityType"`,
-    );
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_SPANS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const rows = await this.#db.client.manyOrNone<{ entityType: string }>(
+        `SELECT DISTINCT "entityType" FROM ${tableName} WHERE "entityType" IS NOT NULL ORDER BY "entityType"`,
+      );
 
-    const validTypes = new Set(Object.values(EntityType));
-    const entityTypes = rows
-      .map(row => row.entityType)
-      .filter((entityType): entityType is EntityType => validTypes.has(entityType as EntityType));
+      const validTypes = new Set(Object.values(EntityType));
+      const entityTypes = rows
+        .map(row => row.entityType)
+        .filter((entityType): entityType is EntityType => validTypes.has(entityType as EntityType));
 
-    return { entityTypes };
+      return { entityTypes };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_ENTITY_TYPES', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: 'Failed to fetch entityTypes from storage',
+        },
+        error,
+      );
+    }
   }
 
   async getEntityNames(args: GetEntityNamesArgs): Promise<GetEntityNamesResponse> {
-    const tableName = getTableName({
-      indexName: TABLE_SPANS,
-      schemaName: getSchemaName(this.#schema),
-    });
-    const conditions = [`"entityName" IS NOT NULL`];
-    const params: string[] = [];
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_SPANS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const conditions = [`"entityName" IS NOT NULL`];
+      const params: string[] = [];
 
-    if (args.entityType) {
-      params.push(args.entityType);
-      conditions.push(`"entityType" = $${params.length}`);
+      if (args.entityType) {
+        params.push(args.entityType);
+        conditions.push(`"entityType" = $${params.length}`);
+      }
+
+      const rows = await this.#db.client.manyOrNone<{ entityName: string }>(
+        `SELECT DISTINCT "entityName" FROM ${tableName} WHERE ${conditions.join(' AND ')} ORDER BY "entityName"`,
+        params,
+      );
+
+      return { names: rows.map(row => row.entityName) };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_ENTITY_NAMES', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: 'Failed to fetch entityNames from storage',
+          ...(args.entityType ? { details: { entityType: args.entityType } } : {}),
+        },
+        error,
+      );
     }
-
-    const rows = await this.#db.client.manyOrNone<{ entityName: string }>(
-      `SELECT DISTINCT "entityName" FROM ${tableName} WHERE ${conditions.join(' AND ')} ORDER BY "entityName"`,
-      params,
-    );
-
-    return { names: rows.map(row => row.entityName) };
   }
 
   async getServiceNames(_args: GetServiceNamesArgs): Promise<GetServiceNamesResponse> {
-    const tableName = getTableName({
-      indexName: TABLE_SPANS,
-      schemaName: getSchemaName(this.#schema),
-    });
-    const rows = await this.#db.client.manyOrNone<{ serviceName: string }>(
-      `SELECT DISTINCT "serviceName" FROM ${tableName} WHERE "serviceName" IS NOT NULL ORDER BY "serviceName"`,
-    );
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_SPANS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const rows = await this.#db.client.manyOrNone<{ serviceName: string }>(
+        `SELECT DISTINCT "serviceName" FROM ${tableName} WHERE "serviceName" IS NOT NULL ORDER BY "serviceName"`,
+      );
 
-    return { serviceNames: rows.map(row => row.serviceName) };
+      return { serviceNames: rows.map(row => row.serviceName) };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_SERVICE_NAMES', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: 'Failed to fetch serviceNames from storage',
+        },
+        error,
+      );
+    }
   }
 
   async getEnvironments(_args: GetEnvironmentsArgs): Promise<GetEnvironmentsResponse> {
-    const tableName = getTableName({
-      indexName: TABLE_SPANS,
-      schemaName: getSchemaName(this.#schema),
-    });
-    const rows = await this.#db.client.manyOrNone<{ environment: string }>(
-      `SELECT DISTINCT "environment" FROM ${tableName} WHERE "environment" IS NOT NULL ORDER BY "environment"`,
-    );
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_SPANS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const rows = await this.#db.client.manyOrNone<{ environment: string }>(
+        `SELECT DISTINCT "environment" FROM ${tableName} WHERE "environment" IS NOT NULL ORDER BY "environment"`,
+      );
 
-    return { environments: rows.map(row => row.environment) };
+      return { environments: rows.map(row => row.environment) };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_ENVIRONMENTS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: 'Failed to fetch environments from storage',
+        },
+        error,
+      );
+    }
   }
 
   async getTags(args: GetTagsArgs): Promise<GetTagsResponse> {
-    const tableName = getTableName({
-      indexName: TABLE_SPANS,
-      schemaName: getSchemaName(this.#schema),
-    });
-    const conditions = [`"tags" IS NOT NULL`, `jsonb_typeof("tags") = 'array'`];
-    const params: string[] = [];
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_SPANS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const conditions = [`"tags" IS NOT NULL`, `jsonb_typeof("tags") = 'array'`];
+      const params: string[] = [];
 
-    if (args.entityType) {
-      params.push(args.entityType);
-      conditions.push(`"entityType" = $${params.length}`);
+      if (args.entityType) {
+        params.push(args.entityType);
+        conditions.push(`"entityType" = $${params.length}`);
+      }
+
+      const rows = await this.#db.client.manyOrNone<{ tag: string }>(
+        `SELECT DISTINCT jsonb_array_elements_text("tags") AS tag
+        FROM ${tableName}
+        WHERE ${conditions.join(' AND ')}
+        ORDER BY tag`,
+        params,
+      );
+
+      return { tags: rows.map(row => row.tag) };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_TAGS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: 'Failed to fetch tags from storage',
+          ...(args.entityType ? { details: { entityType: args.entityType } } : {}),
+        },
+        error,
+      );
     }
-
-    const rows = await this.#db.client.manyOrNone<{ tag: string }>(
-      `SELECT DISTINCT jsonb_array_elements_text("tags") AS tag
-      FROM ${tableName}
-      WHERE ${conditions.join(' AND ')}
-      ORDER BY tag`,
-      params,
-    );
-
-    return { tags: rows.map(row => row.tag) };
   }
 
   public override get tracingStrategy(): {

--- a/stores/pg/src/storage/domains/observability/index.ts
+++ b/stores/pg/src/storage/domains/observability/index.ts
@@ -1,6 +1,7 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   createStorageErrorId,
+  EntityType,
   listTracesArgsSchema,
   ObservabilityStorage,
   TABLE_SCHEMAS,
@@ -27,6 +28,16 @@ import type {
   GetTraceLightResponse,
   LightSpanRecord,
   CreateIndexOptions,
+  GetEntityTypesArgs,
+  GetEntityTypesResponse,
+  GetEntityNamesArgs,
+  GetEntityNamesResponse,
+  GetServiceNamesArgs,
+  GetServiceNamesResponse,
+  GetEnvironmentsArgs,
+  GetEnvironmentsResponse,
+  GetTagsArgs,
+  GetTagsResponse,
 } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
 import { PgDB, resolvePgConfig, generateTableSQL, generateIndexSQL, generateTimestampTriggerSQL } from '../../db';
@@ -236,6 +247,92 @@ export class ObservabilityPG extends ObservabilityStorage {
 
   async dangerouslyClearAll(): Promise<void> {
     await this.#db.clearTable({ tableName: TABLE_SPANS });
+  }
+
+  async getEntityTypes(_args: GetEntityTypesArgs): Promise<GetEntityTypesResponse> {
+    const tableName = getTableName({
+      indexName: TABLE_SPANS,
+      schemaName: getSchemaName(this.#schema),
+    });
+    const rows = await this.#db.client.manyOrNone<{ entityType: string }>(
+      `SELECT DISTINCT "entityType" FROM ${tableName} WHERE "entityType" IS NOT NULL ORDER BY "entityType"`,
+    );
+
+    const validTypes = new Set(Object.values(EntityType));
+    const entityTypes = rows
+      .map(row => row.entityType)
+      .filter((entityType): entityType is EntityType => validTypes.has(entityType as EntityType));
+
+    return { entityTypes };
+  }
+
+  async getEntityNames(args: GetEntityNamesArgs): Promise<GetEntityNamesResponse> {
+    const tableName = getTableName({
+      indexName: TABLE_SPANS,
+      schemaName: getSchemaName(this.#schema),
+    });
+    const conditions = [`"entityName" IS NOT NULL`];
+    const params: string[] = [];
+
+    if (args.entityType) {
+      params.push(args.entityType);
+      conditions.push(`"entityType" = $${params.length}`);
+    }
+
+    const rows = await this.#db.client.manyOrNone<{ entityName: string }>(
+      `SELECT DISTINCT "entityName" FROM ${tableName} WHERE ${conditions.join(' AND ')} ORDER BY "entityName"`,
+      params,
+    );
+
+    return { names: rows.map(row => row.entityName) };
+  }
+
+  async getServiceNames(_args: GetServiceNamesArgs): Promise<GetServiceNamesResponse> {
+    const tableName = getTableName({
+      indexName: TABLE_SPANS,
+      schemaName: getSchemaName(this.#schema),
+    });
+    const rows = await this.#db.client.manyOrNone<{ serviceName: string }>(
+      `SELECT DISTINCT "serviceName" FROM ${tableName} WHERE "serviceName" IS NOT NULL ORDER BY "serviceName"`,
+    );
+
+    return { serviceNames: rows.map(row => row.serviceName) };
+  }
+
+  async getEnvironments(_args: GetEnvironmentsArgs): Promise<GetEnvironmentsResponse> {
+    const tableName = getTableName({
+      indexName: TABLE_SPANS,
+      schemaName: getSchemaName(this.#schema),
+    });
+    const rows = await this.#db.client.manyOrNone<{ environment: string }>(
+      `SELECT DISTINCT "environment" FROM ${tableName} WHERE "environment" IS NOT NULL ORDER BY "environment"`,
+    );
+
+    return { environments: rows.map(row => row.environment) };
+  }
+
+  async getTags(args: GetTagsArgs): Promise<GetTagsResponse> {
+    const tableName = getTableName({
+      indexName: TABLE_SPANS,
+      schemaName: getSchemaName(this.#schema),
+    });
+    const conditions = [`"tags" IS NOT NULL`, `jsonb_typeof("tags") = 'array'`];
+    const params: string[] = [];
+
+    if (args.entityType) {
+      params.push(args.entityType);
+      conditions.push(`"entityType" = $${params.length}`);
+    }
+
+    const rows = await this.#db.client.manyOrNone<{ tag: string }>(
+      `SELECT DISTINCT jsonb_array_elements_text("tags") AS tag
+      FROM ${tableName}
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY tag`,
+      params,
+    );
+
+    return { tags: rows.map(row => row.tag) };
   }
 
   public override get tracingStrategy(): {


### PR DESCRIPTION
## Description

Fixes Postgres observability discovery so Mastra Studio can load observability filter data without throwing unsupported storage errors.
Implemented discovery methods in `ObservabilityPG`:
  - `getEntityTypes`
  - `getEntityNames`
  - `getServiceNames`
  - `getEnvironments`
  - `getTags`

## Related Issue(s)

Fixes #16304 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes a bug that prevented Mastra Studio from loading observability filters when using the Postgres adapter by adding the missing discovery queries and making their DB errors return consistent MastraError values. Studio can now list entity types, names, services, environments, and tags from Postgres without triggering "unsupported storage" failures.

## Changes

- Implements observability discovery methods in ObservabilityPG:
  - getEntityTypes(args): returns distinct entity types from the spans table.
  - getEntityNames(args): returns distinct entity names, optionally filtered by entityType.
  - getServiceNames(args): returns distinct service names.
  - getEnvironments(args): returns distinct environment values.
  - getTags(args): returns distinct tags, optionally filtered by entityType (extracts tag strings from JSONB tags array).
- Each method derives the schema-qualified spans table name, runs SELECT DISTINCT queries with IS NOT NULL filters, and returns typed response objects.
- Database failures in these discovery methods are normalized into MastraError (storage-specific error IDs and messages), ensuring consistent error handling for callers (e.g., Studio).

## Testing

- Adds an integration test suite (stores/pg/.../discovery.test.ts) that:
  - Seeds spans for agent and tool entity types (including duplicate names).
  - Asserts distinct, aggregated results for entity types, entity names (filtered/unfiltered), service names, environments, and tags (filtered/unfiltered).
  - Verifies discovery methods normalize DB client failures into MastraError with method-specific failure messages.

## Impact

- Fixes issue where Studio failed to load observability filter data with the Postgres adapter (resolves linked issue #16304).
- Classified as a bug fix; includes tests and a patch changeset for @mastra/pg documenting the behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->