### PR TITLE
docs: add Browserless MCP integration

### DIFF
--- a/docs/src/content/en/docs/mcp/browserless.mdx
+++ b/docs/src/content/en/docs/mcp/browserless.mdx
@@ -1,0 +1,98 @@
+---
+title: 'Browserless | MCP'
+description: 'Connect Mastra agents to the Browserless MCP server for hosted browser automation.'
+packages:
+  - '@mastra/mcp'
+---
+
+# Browserless
+
+[Browserless](https://browserless.io) is a hosted browser-automation MCP server. It exposes 10 tools — search, smart scraper, map, crawl, export, performance, function, download, and a multi-turn browser agent (`browserless_agent` plus `browserless_skill`) — over a single streamable-HTTP endpoint. Browser sessions are pinned by `Mcp-Session-Id`, so multi-turn flows preserve state across calls without extra session-management code.
+
+## Setup
+
+Install the MCP package:
+
+```bash npm2yarn
+npm install @mastra/mcp
+```
+
+Get an API token at [account.browserless.io](https://account.browserless.io) and store it as `BROWSERLESS_TOKEN` in your environment.
+
+## Quickstart
+
+Connect Browserless via `MCPClient`:
+
+```typescript title="src/mastra/mcp/browserless.ts"
+import { MCPClient } from '@mastra/mcp'
+
+export const mcp = new MCPClient({
+  servers: {
+    browserless: {
+      url: new URL('https://mcp.browserless.io/mcp'),
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${process.env.BROWSERLESS_TOKEN}`,
+        },
+      },
+    },
+  },
+})
+```
+
+The `MCPClient` connects on first use and reuses the same MCP session across tool calls.
+
+## Use within an agent
+
+Pass the loaded tools to a Mastra `Agent`. The model selects which Browserless tool to call at each step.
+
+```typescript title="src/mastra/agents/researcher.ts"
+import { Agent } from '@mastra/core/agent'
+import { anthropic } from '@ai-sdk/anthropic'
+import { mcp } from '../mcp/browserless'
+
+export const researcher = new Agent({
+  name: 'Researcher',
+  instructions: 'Use the Browserless tools to scrape and summarize the web. Cite URLs.',
+  model: anthropic('claude-sonnet-4-6'),
+  tools: await mcp.listTools(),
+})
+```
+
+`mcp.listTools()` returns all 10 tools namespaced as `browserless_<toolName>`. Use `mcp.listToolsets()` if you prefer un-prefixed keys grouped by server.
+
+## Drive a stateful browser
+
+The `browserless_agent` tool drives a stateful browser. Each call (`goto`, `snapshot`, `click`, `type`, `text`, `evaluate`) operates on the same browser session as the previous call. Mastra's `MCPClient` keeps one MCP session alive across `tool.execute()` invocations, so multi-step flows preserve browser state automatically:
+
+```typescript
+const tools = await mcp.listTools()
+const agentTool = tools.browserless_browserless_agent
+
+await agentTool.execute({
+  method: 'goto',
+  params: { url: 'https://example.com' },
+})
+await agentTool.execute({ method: 'snapshot' })
+
+const result = await agentTool.execute({
+  method: 'text',
+  params: { selector: 'h1' },
+})
+// result.content[0].text → "Example Domain"
+```
+
+Snapshot the page before extracting elements so the model knows what selectors are available. Pass selector references from the snapshot when calling `text` or `click`.
+
+:::note
+
+Visit the [`MCPClient` reference](/reference/tools/mcp-client) for the full configuration API.
+
+:::
+
+## Related
+
+- [MCP overview](/docs/mcp/overview)
+- [Browserless documentation](https://docs.browserless.io)
+- [Browserless cookbook for Mastra](https://github.com/browserless/mastra-cookbook)
+- [`@mastra/mcp` package](https://github.com/mastra-ai/mastra/tree/main/packages/mcp)

--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -426,6 +426,29 @@ MCP servers can be discovered through registries. Here's how to connect to some 
 
     As an alternative to MCP, Ampersand's AI SDK also has an adapter for Mastra, so you can [directly import Ampersand tools](https://docs.withampersand.com/ai-sdk#use-with-mastra) for your agent to access.
   </TabItem>
+
+  <TabItem value="browserless" label="Browserless">
+    [Browserless](https://browserless.io) is a hosted browser-automation MCP server. It exposes 10 tools — search, smart scraper, a multi-turn browser agent, and more — over a single streamable-HTTP endpoint, with browser state preserved across calls.
+
+    ```typescript
+    import { MCPClient } from '@mastra/mcp'
+
+    export const mcp = new MCPClient({
+      servers: {
+        browserless: {
+          url: new URL('https://mcp.browserless.io/mcp'),
+          requestInit: {
+            headers: {
+              Authorization: `Bearer ${process.env.BROWSERLESS_TOKEN}`,
+            },
+          },
+        },
+      },
+    })
+    ```
+
+    Get a token at [account.browserless.io](https://account.browserless.io) and store it as `BROWSERLESS_TOKEN`. Visit the [Browserless integration page](/docs/mcp/browserless) for the multi-turn `browserless_agent` example, or the runnable [cookbook](https://github.com/browserless/mastra-cookbook).
+  </TabItem>
 </Tabs>
 
 ## MCP Apps

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -319,6 +319,11 @@ const sidebars = {
           id: 'mcp/mcp-apps',
           label: 'MCP Apps',
         },
+        {
+          type: 'doc',
+          id: 'mcp/browserless',
+          label: 'Browserless',
+        },
       ],
     },
     {


### PR DESCRIPTION
## Description

Adds Browserless to the Mastra MCP docs — a hosted browser-automation MCP server with 10 tools (search, smart scraper, multi-turn browser agent, plus six others).

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds instruction guides to help people use Browserless (a tool for automating web browsers) with Mastra. It's like adding a recipe book so users know how to set it up and use it with their Mastra projects.

## Changes

This PR adds documentation for integrating the Browserless MCP (Model Context Protocol) server with Mastra. The changes span three documentation files:

### New Documentation
**docs/src/content/en/docs/mcp/browserless.mdx** - A comprehensive integration guide covering:
- Setup instructions (installing `@mastra/mcp` and configuring `BROWSERLESS_TOKEN`)
- Quick start configuration showing how to set up an MCP server endpoint with authorization
- Usage examples demonstrating how to load Browserless tools into a Mastra `Agent`
- Multi-turn browser automation examples showing how to drive a stateful browser across multiple `execute()` calls, including snapshotting before extracting selectors

### Updated Documentation
**docs/src/content/en/docs/mcp/overview.mdx** - Added a new Browserless registry entry in the "Connecting to an MCP registry" section with code examples and links to additional resources

**docs/src/content/en/docs/sidebars.js** - Updated navigation to include the new Browserless documentation page under the MCP category

Total additions: +126 lines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->