### PR TITLE
fix(playground): forward client headers on auth actions

### DIFF
--- a/.changeset/forward-client-headers-on-auth-actions.md
+++ b/.changeset/forward-client-headers-on-auth-actions.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed Studio not forwarding custom request headers (such as `Authorization` or `x-tenant-id`) on the SSO login and logout endpoints. Headers configured in Studio settings now flow through to `/auth/sso/login` and `/auth/logout`, matching the behavior of other Studio API calls. This unblocks setups where tenant middleware or composite auth requires a header on the SSO login request.

--- a/packages/playground/src/domains/auth/hooks/__tests__/use-auth-actions.test.ts
+++ b/packages/playground/src/domains/auth/hooks/__tests__/use-auth-actions.test.ts
@@ -102,4 +102,52 @@ describe('auth actions — apiPrefix support (issue #13901)', () => {
       expect(url).toBe('http://localhost:4000/api/auth/logout');
     });
   });
+
+  describe('Client header forwarding', () => {
+    it('should forward client.options.headers on SSO login request', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({ url: 'https://sso.example.com/login' }));
+
+      const { makeSSOLoginRequest } = await import('../use-auth-actions');
+      const mockClient = {
+        options: {
+          baseUrl: 'http://localhost:4000',
+          headers: {
+            'x-tenant-id': 'tenant-123',
+            Authorization: 'Bearer dev-token',
+          },
+        },
+      };
+
+      await makeSSOLoginRequest(mockClient as any, {});
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.headers).toMatchObject({
+        'x-tenant-id': 'tenant-123',
+        Authorization: 'Bearer dev-token',
+      });
+    });
+
+    it('should forward client.options.headers on logout request', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({ success: true }));
+
+      const { makeLogoutRequest } = await import('../use-auth-actions');
+      const mockClient = {
+        options: {
+          baseUrl: 'http://localhost:4000',
+          headers: {
+            'x-tenant-id': 'tenant-123',
+            Authorization: 'Bearer dev-token',
+          },
+        },
+      };
+
+      await makeLogoutRequest(mockClient as any);
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.headers).toMatchObject({
+        'x-tenant-id': 'tenant-123',
+        Authorization: 'Bearer dev-token',
+      });
+    });
+  });
 });

--- a/packages/playground/src/domains/auth/hooks/__tests__/use-auth-actions.test.ts
+++ b/packages/playground/src/domains/auth/hooks/__tests__/use-auth-actions.test.ts
@@ -149,5 +149,43 @@ describe('auth actions — apiPrefix support (issue #13901)', () => {
         Authorization: 'Bearer dev-token',
       });
     });
+
+    it('should not allow client headers to override Content-Type on SSO login', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({ url: 'https://sso.example.com/login' }));
+
+      const { makeSSOLoginRequest } = await import('../use-auth-actions');
+      const mockClient = {
+        options: {
+          baseUrl: 'http://localhost:4000',
+          headers: {
+            'Content-Type': 'text/plain',
+          },
+        },
+      };
+
+      await makeSSOLoginRequest(mockClient as any, {});
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    });
+
+    it('should not allow client headers to override Content-Type on logout', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({ success: true }));
+
+      const { makeLogoutRequest } = await import('../use-auth-actions');
+      const mockClient = {
+        options: {
+          baseUrl: 'http://localhost:4000',
+          headers: {
+            'Content-Type': 'text/plain',
+          },
+        },
+      };
+
+      await makeLogoutRequest(mockClient as any);
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    });
   });
 });

--- a/packages/playground/src/domains/auth/hooks/use-auth-actions.ts
+++ b/packages/playground/src/domains/auth/hooks/use-auth-actions.ts
@@ -41,7 +41,7 @@ export async function makeSSOLoginRequest(
   client: { options: any },
   { redirectUri }: { redirectUri?: string },
 ): Promise<SSOLoginResponse> {
-  const { baseUrl = '', apiPrefix } = client.options || {};
+  const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options || {};
   const raw = (apiPrefix || '/api').trim();
   const prefix = (raw.startsWith('/') ? raw : `/${raw}`).replace(/\/$/, '');
 
@@ -55,6 +55,7 @@ export async function makeSSOLoginRequest(
   const response = await fetch(url, {
     credentials: 'include',
     headers: {
+      ...clientHeaders,
       'Content-Type': 'application/json',
     },
   });
@@ -116,7 +117,7 @@ export function useSSOLogin() {
  * @internal
  */
 export async function makeLogoutRequest(client: { options: any }): Promise<LogoutResponse> {
-  const { baseUrl = '', apiPrefix } = client.options || {};
+  const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options || {};
   const raw = (apiPrefix || '/api').trim();
   const prefix = (raw.startsWith('/') ? raw : `/${raw}`).replace(/\/$/, '');
 
@@ -124,6 +125,7 @@ export async function makeLogoutRequest(client: { options: any }): Promise<Logou
     method: 'POST',
     credentials: 'include',
     headers: {
+      ...clientHeaders,
       'Content-Type': 'application/json',
     },
   });

--- a/packages/playground/src/domains/auth/hooks/use-auth-capabilities.ts
+++ b/packages/playground/src/domains/auth/hooks/use-auth-capabilities.ts
@@ -18,8 +18,8 @@ export async function makeAuthCapabilitiesRequest(client: MastraClient): Promise
   const response = await fetch(`${baseUrl}${prefix}/auth/capabilities`, {
     credentials: 'include',
     headers: {
-      'Content-Type': 'application/json',
       ...clientHeaders,
+      'Content-Type': 'application/json',
     },
   });
 


### PR DESCRIPTION
Closes #15470

Studio's `makeSSOLoginRequest` and `makeLogoutRequest` were calling `fetch` with only `Content-Type`, silently dropping any custom headers configured in Studio settings. This broke prod setups behind tenant middleware or composite auth that require a header (e.g. `x-tenant-id`, `Authorization`) on `/auth/sso/login`.

Now spreads `client.options.headers` into both calls, matching the pattern already used in `use-auth-capabilities`. `Content-Type` is placed after the spread so user headers can't accidentally override it.

Before:
```ts
await fetch(url, {
  credentials: 'include',
  headers: { 'Content-Type': 'application/json' },
});
```

After:
```ts
const { headers: clientHeaders = {} } = client.options || {};
await fetch(url, {
  credentials: 'include',
  headers: { ...clientHeaders, 'Content-Type': 'application/json' },
});
```

Added unit tests covering header forwarding for both `makeSSOLoginRequest` and `makeLogoutRequest`. Same defensive `Content-Type` ordering applied to `use-auth-capabilities` for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When Studio sends a login or logout request, it was accidentally leaving out custom ID badges (custom headers) the user configured. This PR makes Studio include those badges so servers that need them can authenticate Studio correctly.

## Overview

For SSO login and logout, Studio now forwards headers from client.options.headers into the fetch request. Previously those custom headers (e.g., x-tenant-id, Authorization) were dropped, breaking multi-tenant or middleware-protected auth flows. The change also ensures the request Content-Type remains 'application/json' by setting it after spreading client headers.

## Changes Made

- Core fix:
  - Updated makeSSOLoginRequest() and makeLogoutRequest() in packages/playground/src/domains/auth/hooks/use-auth-actions.ts to merge client.options.headers into fetch RequestInit.headers, then set 'Content-Type': 'application/json' after the spread so users cannot override it.
- Consistency:
  - Applied the same defensive header ordering to makeAuthCapabilitiesRequest() in packages/playground/src/domains/auth/hooks/use-auth-capabilities.ts.
- Tests:
  - Added/updated tests in packages/playground/src/domains/auth/hooks/__tests__/use-auth-actions.test.ts to assert client.options.headers are forwarded for SSO login and logout and that user-supplied Content-Type cannot override 'application/json'.
- Changeset:
  - .changeset/forward-client-headers-on-auth-actions.md marking @internal/playground as patched.

## Impact

- Restores ability for local Studio to authenticate against production or tenant-protected servers that require custom headers.
- Aligns SSO endpoint behavior with other Studio API calls while preserving the enforced JSON Content-Type.
- No public API signature changes; only internal behavior and tests updated.

Closes #15470
<!-- end of auto-generated comment: release notes by coderabbit.ai -->