### PR TITLE
fix(playground): stabilize streaming message rendering

### DIFF
--- a/.changeset/quiet-geese-scroll.md
+++ b/.changeset/quiet-geese-scroll.md
@@ -1,0 +1,6 @@
+---
+'@mastra/react': patch
+'@mastra/playground-ui': patch
+---
+
+Fixed Studio streaming render behavior for interleaved reasoning and improved chat autoscroll during rapid output.

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
@@ -3,7 +3,7 @@ import { ChunkFrom } from '@mastra/core/stream';
 import type { WorkflowStreamResult } from '@mastra/core/workflows';
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod/v4';
-import type { MastraUIMessage, MastraUIMessageMetadata } from '../types';
+import type { MastraExtendedTextPart, MastraUIMessage, MastraUIMessageMetadata } from '../types';
 import { toUIMessage, mapWorkflowStreamChunkToWatchResult } from './toUIMessage';
 
 describe('toUIMessage', () => {
@@ -820,6 +820,71 @@ describe('toUIMessage', () => {
         metadata: baseMetadata,
       });
       expect(result[0].id).toMatch(/^reasoning-run-123/);
+    });
+
+    it('should create separate reasoning parts when interleaved with tool calls and text', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'First thought.',
+              state: 'streaming',
+            },
+            {
+              type: 'dynamic-tool',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { query: 'weather' },
+            },
+            {
+              type: 'reasoning',
+              text: 'Second thought.',
+              state: 'streaming',
+            },
+            {
+              type: 'text',
+              text: 'Partial answer.',
+              state: 'streaming',
+              textId: 'text-1',
+            } as MastraExtendedTextPart,
+          ],
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: {
+          type: 'reasoning-delta',
+          payload: {
+            id: 'reasoning-1',
+            text: 'Third thought.',
+            providerMetadata: { model: { name: 'o1' } },
+          },
+          runId: 'run-123',
+          from: ChunkFrom.AGENT,
+        },
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].parts.map(part => part.type)).toEqual([
+        'reasoning',
+        'dynamic-tool',
+        'reasoning',
+        'text',
+        'reasoning',
+      ]);
+      expect(result[0].parts[0]).toMatchObject({ text: 'First thought.' });
+      expect(result[0].parts[2]).toMatchObject({ text: 'Second thought.' });
+      expect(result[0].parts[4]).toMatchObject({
+        type: 'reasoning',
+        text: 'Third thought.',
+        state: 'streaming',
+        providerMetadata: { model: { name: 'o1' } },
+      });
     });
   });
 

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts
@@ -322,26 +322,25 @@ export const toUIMessage = ({ chunk, conversation, metadata }: ToUIMessageArgs):
         return [...result, newMessage];
       }
 
-      // Find or create reasoning part
+      // Continue the current reasoning part only while reasoning chunks are contiguous.
+      // Interleaved tool calls/text should keep their own reasoning blocks in order.
       const parts = [...lastMessage.parts];
-      let reasoningPartIndex = parts.findIndex(part => part.type === 'reasoning');
+      const lastPartIndex = parts.length - 1;
+      const lastPart = parts[lastPartIndex];
 
-      if (reasoningPartIndex === -1) {
+      if (lastPart?.type === 'reasoning') {
+        parts[lastPartIndex] = {
+          ...lastPart,
+          text: lastPart.text + chunk.payload.text,
+          state: 'streaming',
+        };
+      } else {
         parts.push({
           type: 'reasoning',
           text: chunk.payload.text,
           state: 'streaming',
           providerMetadata: chunk.payload.providerMetadata,
         });
-      } else {
-        const reasoningPart = parts[reasoningPartIndex];
-        if (reasoningPart.type === 'reasoning') {
-          parts[reasoningPartIndex] = {
-            ...reasoningPart,
-            text: reasoningPart.text + chunk.payload.text,
-            state: 'streaming',
-          };
-        }
       }
 
       return [

--- a/packages/playground-ui/src/hooks/use-autoscroll.tsx
+++ b/packages/playground-ui/src/hooks/use-autoscroll.tsx
@@ -4,8 +4,13 @@ export interface UseAutoscrollOptions {
   enabled?: boolean;
 }
 
+const SCROLL_END_THRESHOLD = 8;
+
 export const useAutoscroll = (ref: React.RefObject<HTMLElement | null>, { enabled = true }: UseAutoscrollOptions) => {
   const shouldScrollRef = useRef(enabled);
+  const scrollFrameRef = useRef<number | null>(null);
+  const userScrollIntentRef = useRef(false);
+  const userScrollIntentTimeoutRef = useRef<number | null>(null);
 
   React.useEffect(() => {
     if (!enabled) return;
@@ -13,36 +18,88 @@ export const useAutoscroll = (ref: React.RefObject<HTMLElement | null>, { enable
 
     const area = ref.current;
 
-    const observer = new MutationObserver(() => {
-      if (shouldScrollRef.current) {
-        area.scrollTo({ top: area.scrollHeight, behavior: 'smooth' });
-      }
-    });
+    const scrollToEnd = () => {
+      if (!shouldScrollRef.current) return;
 
-    observer.observe(area, {
+      if (scrollFrameRef.current !== null) {
+        cancelAnimationFrame(scrollFrameRef.current);
+      }
+
+      scrollFrameRef.current = requestAnimationFrame(() => {
+        area.scrollTop = area.scrollHeight;
+        scrollFrameRef.current = null;
+      });
+    };
+
+    const mutationObserver = new MutationObserver(scrollToEnd);
+
+    mutationObserver.observe(area, {
       childList: true, // observe direct children changes
       subtree: true, // observe all descendants
       characterData: true, // observe text content changes
     });
 
+    const resizeObserver = new ResizeObserver(scrollToEnd);
+    resizeObserver.observe(area);
+
+    const registerUserScrollIntent = () => {
+      userScrollIntentRef.current = true;
+
+      if (userScrollIntentTimeoutRef.current !== null) {
+        window.clearTimeout(userScrollIntentTimeoutRef.current);
+      }
+
+      userScrollIntentTimeoutRef.current = window.setTimeout(() => {
+        userScrollIntentRef.current = false;
+        userScrollIntentTimeoutRef.current = null;
+      }, 250);
+    };
+
+    const cancelPendingScroll = () => {
+      if (scrollFrameRef.current !== null) {
+        cancelAnimationFrame(scrollFrameRef.current);
+        scrollFrameRef.current = null;
+      }
+    };
+
     const handleScroll = (e: Event) => {
       const scrollElement = e.target as HTMLElement;
       const currentPosition = scrollElement.scrollTop + scrollElement.clientHeight;
       const totalHeight = scrollElement.scrollHeight;
-      const isAtEnd = currentPosition >= totalHeight - 1;
+      const isAtEnd = currentPosition >= totalHeight - SCROLL_END_THRESHOLD;
 
       if (isAtEnd) {
         shouldScrollRef.current = true;
-      } else {
+        return;
+      }
+
+      if (userScrollIntentRef.current) {
         shouldScrollRef.current = false;
+        cancelPendingScroll();
       }
     };
 
+    area.addEventListener('wheel', registerUserScrollIntent, { passive: true });
+    area.addEventListener('touchmove', registerUserScrollIntent, { passive: true });
+    area.addEventListener('pointerdown', registerUserScrollIntent);
+    area.addEventListener('keydown', registerUserScrollIntent);
     area.addEventListener('scroll', handleScroll);
+    scrollToEnd();
 
     return () => {
+      area.removeEventListener('wheel', registerUserScrollIntent);
+      area.removeEventListener('touchmove', registerUserScrollIntent);
+      area.removeEventListener('pointerdown', registerUserScrollIntent);
+      area.removeEventListener('keydown', registerUserScrollIntent);
       area.removeEventListener('scroll', handleScroll);
-      observer.disconnect();
+      mutationObserver.disconnect();
+      resizeObserver.disconnect();
+      cancelPendingScroll();
+
+      if (userScrollIntentTimeoutRef.current !== null) {
+        window.clearTimeout(userScrollIntentTimeoutRef.current);
+        userScrollIntentTimeoutRef.current = null;
+      }
     };
   }, [enabled, ref]);
 };

--- a/packages/playground-ui/src/hooks/use-autoscroll.tsx
+++ b/packages/playground-ui/src/hooks/use-autoscroll.tsx
@@ -26,7 +26,9 @@ export const useAutoscroll = (ref: React.RefObject<HTMLElement | null>, { enable
       }
 
       scrollFrameRef.current = requestAnimationFrame(() => {
-        area.scrollTop = area.scrollHeight;
+        if (shouldScrollRef.current) {
+          area.scrollTop = area.scrollHeight;
+        }
         scrollFrameRef.current = null;
       });
     };
@@ -42,6 +44,18 @@ export const useAutoscroll = (ref: React.RefObject<HTMLElement | null>, { enable
     const resizeObserver = new ResizeObserver(scrollToEnd);
     resizeObserver.observe(area);
 
+    const cancelPendingScroll = () => {
+      if (scrollFrameRef.current !== null) {
+        cancelAnimationFrame(scrollFrameRef.current);
+        scrollFrameRef.current = null;
+      }
+    };
+
+    const stopFollowing = () => {
+      shouldScrollRef.current = false;
+      cancelPendingScroll();
+    };
+
     const registerUserScrollIntent = () => {
       userScrollIntentRef.current = true;
 
@@ -55,10 +69,19 @@ export const useAutoscroll = (ref: React.RefObject<HTMLElement | null>, { enable
       }, 250);
     };
 
-    const cancelPendingScroll = () => {
-      if (scrollFrameRef.current !== null) {
-        cancelAnimationFrame(scrollFrameRef.current);
-        scrollFrameRef.current = null;
+    const handleWheel = (event: WheelEvent) => {
+      registerUserScrollIntent();
+
+      if (event.deltaY < 0) {
+        stopFollowing();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      registerUserScrollIntent();
+
+      if (['ArrowUp', 'PageUp', 'Home'].includes(event.key)) {
+        stopFollowing();
       }
     };
 
@@ -79,18 +102,18 @@ export const useAutoscroll = (ref: React.RefObject<HTMLElement | null>, { enable
       }
     };
 
-    area.addEventListener('wheel', registerUserScrollIntent, { passive: true });
+    area.addEventListener('wheel', handleWheel, { passive: true });
     area.addEventListener('touchmove', registerUserScrollIntent, { passive: true });
     area.addEventListener('pointerdown', registerUserScrollIntent);
-    area.addEventListener('keydown', registerUserScrollIntent);
+    area.addEventListener('keydown', handleKeyDown);
     area.addEventListener('scroll', handleScroll);
     scrollToEnd();
 
     return () => {
-      area.removeEventListener('wheel', registerUserScrollIntent);
+      area.removeEventListener('wheel', handleWheel);
       area.removeEventListener('touchmove', registerUserScrollIntent);
       area.removeEventListener('pointerdown', registerUserScrollIntent);
-      area.removeEventListener('keydown', registerUserScrollIntent);
+      area.removeEventListener('keydown', handleKeyDown);
       area.removeEventListener('scroll', handleScroll);
       mutationObserver.disconnect();
       resizeObserver.disconnect();


### PR DESCRIPTION
This fixes two Studio rendering issues that showed up during fast streaming output.

Reasoning chunks now stay separated when a model interleaves reasoning, tool calls, and text instead of appending everything back into the first reasoning block.

Before:
```tsx
reasoning: "first thought second thought third thought"
tool call
text
```

After:
```tsx
reasoning: "first thought"
tool call
reasoning: "second thought"
text
reasoning: "third thought"
```

Autoscroll also keeps following rapid output from parallel tool calls unless the user intentionally scrolls away, so content growth alone does not disable follow mode.

## Test plan
- `pnpm --filter ./client-sdks/react test src/lib/ai-sdk/utils/toUIMessage.test.ts -- --bail 1 --reporter=dot`
- `pnpm --filter ./packages/playground-ui test -- --bail 1 --reporter=dot`
- `pnpm build:playground-ui`
- `pnpm --filter ./packages/playground build`
