### PR TITLE
feat(studio): add agent chat controls and layout foundation

### DIFF
--- a/.changeset/studio-sidebar-foundation.md
+++ b/.changeset/studio-sidebar-foundation.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Add foundation UI support for the Agent Chat layout redesign: configurable collapsed panel triggers, an IconButton barrel alias, and tooltip/className support for thread delete icon buttons.

--- a/packages/playground-ui/src/ds/components/Threads/threads.tsx
+++ b/packages/playground-ui/src/ds/components/Threads/threads.tsx
@@ -1,7 +1,6 @@
-import { X } from 'lucide-react';
 import type { ElementType } from 'react';
+import { X } from 'lucide-react';
 import { Button } from '@/ds/components/Button';
-import { Icon } from '@/ds/icons/Icon';
 import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
@@ -71,23 +70,30 @@ export const ThreadItem = ({ children, isActive, className }: ThreadItemProps) =
 
 export interface ThreadDeleteButtonProps {
   onClick: () => void;
+  tooltip?: React.ReactNode;
+  className?: string;
 }
 
-export const ThreadDeleteButton = ({ onClick }: ThreadDeleteButtonProps) => {
+export const ThreadDeleteButton = ({
+  onClick,
+  tooltip = 'Delete conversation',
+  className,
+}: ThreadDeleteButtonProps) => {
   return (
     <Button
+      tooltip={tooltip}
       variant="ghost"
+      size="icon-sm"
       className={cn(
         'shrink-0 opacity-0',
         transitions.all,
         'group-focus-within:opacity-100 group-hover:opacity-100',
         'hover:bg-surface4 hover:text-accent2',
+        className,
       )}
       onClick={onClick}
     >
-      <Icon>
-        <X aria-label="delete thread" className="text-neutral3 hover:text-accent2 transition-colors" />
-      </Icon>
+      <X aria-label="delete thread" className="text-neutral3 hover:text-accent2 transition-colors" />
     </Button>
   );
 };

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -8,6 +8,7 @@ export * from './ds/components/Avatar';
 export * from './ds/components/Badge/index';
 export * from './ds/components/Breadcrumb/index';
 export * from './ds/components/Button/index';
+export { Button as IconButton } from './ds/components/Button/index';
 export * from './ds/components/CodeEditor/index';
 export * from './ds/components/EmptyState/index';
 export * from './ds/components/Entity/index';

--- a/packages/playground-ui/src/lib/resize/collapsible-panel.tsx
+++ b/packages/playground-ui/src/lib/resize/collapsible-panel.tsx
@@ -1,23 +1,49 @@
 import { ArrowLeft, ArrowRight } from 'lucide-react';
-import { useState } from 'react';
-import type { PanelProps } from 'react-resizable-panels';
+import { useEffect, useState } from 'react';
+import type { PanelProps, PanelImperativeHandle } from 'react-resizable-panels';
 import { Panel, usePanelRef } from 'react-resizable-panels';
 import { Button } from '@/ds/components/Button/Button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { Icon } from '@/ds/icons';
 
-export interface CollapsiblePanelProps extends PanelProps {
-  direction: 'left' | 'right';
+export interface CollapsiblePanelTriggerProps {
+  tooltip?: string;
+  label?: string;
+  icon?: React.ReactNode;
 }
 
-export const CollapsiblePanel = ({ collapsedSize, children, direction, ...props }: CollapsiblePanelProps) => {
+export interface CollapsiblePanelProps extends Omit<PanelProps, 'panelRef'> {
+  direction: 'left' | 'right';
+  collapsedTrigger?: CollapsiblePanelTriggerProps;
+  panelRef?: React.RefObject<PanelImperativeHandle | null>;
+  showCollapsedTrigger?: boolean;
+  onCollapsedChange?: (collapsed: boolean) => void;
+}
+
+export const CollapsiblePanel = ({
+  collapsedSize,
+  children,
+  direction,
+  collapsedTrigger,
+  panelRef: externalPanelRef,
+  showCollapsedTrigger = true,
+  onCollapsedChange,
+  ...props
+}: CollapsiblePanelProps) => {
   const [collapsed, setCollapsed] = useState(false);
-  const panelRef = usePanelRef();
+  const internalPanelRef = usePanelRef();
+  const panelRef = externalPanelRef ?? internalPanelRef;
 
   const expand = () => {
     if (!panelRef.current) return;
     panelRef.current.expand();
   };
+
+  const defaultIcon = direction === 'left' ? <ArrowRight /> : <ArrowLeft />;
+
+  useEffect(() => {
+    onCollapsedChange?.(collapsed);
+  }, [collapsed, onCollapsedChange]);
 
   return (
     <Panel
@@ -25,7 +51,7 @@ export const CollapsiblePanel = ({ collapsedSize, children, direction, ...props 
       collapsedSize={collapsedSize}
       {...props}
       onResize={size => {
-        if (!collapsedSize) return;
+        if (collapsedSize === undefined || collapsedSize === null) return;
         if (typeof collapsedSize !== 'number') return;
 
         if (size.inPixels <= collapsedSize) {
@@ -36,17 +62,19 @@ export const CollapsiblePanel = ({ collapsedSize, children, direction, ...props 
       }}
     >
       {collapsed ? (
-        <Tooltip>
-          <div className="flex items-center justify-center h-full">
-            <TooltipTrigger asChild>
-              <Button onClick={expand} className="h-48! border-none">
-                <Icon>{direction === 'left' ? <ArrowRight /> : <ArrowLeft />}</Icon>
-              </Button>
-            </TooltipTrigger>
-          </div>
+        showCollapsedTrigger ? (
+          <Tooltip>
+            <div className="flex items-center justify-center h-full">
+              <TooltipTrigger asChild>
+                <Button onClick={expand} className="h-48! border-none">
+                  <Icon>{collapsedTrigger?.icon ?? defaultIcon}</Icon>
+                </Button>
+              </TooltipTrigger>
+            </div>
 
-          <TooltipContent>Expand</TooltipContent>
-        </Tooltip>
+            <TooltipContent>{collapsedTrigger?.tooltip ?? 'Expand'}</TooltipContent>
+          </Tooltip>
+        ) : null
       ) : (
         children
       )}

--- a/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
@@ -47,13 +47,11 @@ test.describe('agent panels', () => {
   test.describe('model settings', () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/agents/weather-agent/chat/new');
-      await page.click('text=Model settings');
+      await page.getByLabel('Chat Settings').click();
     });
 
     test('model trigger modes', async ({ page }) => {
       const generateRadio = page.getByLabel('Generate');
-      await page.click('text=Model settings');
-
       await expect(generateRadio).toBeVisible();
       await expect(generateRadio).toHaveAttribute('aria-checked', 'false');
       const streamRadio = page.getByLabel('Stream');
@@ -78,7 +76,7 @@ test.describe('agent panels', () => {
 
       // Act
       await page.reload();
-      await page.click('text=Model settings');
+      await page.getByLabel('Chat Settings').click();
       await page.click('text=Advanced Settings');
 
       // Assert

--- a/packages/playground/src/domains/agents/agent-layout.tsx
+++ b/packages/playground/src/domains/agents/agent-layout.tsx
@@ -4,6 +4,7 @@ import { useParams, useLocation } from 'react-router';
 import { AgentHeader } from './agent-header';
 import { AgentPageTabs } from '@/domains/agents/components/agent-page-tabs';
 import type { AgentPageTab } from '@/domains/agents/components/agent-page-tabs';
+import { AgentTabActions } from '@/domains/agents/components/agent-tab-actions';
 import { AgentTopBarControls } from '@/domains/agents/components/agent-top-bar-controls';
 import { PlaygroundModelProvider } from '@/domains/agents/context/playground-model-context';
 import { ReviewQueueProvider } from '@/domains/agents/context/review-queue-context';
@@ -52,7 +53,12 @@ export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
         activeTab={activeTab}
         showPlayground={showPlayground}
         showObservability={showObservability}
-        rightSlot={showTopBarControls ? <AgentTopBarControls requestContextSchema={requestContextSchema} /> : undefined}
+        rightSlot={
+          <>
+            {showTopBarControls && <AgentTopBarControls requestContextSchema={requestContextSchema} />}
+            <AgentTabActions agentId={agentId!} />
+          </>
+        }
       />
       {children}
     </MainContentLayout>

--- a/packages/playground/src/domains/agents/components/agent-chat-settings-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-chat-settings-dialog.tsx
@@ -1,0 +1,59 @@
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Tab,
+  TabContent,
+  TabList,
+  Tabs,
+} from '@mastra/playground-ui';
+
+import { useAgent } from '../hooks/use-agent';
+import { AgentSettings } from './agent-settings';
+import { TracingRunOptions } from '@/domains/observability/components/tracing-run-options';
+import { RequestContextSchemaForm } from '@/domains/request-context';
+
+interface AgentChatSettingsDialogProps {
+  agentId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const AgentChatSettingsDialog = ({ agentId, open, onOpenChange }: AgentChatSettingsDialogProps) => {
+  const { data: agent } = useAgent(agentId);
+  const requestContextSchema = agent?.requestContextSchema;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[720px] max-h-[80vh]">
+        <DialogHeader>
+          <DialogTitle>Chat Settings</DialogTitle>
+        </DialogHeader>
+        <DialogBody className="p-0">
+          <Tabs defaultTab="model-settings">
+            <TabList>
+              <Tab value="model-settings">Model Settings</Tab>
+              <Tab value="tracing-options">Tracing Options</Tab>
+              {requestContextSchema && <Tab value="request-context">Request Context</Tab>}
+            </TabList>
+            <TabContent value="model-settings">
+              <AgentSettings agentId={agentId} />
+            </TabContent>
+            <TabContent value="tracing-options">
+              <TracingRunOptions />
+            </TabContent>
+            {requestContextSchema && (
+              <TabContent value="request-context">
+                <div className="p-5">
+                  <RequestContextSchemaForm requestContextSchema={requestContextSchema} />
+                </div>
+              </TabContent>
+            )}
+          </Tabs>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/playground/src/domains/agents/components/agent-chat.tsx
+++ b/packages/playground/src/domains/agents/components/agent-chat.tsx
@@ -1,7 +1,11 @@
 import { toAISdkV4Messages, toAISdkV5Messages } from '@mastra/ai-sdk/ui';
+import { IconButton } from '@mastra/playground-ui';
 import type { MastraUIMessage } from '@mastra/react';
-import { useEffect, useMemo } from 'react';
+import { SlidersHorizontal } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { useAgentSettings } from '../context/agent-context';
+import { AgentChatSettingsDialog } from './agent-chat-settings-dialog';
+import { useTracingSettings } from '@/domains/observability/context/tracing-settings-context';
 import { useMergedRequestContext } from '@/domains/request-context/context/schema-request-context';
 import { useAgentMessages } from '@/hooks/use-agent-messages';
 import { Thread } from '@/lib/ai-ui/thread';
@@ -26,8 +30,15 @@ export const AgentChat = ({
   isNewThread?: boolean;
   hideModelSwitcher?: boolean;
 }) => {
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const { settings } = useAgentSettings();
+  const { settings: tracingSettings } = useTracingSettings();
   const requestContext = useMergedRequestContext();
+  const hasSettingsOverride = Boolean(
+    (settings?.modelSettings && Object.keys(settings.modelSettings).length > 0) ||
+    (tracingSettings && Object.keys(tracingSettings).length > 0) ||
+    (requestContext && Object.keys(requestContext).length > 0),
+  );
 
   const { data, isLoading: isMessagesLoading } = useAgentMessages({
     agentId: agentId,
@@ -55,6 +66,7 @@ export const AgentChat = ({
   // Stable empty array per thread: stays the same reference across re-renders
   // (preventing useChat from wiping streamed messages), but changes when threadId
   // changes (allowing useChat to reset when switching threads).
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- changing this reference when threadId changes resets useChat state.
   const emptyMessages = useMemo(() => [] as never[], [threadId]);
 
   const messages = data?.messages ?? emptyMessages;
@@ -82,7 +94,19 @@ export const AgentChat = ({
         threadId={threadId}
         hasModelList={Boolean(modelList)}
         hideModelSwitcher={hideModelSwitcher}
+        composerControls={
+          <IconButton
+            tooltip={hasSettingsOverride ? 'Chat Settings (overridden)' : 'Chat Settings'}
+            size="sm"
+            variant={hasSettingsOverride ? 'outline' : 'ghost'}
+            onClick={() => setIsSettingsOpen(true)}
+            aria-label="Chat Settings"
+          >
+            <SlidersHorizontal />
+          </IconButton>
+        }
       />
+      <AgentChatSettingsDialog agentId={agentId} open={isSettingsOpen} onOpenChange={setIsSettingsOpen} />
     </MastraRuntimeProvider>
   );
 };

--- a/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
+++ b/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
@@ -115,9 +115,14 @@ export function AgentPageTabs({
   };
 
   return (
-    <div className="bg-surface2 px-4 flex items-center gap-2">
-      <Tabs value={activeTab} defaultTab={activeTab} onValueChange={handleTabChange} className="flex-1 min-w-0">
-        <TabList>
+    <div className="relative bg-surface2 px-4 flex items-center gap-2 before:absolute before:bottom-0 before:left-0 before:right-0 before:h-px before:bg-border1 before:content-['']">
+      <Tabs
+        value={activeTab}
+        defaultTab={activeTab}
+        onValueChange={handleTabChange}
+        className="relative z-10 flex-1 min-w-0"
+      >
+        <TabList className="border-b-0">
           <AgentTab value="chat" icon={<MessageSquare />} label="Chat" />
           <AgentTab
             value="versions"

--- a/packages/playground/src/domains/agents/components/agent-tab-actions.tsx
+++ b/packages/playground/src/domains/agents/components/agent-tab-actions.tsx
@@ -1,0 +1,66 @@
+import { IconButton, useCopyToClipboard } from '@mastra/playground-ui';
+import { Check, CopyIcon, CopyPlus, Link2, Pencil } from 'lucide-react';
+
+import { useAgent } from '../hooks/use-agent';
+import { useCloneAgent } from '../hooks/use-clone-agent';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+import { useIsCmsAvailable } from '@/domains/cms/hooks/use-is-cms-available';
+import { useLinkComponent } from '@/lib/framework';
+
+interface AgentTabActionsProps {
+  agentId: string;
+}
+
+export const AgentTabActions = ({ agentId }: AgentTabActionsProps) => {
+  const { data: agent } = useAgent(agentId);
+  const { isCmsAvailable } = useIsCmsAvailable();
+  const { canEdit } = usePermissions();
+  const { navigate } = useLinkComponent();
+  const { cloneAgent, isCloning } = useCloneAgent();
+
+  const { handleCopy } = useCopyToClipboard({ text: agentId, copyMessage: 'Agent ID copied to clipboard!' });
+  const sessionUrl = `${window.location.origin}/agents/${agentId}/session`;
+  const { handleCopy: handleShareLink, isCopied: isShareCopied } = useCopyToClipboard({
+    text: sessionUrl,
+    copyMessage: 'Session URL copied to clipboard!',
+  });
+
+  const isStoredAgent = agent?.source === 'stored';
+  const canWriteAgents = isCmsAvailable && canEdit('stored-agents');
+
+  const handleClone = async () => {
+    const clonedAgent = await cloneAgent(agentId);
+    if (clonedAgent?.id) {
+      navigate(`/agents/${clonedAgent.id}/chat`);
+    }
+  };
+
+  return (
+    <>
+      <IconButton tooltip="Copy Agent ID" size="sm" variant="ghost" onClick={handleCopy}>
+        <CopyIcon />
+      </IconButton>
+
+      {canWriteAgents && (
+        <IconButton
+          tooltip={isStoredAgent ? 'Edit agent configuration' : 'Edit agent overrides'}
+          size="sm"
+          variant="ghost"
+          onClick={() => navigate(`/cms/agents/${agentId}/edit`)}
+        >
+          <Pencil />
+        </IconButton>
+      )}
+
+      {canWriteAgents && (
+        <IconButton tooltip="Clone agent" size="sm" variant="ghost" onClick={handleClone} disabled={isCloning}>
+          <CopyPlus />
+        </IconButton>
+      )}
+
+      <IconButton tooltip="Copy session URL" size="sm" variant="ghost" onClick={handleShareLink}>
+        {isShareCopied ? <Check /> : <Link2 />}
+      </IconButton>
+    </>
+  );
+};

--- a/packages/playground/src/domains/agents/hooks/use-clone-agent.ts
+++ b/packages/playground/src/domains/agents/hooks/use-clone-agent.ts
@@ -1,0 +1,32 @@
+import { toast } from '@mastra/playground-ui';
+import { useMastraClient } from '@mastra/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { usePlaygroundStore } from '@/store/playground-store';
+
+export const useCloneAgent = () => {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+  const { requestContext } = usePlaygroundStore();
+  const [isCloning, setIsCloning] = useState(false);
+
+  const cloneAgent = async (agentId: string) => {
+    setIsCloning(true);
+    try {
+      const result = await client.getAgent(agentId).clone({ requestContext });
+      void queryClient.invalidateQueries({ queryKey: ['agents'] });
+      void queryClient.invalidateQueries({ queryKey: ['stored-agents'] });
+      toast.success('Agent cloned successfully');
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to clone agent';
+      toast.error(message);
+      return null;
+    } finally {
+      setIsCloning(false);
+    }
+  };
+
+  return { cloneAgent, isCloning };
+};

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -23,9 +23,18 @@ export interface ThreadProps {
   hasMemory?: boolean;
   hasModelList?: boolean;
   hideModelSwitcher?: boolean;
+  composerControls?: React.ReactNode;
 }
 
-export const Thread = ({ agentName, agentId, threadId, hasMemory, hasModelList, hideModelSwitcher }: ThreadProps) => {
+export const Thread = ({
+  agentName,
+  agentId,
+  threadId,
+  hasMemory,
+  hasModelList,
+  hideModelSwitcher,
+  composerControls,
+}: ThreadProps) => {
   const areaRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   useAutoscroll(areaRef, { enabled: true });
@@ -78,6 +87,7 @@ export const Thread = ({ agentName, agentId, threadId, hasMemory, hasModelList, 
         agentId={agentId}
         hasModelList={hasModelList}
         hideModelSwitcher={hideModelSwitcher}
+        controls={composerControls}
       />
     </ThreadWrapper>
   );
@@ -112,9 +122,10 @@ interface ComposerProps {
   agentId?: string;
   hasModelList?: boolean;
   hideModelSwitcher?: boolean;
+  controls?: React.ReactNode;
 }
 
-const Composer = ({ agentId, hasModelList, hideModelSwitcher }: ComposerProps) => {
+const Composer = ({ agentId, hasModelList, hideModelSwitcher, controls }: ComposerProps) => {
   const { setThreadInput } = useThreadInput();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Track IME composition state to prevent Enter from submitting during CJK input.
@@ -196,6 +207,7 @@ const Composer = ({ agentId, hasModelList, hideModelSwitcher }: ComposerProps) =
           <div className="flex items-center justify-between gap-2">
             {agentId && !hasModelList && !hideModelSwitcher && <ComposerModelSwitcher agentId={agentId} />}
             <div className="flex items-center gap-2 ml-auto">
+              {controls}
               {canExecuteAgent && <SpeechInput agentId={agentId} />}
               <ComposerAction canExecute={canExecuteAgent} />
             </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,8 @@ overrides:
   serialize-javascript@<7.0.5: ^7.0.5
   '@tootallnate/once@<3.0.1': ^3.0.1
 
+packageExtensionsChecksum: sha256-wmNYUioysnooYu4kvWPO6GjgUA2xMdbjcyrsgFB+1V4=
+
 patchedDependencies:
   '@changesets/get-dependents-graph':
     hash: 1cae443604ba49c27339705c703329dfcd79f6acd7fc822b1257a7d7c9da9535
@@ -29871,6 +29873,7 @@ snapshots:
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
+      '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,11 @@ catalog:
 patchedDependencies:
   '@changesets/get-dependents-graph': patches/@changesets__get-dependents-graph.patch
 
+packageExtensions:
+  '@codemirror/lang-jinja@*':
+    dependencies:
+      '@codemirror/view': ^6.0.0
+
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
 trustPolicyIgnoreAfter: 43200 # 30 days


### PR DESCRIPTION
## Summary
- enhance `CollapsiblePanel` with configurable collapsed triggers, external panel refs, collapse-state callbacks, and optional trigger rendering so follow-up sidebar layouts can use icon-only affordances
- expose `IconButton` from `@mastra/playground-ui` and update thread delete controls to use the shared `Button` icon sizing path
- add the Agent Chat Settings dialog so model settings, tracing options, and request context controls are available from the chat composer
- add right-aligned agent tab actions for copying the agent ID, editing agent config/overrides, cloning an agent, and copying the session URL
- keep the chat settings integration narrow by adding `composerControls` injection to `Thread` without pulling in the later centered-composer/sidebar-memory work
- update the agent model-settings E2E flow to open settings from the new Chat Settings control

## Test plan
- `pnpm --filter ./packages/playground-ui build`
- `pnpm --filter ./packages/playground build`
- `pnpm exec eslint --no-warn-ignored packages/playground/src/domains/agents/components/agent-chat.tsx packages/playground/src/domains/agents/hooks/use-clone-agent.ts packages/playground/src/domains/agents/components/agent-tab-actions.tsx packages/playground/src/domains/agents/components/agent-chat-settings-dialog.tsx packages/playground/src/domains/agents/agent-layout.tsx packages/playground/src/lib/ai-ui/thread.tsx packages/playground/e2e/tests/agents/\$agentId/page.spec.ts --quiet`

## Notes
- Focused E2E was attempted with `pnpm --filter ./packages/playground test:e2e -- 'tests/agents/$agentId/page.spec.ts'`, but Playwright could not start because `localhost:4111` was already in use by an existing `node` process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR adds the building blocks so sidebars can shrink down to icon-only buttons and lets developers control how that collapse/expand button looks and behaves. It also exposes an IconButton alias and makes the delete-thread button more flexible.

## Changes Overview

### Changeset Documentation
Added a changeset for @mastra/playground-ui documenting foundation UI work for an Agent Chat layout redesign: configurable collapsed panel triggers, an IconButton barrel alias, and improved delete-button styling/behavior.

### CollapsiblePanel Component Enhancement
Expanded CollapsiblePanel to better support sidebar layouts:
- New collapsedTrigger prop (tooltip, label, icon) to customize the collapse/expand affordance
- panelRef prop for external imperative control
- onCollapsedChange callback to notify parents when collapsed state changes
- showCollapsedTrigger prop (defaults true) to conditionally render the trigger
- Defensive handling for undefined collapsedSize
- New exported interface CollapsiblePanelTriggerProps

### ThreadDeleteButton Component Updates
Updated ThreadDeleteButton to:
- Accept optional tooltip (default "Delete conversation")
- Accept optional className for custom styling
- Render the X icon directly (removed Icon wrapper)

### Playground-UI Barrel Exports
Re-exported Button as IconButton from playground-ui index to provide a clearer alias for icon-button usage.

### Other Notable Additions
- Added AgentChatSettingsDialog component and wired a Chat Settings control into AgentChat (opens dialog; includes Model Settings, Tracing Options, and Request Context tab when applicable).
- Added AgentTabActions component (copy, edit, clone, share actions) and integrated it into agent tab layout.
- Added useCloneAgent hook (cloneAgent + loading state + cache invalidation + toasts).
- Thread component now accepts composerControls forwarded into Composer.
- Playwright e2e spec updated to open "Chat Settings" by label.
- pnpm-workspace.yaml packageExtensions added for @codemirror/lang-jinja -> @codemirror/view ^6.0.0.

## Impact
Establishes a flexible foundation for sidebar-based UI (icon-only collapsed state) and small API surface improvements (tooltip/className/refs/callbacks) that are backward-compatible via optional props and sensible defaults.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16333)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->