### PR TITLE
feat: Agent Builder skill registry (COR-832)

### DIFF
--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -147,6 +147,12 @@ import type {
   GetSystemPackagesResponse,
   BuilderSettingsResponse,
   InfrastructureStatusResponse,
+  ListBuilderRegistriesResponse,
+  BuilderRegistrySearchResponse,
+  BuilderRegistryPopularResponse,
+  BuilderRegistryPreviewResponse,
+  BuilderRegistryInstallBody,
+  BuilderRegistryInstallResponse,
   ListScoresResponse as ListScoresResponseOld,
   GetObservationalMemoryParams,
   GetObservationalMemoryResponse,
@@ -1558,6 +1564,78 @@ export class MastraClient extends BaseResource {
    */
   public getInfrastructureStatus(): Promise<InfrastructureStatusResponse> {
     return this.request('/editor/builder/infrastructure');
+  }
+
+  /**
+   * Lists known skill registries surfaced by the Agent Builder config.
+   * Each entry reports whether the registry is enabled. Disabled or unknown
+   * registries return 404 from registry-scoped routes.
+   * Requires `stored-skills:read` permission.
+   */
+  public listBuilderRegistries(): Promise<ListBuilderRegistriesResponse> {
+    return this.request('/editor/builder/registries');
+  }
+
+  /**
+   * Search a builder skill registry. The registry must be enabled or the
+   * server returns 404.
+   * Requires `stored-skills:read` permission.
+   */
+  public searchBuilderRegistry(
+    registryId: string,
+    params: { q: string; limit?: number },
+  ): Promise<BuilderRegistrySearchResponse> {
+    const search = new URLSearchParams({ q: params.q });
+    if (params.limit !== undefined) search.set('limit', String(params.limit));
+    return this.request(`/editor/builder/registries/${encodeURIComponent(registryId)}/search?${search.toString()}`);
+  }
+
+  /**
+   * Fetch the popular skills feed from a builder skill registry.
+   * Requires `stored-skills:read` permission.
+   */
+  public getBuilderRegistryPopular(
+    registryId: string,
+    params?: { limit?: number; offset?: number },
+  ): Promise<BuilderRegistryPopularResponse> {
+    const search = new URLSearchParams();
+    if (params?.limit !== undefined) search.set('limit', String(params.limit));
+    if (params?.offset !== undefined) search.set('offset', String(params.offset));
+    const query = search.toString();
+    return this.request(
+      `/editor/builder/registries/${encodeURIComponent(registryId)}/popular${query ? `?${query}` : ''}`,
+    );
+  }
+
+  /**
+   * Fetch the rendered preview content for a single registry skill.
+   * Requires `stored-skills:read` permission.
+   */
+  public getBuilderRegistryPreview(
+    registryId: string,
+    params: { owner: string; repo: string; path: string },
+  ): Promise<BuilderRegistryPreviewResponse> {
+    const search = new URLSearchParams({
+      owner: params.owner,
+      repo: params.repo,
+      path: params.path,
+    });
+    return this.request(`/editor/builder/registries/${encodeURIComponent(registryId)}/preview?${search.toString()}`);
+  }
+
+  /**
+   * Install a registry skill into the builder's stored-skills DB.
+   * Returns 409 when a stored skill with the derived id already exists.
+   * Requires `stored-skills:write` permission.
+   */
+  public installBuilderRegistrySkill(
+    registryId: string,
+    body: BuilderRegistryInstallBody,
+  ): Promise<BuilderRegistryInstallResponse> {
+    return this.request(`/editor/builder/registries/${encodeURIComponent(registryId)}/install`, {
+      method: 'POST',
+      body,
+    });
   }
 
   // ============================================================================

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -76166,6 +76166,11 @@ export type GetEditorBuilderInfrastructure_Response = {
       value: string;
     }[];
   };
+  registries: {
+    skillsSh: {
+      enabled: boolean;
+    };
+  };
 };
 
 export type GetEditorBuilderInfrastructure_Request = Simplify<
@@ -76180,6 +76185,222 @@ export interface GetEditorBuilderInfrastructure_RouteContract {
   body: never;
   request: GetEditorBuilderInfrastructure_Request;
   response: GetEditorBuilderInfrastructure_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: GET /editor/builder/registries
+// ============================================================================
+export type GetEditorBuilderRegistries_Response = {
+  registries: {
+    /** Stable registry identifier */
+    id: 'skills-sh';
+    /** Whether this registry is enabled in the running deployment */
+    enabled: boolean;
+    /** Human-readable registry name */
+    label: string;
+  }[];
+};
+
+export type GetEditorBuilderRegistries_Request = Simplify<
+  (never extends never ? {} : { params: never }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface GetEditorBuilderRegistries_RouteContract {
+  pathParams: never;
+  queryParams: never;
+  body: never;
+  request: GetEditorBuilderRegistries_Request;
+  response: GetEditorBuilderRegistries_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: GET /editor/builder/registries/:registryId/search
+// ============================================================================
+export type GetEditorBuilderRegistriesRegistryIdSearch_PathParams = {
+  /** Registry identifier (e.g. "skills-sh") */
+  registryId: string;
+};
+
+export type GetEditorBuilderRegistriesRegistryIdSearch_QueryParams = {
+  /** Search query */
+  q: string;
+  /** Maximum number of results */
+  limit: number | undefined;
+};
+
+export type GetEditorBuilderRegistriesRegistryIdSearch_Response = {
+  query: string;
+  searchType: string;
+  skills: {
+    id: string;
+    name: string;
+    installs: number;
+    topSource: string;
+  }[];
+  count: number;
+};
+
+export type GetEditorBuilderRegistriesRegistryIdSearch_Request = Simplify<
+  (GetEditorBuilderRegistriesRegistryIdSearch_PathParams extends never
+    ? {}
+    : { params: GetEditorBuilderRegistriesRegistryIdSearch_PathParams }) &
+    (GetEditorBuilderRegistriesRegistryIdSearch_QueryParams extends never
+      ? {}
+      : {} extends GetEditorBuilderRegistriesRegistryIdSearch_QueryParams
+        ? { query?: GetEditorBuilderRegistriesRegistryIdSearch_QueryParams }
+        : { query: GetEditorBuilderRegistriesRegistryIdSearch_QueryParams }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface GetEditorBuilderRegistriesRegistryIdSearch_RouteContract {
+  pathParams: GetEditorBuilderRegistriesRegistryIdSearch_PathParams;
+  queryParams: GetEditorBuilderRegistriesRegistryIdSearch_QueryParams;
+  body: never;
+  request: GetEditorBuilderRegistriesRegistryIdSearch_Request;
+  response: GetEditorBuilderRegistriesRegistryIdSearch_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: GET /editor/builder/registries/:registryId/popular
+// ============================================================================
+export type GetEditorBuilderRegistriesRegistryIdPopular_PathParams = {
+  /** Registry identifier (e.g. "skills-sh") */
+  registryId: string;
+};
+
+export type GetEditorBuilderRegistriesRegistryIdPopular_QueryParams = {
+  /** Maximum number of results */
+  limit: number | undefined;
+  /** Offset for pagination */
+  offset: number | undefined;
+};
+
+export type GetEditorBuilderRegistriesRegistryIdPopular_Response = {
+  skills: {
+    id: string;
+    name: string;
+    installs: number;
+    topSource: string;
+  }[];
+  count: number;
+  limit: number;
+  offset: number;
+};
+
+export type GetEditorBuilderRegistriesRegistryIdPopular_Request = Simplify<
+  (GetEditorBuilderRegistriesRegistryIdPopular_PathParams extends never
+    ? {}
+    : { params: GetEditorBuilderRegistriesRegistryIdPopular_PathParams }) &
+    (GetEditorBuilderRegistriesRegistryIdPopular_QueryParams extends never
+      ? {}
+      : {} extends GetEditorBuilderRegistriesRegistryIdPopular_QueryParams
+        ? { query?: GetEditorBuilderRegistriesRegistryIdPopular_QueryParams }
+        : { query: GetEditorBuilderRegistriesRegistryIdPopular_QueryParams }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface GetEditorBuilderRegistriesRegistryIdPopular_RouteContract {
+  pathParams: GetEditorBuilderRegistriesRegistryIdPopular_PathParams;
+  queryParams: GetEditorBuilderRegistriesRegistryIdPopular_QueryParams;
+  body: never;
+  request: GetEditorBuilderRegistriesRegistryIdPopular_Request;
+  response: GetEditorBuilderRegistriesRegistryIdPopular_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: GET /editor/builder/registries/:registryId/preview
+// ============================================================================
+export type GetEditorBuilderRegistriesRegistryIdPreview_PathParams = {
+  /** Registry identifier (e.g. "skills-sh") */
+  registryId: string;
+};
+
+export type GetEditorBuilderRegistriesRegistryIdPreview_QueryParams = {
+  /** GitHub repository owner */
+  owner: string;
+  /** GitHub repository name */
+  repo: string;
+  /** Skill name within repo */
+  path: string;
+};
+
+export type GetEditorBuilderRegistriesRegistryIdPreview_Response = {
+  content: string;
+};
+
+export type GetEditorBuilderRegistriesRegistryIdPreview_Request = Simplify<
+  (GetEditorBuilderRegistriesRegistryIdPreview_PathParams extends never
+    ? {}
+    : { params: GetEditorBuilderRegistriesRegistryIdPreview_PathParams }) &
+    (GetEditorBuilderRegistriesRegistryIdPreview_QueryParams extends never
+      ? {}
+      : {} extends GetEditorBuilderRegistriesRegistryIdPreview_QueryParams
+        ? { query?: GetEditorBuilderRegistriesRegistryIdPreview_QueryParams }
+        : { query: GetEditorBuilderRegistriesRegistryIdPreview_QueryParams }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface GetEditorBuilderRegistriesRegistryIdPreview_RouteContract {
+  pathParams: GetEditorBuilderRegistriesRegistryIdPreview_PathParams;
+  queryParams: GetEditorBuilderRegistriesRegistryIdPreview_QueryParams;
+  body: never;
+  request: GetEditorBuilderRegistriesRegistryIdPreview_Request;
+  response: GetEditorBuilderRegistriesRegistryIdPreview_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: POST /editor/builder/registries/:registryId/install
+// ============================================================================
+export type PostEditorBuilderRegistriesRegistryIdInstall_PathParams = {
+  /** Registry identifier (e.g. "skills-sh") */
+  registryId: string;
+};
+
+export type PostEditorBuilderRegistriesRegistryIdInstall_Body = {
+  /** GitHub repository owner */
+  owner: string;
+  /** GitHub repository name */
+  repo: string;
+  /** Skill name from the registry */
+  skillName: string;
+  /** Visibility for the new stored skill */
+  visibility?: ('private' | 'public') | undefined;
+};
+
+export type PostEditorBuilderRegistriesRegistryIdInstall_Response = {
+  /** Id of the newly created stored skill */
+  storedSkillId: string;
+  /** Resolved skill name */
+  name: string;
+  /** Number of files materialized into the skill version snapshot */
+  filesWritten: number;
+};
+
+export type PostEditorBuilderRegistriesRegistryIdInstall_Request = Simplify<
+  (PostEditorBuilderRegistriesRegistryIdInstall_PathParams extends never
+    ? {}
+    : { params: PostEditorBuilderRegistriesRegistryIdInstall_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostEditorBuilderRegistriesRegistryIdInstall_Body extends never
+      ? {}
+      : {} extends PostEditorBuilderRegistriesRegistryIdInstall_Body
+        ? { body?: PostEditorBuilderRegistriesRegistryIdInstall_Body }
+        : { body: PostEditorBuilderRegistriesRegistryIdInstall_Body })
+>;
+
+export interface PostEditorBuilderRegistriesRegistryIdInstall_RouteContract {
+  pathParams: PostEditorBuilderRegistriesRegistryIdInstall_PathParams;
+  queryParams: never;
+  body: PostEditorBuilderRegistriesRegistryIdInstall_Body;
+  request: PostEditorBuilderRegistriesRegistryIdInstall_Request;
+  response: PostEditorBuilderRegistriesRegistryIdInstall_Response;
   responseType: 'json';
 }
 
@@ -77039,6 +77260,11 @@ export interface RouteTypes {
   'GET /background-tasks/:backgroundTaskId': GetBackgroundTasksBackgroundTaskId_RouteContract;
   'GET /editor/builder/settings': GetEditorBuilderSettings_RouteContract;
   'GET /editor/builder/infrastructure': GetEditorBuilderInfrastructure_RouteContract;
+  'GET /editor/builder/registries': GetEditorBuilderRegistries_RouteContract;
+  'GET /editor/builder/registries/:registryId/search': GetEditorBuilderRegistriesRegistryIdSearch_RouteContract;
+  'GET /editor/builder/registries/:registryId/popular': GetEditorBuilderRegistriesRegistryIdPopular_RouteContract;
+  'GET /editor/builder/registries/:registryId/preview': GetEditorBuilderRegistriesRegistryIdPreview_RouteContract;
+  'POST /editor/builder/registries/:registryId/install': PostEditorBuilderRegistriesRegistryIdInstall_RouteContract;
   'GET /schedules': GetSchedules_RouteContract;
   'GET /schedules/:scheduleId': GetSchedulesScheduleId_RouteContract;
   'GET /schedules/:scheduleId/triggers': GetSchedulesScheduleIdTriggers_RouteContract;
@@ -77333,6 +77559,21 @@ export interface Client {
   };
   '/editor/builder/infrastructure': {
     GET: GetEditorBuilderInfrastructure_RouteContract;
+  };
+  '/editor/builder/registries': {
+    GET: GetEditorBuilderRegistries_RouteContract;
+  };
+  '/editor/builder/registries/:registryId/install': {
+    POST: PostEditorBuilderRegistriesRegistryIdInstall_RouteContract;
+  };
+  '/editor/builder/registries/:registryId/popular': {
+    GET: GetEditorBuilderRegistriesRegistryIdPopular_RouteContract;
+  };
+  '/editor/builder/registries/:registryId/preview': {
+    GET: GetEditorBuilderRegistriesRegistryIdPreview_RouteContract;
+  };
+  '/editor/builder/registries/:registryId/search': {
+    GET: GetEditorBuilderRegistriesRegistryIdSearch_RouteContract;
   };
   '/editor/builder/settings': {
     GET: GetEditorBuilderSettings_RouteContract;

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -2880,3 +2880,81 @@ export interface InfrastructureStatusResponse {
     };
   };
 }
+
+// ============================================================================
+// Builder registries (skills.sh and other external skill catalogs)
+// ============================================================================
+
+/**
+ * One known skill registry surfaced from the Agent Builder config.
+ */
+export interface BuilderRegistryDescriptor {
+  id: string;
+  enabled: boolean;
+  label: string;
+}
+
+/**
+ * Response from `GET /editor/builder/registries`.
+ */
+export interface ListBuilderRegistriesResponse {
+  registries: BuilderRegistryDescriptor[];
+}
+
+/**
+ * Single skill summary returned from a registry search/popular endpoint.
+ * Wire shape matches the upstream skills.sh proxy.
+ */
+export interface BuilderRegistrySkillSummary {
+  id: string;
+  name: string;
+  installs: number;
+  /** Repository identifier in `owner/repo` or `owner/repo/path` form. */
+  topSource: string;
+}
+
+/**
+ * Response from `GET /editor/builder/registries/:registryId/search`.
+ */
+export interface BuilderRegistrySearchResponse {
+  query: string;
+  searchType: string;
+  skills: BuilderRegistrySkillSummary[];
+  count: number;
+}
+
+/**
+ * Response from `GET /editor/builder/registries/:registryId/popular`.
+ */
+export interface BuilderRegistryPopularResponse {
+  skills: BuilderRegistrySkillSummary[];
+  count: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Response from `GET /editor/builder/registries/:registryId/preview`.
+ */
+export interface BuilderRegistryPreviewResponse {
+  content: string;
+}
+
+/**
+ * Body for `POST /editor/builder/registries/:registryId/install`.
+ */
+export interface BuilderRegistryInstallBody {
+  owner: string;
+  repo: string;
+  skillName: string;
+  visibility?: 'private' | 'public';
+}
+
+/**
+ * Response from `POST /editor/builder/registries/:registryId/install`.
+ */
+export interface BuilderRegistryInstallResponse {
+  storedSkillId: string;
+  name: string;
+  filesWritten: number;
+}

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -2874,4 +2874,9 @@ export interface InfrastructureStatusResponse {
     sandboxProvider: string | null;
     config: Array<{ key: string; value: string }>;
   };
+  registries: {
+    skillsSh: {
+      enabled: boolean;
+    };
+  };
 }

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -4936,6 +4936,90 @@ export const API_ROUTE_METADATA = {
       "kind": "single"
     }
   },
+  "GET /editor/builder/registries": {
+    "method": "GET",
+    "path": "/editor/builder/registries",
+    "pathParams": [],
+    "queryParams": [],
+    "bodyParams": [],
+    "hasQuery": false,
+    "hasBody": false,
+    "responseShape": {
+      "kind": "object-property",
+      "listProperty": "registries"
+    }
+  },
+  "GET /editor/builder/registries/:registryId/search": {
+    "method": "GET",
+    "path": "/editor/builder/registries/:registryId/search",
+    "pathParams": [
+      "registryId"
+    ],
+    "queryParams": [
+      "limit",
+      "q"
+    ],
+    "bodyParams": [],
+    "hasQuery": true,
+    "hasBody": false,
+    "responseShape": {
+      "kind": "single"
+    }
+  },
+  "GET /editor/builder/registries/:registryId/popular": {
+    "method": "GET",
+    "path": "/editor/builder/registries/:registryId/popular",
+    "pathParams": [
+      "registryId"
+    ],
+    "queryParams": [
+      "limit",
+      "offset"
+    ],
+    "bodyParams": [],
+    "hasQuery": true,
+    "hasBody": false,
+    "responseShape": {
+      "kind": "single"
+    }
+  },
+  "GET /editor/builder/registries/:registryId/preview": {
+    "method": "GET",
+    "path": "/editor/builder/registries/:registryId/preview",
+    "pathParams": [
+      "registryId"
+    ],
+    "queryParams": [
+      "owner",
+      "path",
+      "repo"
+    ],
+    "bodyParams": [],
+    "hasQuery": true,
+    "hasBody": false,
+    "responseShape": {
+      "kind": "single"
+    }
+  },
+  "POST /editor/builder/registries/:registryId/install": {
+    "method": "POST",
+    "path": "/editor/builder/registries/:registryId/install",
+    "pathParams": [
+      "registryId"
+    ],
+    "queryParams": [],
+    "bodyParams": [
+      "owner",
+      "repo",
+      "skillName",
+      "visibility"
+    ],
+    "hasQuery": false,
+    "hasBody": true,
+    "responseShape": {
+      "kind": "single"
+    }
+  },
   "GET /schedules": {
     "method": "GET",
     "path": "/schedules",

--- a/packages/core/src/agent-builder/ee/types.ts
+++ b/packages/core/src/agent-builder/ee/types.ts
@@ -284,6 +284,24 @@ export interface AgentBuilderOptions {
   configuration?: {
     agent?: BuilderAgentDefaults;
   };
+
+  /**
+   * Skill registries the Agent Builder is allowed to browse and install from.
+   *
+   * Each registry is opt-in. When no registries are enabled, the Builder hides
+   * registry browse UI entirely. When at least one is enabled, the Builder
+   * shows a "Browse registries" entry alongside "Create skill".
+   */
+  registries?: {
+    /**
+     * The public skills.sh registry (https://skills.sh).
+     * Off by default — admins must explicitly opt in.
+     */
+    skillsSh?: {
+      /** When true, the Builder may browse and install from skills.sh. */
+      enabled: boolean;
+    };
+  };
 }
 
 /**
@@ -294,6 +312,11 @@ export interface IAgentBuilder {
   readonly enabled: boolean;
   getFeatures(): AgentBuilderOptions['features'];
   getConfiguration(): AgentBuilderOptions['configuration'];
+  /**
+   * The opt-in skill registries this Builder is allowed to browse and install
+   * from. Returns `undefined` when the admin has not configured any registries.
+   */
+  getRegistries?(): AgentBuilderOptions['registries'];
   /**
    * Optional warnings produced during construction-time validation
    * (e.g. allowlist entries with unknown providers that lack `kind: 'custom'`).

--- a/packages/core/src/workspace/skills/publish.ts
+++ b/packages/core/src/workspace/skills/publish.ts
@@ -149,6 +149,61 @@ function collectSubdirPaths(allPaths: string[], subdir: string): string[] {
 // =============================================================================
 
 /**
+ * A flat file entry used by snapshot parsing helpers.
+ * Path is the skill-relative path (e.g. `SKILL.md`, `references/foo.md`).
+ */
+export interface SkillSnapshotFile {
+  path: string;
+  content: string | Buffer;
+}
+
+/**
+ * Parse a flat array of skill files into a denormalized snapshot.
+ *
+ * Finds `SKILL.md`, parses its YAML frontmatter into structured fields
+ * (name, description, license, compatibility, metadata), and uses the
+ * markdown body as `instructions`. Discovers `references/`, `scripts/`,
+ * and `assets/` subdirectory paths from the file list.
+ *
+ * Used by both the publish flow (which has files from a SkillSource walk)
+ * and the registry install flow (which has files fetched from an external
+ * registry like skills.sh). The Agent Skills spec puts metadata in
+ * frontmatter and agent-facing prose in the body — this helper enforces
+ * that split so frontmatter never leaks into the runtime instructions.
+ *
+ * @throws if `SKILL.md` is missing from the file list
+ */
+export function parseSkillSnapshotFromFiles(files: SkillSnapshotFile[]): Omit<StorageSkillSnapshotType, 'tree'> {
+  const skillMdFile = files.find(f => f.path === 'SKILL.md');
+  if (!skillMdFile) {
+    throw new Error('SKILL.md not found in skill files');
+  }
+
+  const skillMdContent =
+    typeof skillMdFile.content === 'string' ? skillMdFile.content : skillMdFile.content.toString('utf-8');
+  const parsed = matter(skillMdContent);
+  const frontmatter = parsed.data;
+  const instructions = parsed.content.trim();
+
+  const allPaths = files.map(f => f.path);
+  const references = collectSubdirPaths(allPaths, 'references');
+  const scripts = collectSubdirPaths(allPaths, 'scripts');
+  const assets = collectSubdirPaths(allPaths, 'assets');
+
+  return {
+    name: frontmatter.name,
+    description: frontmatter.description,
+    instructions,
+    license: frontmatter.license,
+    compatibility: frontmatter.compatibility,
+    metadata: frontmatter.metadata,
+    ...(references.length > 0 ? { references } : {}),
+    ...(scripts.length > 0 ? { scripts } : {}),
+    ...(assets.length > 0 ? { assets } : {}),
+  };
+}
+
+/**
  * Collect a skill from a SkillSource for publishing.
  * Walks the skill directory, hashes all files, parses SKILL.md frontmatter,
  * and returns everything needed to create a new version.
@@ -217,34 +272,17 @@ export async function collectSkillForPublish(source: SkillSource, skillPath: str
   const tree: SkillVersionTree = { entries: treeEntries };
   const blobs = Array.from(blobMap.values());
 
-  // 3. Parse SKILL.md with gray-matter for denormalized fields
-  const skillMdFile = files.find(f => f.path === 'SKILL.md');
-  if (!skillMdFile) {
-    throw new Error(`SKILL.md not found in ${skillPath}`);
+  // 3. Parse SKILL.md frontmatter and discover references/scripts/assets paths
+  let snapshot: Omit<StorageSkillSnapshotType, 'tree'>;
+  try {
+    snapshot = parseSkillSnapshotFromFiles(files);
+  } catch (err) {
+    // Surface the skill path to make the error easier to debug
+    if (err instanceof Error && err.message.includes('SKILL.md not found')) {
+      throw new Error(`SKILL.md not found in ${skillPath}`);
+    }
+    throw err;
   }
-
-  const parsed = matter(skillMdFile.content as string);
-  const frontmatter = parsed.data;
-  const instructions = parsed.content.trim();
-
-  // 4. Discover references/, scripts/, assets/ subdirectories for the path arrays
-  const allPaths = files.map(f => f.path);
-  const references = collectSubdirPaths(allPaths, 'references');
-  const scripts = collectSubdirPaths(allPaths, 'scripts');
-  const assets = collectSubdirPaths(allPaths, 'assets');
-
-  // 5. Build snapshot
-  const snapshot: Omit<StorageSkillSnapshotType, 'tree'> = {
-    name: frontmatter.name,
-    description: frontmatter.description,
-    instructions,
-    license: frontmatter.license,
-    compatibility: frontmatter.compatibility,
-    metadata: frontmatter.metadata,
-    ...(references.length > 0 ? { references } : {}),
-    ...(scripts.length > 0 ? { scripts } : {}),
-    ...(assets.length > 0 ? { assets } : {}),
-  };
 
   return { snapshot, tree, blobs };
 }

--- a/packages/editor/src/ee/agent-builder.ts
+++ b/packages/editor/src/ee/agent-builder.ts
@@ -62,6 +62,10 @@ export class EditorAgentBuilder implements IAgentBuilder {
     return this.options.configuration;
   }
 
+  getRegistries(): AgentBuilderOptions['registries'] {
+    return this.options.registries;
+  }
+
   getModelPolicyWarnings(): string[] {
     return [...this.modelPolicyWarnings, ...this.browserConfigWarnings];
   }

--- a/packages/playground/src/domains/agent-builder/components/skill-builder-list/skill-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-builder-list/skill-builder-list.tsx
@@ -1,6 +1,6 @@
 import type { StoredSkillResponse } from '@mastra/client-js';
 import { EmptyState, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
-import { DownloadIcon, LockIcon, SearchIcon, SparklesIcon } from 'lucide-react';
+import { DownloadIcon, GitForkIcon, LockIcon, SearchIcon, SparklesIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { SkillStarButton } from '@/domains/agents/components/skill-star-button';
 import { getSkillOrigin } from '@/domains/agents/utils/skill-origin';
@@ -85,21 +85,25 @@ export function SkillBuilderList({ skills, search, onSkillClick, showStars = tru
                 {(() => {
                   const origin = getSkillOrigin(skill.metadata);
                   if (!origin) return null;
+                  const isFork = origin.type === 'library-fork';
                   return (
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <span
                           className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-surface5 text-neutral4 shrink-0"
-                          aria-label="Imported skill"
+                          aria-label={isFork ? 'Forked skill' : 'Imported skill'}
                           data-testid="skill-builder-origin-badge"
                         >
-                          <DownloadIcon className="h-2.5 w-2.5" />
-                          {origin.type === 'skills-sh' ? 'skills.sh' : 'imported'}
+                          {isFork ? <GitForkIcon className="h-2.5 w-2.5" /> : <DownloadIcon className="h-2.5 w-2.5" />}
+                          {origin.type === 'skills-sh' ? 'skills.sh' : isFork ? 'forked' : 'imported'}
                         </span>
                       </TooltipTrigger>
                       <TooltipContent>
-                        Imported from{' '}
-                        {origin.type === 'skills-sh' ? `${origin.owner}/${origin.repo}` : 'external registry'}
+                        {origin.type === 'skills-sh'
+                          ? `Imported from ${origin.owner}/${origin.repo}`
+                          : isFork
+                            ? `Forked from "${origin.sourceSkillName}"`
+                            : 'Imported from external registry'}
                       </TooltipContent>
                     </Tooltip>
                   );

--- a/packages/playground/src/domains/agent-builder/components/skill-builder-list/skill-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-builder-list/skill-builder-list.tsx
@@ -1,6 +1,6 @@
 import type { StoredSkillResponse } from '@mastra/client-js';
 import { EmptyState, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
-import { DownloadIcon, GitForkIcon, LockIcon, SearchIcon, SparklesIcon } from 'lucide-react';
+import { CopyIcon, DownloadIcon, LockIcon, SearchIcon, SparklesIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { SkillStarButton } from '@/domains/agents/components/skill-star-button';
 import { getSkillOrigin } from '@/domains/agents/utils/skill-origin';
@@ -85,24 +85,24 @@ export function SkillBuilderList({ skills, search, onSkillClick, showStars = tru
                 {(() => {
                   const origin = getSkillOrigin(skill.metadata);
                   if (!origin) return null;
-                  const isFork = origin.type === 'library-fork';
+                  const isCopy = origin.type === 'library-copy';
                   return (
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <span
                           className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-surface5 text-neutral4 shrink-0"
-                          aria-label={isFork ? 'Forked skill' : 'Imported skill'}
+                          aria-label={isCopy ? 'Copied skill' : 'Imported skill'}
                           data-testid="skill-builder-origin-badge"
                         >
-                          {isFork ? <GitForkIcon className="h-2.5 w-2.5" /> : <DownloadIcon className="h-2.5 w-2.5" />}
-                          {origin.type === 'skills-sh' ? 'skills.sh' : isFork ? 'forked' : 'imported'}
+                          {isCopy ? <CopyIcon className="h-2.5 w-2.5" /> : <DownloadIcon className="h-2.5 w-2.5" />}
+                          {origin.type === 'skills-sh' ? 'skills.sh' : isCopy ? 'copied' : 'imported'}
                         </span>
                       </TooltipTrigger>
                       <TooltipContent>
                         {origin.type === 'skills-sh'
                           ? `Imported from ${origin.owner}/${origin.repo}`
-                          : isFork
-                            ? `Forked from "${origin.sourceSkillName}"`
+                          : isCopy
+                            ? `Copied from "${origin.sourceSkillName}"`
                             : 'Imported from external registry'}
                       </TooltipContent>
                     </Tooltip>

--- a/packages/playground/src/domains/agent-builder/components/skill-builder-list/skill-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-builder-list/skill-builder-list.tsx
@@ -1,8 +1,9 @@
 import type { StoredSkillResponse } from '@mastra/client-js';
 import { EmptyState, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
-import { LockIcon, SearchIcon, SparklesIcon } from 'lucide-react';
+import { DownloadIcon, LockIcon, SearchIcon, SparklesIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { SkillStarButton } from '@/domains/agents/components/skill-star-button';
+import { getSkillOrigin } from '@/domains/agents/utils/skill-origin';
 
 function formatRelativeTime(iso: string): string {
   const then = new Date(iso).getTime();
@@ -81,6 +82,28 @@ export function SkillBuilderList({ skills, search, onSkillClick, showStars = tru
                     <TooltipContent>Only visible to you</TooltipContent>
                   </Tooltip>
                 )}
+                {(() => {
+                  const origin = getSkillOrigin(skill.metadata);
+                  if (!origin) return null;
+                  return (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-surface5 text-neutral4 shrink-0"
+                          aria-label="Imported skill"
+                          data-testid="skill-builder-origin-badge"
+                        >
+                          <DownloadIcon className="h-2.5 w-2.5" />
+                          {origin.type === 'skills-sh' ? 'skills.sh' : 'imported'}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Imported from{' '}
+                        {origin.type === 'skills-sh' ? `${origin.owner}/${origin.repo}` : 'external registry'}
+                      </TooltipContent>
+                    </Tooltip>
+                  );
+                })()}
               </div>
               <div className="flex items-center gap-2 mt-0.5">
                 <span className="text-ui-sm text-neutral3 line-clamp-1">{skill.description || 'No description'}</span>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/builder-add-skill-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/builder-add-skill-dialog.tsx
@@ -1,0 +1,359 @@
+import type { BuilderRegistrySkillSummary } from '@mastra/client-js';
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  MarkdownRenderer,
+  ScrollArea,
+  SkillIcon,
+  cn,
+} from '@mastra/playground-ui';
+import { Check, Download, ExternalLink, Github, Loader2, Package, Search } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+
+import {
+  useBuilderRegistryPreview,
+  useInstallBuilderRegistrySkill,
+  usePopularBuilderRegistrySkills,
+  useSearchBuilderRegistry,
+} from '@/domains/agents/hooks/use-builder-registries';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Parse a registry skill's `topSource` field to extract owner/repo. Mirrors
+ * the workspace-side helper but kept private to the Builder dialog so the two
+ * surfaces can evolve independently.
+ *
+ * Accepts:
+ *   - `owner/repo`
+ *   - `owner/repo/path/...`
+ *   - `github.com/owner/repo/...`
+ *   - `https://github.com/owner/repo/...`
+ */
+function parseSkillSource(topSource: string): { owner: string; repo: string } | null {
+  if (!topSource) return null;
+  let cleaned = topSource.replace(/^https?:\/\//, '').replace(/^github\.com\//, '');
+  const parts = cleaned.split('/').filter(Boolean);
+  if (parts.length < 2) return null;
+  return { owner: parts[0]!, repo: parts[1]! };
+}
+
+function getSkillUniqueId(skill: BuilderRegistrySkillSummary): string {
+  return `${skill.topSource}/${skill.name}`;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export interface BuilderAddSkillDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  registryId: string;
+  registryLabel: string;
+  /** Stored skill ids that already exist locally (collision check). */
+  installedSkillIds?: string[];
+  /** Called after a successful install with the new stored skill id. */
+  onInstalled?: (storedSkillId: string) => void;
+  /**
+   * Called when a 409 collision is detected. Receives the offending skill name
+   * so the parent can navigate to or focus the existing stored skill.
+   */
+  onCollision?: (skillName: string) => void;
+}
+
+export function BuilderAddSkillDialog({
+  open,
+  onOpenChange,
+  registryId,
+  registryLabel,
+  installedSkillIds = [],
+  onInstalled,
+  onCollision,
+}: BuilderAddSkillDialogProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedSkill, setSelectedSkill] = useState<BuilderRegistrySkillSummary | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
+
+  const { data: popularData, isLoading: isLoadingPopular } = usePopularBuilderRegistrySkills(
+    open ? registryId : undefined,
+  );
+  const searchMutation = useSearchBuilderRegistry(registryId);
+  const installMutation = useInstallBuilderRegistrySkill(registryId);
+
+  const parsedSource = useMemo(() => {
+    if (!selectedSkill?.topSource) return null;
+    return parseSkillSource(selectedSkill.topSource);
+  }, [selectedSkill]);
+
+  const { data: previewContent, isLoading: isLoadingPreview } = useBuilderRegistryPreview(
+    registryId,
+    parsedSource?.owner,
+    parsedSource?.repo,
+    selectedSkill?.name,
+    { enabled: !!parsedSource && !!selectedSkill && open },
+  );
+
+  const debouncedSearch = useDebouncedCallback((query: string) => {
+    if (query.trim().length >= 2) {
+      searchMutation.mutate(query);
+    }
+  }, 300);
+
+  const handleSearch = useCallback(
+    (query: string) => {
+      setSearchQuery(query);
+      debouncedSearch(query);
+    },
+    [debouncedSearch],
+  );
+
+  const displaySkills = useMemo(() => {
+    if (searchQuery.trim().length >= 2) {
+      return searchMutation.data?.skills ?? [];
+    }
+    return popularData?.skills ?? [];
+  }, [searchQuery, searchMutation.data, popularData]);
+
+  const isSearching = searchMutation.isPending;
+  const hasSearchResults = searchQuery.trim().length >= 2;
+
+  const isSelectedInstalled = useMemo(() => {
+    if (!selectedSkill) return false;
+    return installedSkillIds.includes(selectedSkill.name);
+  }, [selectedSkill, installedSkillIds]);
+
+  const githubUrl = useMemo(() => {
+    if (!parsedSource) return null;
+    return `https://github.com/${parsedSource.owner}/${parsedSource.repo}`;
+  }, [parsedSource]);
+
+  const handleInstall = useCallback(async () => {
+    if (!selectedSkill || !parsedSource) return;
+    setInstallError(null);
+    try {
+      const result = await installMutation.mutateAsync({
+        owner: parsedSource.owner,
+        repo: parsedSource.repo,
+        skillName: selectedSkill.name,
+      });
+      onInstalled?.(result.storedSkillId);
+      onOpenChange(false);
+    } catch (err: any) {
+      const message: string = err?.message ?? 'Install failed';
+      // Detect 409 from the stringified error body. The collision case is the
+      // only one we need to upgrade into a navigation hint.
+      if (/409/.test(message) || /already exists/i.test(message)) {
+        onCollision?.(selectedSkill.name);
+        setInstallError('A skill with this name already exists. Open the existing skill instead.');
+      } else {
+        setInstallError(message);
+      }
+    }
+  }, [selectedSkill, parsedSource, installMutation, onInstalled, onOpenChange, onCollision]);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) {
+        setSearchQuery('');
+        setSelectedSkill(null);
+        setInstallError(null);
+      }
+      onOpenChange(next);
+    },
+    [onOpenChange],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-4xl h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Browse {registryLabel}</DialogTitle>
+          <DialogDescription>
+            Find a public skill from {registryLabel} and import it into your Builder skill library.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogBody className="flex-1 flex flex-col gap-4 overflow-hidden max-h-none">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral3" />
+            <Input
+              placeholder={`Search ${registryLabel}...`}
+              value={searchQuery}
+              onChange={e => handleSearch(e.target.value)}
+              className="pl-9"
+              data-testid="builder-add-skill-search"
+            />
+          </div>
+
+          <div className="flex flex-1 gap-4 min-h-0">
+            {/* Skills list */}
+            <div className="w-1/2 flex flex-col min-h-0">
+              <div className="text-xs font-medium text-neutral4 uppercase tracking-wide mb-2">
+                {hasSearchResults ? 'Search results' : 'Popular skills'}
+              </div>
+              <ScrollArea className="flex-1 border border-border1 rounded-lg">
+                {isLoadingPopular || isSearching ? (
+                  <div className="flex items-center justify-center py-8">
+                    <Loader2 className="h-6 w-6 animate-spin text-neutral3" />
+                  </div>
+                ) : displaySkills.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-8 text-neutral4">
+                    <Package className="h-8 w-8 mb-2" />
+                    <p className="text-sm">{hasSearchResults ? 'No skills found' : 'No skills available'}</p>
+                  </div>
+                ) : (
+                  <div className="p-2 space-y-1">
+                    {displaySkills.map(skill => {
+                      const skillUniqueId = getSkillUniqueId(skill);
+                      const isInstalled = installedSkillIds.includes(skill.name);
+                      const selectedUniqueId = selectedSkill ? getSkillUniqueId(selectedSkill) : null;
+                      return (
+                        <button
+                          key={skillUniqueId}
+                          onClick={() => setSelectedSkill(skill)}
+                          className={cn(
+                            'w-full text-left px-3 py-2 rounded-md transition-colors',
+                            'hover:bg-surface4',
+                            selectedUniqueId === skillUniqueId && 'bg-surface5 border border-accent1',
+                          )}
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-2">
+                                <span className="font-medium text-sm text-neutral6 truncate">{skill.name}</span>
+                                {isInstalled && (
+                                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent1/20 text-accent1">
+                                    <Check className="h-2.5 w-2.5" />
+                                    Installed
+                                  </span>
+                                )}
+                              </div>
+                              <div className="text-xs text-neutral4 truncate">{skill.topSource}</div>
+                            </div>
+                            <div className="flex items-center gap-1 text-xs text-neutral3 shrink-0">
+                              <Download className="h-3 w-3" />
+                              <span>{skill.installs.toLocaleString()}</span>
+                            </div>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </ScrollArea>
+            </div>
+
+            {/* Preview pane */}
+            <div className="w-1/2 flex flex-col min-h-0 border border-border1 rounded-lg overflow-hidden">
+              {!selectedSkill ? (
+                <div className="flex-1 flex flex-col items-center justify-center text-neutral4">
+                  <Package className="h-8 w-8 mb-2" />
+                  <p className="text-sm">Select a skill to preview</p>
+                </div>
+              ) : (
+                <>
+                  <div className="p-4 border-b border-border1 bg-surface3">
+                    <div className="flex items-start gap-3">
+                      <div className="p-2 rounded-lg bg-surface5">
+                        <SkillIcon className="h-5 w-5 text-neutral4" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h3 className="font-semibold text-neutral6 truncate">{selectedSkill.name}</h3>
+                        <div className="flex items-center gap-3 mt-1 text-xs text-neutral4">
+                          <span className="flex items-center gap-1">
+                            <Github className="h-3 w-3" />
+                            {selectedSkill.topSource}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <Download className="h-3 w-3" />
+                            {selectedSkill.installs.toLocaleString()} installs
+                          </span>
+                        </div>
+                      </div>
+                      {githubUrl && (
+                        <a
+                          href={githubUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-neutral4 hover:text-neutral5 transition-colors"
+                          title="View on GitHub"
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </a>
+                      )}
+                    </div>
+                  </div>
+
+                  {isLoadingPreview ? (
+                    <div className="flex-1 flex items-center justify-center">
+                      <Loader2 className="h-6 w-6 animate-spin text-neutral3" />
+                    </div>
+                  ) : previewContent ? (
+                    <ScrollArea className="flex-1">
+                      <div className="p-4">
+                        <MarkdownRenderer>{previewContent}</MarkdownRenderer>
+                      </div>
+                    </ScrollArea>
+                  ) : (
+                    <div className="flex-1 flex flex-col items-center justify-center text-neutral4">
+                      <Package className="h-8 w-8 mb-2" />
+                      <p className="text-sm">Preview unavailable</p>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+
+          {selectedSkill && (
+            <div className="flex flex-col gap-3 pt-4 border-t border-border1">
+              {installError && (
+                <div className="text-sm text-red-400 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/20">
+                  {installError}
+                </div>
+              )}
+              <div className="flex items-center justify-end gap-2">
+                <Button variant="default" onClick={() => handleOpenChange(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  onClick={handleInstall}
+                  disabled={!parsedSource || installMutation.isPending || isSelectedInstalled}
+                  data-testid="builder-install-skill-button"
+                >
+                  {installMutation.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Installing...
+                    </>
+                  ) : isSelectedInstalled ? (
+                    <>
+                      <Check className="h-4 w-4 mr-2" />
+                      Already installed
+                    </>
+                  ) : (
+                    <>
+                      <Download className="h-4 w-4 mr-2" />
+                      Install
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/copy-skill-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/copy-skill-dialog.tsx
@@ -1,42 +1,42 @@
 import { AlertDialog, Input } from '@mastra/playground-ui';
 import { useEffect, useState } from 'react';
 
-export interface ForkSkillDialogProps {
+export interface CopySkillDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** The original skill being forked. Used to suggest a default name. */
+  /** The original skill being copied. Used to suggest a default name. */
   sourceName: string;
   /** Names of the user's existing skills, to detect collisions before submit. */
   existingNames: string[];
-  /** Whether a fork mutation is currently pending. */
+  /** Whether a copy mutation is currently pending. */
   isPending?: boolean;
   /** Called with the chosen name when the user confirms. */
   onConfirm: (name: string) => void;
 }
 
-function suggestForkName(sourceName: string, existingNames: string[]): string {
-  const base = `${sourceName}-fork`;
+function suggestCopyName(sourceName: string, existingNames: string[]): string {
+  const base = `${sourceName}-copy`;
   if (!existingNames.includes(base)) return base;
   for (let i = 2; i < 100; i++) {
-    const candidate = `${sourceName}-fork-${i}`;
+    const candidate = `${sourceName}-copy-${i}`;
     if (!existingNames.includes(candidate)) return candidate;
   }
   return base;
 }
 
-export function ForkSkillDialog({
+export function CopySkillDialog({
   open,
   onOpenChange,
   sourceName,
   existingNames,
   isPending,
   onConfirm,
-}: ForkSkillDialogProps) {
+}: CopySkillDialogProps) {
   const [name, setName] = useState('');
 
   // Re-seed the suggested name whenever the dialog opens for a different source.
   useEffect(() => {
-    if (open) setName(suggestForkName(sourceName, existingNames));
+    if (open) setName(suggestCopyName(sourceName, existingNames));
   }, [open, sourceName, existingNames]);
 
   const trimmed = name.trim();
@@ -47,22 +47,22 @@ export function ForkSkillDialog({
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialog.Content>
         <AlertDialog.Header>
-          <AlertDialog.Title>Fork "{sourceName}"</AlertDialog.Title>
+          <AlertDialog.Title>Copy "{sourceName}"</AlertDialog.Title>
           <AlertDialog.Description>
             Creates a private copy in your skills that you can edit. The original stays untouched.
           </AlertDialog.Description>
         </AlertDialog.Header>
         <div className="px-6 py-2">
-          <label className="block text-ui-sm text-neutral4 mb-1.5" htmlFor="fork-skill-name">
+          <label className="block text-ui-sm text-neutral4 mb-1.5" htmlFor="copy-skill-name">
             New skill name
           </label>
           <Input
-            id="fork-skill-name"
+            id="copy-skill-name"
             value={name}
             onChange={e => setName(e.target.value)}
-            placeholder="my-skill-fork"
+            placeholder="my-skill-copy"
             autoFocus
-            data-testid="fork-skill-name-input"
+            data-testid="copy-skill-name-input"
           />
           {collides && (
             <div className="mt-1.5 text-ui-xs text-red-400">You already have a skill named "{trimmed}".</div>
@@ -79,9 +79,9 @@ export function ForkSkillDialog({
               }
               onConfirm(trimmed);
             }}
-            data-testid="fork-skill-confirm"
+            data-testid="copy-skill-confirm"
           >
-            {isPending ? 'Forking...' : 'Fork skill'}
+            {isPending ? 'Copying...' : 'Copy skill'}
           </AlertDialog.Action>
         </AlertDialog.Footer>
       </AlertDialog.Content>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/fork-skill-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/fork-skill-dialog.tsx
@@ -1,0 +1,90 @@
+import { AlertDialog, Input } from '@mastra/playground-ui';
+import { useEffect, useState } from 'react';
+
+export interface ForkSkillDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The original skill being forked. Used to suggest a default name. */
+  sourceName: string;
+  /** Names of the user's existing skills, to detect collisions before submit. */
+  existingNames: string[];
+  /** Whether a fork mutation is currently pending. */
+  isPending?: boolean;
+  /** Called with the chosen name when the user confirms. */
+  onConfirm: (name: string) => void;
+}
+
+function suggestForkName(sourceName: string, existingNames: string[]): string {
+  const base = `${sourceName}-fork`;
+  if (!existingNames.includes(base)) return base;
+  for (let i = 2; i < 100; i++) {
+    const candidate = `${sourceName}-fork-${i}`;
+    if (!existingNames.includes(candidate)) return candidate;
+  }
+  return base;
+}
+
+export function ForkSkillDialog({
+  open,
+  onOpenChange,
+  sourceName,
+  existingNames,
+  isPending,
+  onConfirm,
+}: ForkSkillDialogProps) {
+  const [name, setName] = useState('');
+
+  // Re-seed the suggested name whenever the dialog opens for a different source.
+  useEffect(() => {
+    if (open) setName(suggestForkName(sourceName, existingNames));
+  }, [open, sourceName, existingNames]);
+
+  const trimmed = name.trim();
+  const collides = existingNames.includes(trimmed);
+  const canSubmit = trimmed.length > 0 && !collides && !isPending;
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialog.Content>
+        <AlertDialog.Header>
+          <AlertDialog.Title>Fork "{sourceName}"</AlertDialog.Title>
+          <AlertDialog.Description>
+            Creates a private copy in your skills that you can edit. The original stays untouched.
+          </AlertDialog.Description>
+        </AlertDialog.Header>
+        <div className="px-6 py-2">
+          <label className="block text-ui-sm text-neutral4 mb-1.5" htmlFor="fork-skill-name">
+            New skill name
+          </label>
+          <Input
+            id="fork-skill-name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="my-skill-fork"
+            autoFocus
+            data-testid="fork-skill-name-input"
+          />
+          {collides && (
+            <div className="mt-1.5 text-ui-xs text-red-400">You already have a skill named "{trimmed}".</div>
+          )}
+        </div>
+        <AlertDialog.Footer>
+          <AlertDialog.Cancel disabled={isPending}>Cancel</AlertDialog.Cancel>
+          <AlertDialog.Action
+            disabled={!canSubmit}
+            onClick={e => {
+              if (!canSubmit) {
+                e.preventDefault();
+                return;
+              }
+              onConfirm(trimmed);
+            }}
+            data-testid="fork-skill-confirm"
+          >
+            {isPending ? 'Forking...' : 'Fork skill'}
+          </AlertDialog.Action>
+        </AlertDialog.Footer>
+      </AlertDialog.Content>
+    </AlertDialog>
+  );
+}

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
@@ -12,7 +12,16 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@mastra/playground-ui';
-import { AlertTriangle, ChevronDown, ChevronRight, Globe, LockIcon, Pencil, Settings2 } from 'lucide-react';
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  GitForkIcon,
+  Globe,
+  LockIcon,
+  Pencil,
+  Settings2,
+} from 'lucide-react';
 import { nanoid } from 'nanoid';
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 
@@ -47,6 +56,11 @@ export interface SkillEditDialogProps {
   currentUserId?: string;
   /** Whether the current user is an admin (enables advanced file-tree mode) */
   isAdmin?: boolean;
+  /**
+   * Optional fork action shown when viewing a public skill the user does not own.
+   * Call site is responsible for prompting for a name and invoking the fork mutation.
+   */
+  onFork?: (skill: StoredSkillResponse) => void;
 }
 
 export function SkillEditDialog({
@@ -57,6 +71,7 @@ export function SkillEditDialog({
   skill,
   currentUserId,
   isAdmin,
+  onFork,
 }: SkillEditDialogProps) {
   const [mode, setMode] = useState<DialogMode>('simple');
   const [isEditing, setIsEditing] = useState(false);
@@ -262,6 +277,16 @@ export function SkillEditDialog({
             <Button variant="secondary" size="sm" onClick={() => setIsEditing(true)}>
               <Pencil className="h-3.5 w-3.5" /> Edit
             </Button>
+          )}
+          {isViewMode && !isOwner && onFork && skill && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="secondary" size="sm" onClick={() => onFork(skill)}>
+                  <GitForkIcon className="h-3.5 w-3.5" /> Fork
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Make your own private copy you can edit</TooltipContent>
+            </Tooltip>
           )}
           {!isReadOnly && (
             <>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
@@ -12,16 +12,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@mastra/playground-ui';
-import {
-  AlertTriangle,
-  ChevronDown,
-  ChevronRight,
-  GitForkIcon,
-  Globe,
-  LockIcon,
-  Pencil,
-  Settings2,
-} from 'lucide-react';
+import { AlertTriangle, ChevronDown, ChevronRight, CopyIcon, Globe, LockIcon, Pencil, Settings2 } from 'lucide-react';
 import { nanoid } from 'nanoid';
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 
@@ -57,10 +48,10 @@ export interface SkillEditDialogProps {
   /** Whether the current user is an admin (enables advanced file-tree mode) */
   isAdmin?: boolean;
   /**
-   * Optional fork action shown when viewing a public skill the user does not own.
-   * Call site is responsible for prompting for a name and invoking the fork mutation.
+   * Optional copy action shown when viewing a public skill the user does not own.
+   * Call site is responsible for prompting for a name and invoking the copy mutation.
    */
-  onFork?: (skill: StoredSkillResponse) => void;
+  onCopy?: (skill: StoredSkillResponse) => void;
 }
 
 export function SkillEditDialog({
@@ -71,7 +62,7 @@ export function SkillEditDialog({
   skill,
   currentUserId,
   isAdmin,
-  onFork,
+  onCopy,
 }: SkillEditDialogProps) {
   const [mode, setMode] = useState<DialogMode>('simple');
   const [isEditing, setIsEditing] = useState(false);
@@ -278,11 +269,11 @@ export function SkillEditDialog({
               <Pencil className="h-3.5 w-3.5" /> Edit
             </Button>
           )}
-          {isViewMode && !isOwner && onFork && skill && (
+          {isViewMode && !isOwner && onCopy && skill && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="secondary" size="sm" onClick={() => onFork(skill)}>
-                  <GitForkIcon className="h-3.5 w-3.5" /> Fork
+                <Button variant="secondary" size="sm" onClick={() => onCopy(skill)}>
+                  <CopyIcon className="h-3.5 w-3.5" /> Copy
                 </Button>
               </TooltipTrigger>
               <TooltipContent>Make your own private copy you can edit</TooltipContent>

--- a/packages/playground/src/domains/agents/hooks/use-builder-registries.ts
+++ b/packages/playground/src/domains/agents/hooks/use-builder-registries.ts
@@ -1,0 +1,114 @@
+import type {
+  BuilderRegistryInstallBody,
+  BuilderRegistryInstallResponse,
+  BuilderRegistryPopularResponse,
+  BuilderRegistryPreviewResponse,
+  BuilderRegistrySearchResponse,
+  ListBuilderRegistriesResponse,
+} from '@mastra/client-js';
+import { useMastraClient } from '@mastra/react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+// =============================================================================
+// Builder skill registry hooks
+//
+// Wrap the `/editor/builder/registries/*` routes with React Query. The registry
+// surface is hard-gated server-side, so callers can rely on errors (404) rather
+// than guessing whether a registry is enabled.
+// =============================================================================
+
+const STALE_POPULAR_MS = 5 * 60 * 1000;
+
+/**
+ * List known builder skill registries with their enabled state.
+ */
+export function useBuilderRegistries(options?: { enabled?: boolean }) {
+  const client = useMastraClient();
+  return useQuery({
+    queryKey: ['builder-registries'],
+    queryFn: (): Promise<ListBuilderRegistriesResponse> => client.listBuilderRegistries(),
+    enabled: options?.enabled ?? true,
+    retry: false,
+  });
+}
+
+/**
+ * Run a free-text search against a builder skill registry. The mutation
+ * shape mirrors the existing skills.sh hook so the dialog can call it on
+ * submit.
+ */
+export function useSearchBuilderRegistry(registryId: string | undefined) {
+  const client = useMastraClient();
+  return useMutation({
+    mutationFn: async (query: string): Promise<BuilderRegistrySearchResponse> => {
+      if (!registryId) throw new Error('Registry ID is required');
+      return client.searchBuilderRegistry(registryId, { q: query, limit: 10 });
+    },
+  });
+}
+
+/**
+ * Fetch the popular skills feed for a registry. Cached for 5 minutes so
+ * navigating in and out of the dialog doesn't refetch.
+ */
+export function usePopularBuilderRegistrySkills(registryId: string | undefined) {
+  const client = useMastraClient();
+  return useQuery({
+    queryKey: ['builder-registry', registryId, 'popular'],
+    queryFn: (): Promise<BuilderRegistryPopularResponse> => {
+      if (!registryId) throw new Error('Registry ID is required');
+      return client.getBuilderRegistryPopular(registryId, { limit: 10, offset: 0 });
+    },
+    enabled: !!registryId,
+    staleTime: STALE_POPULAR_MS,
+    retry: false,
+  });
+}
+
+/**
+ * Fetch the rendered preview for a single registry skill.
+ */
+export function useBuilderRegistryPreview(
+  registryId: string | undefined,
+  owner: string | undefined,
+  repo: string | undefined,
+  skillPath: string | undefined,
+  options?: { enabled?: boolean },
+) {
+  const client = useMastraClient();
+  return useQuery({
+    queryKey: ['builder-registry', registryId, 'preview', owner, repo, skillPath],
+    queryFn: async (): Promise<string> => {
+      if (!registryId || !owner || !repo || !skillPath) {
+        throw new Error('registryId, owner, repo, and skillPath are required');
+      }
+      const data: BuilderRegistryPreviewResponse = await client.getBuilderRegistryPreview(registryId, {
+        owner,
+        repo,
+        path: skillPath,
+      });
+      return data.content;
+    },
+    enabled: options?.enabled !== false && !!registryId && !!owner && !!repo && !!skillPath,
+    retry: false,
+  });
+}
+
+/**
+ * Install a skill from a builder registry into the stored-skills DB.
+ * Returns 409 when a stored skill with the derived id already exists — the
+ * UI is responsible for surfacing the existing skill via "Open existing".
+ */
+export function useInstallBuilderRegistrySkill(registryId: string | undefined) {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: BuilderRegistryInstallBody): Promise<BuilderRegistryInstallResponse> => {
+      if (!registryId) throw new Error('Registry ID is required');
+      return client.installBuilderRegistrySkill(registryId, body);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['stored-skills'] });
+    },
+  });
+}

--- a/packages/playground/src/domains/agents/hooks/use-copy-skill.ts
+++ b/packages/playground/src/domains/agents/hooks/use-copy-skill.ts
@@ -3,10 +3,10 @@ import { toast } from '@mastra/playground-ui';
 import { useMastraClient } from '@mastra/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import type { LibraryForkOrigin } from '../utils/skill-origin';
+import type { LibraryCopyOrigin } from '../utils/skill-origin';
 
-export interface ForkSkillParams {
-  /** The public Library skill being forked. */
+export interface CopySkillParams {
+  /** The public Library skill being copied. */
   source: StoredSkillResponse;
   /** Name to give the new private copy. Should not collide with existing user skills. */
   name: string;
@@ -15,25 +15,23 @@ export interface ForkSkillParams {
 }
 
 /**
- * Fork a public Library skill into the caller's own catalog as a private copy.
+ * Copy a public Library skill into the caller's own catalog as a private skill.
  *
- * This is "Studio is the registry" in action — when registries.skillsSh is off
- * and no custom registries are wired, users still need a way to take a public
- * skill and customize it without affecting the canonical version. We just call
- * `createStoredSkill` with the source's content and an `origin: library-fork`
- * tag so the UI can show provenance later.
+ * Users can take a public skill and customize it without affecting the
+ * canonical version. We call `createStoredSkill` with the source's content and
+ * an `origin: library-copy` tag so the UI can show provenance later.
  */
-export function useForkSkill() {
+export function useCopySkill() {
   const client = useMastraClient();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (params: ForkSkillParams): Promise<StoredSkillResponse> => {
+    mutationFn: async (params: CopySkillParams): Promise<StoredSkillResponse> => {
       const { source, name } = params;
       const description = params.description ?? source.description ?? '';
 
-      const origin: LibraryForkOrigin = {
-        type: 'library-fork',
+      const origin: LibraryCopyOrigin = {
+        type: 'library-copy',
         sourceSkillId: source.id,
         sourceSkillName: source.name,
         ...(source.authorId ? { sourceAuthorId: source.authorId } : {}),
@@ -47,16 +45,16 @@ export function useForkSkill() {
         license: source.license,
         files: source.files,
         metadata: {
-          origin: { ...origin, forkedAt: new Date().toISOString() },
+          origin: { ...origin, copiedAt: new Date().toISOString() },
         },
       });
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['stored-skills'] });
-      toast.success('Skill forked');
+      toast.success('Skill copied');
     },
     onError: error => {
-      toast.error(`Failed to fork skill: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      toast.error(`Failed to copy skill: ${error instanceof Error ? error.message : 'Unknown error'}`);
     },
   });
 }

--- a/packages/playground/src/domains/agents/hooks/use-fork-skill.ts
+++ b/packages/playground/src/domains/agents/hooks/use-fork-skill.ts
@@ -1,0 +1,62 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import { toast } from '@mastra/playground-ui';
+import { useMastraClient } from '@mastra/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { LibraryForkOrigin } from '../utils/skill-origin';
+
+export interface ForkSkillParams {
+  /** The public Library skill being forked. */
+  source: StoredSkillResponse;
+  /** Name to give the new private copy. Should not collide with existing user skills. */
+  name: string;
+  /** Optional override of the description. Defaults to the source description. */
+  description?: string;
+}
+
+/**
+ * Fork a public Library skill into the caller's own catalog as a private copy.
+ *
+ * This is "Studio is the registry" in action — when registries.skillsSh is off
+ * and no custom registries are wired, users still need a way to take a public
+ * skill and customize it without affecting the canonical version. We just call
+ * `createStoredSkill` with the source's content and an `origin: library-fork`
+ * tag so the UI can show provenance later.
+ */
+export function useForkSkill() {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: ForkSkillParams): Promise<StoredSkillResponse> => {
+      const { source, name } = params;
+      const description = params.description ?? source.description ?? '';
+
+      const origin: LibraryForkOrigin = {
+        type: 'library-fork',
+        sourceSkillId: source.id,
+        sourceSkillName: source.name,
+        ...(source.authorId ? { sourceAuthorId: source.authorId } : {}),
+      };
+
+      return client.createStoredSkill({
+        name,
+        description,
+        visibility: 'private',
+        instructions: source.instructions,
+        license: source.license,
+        files: source.files,
+        metadata: {
+          origin: { ...origin, forkedAt: new Date().toISOString() },
+        },
+      });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['stored-skills'] });
+      toast.success('Skill forked');
+    },
+    onError: error => {
+      toast.error(`Failed to fork skill: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    },
+  });
+}

--- a/packages/playground/src/domains/agents/utils/skill-origin.ts
+++ b/packages/playground/src/domains/agents/utils/skill-origin.ts
@@ -16,14 +16,14 @@ export interface SkillsShOrigin {
   skillName: string;
 }
 
-export interface LibraryForkOrigin {
-  type: 'library-fork';
+export interface LibraryCopyOrigin {
+  type: 'library-copy';
   sourceSkillId: string;
   sourceSkillName: string;
   sourceAuthorId?: string;
 }
 
-export type SkillOrigin = SkillsShOrigin | LibraryForkOrigin;
+export type SkillOrigin = SkillsShOrigin | LibraryCopyOrigin;
 
 export function getSkillOrigin(metadata: Record<string, unknown> | undefined | null): SkillOrigin | null {
   if (!metadata || typeof metadata !== 'object') return null;
@@ -44,12 +44,12 @@ export function getSkillOrigin(metadata: Record<string, unknown> | undefined | n
     };
   }
   if (
-    candidate.type === 'library-fork' &&
+    candidate.type === 'library-copy' &&
     typeof candidate.sourceSkillId === 'string' &&
     typeof candidate.sourceSkillName === 'string'
   ) {
     return {
-      type: 'library-fork',
+      type: 'library-copy',
       sourceSkillId: candidate.sourceSkillId,
       sourceSkillName: candidate.sourceSkillName,
       sourceAuthorId: typeof candidate.sourceAuthorId === 'string' ? candidate.sourceAuthorId : undefined,
@@ -65,8 +65,8 @@ export function formatSkillOriginLabel(origin: SkillOrigin): string {
   switch (origin.type) {
     case 'skills-sh':
       return `skills.sh · ${origin.owner}/${origin.repo}`;
-    case 'library-fork':
-      return `Forked from "${origin.sourceSkillName}"`;
+    case 'library-copy':
+      return `Copied from "${origin.sourceSkillName}"`;
     default:
       return 'imported';
   }
@@ -79,7 +79,7 @@ export function getSkillOriginUrl(origin: SkillOrigin): string | null {
   switch (origin.type) {
     case 'skills-sh':
       return `https://skills.sh/${origin.owner}/${origin.repo}/${origin.skillName}`;
-    case 'library-fork':
+    case 'library-copy':
       return null;
     default:
       return null;

--- a/packages/playground/src/domains/agents/utils/skill-origin.ts
+++ b/packages/playground/src/domains/agents/utils/skill-origin.ts
@@ -16,13 +16,20 @@ export interface SkillsShOrigin {
   skillName: string;
 }
 
-export type SkillOrigin = SkillsShOrigin;
+export interface LibraryForkOrigin {
+  type: 'library-fork';
+  sourceSkillId: string;
+  sourceSkillName: string;
+  sourceAuthorId?: string;
+}
+
+export type SkillOrigin = SkillsShOrigin | LibraryForkOrigin;
 
 export function getSkillOrigin(metadata: Record<string, unknown> | undefined | null): SkillOrigin | null {
   if (!metadata || typeof metadata !== 'object') return null;
   const origin = (metadata as { origin?: unknown }).origin;
   if (!origin || typeof origin !== 'object') return null;
-  const candidate = origin as { type?: unknown; owner?: unknown; repo?: unknown; skillName?: unknown };
+  const candidate = origin as Record<string, unknown>;
   if (
     candidate.type === 'skills-sh' &&
     typeof candidate.owner === 'string' &&
@@ -36,6 +43,18 @@ export function getSkillOrigin(metadata: Record<string, unknown> | undefined | n
       skillName: candidate.skillName,
     };
   }
+  if (
+    candidate.type === 'library-fork' &&
+    typeof candidate.sourceSkillId === 'string' &&
+    typeof candidate.sourceSkillName === 'string'
+  ) {
+    return {
+      type: 'library-fork',
+      sourceSkillId: candidate.sourceSkillId,
+      sourceSkillName: candidate.sourceSkillName,
+      sourceAuthorId: typeof candidate.sourceAuthorId === 'string' ? candidate.sourceAuthorId : undefined,
+    };
+  }
   return null;
 }
 
@@ -46,6 +65,8 @@ export function formatSkillOriginLabel(origin: SkillOrigin): string {
   switch (origin.type) {
     case 'skills-sh':
       return `skills.sh · ${origin.owner}/${origin.repo}`;
+    case 'library-fork':
+      return `Forked from "${origin.sourceSkillName}"`;
     default:
       return 'imported';
   }
@@ -58,6 +79,8 @@ export function getSkillOriginUrl(origin: SkillOrigin): string | null {
   switch (origin.type) {
     case 'skills-sh':
       return `https://skills.sh/${origin.owner}/${origin.repo}/${origin.skillName}`;
+    case 'library-fork':
+      return null;
     default:
       return null;
   }

--- a/packages/playground/src/domains/agents/utils/skill-origin.ts
+++ b/packages/playground/src/domains/agents/utils/skill-origin.ts
@@ -1,0 +1,64 @@
+/**
+ * Helpers for reading the `metadata.origin` field on stored skills. Skills
+ * that were imported from an external registry (skills.sh today, more later)
+ * carry their provenance here so the UI can show a badge and link back.
+ *
+ * The shape lines up with `skillOriginSchema` in
+ * `packages/server/src/server/schemas/stored-skills.ts`. We narrow at the
+ * boundary because `StoredSkillResponse.metadata` is loosely typed as
+ * `Record<string, unknown>` on the wire.
+ */
+
+export interface SkillsShOrigin {
+  type: 'skills-sh';
+  owner: string;
+  repo: string;
+  skillName: string;
+}
+
+export type SkillOrigin = SkillsShOrigin;
+
+export function getSkillOrigin(metadata: Record<string, unknown> | undefined | null): SkillOrigin | null {
+  if (!metadata || typeof metadata !== 'object') return null;
+  const origin = (metadata as { origin?: unknown }).origin;
+  if (!origin || typeof origin !== 'object') return null;
+  const candidate = origin as { type?: unknown; owner?: unknown; repo?: unknown; skillName?: unknown };
+  if (
+    candidate.type === 'skills-sh' &&
+    typeof candidate.owner === 'string' &&
+    typeof candidate.repo === 'string' &&
+    typeof candidate.skillName === 'string'
+  ) {
+    return {
+      type: 'skills-sh',
+      owner: candidate.owner,
+      repo: candidate.repo,
+      skillName: candidate.skillName,
+    };
+  }
+  return null;
+}
+
+/**
+ * Build a human-readable label for an origin (e.g. `skills.sh · owner/repo`).
+ */
+export function formatSkillOriginLabel(origin: SkillOrigin): string {
+  switch (origin.type) {
+    case 'skills-sh':
+      return `skills.sh · ${origin.owner}/${origin.repo}`;
+    default:
+      return 'imported';
+  }
+}
+
+/**
+ * Build the upstream URL for an origin, when known.
+ */
+export function getSkillOriginUrl(origin: SkillOrigin): string | null {
+  switch (origin.type) {
+    case 'skills-sh':
+      return `https://skills.sh/${origin.owner}/${origin.repo}/${origin.skillName}`;
+    default:
+      return null;
+  }
+}

--- a/packages/playground/src/pages/agent-builder/library/index.tsx
+++ b/packages/playground/src/pages/agent-builder/library/index.tsx
@@ -23,9 +23,9 @@ import {
 } from '@/domains/agent-builder/components/skill-builder-list/skill-builder-list';
 import { useBuilderAgentAccess } from '@/domains/agent-builder/hooks/use-builder-agent-access';
 import { useBuilderAgentFeatures } from '@/domains/agent-builder/hooks/use-builder-agent-features';
-import { ForkSkillDialog } from '@/domains/agents/components/agent-cms-pages/fork-skill-dialog';
+import { CopySkillDialog } from '@/domains/agents/components/agent-cms-pages/copy-skill-dialog';
 import { SkillEditDialog } from '@/domains/agents/components/agent-cms-pages/skill-edit-dialog';
-import { useForkSkill } from '@/domains/agents/hooks/use-fork-skill';
+import { useCopySkill } from '@/domains/agents/hooks/use-copy-skill';
 import { useStoredAgents } from '@/domains/agents/hooks/use-stored-agents';
 import { useStoredSkills } from '@/domains/agents/hooks/use-stored-skills';
 import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
@@ -37,7 +37,7 @@ export default function AgentBuilderLibraryPage() {
   const [search, setSearch] = useState('');
   const [tab, setTab] = useState<Tab>('agents');
   const [selectedSkill, setSelectedSkill] = useState<StoredSkillResponse | null>(null);
-  const [forkSource, setForkSource] = useState<StoredSkillResponse | null>(null);
+  const [copySource, setCopySource] = useState<StoredSkillResponse | null>(null);
   const features = useBuilderAgentFeatures();
   const { canUseFavorites } = useBuilderAgentAccess();
   const { data: currentUser } = useCurrentUser();
@@ -54,12 +54,12 @@ export default function AgentBuilderLibraryPage() {
     error: skillsError,
   } = useStoredSkills(skillListParams, { enabled: tab === 'skills' && features.skills });
 
-  // Fetch the user's existing skills only when needed (i.e. they have fork-write capability),
-  // so we can suggest a non-colliding fork name and detect collisions before submit.
+  // Fetch the user's existing skills only when needed (i.e. they have copy-write capability),
+  // so we can suggest a non-colliding copy name and detect collisions before submit.
   const { data: ownSkillsData } = useStoredSkills(undefined, { enabled: canWriteSkills });
   const ownSkillNames = useMemo(() => (ownSkillsData?.skills ?? []).map(s => s.name), [ownSkillsData]);
 
-  const forkSkill = useForkSkill();
+  const copySkill = useCopySkill();
 
   const agents = agentsData?.agents ?? [];
   const skills = skillsData?.skills ?? [];
@@ -181,29 +181,29 @@ export default function AgentBuilderLibraryPage() {
           skill={selectedSkill}
           currentUserId={currentUser?.id}
           isAdmin={canWriteSkills}
-          onFork={
+          onCopy={
             canWriteSkills
               ? skill => {
-                  setForkSource(skill);
+                  setCopySource(skill);
                 }
               : undefined
           }
         />
       )}
 
-      {forkSource && (
-        <ForkSkillDialog
-          open={!!forkSource}
+      {copySource && (
+        <CopySkillDialog
+          open={!!copySource}
           onOpenChange={open => {
-            if (!open && !forkSkill.isPending) setForkSource(null);
+            if (!open && !copySkill.isPending) setCopySource(null);
           }}
-          sourceName={forkSource.name}
+          sourceName={copySource.name}
           existingNames={ownSkillNames}
-          isPending={forkSkill.isPending}
+          isPending={copySkill.isPending}
           onConfirm={async name => {
             try {
-              await forkSkill.mutateAsync({ source: forkSource, name });
-              setForkSource(null);
+              await copySkill.mutateAsync({ source: copySource, name });
+              setCopySource(null);
               setSelectedSkill(null);
             } catch (err) {
               if (err instanceof Error && err.message.toLowerCase().includes('already exists')) {

--- a/packages/playground/src/pages/agent-builder/library/index.tsx
+++ b/packages/playground/src/pages/agent-builder/library/index.tsx
@@ -9,6 +9,7 @@ import {
   SessionExpired,
   is401UnauthorizedError,
   is403ForbiddenError,
+  toast,
 } from '@mastra/playground-ui';
 import { LibraryIcon, SparklesIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -22,7 +23,9 @@ import {
 } from '@/domains/agent-builder/components/skill-builder-list/skill-builder-list';
 import { useBuilderAgentAccess } from '@/domains/agent-builder/hooks/use-builder-agent-access';
 import { useBuilderAgentFeatures } from '@/domains/agent-builder/hooks/use-builder-agent-features';
+import { ForkSkillDialog } from '@/domains/agents/components/agent-cms-pages/fork-skill-dialog';
 import { SkillEditDialog } from '@/domains/agents/components/agent-cms-pages/skill-edit-dialog';
+import { useForkSkill } from '@/domains/agents/hooks/use-fork-skill';
 import { useStoredAgents } from '@/domains/agents/hooks/use-stored-agents';
 import { useStoredSkills } from '@/domains/agents/hooks/use-stored-skills';
 import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
@@ -34,6 +37,7 @@ export default function AgentBuilderLibraryPage() {
   const [search, setSearch] = useState('');
   const [tab, setTab] = useState<Tab>('agents');
   const [selectedSkill, setSelectedSkill] = useState<StoredSkillResponse | null>(null);
+  const [forkSource, setForkSource] = useState<StoredSkillResponse | null>(null);
   const features = useBuilderAgentFeatures();
   const { canUseFavorites } = useBuilderAgentAccess();
   const { data: currentUser } = useCurrentUser();
@@ -49,6 +53,13 @@ export default function AgentBuilderLibraryPage() {
     isLoading: skillsLoading,
     error: skillsError,
   } = useStoredSkills(skillListParams, { enabled: tab === 'skills' && features.skills });
+
+  // Fetch the user's existing skills only when needed (i.e. they have fork-write capability),
+  // so we can suggest a non-colliding fork name and detect collisions before submit.
+  const { data: ownSkillsData } = useStoredSkills(undefined, { enabled: canWriteSkills });
+  const ownSkillNames = useMemo(() => (ownSkillsData?.skills ?? []).map(s => s.name), [ownSkillsData]);
+
+  const forkSkill = useForkSkill();
 
   const agents = agentsData?.agents ?? [];
   const skills = skillsData?.skills ?? [];
@@ -170,6 +181,37 @@ export default function AgentBuilderLibraryPage() {
           skill={selectedSkill}
           currentUserId={currentUser?.id}
           isAdmin={canWriteSkills}
+          onFork={
+            canWriteSkills
+              ? skill => {
+                  setForkSource(skill);
+                }
+              : undefined
+          }
+        />
+      )}
+
+      {forkSource && (
+        <ForkSkillDialog
+          open={!!forkSource}
+          onOpenChange={open => {
+            if (!open && !forkSkill.isPending) setForkSource(null);
+          }}
+          sourceName={forkSource.name}
+          existingNames={ownSkillNames}
+          isPending={forkSkill.isPending}
+          onConfirm={async name => {
+            try {
+              await forkSkill.mutateAsync({ source: forkSource, name });
+              setForkSource(null);
+              setSelectedSkill(null);
+            } catch (err) {
+              if (err instanceof Error && err.message.toLowerCase().includes('already exists')) {
+                toast.error(`A skill named "${name}" already exists. Try a different name.`);
+              }
+              // Other errors are surfaced via the mutation's onError toast.
+            }
+          }}
         />
       )}
     </>

--- a/packages/playground/src/pages/agent-builder/skills/index.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/index.tsx
@@ -103,7 +103,7 @@ export default function AgentBuilderSkillsPage() {
                       variant="default"
                       onClick={() => setRegistryDialog({ id: enabledRegistry.id, label: enabledRegistry.label })}
                     >
-                      <DownloadIcon /> Browse {enabledRegistry.label}
+                      <DownloadIcon /> Browse registry
                     </Button>
                   )}
                 </div>
@@ -135,7 +135,7 @@ export default function AgentBuilderSkillsPage() {
                     variant="default"
                     onClick={() => setRegistryDialog({ id: enabledRegistry.id, label: enabledRegistry.label })}
                   >
-                    <DownloadIcon /> Browse {enabledRegistry.label}
+                    <DownloadIcon /> Browse registry
                   </Button>
                 )}
                 <Button variant="primary" onClick={() => setIsCreateDialogOpen(true)}>

--- a/packages/playground/src/pages/agent-builder/skills/index.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/index.tsx
@@ -11,13 +11,16 @@ import {
   is401UnauthorizedError,
   is403ForbiddenError,
 } from '@mastra/playground-ui';
-import { PlusIcon, SparklesIcon } from 'lucide-react';
+import { DownloadIcon, PlusIcon, SparklesIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
 import {
   SkillBuilderList,
   SkillBuilderListSkeleton,
 } from '@/domains/agent-builder/components/skill-builder-list/skill-builder-list';
+import { BuilderAddSkillDialog } from '@/domains/agents/components/agent-cms-pages/builder-add-skill-dialog';
 import { SkillEditDialog } from '@/domains/agents/components/agent-cms-pages/skill-edit-dialog';
+import { useBuilderRegistries } from '@/domains/agents/hooks/use-builder-registries';
 import { useStoredSkills } from '@/domains/agents/hooks/use-stored-skills';
 import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
 import { usePermissions } from '@/domains/auth/hooks/use-permissions';
@@ -26,7 +29,9 @@ export default function AgentBuilderSkillsPage() {
   const { data: currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
   const { hasPermission, rbacEnabled } = usePermissions();
   const canWriteSkills = !rbacEnabled || hasPermission('stored-skills:write');
+  const canReadSkills = !rbacEnabled || hasPermission('stored-skills:read');
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [registryDialog, setRegistryDialog] = useState<{ id: string; label: string } | null>(null);
   const [selectedSkill, setSelectedSkill] = useState<StoredSkillResponse | null>(null);
 
   const listParams = useMemo<ListStoredSkillsParams>(() => {
@@ -40,7 +45,14 @@ export default function AgentBuilderSkillsPage() {
   const { data, isLoading, error } = useStoredSkills(listParams, { enabled: !isCurrentUserLoading });
   const [search, setSearch] = useState('');
 
-  const skills = data?.skills ?? [];
+  const skills = useMemo(() => data?.skills ?? [], [data?.skills]);
+  const installedSkillIds = useMemo(() => skills.map(s => s.id), [skills]);
+
+  // Surface registry browse only for users who can read AND write skills, and
+  // only when at least one registry is actually enabled. This is the gate
+  // requested in COR-832: invisible when there's nothing useful to do.
+  const { data: registriesData } = useBuilderRegistries({ enabled: canReadSkills && canWriteSkills });
+  const enabledRegistry = useMemo(() => registriesData?.registries.find(r => r.enabled) ?? null, [registriesData]);
 
   const handleSkillClick = (skill: StoredSkillResponse) => {
     setSelectedSkill(skill);
@@ -82,9 +94,19 @@ export default function AgentBuilderSkillsPage() {
             descriptionSlot="Create your first skill to give agents new capabilities."
             actionSlot={
               canWriteSkills ? (
-                <Button variant="primary" onClick={() => setIsCreateDialogOpen(true)}>
-                  <PlusIcon /> New skill
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button variant="primary" onClick={() => setIsCreateDialogOpen(true)}>
+                    <PlusIcon /> New skill
+                  </Button>
+                  {enabledRegistry && (
+                    <Button
+                      variant="default"
+                      onClick={() => setRegistryDialog({ id: enabledRegistry.id, label: enabledRegistry.label })}
+                    >
+                      <DownloadIcon /> Browse {enabledRegistry.label}
+                    </Button>
+                  )}
+                </div>
               ) : undefined
             }
           />
@@ -107,7 +129,15 @@ export default function AgentBuilderSkillsPage() {
               <PageHeader.Description>Skills you've created.</PageHeader.Description>
             </PageHeader>
             {skills.length > 0 && canWriteSkills && (
-              <div className="shrink-0">
+              <div className="shrink-0 flex items-center gap-2">
+                {enabledRegistry && (
+                  <Button
+                    variant="default"
+                    onClick={() => setRegistryDialog({ id: enabledRegistry.id, label: enabledRegistry.label })}
+                  >
+                    <DownloadIcon /> Browse {enabledRegistry.label}
+                  </Button>
+                )}
                 <Button variant="primary" onClick={() => setIsCreateDialogOpen(true)}>
                   <PlusIcon /> New skill
                 </Button>
@@ -138,6 +168,35 @@ export default function AgentBuilderSkillsPage() {
         currentUserId={currentUser?.id}
         isAdmin={canWriteSkills}
       />
+
+      {registryDialog && (
+        <BuilderAddSkillDialog
+          open={!!registryDialog}
+          onOpenChange={open => {
+            if (!open) setRegistryDialog(null);
+          }}
+          registryId={registryDialog.id}
+          registryLabel={registryDialog.label}
+          installedSkillIds={installedSkillIds}
+          onInstalled={storedSkillId => {
+            const installed = skills.find(s => s.id === storedSkillId);
+            toast.success(installed ? `Imported "${installed.name}"` : 'Skill imported');
+          }}
+          onCollision={skillName => {
+            const existing = skills.find(s => s.id === skillName || s.name === skillName);
+            if (existing) {
+              toast.error(`"${existing.name}" is already in your library`, {
+                action: {
+                  label: 'Open existing',
+                  onClick: () => setSelectedSkill(existing),
+                },
+              });
+            } else {
+              toast.error(`A skill named "${skillName}" already exists.`);
+            }
+          }}
+        />
+      )}
     </>
   );
 }

--- a/packages/server/src/server/handlers/builder-registry.test.ts
+++ b/packages/server/src/server/handlers/builder-registry.test.ts
@@ -1,0 +1,389 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BUILDER_REGISTRY_INSTALL_ROUTE,
+  BUILDER_REGISTRY_POPULAR_ROUTE,
+  BUILDER_REGISTRY_PREVIEW_ROUTE,
+  BUILDER_REGISTRY_SEARCH_ROUTE,
+  LIST_BUILDER_REGISTRIES_ROUTE,
+} from './builder-registry';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+interface BuildMastraOpts {
+  registryEnabled?: boolean;
+  noEditor?: boolean;
+  noBuilder?: boolean;
+  storage?: any;
+}
+
+const buildMastra = ({
+  registryEnabled = true,
+  noEditor = false,
+  noBuilder = false,
+  storage,
+}: BuildMastraOpts = {}) => {
+  if (noEditor) {
+    return { getEditor: () => undefined } as any;
+  }
+  const builder = noBuilder
+    ? undefined
+    : {
+        getRegistries: () => ({ skillsSh: { enabled: registryEnabled } }),
+      };
+  return {
+    getEditor: () => ({
+      resolveBuilder: vi.fn().mockResolvedValue(builder),
+    }),
+    getStorage: () => storage,
+  } as any;
+};
+
+const ctx = (overrides: Record<string, unknown> = {}) =>
+  ({
+    requestContext: {
+      get: () => undefined,
+    },
+    ...overrides,
+  }) as any;
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('GET /editor/builder/registries', () => {
+  it('reports skills-sh disabled when no editor configured', async () => {
+    const mastra = buildMastra({ noEditor: true });
+    const result = (await LIST_BUILDER_REGISTRIES_ROUTE.handler({ mastra, ...ctx() })) as any;
+    expect(result.registries).toEqual([{ id: 'skills-sh', enabled: false, label: 'skills.sh' }]);
+  });
+
+  it('reports skills-sh disabled when builder lacks registries config', async () => {
+    const mastra = buildMastra({ noBuilder: true });
+    const result = (await LIST_BUILDER_REGISTRIES_ROUTE.handler({ mastra, ...ctx() })) as any;
+    expect(result.registries).toEqual([{ id: 'skills-sh', enabled: false, label: 'skills.sh' }]);
+  });
+
+  it('reports skills-sh enabled when builder config sets it', async () => {
+    const mastra = buildMastra({ registryEnabled: true });
+    const result = (await LIST_BUILDER_REGISTRIES_ROUTE.handler({ mastra, ...ctx() })) as any;
+    expect(result.registries).toEqual([{ id: 'skills-sh', enabled: true, label: 'skills.sh' }]);
+  });
+});
+
+describe('GET /editor/builder/registries/:registryId/search', () => {
+  const mockFetch = vi.fn();
+  beforeEach(() => vi.stubGlobal('fetch', mockFetch));
+  afterEach(() => {
+    mockFetch.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('404s when registry is disabled', async () => {
+    const mastra = buildMastra({ registryEnabled: false });
+    await expect(
+      BUILDER_REGISTRY_SEARCH_ROUTE.handler({ mastra, ...ctx({ registryId: 'skills-sh', q: 'foo', limit: 10 }) }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('404s when registryId is unknown', async () => {
+    const mastra = buildMastra();
+    await expect(
+      BUILDER_REGISTRY_SEARCH_ROUTE.handler({ mastra, ...ctx({ registryId: 'unknown', q: 'foo', limit: 10 }) }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('proxies to upstream when registry is enabled', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ skills: [], total: 0 }),
+    });
+    const mastra = buildMastra();
+    const result = (await BUILDER_REGISTRY_SEARCH_ROUTE.handler({
+      mastra,
+      ...ctx({ registryId: 'skills-sh', q: 'foo', limit: 10 }),
+    })) as any;
+    expect(result).toEqual({ query: 'foo', searchType: 'query', skills: [], count: 0 });
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+});
+
+describe('GET /editor/builder/registries/:registryId/popular', () => {
+  const mockFetch = vi.fn();
+  beforeEach(() => vi.stubGlobal('fetch', mockFetch));
+  afterEach(() => {
+    mockFetch.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('404s when registry is disabled', async () => {
+    const mastra = buildMastra({ registryEnabled: false });
+    await expect(
+      BUILDER_REGISTRY_POPULAR_ROUTE.handler({ mastra, ...ctx({ registryId: 'skills-sh', limit: 10, offset: 0 }) }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('proxies to upstream when registry is enabled', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ skills: [], total: 0 }),
+    });
+    const mastra = buildMastra();
+    const result = (await BUILDER_REGISTRY_POPULAR_ROUTE.handler({
+      mastra,
+      ...ctx({ registryId: 'skills-sh', limit: 10, offset: 0 }),
+    })) as any;
+    expect(result).toEqual({ skills: [], count: 0, limit: 10, offset: 0 });
+  });
+});
+
+describe('GET /editor/builder/registries/:registryId/preview', () => {
+  const mockFetch = vi.fn();
+  beforeEach(() => vi.stubGlobal('fetch', mockFetch));
+  afterEach(() => {
+    mockFetch.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('404s when registry is disabled', async () => {
+    const mastra = buildMastra({ registryEnabled: false });
+    await expect(
+      BUILDER_REGISTRY_PREVIEW_ROUTE.handler({
+        mastra,
+        ...ctx({ registryId: 'skills-sh', owner: 'a', repo: 'b', path: 'c' }),
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('returns content when registry is enabled', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ instructions: '# hello' }),
+    });
+    const mastra = buildMastra();
+    const result = (await BUILDER_REGISTRY_PREVIEW_ROUTE.handler({
+      mastra,
+      ...ctx({ registryId: 'skills-sh', owner: 'a', repo: 'b', path: 'c' }),
+    })) as any;
+    expect(result.content).toBe('# hello');
+  });
+});
+
+describe('POST /editor/builder/registries/:registryId/install', () => {
+  const mockFetch = vi.fn();
+
+  const buildSkillStore = () => {
+    const skills = new Map<string, any>();
+    return {
+      _skills: skills,
+      getById: vi.fn(async (id: string) => skills.get(id) ?? null),
+      create: vi.fn(async ({ skill }: { skill: any }) => {
+        skills.set(skill.id, skill);
+        return skill;
+      }),
+    };
+  };
+
+  const buildStorage = (skillStore: ReturnType<typeof buildSkillStore>) => ({
+    getStore: vi.fn(async (domain: string) => (domain === 'skills' ? skillStore : null)),
+  });
+
+  beforeEach(() => vi.stubGlobal('fetch', mockFetch));
+  afterEach(() => {
+    mockFetch.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('404s when registry is disabled', async () => {
+    const mastra = buildMastra({ registryEnabled: false });
+    await expect(
+      BUILDER_REGISTRY_INSTALL_ROUTE.handler({
+        mastra,
+        ...ctx({ registryId: 'skills-sh', owner: 'a', repo: 'b', skillName: 'demo' }),
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('500s when storage is missing', async () => {
+    const mastra = buildMastra({ storage: undefined });
+    await expect(
+      BUILDER_REGISTRY_INSTALL_ROUTE.handler({
+        mastra,
+        ...ctx({ registryId: 'skills-sh', owner: 'a', repo: 'b', skillName: 'demo' }),
+      }),
+    ).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('404s when upstream has no files', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' });
+    const skillStore = buildSkillStore();
+    const mastra = buildMastra({ storage: buildStorage(skillStore) });
+    await expect(
+      BUILDER_REGISTRY_INSTALL_ROUTE.handler({
+        mastra,
+        ...ctx({ registryId: 'skills-sh', owner: 'a', repo: 'b', skillName: 'missing' }),
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('persists a stored skill with origin metadata + parsed frontmatter', async () => {
+    const skillMd = `---
+name: My Demo
+description: Demo skill imported from skills.sh
+---
+
+Body content.`;
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        skillId: 'demo-skill',
+        owner: 'a',
+        repo: 'b',
+        branch: 'main',
+        files: [
+          { path: 'SKILL.md', content: skillMd, encoding: 'utf-8' },
+          { path: 'references/notes.md', content: 'extra', encoding: 'utf-8' },
+        ],
+      }),
+    });
+
+    const skillStore = buildSkillStore();
+    const mastra = buildMastra({ storage: buildStorage(skillStore) });
+
+    const result = (await BUILDER_REGISTRY_INSTALL_ROUTE.handler({
+      mastra,
+      ...ctx({ registryId: 'skills-sh', owner: 'a', repo: 'b', skillName: 'demo-skill' }),
+    })) as any;
+
+    expect(result).toEqual({
+      storedSkillId: 'my-demo',
+      name: 'My Demo',
+      filesWritten: 2,
+    });
+
+    expect(skillStore.create).toHaveBeenCalledOnce();
+    const createdSkill = skillStore.create.mock.calls[0]![0]!.skill;
+    expect(createdSkill.id).toBe('my-demo');
+    expect(createdSkill.name).toBe('My Demo');
+    expect(createdSkill.description).toBe('Demo skill imported from skills.sh');
+    expect(createdSkill.metadata).toEqual({
+      origin: { type: 'skills-sh', owner: 'a', repo: 'b', skillName: 'demo-skill' },
+    });
+    expect(createdSkill.visibility).toBe('public'); // no caller -> public
+    expect(createdSkill.files).toHaveLength(2);
+    expect(createdSkill.files[1]).toEqual({
+      name: 'references',
+      type: 'folder',
+      children: [{ name: 'notes.md', type: 'file', content: 'extra' }],
+    });
+  });
+
+  it('falls back to skillName when SKILL.md is missing or has no frontmatter', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        skillId: 'plain-skill',
+        owner: 'a',
+        repo: 'b',
+        branch: 'main',
+        files: [{ path: 'README.md', content: 'no frontmatter here', encoding: 'utf-8' }],
+      }),
+    });
+
+    const skillStore = buildSkillStore();
+    const mastra = buildMastra({ storage: buildStorage(skillStore) });
+
+    const result = (await BUILDER_REGISTRY_INSTALL_ROUTE.handler({
+      mastra,
+      ...ctx({ registryId: 'skills-sh', owner: 'a', repo: 'b', skillName: 'plain-skill' }),
+    })) as any;
+
+    expect(result.name).toBe('plain-skill');
+    expect(result.storedSkillId).toBe('plain-skill');
+    const createdSkill = skillStore.create.mock.calls[0]![0]!.skill;
+    expect(createdSkill.description).toBe('Imported from a/b');
+  });
+
+  it('409s when a skill with the derived id already exists', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        skillId: 'taken',
+        owner: 'a',
+        repo: 'b',
+        branch: 'main',
+        files: [{ path: 'SKILL.md', content: '# taken', encoding: 'utf-8' }],
+      }),
+    });
+
+    const skillStore = buildSkillStore();
+    skillStore._skills.set('taken', { id: 'taken' });
+    const mastra = buildMastra({ storage: buildStorage(skillStore) });
+
+    await expect(
+      BUILDER_REGISTRY_INSTALL_ROUTE.handler({
+        mastra,
+        ...ctx({ registryId: 'skills-sh', owner: 'a', repo: 'b', skillName: 'taken' }),
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(skillStore.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects path traversal attempts in upstream files', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        skillId: 'evil',
+        owner: 'a',
+        repo: 'b',
+        branch: 'main',
+        files: [{ path: '../../escape.txt', content: 'pwned', encoding: 'utf-8' }],
+      }),
+    });
+
+    const skillStore = buildSkillStore();
+    const mastra = buildMastra({ storage: buildStorage(skillStore) });
+
+    await expect(
+      BUILDER_REGISTRY_INSTALL_ROUTE.handler({
+        mastra,
+        ...ctx({ registryId: 'skills-sh', owner: 'a', repo: 'b', skillName: 'evil' }),
+      }),
+    ).rejects.toThrow();
+    expect(skillStore.create).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Route metadata
+// =============================================================================
+
+describe('Route metadata', () => {
+  it('list-registries route uses GET + correct path + stored-skills:read permission', () => {
+    expect(LIST_BUILDER_REGISTRIES_ROUTE.method).toBe('GET');
+    expect(LIST_BUILDER_REGISTRIES_ROUTE.path).toBe('/editor/builder/registries');
+    expect(LIST_BUILDER_REGISTRIES_ROUTE.requiresPermission).toBe('stored-skills:read');
+    expect(LIST_BUILDER_REGISTRIES_ROUTE.requiresAuth).toBe(true);
+  });
+
+  it('search/popular/preview routes are GET + stored-skills:read', () => {
+    for (const route of [
+      BUILDER_REGISTRY_SEARCH_ROUTE,
+      BUILDER_REGISTRY_POPULAR_ROUTE,
+      BUILDER_REGISTRY_PREVIEW_ROUTE,
+    ]) {
+      expect(route.method).toBe('GET');
+      expect(route.requiresPermission).toBe('stored-skills:read');
+      expect(route.requiresAuth).toBe(true);
+    }
+  });
+
+  it('install route is POST + stored-skills:write', () => {
+    expect(BUILDER_REGISTRY_INSTALL_ROUTE.method).toBe('POST');
+    expect(BUILDER_REGISTRY_INSTALL_ROUTE.path).toBe('/editor/builder/registries/:registryId/install');
+    expect(BUILDER_REGISTRY_INSTALL_ROUTE.requiresPermission).toBe('stored-skills:write');
+    expect(BUILDER_REGISTRY_INSTALL_ROUTE.requiresAuth).toBe(true);
+  });
+});

--- a/packages/server/src/server/handlers/builder-registry.test.ts
+++ b/packages/server/src/server/handlers/builder-registry.test.ts
@@ -268,6 +268,11 @@ Body content.`;
     expect(createdSkill.id).toBe('my-demo');
     expect(createdSkill.name).toBe('My Demo');
     expect(createdSkill.description).toBe('Demo skill imported from skills.sh');
+    // Frontmatter must be stripped from the agent-facing instructions field;
+    // it's already lifted into name/description columns above. Per the Agent
+    // Skills spec, frontmatter is metadata, not instructions.
+    expect(createdSkill.instructions).toBe('Body content.');
+    expect(createdSkill.instructions).not.toMatch(/^---/);
     expect(createdSkill.metadata).toEqual({
       origin: { type: 'skills-sh', owner: 'a', repo: 'b', skillName: 'demo-skill' },
     });
@@ -304,6 +309,34 @@ Body content.`;
     expect(result.storedSkillId).toBe('plain-skill');
     const createdSkill = skillStore.create.mock.calls[0]![0]!.skill;
     expect(createdSkill.description).toBe('Imported from a/b');
+    // No SKILL.md at all -> instructions falls back to the description so
+    // resolved.snapshot.instructions stays non-empty.
+    expect(createdSkill.instructions).toBe('Imported from a/b');
+  });
+
+  it('preserves SKILL.md body verbatim when there is no frontmatter to strip', async () => {
+    const skillMd = '# Plain Skill\n\nNo frontmatter, just body.';
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        skillId: 'no-frontmatter-skill',
+        owner: 'a',
+        repo: 'b',
+        branch: 'main',
+        files: [{ path: 'SKILL.md', content: skillMd, encoding: 'utf-8' }],
+      }),
+    });
+
+    const skillStore = buildSkillStore();
+    const mastra = buildMastra({ storage: buildStorage(skillStore) });
+
+    await BUILDER_REGISTRY_INSTALL_ROUTE.handler({
+      mastra,
+      ...ctx({ registryId: 'skills-sh', owner: 'a', repo: 'b', skillName: 'no-frontmatter-skill' }),
+    });
+
+    const createdSkill = skillStore.create.mock.calls[0]![0]!.skill;
+    expect(createdSkill.instructions).toBe(skillMd);
   });
 
   it('409s when a skill with the derived id already exists', async () => {

--- a/packages/server/src/server/handlers/builder-registry.ts
+++ b/packages/server/src/server/handlers/builder-registry.ts
@@ -1,0 +1,391 @@
+/**
+ * Builder Registry Handlers
+ *
+ * Routes that let admins browse and install skills from configured external
+ * registries (currently just skills.sh) directly into the Builder's stored
+ * skills DB. Distinct from the workspace skills.sh routes, which write to a
+ * workspace filesystem and never touch storage.
+ *
+ * Registry availability is driven by `AgentBuilderOptions.registries`. When
+ * the requested registry is disabled (or the builder is missing entirely),
+ * the routes 404 instead of leaking the surface.
+ */
+
+import type { Mastra } from '@mastra/core';
+import type { StorageSkillFileNode } from '@mastra/core/storage';
+
+import { HTTPException } from '../http-exception';
+import {
+  builderRegistriesResponseSchema,
+  builderRegistryInstallBodySchema,
+  builderRegistryInstallResponseSchema,
+  builderRegistryPathParams,
+  builderRegistryPopularQuerySchema,
+  builderRegistryPreviewQuerySchema,
+  builderRegistrySearchQuerySchema,
+} from '../schemas/builder-registry';
+import {
+  skillsShListResponseSchema,
+  skillsShPreviewResponseSchema,
+  skillsShSearchResponseSchema,
+} from '../schemas/workspace';
+import { createRoute } from '../server-adapter/routes/route-builder';
+import { toSlug } from '../utils';
+import { getCallerAuthorId } from './authorship';
+import { handleError } from './error';
+import {
+  assertSafeFilePath,
+  assertSafeSkillName,
+  fetchSkillFiles,
+  getPopularSkillsSh,
+  previewSkillsSh,
+  searchSkillsSh,
+} from './skills-sh-shared';
+
+// =============================================================================
+// Registry resolution
+// =============================================================================
+
+/** Stable identifiers + display labels for every supported registry. */
+const REGISTRY_LABELS: Record<string, string> = {
+  'skills-sh': 'skills.sh',
+};
+
+interface RegistryStatus {
+  id: 'skills-sh';
+  enabled: boolean;
+  label: string;
+}
+
+/**
+ * Resolve which registries are enabled for the running deployment by reading
+ * the builder's `registries` config. Returns a list with all known registries
+ * (so the frontend can render an empty/disabled state) plus their enabled
+ * flag.
+ */
+async function resolveRegistries(mastra: Mastra): Promise<RegistryStatus[]> {
+  const editor = mastra.getEditor();
+  if (!editor || typeof editor.resolveBuilder !== 'function') {
+    return [{ id: 'skills-sh', enabled: false, label: REGISTRY_LABELS['skills-sh']! }];
+  }
+  const builder = await editor.resolveBuilder();
+  const registries = builder?.getRegistries?.();
+  return [
+    {
+      id: 'skills-sh',
+      enabled: registries?.skillsSh?.enabled === true,
+      label: REGISTRY_LABELS['skills-sh']!,
+    },
+  ];
+}
+
+/**
+ * Hard-gate: throws 404 when the requested registry is unknown or disabled.
+ * Mirrors `requireBuilderFeature` semantics — no surface leak for OFF registries.
+ */
+async function requireEnabledRegistry(mastra: Mastra, registryId: string): Promise<void> {
+  const list = await resolveRegistries(mastra);
+  const match = list.find(r => r.id === registryId);
+  if (!match || !match.enabled) {
+    throw new HTTPException(404, { message: 'Registry not found' });
+  }
+}
+
+// =============================================================================
+// File-tree helpers
+// =============================================================================
+
+/**
+ * Convert a flat list of `{ path, content, encoding }` entries into the
+ * `StorageSkillFileNode` tree shape expected by the stored-skills create path.
+ *
+ * Each path is validated via `assertSafeFilePath` to prevent traversal from
+ * upstream-controlled responses. Folder nodes are created on demand.
+ */
+function buildFileTree(
+  files: Array<{ path: string; content: string; encoding: 'utf-8' | 'base64' }>,
+): StorageSkillFileNode[] {
+  const root: StorageSkillFileNode[] = [];
+
+  for (const file of files) {
+    const safePath = assertSafeFilePath(file.path);
+    const segments = safePath.split('/').filter(Boolean);
+    if (segments.length === 0) continue;
+
+    let cursor = root;
+    for (let i = 0; i < segments.length - 1; i++) {
+      const segment = segments[i]!;
+      let folder = cursor.find(node => node.type === 'folder' && node.name === segment);
+      if (!folder) {
+        folder = { name: segment, type: 'folder', children: [] };
+        cursor.push(folder);
+      }
+      if (!folder.children) folder.children = [];
+      cursor = folder.children;
+    }
+
+    const fileName = segments[segments.length - 1]!;
+    const content = file.encoding === 'base64' ? Buffer.from(file.content, 'base64').toString('utf-8') : file.content;
+    cursor.push({ name: fileName, type: 'file', content });
+  }
+
+  return root;
+}
+
+/**
+ * Pull `name` and `description` out of an inline SKILL.md frontmatter block.
+ * Returns nulls when the file is missing or has no frontmatter — callers fall
+ * back to the registry-provided skillName / a generated description.
+ */
+function parseSkillMetadata(files: StorageSkillFileNode[]): {
+  name: string | null;
+  description: string | null;
+} {
+  const skillMd = files.find(f => f.type === 'file' && f.name.toLowerCase() === 'skill.md');
+  if (!skillMd || !skillMd.content) return { name: null, description: null };
+
+  const match = skillMd.content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return { name: null, description: null };
+
+  const frontmatter = match[1]!;
+  const readField = (key: string): string | null => {
+    const re = new RegExp(`^${key}\\s*:\\s*(.+?)\\s*$`, 'm');
+    const m = frontmatter.match(re);
+    if (!m) return null;
+    let value = m[1]!.trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    return value || null;
+  };
+
+  return { name: readField('name'), description: readField('description') };
+}
+
+// =============================================================================
+// Routes
+// =============================================================================
+
+/**
+ * GET /editor/builder/registries
+ *
+ * Lists every known registry and whether it's enabled in this deployment.
+ * Used by the Builder UI to decide whether to show the "Browse registry"
+ * entry point at all.
+ */
+export const LIST_BUILDER_REGISTRIES_ROUTE = createRoute({
+  method: 'GET',
+  path: '/editor/builder/registries',
+  responseType: 'json',
+  responseSchema: builderRegistriesResponseSchema,
+  summary: 'List available skill registries',
+  description: 'Returns the configured external skill registries and their enabled state.',
+  tags: ['Editor'],
+  requiresAuth: true,
+  requiresPermission: 'stored-skills:read',
+  handler: async ({ mastra }) => {
+    try {
+      const registries = await resolveRegistries(mastra);
+      return { registries };
+    } catch (error) {
+      return handleError(error, 'Error listing builder registries');
+    }
+  },
+});
+
+/**
+ * GET /editor/builder/registries/:registryId/search
+ *
+ * Proxies a search query to the underlying registry. Currently only
+ * registryId="skills-sh" is supported.
+ */
+export const BUILDER_REGISTRY_SEARCH_ROUTE = createRoute({
+  method: 'GET',
+  path: '/editor/builder/registries/:registryId/search',
+  responseType: 'json',
+  pathParamSchema: builderRegistryPathParams,
+  queryParamSchema: builderRegistrySearchQuerySchema,
+  responseSchema: skillsShSearchResponseSchema,
+  summary: 'Search skills in a registry',
+  description: 'Proxies a search request to the configured registry to avoid CORS issues.',
+  tags: ['Editor', 'Skills'],
+  requiresAuth: true,
+  requiresPermission: 'stored-skills:read',
+  handler: async ({ mastra, registryId, q, limit }) => {
+    try {
+      await requireEnabledRegistry(mastra, registryId);
+      return await searchSkillsSh({ q, limit });
+    } catch (error) {
+      if (error instanceof HTTPException) throw error;
+      return handleError(error, 'Error searching registry');
+    }
+  },
+});
+
+/**
+ * GET /editor/builder/registries/:registryId/popular
+ *
+ * Returns the most popular skills in a registry.
+ */
+export const BUILDER_REGISTRY_POPULAR_ROUTE = createRoute({
+  method: 'GET',
+  path: '/editor/builder/registries/:registryId/popular',
+  responseType: 'json',
+  pathParamSchema: builderRegistryPathParams,
+  queryParamSchema: builderRegistryPopularQuerySchema,
+  responseSchema: skillsShListResponseSchema,
+  summary: 'Get popular skills from a registry',
+  description: 'Proxies a popular-skills request to the configured registry to avoid CORS issues.',
+  tags: ['Editor', 'Skills'],
+  requiresAuth: true,
+  requiresPermission: 'stored-skills:read',
+  handler: async ({ mastra, registryId, limit, offset }) => {
+    try {
+      await requireEnabledRegistry(mastra, registryId);
+      return await getPopularSkillsSh({ limit, offset });
+    } catch (error) {
+      if (error instanceof HTTPException) throw error;
+      return handleError(error, 'Error fetching popular skills');
+    }
+  },
+});
+
+/**
+ * GET /editor/builder/registries/:registryId/preview
+ *
+ * Returns the rendered SKILL.md content for a single skill in the registry.
+ */
+export const BUILDER_REGISTRY_PREVIEW_ROUTE = createRoute({
+  method: 'GET',
+  path: '/editor/builder/registries/:registryId/preview',
+  responseType: 'json',
+  pathParamSchema: builderRegistryPathParams,
+  queryParamSchema: builderRegistryPreviewQuerySchema,
+  responseSchema: skillsShPreviewResponseSchema,
+  summary: 'Preview a skill from a registry',
+  description: 'Fetches the SKILL.md content for a single skill in the configured registry.',
+  tags: ['Editor', 'Skills'],
+  requiresAuth: true,
+  requiresPermission: 'stored-skills:read',
+  handler: async ({ mastra, registryId, owner, repo, path: skillName }) => {
+    try {
+      await requireEnabledRegistry(mastra, registryId);
+      return await previewSkillsSh({ owner, repo, skillName });
+    } catch (error) {
+      if (error instanceof HTTPException) throw error;
+      return handleError(error, 'Error fetching skill preview');
+    }
+  },
+});
+
+/**
+ * POST /editor/builder/registries/:registryId/install
+ *
+ * Fetches the full file tree for a skill from the registry, parses the
+ * SKILL.md frontmatter for name/description, and persists everything as a
+ * new stored skill. The registry origin is recorded under `metadata.origin`
+ * so the UI can surface "imported from skills.sh" badges and re-resolve the
+ * source later.
+ *
+ * Collisions (a stored skill with the derived id already exists) return 409
+ * so the UI can offer an "Open existing" link instead of silently
+ * overwriting.
+ */
+export const BUILDER_REGISTRY_INSTALL_ROUTE = createRoute({
+  method: 'POST',
+  path: '/editor/builder/registries/:registryId/install',
+  responseType: 'json',
+  pathParamSchema: builderRegistryPathParams,
+  bodySchema: builderRegistryInstallBodySchema,
+  responseSchema: builderRegistryInstallResponseSchema,
+  summary: 'Install a registry skill into stored skills',
+  description: 'Fetches a skill from the configured registry and persists it as a new stored skill.',
+  tags: ['Editor', 'Skills'],
+  requiresAuth: true,
+  requiresPermission: 'stored-skills:write',
+  handler: async ({ mastra, requestContext, registryId, owner, repo, skillName, visibility: bodyVisibility }) => {
+    try {
+      await requireEnabledRegistry(mastra, registryId);
+
+      const storage = mastra.getStorage();
+      if (!storage) {
+        throw new HTTPException(500, { message: 'Storage is not configured' });
+      }
+      const skillStore = await storage.getStore('skills');
+      if (!skillStore) {
+        throw new HTTPException(500, { message: 'Skills storage domain is not available' });
+      }
+
+      // Pull files from the registry
+      const result = await fetchSkillFiles(owner, repo, skillName);
+      if (!result || result.files.length === 0) {
+        throw new HTTPException(404, {
+          message: `Could not find skill "${skillName}" in ${owner}/${repo}.`,
+        });
+      }
+
+      const safeSkillId = assertSafeSkillName(result.skillId);
+      const files = buildFileTree(result.files);
+      const meta = parseSkillMetadata(files);
+
+      const resolvedName = meta.name ?? safeSkillId;
+      const description = meta.description ?? `Imported from ${owner}/${repo}`;
+      const id = toSlug(resolvedName) || safeSkillId;
+
+      if (!id) {
+        throw new HTTPException(400, {
+          message: 'Could not derive skill ID from registry skill metadata.',
+        });
+      }
+
+      // Reject collisions instead of silently overwriting; UI offers "Open existing".
+      const existing = await skillStore.getById(id);
+      if (existing) {
+        throw new HTTPException(409, {
+          message: `Skill with id "${id}" already exists.`,
+          // Surface the existing id so the client can deep-link.
+          cause: { storedSkillId: id },
+        });
+      }
+
+      // Match the standard create flow: no caller = always public, otherwise default private.
+      const authorId = getCallerAuthorId(requestContext) ?? undefined;
+      const visibility: 'private' | 'public' = authorId ? (bodyVisibility ?? 'private') : 'public';
+
+      // Find a SKILL.md to use as the canonical instructions field; otherwise
+      // fall back to the description so resolved.snapshot.instructions stays
+      // non-empty.
+      const skillMd = files.find(f => f.type === 'file' && f.name.toLowerCase() === 'skill.md');
+      const instructions = skillMd?.content ?? description;
+
+      await skillStore.create({
+        skill: {
+          id,
+          authorId,
+          visibility,
+          name: resolvedName,
+          description,
+          instructions,
+          files,
+          metadata: {
+            origin: {
+              type: 'skills-sh',
+              owner,
+              repo,
+              skillName,
+            },
+          },
+        },
+      });
+
+      return {
+        storedSkillId: id,
+        name: resolvedName,
+        filesWritten: result.files.length,
+      };
+    } catch (error) {
+      if (error instanceof HTTPException) throw error;
+      return handleError(error, 'Error installing registry skill');
+    }
+  },
+});

--- a/packages/server/src/server/handlers/builder-registry.ts
+++ b/packages/server/src/server/handlers/builder-registry.ts
@@ -133,33 +133,57 @@ function buildFileTree(
 }
 
 /**
- * Pull `name` and `description` out of an inline SKILL.md frontmatter block.
- * Returns nulls when the file is missing or has no frontmatter — callers fall
- * back to the registry-provided skillName / a generated description.
+ * Locally-bound SKILL.md frontmatter parser.
+ *
+ * Mirrors `parseSkillSnapshotFromFiles` from `@mastra/core/workspace`, but
+ * inlined here because the server package's `@mastra/core` peer floor
+ * (>=1.32.0) predates that helper. Once the floor is bumped to a release
+ * containing the helper, this can be replaced by the shared core import.
+ *
+ * Only SKILL.md is consulted — frontmatter is split from the body using a
+ * minimal YAML key:value reader sufficient for the fields registries
+ * actually use (name, description). The body is everything after the
+ * second `---` line, trimmed.
  */
-function parseSkillMetadata(files: StorageSkillFileNode[]): {
-  name: string | null;
-  description: string | null;
-} {
-  const skillMd = files.find(f => f.type === 'file' && f.name.toLowerCase() === 'skill.md');
-  if (!skillMd || !skillMd.content) return { name: null, description: null };
+type ParsedSkillSnapshot = {
+  name?: string;
+  description?: string;
+  instructions: string;
+};
 
-  const match = skillMd.content.match(/^---\s*\n([\s\S]*?)\n---/);
-  if (!match) return { name: null, description: null };
+function parseSkillSnapshot(
+  files: Array<{ path: string; content: string; encoding: 'utf-8' | 'base64' }>,
+): ParsedSkillSnapshot | null {
+  const skillMd = files.find(f => f.path === 'SKILL.md');
+  if (!skillMd) return null;
 
-  const frontmatter = match[1]!;
-  const readField = (key: string): string | null => {
-    const re = new RegExp(`^${key}\\s*:\\s*(.+?)\\s*$`, 'm');
-    const m = frontmatter.match(re);
-    if (!m) return null;
-    let value = m[1]!.trim();
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
-    }
-    return value || null;
+  const raw =
+    skillMd.encoding === 'base64' ? Buffer.from(skillMd.content, 'base64').toString('utf-8') : skillMd.content;
+
+  const fmMatch = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!fmMatch) {
+    return { instructions: raw.trim() };
+  }
+
+  const fmBlock = fmMatch[1] ?? '';
+  const body = fmMatch[2] ?? '';
+  const frontmatter: Record<string, string> = {};
+  for (const line of fmBlock.split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    const value = m[2] ?? '';
+    if (!key) continue;
+    // Strip surrounding quotes, leave the rest as-is. Registry SKILL.md
+    // frontmatter is consistently flat string fields in practice.
+    frontmatter[key] = value.trim().replace(/^["'](.*)["']$/, '$1');
+  }
+
+  return {
+    name: frontmatter.name,
+    description: frontmatter.description,
+    instructions: body.trim(),
   };
-
-  return { name: readField('name'), description: readField('description') };
 }
 
 // =============================================================================
@@ -326,10 +350,16 @@ export const BUILDER_REGISTRY_INSTALL_ROUTE = createRoute({
 
       const safeSkillId = assertSafeSkillName(result.skillId);
       const files = buildFileTree(result.files);
-      const meta = parseSkillMetadata(files);
 
-      const resolvedName = meta.name ?? safeSkillId;
-      const description = meta.description ?? `Imported from ${owner}/${repo}`;
+      // Parse SKILL.md frontmatter into structured fields. Splitting
+      // frontmatter (name/description) from the markdown body keeps the
+      // body as the agent-facing `instructions` instead of polluting it
+      // with raw YAML metadata. SKILL.md missing or unparseable simply
+      // yields a null snapshot — registry-provided values then fill in.
+      const snapshot = parseSkillSnapshot(result.files);
+
+      const resolvedName = snapshot?.name ?? safeSkillId;
+      const description = snapshot?.description ?? `Imported from ${owner}/${repo}`;
       const id = toSlug(resolvedName) || safeSkillId;
 
       if (!id) {
@@ -352,11 +382,12 @@ export const BUILDER_REGISTRY_INSTALL_ROUTE = createRoute({
       const authorId = getCallerAuthorId(requestContext) ?? undefined;
       const visibility: 'private' | 'public' = authorId ? (bodyVisibility ?? 'private') : 'public';
 
-      // Find a SKILL.md to use as the canonical instructions field; otherwise
-      // fall back to the description so resolved.snapshot.instructions stays
-      // non-empty.
-      const skillMd = files.find(f => f.type === 'file' && f.name.toLowerCase() === 'skill.md');
-      const instructions = skillMd?.content ?? description;
+      // Use the SKILL.md body (post-frontmatter) as instructions. Frontmatter
+      // values are already lifted into structured columns above, so re-storing
+      // them in `instructions` would both duplicate metadata and feed YAML
+      // into the agent's prompt. Fall back to description when no usable body
+      // exists so `resolved.snapshot.instructions` stays non-empty.
+      const instructions = snapshot?.instructions?.trim() ? snapshot.instructions : description;
 
       await skillStore.create({
         skill: {

--- a/packages/server/src/server/handlers/editor-builder.test.ts
+++ b/packages/server/src/server/handlers/editor-builder.test.ts
@@ -399,7 +399,37 @@ describe('GET /editor/builder/infrastructure', () => {
         sandboxProvider: null,
         config: [],
       },
+      registries: { skillsSh: { enabled: false } },
     });
+  });
+
+  it('reports skills.sh registry enabled flag from builder config', async () => {
+    const builder = {
+      getConfiguration: () => ({}),
+      getRegistries: () => ({ skillsSh: { enabled: true } }),
+    };
+    const editor = {
+      __browsers: new Map(),
+      resolveBuilder: vi.fn().mockResolvedValue(builder),
+    };
+    const mastra = createInfraMastra({ editor });
+
+    const result = (await GET_INFRASTRUCTURE_STATUS_ROUTE.handler({ mastra } as any)) as any;
+
+    expect(result.registries).toEqual({ skillsSh: { enabled: true } });
+  });
+
+  it('reports skills.sh registry disabled when builder lacks getRegistries', async () => {
+    const builder = { getConfiguration: () => ({}) };
+    const editor = {
+      __browsers: new Map(),
+      resolveBuilder: vi.fn().mockResolvedValue(builder),
+    };
+    const mastra = createInfraMastra({ editor });
+
+    const result = (await GET_INFRASTRUCTURE_STATUS_ROUTE.handler({ mastra } as any)) as any;
+
+    expect(result.registries).toEqual({ skillsSh: { enabled: false } });
   });
 
   it('reports configured channel provider info', async () => {

--- a/packages/server/src/server/handlers/editor-builder.ts
+++ b/packages/server/src/server/handlers/editor-builder.ts
@@ -247,10 +247,17 @@ export const GET_INFRASTRUCTURE_STATUS_ROUTE = createRoute({
         sandboxProvider: null,
         config: [],
       };
+      let registries: InfrastructureStatus['registries'] = {
+        skillsSh: { enabled: false },
+      };
 
       if (editor?.resolveBuilder) {
         const browsers = (editor as unknown as { __browsers?: Map<string, unknown> }).__browsers;
         const builder = await editor.resolveBuilder();
+        const builderRegistries = builder?.getRegistries?.();
+        registries = {
+          skillsSh: { enabled: builderRegistries?.skillsSh?.enabled === true },
+        };
         const configuration = builder?.getConfiguration?.()?.agent as
           | {
               browser?: { type?: string; config?: { provider?: string; env?: string } };
@@ -309,7 +316,7 @@ export const GET_INFRASTRUCTURE_STATUS_ROUTE = createRoute({
         };
       }
 
-      return { channels, browser, workspace };
+      return { channels, browser, workspace, registries };
     } catch (error) {
       return handleError(error, 'Error getting infrastructure status');
     }

--- a/packages/server/src/server/handlers/skills-sh-shared.test.ts
+++ b/packages/server/src/server/handlers/skills-sh-shared.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HTTPException } from '../http-exception';
+import {
+  SKILLS_SH_API_URL,
+  SKILLS_SH_DIR,
+  assertSafeFilePath,
+  assertSafeSkillName,
+  fetchSkillFiles,
+  getPopularSkillsSh,
+  previewSkillsSh,
+  searchSkillsSh,
+} from './skills-sh-shared';
+
+describe('skills-sh-shared constants', () => {
+  it('points SKILLS_SH_DIR at the .agents/skills convention', () => {
+    expect(SKILLS_SH_DIR).toBe('.agents/skills');
+  });
+
+  it('exposes the skills.sh API URL', () => {
+    expect(SKILLS_SH_API_URL).toBe('https://skills-api-production.up.railway.app');
+  });
+});
+
+describe('assertSafeSkillName', () => {
+  it.each(['mastra', 'my-skill', 'skill_v2', 'a1b2c3', 'A1', 'foo-bar_baz-1'])('accepts %s', name => {
+    expect(assertSafeSkillName(name)).toBe(name);
+  });
+
+  it.each(['', '-foo', '_foo', '../escape', 'foo/bar', 'foo bar', 'foo.bar', 'foo$bar'])('rejects %s', name => {
+    expect(() => assertSafeSkillName(name)).toThrow(HTTPException);
+  });
+});
+
+describe('assertSafeFilePath', () => {
+  it.each(['SKILL.md', 'src/index.ts', 'a/b/c/d.txt', 'foo/bar.md'])('accepts %s', path => {
+    expect(assertSafeFilePath(path)).toBe(path);
+  });
+
+  it('rejects absolute paths', () => {
+    expect(() => assertSafeFilePath('/etc/passwd')).toThrow(HTTPException);
+    expect(() => assertSafeFilePath('C:/Windows/System32')).toThrow(HTTPException);
+  });
+
+  it('rejects path traversal', () => {
+    expect(() => assertSafeFilePath('../escape')).toThrow(HTTPException);
+    expect(() => assertSafeFilePath('foo/../bar')).toThrow(HTTPException);
+    expect(() => assertSafeFilePath('./local')).toThrow(HTTPException);
+  });
+});
+
+describe('searchSkillsSh', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('shapes upstream response into the wire format', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        skills: [
+          {
+            skillId: 'mastra',
+            name: 'mastra',
+            installs: 42,
+            source: 'mastra-ai/mastra/mastra',
+            owner: 'mastra-ai',
+            repo: 'mastra',
+            githubUrl: '',
+            displayName: 'Mastra',
+          },
+        ],
+        total: 1,
+      }),
+    });
+
+    const result = await searchSkillsSh({ q: 'mastra', limit: 10 });
+
+    expect(result).toEqual({
+      query: 'mastra',
+      searchType: 'query',
+      skills: [{ id: 'mastra', name: 'mastra', installs: 42, topSource: 'mastra-ai/mastra/mastra' }],
+      count: 1,
+    });
+  });
+
+  it('throws HTTPException 502 on upstream failure', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' });
+
+    await expect(searchSkillsSh({ q: 'foo', limit: 10 })).rejects.toThrow(HTTPException);
+  });
+});
+
+describe('getPopularSkillsSh', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('translates offset to a 1-indexed page parameter', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ skills: [], total: 0 }),
+    });
+
+    await getPopularSkillsSh({ limit: 10, offset: 20 });
+
+    const url = mockFetch.mock.calls[0]?.[0] as string;
+    expect(url).toContain('pageSize=10');
+    expect(url).toContain('page=3');
+  });
+
+  it('uses page=1 when offset is zero', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ skills: [], total: 0 }),
+    });
+
+    await getPopularSkillsSh({ limit: 10, offset: 0 });
+
+    const url = mockFetch.mock.calls[0]?.[0] as string;
+    expect(url).toContain('page=1');
+  });
+
+  it('echoes limit and offset in the response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ skills: [], total: 0 }),
+    });
+
+    const result = await getPopularSkillsSh({ limit: 25, offset: 50 });
+    expect(result.limit).toBe(25);
+    expect(result.offset).toBe(50);
+  });
+});
+
+describe('previewSkillsSh', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('prefers instructions over raw', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ instructions: 'use this skill', raw: 'raw markdown' }),
+    });
+
+    const result = await previewSkillsSh({ owner: 'a', repo: 'b', skillName: 'c' });
+    expect(result.content).toBe('use this skill');
+  });
+
+  it('falls back to raw when instructions are missing', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ raw: 'raw markdown' }),
+    });
+
+    const result = await previewSkillsSh({ owner: 'a', repo: 'b', skillName: 'c' });
+    expect(result.content).toBe('raw markdown');
+  });
+
+  it('throws 404 when upstream is not OK', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' });
+
+    await expect(previewSkillsSh({ owner: 'a', repo: 'b', skillName: 'missing' })).rejects.toThrow(HTTPException);
+  });
+
+  it('throws 404 when upstream returns empty content', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    await expect(previewSkillsSh({ owner: 'a', repo: 'b', skillName: 'empty' })).rejects.toThrow(HTTPException);
+  });
+});
+
+describe('fetchSkillFiles', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the upstream response unchanged on success', async () => {
+    const payload = {
+      skillId: 'skill-1',
+      owner: 'a',
+      repo: 'b',
+      branch: 'main',
+      files: [{ path: 'SKILL.md', content: '# hi', encoding: 'utf-8' as const }],
+    };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => payload });
+
+    const result = await fetchSkillFiles('a', 'b', 'skill-1');
+    expect(result).toEqual(payload);
+  });
+
+  it('returns null on 404', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const result = await fetchSkillFiles('a', 'b', 'missing');
+    expect(result).toBeNull();
+  });
+
+  it('throws on non-404 upstream errors', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' });
+
+    await expect(fetchSkillFiles('a', 'b', 'broken')).rejects.toThrow();
+  });
+});

--- a/packages/server/src/server/handlers/skills-sh-shared.ts
+++ b/packages/server/src/server/handlers/skills-sh-shared.ts
@@ -1,0 +1,273 @@
+/**
+ * Shared skills.sh helpers
+ *
+ * Pure proxy + safety logic for talking to the skills.sh API. Used by:
+ *   - Workspace skills.sh routes (filesystem-only install).
+ *   - Builder registry routes (stored-skill install with optional workspace
+ *     materialization).
+ *
+ * No workspace or stored-skill concepts leak into this module. Path resolution,
+ * filesystem writes, and DB writes happen in the callers.
+ */
+
+import { HTTPException } from '../http-exception';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Upstream skills.sh API base URL. */
+export const SKILLS_SH_API_URL = 'https://skills-api-production.up.railway.app';
+
+/**
+ * Directory path for skills installed via skills.sh, relative to the workspace
+ * filesystem root (or to a CompositeFilesystem mount). Matches the convention
+ * shared with Claude Code and other agent runtimes.
+ */
+export const SKILLS_SH_DIR = '.agents/skills';
+
+const SEARCH_TIMEOUT_MS = 10_000;
+const PREVIEW_TIMEOUT_MS = 10_000;
+const FILE_FETCH_TIMEOUT_MS = 30_000;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Single skill summary returned by search/popular endpoints. */
+export interface SkillsShSkillSummary {
+  id: string;
+  name: string;
+  installs: number;
+  topSource: string;
+}
+
+export interface SkillsShSearchResult {
+  query: string;
+  searchType: 'query';
+  skills: SkillsShSkillSummary[];
+  count: number;
+}
+
+export interface SkillsShPopularResult {
+  skills: SkillsShSkillSummary[];
+  count: number;
+  limit: number;
+  offset: number;
+}
+
+/** A single file from the skills.sh files endpoint. */
+export interface SkillFileEntry {
+  path: string;
+  content: string;
+  encoding: 'utf-8' | 'base64';
+}
+
+/** Response from the skills.sh files endpoint. */
+export interface SkillFilesResponse {
+  skillId: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  files: SkillFileEntry[];
+}
+
+// =============================================================================
+// Safety validators
+// =============================================================================
+
+/**
+ * Validate skill name to prevent path traversal attacks. Only allows
+ * alphanumeric characters, hyphens, and underscores; must start with an
+ * alphanumeric character.
+ *
+ * Throws an HTTP 400 on invalid input. Returns the validated name on success
+ * so it can be used inline.
+ */
+const SKILL_NAME_REGEX = /^[a-z0-9][a-z0-9-_]*$/i;
+
+export function assertSafeSkillName(name: string): string {
+  if (!SKILL_NAME_REGEX.test(name)) {
+    throw new HTTPException(400, {
+      message: `Invalid skill name "${name}". Names must start with alphanumeric and contain only letters, numbers, hyphens, and underscores.`,
+    });
+  }
+  return name;
+}
+
+/**
+ * Validate that a file path is safe (no traversal, no absolute paths).
+ * Prevents malicious API responses from writing files outside the skill
+ * directory.
+ */
+export function assertSafeFilePath(filePath: string): string {
+  if (filePath.startsWith('/') || /^[a-zA-Z]:/.test(filePath)) {
+    throw new HTTPException(400, {
+      message: `Invalid file path "${filePath}". Absolute paths are not allowed.`,
+    });
+  }
+  const segments = filePath.split('/');
+  for (const segment of segments) {
+    if (segment === '..' || segment === '.') {
+      throw new HTTPException(400, {
+        message: `Invalid file path "${filePath}". Path traversal is not allowed.`,
+      });
+    }
+  }
+  return filePath;
+}
+
+// =============================================================================
+// API calls
+// =============================================================================
+
+interface UpstreamSkillsList {
+  skills: Array<{
+    skillId: string;
+    name: string;
+    installs: number;
+    source: string;
+    owner: string;
+    repo: string;
+    githubUrl: string;
+    displayName: string;
+  }>;
+  total: number;
+  page?: number;
+  pageSize?: number;
+  totalPages?: number;
+}
+
+/** Search skills.sh by query string. Throws HTTPException on upstream failure. */
+export async function searchSkillsSh({ q, limit }: { q: string; limit: number }): Promise<SkillsShSearchResult> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), SEARCH_TIMEOUT_MS);
+
+  try {
+    const url = `${SKILLS_SH_API_URL}/api/skills?query=${encodeURIComponent(q)}&pageSize=${limit}`;
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      throw new HTTPException(502, {
+        message: `Skills API error: ${response.status} ${response.statusText}`,
+      });
+    }
+
+    const data = (await response.json()) as UpstreamSkillsList;
+    return {
+      query: q,
+      searchType: 'query',
+      skills: data.skills.map(s => ({ id: s.skillId, name: s.name, installs: s.installs, topSource: s.source })),
+      count: data.total,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/** Fetch the popular skills list from skills.sh. */
+export async function getPopularSkillsSh({
+  limit,
+  offset,
+}: {
+  limit: number;
+  offset: number;
+}): Promise<SkillsShPopularResult> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), SEARCH_TIMEOUT_MS);
+
+  try {
+    const page = offset > 0 ? Math.floor(offset / limit) + 1 : 1;
+    const url = `${SKILLS_SH_API_URL}/api/skills/top?pageSize=${limit}&page=${page}`;
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      throw new HTTPException(502, {
+        message: `Skills API error: ${response.status} ${response.statusText}`,
+      });
+    }
+
+    const data = (await response.json()) as UpstreamSkillsList;
+    return {
+      skills: data.skills.map(s => ({ id: s.skillId, name: s.name, installs: s.installs, topSource: s.source })),
+      count: data.total,
+      limit,
+      offset,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Fetch the rendered SKILL.md / instructions content for a single skill.
+ * Returns the content string, or throws HTTPException(404) when the skill
+ * doesn't exist or has no content.
+ */
+export async function previewSkillsSh({
+  owner,
+  repo,
+  skillName,
+}: {
+  owner: string;
+  repo: string;
+  skillName: string;
+}): Promise<{ content: string }> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), PREVIEW_TIMEOUT_MS);
+
+  try {
+    const url = `${SKILLS_SH_API_URL}/api/skills/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(skillName)}/content`;
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      throw new HTTPException(404, {
+        message: `Could not find skill "${skillName}" for ${owner}/${repo}`,
+      });
+    }
+
+    const data = (await response.json()) as { instructions?: string; raw?: string };
+    const content = data.instructions || data.raw || '';
+
+    if (!content) {
+      throw new HTTPException(404, {
+        message: `No content available for skill "${skillName}"`,
+      });
+    }
+
+    return { content };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Fetch the full file tree for a skill from the skills.sh files endpoint.
+ * Returns null when the skill doesn't exist (404). Throws on other upstream
+ * errors. Caller is responsible for validating each returned file path with
+ * `assertSafeFilePath` before writing to disk.
+ */
+export async function fetchSkillFiles(
+  owner: string,
+  repo: string,
+  skillName: string,
+): Promise<SkillFilesResponse | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FILE_FETCH_TIMEOUT_MS);
+
+  try {
+    const url = `${SKILLS_SH_API_URL}/api/skills/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(skillName)}/files`;
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return null;
+      }
+      throw new Error(`Skills API error: ${response.status} ${response.statusText}`);
+    }
+
+    return (await response.json()) as SkillFilesResponse;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -60,13 +60,15 @@ import {
 } from '../schemas/workspace';
 import { createRoute } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
-
-// =============================================================================
-// Constants
-// =============================================================================
-
-/** Directory path for skills installed via skills.sh */
-const SKILLS_SH_DIR = '.agents/skills';
+import {
+  SKILLS_SH_DIR,
+  assertSafeFilePath,
+  assertSafeSkillName,
+  fetchSkillFiles,
+  getPopularSkillsSh,
+  previewSkillsSh,
+  searchSkillsSh,
+} from './skills-sh-shared';
 
 // =============================================================================
 // Helper Functions
@@ -1180,8 +1182,6 @@ export const WORKSPACE_SEARCH_SKILLS_ROUTE = createRoute({
 // skills.sh Proxy Routes
 // =============================================================================
 
-const SKILLS_SH_API_URL = 'https://skills-api-production.up.railway.app';
-
 export const WORKSPACE_SKILLS_SH_SEARCH_ROUTE = createRoute({
   method: 'GET',
   path: '/workspaces/:workspaceId/skills-sh/search',
@@ -1195,41 +1195,7 @@ export const WORKSPACE_SKILLS_SH_SEARCH_ROUTE = createRoute({
   tags: ['Workspace', 'Skills'],
   handler: async ({ q, limit }) => {
     try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10000);
-
-      const url = `${SKILLS_SH_API_URL}/api/skills?query=${encodeURIComponent(q)}&pageSize=${limit}`;
-      const response = await fetch(url, { signal: controller.signal });
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        throw new HTTPException(502, {
-          message: `Skills API error: ${response.status} ${response.statusText}`,
-        });
-      }
-
-      const data = (await response.json()) as {
-        skills: Array<{
-          skillId: string;
-          name: string;
-          installs: number;
-          source: string;
-          owner: string;
-          repo: string;
-          githubUrl: string;
-          displayName: string;
-        }>;
-        total: number;
-        page: number;
-        pageSize: number;
-        totalPages: number;
-      };
-      return {
-        query: q,
-        searchType: 'query',
-        skills: data.skills.map(s => ({ id: s.skillId, name: s.name, installs: s.installs, topSource: s.source })),
-        count: data.total,
-      };
+      return await searchSkillsSh({ q, limit });
     } catch (error) {
       if (error instanceof HTTPException) {
         throw error;
@@ -1252,39 +1218,7 @@ export const WORKSPACE_SKILLS_SH_POPULAR_ROUTE = createRoute({
   tags: ['Workspace', 'Skills'],
   handler: async ({ limit, offset }) => {
     try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10000);
-
-      const page = offset > 0 ? Math.floor(offset / limit) + 1 : 1;
-      const url = `${SKILLS_SH_API_URL}/api/skills/top?pageSize=${limit}&page=${page}`;
-      const response = await fetch(url, { signal: controller.signal });
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        throw new HTTPException(502, {
-          message: `Skills API error: ${response.status} ${response.statusText}`,
-        });
-      }
-
-      const data = (await response.json()) as {
-        skills: Array<{
-          skillId: string;
-          name: string;
-          installs: number;
-          source: string;
-          owner: string;
-          repo: string;
-          githubUrl: string;
-          displayName: string;
-        }>;
-        total: number;
-      };
-      return {
-        skills: data.skills.map(s => ({ id: s.skillId, name: s.name, installs: s.installs, topSource: s.source })),
-        count: data.total,
-        limit,
-        offset,
-      };
+      return await getPopularSkillsSh({ limit, offset });
     } catch (error) {
       if (error instanceof HTTPException) {
         throw error;
@@ -1293,84 +1227,6 @@ export const WORKSPACE_SKILLS_SH_POPULAR_ROUTE = createRoute({
     }
   },
 });
-
-// =============================================================================
-// Skills API helpers
-// =============================================================================
-
-/**
- * Validate skill name to prevent path traversal attacks.
- * Only allows alphanumeric characters, hyphens, and underscores.
- */
-const SKILL_NAME_REGEX = /^[a-z0-9][a-z0-9-_]*$/i;
-
-function assertSafeSkillName(name: string): string {
-  if (!SKILL_NAME_REGEX.test(name)) {
-    throw new HTTPException(400, {
-      message: `Invalid skill name "${name}". Names must start with alphanumeric and contain only letters, numbers, hyphens, and underscores.`,
-    });
-  }
-  return name;
-}
-
-/**
- * Validate that a file path is safe (no traversal, no absolute paths).
- * Prevents malicious API responses from writing files outside the skill directory.
- */
-function assertSafeFilePath(filePath: string): string {
-  // Reject absolute paths
-  if (filePath.startsWith('/') || /^[a-zA-Z]:/.test(filePath)) {
-    throw new HTTPException(400, {
-      message: `Invalid file path "${filePath}". Absolute paths are not allowed.`,
-    });
-  }
-  // Reject path traversal attempts
-  const segments = filePath.split('/');
-  for (const segment of segments) {
-    if (segment === '..' || segment === '.') {
-      throw new HTTPException(400, {
-        message: `Invalid file path "${filePath}". Path traversal is not allowed.`,
-      });
-    }
-  }
-  return filePath;
-}
-
-interface SkillFileEntry {
-  path: string;
-  content: string;
-  encoding: 'utf-8' | 'base64';
-}
-
-interface SkillFilesResponse {
-  skillId: string;
-  owner: string;
-  repo: string;
-  branch: string;
-  files: SkillFileEntry[];
-}
-
-/**
- * Fetch skill files from the Skills API.
- * Returns all files for a skill with their content.
- */
-async function fetchSkillFiles(owner: string, repo: string, skillName: string): Promise<SkillFilesResponse | null> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 30000); // 30s for file downloads
-
-  const url = `${SKILLS_SH_API_URL}/api/skills/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(skillName)}/files`;
-  const response = await fetch(url, { signal: controller.signal });
-  clearTimeout(timeoutId);
-
-  if (!response.ok) {
-    if (response.status === 404) {
-      return null;
-    }
-    throw new Error(`Skills API error: ${response.status} ${response.statusText}`);
-  }
-
-  return (await response.json()) as SkillFilesResponse;
-}
 
 // =============================================================================
 // skills.sh Preview Route
@@ -1389,29 +1245,7 @@ export const WORKSPACE_SKILLS_SH_PREVIEW_ROUTE = createRoute({
   tags: ['Workspace', 'Skills'],
   handler: async ({ owner, repo, path: skillName }) => {
     try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10000);
-
-      const url = `${SKILLS_SH_API_URL}/api/skills/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(skillName)}/content`;
-      const response = await fetch(url, { signal: controller.signal });
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        throw new HTTPException(404, {
-          message: `Could not find skill "${skillName}" for ${owner}/${repo}`,
-        });
-      }
-
-      const data = (await response.json()) as { instructions: string; raw: string };
-      const content = data.instructions || data.raw || '';
-
-      if (!content) {
-        throw new HTTPException(404, {
-          message: `No content available for skill "${skillName}"`,
-        });
-      }
-
-      return { content };
+      return await previewSkillsSh({ owner, repo, skillName });
     } catch (error) {
       if (error instanceof HTTPException) {
         throw error;

--- a/packages/server/src/server/schemas/builder-registry.ts
+++ b/packages/server/src/server/schemas/builder-registry.ts
@@ -1,0 +1,87 @@
+/**
+ * Builder Registry Schemas
+ *
+ * Schemas for the Agent Builder skill registry routes. These are distinct from
+ * the workspace skills.sh proxy schemas because:
+ *   - Builder routes are not scoped to a workspace.
+ *   - Builder install does not accept a `mount` field.
+ *   - Builder install body carries visibility + the resolved registry id.
+ *   - Builder install response returns the created stored skill id.
+ *
+ * The upstream skills.sh proxy response shapes are reused via the shared
+ * `skillsShSearchResponseSchema`, `skillsShListResponseSchema`, and
+ * `skillsShPreviewResponseSchema` since the wire shape from skills.sh is
+ * registry-independent.
+ */
+
+import { z } from 'zod/v4';
+
+// =============================================================================
+// Registry list
+// =============================================================================
+
+/** Single entry in the registries list. */
+export const builderRegistryEntrySchema = z.object({
+  id: z.literal('skills-sh').describe('Stable registry identifier'),
+  enabled: z.boolean().describe('Whether this registry is enabled in the running deployment'),
+  label: z.string().describe('Human-readable registry name'),
+});
+
+/** Response for `GET /editor/builder/registries`. */
+export const builderRegistriesResponseSchema = z.object({
+  registries: z.array(builderRegistryEntrySchema),
+});
+
+// =============================================================================
+// Search / popular / preview
+// =============================================================================
+
+/** Path params used by every per-registry route. */
+export const builderRegistryPathParams = z.object({
+  registryId: z.string().describe('Registry identifier (e.g. "skills-sh")'),
+});
+
+export const builderRegistrySearchQuerySchema = z.object({
+  q: z.string().describe('Search query'),
+  limit: z.coerce.number().optional().default(10).describe('Maximum number of results'),
+});
+
+export const builderRegistryPopularQuerySchema = z.object({
+  limit: z.coerce.number().optional().default(10).describe('Maximum number of results'),
+  offset: z.coerce.number().optional().default(0).describe('Offset for pagination'),
+});
+
+export const builderRegistryPreviewQuerySchema = z.object({
+  owner: z.string().describe('GitHub repository owner'),
+  repo: z.string().describe('GitHub repository name'),
+  path: z.string().describe('Skill name within repo'),
+});
+
+// =============================================================================
+// Install
+// =============================================================================
+
+/**
+ * Body for `POST /editor/builder/registries/:registryId/install`.
+ *
+ * Visibility behaves like the standard stored-skill create flow: optional,
+ * defaults to private when the caller is authenticated.
+ */
+export const builderRegistryInstallBodySchema = z.object({
+  owner: z.string().describe('GitHub repository owner'),
+  repo: z.string().describe('GitHub repository name'),
+  skillName: z.string().describe('Skill name from the registry'),
+  visibility: z.enum(['private', 'public']).optional().describe('Visibility for the new stored skill'),
+});
+
+/** Response for the install route. Mirrors stored-skill identity fields. */
+export const builderRegistryInstallResponseSchema = z.object({
+  storedSkillId: z.string().describe('Id of the newly created stored skill'),
+  name: z.string().describe('Resolved skill name'),
+  filesWritten: z.number().describe('Number of files materialized into the skill version snapshot'),
+});
+
+export type BuilderRegistryEntry = z.infer<typeof builderRegistryEntrySchema>;
+export type BuilderRegistriesResponse = z.infer<typeof builderRegistriesResponseSchema>;
+export type BuilderRegistryInstallBody = z.infer<typeof builderRegistryInstallBodySchema>;
+export type BuilderRegistryInstallResponse = z.infer<typeof builderRegistryInstallResponseSchema>;

--- a/packages/server/src/server/schemas/editor-builder.ts
+++ b/packages/server/src/server/schemas/editor-builder.ts
@@ -213,6 +213,11 @@ export const infrastructureStatusResponseSchema = z.object({
     sandboxProvider: z.string().nullable(),
     config: z.array(z.object({ key: z.string(), value: z.string() })),
   }),
+  registries: z.object({
+    skillsSh: z.object({
+      enabled: z.boolean(),
+    }),
+  }),
 });
 
 export type InfrastructureStatus = z.infer<typeof infrastructureStatusResponseSchema>;

--- a/packages/server/src/server/schemas/stored-skills.test.ts
+++ b/packages/server/src/server/schemas/stored-skills.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { SKILL_ORIGIN_METADATA_KEY, buildOriginMetadata, readSkillOrigin, skillOriginSchema } from './stored-skills';
+import type { SkillOrigin } from './stored-skills';
+
+describe('skillOriginSchema', () => {
+  it('accepts a skills-sh origin', () => {
+    const origin: SkillOrigin = {
+      type: 'skills-sh',
+      owner: 'mastra-ai',
+      repo: 'mastra',
+      skillName: 'foo',
+      installedAt: '2026-05-07T12:00:00Z',
+    };
+    expect(skillOriginSchema.parse(origin)).toEqual(origin);
+  });
+
+  it('rejects unknown types', () => {
+    const result = skillOriginSchema.safeParse({
+      type: 'github',
+      owner: 'a',
+      repo: 'b',
+      skillName: 'c',
+      installedAt: 'now',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing fields', () => {
+    const result = skillOriginSchema.safeParse({
+      type: 'skills-sh',
+      owner: 'a',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('readSkillOrigin', () => {
+  const validOrigin: SkillOrigin = {
+    type: 'skills-sh',
+    owner: 'mastra-ai',
+    repo: 'mastra',
+    skillName: 'foo',
+    installedAt: '2026-05-07T12:00:00Z',
+  };
+
+  it('returns null when metadata is undefined', () => {
+    expect(readSkillOrigin(undefined)).toBeNull();
+  });
+
+  it('returns null when metadata is empty', () => {
+    expect(readSkillOrigin({})).toBeNull();
+  });
+
+  it('returns null when origin key is absent', () => {
+    expect(readSkillOrigin({ tags: ['foo'] })).toBeNull();
+  });
+
+  it('returns null when origin is malformed', () => {
+    expect(readSkillOrigin({ origin: { type: 'github', owner: 'a' } })).toBeNull();
+  });
+
+  it('returns the typed origin when valid', () => {
+    expect(readSkillOrigin({ origin: validOrigin })).toEqual(validOrigin);
+  });
+});
+
+describe('buildOriginMetadata', () => {
+  it('writes under the documented metadata key', () => {
+    const origin: SkillOrigin = {
+      type: 'skills-sh',
+      owner: 'a',
+      repo: 'b',
+      skillName: 'c',
+      installedAt: '2026-05-07T12:00:00Z',
+    };
+    expect(buildOriginMetadata(origin)).toEqual({ [SKILL_ORIGIN_METADATA_KEY]: origin });
+    expect(SKILL_ORIGIN_METADATA_KEY).toBe('origin');
+  });
+
+  it('round-trips through readSkillOrigin', () => {
+    const origin: SkillOrigin = {
+      type: 'skills-sh',
+      owner: 'a',
+      repo: 'b',
+      skillName: 'c',
+      installedAt: '2026-05-07T12:00:00Z',
+    };
+    expect(readSkillOrigin(buildOriginMetadata(origin))).toEqual(origin);
+  });
+});

--- a/packages/server/src/server/schemas/stored-skills.test.ts
+++ b/packages/server/src/server/schemas/stored-skills.test.ts
@@ -33,6 +33,35 @@ describe('skillOriginSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('accepts a library-fork origin with optional sourceAuthorId', () => {
+    const origin: SkillOrigin = {
+      type: 'library-fork',
+      sourceSkillId: 'public-skill-1',
+      sourceSkillName: 'Public Skill',
+      sourceAuthorId: 'user-42',
+      forkedAt: '2026-05-08T18:00:00Z',
+    };
+    expect(skillOriginSchema.parse(origin)).toEqual(origin);
+  });
+
+  it('accepts a library-fork origin without sourceAuthorId', () => {
+    const origin: SkillOrigin = {
+      type: 'library-fork',
+      sourceSkillId: 'public-skill-1',
+      sourceSkillName: 'Public Skill',
+      forkedAt: '2026-05-08T18:00:00Z',
+    };
+    expect(skillOriginSchema.parse(origin)).toEqual(origin);
+  });
+
+  it('rejects library-fork with missing required fields', () => {
+    const result = skillOriginSchema.safeParse({
+      type: 'library-fork',
+      sourceSkillId: 'public-skill-1',
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('readSkillOrigin', () => {

--- a/packages/server/src/server/schemas/stored-skills.test.ts
+++ b/packages/server/src/server/schemas/stored-skills.test.ts
@@ -34,30 +34,30 @@ describe('skillOriginSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('accepts a library-fork origin with optional sourceAuthorId', () => {
+  it('accepts a library-copy origin with optional sourceAuthorId', () => {
     const origin: SkillOrigin = {
-      type: 'library-fork',
+      type: 'library-copy',
       sourceSkillId: 'public-skill-1',
       sourceSkillName: 'Public Skill',
       sourceAuthorId: 'user-42',
-      forkedAt: '2026-05-08T18:00:00Z',
+      copiedAt: '2026-05-08T18:00:00Z',
     };
     expect(skillOriginSchema.parse(origin)).toEqual(origin);
   });
 
-  it('accepts a library-fork origin without sourceAuthorId', () => {
+  it('accepts a library-copy origin without sourceAuthorId', () => {
     const origin: SkillOrigin = {
-      type: 'library-fork',
+      type: 'library-copy',
       sourceSkillId: 'public-skill-1',
       sourceSkillName: 'Public Skill',
-      forkedAt: '2026-05-08T18:00:00Z',
+      copiedAt: '2026-05-08T18:00:00Z',
     };
     expect(skillOriginSchema.parse(origin)).toEqual(origin);
   });
 
-  it('rejects library-fork with missing required fields', () => {
+  it('rejects library-copy with missing required fields', () => {
     const result = skillOriginSchema.safeParse({
-      type: 'library-fork',
+      type: 'library-copy',
       sourceSkillId: 'public-skill-1',
     });
     expect(result.success).toBe(false);

--- a/packages/server/src/server/schemas/stored-skills.ts
+++ b/packages/server/src/server/schemas/stored-skills.ts
@@ -83,6 +83,13 @@ export const skillOriginSchema = z.discriminatedUnion('type', [
     skillName: z.string().describe('Original skill name on skills.sh'),
     installedAt: z.string().describe('ISO-8601 timestamp of the install'),
   }),
+  z.object({
+    type: z.literal('library-fork'),
+    sourceSkillId: z.string().describe('ID of the public Library skill this was forked from'),
+    sourceSkillName: z.string().describe('Name of the source skill at fork time'),
+    sourceAuthorId: z.string().optional().describe('Author of the source skill at fork time, when known'),
+    forkedAt: z.string().describe('ISO-8601 timestamp of the fork'),
+  }),
 ]);
 
 export type SkillOrigin = z.infer<typeof skillOriginSchema>;

--- a/packages/server/src/server/schemas/stored-skills.ts
+++ b/packages/server/src/server/schemas/stored-skills.ts
@@ -84,11 +84,11 @@ export const skillOriginSchema = z.discriminatedUnion('type', [
     installedAt: z.string().describe('ISO-8601 timestamp of the install'),
   }),
   z.object({
-    type: z.literal('library-fork'),
-    sourceSkillId: z.string().describe('ID of the public Library skill this was forked from'),
-    sourceSkillName: z.string().describe('Name of the source skill at fork time'),
-    sourceAuthorId: z.string().optional().describe('Author of the source skill at fork time, when known'),
-    forkedAt: z.string().describe('ISO-8601 timestamp of the fork'),
+    type: z.literal('library-copy'),
+    sourceSkillId: z.string().describe('ID of the public Library skill this was copied from'),
+    sourceSkillName: z.string().describe('Name of the source skill at copy time'),
+    sourceAuthorId: z.string().optional().describe('Author of the source skill at copy time, when known'),
+    copiedAt: z.string().describe('ISO-8601 timestamp of the copy'),
   }),
 ]);
 

--- a/packages/server/src/server/schemas/stored-skills.ts
+++ b/packages/server/src/server/schemas/stored-skills.ts
@@ -66,6 +66,47 @@ const fileNodeSchema: z.ZodType<FileNode> = z.object({
   children: z.lazy(() => z.array(fileNodeSchema)).optional(),
 });
 
+// ============================================================================
+// Origin Schema (metadata.origin)
+// ============================================================================
+
+/**
+ * Identifies where a stored skill came from.
+ * Persisted as `metadata.origin` on the stored skill so that registry-installed
+ * skills can be distinguished from skills authored directly in the Builder.
+ */
+export const skillOriginSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('skills-sh'),
+    owner: z.string().describe('Repository owner on skills.sh'),
+    repo: z.string().describe('Repository name on skills.sh'),
+    skillName: z.string().describe('Original skill name on skills.sh'),
+    installedAt: z.string().describe('ISO-8601 timestamp of the install'),
+  }),
+]);
+
+export type SkillOrigin = z.infer<typeof skillOriginSchema>;
+
+/** Metadata key under which origin information is persisted on a stored skill. */
+export const SKILL_ORIGIN_METADATA_KEY = 'origin';
+
+/**
+ * Read a typed origin off a stored skill's metadata blob, if present and valid.
+ * Returns null when the skill has no origin (i.e., authored directly in the Builder).
+ */
+export function readSkillOrigin(metadata: Record<string, unknown> | undefined): SkillOrigin | null {
+  if (!metadata) return null;
+  const raw = metadata[SKILL_ORIGIN_METADATA_KEY];
+  if (!raw) return null;
+  const parsed = skillOriginSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+/** Build a metadata patch for an origin, suitable for spreading into the create body. */
+export function buildOriginMetadata(origin: SkillOrigin): Record<string, unknown> {
+  return { [SKILL_ORIGIN_METADATA_KEY]: origin };
+}
+
 const snapshotConfigSchema = z.object({
   name: z.string().describe('Name of the skill'),
   description: z.string().describe('Description of what the skill does and when to use it'),

--- a/packages/server/src/server/server-adapter/routes/editor-builder.ts
+++ b/packages/server/src/server/server-adapter/routes/editor-builder.ts
@@ -1,8 +1,24 @@
+import {
+  BUILDER_REGISTRY_INSTALL_ROUTE,
+  BUILDER_REGISTRY_POPULAR_ROUTE,
+  BUILDER_REGISTRY_PREVIEW_ROUTE,
+  BUILDER_REGISTRY_SEARCH_ROUTE,
+  LIST_BUILDER_REGISTRIES_ROUTE,
+} from '../../handlers/builder-registry';
 import { GET_EDITOR_BUILDER_SETTINGS_ROUTE, GET_INFRASTRUCTURE_STATUS_ROUTE } from '../../handlers/editor-builder';
 
 /**
  * Editor Builder Routes
  *
- * Routes for agent builder settings and configuration.
+ * Routes for agent builder settings, infrastructure status, and external
+ * skill registries.
  */
-export const EDITOR_BUILDER_ROUTES = [GET_EDITOR_BUILDER_SETTINGS_ROUTE, GET_INFRASTRUCTURE_STATUS_ROUTE] as const;
+export const EDITOR_BUILDER_ROUTES = [
+  GET_EDITOR_BUILDER_SETTINGS_ROUTE,
+  GET_INFRASTRUCTURE_STATUS_ROUTE,
+  LIST_BUILDER_REGISTRIES_ROUTE,
+  BUILDER_REGISTRY_SEARCH_ROUTE,
+  BUILDER_REGISTRY_POPULAR_ROUTE,
+  BUILDER_REGISTRY_PREVIEW_ROUTE,
+  BUILDER_REGISTRY_INSTALL_ROUTE,
+] as const;

--- a/server-adapters/_test-utils/src/route-adapter-test-suite.ts
+++ b/server-adapters/_test-utils/src/route-adapter-test-suite.ts
@@ -101,6 +101,12 @@ export function createRouteAdapterTestSuite(config: AdapterTestSuiteConfig) {
       '/workspaces/:workspaceId/skills-sh/install',
       '/workspaces/:workspaceId/skills-sh/remove',
       '/workspaces/:workspaceId/skills-sh/update',
+      // Builder registry routes that require external API calls + builder config
+      '/editor/builder/registries',
+      '/editor/builder/registries/:registryId/search',
+      '/editor/builder/registries/:registryId/popular',
+      '/editor/builder/registries/:registryId/preview',
+      '/editor/builder/registries/:registryId/install',
       // observational memory routes require OM-enabled agent configuration
       '/memory/observational-memory',
       '/memory/observational-memory/buffer-status',

--- a/server-adapters/_test-utils/src/route-test-utils.ts
+++ b/server-adapters/_test-utils/src/route-test-utils.ts
@@ -413,6 +413,9 @@ export function getDefaultValidPathParams(route: ServerRoute): Record<string, an
   // Channel route params
   if (route.path.includes(':platform')) params.platform = 'test-platform';
 
+  // Builder registry route params
+  if (route.path.includes(':registryId')) params.registryId = 'skills-sh';
+
   return params;
 }
 
@@ -422,6 +425,10 @@ export function getDefaultInvalidPathParams(route: ServerRoute): Array<Record<st
 
   if (route.path.includes(':agentId')) {
     invalid.push({ agentId: 123 });
+  }
+
+  if (route.path.includes(':registryId')) {
+    invalid.push({ registryId: 123 });
   }
 
   return invalid;


### PR DESCRIPTION
Linear: [COR-832](https://linear.app/mastra/issue/COR-832)

## Summary

Adds a first-party "skill registry" surface to Agent Builder. Today the
only way to install community skills is the **skills.sh** flow inside a
Studio workspace, which writes files directly to the workspace
filesystem. Public skills in Agent Builder should live in their own
registry concept: skills installed from a registry land in the user's
stored-skills library (DB-backed) instead of a workspace, recording
their provenance in `metadata.origin` so the UI can show where each
imported skill came from.

This PR keeps Studio's existing skills.sh flow exactly as-is and adds a
parallel registry path for Agent Builder. The new path is **off by
default** — admins opt in via Builder config:

```ts
agentBuilder({
  registries: { skillsSh: { enabled: true } },
})
```

When no registry is enabled, the new UI is invisible (no Browse button,
no API surface).

## What changed

### Server
- `refactor(server)`: extracts the skills.sh proxy/install helpers from
  the workspace handler into a shared module so both Studio and Agent
  Builder can reuse them. No behavior change for Studio.
- `feat(server)`: adds a typed `skillOriginSchema` for
  `metadata.origin` on stored skills (existing `metadata` column flowed
  end-to-end already; this just narrows the shape).
- `feat`: adds `registries.skillsSh.enabled` to `AgentBuilderOptions`,
  exposes it via `IAgentBuilder.getRegistries()`, and surfaces it on
  `GET /editor/builder/infrastructure`.
- `feat(server)`: adds 5 Builder registry routes under
  `/editor/builder/registries/*`:
  - `GET /` — list enabled registries
  - `GET /:id/search?query=&pageSize=`
  - `GET /:id/popular?pageSize=&page=`
  - `GET /:id/preview/:owner/:repo/:skillName`
  - `POST /:id/install` — fetches files from skills.sh, parses
    `SKILL.md` frontmatter, writes a stored skill (private by default)
    with `metadata.origin = { type: 'skills-sh', owner, repo, skillName }`.
    Returns 409 with the existing skill id on collision.
  - Catalog browse routes require `stored-skills:read`; install
    requires `stored-skills:write`.

### Client / Playground
- `client-js`: 6 new methods (`listBuilderRegistries`,
  `searchBuilderRegistry`, `getBuilderRegistryPopular`,
  `previewBuilderRegistrySkill`, `installBuilderRegistrySkill`) plus
  matching response types.
- `feat(playground)`: new `BuilderAddSkillDialog` mirrors the workspace
  skills.sh dialog but without filesystem/mount semantics.
- Standalone Agent Builder skills page (`/agent-builder/skills`) gets a
  **Browse {registry}** button next to **New skill**, gated on
  `stored-skills:read+write` AND at least one enabled registry.
- 409 collisions surface a toast with **Open existing**, which opens
  the existing skill in the edit dialog.
- Imported skills show a small `skills.sh` badge in the skill list
  with a tooltip showing `owner/repo`.

## Out of scope (next commit before merge)

- Custom registry support beyond skills.sh — the registry list endpoint
  and dialog are written to be registry-agnostic, but only `skillsSh`
  is wired through config today. The follow-up work is a separate
  commit on this branch defining the registry protocol so admins can
  point at their own registries.

## Test plan

This package is primarily validated via E2E coverage (per
`packages/playground/AGENTS.md`):

- [ ] `pnpm --filter ./packages/playground build` — passes
- [ ] Server unit tests cover all 5 new routes (search/popular/preview/
      install happy paths, 404, name validation, collision, frontmatter
      parsing).
- [ ] Manual smoke (will run before un-drafting):
  - With `registries.skillsSh.enabled: false` (default): no Browse
    button on `/agent-builder/skills`, no registry calls.
  - With it enabled: Browse opens the dialog, search/popular work,
    preview renders SKILL.md, install lands a private stored skill
    with the origin badge visible.
  - Re-installing the same skill returns 409 → toast with **Open
    existing** opens the skill in the edit dialog.

EOF
