### PR TITLE
fix(playground-ui): unbreak storybook build (codemirror lang-jinja missing peer deps)

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,14 @@
     "patchedDependencies": {
       "@changesets/get-dependents-graph": "patches/@changesets__get-dependents-graph.patch",
       "tsup@8.5.1": "patches/tsup@8.5.1.patch"
+    },
+    "packageExtensions": {
+      "@codemirror/lang-jinja@6.0.0": {
+        "dependencies": {
+          "@codemirror/view": "^6.0.0",
+          "@codemirror/state": "^6.0.0"
+        }
+      }
     }
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -124,19 +124,12 @@
       "lodash@<=4.17.23": "^4.18.0",
       "prismjs@<1.30.0": "^1.30.0",
       "serialize-javascript@<7.0.5": "^7.0.5",
-      "@tootallnate/once@<3.0.1": "^3.0.1"
+      "@tootallnate/once@<3.0.1": "^3.0.1",
+      "@codemirror/lang-jinja": "^6.0.1"
     },
     "patchedDependencies": {
       "@changesets/get-dependents-graph": "patches/@changesets__get-dependents-graph.patch",
       "tsup@8.5.1": "patches/tsup@8.5.1.patch"
-    },
-    "packageExtensions": {
-      "@codemirror/lang-jinja@6.0.0": {
-        "dependencies": {
-          "@codemirror/view": "^6.0.0",
-          "@codemirror/state": "^6.0.0"
-        }
-      }
     }
   },
   "license": "Apache-2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,8 @@ overrides:
   serialize-javascript@<7.0.5: ^7.0.5
   '@tootallnate/once@<3.0.1': ^3.0.1
 
+packageExtensionsChecksum: sha256-dhWAp0Q03uv8VBf6e05Iny76MdWwn9mfL4n9fiKMjT4=
+
 patchedDependencies:
   '@changesets/get-dependents-graph':
     hash: 1cae443604ba49c27339705c703329dfcd79f6acd7fc822b1257a7d7c9da9535
@@ -29871,6 +29873,8 @@ snapshots:
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,7 @@ overrides:
   prismjs@<1.30.0: ^1.30.0
   serialize-javascript@<7.0.5: ^7.0.5
   '@tootallnate/once@<3.0.1': ^3.0.1
-
-packageExtensionsChecksum: sha256-dhWAp0Q03uv8VBf6e05Iny76MdWwn9mfL4n9fiKMjT4=
+  '@codemirror/lang-jinja': ^6.0.1
 
 patchedDependencies:
   '@changesets/get-dependents-graph':
@@ -9459,8 +9458,8 @@ packages:
   '@codemirror/lang-javascript@6.2.5':
     resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
 
-  '@codemirror/lang-jinja@6.0.0':
-    resolution: {integrity: sha512-47MFmRcR8UAxd8DReVgj7WJN1WSAMT7OJnewwugZM4XiHWkOjgJQqvEM1NpMj9ALMPyxmlziEI1opH9IaEvmaw==}
+  '@codemirror/lang-jinja@6.0.1':
+    resolution: {integrity: sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==}
 
   '@codemirror/lang-json@6.0.2':
     resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
@@ -29869,8 +29868,9 @@ snapshots:
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
 
-  '@codemirror/lang-jinja@6.0.0':
+  '@codemirror/lang-jinja@6.0.1':
     dependencies:
+      '@codemirror/autocomplete': 6.20.1
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
@@ -29995,7 +29995,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-java': 6.0.2
       '@codemirror/lang-javascript': 6.2.5
-      '@codemirror/lang-jinja': 6.0.0
+      '@codemirror/lang-jinja': 6.0.1
       '@codemirror/lang-json': 6.0.2
       '@codemirror/lang-less': 6.0.2
       '@codemirror/lang-liquid': 6.3.0


### PR DESCRIPTION
## Summary

- Vercel preview's `pnpm build-storybook` for `@mastra/playground-ui` started failing on every PR with `[vite]: Rollup failed to resolve import "@codemirror/view" from "@codemirror/lang-jinja"`.
- Root cause: upstream bug in `@codemirror/lang-jinja@6.0.0` — it imports `@codemirror/view` and `@codemirror/state` but does not declare them as deps. Pulled in transitively via `@codemirror/language-data` lazy import (added to playground-ui in #9302).
- Latent until #16245 (`chore(deps): lock file maintenance`) regenerated the pnpm graph (bumped `@codemirror/view` 6.41.0 → 6.41.1, `@codemirror/search` 6.6.0 → 6.7.0). New hoisting layout no longer placed `@codemirror/view` next to `lang-jinja`, so Rollup strict resolution failed. Vite dev hides it via pre-bundling; Rollup prod build does not.
- Fix: use `pnpm.packageExtensions` to inject the missing deps into `lang-jinja`. Standard pnpm mechanism for upstream peer-dep gaps; no revert needed.

## Test plan

- [x] `pnpm install` — lock regenerated cleanly
- [x] Verified `node_modules/.pnpm/@codemirror+lang-jinja@6.0.0/node_modules/@codemirror/` now contains `state` and `view`
- [x] `pnpm --filter @mastra/playground-ui build-storybook` — build green locally
- [ ] Vercel preview build green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The package that needed two helper tools (@codemirror/view and @codemirror/state) was fixed upstream, and this PR tells our package manager to use that fixed version so Storybook can build again.

## Problem

Vercel preview builds for @mastra/playground-ui Storybook failed during Rollup bundling because @codemirror/lang-jinja@6.0.0 imported @codemirror/view and @codemirror/state but did not declare them as dependencies. Lockfile maintenance (#16245) changed pnpm hoisting and revealed the missing deps (Vite dev pre-bundling had hidden the issue).

## Solution

Use pnpm overrides to pin @codemirror/lang-jinja to ^6.0.1, which upstream released with @codemirror/view and @codemirror/state properly declared, removing the previous packageExtensions workaround.

## Changes

- package.json: added pnpm.overrides entry for @codemirror/lang-jinja -> ^6.0.1 (net +2/-1 lines)

## Verification

- `pnpm install` — lockfile regenerated cleanly
- Confirmed node_modules contains @codemirror/state and @codemirror/view under @codemirror/lang-jinja@6.0.1
- `pnpm --filter @mastra/playground-ui build-storybook` — local build succeeds
- Vercel preview build: pending
<!-- end of auto-generated comment: release notes by coderabbit.ai -->