### PR TITLE
fix(core): pass OpenAI Files API file IDs through without base64 wrapping

### DIFF
--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
@@ -223,6 +223,23 @@ export class AIV5Adapter {
             continue;
           }
 
+          // OpenAI Files API file IDs (e.g. "file-abc123") must reach @ai-sdk/openai
+          // as the raw string so the provider sends { file_id: "..." } instead of
+          // wrapping it as a base64 data URI. categorizeFileData() treats these as
+          // "raw" strings because new URL("file-abc123") throws (no scheme), and
+          // createDataUri() would then produce "data:…;base64,file-abc123" which
+          // fails at fetch time with "failed to fetch the data URL".
+          if (typeof part.data === 'string' && part.data.startsWith('file-')) {
+            const v5UIPart: AIV5Type.FileUIPart = {
+              type: 'file' as const,
+              url: part.data,
+              mediaType: part.mimeType || 'application/octet-stream',
+            };
+            v5UIPart.providerMetadata = mergeMastraCreatedAt(part.providerMetadata, part.createdAt);
+            parts.push(v5UIPart);
+            continue;
+          }
+
           const categorized =
             typeof part.data === 'string'
               ? categorizeFileData(part.data, part.mimeType)


### PR DESCRIPTION
## Problem

When an input processor returns a file part with `data: "file-abc123"` (an OpenAI Files API file ID), the message hits this path in `AIV5Adapter.toUIMessage`:

```ts
const categorized = categorizeFileData(part.data, part.mimeType);
```

`categorizeFileData` calls `new URL("file-abc123")` which **throws** — the string has no URL scheme. The function falls back to type `"raw"`, and the code reaches:

```ts
dataUri = createDataUri(filePartData, finalMimeType);
// → "data:application/pdf;base64,file-abc123"
```

`downloadAssetsFromMessages` then tries to `fetch("data:application/pdf;base64,file-abc123")` and fails with:

```
MastraError: Failed to download asset – failed to fetch the data URL
```

The colon in `"file-abc123"` makes it invalid base64.

## Root cause

`@ai-sdk/openai` already handles `"file-"` prefixed strings correctly — it detects them and sends `{ file_id: "file-abc123" }` to the OpenAI API instead of inline bytes. The problem is that the string never reaches the provider intact; `AIV5Adapter` corrupts it first.

## Fix

Add an early-exit guard in `AIV5Adapter.toUIMessage` for file parts whose `data` starts with `"file-"`. These are passed through as `url: part.data` directly, bypassing `categorizeFileData` / `createDataUri`, so `@ai-sdk/openai` receives the raw file ID and uses the Files API reference as intended.

```ts
if (typeof part.data === 'string' && part.data.startsWith('file-')) {
  const v5UIPart: AIV5Type.FileUIPart = {
    type: 'file' as const,
    url: part.data,
    mediaType: part.mimeType || 'application/octet-stream',
  };
  v5UIPart.providerMetadata = mergeMastraCreatedAt(part.providerMetadata, part.createdAt);
  parts.push(v5UIPart);
  continue;
}
```

## Reproduction

1. Configure an agent with an input processor that uploads a file to the OpenAI Files API and returns `data: "file-<id>"` on the file part.
2. Send a message to the agent with a file attachment.
3. Without this fix: `MastraError: Failed to download asset` / `"failed to fetch the data URL"`.
4. With this fix: the file ID reaches `@ai-sdk/openai` as a raw string and the Files API reference is used correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When code tries to use OpenAI's file system (where files have IDs like "file-abc123"), the system was accidentally breaking those IDs by treating them like image data and wrapping them in a weird format. This fix detects those special file IDs and passes them through unchanged so OpenAI's tools can use them properly.

## Changes

Modified `AIV5Adapter.toUIMessage` in `packages/core/src/agent/message-list/adapters/AIV5Adapter.ts` to add special handling for OpenAI Files API file IDs.

## Problem

When an input processor returns a file part whose data is an OpenAI Files API file ID string (e.g., `"file-abc123"`), the adapter's `categorizeFileData()` function would fail to parse it as a URL. The code would then fall back to treating it as raw data and wrap it in a base64 data URI (`"data:...;base64,file-abc123"`). When downstream code tried to fetch this data URL, it would fail because the file ID contains a colon and is not valid base64.

## Solution

Added an early-exit guard for file parts where `part.data` is a string starting with `"file-"`. Such parts are now:
1. Converted directly to a `FileUIPart` with `url: part.data` (the raw file ID)
2. Given a `mediaType` from `part.mimeType` (defaulting to `application/octet-stream`)
3. Assigned `providerMetadata` with `createdAt` info merged in
4. Pushed to the parts array without going through `categorizeFileData()` or `createDataUri()`

This ensures the raw file ID reaches `@ai-sdk/openai` unchanged, allowing the provider to send the proper `{ file_id: "file-abc123" }` reference to the OpenAI Files API instead of attempting to fetch a corrupted data URL.

## Impact

- **Lines changed:** +17/-0
- **Scope:** Core message adapter for AI SDK v5 compatibility
- **Risk:** Low – the change only affects file parts with data matching the `"file-*"` pattern, which are OpenAI file references; all other file handling remains unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->