### PR TITLE
Fix MODEL_INFERENCE span timing to exclude processor work

### DIFF
--- a/.changeset/solid-snakes-double.md
+++ b/.changeset/solid-snakes-double.md
@@ -1,0 +1,6 @@
+---
+'@mastra/observability': patch
+'@mastra/core': patch
+---
+
+Fixed `MODEL_INFERENCE` span timing so it measures pure model latency.

--- a/observability/mastra/src/model-tracing.test.ts
+++ b/observability/mastra/src/model-tracing.test.ts
@@ -1540,6 +1540,130 @@ describe('ModelSpanTracker', () => {
       });
     });
 
+    it('does not open MODEL_INFERENCE from startStep — only MODEL_STEP starts', () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+        attributes: { model: 'gpt-test', provider: 'test' },
+      });
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      tracker.startStep({ messageId: 'msg-1', request: {} });
+
+      // No MODEL_INFERENCE has been emitted yet — the inference span only
+      // opens via startInference() / first chunk arrival, so processor work
+      // between startStep and the model call is excluded from its duration.
+      const liveInferenceStarts = testExporter.events.filter(
+        e => e.type === TracingEventType.SPAN_STARTED && e.exportedSpan.type === SpanType.MODEL_INFERENCE,
+      );
+      expect(liveInferenceStarts).toHaveLength(0);
+    });
+
+    it('startInference() opens MODEL_INFERENCE with the latest setInferenceContext snapshot', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+        attributes: { model: 'gpt-test', provider: 'test' },
+      });
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      tracker.startStep();
+      // Simulate input processors mutating the tool set after startStep
+      tracker.setInferenceContext({
+        availableTools: ['searchDocs', 'lookupOrder'],
+        toolChoice: 'required',
+      });
+      tracker.startInference();
+
+      const chunks = [
+        { type: 'text-delta', payload: { text: 'ok' } },
+        {
+          type: 'step-finish',
+          payload: { output: {}, stepResult: { reason: 'stop', warnings: [] }, metadata: {} },
+        },
+      ];
+      await consumeStream(tracker.wrapStream(createMockStream(chunks)));
+      modelSpan.end();
+
+      const [inferenceSpan] = testExporter.getSpansByType(SpanType.MODEL_INFERENCE);
+      expect(inferenceSpan).toBeDefined();
+      expect(inferenceSpan!.attributes?.availableTools).toEqual(['searchDocs', 'lookupOrder']);
+      expect(inferenceSpan!.attributes?.toolChoice).toEqual('required');
+    });
+
+    it('MODEL_INFERENCE.startTime excludes work between startStep and startInference', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+        attributes: { model: 'gpt-test', provider: 'test' },
+      });
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      tracker.startStep();
+      const stepStartedAt = Date.now();
+      // Simulate processor work between startStep and the model call
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const beforeInference = Date.now();
+      tracker.startInference();
+
+      await consumeStream(
+        tracker.wrapStream(
+          createMockStream([
+            { type: 'text-delta', payload: { text: 'ok' } },
+            {
+              type: 'step-finish',
+              payload: { output: {}, stepResult: { reason: 'stop', warnings: [] }, metadata: {} },
+            },
+          ]),
+        ),
+      );
+      modelSpan.end();
+
+      const [stepSpan] = testExporter.getSpansByType(SpanType.MODEL_STEP);
+      const [inferenceSpan] = testExporter.getSpansByType(SpanType.MODEL_INFERENCE);
+
+      const stepStart = new Date(stepSpan!.startTime).getTime();
+      const inferenceStart = new Date(inferenceSpan!.startTime).getTime();
+
+      expect(stepStart).toBeGreaterThanOrEqual(stepStartedAt - 5);
+      expect(inferenceStart).toBeGreaterThanOrEqual(beforeInference - 5);
+      // MODEL_INFERENCE started at least ~50ms after MODEL_STEP (the simulated processor work).
+      expect(inferenceStart - stepStart).toBeGreaterThanOrEqual(40);
+    });
+
+    it('chunk-arrival auto-creates MODEL_INFERENCE when caller did not call startInference', async () => {
+      const modelSpan = tracing.startSpan({
+        type: SpanType.MODEL_GENERATION,
+        name: 'test-generation',
+        attributes: { model: 'gpt-test', provider: 'test' },
+      });
+      const tracker = new ModelSpanTracker(modelSpan);
+
+      tracker.startStep();
+      // Caller forgets startInference() — chunk handlers should auto-create it
+      // so chunks still parent under MODEL_INFERENCE rather than MODEL_STEP.
+      await consumeStream(
+        tracker.wrapStream(
+          createMockStream([
+            { type: 'text-delta', payload: { text: 'ok' } },
+            {
+              type: 'step-finish',
+              payload: { output: {}, stepResult: { reason: 'stop', warnings: [] }, metadata: {} },
+            },
+          ]),
+        ),
+      );
+      modelSpan.end();
+
+      const [inferenceSpan] = testExporter.getSpansByType(SpanType.MODEL_INFERENCE);
+      const chunkSpans = testExporter.getSpansByType(SpanType.MODEL_CHUNK);
+      expect(inferenceSpan).toBeDefined();
+      expect(chunkSpans.length).toBeGreaterThan(0);
+      for (const chunk of chunkSpans) {
+        expect(chunk.parentSpanId).toBe(inferenceSpan!.id);
+      }
+    });
+
     it('closes MODEL_INFERENCE on step-finish even when step-close is deferred (durable mode)', async () => {
       const modelSpan = tracing.startSpan({
         type: SpanType.MODEL_GENERATION,

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -562,6 +562,22 @@ export class ModelSpanTracker {
   }
 
   /**
+   * Safety-net invoked from chunk handlers: auto-create MODEL_STEP and
+   * MODEL_INFERENCE if a chunk arrives before the loop has explicitly opened
+   * them, so chunks parent under MODEL_INFERENCE rather than falling through
+   * to MODEL_STEP. Idempotent — each public start* method is itself a no-op
+   * when its span is already live.
+   */
+  #ensureStepAndInference(): void {
+    if (!this.#currentStepSpan) {
+      this.startStep();
+    }
+    if (!this.#currentInferenceSpan) {
+      this.startInference();
+    }
+  }
+
+  /**
    * Create a new chunk span (for multi-part chunks like text-start/delta/end)
    */
   #startChunkSpan(chunkType: string, initialData?: Record<string, any>) {
@@ -569,14 +585,7 @@ export class ModelSpanTracker {
     // (handles transitions like text-delta → tool-call without text-end)
     this.#endChunkSpan();
 
-    // Auto-create step + inference if we see a chunk before step-start so chunks
-    // parent under MODEL_INFERENCE rather than falling through to MODEL_STEP.
-    if (!this.#currentStepSpan) {
-      this.startStep();
-    }
-    if (!this.#currentInferenceSpan) {
-      this.startInference();
-    }
+    this.#ensureStepAndInference();
 
     this.#currentChunkSpan = this.#chunkParent()?.createChildSpan({
       name: `chunk: '${chunkType}'`,
@@ -625,14 +634,7 @@ export class ModelSpanTracker {
     output: any,
     options?: { attributes?: Record<string, any>; metadata?: Record<string, any> },
   ) {
-    // Auto-create step + inference if we see a chunk before step-start so chunks
-    // parent under MODEL_INFERENCE rather than falling through to MODEL_STEP.
-    if (!this.#currentStepSpan) {
-      this.startStep();
-    }
-    if (!this.#currentInferenceSpan) {
-      this.startInference();
-    }
+    this.#ensureStepAndInference();
 
     const span = this.#chunkParent()?.createEventSpan({
       name: `chunk: '${chunkType}'`,
@@ -782,14 +784,7 @@ export class ModelSpanTracker {
     if (chunk.type !== 'tool-call-approval') return;
     const payload = chunk.payload;
 
-    // Auto-create step + inference if we see a chunk before step-start so chunks
-    // parent under MODEL_INFERENCE rather than falling through to MODEL_STEP.
-    if (!this.#currentStepSpan) {
-      this.startStep();
-    }
-    if (!this.#currentInferenceSpan) {
-      this.startInference();
-    }
+    this.#ensureStepAndInference();
 
     // Create an event span for the approval request
     // Using createEventSpan since approvals are point-in-time events (not time ranges)

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -378,9 +378,10 @@ export class ModelSpanTracker {
    * This should be called at the beginning of LLM execution to capture accurate startTime.
    * The step-start chunk payload can be passed later via updateStep() if needed.
    *
-   * Also opens a MODEL_INFERENCE child span that wraps the provider call. Chunks
-   * parent under MODEL_INFERENCE so processors/tool executions (which use the
-   * step span as their parent) remain siblings of the inference.
+   * Note: this only opens MODEL_STEP. The MODEL_INFERENCE child span is opened
+   * separately via startInference() so its duration excludes input processor work.
+   * Callers that don't call startInference() explicitly will get one auto-created
+   * when the first model chunk arrives.
    */
   startStep(payload?: StepStartPayload): void {
     // Don't create duplicate step spans
@@ -402,8 +403,6 @@ export class ModelSpanTracker {
     this.#currentStepInputIsFinal = Array.isArray(payload?.inputMessages);
     // Reset chunk sequence for new step
     this.#chunkSequence = 0;
-
-    this.#startInferenceSpan(input);
   }
 
   /**
@@ -437,11 +436,17 @@ export class ModelSpanTracker {
    * chunks emitted by the model) parent under this span so its duration reflects
    * pure model latency.
    *
+   * Should be called immediately before invoking the model — after any input
+   * processors / `prepareStep` work has completed — so the span's startTime
+   * does not include processor time. The latest `#inferenceContext` (set via
+   * setInferenceContext) is snapshotted onto the span at creation.
+   *
    * No-ops when the installed @mastra/core lacks the `model-inference-span`
-   * feature flag. Chunks then fall back to parenting under MODEL_STEP via
-   * #chunkParent(), preserving the pre-MODEL_INFERENCE hierarchy.
+   * feature flag, or when called without an active step span. Auto-invoked from
+   * chunk handlers as a safety net; explicit callers get the most accurate
+   * start time.
    */
-  #startInferenceSpan(input: StepInputPreview): void {
+  startInference(payload?: StepStartPayload): void {
     if (!supportsModelInference()) {
       return;
     }
@@ -449,6 +454,7 @@ export class ModelSpanTracker {
       return;
     }
 
+    const input = extractStepInput(payload);
     const generationAttrs = this.#modelSpan?.attributes;
     const ctx = this.#inferenceContext;
     this.#currentInferenceSpan = this.#currentStepSpan.createChildSpan({
@@ -563,9 +569,13 @@ export class ModelSpanTracker {
     // (handles transitions like text-delta → tool-call without text-end)
     this.#endChunkSpan();
 
-    // Auto-create step if we see a chunk before step-start
+    // Auto-create step + inference if we see a chunk before step-start so chunks
+    // parent under MODEL_INFERENCE rather than falling through to MODEL_STEP.
     if (!this.#currentStepSpan) {
       this.startStep();
+    }
+    if (!this.#currentInferenceSpan) {
+      this.startInference();
     }
 
     this.#currentChunkSpan = this.#chunkParent()?.createChildSpan({
@@ -615,9 +625,13 @@ export class ModelSpanTracker {
     output: any,
     options?: { attributes?: Record<string, any>; metadata?: Record<string, any> },
   ) {
-    // Auto-create step if we see a chunk before step-start
+    // Auto-create step + inference if we see a chunk before step-start so chunks
+    // parent under MODEL_INFERENCE rather than falling through to MODEL_STEP.
     if (!this.#currentStepSpan) {
       this.startStep();
+    }
+    if (!this.#currentInferenceSpan) {
+      this.startInference();
     }
 
     const span = this.#chunkParent()?.createEventSpan({
@@ -768,9 +782,13 @@ export class ModelSpanTracker {
     if (chunk.type !== 'tool-call-approval') return;
     const payload = chunk.payload;
 
-    // Auto-create step if we see a chunk before step-start
+    // Auto-create step + inference if we see a chunk before step-start so chunks
+    // parent under MODEL_INFERENCE rather than falling through to MODEL_STEP.
     if (!this.#currentStepSpan) {
       this.startStep();
+    }
+    if (!this.#currentInferenceSpan) {
+      this.startInference();
     }
 
     // Create an event span for the approval request
@@ -843,6 +861,13 @@ export class ModelSpanTracker {
                 this.updateStep(chunk.payload);
               } else {
                 this.startStep(chunk.payload);
+              }
+              // step-start fires when the provider stream has begun. Open the
+              // inference span here as a safety net for callers that don't
+              // explicitly call startInference() before invoking the model —
+              // chunks that follow will parent under MODEL_INFERENCE.
+              if (!this.#currentInferenceSpan) {
+                this.startInference(chunk.payload);
               }
               break;
 

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -295,12 +295,15 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             // Apply post-processor request-side context to MODEL_INFERENCE then
             // open the inference span immediately before the model call so its
             // startTime excludes any input processor work and availableTools /
-            // toolChoice reflect per-step mutations.
+            // toolChoice reflect per-step mutations. responseFormat tracks the
+            // actual structuredOutput payload sent to execute() — which is
+            // undefined when structuringModelConfig routes through a separate
+            // structuring step instead of asking the model for json_schema.
             modelSpanTracker?.setInferenceContext?.({
               parameters: currentModelSettings as Record<string, unknown> | undefined,
               availableTools: getStepAvailableToolNames(currentTools as Record<string, unknown> | undefined),
               toolChoice: currentToolChoice,
-              responseFormat: execOptions.structuredOutput ? 'json_schema' : undefined,
+              responseFormat: structuredOutput ? 'json_schema' : undefined,
             });
             modelSpanTracker?.startInference?.();
 

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import type { PubSub } from '../../../../events/pubsub';
 import type { Mastra } from '../../../../mastra';
 import type { SpanType, AIModelGenerationSpan, ExportedSpan, IModelSpanTracker } from '../../../../observability';
+import { getStepAvailableToolNames } from '../../../../observability/utils';
 import { ProcessorRunner } from '../../../../processors/runner';
 import { execute } from '../../../../stream/aisdk/v5/execute';
 import { MastraModelOutput } from '../../../../stream/base/output';
@@ -213,16 +214,6 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             const stepIndex = (inputData as any).stepIndex ?? 0;
             modelSpanTracker?.setStepIndex(stepIndex);
 
-            // Apply request-side context to MODEL_INFERENCE spans the tracker creates.
-            // setInferenceContext is optional on the interface; older trackers
-            // without the method gracefully no-op.
-            modelSpanTracker?.setInferenceContext?.({
-              parameters: currentModelSettings as Record<string, unknown> | undefined,
-              availableTools: currentTools ? Object.keys(currentTools) : undefined,
-              toolChoice: currentToolChoice,
-              responseFormat: execOptions.structuredOutput ? 'json_schema' : undefined,
-            });
-
             // Build structured output for AI SDK if configured
             const structuredOutputConfig = execOptions.structuredOutput;
             const structuredOutput =
@@ -300,6 +291,18 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
 
             // 8. Start MODEL_STEP span at the beginning of LLM execution
             modelSpanTracker?.startStep();
+
+            // Apply post-processor request-side context to MODEL_INFERENCE then
+            // open the inference span immediately before the model call so its
+            // startTime excludes any input processor work and availableTools /
+            // toolChoice reflect per-step mutations.
+            modelSpanTracker?.setInferenceContext?.({
+              parameters: currentModelSettings as Record<string, unknown> | undefined,
+              availableTools: getStepAvailableToolNames(currentTools as Record<string, unknown> | undefined),
+              toolChoice: currentToolChoice,
+              responseFormat: execOptions.structuredOutput ? 'json_schema' : undefined,
+            });
+            modelSpanTracker?.startInference?.();
 
             // 10. Execute LLM call
             const modelResult = execute({

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -183,19 +183,10 @@ export class MastraLLMVNext extends MastraBase {
       });
     }
 
-    // Create model span tracker that will be shared across all LLM execution steps
+    // Create model span tracker that will be shared across all LLM execution steps.
+    // The agentic loop calls setInferenceContext + startInference per-step so the
+    // MODEL_INFERENCE span reflects the post-processor tool set / parameters.
     const modelSpanTracker = modelSpan?.createTracker();
-
-    // Apply request-side context to MODEL_INFERENCE spans the tracker creates.
-    // setInferenceContext is optional on the interface; older trackers without
-    // the method gracefully no-op.
-    modelSpanTracker?.setInferenceContext?.({
-      parameters: modelSettings as Record<string, unknown> | undefined,
-      providerOptions: providerOptions as Record<string, unknown> | undefined,
-      availableTools: tools ? Object.keys(tools) : undefined,
-      toolChoice,
-      responseFormat: structuredOutput ? 'json_schema' : undefined,
-    });
 
     try {
       const loopOptions: LoopOptions<Tools, OUTPUT> = {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -15,7 +15,8 @@ import type { MastraLanguageModel, SharedProviderOptions } from '../../../llm/mo
 import type { IMastraLogger } from '../../../logger';
 import { ConsoleLogger } from '../../../logger';
 import { createObservabilityContext, SpanType } from '../../../observability';
-import { executeWithContextSync } from '../../../observability/utils';
+import type { ModelInferenceContext } from '../../../observability';
+import { executeWithContextSync, getStepAvailableToolNames } from '../../../observability/utils';
 import type { InputProcessorOrWorkflow, ProcessorStreamWriter } from '../../../processors/index';
 import { isProcessorWorkflow } from '../../../processors/index';
 import { PrepareStepProcessor } from '../../../processors/processors/prepare-step';
@@ -868,6 +869,28 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           }
 
           if (isSupportedLanguageModel(currentStep.model)) {
+            // Apply request-side context to MODEL_INFERENCE using the post-processor
+            // tool set + per-step settings, then open the inference span. Doing this
+            // immediately before execute() ensures the span's startTime excludes
+            // input processor / prepareStep / processLLMRequest work, and that
+            // availableTools / toolChoice reflect any per-step mutations.
+            modelSpanTracker?.setInferenceContext?.({
+              parameters: {
+                ...currentStep.modelSettings,
+                ...modelConfig.modelSettings,
+              } as Record<string, unknown> | undefined,
+              providerOptions: mergeProviderOptions(currentStep.providerOptions, modelConfig.providerOptions) as
+                | Record<string, unknown>
+                | undefined,
+              availableTools: getStepAvailableToolNames(
+                currentStep.tools as Record<string, unknown> | undefined,
+                currentStep.activeTools as readonly string[] | undefined,
+              ),
+              toolChoice: currentStep.toolChoice as ModelInferenceContext['toolChoice'],
+              responseFormat: currentStep.structuredOutput ? 'json_schema' : undefined,
+            });
+            modelSpanTracker?.startInference?.();
+
             modelResult = executeWithContextSync({
               span: modelSpanTracker?.getTracingContext()?.currentSpan,
               fn: () =>

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -916,9 +916,18 @@ export interface IModelSpanTracker {
   updateStep?(payload?: StepStartPayload): void;
 
   /**
+   * Open the MODEL_INFERENCE span for the current step. Call this immediately
+   * before invoking the model so the span's startTime excludes input processor
+   * work (and `setInferenceContext` reflects the post-processor tool set).
+   * Falls back to auto-creation on first chunk if the caller forgets.
+   */
+  startInference?(payload?: StepStartPayload): void;
+
+  /**
    * Set the request-side context applied to subsequent MODEL_INFERENCE spans
    * (parameters, providerOptions, availableTools, toolChoice, responseFormat).
-   * Call once after creating the tracker; later calls overwrite.
+   * Call after input processors have finalised the tool set, just before
+   * `startInference()`; the next inference span snapshots this context.
    */
   setInferenceContext?(context: ModelInferenceContext): void;
 

--- a/packages/core/src/observability/utils.test.ts
+++ b/packages/core/src/observability/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { SpanType } from './types';
-import { getEntityTypeForSpan } from './utils';
+import { getEntityTypeForSpan, getStepAvailableToolNames } from './utils';
 
 describe('getEntityTypeForSpan', () => {
   it('maps rag ingestion spans to the rag_ingestion entity type', () => {
@@ -15,5 +15,28 @@ describe('getEntityTypeForSpan', () => {
         spanType: SpanType.GENERIC,
       }),
     ).toBe('rag_ingestion');
+  });
+});
+
+describe('getStepAvailableToolNames', () => {
+  it('returns activeTools when present, ignoring tools', () => {
+    expect(getStepAvailableToolNames({ a: {}, b: {}, c: {} }, ['a', 'b'])).toEqual(['a', 'b']);
+  });
+
+  it('falls back to tool keys when activeTools is undefined', () => {
+    expect(getStepAvailableToolNames({ a: {}, b: {} })).toEqual(['a', 'b']);
+  });
+
+  it('falls back to tool keys when activeTools is empty', () => {
+    expect(getStepAvailableToolNames({ a: {} }, [])).toEqual(['a']);
+  });
+
+  it('returns [] (not undefined) for tool-less agents so observers see a definitive empty set', () => {
+    expect(getStepAvailableToolNames({}, undefined)).toEqual([]);
+    expect(getStepAvailableToolNames({}, [])).toEqual([]);
+  });
+
+  it('returns undefined when tools is undefined', () => {
+    expect(getStepAvailableToolNames(undefined, undefined)).toBeUndefined();
   });
 });

--- a/packages/core/src/observability/utils.test.ts
+++ b/packages/core/src/observability/utils.test.ts
@@ -27,8 +27,8 @@ describe('getStepAvailableToolNames', () => {
     expect(getStepAvailableToolNames({ a: {}, b: {} })).toEqual(['a', 'b']);
   });
 
-  it('falls back to tool keys when activeTools is empty', () => {
-    expect(getStepAvailableToolNames({ a: {} }, [])).toEqual(['a']);
+  it('honors explicit empty activeTools as "no tools enabled" instead of falling back to tool keys', () => {
+    expect(getStepAvailableToolNames({ a: {}, b: {} }, [])).toEqual([]);
   });
 
   it('returns [] (not undefined) for tool-less agents so observers see a definitive empty set', () => {

--- a/packages/core/src/observability/utils.ts
+++ b/packages/core/src/observability/utils.ts
@@ -25,6 +25,28 @@ export function generateSignalId(): string {
   return crypto.randomUUID();
 }
 
+/**
+ * Compute the names of tools the model can call on a single inference step,
+ * applying `activeTools` filtering when present. Used to populate the
+ * `availableTools` attribute on MODEL_INFERENCE spans so observers see the
+ * post-processor tool set, which can differ per-step from the AGENT_RUN view.
+ *
+ * Returns `[]` (not `undefined`) when `tools` is provided but empty, so a
+ * tool-less agent still reports a definitive empty list to observers.
+ */
+export function getStepAvailableToolNames(
+  tools?: Record<string, unknown> | undefined,
+  activeTools?: readonly string[] | undefined,
+): string[] | undefined {
+  if (activeTools && activeTools.length > 0) {
+    return [...activeTools];
+  }
+  if (tools) {
+    return Object.keys(tools);
+  }
+  return undefined;
+}
+
 // --- Lazy resolvers for executeWithContext / executeWithContextSync ---
 // The real implementations live in context-storage.ts (which imports AsyncLocalStorage).
 // context-storage.ts registers them at import time so that consumer code can call these

--- a/packages/core/src/observability/utils.ts
+++ b/packages/core/src/observability/utils.ts
@@ -31,6 +31,8 @@ export function generateSignalId(): string {
  * `availableTools` attribute on MODEL_INFERENCE spans so observers see the
  * post-processor tool set, which can differ per-step from the AGENT_RUN view.
  *
+ * `activeTools` is treated by presence, not truthiness: an explicit empty
+ * array means "no tools enabled for this step" and is honored as such.
  * Returns `[]` (not `undefined`) when `tools` is provided but empty, so a
  * tool-less agent still reports a definitive empty list to observers.
  */
@@ -38,7 +40,7 @@ export function getStepAvailableToolNames(
   tools?: Record<string, unknown> | undefined,
   activeTools?: readonly string[] | undefined,
 ): string[] | undefined {
-  if (activeTools && activeTools.length > 0) {
+  if (activeTools !== undefined) {
     return [...activeTools];
   }
   if (tools) {


### PR DESCRIPTION
## Description

Fixed `MODEL_INFERENCE` span timing so it accurately measures pure model latency, excluding input processor and `prepareStep` work. Previously, the inference span opened from `startStep()`, which the agentic loop calls before processors run, inflating the span's duration.

The span now opens immediately before the model call via a new `startInference()` method on the tracker. Chunk-arrival auto-creation remains as a fallback for callers that don't explicitly call it.

Additionally, `setInferenceContext()` is now applied per-step after input processors finalize the tool set, so `availableTools` and `toolChoice` on `MODEL_INFERENCE` spans reflect per-step mutations (input processors, `prepareStep`, `activeTools` filtering) instead of the agent-run-level snapshot.

### Changes

- **ModelSpanTracker**: Removed automatic inference span creation from `startStep()`. Added public `startInference()` method to open the span immediately before model invocation, snapshotting the latest `#inferenceContext`.
- **Auto-creation safety net**: Inference spans are auto-created on first chunk arrival (or step-start chunk) if the caller didn't explicitly call `startInference()`, ensuring chunks always parent under `MODEL_INFERENCE` rather than `MODEL_STEP`.
- **LLM execution steps**: Both agentic and durable execution steps now call `setInferenceContext()` + `startInference()` immediately before the model call, after input processors and `prepareStep` have completed.
- **Utility function**: Added `getStepAvailableToolNames()` to compute the post-processor tool set, applying `activeTools` filtering when present.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code refactoring

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
  - Added 4 new test cases covering: span timing exclusion, inference context snapshotting, auto-creation on chunk arrival, and explicit `startInference()` behavior
  - Added unit tests for `getStepAvailableToolNames()` utility function
- [x] Existing tests pass

https://claude.ai/code/session_01TURPcy3KRBWnmRV7WuQqun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the AI model timer more accurate by starting the model-timing span immediately before the model runs (after input processing), so measured latency reflects only the model call itself.

---

## Overview

Refactors MODEL_INFERENCE span lifecycle so inference spans are opened and contextualized right before the model invocation (excluding input processors and prepareStep work). Introduces an explicit startInference() API, auto-creation safety-net for streaming chunks, per-step inference-context snapshotting, and a utility to compute available tools for a step.

---

## Key Changes

- ModelSpanTracker behavior
  - startStep() now opens only MODEL_STEP.
  - New public startInference(payload?) opens MODEL_INFERENCE immediately before model invocation and snapshots the latest inferenceContext.
  - Auto-creation safety-net: if chunks (including step-start chunks) arrive before startInference() is called, the tracker auto-creates missing MODEL_STEP and MODEL_INFERENCE so chunk spans parent under MODEL_INFERENCE.

- Inference-context timing
  - Agentic and durable execution paths now call setInferenceContext() and startInference() immediately before the model call (after input processors and prepareStep), so availableTools, toolChoice, and responseFormat reflect post-processor mutations.
  - Durable execution: responseFormat for inference context is derived from the actual structuredOutput payload sent to execute(), avoiding incorrect reporting when structuringModelConfig is used.

- Utility
  - Added getStepAvailableToolNames(tools?, activeTools?) which:
    - Returns a shallow copy of activeTools whenever activeTools is provided (including an explicit empty array, allowing explicit disabling of tools),
    - Otherwise returns Object.keys(tools) when tools is provided (may be []),
    - Otherwise returns undefined.

- Safety & consolidation
  - Extracted ensureStepAndInference helper to consolidate auto-create logic used by chunk handlers and wrapStream (which treats step-start as a point to open inference if not yet opened).

---

## Public API Changes

- IModelSpanTracker (packages/core/src/observability/types/tracing.ts)
  - Added optional startInference?(payload?: StepStartPayload): void with docs noting it should be called immediately before invoking the model and that it snapshots inference context and supports fallback auto-creation.

- ModelSpanTracker (observability/mastra/src/model-tracing.ts)
  - Added public startInference(payload?: StepStartPayload): void and moved related logic into ensureStepAndInference helper.

- New exported utility
  - getStepAvailableToolNames(tools?: Record<string, unknown>, activeTools?: readonly string[]): string[] | undefined

---

## Tests

- Added four new tests in model-tracing.test.ts:
  1. startStep() does not create MODEL_INFERENCE
  2. startInference() snapshots latest inference context into the emitted span
  3. MODEL_INFERENCE.startTime is recorded at startInference() (excluding earlier delays)
  4. Receiving chunks auto-creates MODEL_INFERENCE if caller never called startInference()

- Added unit tests for getStepAvailableToolNames covering activeTools precedence (including explicit []), fallback to tools keys, empty-tool cases, and undefined behavior.

---

## Files Modified

- .changeset/solid-snakes-double.md
- observability/mastra/src/model-tracing.ts
- observability/mastra/src/model-tracing.test.ts
- packages/core/src/observability/types/tracing.ts
- packages/core/src/observability/utils.ts
- packages/core/src/observability/utils.test.ts
- packages/core/src/agent/durable/workflows/steps/llm-execution.ts
- packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
- packages/core/src/llm/model/model.loop.ts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->