### PR TITLE
Fix flaky test by sorting thread IDs in memory handler test

### DIFF
--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -1923,7 +1923,7 @@ describe('Memory Handlers', () => {
           perPage: 10,
         });
 
-        expect(result.threads.map(t => t.id)).toEqual(['thread-a', 'thread-c']);
+        expect(result.threads.map(t => t.id).sort()).toEqual(['thread-a', 'thread-c']);
         expect(result.total).toBe(2);
         expect(result.hasMore).toBe(false);
         expect(filterAccessible).toHaveBeenCalledWith(


### PR DESCRIPTION
## Description

This PR fixes a flaky test in the memory handlers test suite. The test was asserting thread IDs in a specific order without guaranteeing that order from the API response. By sorting the thread IDs before comparison, the test now reliably passes regardless of the order in which threads are returned.

no changset required.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, if applicable -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test Plan

The existing test in `packages/server/src/server/handlers/memory.test.ts` now passes reliably. The change only affects test assertion order and does not modify any production code behavior.

https://claude.ai/code/session_01RGNgHJmAGDZM8xEsSA7GW1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A test was failing unpredictably because it expected thread IDs in a specific order, but the API doesn't guarantee a consistent order. The fix sorts the thread IDs before comparing them, making the test reliable.

## Changes

Updated the `Authorization - Reserved Context Keys` test in the memory handlers test suite to make thread ID assertions order-independent by sorting the returned thread IDs before comparison. This eliminates flakiness caused by the `filterAccessible` FGA filter not guaranteeing stable return order.

**Files changed:**
- `packages/server/src/server/handlers/memory.test.ts` (+1/-1)

**Category:** Non-breaking bug fix (test-only change)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->