### PR TITLE
Gate FGA behind EE license

### DIFF
--- a/.changeset/slow-streets-knock.md
+++ b/.changeset/slow-streets-knock.md
@@ -1,0 +1,6 @@
+---
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Fixed FGA EE license gating so production servers require an Enterprise license when FGA is configured.

--- a/packages/core/src/auth/ee/license.test.ts
+++ b/packages/core/src/auth/ee/license.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { isDevEnvironment, isEEEnabled, isLicenseValid, validateLicense, clearLicenseCache } from './license';
+import {
+  isDevEnvironment,
+  isEEEnabled,
+  isFeatureEnabled,
+  isLicenseValid,
+  validateLicense,
+  clearLicenseCache,
+} from './license';
 
 describe('license', () => {
   let originalNodeEnv: string | undefined;
@@ -37,6 +44,7 @@ describe('license', () => {
       const result = validateLicense(key);
       expect(result.valid).toBe(true);
       expect(result.tier).toBe('enterprise');
+      expect(result.features).toContain('fga');
     });
 
     it('should read from MASTRA_EE_LICENSE env var when no key argument', () => {
@@ -55,6 +63,13 @@ describe('license', () => {
     it('should return true when valid license key is set', () => {
       process.env['MASTRA_EE_LICENSE'] = 'a'.repeat(32);
       expect(isLicenseValid()).toBe(true);
+    });
+  });
+
+  describe('isFeatureEnabled', () => {
+    it('should return true for fga when a valid license key is set', () => {
+      process.env['MASTRA_EE_LICENSE'] = 'a'.repeat(32);
+      expect(isFeatureEnabled('fga')).toBe(true);
     });
   });
 

--- a/packages/core/src/auth/ee/license.ts
+++ b/packages/core/src/auth/ee/license.ts
@@ -53,7 +53,7 @@ export function validateLicense(licenseKey?: string): LicenseInfo {
 
   return {
     valid: true,
-    features: ['user', 'session', 'sso', 'rbac', 'acl'],
+    features: ['user', 'session', 'sso', 'rbac', 'acl', 'fga'],
     tier: 'enterprise',
   };
 }

--- a/packages/server/src/server/server-adapter/index.test.ts
+++ b/packages/server/src/server/server-adapter/index.test.ts
@@ -2,7 +2,19 @@
  * @license Mastra Enterprise License - see ee/LICENSE
  */
 import type { IFGAProvider } from '@mastra/core/auth/ee';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Mastra } from '@mastra/core/mastra';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MastraServer } from './index';
+
+class TestMastraServer extends MastraServer<any, any, any> {
+  stream = vi.fn();
+  getParams = vi.fn();
+  sendResponse = vi.fn();
+  registerRoute = vi.fn();
+  registerContextMiddleware = vi.fn();
+  registerAuthMiddleware = vi.fn();
+  registerHttpLoggingMiddleware = vi.fn();
+}
 
 function createMockFGAProvider(authorized = true): IFGAProvider {
   return {
@@ -179,6 +191,76 @@ describe('FGA Middleware - checkRouteFGA', () => {
         permission: 'tenant-resource:read',
         context: { resourceId: 'tenant-1:resource-1', requestContext },
       },
+    );
+  });
+});
+
+describe('EE license validation', () => {
+  let originalNodeEnv: string | undefined;
+  let originalLicense: string | undefined;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env['NODE_ENV'];
+    originalLicense = process.env['MASTRA_EE_LICENSE'];
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv !== undefined) process.env['NODE_ENV'] = originalNodeEnv;
+    else delete process.env['NODE_ENV'];
+    if (originalLicense !== undefined) process.env['MASTRA_EE_LICENSE'] = originalLicense;
+    else delete process.env['MASTRA_EE_LICENSE'];
+    vi.resetModules();
+  });
+
+  it('should reject FGA in production without a valid EE license', async () => {
+    process.env['NODE_ENV'] = 'production';
+    delete process.env['MASTRA_EE_LICENSE'];
+
+    const mastra = new Mastra({
+      server: {
+        fga: createMockFGAProvider(),
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    await expect(adapter.validateEELicense()).rejects.toThrow('FGA is configured but no valid EE license was found');
+  });
+
+  it('should allow FGA in production with a valid EE license', async () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['MASTRA_EE_LICENSE'] = 'a'.repeat(32);
+
+    const mastra = new Mastra({
+      server: {
+        fga: createMockFGAProvider(),
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    await expect(adapter.validateEELicense()).resolves.toBeUndefined();
+  });
+
+  it('should mention both configured EE authorization features when both are unlicensed', async () => {
+    process.env['NODE_ENV'] = 'production';
+    delete process.env['MASTRA_EE_LICENSE'];
+
+    const mastra = new Mastra({
+      server: {
+        rbac: {
+          getRoles: vi.fn(),
+          getPermissions: vi.fn(),
+          hasPermission: vi.fn(),
+          hasAllPermissions: vi.fn(),
+          hasAnyPermission: vi.fn(),
+        },
+        fga: createMockFGAProvider(),
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    await expect(adapter.validateEELicense()).rejects.toThrow(
+      'RBAC and FGA are configured but no valid EE license was found',
     );
   });
 });

--- a/packages/server/src/server/server-adapter/index.test.ts
+++ b/packages/server/src/server/server-adapter/index.test.ts
@@ -197,17 +197,22 @@ describe('FGA Middleware - checkRouteFGA', () => {
 
 describe('EE license validation', () => {
   let originalNodeEnv: string | undefined;
+  let originalMastraDev: string | undefined;
   let originalLicense: string | undefined;
 
   beforeEach(() => {
     originalNodeEnv = process.env['NODE_ENV'];
+    originalMastraDev = process.env['MASTRA_DEV'];
     originalLicense = process.env['MASTRA_EE_LICENSE'];
+    delete process.env['MASTRA_DEV'];
     vi.resetModules();
   });
 
   afterEach(() => {
     if (originalNodeEnv !== undefined) process.env['NODE_ENV'] = originalNodeEnv;
     else delete process.env['NODE_ENV'];
+    if (originalMastraDev !== undefined) process.env['MASTRA_DEV'] = originalMastraDev;
+    else delete process.env['MASTRA_DEV'];
     if (originalLicense !== undefined) process.env['MASTRA_EE_LICENSE'] = originalLicense;
     else delete process.env['MASTRA_EE_LICENSE'];
     vi.resetModules();

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -484,18 +484,23 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
 
   /**
    * Validate that EE features have a valid license in production.
-   * Throws if RBAC is configured without a valid license outside dev/test environments.
+   * Throws if RBAC or FGA is configured without a valid license outside dev/test environments.
    */
   async validateEELicense(): Promise<void> {
-    const rbacProvider = this.mastra.getServer()?.rbac;
-    if (!rbacProvider) return;
+    const serverConfig = this.mastra.getServer();
+    const configuredFeatures = [serverConfig?.rbac ? 'RBAC' : null, serverConfig?.fga ? 'FGA' : null].filter(
+      (feature): feature is string => feature !== null,
+    );
+
+    if (configuredFeatures.length === 0) return;
 
     try {
       const { isEEEnabled } = await import('@mastra/core/auth/ee');
       if (!isEEEnabled()) {
+        const featureList = configuredFeatures.join(' and ');
         throw new Error(
-          '[mastra/auth-ee] RBAC is configured but no valid EE license was found.\n' +
-            'RBAC requires a Mastra Enterprise License for production use.\n' +
+          `[mastra/auth-ee] ${featureList} ${configuredFeatures.length === 1 ? 'is' : 'are'} configured but no valid EE license was found.\n` +
+            `${featureList} ${configuredFeatures.length === 1 ? 'requires' : 'require'} a Mastra Enterprise License for production use.\n` +
             'Set the MASTRA_EE_LICENSE environment variable with your license key.\n' +
             'Learn more: https://github.com/mastra-ai/mastra/blob/main/ee/LICENSE',
         );
@@ -504,9 +509,9 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
       if (err instanceof Error && err.message.startsWith('[mastra/auth-ee]')) {
         throw err;
       }
-      // @mastra/core/auth/ee module not available — RBAC cannot function
+      // @mastra/core/auth/ee module not available; EE authorization cannot function.
       throw new Error(
-        '[mastra/auth-ee] RBAC is configured but the EE module (@mastra/core/auth/ee) could not be loaded.\n' +
+        `[mastra/auth-ee] ${configuredFeatures.join(' and ')} ${configuredFeatures.length === 1 ? 'is' : 'are'} configured but the EE module (@mastra/core/auth/ee) could not be loaded.\n` +
           'Ensure @mastra/core is updated to a version that includes EE support.',
       );
     }


### PR DESCRIPTION
## Description

Adds FGA to EE license feature metadata and extends the existing server EE startup validation so `server.fga` follows the same production license requirement as `server.rbac`.
Adds tests for licensed and unlicensed FGA behavior, plus a changeset for `@mastra/core` and `@mastra/server`.
Validated with focused core/server tests, package builds, and core typecheck.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

FGA (fine-grained access control) is now treated like RBAC: if you turn it on for a production server, the system will require an Enterprise Edition license and will refuse to start without one. This PR adds that check and tests to make sure it works.

---

## Changes Summary

This PR gates the FGA (Fine-Grained Access) feature behind the Enterprise Edition license, ensuring that FGA configured in production requires a valid EE license, the same as RBAC.

### License Feature Configuration

- Updated packages/core/src/auth/ee/license.ts: validateLicense() now enables the 'fga' feature flag when a valid EE license key is present (no other public API changes).

### Server-Side License Validation

- Updated packages/server/src/server/server-adapter/index.ts: validateEELicense() now checks for configured EE features (RBAC and FGA), returns early if none are configured, and throws a clearer EE license error that lists the configured feature(s) with correct pluralization. Improved the failure message when the EE module cannot be loaded to reference the combined configured feature set.

### Test Coverage

- Added/updated tests in packages/core/src/auth/ee/license.test.ts: verifies isFeatureEnabled('fga') returns true when a valid EE license is set.
- Added/updated tests in packages/server/src/server/server-adapter/index.test.ts: exercises validateEELicense() in production, verifying FGA is rejected without a license, accepted with a valid license, and that combined RBAC+FGA misconfiguration produces an error mentioning both features.
- Test harness updates include restoring NODE_ENV, MASTRA_DEV, and MASTRA_EE_LICENSE between tests for reliability (commit message: "Stabilize EE license tests").

### Versioning

- Added changeset .changeset/slow-streets-knock.md: records patch bumps for @mastra/core and @mastra/server and notes that FGA is now EE-gated in production.

--- 

Type: Bug fix (non-breaking), Test update
<!-- end of auto-generated comment: release notes by coderabbit.ai -->