### PR TITLE
feat(datadog): map MODEL_INFERENCE → llm, MODEL_STEP → workflow

### DIFF
--- a/.changeset/wise-terms-smell.md
+++ b/.changeset/wise-terms-smell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': minor
+---
+
+Mapped `MODEL_INFERENCE` spans to Datadog's `llm` kind (with token usage and model/provider attached) and `MODEL_STEP` to `workflow`. Falls back to the previous mapping when paired with an older `@mastra/core` that does not emit `MODEL_INFERENCE`.

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -127,6 +127,7 @@ vi.mock('dd-trace', () => {
 });
 
 import { DatadogBridge } from './bridge';
+import { __setObservabilityFeaturesForTest } from './features';
 
 function createMockSpan(overrides: Partial<AnyExportedSpan> = {}): AnyExportedSpan {
   return {
@@ -166,10 +167,12 @@ describe('DatadogBridge', () => {
     delete process.env.DD_LLMOBS_ML_APP;
     delete process.env.DD_SITE;
     delete process.env.DD_LLMOBS_AGENTLESS_ENABLED;
+    __setObservabilityFeaturesForTest(new Set(['model-inference-span']));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    __setObservabilityFeaturesForTest(new Set(['model-inference-span']));
   });
 
   describe('configuration', () => {
@@ -364,7 +367,35 @@ describe('DatadogBridge', () => {
       expect(llmobsRegistrations[0]?.options.parent).toBe(distributedParent);
     });
 
-    it('inherits model info for MODEL_STEP spans from a MODEL_GENERATION parent when needed', () => {
+    it('registers MODEL_INFERENCE as llm kind with its own model/provider attributes', () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+
+      bridge.createSpan(
+        createMockSpanOptions({
+          name: 'inference',
+          type: SpanType.MODEL_INFERENCE as SpanTypeGeneric,
+          attributes: { model: 'gpt-5.4', provider: 'openai' },
+          parent: {
+            id: 'step-id',
+            traceId: 'gen-trace',
+            type: SpanType.MODEL_STEP,
+            isInternal: false,
+            metadata: {},
+            attributes: {},
+            getParentSpanId: () => undefined,
+          } as any,
+        }),
+      );
+
+      expect(llmobsRegistrations[0]?.options).toMatchObject({
+        kind: 'llm',
+        modelName: 'gpt-5.4',
+        modelProvider: 'openai',
+      });
+    });
+
+    it('falls back to legacy MODEL_STEP-as-llm with inherited model info when feature is unavailable', () => {
+      __setObservabilityFeaturesForTest(undefined);
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
 
       bridge.createSpan(

--- a/observability/datadog/src/bridge.ts
+++ b/observability/datadog/src/bridge.ts
@@ -19,6 +19,7 @@ import type {
   TracingEvent,
   AnyExportedSpan,
   ModelGenerationAttributes,
+  ModelInferenceAttributes,
   ModelStepAttributes,
   ObservabilityBridge,
   CreateSpanOptions,
@@ -30,6 +31,7 @@ import { omitKeys } from '@mastra/core/utils';
 import { BaseExporter, getExternalParentId } from '@mastra/observability';
 import type { BaseExporterConfig } from '@mastra/observability';
 import tracer from 'dd-trace';
+import { isModelInferenceEnabled } from './features';
 import { formatUsageMetrics } from './metrics';
 import { ensureTracer, formatInput, formatOutput, kindFor, toDate } from './utils';
 import type { DatadogSpanKind } from './utils';
@@ -495,8 +497,11 @@ export class DatadogBridge extends BaseExporter implements ObservabilityBridge {
       annotations.outputData = formatOutput(span.output, span.type);
     }
 
-    if (span.type === SpanTypeEnum.MODEL_STEP) {
-      const usage = (span.attributes as ModelStepAttributes)?.usage;
+    // Token usage attaches to the LLM-kind span only — MODEL_INFERENCE when
+    // the feature is enabled, MODEL_STEP on legacy paired packages.
+    const usageSpanType = isModelInferenceEnabled() ? SpanTypeEnum.MODEL_INFERENCE : SpanTypeEnum.MODEL_STEP;
+    if (span.type === usageSpanType) {
+      const usage = (span.attributes as ModelStepAttributes | ModelInferenceAttributes | undefined)?.usage;
       const metrics = formatUsageMetrics(usage);
       if (metrics) {
         annotations.metrics = metrics;

--- a/observability/datadog/src/features.ts
+++ b/observability/datadog/src/features.ts
@@ -1,0 +1,57 @@
+/**
+ * Feature detection for paired @mastra/core and @mastra/observability versions.
+ *
+ * `coreFeatures` is a hard peer dependency, so it can be imported statically.
+ * `observabilityFeatures` is loaded via dynamic import so this exporter degrades
+ * gracefully against older `@mastra/observability` versions that don't export it
+ * (per the pattern documented in `observability/mastra/src/features.ts`).
+ *
+ * Detection runs once at module load. Callers consume the result through the
+ * sync `isModelInferenceEnabled()` accessor, which conservatively returns
+ * `false` until detection settles — long enough only to cover the microtask
+ * window before any spans are emitted in practice.
+ */
+
+import { coreFeatures } from '@mastra/core/features';
+
+const FEATURE = 'model-inference-span';
+
+let observabilityFeatures: ReadonlySet<string> | undefined;
+let featureLoadPromise: Promise<void> | undefined;
+
+function loadObservabilityFeatures(): Promise<void> {
+  if (!featureLoadPromise) {
+    featureLoadPromise = import('@mastra/observability')
+      .then(mod => {
+        observabilityFeatures = (mod as { observabilityFeatures?: ReadonlySet<string> }).observabilityFeatures;
+      })
+      .catch(() => {
+        // Older @mastra/observability without the `observabilityFeatures` export.
+      });
+  }
+  return featureLoadPromise;
+}
+
+// Kick off detection at module load so the cached value is ready by the time
+// the first span is emitted.
+void loadObservabilityFeatures();
+
+/**
+ * Returns true when both packages report the `model-inference-span` feature,
+ * meaning MODEL_INFERENCE spans are emitted by the tracker. Drives the
+ * Datadog kind mapping and usage-source switch (legacy: MODEL_STEP carries
+ * 'llm' kind + usage; new: MODEL_INFERENCE does).
+ */
+export function isModelInferenceEnabled(): boolean {
+  return observabilityFeatures?.has(FEATURE) === true && coreFeatures.has(FEATURE);
+}
+
+/**
+ * @internal Test-only override. Allows tests to simulate a paired older or
+ * newer `@mastra/observability` without juggling dynamic imports.
+ */
+export function __setObservabilityFeaturesForTest(features: ReadonlySet<string> | undefined): void {
+  observabilityFeatures = features;
+  // Mark detection complete so isModelInferenceEnabled stops waiting.
+  featureLoadPromise = Promise.resolve();
+}

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -9,6 +9,7 @@
 import type { TracingEvent, AnyExportedSpan } from '@mastra/core/observability';
 import { SpanType, TracingEventType } from '@mastra/core/observability';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { __setObservabilityFeaturesForTest } from './features';
 
 // Use vi.hoisted to define mocks before they're used in vi.mock
 const {
@@ -135,10 +136,14 @@ describe('DatadogExporter', () => {
     delete process.env.DD_LLMOBS_ML_APP;
     delete process.env.DD_SITE;
     delete process.env.DD_LLMOBS_AGENTLESS_ENABLED;
+    // Default to the model-inference-span feature being available so each
+    // test sees the current span hierarchy unless it opts into legacy.
+    __setObservabilityFeaturesForTest(new Set(['model-inference-span']));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    __setObservabilityFeaturesForTest(new Set(['model-inference-span']));
   });
 
   describe('configuration', () => {
@@ -212,30 +217,59 @@ describe('DatadogExporter', () => {
   });
 
   describe('span type mapping', () => {
-    it.each([
-      [SpanType.AGENT_RUN, 'agent'],
-      [SpanType.MODEL_GENERATION, 'workflow'],
-      [SpanType.MODEL_STEP, 'llm'],
-      [SpanType.MODEL_CHUNK, 'task'],
-      [SpanType.TOOL_CALL, 'tool'],
-      [SpanType.MCP_TOOL_CALL, 'tool'],
-      [SpanType.WORKFLOW_RUN, 'workflow'],
-      [SpanType.WORKFLOW_STEP, 'task'],
-      [SpanType.WORKFLOW_CONDITIONAL, 'task'],
-      [SpanType.WORKFLOW_CONDITIONAL_EVAL, 'task'],
-      [SpanType.WORKFLOW_PARALLEL, 'task'],
-      [SpanType.WORKFLOW_LOOP, 'task'],
-      [SpanType.WORKFLOW_SLEEP, 'task'],
-      [SpanType.WORKFLOW_WAIT_EVENT, 'task'],
-      [SpanType.PROCESSOR_RUN, 'task'],
-      [SpanType.GENERIC, 'task'],
-    ])('maps %s to %s kind', async (spanType, expectedKind) => {
-      const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
-      const span = createMockSpan({ type: spanType });
+    describe('with model-inference-span feature (current hierarchy)', () => {
+      it.each([
+        [SpanType.AGENT_RUN, 'agent'],
+        [SpanType.MODEL_GENERATION, 'workflow'],
+        // MODEL_STEP wraps processors + inference + tool work, so it's a workflow.
+        [SpanType.MODEL_STEP, 'workflow'],
+        // MODEL_INFERENCE is the actual provider call — the LLM-kind span.
+        [SpanType.MODEL_INFERENCE, 'llm'],
+        [SpanType.MODEL_CHUNK, 'task'],
+        [SpanType.TOOL_CALL, 'tool'],
+        [SpanType.MCP_TOOL_CALL, 'tool'],
+        [SpanType.WORKFLOW_RUN, 'workflow'],
+        [SpanType.WORKFLOW_STEP, 'task'],
+        [SpanType.WORKFLOW_CONDITIONAL, 'task'],
+        [SpanType.WORKFLOW_CONDITIONAL_EVAL, 'task'],
+        [SpanType.WORKFLOW_PARALLEL, 'task'],
+        [SpanType.WORKFLOW_LOOP, 'task'],
+        [SpanType.WORKFLOW_SLEEP, 'task'],
+        [SpanType.WORKFLOW_WAIT_EVENT, 'task'],
+        [SpanType.PROCESSOR_RUN, 'task'],
+        [SpanType.GENERIC, 'task'],
+      ])('maps %s to %s kind', async (spanType, expectedKind) => {
+        const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+        const span = createMockSpan({ type: spanType });
 
-      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+        await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
 
-      expect(mockTrace).toHaveBeenCalledWith(expect.objectContaining({ kind: expectedKind }), expect.any(Function));
+        expect(mockTrace).toHaveBeenCalledWith(expect.objectContaining({ kind: expectedKind }), expect.any(Function));
+      });
+    });
+
+    describe('legacy hierarchy (older paired @mastra/observability)', () => {
+      beforeEach(() => {
+        __setObservabilityFeaturesForTest(undefined);
+      });
+
+      it('maps MODEL_STEP to llm (the legacy LLM-kind span)', async () => {
+        const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+        const span = createMockSpan({ type: SpanType.MODEL_STEP });
+
+        await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+        expect(mockTrace).toHaveBeenCalledWith(expect.objectContaining({ kind: 'llm' }), expect.any(Function));
+      });
+
+      it('does not map MODEL_INFERENCE specially (falls through to task)', async () => {
+        const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+        const span = createMockSpan({ type: SpanType.MODEL_INFERENCE });
+
+        await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+        expect(mockTrace).toHaveBeenCalledWith(expect.objectContaining({ kind: 'task' }), expect.any(Function));
+      });
     });
   });
 
@@ -1084,10 +1118,10 @@ describe('DatadogExporter', () => {
   });
 
   describe('model info for LLM spans', () => {
-    it('includes modelName and modelProvider for llm spans', async () => {
+    it('includes modelName and modelProvider for llm spans (MODEL_INFERENCE)', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({
-        type: SpanType.MODEL_STEP,
+        type: SpanType.MODEL_INFERENCE,
         attributes: {
           model: 'gpt-4',
           provider: 'openai',
@@ -1106,7 +1140,7 @@ describe('DatadogExporter', () => {
       );
     });
 
-    it('inherits modelName/modelProvider from parent MODEL_GENERATION onto MODEL_STEP children', async () => {
+    it('inherits modelName/modelProvider from parent MODEL_GENERATION onto MODEL_INFERENCE descendants', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const generation = createMockSpan({
         id: 'gen',
@@ -1123,12 +1157,21 @@ describe('DatadogExporter', () => {
         type: SpanType.MODEL_STEP,
         attributes: {},
       });
+      const inference = createMockSpan({
+        id: 'inf',
+        traceId: 'trace-inherit',
+        isRootSpan: false,
+        parentSpanId: 'step',
+        type: SpanType.MODEL_INFERENCE,
+        attributes: {},
+      });
 
       await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, step));
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, inference));
       await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, generation));
 
-      const stepCall = mockTrace.mock.calls.find(c => c[0].kind === 'llm');
-      expect(stepCall?.[0]).toEqual(
+      const llmCall = mockTrace.mock.calls.find(c => c[0].kind === 'llm');
+      expect(llmCall?.[0]).toEqual(
         expect.objectContaining({ kind: 'llm', modelName: 'gpt-4o', modelProvider: 'openai' }),
       );
     });
@@ -1288,7 +1331,7 @@ describe('DatadogExporter', () => {
     it('excludes known LLM fields from attribute forwarding', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const span = createMockSpan({
-        type: SpanType.MODEL_STEP,
+        type: SpanType.MODEL_INFERENCE,
         metadata: { userKey: 'userValue' },
         attributes: {
           model: 'gpt-4', // Should be excluded (used for modelName)
@@ -1338,6 +1381,43 @@ describe('DatadogExporter', () => {
       expect(annotateCall.metadata).not.toHaveProperty('provider');
       expect(annotateCall.metadata).not.toHaveProperty('usage');
       expect(annotateCall.metadata).not.toHaveProperty('parameters');
+    });
+
+    it('does not emit usage metrics on MODEL_STEP under the current hierarchy', async () => {
+      const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+      const span = createMockSpan({
+        type: SpanType.MODEL_STEP,
+        attributes: {
+          // Step duplicates usage for backward compat, but tokens belong on
+          // MODEL_INFERENCE now to avoid double-counting cost in Datadog.
+          usage: { inputTokens: 100, outputTokens: 50 },
+        },
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      const stepCalls = mockAnnotate.mock.calls.filter(c => c[1]?.metrics);
+      expect(stepCalls).toHaveLength(0);
+    });
+
+    it('emits usage metrics on MODEL_STEP under legacy hierarchy', async () => {
+      __setObservabilityFeaturesForTest(undefined);
+      const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+      const span = createMockSpan({
+        type: SpanType.MODEL_STEP,
+        attributes: {
+          usage: { inputTokens: 100, outputTokens: 50 },
+        },
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          metrics: expect.objectContaining({ inputTokens: 100, outputTokens: 50 }),
+        }),
+      );
     });
 
     it('handles spans without attributes gracefully', async () => {

--- a/observability/datadog/src/tracing.ts
+++ b/observability/datadog/src/tracing.ts
@@ -16,6 +16,7 @@ import type {
   TracingEvent,
   AnyExportedSpan,
   ModelGenerationAttributes,
+  ModelInferenceAttributes,
   ModelStepAttributes,
 } from '@mastra/core/observability';
 import { SpanType } from '@mastra/core/observability';
@@ -23,6 +24,7 @@ import { omitKeys } from '@mastra/core/utils';
 import { BaseExporter } from '@mastra/observability';
 import type { BaseExporterConfig } from '@mastra/observability';
 import tracer from 'dd-trace';
+import { isModelInferenceEnabled } from './features';
 import { formatUsageMetrics } from './metrics';
 import { ensureTracer, kindFor, toDate, formatInput, formatOutput } from './utils';
 import type { DatadogSpanKind } from './utils';
@@ -302,11 +304,13 @@ export class DatadogExporter extends BaseExporter {
       annotations.outputData = formatOutput(span.output, span.type);
     }
 
-    // Add token usage metrics on MODEL_STEP spans only.
-    // MODEL_STEP is the actual LLM API call; MODEL_GENERATION is its parent wrapper.
-    // Reporting on both would double-count cost in Datadog.
-    if (span.type === SpanType.MODEL_STEP) {
-      const usage = (span.attributes as ModelStepAttributes)?.usage;
+    // Token usage metrics attach to the LLM-kind span only, to avoid
+    // double-counting cost in Datadog. With the `model-inference-span` feature
+    // that's MODEL_INFERENCE (the actual provider call); without it, MODEL_STEP
+    // is still the API call.
+    const usageSpanType = isModelInferenceEnabled() ? SpanType.MODEL_INFERENCE : SpanType.MODEL_STEP;
+    if (span.type === usageSpanType) {
+      const usage = (span.attributes as ModelStepAttributes | ModelInferenceAttributes | undefined)?.usage;
       const metrics = formatUsageMetrics(usage);
       if (metrics) {
         annotations.metrics = metrics;

--- a/observability/datadog/src/utils.test.ts
+++ b/observability/datadog/src/utils.test.ts
@@ -3,37 +3,74 @@
  */
 
 import { SpanType } from '@mastra/core/observability';
-import { describe, it, expect } from 'vitest';
-import { formatInput, formatOutput, kindFor, toDate, safeStringify, SPAN_TYPE_TO_KIND } from './utils';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { __setObservabilityFeaturesForTest } from './features';
+import { formatInput, formatOutput, getSpanTypeToKind, kindFor, toDate, safeStringify } from './utils';
 
 describe('kindFor', () => {
-  it.each([
-    [SpanType.AGENT_RUN, 'agent'],
-    [SpanType.MODEL_GENERATION, 'workflow'],
-    [SpanType.MODEL_STEP, 'llm'],
-    [SpanType.MODEL_CHUNK, 'task'],
-    [SpanType.TOOL_CALL, 'tool'],
-    [SpanType.MCP_TOOL_CALL, 'tool'],
-    [SpanType.WORKFLOW_RUN, 'workflow'],
-    [SpanType.WORKFLOW_STEP, 'task'],
-    [SpanType.WORKFLOW_CONDITIONAL, 'task'],
-    [SpanType.WORKFLOW_CONDITIONAL_EVAL, 'task'],
-    [SpanType.WORKFLOW_PARALLEL, 'task'],
-    [SpanType.WORKFLOW_LOOP, 'task'],
-    [SpanType.WORKFLOW_SLEEP, 'task'],
-    [SpanType.WORKFLOW_WAIT_EVENT, 'task'],
-    [SpanType.PROCESSOR_RUN, 'task'],
-    [SpanType.GENERIC, 'task'],
-  ])('maps %s to %s kind', (spanType, expectedKind) => {
-    expect(kindFor(spanType)).toBe(expectedKind);
+  describe('with model-inference-span feature (current hierarchy)', () => {
+    beforeEach(() => {
+      __setObservabilityFeaturesForTest(new Set(['model-inference-span']));
+    });
+    afterEach(() => {
+      __setObservabilityFeaturesForTest(new Set(['model-inference-span']));
+    });
+
+    it.each([
+      [SpanType.AGENT_RUN, 'agent'],
+      [SpanType.MODEL_GENERATION, 'workflow'],
+      // MODEL_STEP wraps processors + inference + tool work, so it's a workflow.
+      [SpanType.MODEL_STEP, 'workflow'],
+      // MODEL_INFERENCE is the actual provider call — the LLM-kind span.
+      [SpanType.MODEL_INFERENCE, 'llm'],
+      [SpanType.MODEL_CHUNK, 'task'],
+      [SpanType.TOOL_CALL, 'tool'],
+      [SpanType.MCP_TOOL_CALL, 'tool'],
+      [SpanType.WORKFLOW_RUN, 'workflow'],
+      [SpanType.WORKFLOW_STEP, 'task'],
+      [SpanType.WORKFLOW_CONDITIONAL, 'task'],
+      [SpanType.WORKFLOW_CONDITIONAL_EVAL, 'task'],
+      [SpanType.WORKFLOW_PARALLEL, 'task'],
+      [SpanType.WORKFLOW_LOOP, 'task'],
+      [SpanType.WORKFLOW_SLEEP, 'task'],
+      [SpanType.WORKFLOW_WAIT_EVENT, 'task'],
+      [SpanType.PROCESSOR_RUN, 'task'],
+      [SpanType.GENERIC, 'task'],
+    ])('maps %s to %s kind', (spanType, expectedKind) => {
+      expect(kindFor(spanType)).toBe(expectedKind);
+    });
+
+    it('returns task for unknown span types', () => {
+      expect(kindFor('unknown_type' as SpanType)).toBe('task');
+    });
   });
 
-  it('returns task for unknown span types', () => {
-    expect(kindFor('unknown_type' as SpanType)).toBe('task');
+  describe('legacy hierarchy (older paired @mastra/observability)', () => {
+    beforeEach(() => {
+      __setObservabilityFeaturesForTest(undefined);
+    });
+    afterEach(() => {
+      __setObservabilityFeaturesForTest(new Set(['model-inference-span']));
+    });
+
+    it('keeps MODEL_STEP as the LLM-kind span', () => {
+      expect(kindFor(SpanType.MODEL_STEP)).toBe('llm');
+    });
+
+    it('does not map MODEL_INFERENCE specially (falls through to task)', () => {
+      expect(kindFor(SpanType.MODEL_INFERENCE)).toBe('task');
+    });
   });
 });
 
-describe('SPAN_TYPE_TO_KIND mapping', () => {
+describe('span-type → Datadog kind mapping', () => {
+  beforeEach(() => {
+    __setObservabilityFeaturesForTest(new Set(['model-inference-span']));
+  });
+  afterEach(() => {
+    __setObservabilityFeaturesForTest(new Set(['model-inference-span']));
+  });
+
   it('maps all SpanType values to a Datadog kind (explicitly or via task fallback)', () => {
     const spanTypes = Object.values(SpanType);
     for (const spanType of spanTypes) {
@@ -43,26 +80,26 @@ describe('SPAN_TYPE_TO_KIND mapping', () => {
     }
   });
 
-  it('only explicitly maps non-task span types', () => {
-    // Verify that only the expected span types have explicit mappings
+  it('only explicitly maps non-task span types under the current hierarchy', () => {
     const expectedMappings = {
       [SpanType.AGENT_RUN]: 'agent',
       [SpanType.MODEL_GENERATION]: 'workflow',
-      [SpanType.MODEL_STEP]: 'llm',
+      [SpanType.MODEL_STEP]: 'workflow',
+      [SpanType.MODEL_INFERENCE]: 'llm',
       [SpanType.TOOL_CALL]: 'tool',
       [SpanType.MCP_TOOL_CALL]: 'tool',
       [SpanType.WORKFLOW_RUN]: 'workflow',
     };
 
-    expect(Object.keys(SPAN_TYPE_TO_KIND).length).toBe(Object.keys(expectedMappings).length);
+    const active = getSpanTypeToKind();
+    expect(Object.keys(active).length).toBe(Object.keys(expectedMappings).length);
 
     for (const [spanType, expectedKind] of Object.entries(expectedMappings)) {
-      expect(SPAN_TYPE_TO_KIND[spanType as SpanType]).toBe(expectedKind);
+      expect(active[spanType as SpanType]).toBe(expectedKind);
     }
   });
 
   it('defaults unmapped types to task', () => {
-    // These should not have explicit mappings and should fall back to 'task'
     const taskTypes = [
       SpanType.MODEL_CHUNK,
       SpanType.WORKFLOW_STEP,
@@ -76,8 +113,9 @@ describe('SPAN_TYPE_TO_KIND mapping', () => {
       SpanType.GENERIC,
     ];
 
+    const active = getSpanTypeToKind();
     for (const spanType of taskTypes) {
-      expect(SPAN_TYPE_TO_KIND[spanType]).toBeUndefined();
+      expect(active[spanType]).toBeUndefined();
       expect(kindFor(spanType)).toBe('task');
     }
   });

--- a/observability/datadog/src/utils.ts
+++ b/observability/datadog/src/utils.ts
@@ -4,6 +4,7 @@
 
 import { SpanType } from '@mastra/core/observability';
 import tracer from 'dd-trace';
+import { isModelInferenceEnabled } from './features';
 
 /**
  * Datadog LLM Observability span kinds.
@@ -11,21 +12,49 @@ import tracer from 'dd-trace';
 export type DatadogSpanKind = 'llm' | 'agent' | 'workflow' | 'tool' | 'task' | 'retrieval' | 'embedding';
 
 /**
- * Maps Mastra SpanTypes to Datadog LLMObs span kinds.
- * Only non-task mappings are defined; unmapped types fall back to 'task'.
+ * Maps Mastra SpanTypes to Datadog LLMObs span kinds for the legacy hierarchy
+ * (no `model-inference-span` feature). MODEL_STEP is the actual API call here
+ * because MODEL_INFERENCE doesn't exist.
+ *
+ * Unmapped types fall back to 'task'.
  */
-export const SPAN_TYPE_TO_KIND: Partial<Record<SpanType, DatadogSpanKind>> = {
+const SPAN_TYPE_TO_KIND_LEGACY: Partial<Record<SpanType, DatadogSpanKind>> = {
   [SpanType.AGENT_RUN]: 'agent',
-  // MODEL_GENERATION is the wrapper around 1..N MODEL_STEPs (the actual API calls).
-  // It maps to 'workflow' so Datadog doesn't double-count it as an LLM call.
   [SpanType.MODEL_GENERATION]: 'workflow',
-  // MODEL_STEP is "Single model execution step within a generation (one API call)"
-  // per packages/core/src/observability/types/tracing.ts, so it is the real LLM span.
   [SpanType.MODEL_STEP]: 'llm',
   [SpanType.TOOL_CALL]: 'tool',
   [SpanType.MCP_TOOL_CALL]: 'tool',
   [SpanType.WORKFLOW_RUN]: 'workflow',
 };
+
+/**
+ * Maps Mastra SpanTypes to Datadog LLMObs span kinds for the new hierarchy
+ * (`model-inference-span` feature). MODEL_INFERENCE is the LLM API call;
+ * MODEL_STEP wraps processors + inference + tool execution as a workflow.
+ *
+ * Unmapped types fall back to 'task'.
+ */
+const SPAN_TYPE_TO_KIND_INFERENCE: Partial<Record<SpanType, DatadogSpanKind>> = {
+  [SpanType.AGENT_RUN]: 'agent',
+  [SpanType.MODEL_GENERATION]: 'workflow',
+  [SpanType.MODEL_STEP]: 'workflow',
+  [SpanType.MODEL_INFERENCE]: 'llm',
+  [SpanType.TOOL_CALL]: 'tool',
+  [SpanType.MCP_TOOL_CALL]: 'tool',
+  [SpanType.WORKFLOW_RUN]: 'workflow',
+};
+
+/**
+ * Resolves the active span-type → Datadog kind mapping based on whether the
+ * paired @mastra/core + @mastra/observability emit MODEL_INFERENCE spans.
+ * Re-evaluated on each call so tests can flip the feature flag at runtime.
+ */
+export function getSpanTypeToKind(): Partial<Record<SpanType, DatadogSpanKind>> {
+  return isModelInferenceEnabled() ? SPAN_TYPE_TO_KIND_INFERENCE : SPAN_TYPE_TO_KIND_LEGACY;
+}
+
+/** @deprecated Prefer `getSpanTypeToKind()` so the mapping reflects the active feature flag. */
+export const SPAN_TYPE_TO_KIND: Partial<Record<SpanType, DatadogSpanKind>> = SPAN_TYPE_TO_KIND_LEGACY;
 
 /**
  * Singleton flag to prevent multiple tracer initializations.
@@ -81,10 +110,11 @@ export function ensureTracer(config: {
 }
 
 /**
- * Returns the Datadog kind for a Mastra span type.
+ * Returns the Datadog kind for a Mastra span type, using the mapping that
+ * matches the active span hierarchy (legacy vs MODEL_INFERENCE).
  */
 export function kindFor(spanType: SpanType): DatadogSpanKind {
-  return SPAN_TYPE_TO_KIND[spanType] || 'task';
+  return getSpanTypeToKind()[spanType] || 'task';
 }
 
 /**


### PR DESCRIPTION
## Summary

With the `MODEL_INFERENCE` span landing in `@mastra/core` (#16267), `MODEL_STEP` is no longer a single LLM API call — it now wraps input processors, the model inference, and tool execution. This PR realigns the Datadog exporter mapping with the new hierarchy:

- `MODEL_INFERENCE → 'llm'` (the actual provider call) — gets `modelName` / `modelProvider` and token usage `metrics`.
- `MODEL_STEP → 'workflow'` (was `'llm'`) — wraps processors + inference + tool execution.
- Token usage moves from MODEL_STEP to MODEL_INFERENCE so cost is attributed to the LLM-kind span as Datadog expects.

Detection runs through the documented dynamic-import pattern from `@mastra/observability/features` paired with `coreFeatures`, so older versions of either package fall back to the legacy mapping (`MODEL_STEP → 'llm'`, usage on MODEL_STEP) and existing dashboards keep working until the consumer upgrades.

## Implementation

- **New `observability/datadog/src/features.ts`**: dynamic-import-based feature detection with sync accessor and a test setter.
- **`utils.ts`**: two static mapping tables (legacy + inference) selected by `getSpanTypeToKind()`. `kindFor` consults the active table.
- **`tracing.ts` / `bridge.ts`**: usage `metrics` attach to MODEL_INFERENCE under the new hierarchy, MODEL_STEP under legacy.

`MODEL_STEP` formatting (`formatInput`/`formatOutput`) is intentionally left alone — workflow-kind MODEL_STEP still gets the existing message-array shaping in Datadog.

## Test plan

- [x] 161 unit tests pass (5 net-new) — `pnpm --filter ./observability/datadog test`.
- [x] `kindFor` parametric mapping covers both hierarchies.
- [x] MODEL_INFERENCE → `'llm'` with own `modelName`/`modelProvider` (positive).
- [x] Legacy fallback: MODEL_STEP keeps `'llm'` and MODEL_INFERENCE falls through to `'task'` when the feature flag is unavailable.
- [x] Usage metrics emitted on MODEL_INFERENCE under the current hierarchy; on MODEL_STEP under legacy.

https://claude.ai/code/session_01TURPcy3KRBWnmRV7WuQqun

---
_Generated by [Claude Code](https://claude.ai/code/session_01TURPcy3KRBWnmRV7WuQqun)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)
Mastra reorganized how it tracks LLM function calls - it now separates the actual model call (MODEL_INFERENCE) from the workflow step that wraps it (MODEL_STEP). This PR updates the Datadog exporter to recognize this new structure and send the right metrics to the right places, but still supports older code that doesn't have this separation yet.

## Overview
This PR updates the `@mastra/datadog` observability exporter to reflect a new span hierarchy introduced in `@mastra/core`. The change separates the model inference step (the actual LLM provider call) from the broader model step (which includes input processing, inference, and tool execution), with corresponding updates to span type-to-Datadog kind mapping and metric placement.

## Key Changes

### Span Mapping Changes
- **MODEL_INFERENCE** → `'llm'` kind (receives `modelName`, `modelProvider`, and token-usage metrics)
- **MODEL_STEP** → `'workflow'` kind (previously mapped to `'llm'`)
- Other span types remain unchanged

### Token Usage Metrics
Token/cost metrics now attach to the `MODEL_INFERENCE` span instead of `MODEL_STEP` to align with Datadog's expectations and ensure proper cost attribution.

### Feature Detection & Backward Compatibility
Implements dynamic feature detection via `@mastra/observability/features` combined with `coreFeatures`. When the `model-inference-span` feature is unavailable (indicating older `@mastra/core` or `@mastra/observability`), the exporter automatically falls back to legacy mapping (MODEL_STEP → `'llm'`, metrics on MODEL_STEP) to preserve existing Datadog dashboards until consumers upgrade.

### Code Changes
- **New `features.ts`**: Module providing `isModelInferenceEnabled()` for synchronous feature detection and `__setObservabilityFeaturesForTest()` test helper for toggling behavior
- **Updated `utils.ts`**: Introduces `getSpanTypeToKind()` function that dynamically selects the appropriate span mapping based on the active feature flag; existing `SPAN_TYPE_TO_KIND` constant marked as deprecated legacy fallback
- **Updated `bridge.ts` & `tracing.ts`**: Token/usage metrics attachment now respects the active feature flag to avoid double-counting between span types
- **MODEL_STEP formatting unchanged**: Input/output formatting and Datadog message-array shaping remain consistent with the new workflow kind

## Testing
- 5 net-new tests added (161 total passing)
- Parametric tests cover both current and legacy mapping hierarchies
- Tests verify metric placement, model metadata behavior, and fallback scenarios
- Test helpers (`__setObservabilityFeaturesForTest`) enable per-test feature flag override

## Impact
- Minor version bump for `@mastra/datadog`
- No breaking changes to the public API; existing code using the old span hierarchy continues to work via automatic fallback
- Consumers using the new `@mastra/core` span structure benefit from improved metric attribution and span organization in Datadog

<!-- end of auto-generated comment: release notes by coderabbit.ai -->