### PR TITLE
fix(playground): persist enum selections in workflow forms

### DIFF
--- a/.changeset/fix-studio-enum-dropdown.md
+++ b/.changeset/fix-studio-enum-dropdown.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed Studio workflow enum dropdowns so selected values stay visible and are used when running workflows.

--- a/packages/playground/e2e/kitchen-sink/src/mastra/index.ts
+++ b/packages/playground/e2e/kitchen-sink/src/mastra/index.ts
@@ -9,11 +9,11 @@ import { simpleMcpServer } from './mcps';
 import { loggingProcessor, contentFilterProcessor } from './processors';
 import { responseQualityScorer, responseTimeScorer } from './scorers';
 import { storage } from './storage';
-import { complexWorkflow, lessComplexWorkflow } from './workflows/complex-workflow';
+import { complexWorkflow, enumWorkflow, lessComplexWorkflow } from './workflows/complex-workflow';
 import { scheduledWorkflow, multiScheduledWorkflow } from './workflows/scheduled-workflow';
 
 export const mastra = new Mastra({
-  workflows: { complexWorkflow, lessComplexWorkflow, scheduledWorkflow, multiScheduledWorkflow },
+  workflows: { complexWorkflow, lessComplexWorkflow, enumWorkflow, scheduledWorkflow, multiScheduledWorkflow },
   agents: { weatherAgent, omAgent, omAdaptiveAgent },
   logger: new PinoLogger({
     name: 'Mastra',

--- a/packages/playground/e2e/kitchen-sink/src/mastra/workflows/complex-workflow.ts
+++ b/packages/playground/e2e/kitchen-sink/src/mastra/workflows/complex-workflow.ts
@@ -149,6 +149,17 @@ const finalStep = createStep({
   },
 });
 
+const echoModeStep = createStep({
+  id: 'echo-mode',
+  inputSchema: z.object({
+    mode: z.enum(['a', 'b']),
+  }),
+  outputSchema: z.object({
+    mode: z.enum(['a', 'b']),
+  }),
+  execute: async ({ inputData }) => inputData,
+});
+
 // Nested workflow that processes text
 export const nestedTextProcessor = createWorkflow({
   id: 'nested-text-processor',
@@ -209,6 +220,18 @@ export const complexWorkflow = createWorkflow({
 
   // Final step
   .then(finalStep)
+  .commit();
+
+export const enumWorkflow = createWorkflow({
+  id: 'enumWorkflow',
+  inputSchema: z.object({
+    mode: z.enum(['a', 'b']).default('a'),
+  }),
+  outputSchema: z.object({
+    mode: z.enum(['a', 'b']),
+  }),
+})
+  .then(echoModeStep)
   .commit();
 
 export const lessComplexWorkflow = createWorkflow({

--- a/packages/playground/e2e/tests/workflows/$workflowId/page.spec.ts
+++ b/packages/playground/e2e/tests/workflows/$workflowId/page.spec.ts
@@ -92,6 +92,26 @@ test('running the workflow (json) - long condition', async ({ page }) => {
   await checkLongPath(page);
 });
 
+test('running a workflow with an enum input uses the selected form value', async ({ page }) => {
+  // FEATURE: Workflow enum input forms
+  // USER STORY: As a Studio user, I want enum dropdown choices to update run input so workflows execute with my selection.
+  // BEHAVIOR UNDER TEST: Selecting a non-default enum option persists in the form and reaches the workflow output.
+  await page.goto('/workflows/enumWorkflow/graph');
+
+  await page.getByRole('combobox', { name: 'Mode' }).click();
+  await page.getByRole('option', { name: 'b' }).click();
+
+  await expect(page.getByRole('combobox', { name: 'Mode' })).toContainText('b');
+
+  await page.getByRole('button', { name: 'Run' }).click();
+
+  const nodes = page.locator('[data-workflow-node]');
+  await expect(nodes.nth(0)).toHaveAttribute('data-workflow-step-status', 'success', { timeout: 20000 });
+
+  await page.getByRole('button', { name: 'Open Workflow Execution (JSON)' }).click();
+  await expect(page.getByRole('dialog')).toContainText('"mode": "b"');
+});
+
 test('resuming a workflow', async ({ page }) => {
   await page.getByRole('textbox', { name: 'Text' }).fill('A');
   await page.getByRole('button', { name: 'Run' }).click();

--- a/packages/playground/src/lib/form/__tests__/custom-auto-form.test.tsx
+++ b/packages/playground/src/lib/form/__tests__/custom-auto-form.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import type { AutoFormFieldProps } from '@autoform/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { FormHTMLAttributes, PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { CustomAutoForm } from '../custom-auto-form';
+import { CustomZodProvider } from '../zod-provider';
+
+const uiComponents = {
+  Form: ({ children, ...props }: PropsWithChildren<FormHTMLAttributes<HTMLFormElement>>) => (
+    <form {...props}>{children}</form>
+  ),
+  FieldWrapper: ({ label, children }: PropsWithChildren<{ label: string }>) => (
+    <label>
+      {label}
+      {children}
+    </label>
+  ),
+  SubmitButton: ({ children }: PropsWithChildren) => <button type="submit">{children}</button>,
+  ErrorMessage: ({ error }: { error: string }) => <p>{error}</p>,
+  ObjectWrapper: ({ children }: PropsWithChildren) => <fieldset>{children}</fieldset>,
+  ArrayWrapper: ({ children }: PropsWithChildren) => <fieldset>{children}</fieldset>,
+  ArrayElementWrapper: ({ children }: PropsWithChildren) => <div>{children}</div>,
+};
+
+function SelectProbe({ value, inputProps }: AutoFormFieldProps) {
+  return (
+    <div>
+      <output data-testid="selected-mode">{String(value ?? '')}</output>
+      <button
+        type="button"
+        onClick={() => {
+          inputProps.onChange({
+            target: { name: inputProps.name, value: 'b' },
+          });
+        }}
+      >
+        Select b
+      </button>
+    </div>
+  );
+}
+
+describe('CustomAutoForm', () => {
+  it('updates controlled enum fields when their form value changes', async () => {
+    const onSubmit = vi.fn();
+    const schema = new CustomZodProvider(
+      z.object({
+        mode: z.enum(['a', 'b']).default('a'),
+      }),
+    );
+
+    render(
+      <CustomAutoForm
+        schema={schema}
+        uiComponents={uiComponents}
+        formComponents={{ select: SelectProbe }}
+        onSubmit={onSubmit}
+        withSubmit
+      />,
+    );
+
+    expect(screen.getByTestId('selected-mode').textContent).toBe('a');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select b' }));
+
+    await expect.poll(() => screen.getByTestId('selected-mode').textContent).toBe('b');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ mode: 'b' }, expect.anything());
+    });
+  });
+});

--- a/packages/playground/src/lib/form/components/custom-auto-form-field.tsx
+++ b/packages/playground/src/lib/form/components/custom-auto-form-field.tsx
@@ -3,7 +3,7 @@ import { getLabel } from '@autoform/core';
 import type { AutoFormFieldProps } from '@autoform/react';
 import { getPathInObject, useAutoForm } from '@autoform/react';
 import React, { useMemo } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { CustomArrayField } from './custom-array-field';
 import { CustomObjectField } from './custom-object-field';
 
@@ -16,11 +16,13 @@ export const CustomAutoFormField: React.FC<{
     register,
     formState: { errors, defaultValues },
     getValues,
+    control,
   } = useFormContext();
 
   const fullPath = path.join('.');
   const error = getPathInObject(errors, path)?.message as string | undefined;
-  const value = getValues(fullPath);
+  const watchedValue = useWatch({ control, name: fullPath });
+  const value = watchedValue === undefined ? getValues(fullPath) : watchedValue;
 
   const fieldDefault = useMemo(() => {
     if (!defaultValues) return field.default;


### PR DESCRIPTION
## Description

Fixes Studio workflow enum form fields so selecting a non-default dropdown value stays visible and is submitted to the workflow run. The form field wrapper now subscribes to react-hook-form value updates, and the PR adds unit and Studio E2E regression coverage for enum workflow inputs.

## Related Issue(s)

Fixes #16219

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When you tried to pick a different option from a dropdown menu in Mastra Studio, it would look like your choice got selected for a moment, but then it would go back to the default option. This PR fixes that by making the form properly remember and submit the value you actually chose.

## Overview
Fixes a bug in Mastra Studio where enum dropdown selections in workflow forms would not persist. When users selected a non-default enum value in a workflow input form, the UI would revert to the default value instead of keeping the selected choice.

## Changes

**Form Field Logic (`custom-auto-form-field.tsx`)**
- Updated `CustomAutoFormField` to use `react-hook-form`'s `useWatch` hook to subscribe to form value changes
- The field now properly derives its `value` from the form `control` in real-time, falling back to `getValues()` when needed
- This ensures controlled enum selects reflect changes immediately after an option is chosen

**Test Coverage**
- Added Vitest + React Testing Library test for `CustomAutoForm` verifying controlled enum behavior when form values change via custom select UI
- Test confirms that selecting a non-default enum option updates the form and is submitted correctly with the selected value

**E2E Test (`page.spec.ts`)**
- Added Playwright e2e test that navigates to the enum workflow, selects a non-default enum value ("b") in the Mode combobox, runs the workflow, verifies successful completion, and confirms the execution result contains the selected value

**Test Workflow (`complex-workflow.ts`)**
- Introduced `enumWorkflow` with a `mode` input using `z.enum(['a','b']).default('a')`
- Added `echoModeStep` that validates and echoes the mode input
- Registered the new `enumWorkflow` in the Mastra instance configuration

**Changeset**
- Recorded patch release for `@internal/playground` package documenting the enum dropdown persistence fix

## Related Issue
Fixes #16219

<!-- end of auto-generated comment: release notes by coderabbit.ai -->