### PR TITLE
fix(libsql): prevent safeStringify from dropping shared object references

### DIFF
--- a/.changeset/fast-pianos-grow.md
+++ b/.changeset/fast-pianos-grow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+**Fixed** Workflow run snapshots no longer lose fields when serialized for storage. The libsql `safeStringify` cycle-detection treated any object that appeared more than once in a snapshot as a circular reference and dropped it. Because `snapshot.result` and the final step's `context[step].output` share the same reference on success, `snapshot.result` was being silently stripped on every persist. This caused `listWorkflowRuns` to return runs with `snapshot.result === undefined` and broke workflow resume when suspended-state fields were shared elsewhere in the snapshot.

--- a/stores/libsql/src/storage/db/safe-stringify.test.ts
+++ b/stores/libsql/src/storage/db/safe-stringify.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+
+import { safeStringify } from './utils';
+
+describe('safeStringify', () => {
+  describe('preserves the original sanitization behaviour', () => {
+    it('drops true circular references', () => {
+      const a: Record<string, any> = { name: 'a' };
+      a.self = a;
+
+      const json = safeStringify(a);
+
+      expect(JSON.parse(json)).toEqual({ name: 'a' });
+    });
+
+    it('drops circular references nested deeper in the graph', () => {
+      const root: Record<string, any> = { name: 'root' };
+      const child: Record<string, any> = { name: 'child' };
+      root.child = child;
+      child.parent = root;
+
+      const json = safeStringify(root);
+
+      expect(JSON.parse(json)).toEqual({ name: 'root', child: { name: 'child' } });
+    });
+
+    it('drops functions and symbols', () => {
+      const value = {
+        keep: 1,
+        fn: () => 'nope',
+        sym: Symbol('nope'),
+      };
+
+      expect(JSON.parse(safeStringify(value))).toEqual({ keep: 1 });
+    });
+
+    it('coerces BigInt to string', () => {
+      expect(safeStringify({ n: 10n })).toBe('{"n":"10"}');
+    });
+
+    it('honours toJSON when provided (e.g. RequestContext-style objects)', () => {
+      const value = {
+        toJSON: () => ({ serialized: true }),
+      };
+
+      expect(JSON.parse(safeStringify(value))).toEqual({ serialized: true });
+    });
+
+    it('tolerates RPC-proxy-style objects that throw on property access', () => {
+      // Cloudflare Workers RPC proxies throw when any property (including toJSON)
+      // is accessed. safeStringify should drop these instead of crashing.
+      const proxy = new Proxy(
+        {},
+        {
+          get() {
+            throw new Error('RPC proxy: cannot access properties synchronously');
+          },
+          ownKeys() {
+            throw new Error('RPC proxy: cannot enumerate properties');
+          },
+        },
+      );
+
+      const value = { keep: 1, proxy };
+
+      expect(JSON.parse(safeStringify(value))).toEqual({ keep: 1 });
+    });
+
+    it('serializes arrays recursively', () => {
+      const value = [1, { a: 2 }, [3, () => 4]];
+
+      expect(JSON.parse(safeStringify(value))).toEqual([1, { a: 2 }, [3, null]]);
+    });
+
+    it('returns the string "null" when the input itself is undefined', () => {
+      expect(safeStringify(undefined)).toBe('null');
+    });
+  });
+
+  describe('preserves shared (non-circular) references', () => {
+    // Regression test for a bug where the cycle-detection WeakSet was added to
+    // but never cleared, causing any object that appeared in two places in the
+    // graph (e.g. snapshot.result and context[step].output of a workflow run)
+    // to be silently dropped on the second visit.
+    it('serializes the same object reference appearing in sibling branches', () => {
+      const shared = { result: 3 };
+      const value = {
+        result: shared,
+        context: {
+          'add-numbers': { output: shared },
+        },
+      };
+
+      const parsed = JSON.parse(safeStringify(value));
+
+      expect(parsed.result).toEqual({ result: 3 });
+      expect(parsed.context['add-numbers'].output).toEqual({ result: 3 });
+    });
+
+    it('serializes shared references repeated inside an array', () => {
+      const shared = { id: 'shared' };
+
+      const parsed = JSON.parse(safeStringify({ items: [shared, shared, shared] }));
+
+      expect(parsed.items).toEqual([{ id: 'shared' }, { id: 'shared' }, { id: 'shared' }]);
+    });
+
+    it('still drops a reference that becomes a true ancestor cycle even when shared elsewhere', () => {
+      const shared: Record<string, any> = { id: 'shared' };
+      const branchA: Record<string, any> = { shared };
+      shared.back = branchA; // ancestor cycle: branchA -> shared -> branchA
+
+      const value = { branchA, branchB: { shared } };
+      const parsed = JSON.parse(safeStringify(value));
+
+      // In branchA, walking branchA -> shared -> back hits branchA on the
+      // path, so `back` is dropped: { id: 'shared' }
+      expect(parsed.branchA.shared).toEqual({ id: 'shared' });
+      // In branchB, walking branchB -> shared -> back -> branchA re-enters
+      // shared which is on the path, so the inner `shared` is dropped but
+      // `back` itself is kept as an empty object.
+      expect(parsed.branchB.shared).toEqual({ id: 'shared', back: {} });
+    });
+  });
+});

--- a/stores/libsql/src/storage/db/utils.ts
+++ b/stores/libsql/src/storage/db/utils.ts
@@ -15,7 +15,11 @@ import { parseSqlIdentifier } from '@mastra/core/utils';
  * @returns JSON string representation, with non-serializable values removed
  */
 export const safeStringify = (value: unknown): string => {
-  const seen = new WeakSet<object>();
+  // Track ancestors on the current recursion path to detect true circular references.
+  // Using a per-call stack (rather than a global WeakSet) avoids incorrectly
+  // dropping shared but non-circular references that appear in multiple branches
+  // of the same object graph.
+  const ancestors = new Set<object>();
 
   const sanitize = (val: unknown): unknown => {
     if (val === null || val === undefined) return val;
@@ -24,9 +28,9 @@ export const safeStringify = (value: unknown): string => {
     if (typeof val === 'bigint') return val.toString();
     if (typeof val !== 'object') return val;
 
-    // Circular reference check
-    if (seen.has(val)) return undefined;
-    seen.add(val);
+    // Circular reference check: only drop if this object is an ancestor on the
+    // current path. Shared sibling references must still be serialized.
+    if (ancestors.has(val)) return undefined;
 
     // Check for RPC proxy (throws on property access including toJSON)
     try {
@@ -41,20 +45,25 @@ export const safeStringify = (value: unknown): string => {
       return sanitize((val as { toJSON: () => unknown }).toJSON());
     }
 
-    // Recursively sanitize arrays
-    if (Array.isArray(val)) {
-      return val.map(item => sanitize(item));
-    }
-
-    // Recursively sanitize objects
-    const result: Record<string, unknown> = {};
-    for (const key of Object.keys(val)) {
-      const sanitized = sanitize((val as Record<string, unknown>)[key]);
-      if (sanitized !== undefined) {
-        result[key] = sanitized;
+    ancestors.add(val);
+    try {
+      // Recursively sanitize arrays
+      if (Array.isArray(val)) {
+        return val.map(item => sanitize(item));
       }
+
+      // Recursively sanitize objects
+      const result: Record<string, unknown> = {};
+      for (const key of Object.keys(val)) {
+        const sanitized = sanitize((val as Record<string, unknown>)[key]);
+        if (sanitized !== undefined) {
+          result[key] = sanitized;
+        }
+      }
+      return result;
+    } finally {
+      ancestors.delete(val);
     }
-    return result;
   };
 
   return JSON.stringify(sanitize(value)) ?? 'null';

--- a/stores/libsql/src/storage/domains/workflows/index.test.ts
+++ b/stores/libsql/src/storage/domains/workflows/index.test.ts
@@ -1,0 +1,81 @@
+import { createClient } from '@libsql/client';
+import { TABLE_WORKFLOW_SNAPSHOT, TABLE_SCHEMAS } from '@mastra/core/storage';
+import type { WorkflowRunState } from '@mastra/core/workflows';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { LibSQLDB } from '../../db';
+import { WorkflowsLibSQL } from './index';
+
+describe('WorkflowsLibSQL — snapshot serialization', () => {
+  let workflows: WorkflowsLibSQL;
+
+  beforeEach(async () => {
+    const client = createClient({ url: ':memory:' });
+    const db = new LibSQLDB({ client, maxRetries: 1, initialBackoffMs: 10 });
+    await db.createTable({
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      schema: TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT],
+    });
+    workflows = new WorkflowsLibSQL({ client });
+  });
+
+  // Regression test: the default workflow executor builds the success snapshot
+  // with `snapshot.result` pointing at the same object as `context[step].output`.
+  // safeStringify previously dropped the second visit of any shared reference,
+  // silently stripping `snapshot.result` from every persisted run. listWorkflowRuns
+  // and getWorkflowRunById then returned snapshots without `result`.
+  it('preserves shared references between snapshot.result and context[step].output', async () => {
+    const sharedOutput = { result: 3 };
+
+    const snapshot = {
+      runId: 'shared-ref-run',
+      status: 'success',
+      result: sharedOutput,
+      value: {},
+      context: {
+        input: { a: 1, b: 2 },
+        'add-numbers': {
+          status: 'success',
+          output: sharedOutput,
+          startedAt: 1,
+          endedAt: 2,
+          payload: { a: 1, b: 2 },
+        },
+      },
+      activePaths: [],
+      serializedStepGraph: [],
+      suspendedPaths: {},
+      waitingPaths: {},
+      timestamp: Date.now(),
+    } as unknown as WorkflowRunState;
+
+    await workflows.persistWorkflowSnapshot({
+      workflowName: 'add-workflow',
+      runId: 'shared-ref-run',
+      snapshot,
+    });
+
+    const loaded = await workflows.loadWorkflowSnapshot({
+      workflowName: 'add-workflow',
+      runId: 'shared-ref-run',
+    });
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.status).toBe('success');
+    expect(loaded!.result).toEqual({ result: 3 });
+
+    const byId = await workflows.getWorkflowRunById({
+      runId: 'shared-ref-run',
+      workflowName: 'add-workflow',
+    });
+    expect(byId).not.toBeNull();
+    const byIdSnapshot = byId!.snapshot as WorkflowRunState;
+    expect(byIdSnapshot.result).toEqual({ result: 3 });
+
+    const listed = await workflows.listWorkflowRuns({ workflowName: 'add-workflow' });
+    expect(listed.runs).toHaveLength(1);
+    const listedSnapshot = listed.runs[0]!.snapshot as WorkflowRunState;
+    expect(listedSnapshot.result).toEqual({ result: 3 });
+    expect((listedSnapshot.context as any)['add-numbers'].output).toEqual({ result: 3 });
+  });
+});


### PR DESCRIPTION
Workflow runs were being persisted without their top-level `result` field because libsql's `safeStringify` was treating shared (non-circular) object references as cycles.

The cycle-detection used a single `WeakSet` that was added to but never cleared, so any object that appeared more than once in the graph got dropped. In workflow snapshots, `snapshot.result` and `context[step].output` are the same reference on success, so `snapshot.result` was being silently stripped on every persist.

This broke `listWorkflowRuns` (snapshots came back with `result: undefined`) and workflow resume.

Before:
```ts
const seen = new WeakSet();
const sanitize = (val) => {
  if (seen.has(val)) return undefined; // dropped on second visit
  seen.add(val);
  // ...recurse...
};
```

After:
```ts
const ancestors = new Set();
const sanitize = (val) => {
  if (ancestors.has(val)) return undefined; // only true cycles
  ancestors.add(val);
  try { /* ...recurse... */ } finally { ancestors.delete(val); }
};
```

Regression from #12573.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

A serializer was mistakenly throwing away shared toys when it saw the same object twice. The fix makes it only remove objects that actually form a loop, so shared objects are kept and workflow snapshots no longer lose data.

## Changes

### Fix: correct circular-reference detection in safeStringify
- File: stores/libsql/src/storage/db/utils.ts
- Replaced a global WeakSet that tracked every visited object with a per-call ancestor Set that tracks only objects on the current recursion path. Values are added on entry and removed on exit (try/finally), so only true cycles are detected.
- Result: shared (non-circular) object references are no longer treated as cycles and are preserved during serialization. This fixes a regression where snapshot.result was being stripped when it referenced the same object as context[step].output.

### Tests added
- File: stores/libsql/src/storage/db/safe-stringify.test.ts
  - New unit tests for safeStringify covering: true cycles, functions, symbols, BigInt, toJSON, throwing getters/Proxy behavior, arrays, undefined input, and importantly shared-but-non-circular reference preservation and regression cases.
- File: stores/libsql/src/storage/domains/workflows/index.test.ts
  - Regression test using an in-memory LibSQL instance verifying that persisting/loading workflow snapshots preserves the shared reference between snapshot.result and context[step].output across loadWorkflowSnapshot, getWorkflowRunById, and listWorkflowRuns.

### Changeset
- File: .changeset/fast-pianos-grow.md
  - New changeset documenting the @mastra/libsql patch that fixes workflow run snapshot persistence where repeated references were incorrectly dropped.

## Notes
- No public API signatures changed.
- This restores correct behavior for listing and resuming workflow runs that relied on shared object references in persisted snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->