### PR TITLE
fix(core): register workflow step scorers with Mastra

### DIFF
--- a/.changeset/workflow-scorers-register.md
+++ b/.changeset/workflow-scorers-register.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Configured workflow step scorers now automatically emit scores through the observability score pipeline.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -2447,7 +2447,8 @@ export class Mastra<
    * This method allows dynamic registration of scorers after the Mastra instance
    * has been created.
    *
-   * @throws {MastraError} When a scorer with the same key already exists
+   * If a scorer with the same key already exists, this method leaves the existing
+   * scorer registered and returns.
    *
    * @example
    * ```typescript

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -3278,6 +3278,8 @@ export class Mastra<
     }
     workflows[workflowKey] = workflow;
 
+    this.registerStaticWorkflowScorers(workflow);
+
     // If a schedule is declared, mark the flag and either register into the
     // running scheduler or trigger a lazy ensure.
     if (hasSchedule) {
@@ -3297,6 +3299,19 @@ export class Mastra<
         })();
       } else {
         this.#ensureScheduler();
+      }
+    }
+  }
+
+  private registerStaticWorkflowScorers(workflow: AnyWorkflow): void {
+    for (const step of Object.values(workflow.steps ?? {})) {
+      const scorers = step.scorers;
+      if (!scorers || typeof scorers === 'function') {
+        continue;
+      }
+
+      for (const [, entry] of Object.entries(scorers)) {
+        this.addScorer(entry.scorer, undefined, { source: 'code' });
       }
     }
   }

--- a/packages/core/src/mastra/scorer-registration.test.ts
+++ b/packages/core/src/mastra/scorer-registration.test.ts
@@ -1,7 +1,12 @@
 import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
 import { Agent } from '../agent';
 import { createScorer } from '../evals/base';
+import { RequestContext } from '../request-context';
+import { createStep, createWorkflow } from '../workflows';
+import { DefaultExecutionEngine } from '../workflows/default';
+import { runScorersForStep } from '../workflows/handlers/step';
 import { Mastra } from './index';
 
 /**
@@ -206,5 +211,120 @@ describe('Scorer Registration', () => {
     expect(Object.keys(allScorers || {})).toHaveLength(2);
     expect(allScorers?.['mastra-level-scorer']).toBeDefined();
     expect(allScorers?.['agent-level-scorer']).toBeDefined();
+  });
+
+  it('should register static workflow step scorers before addWorkflow returns', () => {
+    const workflowScorer = createTestScorer('workflow-step-scorer');
+    const step = createStep({
+      id: 'scored-step',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      scorers: {
+        workflowStep: { scorer: workflowScorer },
+      },
+      execute: async ({ inputData }) => inputData,
+    });
+    const workflow = createWorkflow({
+      id: 'scored-workflow',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+    })
+      .then(step)
+      .commit();
+
+    const mastra = new Mastra({ logger: false });
+    mastra.addWorkflow(workflow);
+
+    expect(mastra.getScorerById('workflow-step-scorer')).toBe(workflowScorer);
+  });
+
+  it('should register dynamic workflow step scorers before running them', async () => {
+    const workflowScorer = createTestScorer('dynamic-workflow-step-scorer');
+    const mastra = new Mastra({ logger: false });
+    const engine = new DefaultExecutionEngine({
+      mastra,
+      options: {
+        validateInputs: true,
+        shouldPersistSnapshot: () => true,
+      },
+    });
+
+    await runScorersForStep({
+      engine,
+      scorers: async () => ({
+        dynamicWorkflowStep: { scorer: workflowScorer },
+      }),
+      runId: 'run-1',
+      workflowId: 'workflow-1',
+      stepId: 'step-1',
+      input: { value: 'input' },
+      output: { value: 'output' },
+      requestContext: new RequestContext(),
+      disableScorers: false,
+    });
+
+    expect(mastra.getScorerById('dynamic-workflow-step-scorer')).toBe(workflowScorer);
+  });
+
+  it('should emit score events when workflow step scorers run', async () => {
+    const workflowScorer = createTestScorer('workflow-score-event-scorer');
+    const workflowScorers = vi.fn().mockReturnValue({
+      workflowStep: { scorer: workflowScorer },
+    });
+    const step = createStep({
+      id: 'scored-step',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      scorers: workflowScorers,
+      execute: async ({ inputData }) => inputData,
+    });
+    const workflow = createWorkflow({
+      id: 'workflow-score-event',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+    })
+      .then(step)
+      .commit();
+
+    const mastra = new Mastra({
+      logger: false,
+      storage: {
+        init: vi.fn().mockResolvedValue(undefined),
+        getStore: vi.fn(async (domain: string) => {
+          if (domain === 'scores') {
+            return {
+              saveScore: vi.fn().mockResolvedValue({ score: {} }),
+            };
+          }
+          return null;
+        }),
+        __setLogger: vi.fn(),
+      } as any,
+      workflows: { workflow },
+    });
+    const addScoreSpy = vi.spyOn(mastra.observability, 'addScore').mockResolvedValue(undefined);
+    const scorerRunSpy = vi.spyOn(workflowScorer, 'run');
+
+    const run = await workflow.createRun({ disableScorers: false });
+    const result = await run.start({ inputData: { value: 'input' } });
+
+    expect(result.status).toBe('success');
+    expect(workflowScorers).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(scorerRunSpy).toHaveBeenCalled();
+    });
+
+    await vi.waitFor(() => {
+      expect(addScoreSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          score: expect.objectContaining({
+            scorerId: 'workflow-score-event-scorer',
+            scorerName: 'workflow-score-event-scorer-name',
+            targetEntityType: 'workflow_run',
+            score: 1,
+          }),
+        }),
+      );
+    });
   });
 });

--- a/packages/core/src/mastra/scorer-registration.test.ts
+++ b/packages/core/src/mastra/scorer-registration.test.ts
@@ -238,6 +238,43 @@ describe('Scorer Registration', () => {
     expect(mastra.getScorerById('workflow-step-scorer')).toBe(workflowScorer);
   });
 
+  it('should register a shared workflow step scorer once by id', () => {
+    const workflowScorer = createTestScorer('shared-workflow-step-scorer');
+    const firstStep = createStep({
+      id: 'first-scored-step',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      scorers: {
+        shared: { scorer: workflowScorer },
+      },
+      execute: async ({ inputData }) => inputData,
+    });
+    const secondStep = createStep({
+      id: 'second-scored-step',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      scorers: {
+        shared: { scorer: workflowScorer },
+      },
+      execute: async ({ inputData }) => inputData,
+    });
+    const workflow = createWorkflow({
+      id: 'shared-scorer-workflow',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+    })
+      .then(firstStep)
+      .then(secondStep)
+      .commit();
+
+    const mastra = new Mastra({ logger: false });
+    mastra.addWorkflow(workflow);
+
+    const allScorers = mastra.listScorers();
+    expect(Object.keys(allScorers || {})).toEqual(['shared-workflow-step-scorer']);
+    expect(mastra.getScorerById('shared-workflow-step-scorer')).toBe(workflowScorer);
+  });
+
   it('should register dynamic workflow step scorers before running them', async () => {
     const workflowScorer = createTestScorer('dynamic-workflow-step-scorer');
     const mastra = new Mastra({ logger: false });

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -572,8 +572,12 @@ export async function runScorersForStep(params: RunScorersParams): Promise<void>
 
   if (!disableScorers && scorersToUse && Object.keys(scorersToUse || {}).length > 0) {
     for (const [_id, scorerObject] of Object.entries(scorersToUse || {})) {
+      if (engine.mastra) {
+        scorerObject.scorer.__registerMastra(engine.mastra);
+        engine.mastra.addScorer(scorerObject.scorer, undefined, { source: 'code' });
+      }
       runScorer({
-        scorerId: scorerObject.name,
+        scorerId: scorerObject.scorer.id,
         scorerObject: scorerObject,
         runId: runId,
         input: input,


### PR DESCRIPTION
## Description

Registers workflow step scorers with the owning Mastra instance so workflow scorer runs can emit scores through the observability score pipeline.

This keeps static workflow scorers discoverable after workflow registration and registers dynamic workflow scorers at execution time, when request context is available.

## Related Issue(s)

Follow-up to #16185.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Testing

- pnpm --filter ./packages/core test src/mastra/scorer-registration.test.ts
- pnpm --filter ./packages/core check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Workflow step scorers are little checks that rate each step of a process. This PR makes sure those checkers are registered with Mastra (either when the workflow is added or at execution time) so their scores are emitted into the observability pipeline and tracked.

## Changes

**Changeset Addition** (`.changeset/workflow-scorers-register.md`)
- Adds a changelog entry (minor) for `@mastra/core` noting that configured workflow step scorers now automatically emit scores through the observability score pipeline.

**Core Registration Logic** (`packages/core/src/mastra/index.ts`)
- Added a private helper to register static workflow step scorers found on workflow steps.
- `Mastra.addWorkflow()` now invokes that helper after committing/registering a workflow so static (non-function) `step.scorers` are registered with source `'code'`.
- Removed the previous declarative schedule auto-registration side-effect (it no longer sets `#hasScheduledWorkflow` or triggers scheduler bootstrap/registration based on collected schedules).
- Documented `addScorer()` behavior regarding duplicate keys.

**Workflow Step Execution** (`packages/core/src/workflows/handlers/step.ts`)
- `runScorersForStep()` now ensures dynamic scorers are registered with `engine.mastra` before execution by invoking the scorer's internal register helper and calling `mastra.addScorer(...)`.
- When emitting scores, scorer identification now uses `scorerObject.scorer.id` (instead of the prior `scorerObject.name`).

**Tests** (`packages/core/src/mastra/scorer-registration.test.ts`)
- Expanded tests to cover workflow step scorer registration (static and dynamic) in addition to existing agent-level tests.
- New/updated test cases verify:
  - Static workflow step scorers are registered after `addWorkflow()` returns and are findable via `getScorerById`.
  - Shared static scorers are not duplicated (one registration per id).
  - Dynamic workflow step scorers are registered before they run.
  - Score events are emitted through `mastra.observability.addScore` with expected scorer id/name, `targetEntityType: 'workflow_run'`, and numeric score values.

## Impact

Fixes a bug where workflow step scorers (both static and dynamic) could be undiscoverable by Mastra; ensures they are registered so their emitted scores flow through the observability score pipeline and are captured for reporting and analysis.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16371)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->