### PR TITLE
fix(arize): support PHOENIX_COLLECTOR_ENDPOINT env var

### DIFF
--- a/.changeset/phoenix-collector-endpoint.md
+++ b/.changeset/phoenix-collector-endpoint.md
@@ -1,0 +1,15 @@
+---
+'@mastra/arize': patch
+---
+
+Align the Arize exporter's Phoenix endpoint env var with Arize Phoenix's documented convention.
+
+The exporter now reads `PHOENIX_COLLECTOR_ENDPOINT` first, which matches the variable Arize Phoenix uses across its own SDKs and documentation. `PHOENIX_ENDPOINT` continues to work as a fallback so existing configurations are not affected. Explicit `endpoint` config still takes precedence over both env vars.
+
+```bash
+# New (preferred) — matches Arize Phoenix's documented convention
+PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006/v1/traces
+
+# Still supported for backwards compatibility
+PHOENIX_ENDPOINT=http://localhost:6006/v1/traces
+```

--- a/docs/src/content/en/docs/observability/tracing/exporters/arize.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/arize.mdx
@@ -31,8 +31,8 @@ Phoenix is an open-source observability platform that can be self-hosted or used
 1. **Environment Variables**: Set your configuration
 
 ```bash title=".env"
-# Required
-PHOENIX_ENDPOINT=http://localhost:6006/v1/traces  # Or your Phoenix Cloud URL
+# Required - matches Arize Phoenix's documented convention. PHOENIX_ENDPOINT is also accepted as a fallback.
+PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006/v1/traces  # Or your Phoenix Cloud URL
 
 # Optional
 PHOENIX_API_KEY=your-api-key  # For authenticated Phoenix instances
@@ -76,7 +76,7 @@ export const mastra = new Mastra({
         serviceName: process.env.PHOENIX_PROJECT_NAME || 'mastra-service',
         exporters: [
           new ArizeExporter({
-            endpoint: process.env.PHOENIX_ENDPOINT!,
+            endpoint: process.env.PHOENIX_COLLECTOR_ENDPOINT!,
             apiKey: process.env.PHOENIX_API_KEY,
             projectName: process.env.PHOENIX_PROJECT_NAME,
           }),
@@ -97,7 +97,7 @@ docker run --pull=always -d --name arize-phoenix -p 6006:6006 \
   arizephoenix/phoenix:latest
 ```
 
-Set `PHOENIX_ENDPOINT=http://localhost:6006/v1/traces` and run your Mastra agent to see traces at [localhost:6006](http://localhost:6006).
+Set `PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006/v1/traces` and run your Mastra agent to see traces at [localhost:6006](http://localhost:6006).
 
 :::
 
@@ -211,7 +211,7 @@ Control how traces are batched and exported:
 
 ```typescript
 new ArizeExporter({
-  endpoint: process.env.PHOENIX_ENDPOINT!,
+  endpoint: process.env.PHOENIX_COLLECTOR_ENDPOINT!,
   apiKey: process.env.PHOENIX_API_KEY,
 
   // Batch processing configuration
@@ -226,7 +226,7 @@ Add custom attributes to all exported spans:
 
 ```typescript
 new ArizeExporter({
-  endpoint: process.env.PHOENIX_ENDPOINT!,
+  endpoint: process.env.PHOENIX_COLLECTOR_ENDPOINT!,
   resourceAttributes: {
     'deployment.environment': process.env.NODE_ENV,
     'service.namespace': 'production',

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -301,7 +301,7 @@ export const mastra = new Mastra({
         serviceName: 'my-service',
         exporters: [
           new ArizeExporter({
-            endpoint: process.env.PHOENIX_ENDPOINT,
+            endpoint: process.env.PHOENIX_COLLECTOR_ENDPOINT,
             apiKey: process.env.PHOENIX_API_KEY,
           }),
           new DefaultExporter(), // Keep Studio access

--- a/docs/src/content/en/reference/observability/tracing/exporters/arize.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/arize.mdx
@@ -50,7 +50,8 @@ Non-reserved span attributes are serialized into the OpenInference `metadata` pa
   {
     name: 'endpoint',
     type: 'string',
-    description: 'Collector endpoint for trace exports. Falls back to PHOENIX_ENDPOINT env var. Required for Phoenix.',
+    description:
+      'Collector endpoint for trace exports. Falls back to PHOENIX_COLLECTOR_ENDPOINT (preferred) or PHOENIX_ENDPOINT env var. Required for Phoenix.',
     required: false,
   },
   {
@@ -145,7 +146,7 @@ Flushes pending data and shuts down the client.
 ```typescript
 import { ArizeExporter } from '@mastra/arize'
 
-// For Phoenix: Set PHOENIX_ENDPOINT, PHOENIX_API_KEY, PHOENIX_PROJECT_NAME
+// For Phoenix: Set PHOENIX_COLLECTOR_ENDPOINT, PHOENIX_API_KEY, PHOENIX_PROJECT_NAME
 // For Arize AX: Set ARIZE_SPACE_ID, ARIZE_API_KEY, ARIZE_PROJECT_NAME
 const exporter = new ArizeExporter()
 ```

--- a/observability/arize/README.md
+++ b/observability/arize/README.md
@@ -22,7 +22,8 @@ Set environment variables and use zero-config:
 
 ```bash
 # Required - endpoint must end in /v1/traces
-PHOENIX_ENDPOINT=http://localhost:6006/v1/traces
+# Matches Arize Phoenix's documented convention. PHOENIX_ENDPOINT is also accepted as a fallback.
+PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006/v1/traces
 
 # Optional - for authenticated Phoenix instances
 PHOENIX_API_KEY=your-api-key

--- a/observability/arize/src/tracing.config.test.ts
+++ b/observability/arize/src/tracing.config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ARIZE_AX_ENDPOINT, ArizeExporter } from './tracing';
 
 // Mock OtelExporter to spy on its constructor
@@ -80,6 +80,109 @@ describe('ArizeExporterConfig', () => {
       }),
     );
   });
+  describe('endpoint env var resolution', () => {
+    const originalEnv = { ...process.env };
+
+    beforeEach(() => {
+      delete process.env.PHOENIX_COLLECTOR_ENDPOINT;
+      delete process.env.PHOENIX_ENDPOINT;
+    });
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    it('uses PHOENIX_COLLECTOR_ENDPOINT when set', async () => {
+      const { OtelExporter } = await import('@mastra/otel-exporter');
+      const otelExporterSpy = vi.mocked(OtelExporter);
+      otelExporterSpy.mockClear();
+
+      process.env.PHOENIX_COLLECTOR_ENDPOINT = 'https://phoenix-collector.example.com/v1/traces';
+
+      new ArizeExporter();
+
+      expect(otelExporterSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: {
+            custom: {
+              endpoint: 'https://phoenix-collector.example.com/v1/traces',
+              headers: {},
+              protocol: 'http/protobuf',
+            },
+          },
+        }),
+      );
+    });
+
+    it('falls back to PHOENIX_ENDPOINT when PHOENIX_COLLECTOR_ENDPOINT is not set', async () => {
+      const { OtelExporter } = await import('@mastra/otel-exporter');
+      const otelExporterSpy = vi.mocked(OtelExporter);
+      otelExporterSpy.mockClear();
+
+      process.env.PHOENIX_ENDPOINT = 'https://phoenix-legacy.example.com/v1/traces';
+
+      new ArizeExporter();
+
+      expect(otelExporterSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: {
+            custom: {
+              endpoint: 'https://phoenix-legacy.example.com/v1/traces',
+              headers: {},
+              protocol: 'http/protobuf',
+            },
+          },
+        }),
+      );
+    });
+
+    it('prefers PHOENIX_COLLECTOR_ENDPOINT over PHOENIX_ENDPOINT', async () => {
+      const { OtelExporter } = await import('@mastra/otel-exporter');
+      const otelExporterSpy = vi.mocked(OtelExporter);
+      otelExporterSpy.mockClear();
+
+      process.env.PHOENIX_COLLECTOR_ENDPOINT = 'https://phoenix-collector.example.com/v1/traces';
+      process.env.PHOENIX_ENDPOINT = 'https://phoenix-legacy.example.com/v1/traces';
+
+      new ArizeExporter();
+
+      expect(otelExporterSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: {
+            custom: {
+              endpoint: 'https://phoenix-collector.example.com/v1/traces',
+              headers: {},
+              protocol: 'http/protobuf',
+            },
+          },
+        }),
+      );
+    });
+
+    it('config.endpoint takes precedence over both env vars', async () => {
+      const { OtelExporter } = await import('@mastra/otel-exporter');
+      const otelExporterSpy = vi.mocked(OtelExporter);
+      otelExporterSpy.mockClear();
+
+      process.env.PHOENIX_COLLECTOR_ENDPOINT = 'https://phoenix-collector.example.com/v1/traces';
+      process.env.PHOENIX_ENDPOINT = 'https://phoenix-legacy.example.com/v1/traces';
+
+      new ArizeExporter({ endpoint: 'https://config-endpoint.example.com/v1/traces' });
+
+      expect(otelExporterSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: {
+            custom: {
+              endpoint: 'https://config-endpoint.example.com/v1/traces',
+              headers: {},
+              protocol: 'http/protobuf',
+            },
+          },
+        }),
+      );
+    });
+  });
+
   it('merges resource attributes when provided', async () => {
     const { OtelExporter } = await import('@mastra/otel-exporter');
     const otelExporterSpy = vi.mocked(OtelExporter);

--- a/observability/arize/src/tracing.ts
+++ b/observability/arize/src/tracing.ts
@@ -45,8 +45,10 @@ export class ArizeExporter extends OtelExporter {
     const apiKey = config.apiKey ?? process.env.ARIZE_API_KEY ?? process.env.PHOENIX_API_KEY;
     const projectName = config.projectName ?? process.env.ARIZE_PROJECT_NAME ?? process.env.PHOENIX_PROJECT_NAME;
 
-    // Determine endpoint: config > PHOENIX_ENDPOINT > ARIZE_AX_ENDPOINT (if spaceId is set)
-    let endpoint: string | undefined = config.endpoint ?? process.env.PHOENIX_ENDPOINT;
+    // Determine endpoint: config > PHOENIX_COLLECTOR_ENDPOINT > PHOENIX_ENDPOINT > ARIZE_AX_ENDPOINT (if spaceId is set)
+    // PHOENIX_COLLECTOR_ENDPOINT matches Arize Phoenix's documented convention; PHOENIX_ENDPOINT is kept for backwards compatibility.
+    let endpoint: string | undefined =
+      config.endpoint ?? process.env.PHOENIX_COLLECTOR_ENDPOINT ?? process.env.PHOENIX_ENDPOINT;
 
     const headers: Record<string, string> = {
       ...config.headers,
@@ -75,7 +77,7 @@ export class ArizeExporter extends OtelExporter {
     if (!disabledReason && !endpoint) {
       disabledReason =
         `${LOG_PREFIX} Endpoint is required in configuration. ` +
-        `Set PHOENIX_ENDPOINT environment variable, or ARIZE_SPACE_ID for Arize AX, or pass endpoint in config.`;
+        `Set PHOENIX_COLLECTOR_ENDPOINT environment variable, or ARIZE_SPACE_ID for Arize AX, or pass endpoint in config.`;
     }
 
     // If disabled, create with minimal config and disable


### PR DESCRIPTION
## Problem

Closes #16339.

The Arize exporter reads `PHOENIX_ENDPOINT` from the environment, but Arize Phoenix's own SDKs and documentation use `PHOENIX_COLLECTOR_ENDPOINT` everywhere. When users follow [Phoenix's Mastra integration guide](https://arize.com/docs/phoenix/integrations/typescript/mastra/mastra-tracing#self-hosted-phoenix) and rely on the default env vars, the endpoint is silently not picked up because Mastra is looking for a different variable name.

## Solution

Read `PHOENIX_COLLECTOR_ENDPOINT` first to align with the Phoenix convention, falling back to `PHOENIX_ENDPOINT` so existing setups keep working. Explicit `endpoint` config still takes precedence over both env vars.

Resolution order:
1. `config.endpoint`
2. `process.env.PHOENIX_COLLECTOR_ENDPOINT` (preferred — matches Phoenix's convention)
3. `process.env.PHOENIX_ENDPOINT` (kept for backwards compatibility)
4. `ARIZE_AX_ENDPOINT` (when `spaceId` is set)

Docs and the README now point at `PHOENIX_COLLECTOR_ENDPOINT` as the preferred variable while noting that `PHOENIX_ENDPOINT` is still accepted.

## Testing

- Added unit tests in `observability/arize/src/tracing.config.test.ts` covering:
  - `PHOENIX_COLLECTOR_ENDPOINT` is used when set
  - `PHOENIX_ENDPOINT` is used as a fallback
  - `PHOENIX_COLLECTOR_ENDPOINT` takes precedence when both are set
  - Explicit `config.endpoint` still wins over both env vars
- `pnpm --filter @mastra/arize test` — 28 passed (4 new + 24 existing)
- `pnpm --filter @mastra/arize lint` — clean

A `@mastra/arize` patch changeset is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra's Arize integration was looking for a setting called `PHOENIX_ENDPOINT` to know where to send tracing data, but Arize's official documentation uses a different name: `PHOENIX_COLLECTOR_ENDPOINT`. This PR makes Mastra check for the correct name first (following Arize's convention), while still accepting the old name so existing code doesn't break.

## Changes

### Core Implementation
- Updated `ArizeExporter`'s endpoint resolution logic in `observability/arize/src/tracing.ts` to prefer `PHOENIX_COLLECTOR_ENDPOINT` environment variable over `PHOENIX_ENDPOINT`
- Established precedence order for endpoint determination: 1) explicit `config.endpoint`, 2) `PHOENIX_COLLECTOR_ENDPOINT`, 3) `PHOENIX_ENDPOINT`, 4) `ARIZE_AX_ENDPOINT` (when using Arize AX with `spaceId`)
- Updated error messaging to reference `PHOENIX_COLLECTOR_ENDPOINT` as the primary configuration option

### Testing
- Added comprehensive test suite in `observability/arize/src/tracing.config.test.ts` with 104 new lines covering:
  - Endpoint resolution with `PHOENIX_COLLECTOR_ENDPOINT`
  - Fallback behavior to `PHOENIX_ENDPOINT`
  - Explicit config precedence over environment variables
  - Proper test isolation with environment variable save/restore

### Documentation
- Updated `docs/src/content/en/docs/observability/tracing/exporters/arize.mdx` to use `PHOENIX_COLLECTOR_ENDPOINT` in all configuration examples and environment setup instructions
- Modified `docs/src/content/en/docs/observability/tracing/overview.mdx` to reference the new preferred environment variable
- Updated reference documentation in `docs/src/content/en/reference/observability/tracing/exporters/arize.mdx` to clarify the fallback order
- Updated `observability/arize/README.md` to recommend `PHOENIX_COLLECTOR_ENDPOINT` in Zero-Config setup while noting that `PHOENIX_ENDPOINT` remains supported

### Changeset
- Added `@mastra/arize` patch changeset documenting the environment variable preference change and maintaining backward compatibility

## Impact

This change aligns Mastra with Arize Phoenix's official SDKs and documentation while preserving backward compatibility for existing deployments using `PHOENIX_ENDPOINT`. Users following Arize's official guides will now have their configuration automatically picked up without additional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->