### PR TITLE
docs(processors): add community pattern catalog example to RegexFilterProcessor

### DIFF
--- a/docs/src/content/en/reference/processors/regex-filter-processor.mdx
+++ b/docs/src/content/en/reference/processors/regex-filter-processor.mdx
@@ -184,3 +184,27 @@ When the `block` strategy is active (default), `RegexFilterProcessor` throws a `
 | `pii` | Emails, phone numbers, SSNs, credit card numbers | `[EMAIL]`, `[PHONE]`, `[SSN]`, `[CREDIT_CARD]` |
 | `secrets` | API keys, bearer tokens, AWS access keys | `[API_KEY]`, `[BEARER_TOKEN]`, `[AWS_KEY]` |
 | `urls` | HTTP/HTTPS URLs | `[URL]` |
+
+## Using community pattern catalogs
+
+The `rules` parameter accepts arbitrary regex catalogs, including community-curated ones. The example below loads a small set of prompt-injection patterns inspired by Agent Threat Rules (Apache-2.0, https://github.com/Agent-Threat-Rule/agent-threat-rules), an open detection standard for AI agent threats.
+
+```typescript
+import { RegexFilterProcessor } from '@mastra/core/processors'
+
+const atrRules = [
+  { name: 'instruction-override', pattern: /\b(ignore|disregard|forget)\b[^.]{0,40}\b(previous|prior|above)\b[^.]{0,40}\b(instructions?|rules?)\b/i },
+  { name: 'role-hijack', pattern: /\byou\s+are\s+now\b[^.]{0,60}\b(?:dan|jailbroken|developer\s+mode|root)\b/i },
+  { name: 'system-prompt-extraction', pattern: /\b(repeat|print|reveal|show|output)\b[^.]{0,40}\b(system\s+prompt|initial\s+prompt)\b/i },
+  { name: 'delimiter-injection', pattern: /<\|im_(start|end)\|>|<\/?(system|assistant|user)>|\[\/?INST\]/i },
+  { name: 'tool-exfil', pattern: /\b(send|post|fetch)\b[^.]{0,60}\b(api[_-]?key|secret|token)s?\b/i },
+]
+
+const filter = new RegexFilterProcessor({
+  rules: atrRules,
+  strategy: 'block',
+  phase: 'input',
+})
+```
+
+Pattern-based detection runs in microseconds and is complementary to the LLM-backed [PromptInjectionDetector](/reference/processors/prompt-injection-detector). Use both together for defense in depth: pattern check first as a cheap filter, model-based detection second for nuanced cases.

--- a/docs/src/content/en/reference/processors/regex-filter-processor.mdx
+++ b/docs/src/content/en/reference/processors/regex-filter-processor.mdx
@@ -187,7 +187,7 @@ When the `block` strategy is active (default), `RegexFilterProcessor` throws a `
 
 ## Using community pattern catalogs
 
-The `rules` parameter accepts arbitrary regex catalogs, including community-curated ones. The example below loads a small set of prompt-injection patterns inspired by Agent Threat Rules (Apache-2.0, https://github.com/Agent-Threat-Rule/agent-threat-rules), an open detection standard for AI agent threats.
+The `rules` parameter accepts arbitrary regex catalogs, including community-curated ones. The example below demonstrates a small set of prompt-injection patterns inspired by Agent Threat Rules. Agent Threat Rules is an open detection standard for AI agent threats, distributed under Apache-2.0 at https://github.com/Agent-Threat-Rule/agent-threat-rules.
 
 ```typescript
 import { RegexFilterProcessor } from '@mastra/core/processors'


### PR DESCRIPTION
Fixes #16391

This PR adds a docs section to the RegexFilterProcessor reference page showing how to load community-curated regex catalogs into the existing processor. Mastra already ships first-party `pii`, `secrets`, and `urls` presets plus the LLM-backed PromptInjectionDetector. This addition documents a cheaper pattern-based first filter pattern using community rules.

The example uses Agent Threat Rules at https://github.com/Agent-Threat-Rule/agent-threat-rules (Apache-2.0, 330 rules) as the source catalog and shows five inline regex patterns for instruction overrides, role hijacks, system-prompt extraction, delimiter injection, and credential exfiltration. No new dependencies, no new processor, just a new docs example using the existing `rules` parameter.

The doc note explicitly recommends combining pattern-based detection with the existing PromptInjectionDetector for defense in depth, so the addition is positioned as complementary to existing Mastra features rather than competing.

The diff is 24 lines in a single file. The repository the example draws from has been adopted in production at Cisco AI Defense and Microsoft agent-governance-toolkit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a short docs example showing how to plug in ready-made regex pattern catalogs to the RegexFilterProcessor so you can quickly block known prompt-injection tricks without writing every rule yourself.

## Summary

Added a new "Using community pattern catalogs" section to the RegexFilterProcessor reference (docs/src/content/en/reference/processors/regex-filter-processor.mdx). The docs explain that the `rules` constructor parameter accepts externally curated regex catalogs and include a TypeScript example that demonstrates loading a small set of rules inspired by the Agent Threat Rules repository (Apache-2.0, ~330 rules). The inline example provides five prompt-injection patterns: instruction overrides, role hijacks, system-prompt extraction, delimiter injection, and credential/tool exfiltration. The text recommends combining pattern-based detection (fast, zero-cost) with the LLM-backed PromptInjectionDetector for defense in depth. No code or dependency changes — documentation-only update (+24/-0 lines in a single file).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16379)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->