### PR TITLE
fix(client-js): tolerate tool-result chunks on resume streams

### DIFF
--- a/.changeset/client-js-tolerate-resume-tool-result.md
+++ b/.changeset/client-js-tolerate-resume-tool-result.md
@@ -1,0 +1,9 @@
+---
+'@mastra/client-js': patch
+---
+
+Tolerate `tool-result` chunks at the start of resume streams (`approve-tool-call`, `decline-tool-call`, `resume-stream`).
+
+Previously, `processChatResponse` and `processChatResponse_vNext` threw `tool_result must be preceded by a tool_call` whenever a `tool-result` chunk arrived without a matching `tool-call` in the same stream. Because `processStreamResponse` always passes `lastMessage: undefined`, resume streams (which legitimately start with a `tool-result` whose matching `tool-call` was emitted in the prior turn) would trip this validation on every HITL approve/decline and pollute logs with `Error processing stream response: tool_result must be preceded by a tool_call` via the outer `.catch`.
+
+The fix synthesizes a result-only invocation when `toolInvocations` is null at the time the chunk arrives. Strict desync detection is preserved: once a `tool-call` has populated the buffer, an unmatched `toolCallId` still throws `tool_result must be preceded by a tool_call with the same toolCallId`.

--- a/client-sdks/client-js/src/resources/agent.test.ts
+++ b/client-sdks/client-js/src/resources/agent.test.ts
@@ -909,3 +909,70 @@ describe('streaming behavior', () => {
     expect(chunks).toHaveLength(1);
   });
 });
+
+describe('processChatResponse_vNext: resume streams', () => {
+  const mockClientOptions = {
+    baseUrl: 'http://localhost:4111',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-key',
+      'x-mastra-client-type': 'js',
+    },
+  };
+
+  function makeStream(chunks: unknown[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+        }
+        controller.close();
+      },
+    });
+  }
+
+  it('should tolerate a tool-result as the first chunk (approve-tool-call / decline-tool-call resume)', async () => {
+    const agent = new TestAgent(mockClientOptions, 'test-agent');
+    const updates: any[] = [];
+    const stream = makeStream([
+      { type: 'tool-result', payload: { toolCallId: 'call_abc', toolName: 'createPlan', result: { ok: true } } },
+      { type: 'finish' },
+    ]);
+
+    await expect(
+      (agent as any).processChatResponse_vNext({
+        stream,
+        update: (update: any) => updates.push(update),
+        lastMessage: undefined,
+      }),
+    ).resolves.toBeUndefined();
+
+    const last = updates[updates.length - 1].message;
+    expect(last.toolInvocations).toEqual([
+      expect.objectContaining({
+        state: 'result',
+        toolCallId: 'call_abc',
+        toolName: 'createPlan',
+        result: { ok: true },
+      }),
+    ]);
+  });
+
+  it('should still throw on mid-stream desync (tool-result without matching tool-call after another tool-call)', async () => {
+    const agent = new TestAgent(mockClientOptions, 'test-agent');
+    const updates: any[] = [];
+    const stream = makeStream([
+      { type: 'tool-call', payload: { toolCallId: 'call_a', toolName: 'fooTool', args: {} } },
+      { type: 'tool-result', payload: { toolCallId: 'call_b', toolName: 'barTool', result: {} } },
+    ]);
+
+    await expect(
+      (agent as any).processChatResponse_vNext({
+        stream,
+        update: (update: any) => updates.push(update),
+        lastMessage: undefined,
+      }),
+    ).rejects.toThrow('tool_result must be preceded by a tool_call with the same toolCallId');
+  });
+});

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -849,27 +849,35 @@ export class Agent extends BaseResource {
         }
       },
       onToolResultPart(value) {
-        const toolInvocations = message.toolInvocations;
-
-        if (toolInvocations == null) {
-          throw new Error('tool_result must be preceded by a tool_call');
+        // Resume streams (approve-tool-call, decline-tool-call, resume-stream)
+        // emit a tool-result whose matching tool-call was sent in a prior
+        // turn and is therefore absent from this stream's in-memory buffer.
+        // Tolerate that case (synthesize a result-only invocation); preserve
+        // strict desync detection once a tool-call has populated the buffer.
+        const noPriorToolCalls = message.toolInvocations == null;
+        if (noPriorToolCalls) {
+          message.toolInvocations = [];
         }
+        const toolInvocations = message.toolInvocations!;
 
         // find if there is any tool invocation with the same toolCallId
         // and replace it with the result
         const toolInvocationIndex = toolInvocations.findIndex(invocation => invocation.toolCallId === value.toolCallId);
 
-        if (toolInvocationIndex === -1) {
+        if (toolInvocationIndex === -1 && !noPriorToolCalls) {
           throw new Error('tool_result must be preceded by a tool_call with the same toolCallId');
         }
 
-        const invocation = {
-          ...toolInvocations[toolInvocationIndex],
-          state: 'result' as const,
-          ...value,
-        } as const;
+        const invocation =
+          toolInvocationIndex === -1
+            ? ({ state: 'result' as const, step, ...value } as const)
+            : ({ ...toolInvocations[toolInvocationIndex], state: 'result' as const, ...value } as const);
 
-        toolInvocations[toolInvocationIndex] = invocation as ToolInvocation;
+        if (toolInvocationIndex === -1) {
+          toolInvocations.push(invocation as ToolInvocation);
+        } else {
+          toolInvocations[toolInvocationIndex] = invocation as ToolInvocation;
+        }
 
         updateToolInvocationPart(value.toolCallId, invocation as ToolInvocation);
 
@@ -1254,11 +1262,17 @@ export class Agent extends BaseResource {
           }
 
           case 'tool-result': {
-            const toolInvocations = message.toolInvocations;
-
-            if (toolInvocations == null) {
-              throw new Error('tool_result must be preceded by a tool_call');
+            // Resume streams (approve-tool-call, decline-tool-call,
+            // resume-stream) emit a tool-result whose matching tool-call was
+            // sent in a prior turn and is therefore absent from this stream's
+            // in-memory buffer. Tolerate that case (synthesize a result-only
+            // invocation); preserve strict desync detection once a tool-call
+            // has populated the buffer.
+            const noPriorToolCalls = message.toolInvocations == null;
+            if (noPriorToolCalls) {
+              message.toolInvocations = [];
             }
+            const toolInvocations = message.toolInvocations!;
 
             // find if there is any tool invocation with the same toolCallId
             // and replace it with the result
@@ -1266,17 +1280,20 @@ export class Agent extends BaseResource {
               invocation => invocation.toolCallId === chunk.payload.toolCallId,
             );
 
-            if (toolInvocationIndex === -1) {
+            if (toolInvocationIndex === -1 && !noPriorToolCalls) {
               throw new Error('tool_result must be preceded by a tool_call with the same toolCallId');
             }
 
-            const invocation = {
-              ...toolInvocations[toolInvocationIndex],
-              state: 'result' as const,
-              ...chunk.payload,
-            } as const;
+            const invocation =
+              toolInvocationIndex === -1
+                ? ({ state: 'result' as const, step, ...chunk.payload } as const)
+                : ({ ...toolInvocations[toolInvocationIndex], state: 'result' as const, ...chunk.payload } as const);
 
-            toolInvocations[toolInvocationIndex] = invocation as ToolInvocation;
+            if (toolInvocationIndex === -1) {
+              toolInvocations.push(invocation as ToolInvocation);
+            } else {
+              toolInvocations[toolInvocationIndex] = invocation as ToolInvocation;
+            }
 
             updateToolInvocationPart(chunk.payload.toolCallId, invocation as ToolInvocation);
 

--- a/client-sdks/client-js/src/resources/agent.vnext.test.ts
+++ b/client-sdks/client-js/src/resources/agent.vnext.test.ts
@@ -196,6 +196,75 @@ describe('Agent vNext', () => {
     expect(executeSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('resumeStream: still runs client tools when the resume cycle starts with a tool-result (post-suspend)', async () => {
+    // Repro of the deeper bug fixed by tolerating tool-result as the first
+    // chunk of a resume stream:
+    //
+    // 1. The suspended tool's result is the first chunk emitted on resume
+    //    (matching tool-call was sent in the prior turn, before the suspend).
+    // 2. The agent then emits a tool-call for a client-side tool.
+    // 3. finishReason is `tool-calls`, which should trigger the recursive
+    //    client-tool execution path in processStreamResponse.
+    //
+    // Pre-fix: the first chunk (tool-result) tripped
+    // `tool_result must be preceded by a tool_call` inside
+    // processChatResponse_vNext, the outer .catch fired, and onFinish never
+    // ran — so the client tool's execute was never called.
+    const suspendedToolCallId = 'call_suspended';
+    const clientToolCallId = 'call_client';
+
+    const resumeCycle = [
+      {
+        type: 'tool-result',
+        payload: { toolCallId: suspendedToolCallId, toolName: 'serverApprovedTool', result: { ok: true } },
+      },
+      { type: 'step-start', payload: { messageId: 'm1' } },
+      {
+        type: 'tool-call',
+        payload: { toolCallId: clientToolCallId, toolName: 'weatherTool', args: { location: 'NYC' } },
+      },
+      { type: 'step-finish', payload: { stepResult: { isContinued: false } } },
+      { type: 'finish', payload: { stepResult: { reason: 'tool-calls' }, usage: { totalTokens: 2 } } },
+    ];
+
+    const recursiveCycle = [
+      { type: 'step-start', payload: { messageId: 'm2' } },
+      { type: 'text-delta', payload: { text: 'Tool handled' } },
+      { type: 'step-finish', payload: { stepResult: { isContinued: false } } },
+      { type: 'finish', payload: { stepResult: { reason: 'stop' }, usage: { totalTokens: 3 } } },
+    ];
+
+    (global.fetch as any)
+      .mockResolvedValueOnce(sseResponse(resumeCycle))
+      .mockResolvedValueOnce(sseResponse(recursiveCycle));
+
+    const executeSpy = vi.fn(async () => ({ temperature: 72, condition: 'sunny' }));
+    const weatherTool = createTool({
+      id: 'weatherTool',
+      description: 'Weather',
+      inputSchema: z.object({ location: z.string() }),
+      outputSchema: z.object({ temperature: z.number(), condition: z.string() }),
+      execute: executeSpy,
+    });
+
+    const resp = await agent.resumeStream({ approved: true }, {
+      runId: 'run-1',
+      messages: [{ role: 'user', content: 'Original prompt before suspension' }],
+      clientTools: { weatherTool },
+    } as any);
+
+    await resp.processDataStream({
+      onChunk: async () => {},
+    });
+
+    // The recursive call only fires if processChatResponse_vNext successfully
+    // observes finishReason=tool-calls — i.e., did NOT throw on the leading
+    // tool-result. Two fetches confirm the recursion happened.
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(executeSpy).toHaveBeenCalledWith({ location: 'NYC' }, expect.anything());
+  });
+
   it('stream: receives chunks from both initial and recursive requests', async () => {
     const toolCallId = 'call_1';
 


### PR DESCRIPTION
## Problem

`processChatResponse` and `processChatResponse_vNext` (in `client-sdks/client-js/src/resources/agent.ts`) throw `Error: tool_result must be preceded by a tool_call` whenever a `tool-result` chunk arrives without a matching `tool-call` in the same stream.

Resume streams &mdash; `resume-stream`, `approve-tool-call`, and `decline-tool-call` &mdash; legitimately violate that invariant: they start with a `tool-result` whose matching `tool-call` was emitted in the prior turn. Combined with `processStreamResponse` always passing `lastMessage: undefined` to `processChatResponse_vNext`, the in-memory `toolInvocations` buffer is always empty when the first chunk arrives, so the validator throws on every resume.

The throw is caught by the outer `.catch` in `processStreamResponse` and only logged via `console.error("Error processing stream response:", error)`. That makes the failure look cosmetic at first glance, but it is not.

### Two distinct impacts

**1. `resumeStream` + `clientTools`: real, observable bug (UX-level).**

When `resumeStream` is called with `clientTools` and the resume cycle emits another `tool-call` for one of those client tools after the suspended tool's result, the throw aborts processing inside `processChatResponse_vNext`. `onFinish` never fires, so the recursive client-tool execution path in `processStreamResponse` never runs &mdash; the client tool's `execute` is silently never called. From the user's perspective, the agent simply stops mid-conversation: the tool that should have run client-side just doesn't.

This is what the new test `resumeStream: still runs client tools when the resume cycle starts with a tool-result (post-suspend)` demonstrates and protects against.

**2. `approveToolCall` / `declineToolCall`: noisy logs.**

These two methods don't expose `clientTools` in their public signatures, so the recursion path never applies. The resume stream still flows through to the consumer via the controller-side branch of the teed body, so users don't see any UX impact &mdash; just `Error processing stream response: tool_result must be preceded by a tool_call` repeated in logs on every HITL approval, masking real errors and making observability harder.

### Repro (minimal)

```ts
// Scenario 1: resumeStream + clientTools (UX-level bug)
const weatherTool = createTool({
  id: 'weatherTool',
  description: 'Weather',
  inputSchema: z.object({ location: z.string() }),
  execute: async args => ({ ok: true }),
});

const resp = await agent.resumeStream(
  { approved: true },
  { runId, messages: [...], clientTools: { weatherTool } },
);
await resp.processDataStream({ onChunk: () => {} });

// Pre-fix: weatherTool.execute is NEVER called when the resume cycle
// starts with a tool-result and later emits a tool-call for weatherTool.
// The throw aborts processChatResponse_vNext, onFinish never fires,
// recursion never triggers.
```

```ts
// Scenario 2: approveToolCall (log noise)
const stream2 = await agent.approveToolCall({ runId, toolCallId, requestContext });
await stream2.processDataStream({ onChunk: () => {} });
// Pre-fix: server-side console.error fires for every approval.
// User-side stream content is unaffected.
```

Verified the bug exists on every published version from `1.13.4` through `1.18.0-alpha.8` and the most recent tip-of-main snapshot at the time of writing.

## Fix

When `toolInvocations` is null at the time the `tool-result` chunk arrives, initialize it to `[]` and build a result-only invocation directly from the chunk payload. This is the legitimate resume-stream path.

Strict mid-stream desync detection is preserved: once any `tool-call` has populated the buffer, an unmatched `toolCallId` still throws `tool_result must be preceded by a tool_call with the same toolCallId`. Only the first-chunk-of-resume case is relaxed.

The same change is applied in both `processChatResponse` (legacy `onToolResultPart`) and `processChatResponse_vNext` (`case 'tool-result'`), since `processStreamResponse` and `processStreamResponseLegacy` both feed the resume-stream pattern.

## Tests

Three new tests:

1. **`agent.test.ts`** &mdash; `should tolerate a tool-result as the first chunk (approve-tool-call / decline-tool-call resume)`: verifies the validator no longer throws on a leading `tool-result` and produces a result-only invocation.
2. **`agent.test.ts`** &mdash; `should still throw on mid-stream desync (tool-result without matching tool-call after another tool-call)`: verifies the strict desync check still fires once the buffer has been populated.
3. **`agent.vnext.test.ts`** &mdash; `resumeStream: still runs client tools when the resume cycle starts with a tool-result (post-suspend)`: end-to-end repro of scenario 1 above. Asserts that `executeSpy` is called and the recursive fetch fires &mdash; both of which are unreachable on the unfixed SDK because `onFinish` never runs.

Local run on `client-sdks/client-js`: 419 passing tests (3 new). The 2 unrelated failing tests (`agent.test.ts > Agent.stream > should handle vNext step-finish...`, `agent.vnext.test.ts > Agent vNext > resumeStream: omits local seed messages...`) were already failing on `main` before this change &mdash; verified by stashing this PR's changes and re-running.

## Changeset

Patch bump for `@mastra/client-js`. See `.changeset/client-js-tolerate-resume-tool-result.md`.

## Notes

- No public API change; observable as: (a) `resumeStream` + `clientTools` + post-suspend client tool calls now actually run; (b) absence of the spurious server-side log line on `approveToolCall` / `declineToolCall` consumers.
- The fix is fully backward-compatible: streams that currently work continue to work identically. The relaxation kicks in only when `toolInvocations` was previously null at the moment the `tool-result` arrives, which is precisely the resume-stream scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When resuming an interrupted conversation, the client sometimes saw harmless server-side errors because a tool result arrived that referenced a tool-call from the previous turn. This PR stops those noisy errors by accepting a result-only chunk when resuming, so resume flows proceed cleanly.

## Summary

This PR fixes client-js handling of tool-result chunks at the start of resume streams (approve-tool-call, decline-tool-call, resume-stream). Previously, processChatResponse and processChatResponse_vNext threw "tool_result must be preceded by a tool_call" when a tool-result arrived without a matching tool-call in the same stream (the matching call was emitted in a prior turn). Because processStreamResponse passes lastMessage: undefined for resume streams, the in-memory toolInvocations buffer could be empty and the validator errored; the error was caught and logged, producing noisy server-side logs despite correct client behavior.

Fix: when a tool-result chunk arrives and toolInvocations is null, initialize toolInvocations = [] and synthesize a result-only ToolInvocation from the chunk payload. Preserve strict mid-stream desync detection: if the buffer was already populated by a prior tool-call, an unmatched toolCallId still throws. Applied fixes in both processChatResponse (legacy onToolResultPart) and processChatResponse_vNext (case 'tool-result').

### Changes

- client-sdks/client-js/src/resources/agent.ts (+39/-22)
  - Tolerate result-only streams by initializing toolInvocations when null and synthesizing result-only invocations.
  - Retain existing validation when a tool-call buffer is present (unmatched toolCallId still errors).

- client-sdks/client-js/src/resources/agent.test.ts (+67)
  - Added makeStream helper for SSE-like test streams.
  - Test A: first-chunk tool-result (resume scenario) is tolerated and creates a result-state ToolInvocation.
  - Test B: tool-call for call_a followed by tool-result for call_b still throws.

- client-sdks/client-js/src/resources/agent.vnext.test.ts (+69)
  - Added resumeStream test ensuring a resume cycle that starts with a tool-result still triggers the recursive stream and executes the client tool exactly once.

- .changeset/client-js-tolerate-resume-tool-result.md
  - Patch changeset for @mastra/client-js.

### Tests & impact
- Local client-js tests: +2 tests (417 → 419 passing in the reported run). Three unrelated failures in agent.vnext.test.ts existed on main prior to this change.
- No public API changes. Backward-compatible: only relaxes validation when toolInvocations is null (resume-stream case).
- Removes server-side log noise for resume-stream consumers and fixes a case that could block client tool execution in recursive resume cycles.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16385)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->