### PR TITLE
Scope Langfuse traces to agent or workflow that started them

### DIFF
--- a/.changeset/langfuse-scope-trace-per-agent.md
+++ b/.changeset/langfuse-scope-trace-per-agent.md
@@ -2,23 +2,4 @@
 '@mastra/langfuse': patch
 ---
 
-**Scope Langfuse traces to the agent or workflow that started them**
-
-The Langfuse exporter now sets trace-level identity on every root span so Langfuse evaluators (such as LLM-as-a-Judge with a trace name or metadata filter) match only the agent or workflow you target, instead of every invocation across all agents.
-
-For each trace whose root span is an `AGENT_RUN`:
-
-- `langfuse.trace.name` defaults to the agent name (or id, when no name is set)
-- `langfuse.trace.metadata.agentId` is set to the agent id
-- `langfuse.trace.metadata.agentName` is set to the agent name
-
-The same applies to `WORKFLOW_RUN` root spans, which set `langfuse.trace.metadata.workflowId` and `langfuse.trace.metadata.workflowName`.
-
-A custom `traceName` set via `mastra.metadata.traceName` still takes precedence over the agent default.
-
-In Langfuse, scope an evaluator to a specific agent by filtering on:
-
-- **Trace name** equals the agent name (for example, `weather-agent`)
-- **Metadata** `agentId` equals the agent id
-
-Resolves [#15263](https://github.com/mastra-ai/mastra/issues/15263).
+Scope Langfuse traces to the agent or workflow that started them. See [Scoping evaluators per agent](https://mastra.ai/docs/observability/tracing/exporters/langfuse#scoping-evaluators-per-agent) for more info.

--- a/.changeset/langfuse-scope-trace-per-agent.md
+++ b/.changeset/langfuse-scope-trace-per-agent.md
@@ -1,0 +1,24 @@
+---
+'@mastra/langfuse': patch
+---
+
+**Scope Langfuse traces to the agent or workflow that started them**
+
+The Langfuse exporter now sets trace-level identity on every root span so Langfuse evaluators (such as LLM-as-a-Judge with a trace name or metadata filter) match only the agent or workflow you target, instead of every invocation across all agents.
+
+For each trace whose root span is an `AGENT_RUN`:
+
+- `langfuse.trace.name` defaults to the agent name (or id, when no name is set)
+- `langfuse.trace.metadata.agentId` is set to the agent id
+- `langfuse.trace.metadata.agentName` is set to the agent name
+
+The same applies to `WORKFLOW_RUN` root spans, which set `langfuse.trace.metadata.workflowId` and `langfuse.trace.metadata.workflowName`.
+
+A custom `traceName` set via `mastra.metadata.traceName` still takes precedence over the agent default.
+
+In Langfuse, scope an evaluator to a specific agent by filtering on:
+
+- **Trace name** equals the agent name (for example, `weather-agent`)
+- **Metadata** `agentId` equals the agent id
+
+Resolves [#15263](https://github.com/mastra-ai/mastra/issues/15263).

--- a/docs/src/content/en/docs/observability/tracing/exporters/langfuse.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/langfuse.mdx
@@ -160,6 +160,27 @@ new LangfuseExporter({
 })
 ```
 
+## Scoping evaluators per agent
+
+Langfuse evaluators (such as LLM-as-a-Judge) can be filtered to run only against specific traces. The Mastra Langfuse exporter automatically scopes each trace to the agent or workflow that started it, so trace-level filters resolve to the right runs.
+
+For every trace whose root span is an `AGENT_RUN`, the exporter sets:
+
+- `langfuse.trace.name`: the agent name (or id, when no name is set)
+- `langfuse.trace.metadata.agentId`: the agent id
+- `langfuse.trace.metadata.agentName`: the agent name
+
+The same applies to `WORKFLOW_RUN` root spans, which set `langfuse.trace.metadata.workflowId` and `langfuse.trace.metadata.workflowName`.
+
+To scope an evaluator to a specific agent, configure either filter in Langfuse:
+
+- **Trace name**: equals the agent name (for example, `weather-agent`).
+- **Metadata**: `agentId` equals the agent id.
+
+The trace name dropdown in Langfuse evaluator filters lists every distinct value seen, so each agent appears as its own entry once it has produced at least one trace.
+
+If you set a custom `traceName` via `mastra.metadata.traceName`, your value takes precedence over the default agent name.
+
 ## Prompt linking
 
 You can link LLM generations to prompts stored in [Langfuse Prompt Management](https://langfuse.com/docs/prompt-management). This enables version tracking and metrics for your prompts.

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -419,6 +419,97 @@ describe('LangfuseExporter', () => {
       expect(attrs['langfuse.observation.metadata.operationName']).toBeUndefined();
     });
 
+    it('scopes trace name and metadata to the agent on root AGENT_RUN spans', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          entityId: 'weather-agent',
+          entityName: 'Weather Agent',
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.name']).toBe('Weather Agent');
+      expect(attrs['langfuse.trace.metadata.agentId']).toBe('weather-agent');
+      expect(attrs['langfuse.trace.metadata.agentName']).toBe('Weather Agent');
+    });
+
+    it('falls back to entityId for trace name when entityName is missing', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          entityId: 'weather-agent',
+          entityName: undefined,
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.name']).toBe('weather-agent');
+      expect(attrs['langfuse.trace.metadata.agentId']).toBe('weather-agent');
+      expect(attrs['langfuse.trace.metadata.agentName']).toBeUndefined();
+    });
+
+    it('preserves user-provided traceName over the agent default', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: true,
+          entityId: 'weather-agent',
+          entityName: 'Weather Agent',
+          metadata: { traceName: 'custom-trace-name' },
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.name']).toBe('custom-trace-name');
+      expect(attrs['langfuse.trace.metadata.agentId']).toBe('weather-agent');
+      expect(attrs['langfuse.trace.metadata.agentName']).toBe('Weather Agent');
+    });
+
+    it('does not set trace identity on non-root agent spans', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.AGENT_RUN,
+          isRootSpan: false,
+          entityId: 'weather-agent',
+          entityName: 'Weather Agent',
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.name']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.agentId']).toBeUndefined();
+      expect(attrs['langfuse.trace.metadata.agentName']).toBeUndefined();
+    });
+
+    it('scopes trace name and metadata to the workflow on root WORKFLOW_RUN spans', async () => {
+      exporter = new LangfuseExporter({ publicKey: 'pk-test', secretKey: 'sk-test' });
+      await exportSpan(
+        exporter,
+        makeSpan({
+          type: SpanType.WORKFLOW_RUN,
+          isRootSpan: true,
+          entityId: 'order-workflow',
+          entityName: 'Order Workflow',
+        } as any),
+      );
+
+      const attrs = processedSpans[0].attributes;
+      expect(attrs['langfuse.trace.name']).toBe('Order Workflow');
+      expect(attrs['langfuse.trace.metadata.workflowId']).toBe('order-workflow');
+      expect(attrs['langfuse.trace.metadata.workflowName']).toBe('Order Workflow');
+    });
+
     it('sets langfuse.environment and langfuse.release on spans', async () => {
       exporter = new LangfuseExporter({
         publicKey: 'pk-test',

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -10,7 +10,7 @@
 import { LangfuseClient } from '@langfuse/client';
 import { LangfuseSpanProcessor } from '@langfuse/otel';
 import type { TracingEvent, AnyExportedSpan, InitExporterOptions, ScoreEvent } from '@mastra/core/observability';
-import { TracingEventType } from '@mastra/core/observability';
+import { SpanType, TracingEventType } from '@mastra/core/observability';
 import { BaseExporter } from '@mastra/observability';
 import type { BaseExporterConfig } from '@mastra/observability';
 import { SpanConverter } from '@mastra/otel-exporter';
@@ -129,7 +129,7 @@ export class LangfuseExporter extends BaseExporter {
       // endpoint reads them correctly. SpanConverter produces mastra.* attributes,
       // but Langfuse only reads langfuse.* attributes for prompt linking, TTFT, etc.
       // @see https://langfuse.com/integrations/native/opentelemetry#property-mapping
-      mapMastraToLangfuseAttributes(otelSpan.attributes, this.#environment, this.#release);
+      mapMastraToLangfuseAttributes(otelSpan.attributes, span, this.#environment, this.#release);
 
       this.#processor!.onEnd(otelSpan);
     } catch (error) {
@@ -246,7 +246,12 @@ export class LangfuseExporter extends BaseExporter {
  * This function mutates the attributes object in place.
  * @see https://langfuse.com/integrations/native/opentelemetry#property-mapping
  */
-function mapMastraToLangfuseAttributes(attributes: Record<string, any>, environment?: string, release?: string): void {
+function mapMastraToLangfuseAttributes(
+  attributes: Record<string, any>,
+  span: AnyExportedSpan,
+  environment?: string,
+  release?: string,
+): void {
   // Environment and release: set directly since onStart() is not called
   if (environment) {
     attributes['langfuse.environment'] = environment;
@@ -310,6 +315,36 @@ function mapMastraToLangfuseAttributes(attributes: Record<string, any>, environm
   if (attributes['mastra.metadata.version']) {
     attributes['langfuse.trace.version'] = attributes['mastra.metadata.version'];
     delete attributes['mastra.metadata.version'];
+  }
+
+  // Root-span trace identity: scope each Langfuse trace to the entity that
+  // started it (agent or workflow). This makes the Langfuse trace name match
+  // the agent/workflow id and exposes the same identity as trace metadata, so
+  // users can scope Langfuse evaluators per agent via trace name or metadata
+  // filters. User-provided traceName (set via mastra.metadata.traceName) takes
+  // precedence and is preserved.
+  if (span.isRootSpan) {
+    if (span.type === SpanType.AGENT_RUN) {
+      if (!attributes['langfuse.trace.name'] && (span.entityName || span.entityId)) {
+        attributes['langfuse.trace.name'] = span.entityName ?? span.entityId;
+      }
+      if (span.entityId) {
+        attributes['langfuse.trace.metadata.agentId'] = span.entityId;
+      }
+      if (span.entityName) {
+        attributes['langfuse.trace.metadata.agentName'] = span.entityName;
+      }
+    } else if (span.type === SpanType.WORKFLOW_RUN) {
+      if (!attributes['langfuse.trace.name'] && (span.entityName || span.entityId)) {
+        attributes['langfuse.trace.name'] = span.entityName ?? span.entityId;
+      }
+      if (span.entityId) {
+        attributes['langfuse.trace.metadata.workflowId'] = span.entityId;
+      }
+      if (span.entityName) {
+        attributes['langfuse.trace.metadata.workflowName'] = span.entityName;
+      }
+    }
   }
 
   // Observation metadata: map semantic attributes to langfuse.observation.metadata.*


### PR DESCRIPTION
## Description

The Langfuse exporter now automatically sets trace-level identity on root spans so that Langfuse evaluators can be scoped to specific agents or workflows. This enables users to filter evaluators (such as LLM-as-a-Judge) to run only against traces from a particular agent or workflow.

For each trace whose root span is an `AGENT_RUN`:
- `langfuse.trace.name` defaults to the agent name (or id if name is not set)
- `langfuse.trace.metadata.agentId` is set to the agent id
- `langfuse.trace.metadata.agentName` is set to the agent name

The same applies to `WORKFLOW_RUN` root spans, which set `langfuse.trace.metadata.workflowId` and `langfuse.trace.metadata.workflowName`.

A custom `traceName` set via `mastra.metadata.traceName` takes precedence over the agent/workflow default.

## Related Issue(s)

Fixes #15263

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test update

## Changes Made

- Modified `mapMastraToLangfuseAttributes()` to accept the span object and set trace identity attributes for root `AGENT_RUN` and `WORKFLOW_RUN` spans
- Added 5 comprehensive test cases covering:
  - Agent trace identity on root AGENT_RUN spans
  - Fallback to entityId when entityName is missing
  - User-provided traceName taking precedence
  - Non-root agent spans not setting trace identity
  - Workflow trace identity on root WORKFLOW_RUN spans
- Updated documentation with a new "Scoping evaluators per agent" section explaining the feature and how to use it in Langfuse
- Added changeset entry documenting the feature

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works
- [x] Tests cover the main scenarios: root vs non-root spans, agent vs workflow types, and custom traceName precedence

https://claude.ai/code/session_01GE4M5dyc5JTgg8SZonSp86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When Mastra sends traces to Langfuse, this PR labels each trace with the agent or workflow that started it so Langfuse evaluators can run only on traces from that specific agent/workflow (instead of on all traces). A custom traceName still wins if you set one.

## Overview

Adds trace-level identity for root spans so Langfuse evaluator filters can be scoped to the agent or workflow that started the trace. The Langfuse exporter maps Mastra span attributes into the langfuse.* namespace and, for root AGENT_RUN and WORKFLOW_RUN spans, sets a trace name and metadata keys (agentId/agentName or workflowId/workflowName). A user-provided mastra.metadata.traceName (mapped to langfuse.trace.name) takes precedence. Non-root spans are unchanged.

## Changes

### Documentation
- Added "Scoping evaluators per agent" to docs explaining:
  - For AGENT_RUN root spans: langfuse.trace.name defaults to agent name (or id if name missing), and langfuse.trace.metadata.agentId/agentName are set.
  - For WORKFLOW_RUN root spans: analogous workflowId/workflowName metadata are set.
  - mastra.metadata.traceName overrides the default trace name.
- Added a changeset entry noting the behavior change for @mastra/langfuse.

### Implementation
- observability/langfuse/src/tracing.ts:
  - mapMastraToLangfuseAttributes(attributes, span, environment, release) now accepts the span and, when span.isRootSpan and span.type is AGENT_RUN or WORKFLOW_RUN, sets:
    - langfuse.trace.name = span.entityName ?? span.entityId (only if no user-provided trace name exists)
    - langfuse.trace.metadata.agentId / agentName or workflowId / workflowName accordingly
  - Preserves existing mappings (environment/release, prompt linking, TTFT, user/session/tags/version, observation metadata, input/output).
  - Export path passes the exported span into the mapper.

### Tests
- Added tests (observability/langfuse/src/tracing.test.ts) covering:
  - Root AGENT_RUN sets trace name and agent metadata.
  - Fallback to entityId when entityName is missing.
  - User-provided traceName takes precedence.
  - Non-root AGENT_RUN does not set trace identity.
  - Root WORKFLOW_RUN sets workflow trace name and metadata.
- Existing tests also verify other attribute mappings (prompt linking, TTFT, user/session, tags, trace.version, observation metadata).

### Changelog
- New changeset: '@mastra/langfuse': patch — "Scope Langfuse traces to the agent or workflow that started them."

## Related Issue
Fixes issue #15263 — enables scoping Langfuse evaluators to traces from specific agents or workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16393)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->