### PR TITLE
fix(braintrust): allow custom current span resolver

### DIFF
--- a/.changeset/humble-windows-stop.md
+++ b/.changeset/humble-windows-stop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/braintrust': minor
+---
+
+Added a Braintrust current span resolver option so eval traces can nest correctly when applications and Mastra resolve different Braintrust package instances.

--- a/.changeset/humble-windows-stop.md
+++ b/.changeset/humble-windows-stop.md
@@ -2,4 +2,4 @@
 '@mastra/braintrust': minor
 ---
 
-Added a Braintrust current span resolver option so eval traces can nest correctly when applications and Mastra resolve different Braintrust package instances.
+Added a Braintrust current span resolver option so eval traces can nest correctly when applications and Mastra resolve different installed Braintrust SDK copies.

--- a/docs/src/content/en/docs/observability/tracing/exporters/braintrust.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/braintrust.mdx
@@ -93,6 +93,43 @@ new BraintrustExporter({
 })
 ```
 
+## Attach traces to Braintrust evals
+
+When you run Mastra inside Braintrust `Eval()` or `logger.traced()`, pass the Braintrust logger and `currentSpan` resolver to the exporter. Import `currentSpan` from the same `braintrust` package instance that creates the eval or traced span.
+
+This helps Mastra attach its spans under the active Braintrust span when your app and `@mastra/braintrust` resolve different installed copies of the Braintrust SDK.
+
+```typescript title="src/mastra/index.ts"
+import { currentSpan, initLogger } from 'braintrust'
+import { BraintrustExporter } from '@mastra/braintrust'
+
+const logger = initLogger({
+  projectName: 'my-project',
+  apiKey: process.env.BRAINTRUST_API_KEY,
+})
+
+const exporter = new BraintrustExporter({
+  braintrustLogger: logger,
+  currentSpan,
+})
+```
+
+Use the configured Mastra instance inside the Braintrust eval task. The `currentSpan` resolver above reads the active span created by `Eval()`.
+
+```typescript title="src/evals/braintrust.ts"
+import { Eval } from 'braintrust'
+import { mastra } from '../mastra'
+
+await Eval('my-project', {
+  data: () => [{ input: 'Say hello', expected: 'Hello' }],
+  task: async input => {
+    const agent = mastra.getAgent('assistant')
+    return (await agent.generate(input)).text
+  },
+  scores: [],
+})
+```
+
 ## Querying Braintrust with returned `spanId`
 
 For Braintrust, use `spanId` as the root span identifier when searching for traces because Braintrust root-span queries are typically faster than trace-id queries.

--- a/docs/src/content/en/reference/observability/tracing/exporters/braintrust.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/braintrust.mdx
@@ -24,6 +24,8 @@ interface BraintrustExporterConfig extends BaseExporterConfig {
   apiKey?: string
   endpoint?: string
   projectName?: string
+  braintrustLogger?: Logger<true>
+  currentSpan?: () => Span | undefined
   tuningParameters?: Record<string, any>
 }
 ```
@@ -51,6 +53,19 @@ Extends `BaseExporterConfig`, which includes:
     name: 'projectName',
     type: 'string',
     description: "Project name (default: 'mastra-tracing')",
+    required: false,
+  },
+  {
+    name: 'braintrustLogger',
+    type: 'Logger<true>',
+    description: 'Braintrust logger instance for eval and traced span context integration.',
+    required: false,
+  },
+  {
+    name: 'currentSpan',
+    type: '() => Span | undefined',
+    description:
+      'Resolver from the app Braintrust package instance. Use this with braintrustLogger when Eval() or logger.traced() spans are created by a different installed Braintrust SDK copy.',
     required: false,
   },
   {

--- a/observability/braintrust/README.md
+++ b/observability/braintrust/README.md
@@ -66,13 +66,14 @@ const mastra = new Mastra({
 
 ### Configuration Options
 
-| Option             | Type                 | Description                                                    |
-| ------------------ | -------------------- | -------------------------------------------------------------- |
-| `apiKey`           | `string`             | Braintrust API key. Defaults to `BRAINTRUST_API_KEY` env var   |
-| `endpoint`         | `string`             | Custom endpoint URL. Defaults to `BRAINTRUST_ENDPOINT` env var |
-| `projectName`      | `string`             | Project name. Defaults to `'mastra-tracing'`                   |
-| `braintrustLogger` | `Logger<true>`       | Optional Braintrust logger instance for context integration    |
-| `tuningParameters` | `Record<string,any>` | Support tuning parameters                                      |
+| Option             | Type                      | Description                                                    |
+| ------------------ | ------------------------- | -------------------------------------------------------------- |
+| `apiKey`           | `string`                  | Braintrust API key. Defaults to `BRAINTRUST_API_KEY` env var   |
+| `endpoint`         | `string`                  | Custom endpoint URL. Defaults to `BRAINTRUST_ENDPOINT` env var |
+| `projectName`      | `string`                  | Project name. Defaults to `'mastra-tracing'`                   |
+| `braintrustLogger` | `Logger<true>`            | Optional Braintrust logger instance for context integration    |
+| `currentSpan`      | `() => Span \| undefined` | Optional resolver from the app's Braintrust package instance   |
+| `tuningParameters` | `Record<string,any>`      | Support tuning parameters                                      |
 
 ## Features
 
@@ -84,3 +85,22 @@ const mastra = new Mastra({
 - **Hierarchical traces**: Maintains parent-child relationships
 - **Event span support**: Zero-duration spans for event-type traces
 - **Context integration**: Attach to existing Braintrust spans from `logger.traced()` or `Eval()`
+
+### Braintrust eval context
+
+When using Braintrust `Eval()` or `logger.traced()`, pass the `currentSpan` function from the same `braintrust` import that creates the eval or traced span. This lets Mastra attach traces to the active Braintrust span even when the app and `@mastra/braintrust` resolve different installed copies of the Braintrust SDK.
+
+```typescript
+import { currentSpan, initLogger } from 'braintrust';
+import { BraintrustExporter } from '@mastra/braintrust';
+
+const logger = initLogger({
+  projectName: 'my-project',
+  apiKey: process.env.BRAINTRUST_API_KEY,
+});
+
+const exporter = new BraintrustExporter({
+  braintrustLogger: logger,
+  currentSpan,
+});
+```

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -2383,6 +2383,44 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
     expect(traceData.getRoot()).toBe(mockExternalSpan);
   });
 
+  it('should use configured currentSpan resolver before the package currentSpan fallback', async () => {
+    const { currentSpan: realCurrentSpan } = await import('braintrust');
+    const mockedCurrentSpan = vi.mocked(realCurrentSpan);
+
+    mockExternalSpan.startSpan.mockReturnValue(mockExternalSpan);
+    mockedCurrentSpan.mockReturnValue(undefined as any);
+
+    const config: BraintrustExporterConfig = {
+      braintrustLogger: mockLogger as Logger<true>,
+      currentSpan: vi.fn(() => mockExternalSpan as any),
+    };
+    const exporter = new TestBraintrustExporter(config);
+    const rootSpan = createMockSpan({
+      id: 'configured-current-span-root',
+      name: 'configured-current-span-agent',
+      type: SpanType.AGENT_RUN,
+      isRoot: true,
+      attributes: { agentId: 'test-agent' },
+    });
+
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: rootSpan,
+    });
+
+    expect(config.currentSpan).toHaveBeenCalled();
+    expect(mockedCurrentSpan).not.toHaveBeenCalled();
+    expect(mockExternalSpan.startSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spanId: 'configured-current-span-root',
+        name: 'configured-current-span-agent',
+      }),
+    );
+
+    const traceData = exporter._getTraceData(rootSpan.traceId);
+    expect(traceData.getRoot()).toBe(mockExternalSpan);
+  });
+
   it('should nest child spans correctly with external parent', async () => {
     // Mock currentSpan to return an external span
     const { currentSpan: realCurrentSpan } = await import('braintrust');

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -39,6 +39,15 @@ export interface BraintrustExporterConfig extends TrackingExporterConfig {
    */
   braintrustLogger?: Logger<true>;
 
+  /**
+   * Optional resolver for the active Braintrust span.
+   *
+   * Pass Braintrust's `currentSpan` from the same package instance that creates
+   * `Eval()` or `logger.traced()` spans when your app and Mastra may resolve
+   * different copies of the `braintrust` package.
+   */
+  currentSpan?: () => Span | undefined;
+
   /** Braintrust API key. Required if logger is not provided. */
   apiKey?: string;
   /** Optional custom endpoint */
@@ -210,7 +219,13 @@ export class BraintrustExporter extends TrackingExporter<
       // Try to find a Braintrust span to attach to:
       // 1. Auto-detect from Braintrust's current span (logger.traced(), Eval(), etc.)
       // 2. Fall back to the configured logger
-      const externalSpan = currentSpan();
+      let externalSpan: Span | undefined;
+      try {
+        externalSpan = this.config.currentSpan?.();
+      } catch (err) {
+        this.logger.error('Braintrust exporter: Failed to resolve configured currentSpan', { error: err });
+      }
+      externalSpan ??= currentSpan();
 
       // Check if it's a valid span (not the NOOP_SPAN)
       if (externalSpan && externalSpan.id) {


### PR DESCRIPTION
## Description

Braintrust experiments can miss Mastra spans under the eval row when the app and `@mastra/braintrust` resolve different physical copies of the `braintrust` package. In that case `braintrustLogger` is provided, but Mastra's package-local `currentSpan()` cannot see the eval task span, so Mastra spans are written to Braintrust project logs instead of the experiment object.

**Fix:** allow `BraintrustExporter` to receive the app's Braintrust `currentSpan` resolver and prefer it before falling back to the exporter package's resolver.

### What changed

- Added an optional `currentSpan` resolver to `BraintrustExporterConfig`.
- Updated root span attachment to use `config.currentSpan?.() ?? currentSpan()` so apps can pass the resolver from the same `braintrust` import that creates `Eval()` / `logger.traced()` spans.
- Added unit coverage proving the configured resolver wins over the package-local fallback.
- Verified end-to-end against real Braintrust credentials: without `currentSpan`, Mastra spans landed in `project_logs`; with `currentSpan`, the experiment stored `eval task -> Mastra root -> Mastra child`.

## Related Issue(s)

Fixes #11097

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5 Explanation

If your app and Mastra use different copies of the Braintrust library, Mastra couldn't see the app's active eval span and wrote traces to the wrong place; this change lets the app give Mastra a small function that returns the active eval span so Mastra's traces attach to the right eval.

Summary

Fixes a tracing bug where Mastra spans (LLM/tool calls) could be written to project_logs instead of appearing as children of a Braintrust Eval span when the application and Mastra resolved different physical copies of the braintrust package. The Braintrust exporter now accepts an optional resolver from the application that returns the active Braintrust span so Mastra traces nest correctly under the Eval parent.

Changes

- API
  - observability/braintrust/src/tracing.ts
    - Added optional property to BraintrustExporterConfig: currentSpan?: () => Span | undefined
    - Docs also expose braintrustLogger?: Logger<true> where applicable.
- Tracing behavior
  - _buildRoot now attempts config.currentSpan?.() inside a try/catch and prefers its result before falling back to the exporter's imported currentSpan() or existing logger behavior; if no span is found, behavior is unchanged.
- Tests
  - Added unit test (observability/braintrust/src/tracing.test.ts) asserting the configured resolver is called, the package-local currentSpan is not invoked when the resolver is supplied, and the trace root attaches to the provided span.
- Documentation & Release
  - Docs updated with examples and guidance (docs/.../braintrust.mdx, observability/braintrust/README.md) showing how to pass braintrustLogger and the currentSpan resolver from the same braintrust import used for Eval()/logger.traced().
  - Added changeset (.changeset/humble-windows-stop.md) marking a minor release for @mastra/braintrust.

Fixes #11097

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16396)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16396)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->