### PR TITLE
fix(playground): remove global focus-visible outline override

### DIFF
--- a/packages/playground/src/index.css
+++ b/packages/playground/src/index.css
@@ -33,15 +33,6 @@
     scrollbar-color: var(--color-thumb) var(--color-track);
     scrollbar-width: thin;
   }
-  *:focus,
-  *:focus-visible {
-    outline: 2px solid transparent;
-    outline-offset: 2px;
-  }
-  *:focus-visible {
-    outline-style: solid;
-    outline-color: var(--accent1);
-  }
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

- Removed the global `*:focus` / `*:focus-visible` outline rule in `packages/playground/src/index.css`.
- That universal selector applied a 2px `--accent1` outline to every focusable element, overriding per-component focus styles in `playground-ui` (e.g. `Button`'s `sharedFormElementFocusStyle`) and produced a persistent outline on buttons after click.
- Components already own their focus rings, so the global override is no longer needed.

## Test plan

- [ ] `pnpm dev:playground` — click various buttons (default / primary / ghost / icon) and verify no persistent outline after click.
- [ ] Tab through buttons, inputs, selects, comboboxes — verify keyboard focus ring still renders via each component's own `focus-visible` styles.
- [ ] Verify dialogs, dropdown menus, and popovers still show focus on their interactive elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
The playground had a blanket CSS rule that was putting outlines around everything you click on. This was getting in the way of the custom outlines that individual buttons and other components were supposed to have. The fix removes this global rule so each component's own focus styling works as intended.

## Changes
Removed the global `*:focus` and `*:focus-visible` outline styling rules from `packages/playground/src/index.css`. This eliminates an unnecessary CSS override that was interfering with component-specific focus styles defined in playground-ui components (such as Button's `sharedFormElementFocusStyle`), which was causing persistent outlines to appear on buttons after clicking.

## Test Plan
- Run `pnpm dev:playground` and click various buttons (default, primary, ghost, icon) to verify no persistent outline remains after click
- Tab through buttons, inputs, selects, and comboboxes to verify keyboard focus rings still display correctly via each component's `focus-visible` styles
- Verify that dialogs, dropdown menus, and popovers still show proper focus indicators on their interactive elements

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16404)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->