### PR TITLE
feat(playground-ui): polish Combobox items and add primitive escape hatch

### DIFF
--- a/.changeset/giant-clocks-read.md
+++ b/.changeset/giant-clocks-read.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved Combobox dropdown items: selection check moved to the right so unselected items align consistently, tighter spacing for a calmer command-palette feel, and a new `ComboboxPrimitive` escape-hatch export for advanced compositions (virtualization, async status, chips, creatable items).

--- a/.changeset/giant-clocks-read.md
+++ b/.changeset/giant-clocks-read.md
@@ -2,4 +2,32 @@
 '@mastra/playground-ui': patch
 ---
 
-Improved Combobox dropdown items: selection check moved to the right so unselected items align consistently, tighter spacing for a calmer command-palette feel, and a new `ComboboxPrimitive` escape-hatch export for advanced compositions (virtualization, async status, chips, creatable items).
+**Polished Combobox dropdown items**
+
+- Moved the selection check to the right of each item so unselected rows no longer carry an awkward left padding gap and the whole list aligns consistently.
+- Tightened popup search/empty padding and softened the trigger hover for a calmer command-palette feel.
+
+**Added `ComboboxPrimitive` export for advanced compositions**
+
+Re-exports the raw `@base-ui/react/combobox` parts (Root, Trigger, Input, List, Item, Chips, etc.) so callers needing virtualization, async status, chips, or creatable patterns can compose them directly with the shared `comboboxStyles` tokens — without growing the monolithic `<Combobox>` prop surface.
+
+```tsx
+import { ComboboxPrimitive, comboboxStyles } from '@mastra/playground-ui';
+
+<ComboboxPrimitive.Root items={items}>
+  <ComboboxPrimitive.Input className={comboboxStyles.searchInput} />
+  <ComboboxPrimitive.Portal>
+    <ComboboxPrimitive.Positioner>
+      <ComboboxPrimitive.Popup className={comboboxStyles.popup}>
+        <ComboboxPrimitive.List className={comboboxStyles.list}>
+          {(item) => (
+            <ComboboxPrimitive.Item value={item} className={comboboxStyles.item}>
+              {item.label}
+            </ComboboxPrimitive.Item>
+          )}
+        </ComboboxPrimitive.List>
+      </ComboboxPrimitive.Popup>
+    </ComboboxPrimitive.Positioner>
+  </ComboboxPrimitive.Portal>
+</ComboboxPrimitive.Root>
+```

--- a/packages/playground-ui/src/ds/components/Combobox/combobox-styles.ts
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox-styles.ts
@@ -10,7 +10,7 @@ export const comboboxStyles = {
     'inline-flex w-full min-w-32 select-none items-center justify-between gap-1.5 whitespace-nowrap',
     'rounded-lg border border-border1 bg-transparent px-2.5 text-ui-smd leading-ui-sm text-neutral4',
     'outline-none transition-colors duration-normal ease-out-custom',
-    'hover:bg-surface3 hover:text-neutral6 hover:border-border2 active:bg-surface4',
+    'hover:bg-surface2 hover:text-neutral6 hover:border-border2 active:bg-surface3',
     'focus:outline-none focus-visible:outline-none focus-visible:border-border2',
     'data-[popup-open]:bg-surface3 data-[popup-open]:text-neutral6 data-[popup-open]:border-border2',
     'disabled:cursor-not-allowed disabled:opacity-50',
@@ -27,7 +27,7 @@ export const comboboxStyles = {
 
   /** Popup container — concentric with rounded-xl + p-1 (8px items inside 12px container). */
   popup: cn(
-    'min-w-(--anchor-width) w-max max-w-[500px] rounded-xl border border-border1 bg-surface3 text-neutral4',
+    'min-w-(--anchor-width) w-max max-w-(--available-width) rounded-xl border border-border1 bg-surface3 text-neutral4',
     'shadow-dialog',
     'origin-(--transform-origin)',
     'transition-[transform,scale,opacity] duration-150 ease-out',
@@ -39,10 +39,10 @@ export const comboboxStyles = {
   positioner: 'z-50 pointer-events-auto',
 
   /** Search input container — borderless top section, hairline divider below. */
-  searchContainer: cn('flex items-center border-b border-border1 px-2.5 py-2', transitions.colors),
+  searchContainer: cn('flex items-center border-b border-border1 px-2.5 py-1.5', transitions.colors),
 
   /** Search icon */
-  searchIcon: cn('mr-2 h-4 w-4 shrink-0 text-neutral3', transitions.colors),
+  searchIcon: cn('mr-2 h-3.5 w-3.5 shrink-0 text-neutral3', transitions.colors),
 
   /** Search input */
   searchInput: cn(
@@ -53,31 +53,44 @@ export const comboboxStyles = {
   ),
 
   /** Empty state */
-  empty: 'not-empty:block hidden py-6 text-center text-ui-smd text-neutral3',
+  empty: 'not-empty:block hidden py-4 text-center text-ui-smd text-neutral3',
 
   /** Options list */
   list: 'max-h-dropdown-max-height overflow-y-auto overflow-x-hidden p-1',
 
-  /** Option item base — rounded-lg (8px) sits concentrically inside rounded-xl + p-1. */
+  /** Option item base — rounded-md sits concentrically inside rounded-xl + p-1. */
   item: cn(
-    'relative flex cursor-pointer select-none items-center gap-2.5 rounded-lg px-2 py-1.5',
+    'group/item relative flex cursor-pointer select-none items-center gap-2 rounded-md',
+    'pl-2.5 pr-2 py-1.5 min-h-8',
     'text-ui-smd leading-ui-sm text-neutral4',
     'outline-none focus:outline-none focus-visible:outline-none',
     transitions.colors,
     'data-highlighted:bg-surface4 data-highlighted:text-neutral6',
+    'data-selected:text-neutral6',
   ),
 
-  /** Option item with selected state (single select) — quiet emphasis, no accent fill. */
-  itemSelected: 'data-selected:text-neutral6',
+  /** Multi-select item — keeps the left checkbox slot, no right indicator. */
+  itemMulti: cn(
+    'relative flex cursor-pointer select-none items-center gap-2.5 rounded-md',
+    'pl-2 pr-2.5 py-1.5 min-h-8',
+    'text-ui-smd leading-ui-sm text-neutral4',
+    'outline-none focus:outline-none focus-visible:outline-none',
+    transitions.colors,
+    'data-highlighted:bg-surface4 data-highlighted:text-neutral6',
+    'data-selected:text-neutral6',
+  ),
 
-  /** Check indicator container */
-  checkContainer: 'flex h-4 w-4 shrink-0 items-center justify-center',
+  /** Right-aligned slot grouping end content + selection check. */
+  itemRightSlot: 'ml-auto flex items-center gap-2 shrink-0',
+
+  /** Check indicator container — inline, fixed 16x16, shown only when item is selected. */
+  checkContainer: 'flex h-4 w-4 shrink-0 items-center justify-center text-accent1',
 
   /** Check icon (single select) */
-  checkIcon: cn('h-4 w-4 text-neutral6', transitions.opacity),
+  checkIcon: 'h-3.5 w-3.5',
 
   /** Checkbox container (multi select) */
-  checkbox: 'flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border',
+  checkbox: 'flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border',
 
   /** Checkbox selected state */
   checkboxSelected: 'bg-accent1 border-accent1',
@@ -100,8 +113,8 @@ export const comboboxStyles = {
   /** Option description */
   optionDescription: 'text-ui-sm text-neutral3 truncate',
 
-  /** Option end slot */
-  optionEnd: 'ml-auto',
+  /** Option end slot — `ml-auto` makes it push right inside flex containers (used by multi-select). */
+  optionEnd: 'ml-auto flex items-center shrink-0',
 
   /** Error message */
   error: 'text-ui-sm text-accent2',

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.stories.tsx
@@ -117,6 +117,20 @@ export const Variants: Story = {
   ),
 };
 
+export const WithDescriptions: Story = {
+  args: {
+    options: [
+      { label: 'GPT-4', value: 'gpt-4', description: 'Most capable model' },
+      { label: 'GPT-4 Turbo', value: 'gpt-4-turbo', description: 'Faster, cheaper GPT-4' },
+      { label: 'GPT-3.5 Turbo', value: 'gpt-3.5-turbo', description: 'Fast and economical' },
+      { label: 'Claude 3 Opus', value: 'claude-3-opus', description: "Anthropic's most powerful" },
+    ],
+    value: 'gpt-4-turbo',
+    placeholder: 'Select a model...',
+    className: 'w-[280px]',
+  },
+};
+
 export const Sizes: Story = {
   render: () => (
     <div className="flex flex-col gap-3">

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -93,25 +93,21 @@ export function Combobox({
               <BaseCombobox.Empty className={comboboxStyles.empty}>{emptyText}</BaseCombobox.Empty>
               <BaseCombobox.List className={comboboxStyles.list}>
                 {(option: ComboboxOption) => (
-                  <BaseCombobox.Item
-                    key={option.value}
-                    value={option}
-                    className={cn(comboboxStyles.item, comboboxStyles.itemSelected)}
-                  >
-                    <span className={comboboxStyles.checkContainer}>
-                      <BaseCombobox.ItemIndicator>
-                        <Check className={comboboxStyles.checkIcon} />
-                      </BaseCombobox.ItemIndicator>
+                  <BaseCombobox.Item key={option.value} value={option} className={comboboxStyles.item}>
+                    {option.start}
+                    <span className={comboboxStyles.optionText}>
+                      <span className={comboboxStyles.optionLabel}>{option.label}</span>
+                      {option.description && (
+                        <span className={comboboxStyles.optionDescription}>{option.description}</span>
+                      )}
                     </span>
-                    <span className={comboboxStyles.optionContent}>
-                      {option.start}
-                      <span className={comboboxStyles.optionText}>
-                        <span className={comboboxStyles.optionLabel}>{option.label}</span>
-                        {option.description && (
-                          <span className={comboboxStyles.optionDescription}>{option.description}</span>
-                        )}
-                      </span>
+                    <span className={comboboxStyles.itemRightSlot}>
                       {option.end ? <div className={comboboxStyles.optionEnd}>{option.end}</div> : null}
+                      <span className={comboboxStyles.checkContainer}>
+                        <BaseCombobox.ItemIndicator>
+                          <Check className={comboboxStyles.checkIcon} />
+                        </BaseCombobox.ItemIndicator>
+                      </span>
                     </span>
                   </BaseCombobox.Item>
                 )}

--- a/packages/playground-ui/src/ds/components/Combobox/index.ts
+++ b/packages/playground-ui/src/ds/components/Combobox/index.ts
@@ -1,3 +1,4 @@
 export * from './combobox';
 export * from './multi-combobox';
 export { comboboxStyles } from './combobox-styles';
+export { Combobox as ComboboxPrimitive } from '@base-ui/react/combobox';

--- a/packages/playground-ui/src/ds/components/Combobox/multi-combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/multi-combobox.tsx
@@ -89,7 +89,7 @@ export function MultiCombobox({
                 {(option: ComboboxOption) => {
                   const isSelected = value.includes(option.value);
                   return (
-                    <BaseCombobox.Item key={option.value} value={option} className={comboboxStyles.item}>
+                    <BaseCombobox.Item key={option.value} value={option} className={comboboxStyles.itemMulti}>
                       <span
                         className={cn(
                           comboboxStyles.checkbox,

--- a/packages/playground/src/domains/llm/components/llm-providers.tsx
+++ b/packages/playground/src/domains/llm/components/llm-providers.tsx
@@ -1,4 +1,4 @@
-import { Combobox, Skeleton } from '@mastra/playground-ui';
+import { Combobox, Skeleton, cn } from '@mastra/playground-ui';
 import type { ComboboxProps, ComboboxOption } from '@mastra/playground-ui';
 import { Info } from 'lucide-react';
 import { useMemo } from 'react';
@@ -52,7 +52,11 @@ export const LLMProviders = ({
       ),
       end: provider.docUrl ? (
         <Info
-          className="w-4 h-4 text-neutral2 hover:text-neutral3 cursor-pointer"
+          className={cn(
+            'size-3.5 text-neutral2 opacity-0 transition-opacity duration-100 cursor-pointer',
+            'hover:text-neutral4 hover:opacity-100',
+            'group-data-[highlighted]/item:opacity-100',
+          )}
           onClick={e => {
             e.stopPropagation();
             window.open(provider.docUrl, '_blank', 'noopener,noreferrer');


### PR DESCRIPTION
## Summary
- Move selection check to the right of each Combobox item so unselected rows no longer carry a left padding gap; tighten popup search/empty padding and soften trigger hover for a calmer command-palette feel.
- Re-export `ComboboxPrimitive` (raw `@base-ui/react/combobox`) so future virtualized / async-status / chips / creatable use cases can drop down to the primitive without growing the monolithic `<Combobox>` prop surface.
- Dim the docs Info icon in `LLMProviders` and reveal it on row highlight to keep the provider list scannable.

## Why
Visual polish for the Combobox surface in Studio. Items used to have an awkward left padding reserved for the check indicator on every row, which made unselected rows look indented. With the indicator anchored on the right (inline, fixed width) the list reads cleaner and aligns the active row with its neighbors. Keeps the monolithic `<Combobox options={...} value={...}>` API unchanged for all 26 consumers; the new `ComboboxPrimitive` re-export is purely additive for the next caller who needs the compound parts.

## Test plan
- [ ] `pnpm --filter ./packages/playground-ui storybook` — inspect `Composite/Combobox` stories: `Default`, `WithValue`, `WithDescriptions`, `ModelSelector`, `Disabled`, `CustomEmptyText`, `ManyOptions`, `Variants`, `Sizes`.
- [ ] `pnpm dev:playground` — open the LLM provider selector (chat composer): selection check sits on the right of OpenAI; docs `i` icon is hidden by default, visible on row hover / keyboard highlight; no horizontal shift on hover.
- [ ] Open multi-select dropdowns (`tools-section`, `workflows-section`, `scorers-section`, `agents-section`, `property-filter-creator`) — checkbox still on the left, items use the tightened padding, end slot (if any) stays right-aligned via `ml-auto`.
- [ ] Verify error state still shows `border-accent2` on the trigger and the error message below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR cleans up dropdowns so options line up (moves the checkmark to the right), tightens spacing for a sleeker command-palette feel, and exposes the raw Combobox primitives so advanced users can build custom variants without changing the existing simple Combobox API.

## Changes Made

### Combobox Layout & Styling Improvements
- Moved the selection check indicator from the left to the right of each option to remove left padding gaps and keep rows visually aligned.
- Tightened popup/search/empty paddings (search container py-2 → py-1.5; search icon h-4 w-4 → h-3.5 w-3.5; empty py-6 → py-4) for a calmer, command-palette-like feel.
- Softened trigger hover/active surface for less visual prominence.
- Changed popup sizing from fixed max-w-[500px] to use available width constraint (max-w-(--available-width)).

### Multi-select & Option Tokens
- Introduced itemMulti styling token for multi-select options and updated per-option layout to separate start/content from a right-side slot.
- Updated checkbox styling (border radius/sizing) and standardized right-side end slot to `ml-auto flex items-center shrink-0`.
- Multi-select dropdowns (tools/workflows/scorers/agents/property-filter-creator) keep checkboxes on the left and adopt tightened paddings while preserving right-aligned end slots.

### API Extensibility
- Re-exported the raw @base-ui/react/combobox under the alias ComboboxPrimitive from the Combobox barrel (packages/playground-ui/src/ds/components/Combobox/index.ts) to provide an escape hatch for advanced compositions (virtualized lists, async loading, chips, creatable items) without expanding the higher-level Combobox props.
- This is additive and preserves the existing <Combobox options={...} value={...}> API.

### LLMProviders UI Refinement
- Dimmed the docs/info icon by default and reveal it on row hover/keyboard highlight (uses conditional cn classes) to improve scannability.

### Docs / Stories
- Added a WithDescriptions Storybook story demonstrating model-style options with descriptions.
- Expanded changeset documentation with a ComboboxPrimitive usage example.

## Testing / Verification Notes
- Verify Storybook Combobox stories: Default, WithValue, WithDescriptions, ModelSelector, Disabled, CustomEmptyText, ManyOptions, Variants, Sizes.
- In dev playground: confirm right-aligned selection check, docs icon hidden by default and revealed on hover/keyboard highlight, no horizontal shift on hover.
- Confirm multi-select dropdowns retain left-side checkboxes, tightened paddings, and preserved right-aligned end slots.
- Confirm error state still shows border-accent2 on trigger and displays error message below.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16411)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->