### PR TITLE
feat(playground-ui): migrate ScrollArea to Base UI

### DIFF
--- a/.changeset/funky-bags-burn.md
+++ b/.changeset/funky-bags-burn.md
@@ -2,4 +2,20 @@
 '@mastra/playground-ui': patch
 ---
 
-Improved `ScrollArea` to use Base UI internally while keeping its existing public API. No code changes are required for existing `ScrollArea` usage — `showMask`, `maxHeight`, `viewPortClassName`, `autoScroll`, and `orientation` all behave as before.
+Improved `ScrollArea` to use Base UI internally and added a richer mask API. Edges now fade by default based on `orientation` (top/bottom for vertical, left/right for horizontal, all four for both), so most scrollers get the polished fade-out automatically.
+
+The new `mask` prop replaces `showMask` and accepts either a boolean (`false` disables fading entirely) or an object to override individual sides. The `x` and `y` keys are shorthands for the matching axis.
+
+```tsx
+// Default — fades follow `orientation`
+<ScrollArea>...</ScrollArea>
+
+// Opt out entirely
+<ScrollArea mask={false}>...</ScrollArea>
+
+// Keep only the top fade
+<ScrollArea mask={{ bottom: false }}>...</ScrollArea>
+
+// Vertical fades only on a two-axis scroller
+<ScrollArea orientation="both" mask={{ x: false }}>...</ScrollArea>
+```

--- a/.changeset/funky-bags-burn.md
+++ b/.changeset/funky-bags-burn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Migrated ScrollArea from Radix UI to Base UI primitives. The component's public API is preserved, including showMask, maxHeight, viewPortClassName, autoScroll, and orientation. Internally, the manual scroll-overflow attribute hook was removed since Base UI exposes the same data-overflow-y-start/end and data-overflow-x-start/end attributes natively on the viewport. Scrollbar visibility now relies on Base UI's data-hovering and data-scrolling attributes.

--- a/.changeset/funky-bags-burn.md
+++ b/.changeset/funky-bags-burn.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Migrated ScrollArea from Radix UI to Base UI primitives. The component's public API is preserved, including showMask, maxHeight, viewPortClassName, autoScroll, and orientation. Internally, the manual scroll-overflow attribute hook was removed since Base UI exposes the same data-overflow-y-start/end and data-overflow-x-start/end attributes natively on the viewport. Scrollbar visibility now relies on Base UI's data-hovering and data-scrolling attributes.
+Improved `ScrollArea` to use Base UI internally while keeping its existing public API. No code changes are required for existing `ScrollArea` usage — `showMask`, `maxHeight`, `viewPortClassName`, `autoScroll`, and `orientation` all behave as before.

--- a/.changeset/funky-bags-burn.md
+++ b/.changeset/funky-bags-burn.md
@@ -1,10 +1,12 @@
 ---
-'@mastra/playground-ui': patch
+'@mastra/playground-ui': minor
 ---
 
 Improved `ScrollArea` to use Base UI internally and added a richer mask API. Edges now fade by default based on `orientation` (top/bottom for vertical, left/right for horizontal, all four for both), so most scrollers get the polished fade-out automatically.
 
-The new `mask` prop replaces `showMask` and accepts either a boolean (`false` disables fading entirely) or an object to override individual sides. The `x` and `y` keys are shorthands for the matching axis.
+**Heads up — default behavior change:** `ScrollArea` previously rendered without any edge fade unless `showMask` was passed. It now fades the edges that match `orientation` by default. Pass `mask={false}` on the callsites where you want to keep the old hard edges.
+
+**New `mask` prop.** Accepts a boolean (`false` disables the fade entirely) or an object to override individual sides. The `x` and `y` keys are shorthands for the matching axis.
 
 ```tsx
 // Default — fades follow `orientation`
@@ -18,4 +20,16 @@ The new `mask` prop replaces `showMask` and accepts either a boolean (`false` di
 
 // Vertical fades only on a two-axis scroller
 <ScrollArea orientation="both" mask={{ x: false }}>...</ScrollArea>
+```
+
+**Migrating from `showMask`.** The `showMask` boolean is now deprecated but still works — `mask` wins when both are set.
+
+```tsx
+// Before
+<ScrollArea showMask>...</ScrollArea>
+<ScrollArea showMask={false}>...</ScrollArea>
+
+// After
+<ScrollArea>...</ScrollArea>             // default fade matches orientation
+<ScrollArea mask={false}>...</ScrollArea> // explicitly disable
 ```

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -80,7 +80,6 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-radio-group": "^1.3.8",
-    "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav.tsx
@@ -12,9 +12,7 @@ export function MainSidebarNav({
 }: MainSidebarNavProps) {
   return (
     <nav aria-label={ariaLabel} className={cn('flex flex-col flex-1 min-h-0', className)} {...props}>
-      <ScrollArea showMask className="flex-1 min-h-0">
-        {children}
-      </ScrollArea>
+      <ScrollArea className="flex-1 min-h-0">{children}</ScrollArea>
     </nav>
   );
 }

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
@@ -108,3 +108,65 @@ export const ChatMessages: Story = {
     </ScrollArea>
   ),
 };
+
+const MaskItems = () => (
+  <div className="space-y-3">
+    {Array.from({ length: 20 }).map((_, i) => (
+      <p key={i} className="text-sm text-neutral5">
+        Item {i + 1} — Lorem ipsum dolor sit amet
+      </p>
+    ))}
+  </div>
+);
+
+export const MaskDisabled: Story = {
+  name: 'Mask / disabled',
+  render: () => (
+    <ScrollArea mask={false} className="h-[200px] w-[260px] rounded-md border border-border1 p-4">
+      <MaskItems />
+    </ScrollArea>
+  ),
+};
+
+export const MaskTopOnly: Story = {
+  name: 'Mask / top only',
+  render: () => (
+    <ScrollArea mask={{ bottom: false }} className="h-[200px] w-[260px] rounded-md border border-border1 p-4">
+      <MaskItems />
+    </ScrollArea>
+  ),
+};
+
+export const MaskBothAxes: Story = {
+  name: 'Mask / both axes (orientation=both)',
+  render: () => (
+    <ScrollArea orientation="both" className="h-[200px] w-[260px] rounded-md border border-border1 p-4">
+      <div className="w-[600px] space-y-3">
+        {Array.from({ length: 20 }).map((_, i) => (
+          <p key={i} className="text-sm text-neutral5 whitespace-nowrap">
+            Row {i + 1} — long horizontal content stretching past the viewport for x-axis overflow
+          </p>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+};
+
+export const MaskYOnly: Story = {
+  name: 'Mask / y axis only (no horizontal fade)',
+  render: () => (
+    <ScrollArea
+      orientation="both"
+      mask={{ x: false }}
+      className="h-[200px] w-[260px] rounded-md border border-border1 p-4"
+    >
+      <div className="w-[600px] space-y-3">
+        {Array.from({ length: 20 }).map((_, i) => (
+          <p key={i} className="text-sm text-neutral5 whitespace-nowrap">
+            Row {i + 1} — long horizontal content
+          </p>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
@@ -42,7 +42,10 @@ export const WithMaxHeight: Story = {
 
 export const HorizontalScroll: Story = {
   render: () => (
-    <ScrollArea className="h-[100px] w-dropdown-max-height rounded-md border border-border1 p-4">
+    <ScrollArea
+      orientation="horizontal"
+      className="h-[100px] w-dropdown-max-height rounded-md border border-border1 p-4"
+    >
       <div className="flex gap-4 w-[800px]">
         {Array.from({ length: 20 }).map((_, i) => (
           <div key={i} className="h-16 w-16 shrink-0 rounded-md bg-surface4 flex items-center justify-center">
@@ -56,7 +59,7 @@ export const HorizontalScroll: Story = {
 
 export const CodeBlock: Story = {
   render: () => (
-    <ScrollArea className="h-[200px] w-[400px] rounded-md border border-border1 bg-surface2">
+    <ScrollArea orientation="both" className="h-[200px] w-[400px] rounded-md border border-border1 bg-surface2">
       <pre className="p-4 text-sm font-mono text-neutral5">
         {`function example() {
   const data = fetchData();

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
@@ -1,4 +1,4 @@
-import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
+import { ScrollArea as ScrollAreaPrimitive } from '@base-ui/react/scroll-area';
 import * as React from 'react';
 
 import { useAutoscroll } from '@/hooks/use-autoscroll';
@@ -13,36 +13,10 @@ export type ScrollAreaProps = React.ComponentPropsWithoutRef<typeof ScrollAreaPr
   showMask?: boolean;
 };
 
-// Reflects scroll position as data attributes so consumers can style edges
-// (e.g. fade masks) only when there's clipped content past the viewport.
-function useScrollOverflowAttrs(ref: React.RefObject<HTMLDivElement | null>) {
-  React.useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const update = () => {
-      const { scrollTop, scrollLeft, scrollHeight, scrollWidth, clientHeight, clientWidth } = el;
-      el.toggleAttribute('data-overflow-y-start', scrollTop > 0);
-      el.toggleAttribute('data-overflow-y-end', scrollTop + clientHeight < scrollHeight - 1);
-      el.toggleAttribute('data-overflow-x-start', scrollLeft > 0);
-      el.toggleAttribute('data-overflow-x-end', scrollLeft + clientWidth < scrollWidth - 1);
-    };
-    update();
-    el.addEventListener('scroll', update, { passive: true });
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
-    const inner = el.firstElementChild;
-    if (inner) ro.observe(inner);
-    return () => {
-      el.removeEventListener('scroll', update);
-      ro.disconnect();
-    };
-  }, [ref]);
-}
-
 const MASK_CLASSES =
   'data-[overflow-y-start]:mask-t-from-[calc(100%-2rem)] data-[overflow-y-end]:mask-b-from-[calc(100%-2rem)] data-[overflow-x-start]:mask-l-from-[calc(100%-2rem)] data-[overflow-x-end]:mask-r-from-[calc(100%-2rem)]';
 
-const ScrollArea = React.forwardRef<React.ElementRef<typeof ScrollAreaPrimitive.Root>, ScrollAreaProps>(
+const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
   (
     {
       className,
@@ -58,13 +32,12 @@ const ScrollArea = React.forwardRef<React.ElementRef<typeof ScrollAreaPrimitive.
   ) => {
     const areaRef = React.useRef<HTMLDivElement>(null);
     useAutoscroll(areaRef, { enabled: autoScroll });
-    useScrollOverflowAttrs(areaRef);
 
     return (
       <ScrollAreaPrimitive.Root ref={ref} className={cn('relative overflow-hidden', className)} {...props}>
         <ScrollAreaPrimitive.Viewport
           ref={areaRef}
-          className={cn('h-full w-full rounded-[inherit] [&>div]:block!', showMask && MASK_CLASSES, viewPortClassName)}
+          className={cn('h-full w-full rounded-[inherit]', showMask && MASK_CLASSES, viewPortClassName)}
           style={maxHeight ? { maxHeight } : undefined}
         >
           {children}
@@ -76,27 +49,26 @@ const ScrollArea = React.forwardRef<React.ElementRef<typeof ScrollAreaPrimitive.
     );
   },
 );
-ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+ScrollArea.displayName = 'ScrollArea';
 
-const ScrollBar = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
->(({ className, orientation = 'vertical', ...props }, ref) => (
-  <ScrollAreaPrimitive.ScrollAreaScrollbar
-    ref={ref}
-    orientation={orientation}
-    className={cn(
-      'flex touch-none select-none transition-all duration-normal ease-out-custom',
-      'opacity-0 hover:opacity-100 data-[state=visible]:opacity-100',
-      orientation === 'vertical' && 'h-full w-1.5 p-px',
-      orientation === 'horizontal' && 'h-1.5 w-full flex-col p-px',
-      className,
-    )}
-    {...props}
-  >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-neutral4/30 hover:bg-neutral4/60 transition-colors duration-normal" />
-  </ScrollAreaPrimitive.ScrollAreaScrollbar>
-));
-ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+const ScrollBar = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Scrollbar>>(
+  ({ className, orientation = 'vertical', ...props }, ref) => (
+    <ScrollAreaPrimitive.Scrollbar
+      ref={ref}
+      orientation={orientation}
+      className={cn(
+        'flex touch-none select-none transition-opacity duration-normal ease-out-custom',
+        'opacity-0 data-[hovering]:opacity-100 data-[scrolling]:opacity-100 data-[scrolling]:duration-0',
+        orientation === 'vertical' && 'h-full w-1.5 p-px',
+        orientation === 'horizontal' && 'h-1.5 w-full flex-col p-px',
+        className,
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Thumb className="relative flex-1 rounded-full bg-neutral4/30 hover:bg-neutral4/60 transition-colors duration-normal" />
+    </ScrollAreaPrimitive.Scrollbar>
+  ),
+);
+ScrollBar.displayName = 'ScrollBar';
 
 export { ScrollArea, ScrollBar };

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
@@ -31,6 +31,8 @@ export type ScrollAreaProps = React.ComponentPropsWithoutRef<typeof ScrollAreaPr
   orientation?: Orientation;
   /** Fade content at the edges where it's clipped by overflow. Defaults to the axes matching `orientation`. */
   mask?: ScrollAreaMask;
+  /** @deprecated Use `mask` instead. Retained for backward compatibility. */
+  showMask?: boolean;
 };
 
 type ResolvedMask = { top: boolean; bottom: boolean; left: boolean; right: boolean };
@@ -71,13 +73,24 @@ function maskClasses(sides: ResolvedMask) {
 
 const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
   (
-    { className, children, viewPortClassName, maxHeight, autoScroll = false, orientation = 'vertical', mask, ...props },
+    {
+      className,
+      children,
+      viewPortClassName,
+      maxHeight,
+      autoScroll = false,
+      orientation = 'vertical',
+      mask,
+      showMask,
+      ...props
+    },
     ref,
   ) => {
     const areaRef = React.useRef<HTMLDivElement>(null);
     useAutoscroll(areaRef, { enabled: autoScroll });
 
-    const sides = resolveMask(mask, orientation);
+    const effectiveMask: ScrollAreaMask | undefined = mask !== undefined ? mask : showMask;
+    const sides = resolveMask(effectiveMask, orientation);
 
     return (
       <ScrollAreaPrimitive.Root ref={ref} className={cn('relative overflow-hidden', className)} {...props}>

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
@@ -40,7 +40,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
           className={cn('h-full w-full rounded-[inherit]', showMask && MASK_CLASSES, viewPortClassName)}
           style={maxHeight ? { maxHeight } : undefined}
         >
-          {children}
+          <ScrollAreaPrimitive.Content>{children}</ScrollAreaPrimitive.Content>
         </ScrollAreaPrimitive.Viewport>
         {(orientation === 'vertical' || orientation === 'both') && <ScrollBar orientation="vertical" />}
         {(orientation === 'horizontal' || orientation === 'both') && <ScrollBar orientation="horizontal" />}
@@ -51,24 +51,25 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
 );
 ScrollArea.displayName = 'ScrollArea';
 
-const ScrollBar = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Scrollbar>>(
-  ({ className, orientation = 'vertical', ...props }, ref) => (
-    <ScrollAreaPrimitive.Scrollbar
-      ref={ref}
-      orientation={orientation}
-      className={cn(
-        'flex touch-none select-none transition-opacity duration-normal ease-out-custom',
-        'opacity-0 data-[hovering]:opacity-100 data-[scrolling]:opacity-100 data-[scrolling]:duration-0',
-        orientation === 'vertical' && 'h-full w-1.5 p-px',
-        orientation === 'horizontal' && 'h-1.5 w-full flex-col p-px',
-        className,
-      )}
-      {...props}
-    >
-      <ScrollAreaPrimitive.Thumb className="relative flex-1 rounded-full bg-neutral4/30 hover:bg-neutral4/60 transition-colors duration-normal" />
-    </ScrollAreaPrimitive.Scrollbar>
-  ),
-);
+const ScrollBar = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Scrollbar>
+>(({ className, orientation = 'vertical', ...props }, ref) => (
+  <ScrollAreaPrimitive.Scrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      'flex touch-none select-none transition-opacity duration-normal ease-out-custom',
+      'opacity-0 data-[hovering]:opacity-100 data-[scrolling]:opacity-100 data-[scrolling]:duration-0',
+      orientation === 'vertical' && 'h-full w-1.5 p-px',
+      orientation === 'horizontal' && 'h-1.5 w-full flex-col p-px',
+      className,
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Thumb className="relative flex-1 rounded-full bg-neutral4/30 hover:bg-neutral4/60 transition-colors duration-normal" />
+  </ScrollAreaPrimitive.Scrollbar>
+));
 ScrollBar.displayName = 'ScrollBar';
 
 export { ScrollArea, ScrollBar };

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
@@ -4,40 +4,86 @@ import * as React from 'react';
 import { useAutoscroll } from '@/hooks/use-autoscroll';
 import { cn } from '@/lib/utils';
 
+type Orientation = 'vertical' | 'horizontal' | 'both';
+
+export type MaskSides = {
+  top?: boolean;
+  bottom?: boolean;
+  left?: boolean;
+  right?: boolean;
+  /** Shorthand: sets both `left` and `right`. Per-side keys override. */
+  x?: boolean;
+  /** Shorthand: sets both `top` and `bottom`. Per-side keys override. */
+  y?: boolean;
+};
+
+/**
+ * - `true` / omitted: fade the edges that match `orientation`.
+ * - `false`: no fade.
+ * - object: per-side override on top of the orientation default.
+ */
+export type ScrollAreaMask = boolean | MaskSides;
+
 export type ScrollAreaProps = React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
   viewPortClassName?: string;
   maxHeight?: string;
   autoScroll?: boolean;
-  orientation?: 'vertical' | 'horizontal' | 'both';
-  /** Fade content at the edges where it's clipped by overflow. */
-  showMask?: boolean;
+  orientation?: Orientation;
+  /** Fade content at the edges where it's clipped by overflow. Defaults to the axes matching `orientation`. */
+  mask?: ScrollAreaMask;
 };
 
-const MASK_CLASSES =
-  'data-[overflow-y-start]:mask-t-from-[calc(100%-2rem)] data-[overflow-y-end]:mask-b-from-[calc(100%-2rem)] data-[overflow-x-start]:mask-l-from-[calc(100%-2rem)] data-[overflow-x-end]:mask-r-from-[calc(100%-2rem)]';
+type ResolvedMask = { top: boolean; bottom: boolean; left: boolean; right: boolean };
+
+function resolveMask(mask: ScrollAreaMask | undefined, orientation: Orientation): ResolvedMask {
+  if (mask === false) return { top: false, bottom: false, left: false, right: false };
+
+  const vertical = orientation === 'vertical' || orientation === 'both';
+  const horizontal = orientation === 'horizontal' || orientation === 'both';
+  const sides: ResolvedMask = { top: vertical, bottom: vertical, left: horizontal, right: horizontal };
+
+  if (mask === true || mask === undefined) return sides;
+
+  if (mask.y !== undefined) {
+    sides.top = mask.y;
+    sides.bottom = mask.y;
+  }
+  if (mask.x !== undefined) {
+    sides.left = mask.x;
+    sides.right = mask.x;
+  }
+  if (mask.top !== undefined) sides.top = mask.top;
+  if (mask.bottom !== undefined) sides.bottom = mask.bottom;
+  if (mask.left !== undefined) sides.left = mask.left;
+  if (mask.right !== undefined) sides.right = mask.right;
+
+  return sides;
+}
+
+function maskClasses(sides: ResolvedMask) {
+  return cn(
+    sides.top && 'data-[overflow-y-start]:mask-t-from-[calc(100%-2rem)]',
+    sides.bottom && 'data-[overflow-y-end]:mask-b-from-[calc(100%-2rem)]',
+    sides.left && 'data-[overflow-x-start]:mask-l-from-[calc(100%-2rem)]',
+    sides.right && 'data-[overflow-x-end]:mask-r-from-[calc(100%-2rem)]',
+  );
+}
 
 const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
   (
-    {
-      className,
-      children,
-      viewPortClassName,
-      maxHeight,
-      autoScroll = false,
-      orientation = 'vertical',
-      showMask = false,
-      ...props
-    },
+    { className, children, viewPortClassName, maxHeight, autoScroll = false, orientation = 'vertical', mask, ...props },
     ref,
   ) => {
     const areaRef = React.useRef<HTMLDivElement>(null);
     useAutoscroll(areaRef, { enabled: autoScroll });
 
+    const sides = resolveMask(mask, orientation);
+
     return (
       <ScrollAreaPrimitive.Root ref={ref} className={cn('relative overflow-hidden', className)} {...props}>
         <ScrollAreaPrimitive.Viewport
           ref={areaRef}
-          className={cn('h-full w-full rounded-[inherit]', showMask && MASK_CLASSES, viewPortClassName)}
+          className={cn('h-full w-full rounded-[inherit]', maskClasses(sides), viewPortClassName)}
           style={maxHeight ? { maxHeight } : undefined}
         >
           <ScrollAreaPrimitive.Content>{children}</ScrollAreaPrimitive.Content>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4358,9 +4358,6 @@ importers:
       '@radix-ui/react-radio-group':
         specifier: ^1.3.8
         version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-scroll-area':
-        specifier: ^1.2.10
-        version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Summary

- Swap `@radix-ui/react-scroll-area` for `@base-ui/react/scroll-area` in `packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx`.
- Drop the manual `useScrollOverflowAttrs` hook — Base UI's `<ScrollArea.Viewport>` already exposes `data-overflow-y-start`, `data-overflow-y-end`, `data-overflow-x-start`, `data-overflow-x-end` natively, so `MASK_CLASSES` (used by `showMask`) keeps working without any custom JS.
- Scrollbar reveal now uses Base UI's `data-hovering` / `data-scrolling` attrs (instant on scroll, faded transition otherwise) instead of Radix's `data-[state=visible]` + `:hover`.
- Removed the Radix-specific `[&>div]:block!` wrapper hack — Base UI's viewport doesn't wrap children in a `display: table` div.
- Public API of `<ScrollArea>` is unchanged: `showMask`, `maxHeight`, `viewPortClassName`, `autoScroll`, `orientation`, `ref` all preserved, so no callsite changes required across `playground-ui` or `playground`.
- `@radix-ui/react-scroll-area` removed from `packages/playground-ui/package.json` and `pnpm-lock.yaml`.

## Test plan

- [ ] Storybook (`pnpm --filter playground-ui storybook`): verify Default / WithMaxHeight / HorizontalScroll / CodeBlock / ChatMessages stories scroll and reveal scrollbar on hover/scroll.
- [ ] Studio: verify `MainSidebar` (uses `showMask`) still fades content at top/bottom edges.
- [ ] Studio: verify `MetricsDataTable` (uses `orientation="both"` + `maxHeight`) renders both scrollbars and the corner.
- [ ] Studio: verify chat / agent panels still scroll smoothly and `autoScroll` keeps following streamed messages.
- [ ] `pnpm --filter playground-ui build` passes typecheck + bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR swaps the ScrollArea from Radix UI to Base UI so scrolling, scrollbar reveal, and edge fading work with less custom code. It introduces a new, more flexible mask prop while keeping the old showMask prop as a deprecated alias for compatibility.

## Summary

Migrated the `ScrollArea` component in `packages/playground-ui` from `@radix-ui/react-scroll-area` to `@base-ui/react/scroll-area`, simplifying internals by removing a custom overflow hook and relying on Base UI's built-in data attributes for overflow and interaction state.

Key changes:
- Replaced Radix primitives with Base UI primitives in packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx.
- Removed the custom useScrollOverflowAttrs hook — Base UI’s <ScrollArea.Viewport> exposes data-overflow-* attributes so masking works via CSS selectors without JS.
- Switched scrollbar reveal behavior to use Base UI’s data-hovering and data-scrolling attributes (instant on scroll, faded transition otherwise).
- Removed Radix-specific wrapper/CSS hack ([&>div]:block!) because Base UI’s viewport no longer wraps children in a display:table div.
- Wrapped viewport children in <ScrollArea.Content> so Base UI can size content correctly for horizontal/both orientations.
- Reworked masking API: introduced mask?: boolean | MaskSides (supports top/bottom/left/right and x/y shorthands); default masking follows orientation (vertical → top/bottom, horizontal → left/right, both → all sides) and supports per-side/axis overrides.
- Kept showMask as a deprecated alias for compatibility; when both are provided, mask takes precedence.
- Updated ref typings and display names: ScrollArea/ScrollBar forwardRef types now resolve to HTMLDivElement where appropriate; ScrollArea.displayName and ScrollBar.displayName set.
- Removed @radix-ui/react-scroll-area from packages/playground-ui/package.json and pnpm-lock.yaml.
- Storybook: updated CodeBlock and HorizontalScroll stories to correct orientations and added Mask* stories (MaskDisabled, MaskTopOnly, MaskBothAxes, MaskYOnly).
- Changeset updated to document the mask API change and default-on behavior, and to note showMask deprecation.

Public API notes:
- New: mask?: boolean | MaskSides (preferred).
- Deprecated but still supported: showMask?: boolean (mask takes precedence when both provided).
- No other prop changes to maxHeight, viewPortClassName, autoScroll, orientation, ref — no callsite changes required.

Files modified (high level):
- packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
- packages/playground-ui/src/ds/components/ScrollArea/scroll-area.stories.tsx
- packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav.tsx
- packages/playground-ui/package.json
- pnpm-lock.yaml
- .changeset/funky-bags-burn.md

Test plan:
- Storybook: verify Default / WithMaxHeight / HorizontalScroll / CodeBlock / ChatMessages stories scroll and reveal scrollbar on hover/scroll; verify new Mask* stories.
- Studio: verify MainSidebar mask fading; MetricsDataTable (orientation="both" + maxHeight) renders both scrollbars and corner; chat/agent panels scroll smoothly and autoScroll follows streamed messages.
- Ensure pnpm --filter playground-ui build passes typecheck and bundle.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16415)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->