### PR TITLE
Fix `abort()` not cancelling evented workflows

### DIFF
--- a/.changeset/tangy-forks-push.md
+++ b/.changeset/tangy-forks-push.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `abort()` not cancelling evented workflows

--- a/packages/core/src/workflows/evented/evented-workflow.test.ts
+++ b/packages/core/src/workflows/evented/evented-workflow.test.ts
@@ -66,10 +66,6 @@ createWorkflowTestSuite({
 
   // Skip only tests that actually fail - updated after BUG fixes 2026-02
   skipTests: {
-    // Abort - returns 'success' not 'canceled', timeout on signal wait
-    abortStatus: true,
-    abortDuringStep: true,
-
     // Suspend/resume - parallel suspend has race condition (each step publishes workflow.suspend independently)
     resumeParallelMulti: true,
     resumeMultiSuspendError: true,
@@ -115,8 +111,6 @@ createWorkflowTestSuite({
     resumeIncorrectBranches: true,
     // Map-branch resume requires direct Mastra registration (server restart sim)
     resumeMapBranchCondition: true,
-    // Abort propagation to nested workflows times out in evented engine
-    abortNestedPropagation: true,
   },
 
   executeWorkflow: async (workflow, inputData, options = {}): Promise<WorkflowResult> => {

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -168,7 +168,7 @@ export class WorkflowEventProcessor extends EventProcessor {
     });
   }
 
-  protected async processWorkflowCancel({ workflowId, runId }: ProcessorArgs) {
+  protected async processWorkflowCancel({ workflowId, runId, prevResult, ...args }: ProcessorArgs) {
     // Cancel this workflow and all nested child workflows
     this.cancelRunAndChildren(runId);
 
@@ -182,19 +182,13 @@ export class WorkflowEventProcessor extends EventProcessor {
       this.mastra.getLogger()?.warn('Canceling workflow without loaded state', { workflowId, runId });
     }
 
+    //call end workflow with status of canceled to indicate the workflow was canceled
     await this.endWorkflow(
       {
-        workflow: undefined as any,
         workflowId,
         runId,
-        stepResults: (currentState?.context ?? {}) as any,
-        prevResult: { status: 'canceled' } as any,
-        requestContext: (currentState?.requestContext ?? {}) as any,
-        executionPath: [],
-        activeSteps: {},
-        resumeSteps: [],
-        resumeData: undefined,
-        parentWorkflow: undefined,
+        prevResult,
+        ...args,
       },
       'canceled',
     );
@@ -1155,6 +1149,35 @@ export class WorkflowEventProcessor extends EventProcessor {
       });
     }
     requestContext = Object.fromEntries(rc.entries());
+
+    if (abortController?.signal?.aborted) {
+      // Extract updated state from step result
+      const updatedState = (stepResult as any).__state ?? currentState;
+      //cancel the workflow
+      return this.mastra.pubsub.publish('workflows', {
+        type: 'workflow.cancel',
+        runId,
+        data: {
+          parentWorkflow,
+          workflowId,
+          runId,
+          executionPath,
+          resumeSteps,
+          timeTravel,
+          stepResults: {
+            ...stepResults,
+            [step.step.id]: stepResult,
+            __state: updatedState,
+          },
+          prevResult: { ...stepResult, status: 'canceled' }, //set the status to canceled to indicate the workflow was canceled
+          activeSteps,
+          requestContext,
+          perStep,
+          state: updatedState,
+          outputOptions,
+        },
+      });
+    }
 
     // @ts-expect-error - bailed status not in type
     if (stepResult.status === 'bailed') {


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

Fix `abort()` not cancelling evented workflows

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're running a workflow (a series of steps) that's driven by events. If you tried to abort (cancel) it, nothing would happen - it would keep running. This PR fixes that bug so that calling `abort()` now actually stops the workflow and all its nested child workflows properly.

## Changes

### Workflow Event Processor (`workflow-event-processor/index.ts`)

- **Enhanced `processWorkflowCancel`**: Now accepts the full `ProcessorArgs` payload instead of just `workflowId` and `runId`, providing better context for cancellation operations. The method now properly calls `endWorkflow` with the complete arguments, ensuring all workflow state is properly cleaned up.

- **Abort controller integration in `processWorkflowStepRun`**: Added short-circuit logic that detects when a workflow run's `AbortController` has been aborted. When abort is detected:
  - Immediately publishes a `workflow.cancel` event
  - Marks the current step result as `status: 'canceled'`
  - Updates the workflow state from the step result's `__state` (or falls back to `currentState`)
  - Returns early without executing normal step completion logic

- **Abort controller management**: The processor now maintains a map of `AbortController` instances per workflow run and tracks parent-child relationships for nested workflows, allowing cancellation to properly propagate through the entire workflow hierarchy.

### Test Changes (`evented-workflow.test.ts`)

Re-enabled previously skipped abort-related tests:
- `abortStatus` - Tests that abort properly sets workflow status to canceled
- `abortDuringStep` - Tests abort behavior while a step is executing
- `abortNestedPropagation` - Tests that abort cancels nested workflows

These tests now run as part of the evented engine test suite, validating the abort functionality fix.

### Changeset

Recorded a patch release for `@mastra/core` documenting the fix for `abort()` failing to cancel evented workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16416)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->