### PR TITLE
feat(playground-ui): add InputGroup and extend ButtonsGroup

### DIFF
--- a/.changeset/whole-points-grow.md
+++ b/.changeset/whole-points-grow.md
@@ -35,4 +35,14 @@ Added `orientation` (`horizontal` | `vertical`), and new `ButtonsGroupSeparator`
   <ButtonsGroupText>42</ButtonsGroupText>
   <Button variant="outline">+</Button>
 </ButtonsGroup>
+
+<ButtonsGroup orientation="vertical">
+  <Button variant="ghost">Copy</Button>
+  <ButtonsGroupSeparator />
+  <Button variant="ghost">Cut</Button>
+</ButtonsGroup>
 ```
+
+**Tweaked `Button` ghost variant**
+
+Aligned hover/active progression with the outline variant (`surface3` → `surface4`) so click feedback is perceptible on transparent backgrounds. Existing ghost buttons throughout the playground will appear one shade lighter on hover and active.

--- a/.changeset/whole-points-grow.md
+++ b/.changeset/whole-points-grow.md
@@ -1,0 +1,38 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added `InputGroup` and extended `ButtonsGroup` in playground-ui design system.
+
+**New `InputGroup` component**
+
+Compose inputs with leading or trailing icons, buttons, text labels, and keyboard hints. Supports inline (left/right) and block (top/bottom) addon alignment, and works with both inputs and textareas.
+
+```tsx
+import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupButton } from '@mastra/playground-ui';
+import { SearchIcon, XIcon } from 'lucide-react';
+
+<InputGroup>
+  <InputGroupAddon>
+    <SearchIcon />
+  </InputGroupAddon>
+  <InputGroupInput placeholder="Search..." />
+  <InputGroupAddon align="inline-end">
+    <InputGroupButton aria-label="Clear">
+      <XIcon />
+    </InputGroupButton>
+  </InputGroupAddon>
+</InputGroup>;
+```
+
+**Extended `ButtonsGroup`**
+
+Added `orientation` (`horizontal` | `vertical`), and new `ButtonsGroupSeparator` and `ButtonsGroupText` slots. Existing API unchanged.
+
+```tsx
+<ButtonsGroup spacing="close">
+  <Button variant="outline">−</Button>
+  <ButtonsGroupText>42</ButtonsGroupText>
+  <Button variant="outline">+</Button>
+</ButtonsGroup>
+```

--- a/packages/playground-ui/.gitignore
+++ b/packages/playground-ui/.gitignore
@@ -1,0 +1,2 @@
+# LanceDB storage leaked by integration tests booting a Mastra runtime at the package root.
+/test/

--- a/packages/playground-ui/src/ds/components/Button/Button.tsx
+++ b/packages/playground-ui/src/ds/components/Button/Button.tsx
@@ -35,7 +35,7 @@ export const buttonVariants = cva(
           'bg-surface4 border border-border2 hover:bg-surface5 hover:text-neutral6 active:bg-surface6 text-neutral6',
         cta: 'bg-accent1 border border-transparent hover:bg-accent1/90 hover:shadow-glow-accent1 disabled:hover:shadow-none text-surface1 font-medium',
         ghost:
-          'bg-transparent border border-transparent hover:bg-surface4 hover:text-neutral6 active:bg-surface5 text-neutral4',
+          'bg-transparent border border-transparent hover:bg-surface3 hover:text-neutral6 active:bg-surface4 text-neutral4',
         outline:
           'bg-transparent border border-border1 hover:bg-surface3 hover:text-neutral6 active:bg-surface4 text-neutral5',
         link: 'inline-flex justify-start rounded-none h-auto px-0 bg-transparent text-neutral3 hover:text-neutral4 gap-1 [&>svg]:mx-0 w-auto [&>svg]:opacity-70',

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ChevronDown, ChevronDownIcon } from 'lucide-react';
+import { ChevronDownIcon, CopyIcon, ScissorsIcon, ClipboardIcon } from 'lucide-react';
 import { Button } from '../Button';
-import { ButtonsGroup } from './buttons-group';
+import { ButtonsGroup, ButtonsGroupSeparator, ButtonsGroupText } from './buttons-group';
 
 const meta: Meta<typeof ButtonsGroup> = {
   title: 'Composite/ButtonsGroup',
@@ -49,6 +49,87 @@ export const AsSplitButton: Story = {
       <Button aria-label="Open Menu">
         <ChevronDownIcon />
       </Button>
+    </ButtonsGroup>
+  ),
+};
+
+export const Vertical: Story = {
+  render: () => (
+    <ButtonsGroup orientation="vertical">
+      <Button>Top</Button>
+      <Button>Middle</Button>
+      <Button>Bottom</Button>
+    </ButtonsGroup>
+  ),
+};
+
+export const VerticalCloseSpacing: Story = {
+  render: () => (
+    <ButtonsGroup orientation="vertical" spacing="close">
+      <Button variant="ghost">
+        <CopyIcon />
+        Copy
+      </Button>
+      <Button variant="ghost">
+        <ScissorsIcon />
+        Cut
+      </Button>
+      <Button variant="ghost">
+        <ClipboardIcon />
+        Paste
+      </Button>
+    </ButtonsGroup>
+  ),
+};
+
+export const WithSeparator: Story = {
+  render: () => (
+    <ButtonsGroup>
+      <Button variant="ghost">
+        <CopyIcon />
+        Copy
+      </Button>
+      <ButtonsGroupSeparator />
+      <Button variant="ghost">
+        <ScissorsIcon />
+        Cut
+      </Button>
+      <ButtonsGroupSeparator />
+      <Button variant="ghost">
+        <ClipboardIcon />
+        Paste
+      </Button>
+    </ButtonsGroup>
+  ),
+};
+
+export const VerticalWithSeparator: Story = {
+  render: () => (
+    <ButtonsGroup orientation="vertical">
+      <Button variant="ghost">
+        <CopyIcon />
+        Copy
+      </Button>
+      <ButtonsGroupSeparator />
+      <Button variant="ghost">
+        <ScissorsIcon />
+        Cut
+      </Button>
+      <ButtonsGroupSeparator />
+      <Button variant="ghost">
+        <ClipboardIcon />
+        Paste
+      </Button>
+    </ButtonsGroup>
+  ),
+};
+
+export const WithText: Story = {
+  render: () => (
+    <ButtonsGroup spacing="close">
+      <Button variant="outline">−</Button>
+      <ButtonsGroupText>42</ButtonsGroupText>
+      <Button variant="outline">+</Button>
     </ButtonsGroup>
   ),
 };

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.stories.tsx
@@ -66,15 +66,15 @@ export const Vertical: Story = {
 export const VerticalCloseSpacing: Story = {
   render: () => (
     <ButtonsGroup orientation="vertical" spacing="close">
-      <Button variant="ghost">
+      <Button variant="outline">
         <CopyIcon />
         Copy
       </Button>
-      <Button variant="ghost">
+      <Button variant="outline">
         <ScissorsIcon />
         Cut
       </Button>
-      <Button variant="ghost">
+      <Button variant="outline">
         <ClipboardIcon />
         Paste
       </Button>

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx
@@ -1,5 +1,4 @@
 import { cva } from 'class-variance-authority';
-import type { VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 import { formElementSizes } from '@/ds/primitives/form-element';
@@ -56,12 +55,15 @@ const buttonsGroupVariants = cva(
   },
 );
 
-export type ButtonsGroupProps = React.ComponentPropsWithoutRef<'div'> & VariantProps<typeof buttonsGroupVariants>;
+export type ButtonsGroupProps = React.ComponentPropsWithoutRef<'div'> & {
+  orientation?: Orientation;
+  spacing?: 'default' | 'close';
+};
 
 export const ButtonsGroup = React.forwardRef<HTMLDivElement, ButtonsGroupProps>(
   ({ children, className, orientation = 'horizontal', spacing = 'default', ...props }, ref) => {
     return (
-      <ButtonsGroupOrientationContext.Provider value={orientation ?? 'horizontal'}>
+      <ButtonsGroupOrientationContext.Provider value={orientation}>
         <div
           ref={ref}
           role="group"

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx
@@ -1,24 +1,143 @@
+import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { formElementSizes } from '@/ds/primitives/form-element';
+import type { FormElementSize } from '@/ds/primitives/form-element';
 import { cn } from '@/lib/utils';
 
-export type ButtonsGroupProps = {
-  children: React.ReactNode;
-  className?: string;
-  spacing?: 'default' | 'close';
+type Orientation = 'horizontal' | 'vertical';
+
+const ButtonsGroupOrientationContext = React.createContext<Orientation>('horizontal');
+
+const buttonsGroupVariants = cva(
+  // Elevate the focused child's border above its siblings so it isn't clipped in close-spacing.
+  cn('flex', '[&>*:focus-visible]:relative [&>*:focus-visible]:z-10'),
+  {
+    variants: {
+      orientation: {
+        horizontal: 'flex-row items-center',
+        vertical: 'flex-col items-stretch',
+      },
+      spacing: {
+        default: 'gap-2',
+        close: 'gap-0',
+      },
+    },
+    compoundVariants: [
+      {
+        orientation: 'horizontal',
+        spacing: 'close',
+        // Skip separators when collapsing borders so they stay visible.
+        className: cn(
+          '[&>*:not(:last-child)]:rounded-r-none',
+          '[&>*:not(:first-child)]:rounded-l-none',
+          '[&>*:not([data-slot=buttons-group-separator]):not(:first-child)]:-ml-px',
+        ),
+      },
+      {
+        orientation: 'vertical',
+        spacing: 'close',
+        // Children carry `rounded-full` (capsule) which looks awkward when stacked vertically.
+        // Replace the outer corners with a regular `rounded-xl` and flatten the inner ones.
+        className: cn(
+          '[&>*:not(:last-child)]:rounded-b-none',
+          '[&>*:not(:first-child)]:rounded-t-none',
+          '[&>:first-child]:rounded-t-xl',
+          '[&>:last-child]:rounded-b-xl',
+          '[&>*:not([data-slot=buttons-group-separator]):not(:first-child)]:-mt-px',
+        ),
+      },
+    ],
+    defaultVariants: {
+      orientation: 'horizontal',
+      spacing: 'default',
+    },
+  },
+);
+
+export type ButtonsGroupProps = React.ComponentPropsWithoutRef<'div'> & VariantProps<typeof buttonsGroupVariants>;
+
+export const ButtonsGroup = React.forwardRef<HTMLDivElement, ButtonsGroupProps>(
+  ({ children, className, orientation = 'horizontal', spacing = 'default', ...props }, ref) => {
+    return (
+      <ButtonsGroupOrientationContext.Provider value={orientation ?? 'horizontal'}>
+        <div
+          ref={ref}
+          role="group"
+          data-slot="buttons-group"
+          data-orientation={orientation}
+          className={cn(buttonsGroupVariants({ orientation, spacing }), className)}
+          {...props}
+        >
+          {children}
+        </div>
+      </ButtonsGroupOrientationContext.Provider>
+    );
+  },
+);
+ButtonsGroup.displayName = 'ButtonsGroup';
+
+export type ButtonsGroupSeparatorProps = React.ComponentPropsWithoutRef<'div'> & {
+  orientation?: Orientation;
 };
 
-export function ButtonsGroup({ children, className, spacing = 'default' }: ButtonsGroupProps) {
-  return (
-    <div
-      className={cn(
-        `flex gap-2 items-center`,
-        {
-          'gap-0 [&>*:not(:last-child)]:rounded-r-none [&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:-ml-px':
-            spacing === 'close',
-        },
-        className,
-      )}
-    >
-      {children}
-    </div>
-  );
-}
+export const ButtonsGroupSeparator = React.forwardRef<HTMLDivElement, ButtonsGroupSeparatorProps>(
+  ({ className, orientation, ...props }, ref) => {
+    const parentOrientation = React.useContext(ButtonsGroupOrientationContext);
+    // Separator runs perpendicular to the group flow by default.
+    const resolved = orientation ?? (parentOrientation === 'vertical' ? 'horizontal' : 'vertical');
+    return (
+      <div
+        ref={ref}
+        role="separator"
+        aria-orientation={resolved}
+        data-slot="buttons-group-separator"
+        className={cn('self-stretch bg-border1', resolved === 'vertical' ? 'w-px' : 'h-px', className)}
+        {...props}
+      />
+    );
+  },
+);
+ButtonsGroupSeparator.displayName = 'ButtonsGroupSeparator';
+
+const buttonsGroupTextVariants = cva(
+  cn(
+    'inline-flex items-center justify-center bg-surface3 border border-border1 text-neutral5 select-none',
+    'rounded-full gap-[.75em] px-[1em]',
+    '[&>svg]:w-[1.1em] [&>svg]:h-[1.1em] [&>svg]:opacity-50',
+  ),
+  {
+    variants: {
+      size: {
+        sm: `${formElementSizes.sm} text-ui-sm`,
+        md: `${formElementSizes.md} text-ui-md`,
+        default: `${formElementSizes.default} text-ui-md`,
+        lg: `${formElementSizes.lg} text-ui-lg`,
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+    },
+  },
+);
+
+export type ButtonsGroupTextProps = React.ComponentPropsWithoutRef<'div'> & {
+  size?: FormElementSize;
+};
+
+export const ButtonsGroupText = React.forwardRef<HTMLDivElement, ButtonsGroupTextProps>(
+  ({ className, size = 'default', ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        data-slot="buttons-group-text"
+        className={cn(buttonsGroupTextVariants({ size }), className)}
+        {...props}
+      />
+    );
+  },
+);
+ButtonsGroupText.displayName = 'ButtonsGroupText';
+
+export { buttonsGroupVariants };

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx
@@ -1,4 +1,5 @@
 import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 import { formElementSizes } from '@/ds/primitives/form-element';
@@ -55,9 +56,13 @@ const buttonsGroupVariants = cva(
   },
 );
 
+// Derive variant types from cva (single source of truth) and strip `null` that cva injects.
+type ButtonsGroupVariantsProps = VariantProps<typeof buttonsGroupVariants>;
+export type ButtonsGroupSpacing = NonNullable<ButtonsGroupVariantsProps['spacing']>;
+
 export type ButtonsGroupProps = React.ComponentPropsWithoutRef<'div'> & {
   orientation?: Orientation;
-  spacing?: 'default' | 'close';
+  spacing?: ButtonsGroupSpacing;
 };
 
 export const ButtonsGroup = React.forwardRef<HTMLDivElement, ButtonsGroupProps>(

--- a/packages/playground-ui/src/ds/components/InputGroup/index.ts
+++ b/packages/playground-ui/src/ds/components/InputGroup/index.ts
@@ -1,0 +1,1 @@
+export * from './input-group';

--- a/packages/playground-ui/src/ds/components/InputGroup/input-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/InputGroup/input-group.stories.tsx
@@ -1,0 +1,202 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CheckIcon, MailIcon, SearchIcon, SendIcon, XIcon } from 'lucide-react';
+import { Kbd } from '../Kbd';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+  InputGroupTextarea,
+} from './input-group';
+
+const meta: Meta<typeof InputGroup> = {
+  title: 'Composite/InputGroup',
+  component: InputGroup,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof InputGroup>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupInput placeholder="Plain input" />
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const WithInlineStartIcon: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Search..." />
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const WithInlineEndButton: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupInput placeholder="Email address" type="email" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton aria-label="Submit">
+            <SendIcon />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const WithLeadingAndTrailing: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupAddon>
+          <MailIcon />
+        </InputGroupAddon>
+        <InputGroupInput placeholder="you@example.com" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton aria-label="Clear">
+            <XIcon />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const WithText: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupAddon>
+          <InputGroupText>https://</InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput placeholder="example.com" />
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const WithKbd: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Search..." />
+        <InputGroupAddon align="inline-end">
+          <Kbd>⌘K</Kbd>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const BlockStartAddon: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupAddon align="block-start">
+          <InputGroupText>Recipient</InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput placeholder="name@example.com" />
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const BlockEndAddon: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupTextarea placeholder="Type a message..." />
+        <InputGroupAddon align="block-end">
+          <InputGroupButton aria-label="Submit">
+            <CheckIcon />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 w-80">
+      <InputGroup size="sm">
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Small" />
+      </InputGroup>
+      <InputGroup size="md">
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Medium" />
+      </InputGroup>
+      <InputGroup size="default">
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Default" />
+      </InputGroup>
+      <InputGroup size="lg">
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Large" />
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupAddon>
+          <MailIcon />
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Disabled" disabled value="locked@example.com" />
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const Invalid: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupAddon>
+          <MailIcon />
+        </InputGroupAddon>
+        <InputGroupInput placeholder="Invalid" defaultValue="not an email" error />
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const Textarea: Story = {
+  render: () => (
+    <div className="w-80">
+      <InputGroup>
+        <InputGroupTextarea placeholder="Write a comment..." />
+      </InputGroup>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
@@ -79,7 +79,9 @@ describe('InputGroup', () => {
         <InputGroupInput placeholder="x" />
       </InputGroup>,
     );
-    expect(getWrapper().className).toContain('has-[>[data-align=inline-start]]:[&>[data-slot=input-group-control]]:pl-0');
+    expect(getWrapper().className).toContain(
+      'has-[>[data-align=inline-start]]:[&>[data-slot=input-group-control]]:pl-0',
+    );
   });
 
   it('aria-invalid on control turns wrapper into error state via :has', () => {

--- a/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/InputGroup/input-group.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from './input-group';
+
+afterEach(() => {
+  cleanup();
+});
+
+const getWrapper = () => document.querySelector<HTMLDivElement>('[data-slot="input-group"]')!;
+const getInput = () => document.querySelector<HTMLInputElement>('[data-slot="input-group-control"]')!;
+
+describe('InputGroup', () => {
+  it('applies h-form-md to the control by default (md size)', () => {
+    render(
+      <InputGroup>
+        <InputGroupAddon>
+          <InputGroupText>x</InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput placeholder="inline" />
+      </InputGroup>,
+    );
+    const input = getInput();
+    expect(input.className).toContain('h-form-md');
+    expect(input.className).toContain('flex-1');
+  });
+
+  it('applies h-form-lg to the control when wrapper size=lg', () => {
+    render(
+      <InputGroup size="lg">
+        <InputGroupInput placeholder="lg" />
+      </InputGroup>,
+    );
+    expect(getInput().className).toContain('h-form-lg');
+  });
+
+  it('wrapper has the flex-col + flex-none + w-full overrides needed for block-start mode', () => {
+    // Regression test: in flex-col, `flex-1` (flex-basis: 0%) collapses the control's height
+    // to 0 unless we force `flex-none` and `w-full`. The wrapper className must carry the
+    // descendant overrides that kick in via :has().
+    render(
+      <InputGroup>
+        <InputGroupAddon align="block-start">
+          <InputGroupText>Recipient</InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput placeholder="block" />
+      </InputGroup>,
+    );
+    const wrapperClass = getWrapper().className;
+    expect(wrapperClass).toContain('has-[>[data-align=block-start]]:flex-col');
+    expect(wrapperClass).toContain('has-[>[data-align=block-start]]:[&>[data-slot=input-group-control]]:flex-none');
+    expect(wrapperClass).toContain('has-[>[data-align=block-start]]:[&>[data-slot=input-group-control]]:w-full');
+    // The control still carries the height utility — overrides target the flex shorthand only.
+    expect(getInput().className).toContain('h-form-md');
+  });
+
+  it('wrapper has block-end equivalents of the flex-col overrides', () => {
+    render(
+      <InputGroup>
+        <InputGroupInput placeholder="msg" />
+        <InputGroupAddon align="block-end">
+          <InputGroupText>footer</InputGroupText>
+        </InputGroupAddon>
+      </InputGroup>,
+    );
+    const wrapperClass = getWrapper().className;
+    expect(wrapperClass).toContain('has-[>[data-align=block-end]]:flex-col');
+    expect(wrapperClass).toContain('has-[>[data-align=block-end]]:[&>[data-slot=input-group-control]]:flex-none');
+    expect(wrapperClass).toContain('has-[>[data-align=block-end]]:[&>[data-slot=input-group-control]]:w-full');
+  });
+
+  it('inline-start addon zeros the control left padding', () => {
+    render(
+      <InputGroup>
+        <InputGroupAddon>
+          <InputGroupText>@</InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput placeholder="x" />
+      </InputGroup>,
+    );
+    expect(getWrapper().className).toContain('has-[>[data-align=inline-start]]:[&>[data-slot=input-group-control]]:pl-0');
+  });
+
+  it('aria-invalid on control turns wrapper into error state via :has', () => {
+    render(
+      <InputGroup>
+        <InputGroupInput placeholder="x" error />
+      </InputGroup>,
+    );
+    expect(getInput().getAttribute('aria-invalid')).toBe('true');
+    expect(getWrapper().className).toContain('has-[[aria-invalid=true]]:border-error');
+  });
+});

--- a/packages/playground-ui/src/ds/components/InputGroup/input-group.tsx
+++ b/packages/playground-ui/src/ds/components/InputGroup/input-group.tsx
@@ -4,11 +4,7 @@ import * as React from 'react';
 
 import { Button } from '@/ds/components/Button';
 import type { ButtonProps } from '@/ds/components/Button/Button';
-import {
-  formElementSizes,
-  formElementFocusWithin,
-  formElementRadius,
-} from '@/ds/primitives/form-element';
+import { formElementSizes, formElementFocusWithin, formElementRadius } from '@/ds/primitives/form-element';
 import type { FormElementSize } from '@/ds/primitives/form-element';
 import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';

--- a/packages/playground-ui/src/ds/components/InputGroup/input-group.tsx
+++ b/packages/playground-ui/src/ds/components/InputGroup/input-group.tsx
@@ -1,0 +1,195 @@
+import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { Button } from '@/ds/components/Button';
+import type { ButtonProps } from '@/ds/components/Button/Button';
+import {
+  formElementSizes,
+  formElementFocusWithin,
+  formElementRadius,
+} from '@/ds/primitives/form-element';
+import type { FormElementSize } from '@/ds/primitives/form-element';
+import { transitions } from '@/ds/primitives/transitions';
+import { cn } from '@/lib/utils';
+
+const InputGroupSizeContext = React.createContext<FormElementSize>('md');
+
+const inputGroupClassName = cn(
+  'group/input-group relative flex w-full min-w-0 items-stretch',
+  'bg-surface2 border border-border1 text-neutral6',
+  'hover:border-border2',
+  formElementRadius,
+  formElementFocusWithin,
+  transitions.all,
+  'has-[:disabled]:opacity-50 has-[:disabled]:cursor-not-allowed',
+  'has-[[aria-invalid=true]]:border-error has-[[aria-invalid=true]]:focus-within:ring-error has-[[aria-invalid=true]]:focus-within:shadow-glow-accent2',
+  'has-[>[data-align=block-start]]:flex-col',
+  'has-[>[data-align=block-end]]:flex-col',
+  'has-[>[data-align=inline-start]]:[&>[data-slot=input-group-control]]:pl-0',
+  'has-[>[data-align=inline-end]]:[&>[data-slot=input-group-control]]:pr-0',
+  // In flex-col, flex-1 collapses the input to basis-0. Force flex-none so `h-form-*` applies.
+  'has-[>[data-align=block-start]]:[&>[data-slot=input-group-control]]:flex-none has-[>[data-align=block-start]]:[&>[data-slot=input-group-control]]:w-full',
+  'has-[>[data-align=block-end]]:[&>[data-slot=input-group-control]]:flex-none has-[>[data-align=block-end]]:[&>[data-slot=input-group-control]]:w-full',
+);
+
+export type InputGroupProps = React.ComponentPropsWithoutRef<'div'> & {
+  size?: FormElementSize;
+};
+
+const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(({ className, size = 'md', ...props }, ref) => {
+  return (
+    <InputGroupSizeContext.Provider value={size}>
+      <div ref={ref} role="group" data-slot="input-group" className={cn(inputGroupClassName, className)} {...props} />
+    </InputGroupSizeContext.Provider>
+  );
+});
+InputGroup.displayName = 'InputGroup';
+
+const inputGroupAddonVariants = cva(
+  cn(
+    'flex items-center justify-center gap-2 text-neutral3 select-none',
+    'group-has-[:disabled]/input-group:opacity-50',
+    "[&>svg:not([class*='size-'])]:size-4",
+  ),
+  {
+    variants: {
+      align: {
+        'inline-start': 'order-first pl-3 pr-1 has-[>button]:pl-1',
+        'inline-end': 'order-last pr-3 pl-1 has-[>button]:pr-1',
+        'block-start': 'order-first w-full justify-start px-3 pt-2 pb-1 border-b border-border1',
+        'block-end': 'order-last w-full justify-start px-3 pb-2 pt-1 border-t border-border1',
+      },
+    },
+    defaultVariants: {
+      align: 'inline-start',
+    },
+  },
+);
+
+export type InputGroupAddonProps = React.ComponentPropsWithoutRef<'div'> & VariantProps<typeof inputGroupAddonVariants>;
+
+const InputGroupAddon = React.forwardRef<HTMLDivElement, InputGroupAddonProps>(
+  ({ className, align = 'inline-start', onClick, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        role="group"
+        data-slot="input-group-addon"
+        data-align={align}
+        className={cn(inputGroupAddonVariants({ align }), className)}
+        onClick={event => {
+          // Click on non-interactive addon area focuses the control inside the group.
+          // Skip when a button/input handled the click itself.
+          const target = event.target as HTMLElement;
+          if (!target.closest('button, input, textarea, [role="button"]')) {
+            event.currentTarget.parentElement
+              ?.querySelector<HTMLInputElement | HTMLTextAreaElement>('[data-slot=input-group-control]')
+              ?.focus();
+          }
+          onClick?.(event);
+        }}
+        {...props}
+      />
+    );
+  },
+);
+InputGroupAddon.displayName = 'InputGroupAddon';
+
+const inputGroupControlTextSize: Record<FormElementSize, string> = {
+  sm: 'text-ui-sm',
+  md: 'text-ui-md',
+  default: 'text-ui-md',
+  lg: 'text-ui-lg',
+};
+
+export type InputGroupInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> & {
+  testId?: string;
+  error?: boolean;
+};
+
+const InputGroupInput = React.forwardRef<HTMLInputElement, InputGroupInputProps>(
+  ({ className, testId, error, type = 'text', ...props }, ref) => {
+    const size = React.useContext(InputGroupSizeContext);
+    return (
+      <input
+        ref={ref}
+        type={type}
+        data-slot="input-group-control"
+        data-testid={testId}
+        aria-invalid={error}
+        className={cn(
+          'flex-1 min-w-0 bg-transparent text-neutral6 px-3 outline-hidden',
+          formElementSizes[size],
+          inputGroupControlTextSize[size],
+          'placeholder:text-neutral2 placeholder:transition-opacity placeholder:duration-normal',
+          'focus:placeholder:opacity-70',
+          'disabled:cursor-not-allowed',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+InputGroupInput.displayName = 'InputGroupInput';
+
+export type InputGroupTextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  testId?: string;
+  error?: boolean;
+};
+
+const InputGroupTextarea = React.forwardRef<HTMLTextAreaElement, InputGroupTextareaProps>(
+  ({ className, testId, error, ...props }, ref) => {
+    const size = React.useContext(InputGroupSizeContext);
+    return (
+      <textarea
+        ref={ref}
+        data-slot="input-group-control"
+        data-testid={testId}
+        aria-invalid={error}
+        className={cn(
+          'flex-1 min-w-0 min-h-[60px] resize-y bg-transparent text-neutral6 px-3 py-2 outline-hidden',
+          inputGroupControlTextSize[size],
+          'placeholder:text-neutral2 placeholder:transition-opacity placeholder:duration-normal',
+          'focus:placeholder:opacity-70',
+          'disabled:cursor-not-allowed',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+InputGroupTextarea.displayName = 'InputGroupTextarea';
+
+export type InputGroupTextProps = React.ComponentPropsWithoutRef<'span'>;
+
+const InputGroupText = React.forwardRef<HTMLSpanElement, InputGroupTextProps>(({ className, ...props }, ref) => {
+  return (
+    <span
+      ref={ref}
+      className={cn(
+        'flex items-center gap-2 text-ui-sm text-neutral3 [&_svg]:pointer-events-none',
+        "[&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+InputGroupText.displayName = 'InputGroupText';
+
+export type InputGroupButtonProps = Omit<ButtonProps, 'size' | 'variant'> & {
+  size?: ButtonProps['size'];
+  variant?: ButtonProps['variant'];
+};
+
+const InputGroupButton = React.forwardRef<HTMLButtonElement, InputGroupButtonProps>(
+  ({ size = 'icon-sm', variant = 'ghost', type = 'button', ...props }, ref) => {
+    return <Button ref={ref} type={type} size={size} variant={variant} {...props} />;
+  },
+);
+InputGroupButton.displayName = 'InputGroupButton';
+
+export { InputGroup, InputGroupAddon, InputGroupInput, InputGroupTextarea, InputGroupText, InputGroupButton };

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -1,5 +1,8 @@
 import './index.css';
 
+// DS Components - Threads
+export * from './ds/components/Threads';
+
 // DS Components - Existing
 export * from './ds/components/Avatar';
 export * from './ds/components/Badge/index';

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -1,8 +1,5 @@
 import './index.css';
 
-// DS Components - Threads
-export * from './ds/components/Threads';
-
 // DS Components - Existing
 export * from './ds/components/Avatar';
 export * from './ds/components/Badge/index';
@@ -34,6 +31,7 @@ export * from './ds/components/Entry';
 export * from './ds/components/EntityHeader';
 export * from './ds/components/FormFieldBlocks';
 export * from './ds/components/Input';
+export * from './ds/components/InputGroup';
 export * from './ds/components/Kbd';
 export * from './ds/components/Label';
 export * from './ds/components/MarkdownRenderer';


### PR DESCRIPTION
## Summary
- Added `InputGroup` — composes inputs/textareas with inline (`inline-start`, `inline-end`) or block (`block-start`, `block-end`) addons. Slots: `InputGroupAddon`, `InputGroupInput`, `InputGroupTextarea`, `InputGroupText`, `InputGroupButton`. Size propagated to control via context; error/disabled propagate up via `:has()` selectors.
- Extended `ButtonsGroup` — added `orientation` (`horizontal` | `vertical`), `ButtonsGroupSeparator`, `ButtonsGroupText`. Existing API (`spacing`, children) unchanged. Separators excluded from `-ml-px`/`-mt-px` border-collapse so they stay visible. Vertical close-spacing replaces capsule outer corners with `rounded-xl` for a clean fused stack.
- Tweaked `Button` ghost variant — hover/active progression aligned with outline (`surface3` → `surface4`) so click feedback is perceptible on transparent backgrounds.

## Why
`Searchbar` and several inline `<input>` wrappers in playground reimplement the same input-with-icon pattern. `InputGroup` consolidates that. `ButtonsGroup` was minimal — adding orientation/separator/text slots makes it usable for vertical toolbars, segmented controls, and steppers.

## Usage
```tsx
import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupButton } from '@mastra/playground-ui';
import { SearchIcon, XIcon } from 'lucide-react';

<InputGroup>
  <InputGroupAddon>
    <SearchIcon />
  </InputGroupAddon>
  <InputGroupInput placeholder="Search..." />
  <InputGroupAddon align="inline-end">
    <InputGroupButton aria-label="Clear">
      <XIcon />
    </InputGroupButton>
  </InputGroupAddon>
</InputGroup>
```

```tsx
<ButtonsGroup spacing="close">
  <Button variant="outline">−</Button>
  <ButtonsGroupText>42</ButtonsGroupText>
  <Button variant="outline">+</Button>
</ButtonsGroup>

<ButtonsGroup orientation="vertical">
  <Button variant="ghost">Copy</Button>
  <ButtonsGroupSeparator />
  <Button variant="ghost">Cut</Button>
</ButtonsGroup>
```

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm build` clean (Vite + dts)
- [x] `pnpm test -- --run` — 132 tests pass, includes 6 new `InputGroup` regression tests for size propagation and the block-mode `flex-none`/`w-full` overrides
- [ ] Visual check in Storybook for `Composite/InputGroup` and `Composite/ButtonsGroup` stories
- [ ] Visual smoke of any existing `Button variant="ghost"` consumers (sidebar items, toolbars) — ghost hover/active shifted one shade lighter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a tiny toolbox for building input groups (inputs/textarea with inline or block addons like icons, buttons, labels) and improves button grouping so groups can be vertical and support separators/text, while making ghost buttons give clearer hover/press feedback.

---

## Summary

- InputGroup (new component set)
  - Exports: InputGroup, InputGroupAddon, InputGroupInput, InputGroupTextarea, InputGroupText, InputGroupButton.
  - Addon alignment: inline-start / inline-end (left/right) and block-start / block-end (top/bottom).
  - Size is driven by a FormElementSize React context and propagated to controls.
  - Error and disabled states propagate via :has() selectors on the wrapper and aria-invalid on controls.
  - InputGroupAddon focuses the first nested control when clicking non-interactive addon regions.
  - Test coverage: added regression tests for size propagation, block-mode flex/width overrides, inline-padding behavior, and aria-invalid propagation.
  - Stories: examples for default, inline/block addons, sizes, disabled/invalid, keyboard hint, text addon, and a textarea variant.
  - Files added/changed: input-group.tsx, input-group.stories.tsx, input-group.test.tsx, index.ts; package index re-exported InputGroup.

- ButtonsGroup (extended)
  - New prop: orientation: 'horizontal' | 'vertical' (exposed via context).
  - New slots/components: ButtonsGroupSeparator, ButtonsGroupText.
  - Reworked implementation using class-variance-authority (cva) and forwardRef; existing spacing API preserved.
  - close spacing behavior:
    - Separators are excluded from -ml-px / -mt-px border-collapse so they remain visible.
    - Vertical close-spacing replaces capsule outer corners with rounded-xl and flattens inner corners for a fused stacked appearance; focused child elevation handled with z-index.
  - Stories: added Vertical, VerticalCloseSpacing, WithSeparator, VerticalWithSeparator, WithText and other spacing examples.
  - Files changed: buttons-group.tsx, buttons-group.stories.tsx; exports buttonsGroupVariants and ButtonsGroupSpacing type derived from cva.

- Button styling tweak
  - Ghost variant hover/active progression adjusted: hover:bg-surface3 → active:bg-surface4 (previously hover:bg-surface4 / active:bg-surface5) to provide more perceptible feedback on transparent backgrounds.
  - File changed: Button.tsx (buttonVariants).

- Packaging & exports
  - InputGroup re-exported from packages/playground-ui/src/ds/components/InputGroup and added to package index export.
  - Threads export present in package index (restored to avoid downstream breakage).
  - Updated packages/playground-ui/.gitignore to ignore leaked test/ storage.

- Tests & build
  - Type-check and build pass.
  - pnpm test: 132 passing tests including 6 new InputGroup regression tests.
  - Pending: visual Storybook checks and visual smoke tests for ghost-button consumers.

## Notable changed/added files (high level)
- Added: packages/playground-ui/src/ds/components/InputGroup/{input-group.tsx,input-group.stories.tsx,input-group.test.tsx,index.ts}
- Modified: packages/playground-ui/src/ds/components/ButtonsGroup/{buttons-group.tsx,buttons-group.stories.tsx}
- Modified: packages/playground-ui/src/ds/components/Button/Button.tsx
- Updated: packages/playground-ui/src/index.ts (exports InputGroup; Threads export present)
- Misc: packages/playground-ui/.gitignore updated

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16417)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->