### PR TITLE
Remove search from Traces page

### DIFF
--- a/.changeset/traces-page-remove-search.md
+++ b/.changeset/traces-page-remove-search.md
@@ -2,4 +2,4 @@
 'mastra': patch
 ---
 
-Removed mistakenly added the search input from the Traces page in Studio.
+Removed the unintended search input from the Traces page in Studio.

--- a/.changeset/traces-page-remove-search.md
+++ b/.changeset/traces-page-remove-search.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Removed mistakenly added the search input from the Traces page in Studio.

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -2,7 +2,6 @@ import { EntityType } from '@mastra/core/observability';
 import {
   ButtonWithTooltip,
   DateTimeRangePicker,
-  ListSearch,
   NoTracesInfo,
   PageHeader,
   PageLayout,
@@ -51,7 +50,6 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
   const isScoped = !!scopedEntityId;
   const [searchParams, setSearchParams] = useSearchParams();
   const [groupByThread, setGroupByThread] = useState<boolean>(false);
-  const [search, setSearch] = useState<string>('');
   const url = useTraceUrlState(searchParams, setSearchParams, {
     onRemoveAll: () => setGroupByThread(false),
   });
@@ -179,20 +177,6 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
   const traces = useMemo(() => tracesData?.spans ?? [], [tracesData?.spans]);
   const threadTitles = tracesData?.threadTitles ?? {};
 
-  const filteredTraces = useMemo(() => {
-    if (!search) return traces;
-    const q = search.toLowerCase();
-    return traces.filter(t => {
-      const parts: unknown[] = [t.input, t.output, t.error, t.name];
-      for (const part of parts) {
-        if (part == null) continue;
-        const str = typeof part === 'string' ? part : JSON.stringify(part);
-        if (str.toLowerCase().includes(q)) return true;
-      }
-      return false;
-    });
-  }, [traces, search]);
-
   const { handlePreviousSpan, handleNextSpan } = useTraceSpanNavigation(lightSpans, url.spanIdParam ?? null, id =>
     url.handleSpanChange(id),
   );
@@ -207,7 +191,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
   );
 
   const { handlePreviousTrace, handleNextTrace } = useTraceListNavigation(
-    filteredTraces,
+    traces,
     url.traceIdParam,
     url.handleTraceClick,
   );
@@ -229,14 +213,6 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
 
   const toolbarControls = (
     <>
-      <div className="w-64">
-        <ListSearch
-          onSearch={setSearch}
-          label="Search traces"
-          placeholder="Search input, output or error..."
-          debounceMs={300}
-        />
-      </div>
       <DateTimeRangePicker
         preset={url.datePreset}
         onPresetChange={url.handleDatePresetChange}
@@ -345,12 +321,12 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
         traceCollapsed={traceCollapsed}
         listSlot={
           <TracesListView
-            traces={filteredTraces}
+            traces={traces}
             isLoading={isTracesLoading}
             isFetchingNextPage={isFetchingNextPage}
             hasNextPage={hasNextPage}
             setEndOfListElement={setEndOfListElement}
-            filtersApplied={filtersApplied || !!search}
+            filtersApplied={filtersApplied}
             featuredTraceId={url.traceIdParam}
             onTraceClick={trace => url.handleTraceClick(url.traceIdParam === trace.traceId ? '' : trace.traceId)}
             groupByThread={groupByThread}


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

We do not have supported by backend search feature for Traces list. 

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR removes an accidental search box from the Traces page so traces are no longer filtered locally by a free-text search. The page will now show the full list of traces, and only official URL/query filters count as applied filters.

## Changes
- Removed local free-text search state and the rendered `ListSearch` control from the Traces page.
- Eliminated client-side filtering that matched `input`, `output`, `error`, or `name` against the search query.
- Updated the "filters applied" calculation passed to `TracesListView` to exclude the removed search text (only URL/query-based filters are considered).
- Added a Changesets entry documenting the removal as a patch for `mastra`.

## Files Modified
- `packages/playground/src/pages/traces/index.tsx` (+3/−27)
- `.changeset/traces-page-remove-search.md` (+5)

## Impact
The Traces page no longer performs client-side free-text searches; it displays traces as returned by `useTraces`, and the filters-applied indicator reflects only persisted/query filters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16418)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->