### PR TITLE
fix(koa): correctly read user permissions from request context

### DIFF
--- a/.changeset/dark-friends-pay.md
+++ b/.changeset/dark-friends-pay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/koa': patch
+---
+
+Fixed RBAC permission checks rejecting authenticated users with valid permissions. The Koa adapter was reading user permissions from the wrong key in the request context, causing every permission check to deny access (403). Now aligned with the Express, Fastify, and Hono adapters.

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -454,7 +454,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
     if (authConfig) {
       const hasPermission = await loadHasPermission();
       if (hasPermission) {
-        const userPermissions = ctx.state.requestContext.get('userPermissions') as string[] | undefined;
+        const userPermissions = ctx.state.requestContext.get('mastra__userPermissions') as string[] | undefined;
         const permissionError = this.checkRoutePermission(route, userPermissions, hasPermission);
 
         if (permissionError) {
@@ -888,7 +888,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
           if (authConfig) {
             const hasPermission = await loadHasPermission();
             if (hasPermission) {
-              const userPermissions = ctx.state.requestContext.get('userPermissions') as string[] | undefined;
+              const userPermissions = ctx.state.requestContext.get('mastra__userPermissions') as string[] | undefined;
               const permissionError = server.checkRoutePermission(serverRoute, userPermissions, hasPermission);
               if (permissionError) {
                 ctx.status = permissionError.status;

--- a/stores/mongodb/src/storage/domains/agents/index.ts
+++ b/stores/mongodb/src/storage/domains/agents/index.ts
@@ -243,13 +243,7 @@ export class MongoDBAgentsStorage extends AgentsStorage {
       await collection.insertOne(this.serializeAgent(newAgent));
 
       // Extract config fields from the flat input
-      const {
-        id: _id,
-        authorId: _authorId,
-        visibility: _visibility,
-        metadata: _metadata,
-        ...snapshotConfig
-      } = agent;
+      const { id: _id, authorId: _authorId, visibility: _visibility, metadata: _metadata, ...snapshotConfig } = agent;
 
       // Create version 1 from the config
       const versionId = randomUUID();


### PR DESCRIPTION
## Summary

The Koa server adapter was rejecting authenticated users with valid permissions because it read the user's permissions from the wrong key in the request context.

The core auth middleware stores user permissions under `mastra__userPermissions` (the value of `MASTRA_USER_PERMISSIONS_KEY`), but the Koa adapter was reading from `userPermissions`. As a result, the lookup always returned `undefined` and every authenticated request — including ones for routes the user was explicitly allowed to access — was denied with `403 Forbidden`.

This change aligns the Koa adapter with the Express, Fastify, and Hono adapters, which all use the correct key.

A small prettier formatting fix to `stores/mongodb/src/storage/domains/agents/index.ts` is also included to keep the codebase clean.

## Test Plan

- `pnpm test` in `server-adapters/koa` — all 2185 tests pass (previously 6 failures in `rbac-permissions.test.ts`).
- The 6 previously-failing tests now pass, including viewer/member access to allowed routes, wildcard permissions, and the derived-permission route case.
- `pnpm prettier --check` is clean for the modified files.
