### PR TITLE
Skip applied ALTERs in ClickHouse init to prevent replica races

### DIFF
--- a/.changeset/clickhouse-skip-applied-alters.md
+++ b/.changeset/clickhouse-skip-applied-alters.md
@@ -1,0 +1,7 @@
+---
+'@mastra/clickhouse': patch
+---
+
+Fixed intermittent agent hangs when ClickHouse observability storage was configured. On Replicated/Shared MergeTree, every `ALTER` bumps the table's metadata version even when the change is a no-op, so re-issuing `ADD COLUMN IF NOT EXISTS`, `ADD INDEX IF NOT EXISTS`, and `MODIFY TTL` statements on every process boot caused replica catch-up races. When a replica fell behind, init failed with "metadata version on replica is N, while common metadata is N+1. Please retry this query.", the storage proxy cached the rejected init promise, and every subsequent storage call hung — including memory and trace writes during streaming.
+
+Init now introspects `system.columns`, `system.data_skipping_indices`, and `system.tables.create_table_query` and skips ALTERs whose target is already in place. On a steady-state database init issues zero ALTERs, eliminating the metadata churn.

--- a/.changeset/clickhouse-skip-applied-alters.md
+++ b/.changeset/clickhouse-skip-applied-alters.md
@@ -2,6 +2,4 @@
 '@mastra/clickhouse': patch
 ---
 
-Fixed intermittent agent hangs when ClickHouse observability storage was configured. On Replicated/Shared MergeTree, every `ALTER` bumps the table's metadata version even when the change is a no-op, so re-issuing `ADD COLUMN IF NOT EXISTS`, `ADD INDEX IF NOT EXISTS`, and `MODIFY TTL` statements on every process boot caused replica catch-up races. When a replica fell behind, init failed with "metadata version on replica is N, while common metadata is N+1. Please retry this query.", the storage proxy cached the rejected init promise, and every subsequent storage call hung — including memory and trace writes during streaming.
-
-Init now introspects `system.columns`, `system.data_skipping_indices`, and `system.tables.create_table_query` and skips ALTERs whose target is already in place. On a steady-state database init issues zero ALTERs, eliminating the metadata churn.
+Fixed agent streams intermittently hanging when observability storage was backed by Replicated/Shared ClickHouse. Startup no longer re-applies no-op schema updates (e.g. `ADD COLUMN IF NOT EXISTS`, `ADD INDEX IF NOT EXISTS`, `MODIFY TTL`), so it no longer triggers replica-lag retry errors that could leave storage in a stuck state.

--- a/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
@@ -899,12 +899,16 @@ export function buildRetentionDDL(retention: RetentionConfig): string[] {
  * Parses a ClickHouse `TTL` expression of the form
  *   `TTL <col> + INTERVAL <N> DAY`     (input form)
  *   `TTL <col> + toIntervalDay(<N>)`   (normalized form in system.tables)
+ * The column may appear as `\`col\`` (backtick-quoted, common in
+ * system.tables.create_table_query) or as a plain identifier.
  * Returns `{ column, days }` if matched, otherwise null.
  */
 export function parseTtlExpression(expr: string): { column: string; days: number } | null {
-  const match = expr.match(/TTL\s+(\w+)\s*\+\s*(?:toIntervalDay\((\d+)\)|INTERVAL\s+(\d+)\s+DAY)/i);
+  const match = expr.match(/TTL\s+(?:`([^`]+)`|(\w+))\s*\+\s*(?:toIntervalDay\((\d+)\)|INTERVAL\s+(\d+)\s+DAY)/i);
   if (!match) return null;
-  const days = Number(match[2] ?? match[3]);
+  const column = match[1] ?? match[2];
+  if (!column) return null;
+  const days = Number(match[3] ?? match[4]);
   if (!Number.isFinite(days)) return null;
-  return { column: match[1]!, days };
+  return { column, days };
 }

--- a/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
@@ -708,45 +708,68 @@ export const DISCOVERY_MV_DDL = [DISCOVERY_VALUES_MV_DDL, DISCOVERY_PAIRS_MV_DDL
  * Additive migrations for existing ClickHouse databases.
  * ClickHouse's `CREATE TABLE IF NOT EXISTS` skips if the table already exists,
  * so new columns must be added explicitly via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`.
+ *
+ * Entries are structured so init() can skip ones whose target column/index
+ * already exists. On Replicated/Shared MergeTree, every issued ALTER bumps the
+ * metadata version regardless of `IF NOT EXISTS`, causing replica catch-up
+ * races on every boot. Skipping no-op ALTERs eliminates that churn.
  */
-export const ALL_MIGRATIONS = [
+export type MigrationEntry =
+  | { kind: 'column'; table: string; name: string; sql: string }
+  | { kind: 'index'; table: string; name: string; sql: string };
+
+const addColumn = (table: string, name: string, type: string): MigrationEntry => ({
+  kind: 'column',
+  table,
+  name,
+  sql: `ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS ${name} ${type}`,
+});
+
+const addBloomIndex = (table: string, name: string, column: string): MigrationEntry => ({
+  kind: 'index',
+  table,
+  name,
+  sql: `ALTER TABLE ${table} ADD INDEX IF NOT EXISTS ${name} ${column} TYPE bloom_filter(0.01) GRANULARITY 2`,
+});
+
+export const ALL_MIGRATIONS: readonly MigrationEntry[] = [
   // Span events
-  `ALTER TABLE ${TABLE_SPAN_EVENTS} ADD COLUMN IF NOT EXISTS entityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_SPAN_EVENTS} ADD COLUMN IF NOT EXISTS parentEntityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_SPAN_EVENTS} ADD COLUMN IF NOT EXISTS rootEntityVersionId Nullable(String)`,
+  addColumn(TABLE_SPAN_EVENTS, 'entityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_SPAN_EVENTS, 'parentEntityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_SPAN_EVENTS, 'rootEntityVersionId', 'Nullable(String)'),
   // Trace roots
-  `ALTER TABLE ${TABLE_TRACE_ROOTS} ADD COLUMN IF NOT EXISTS entityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_TRACE_ROOTS} ADD COLUMN IF NOT EXISTS parentEntityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_TRACE_ROOTS} ADD COLUMN IF NOT EXISTS rootEntityVersionId Nullable(String)`,
+  addColumn(TABLE_TRACE_ROOTS, 'entityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_TRACE_ROOTS, 'parentEntityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_TRACE_ROOTS, 'rootEntityVersionId', 'Nullable(String)'),
   // Metrics
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD COLUMN IF NOT EXISTS entityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD COLUMN IF NOT EXISTS parentEntityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD COLUMN IF NOT EXISTS rootEntityVersionId Nullable(String)`,
+  addColumn(TABLE_METRIC_EVENTS, 'entityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_METRIC_EVENTS, 'parentEntityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_METRIC_EVENTS, 'rootEntityVersionId', 'Nullable(String)'),
   // Logs
-  `ALTER TABLE ${TABLE_LOG_EVENTS} ADD COLUMN IF NOT EXISTS entityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_LOG_EVENTS} ADD COLUMN IF NOT EXISTS parentEntityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_LOG_EVENTS} ADD COLUMN IF NOT EXISTS rootEntityVersionId Nullable(String)`,
+  addColumn(TABLE_LOG_EVENTS, 'entityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_LOG_EVENTS, 'parentEntityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_LOG_EVENTS, 'rootEntityVersionId', 'Nullable(String)'),
   // Scores
-  `ALTER TABLE ${TABLE_SCORE_EVENTS} ADD COLUMN IF NOT EXISTS entityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_SCORE_EVENTS} ADD COLUMN IF NOT EXISTS parentEntityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_SCORE_EVENTS} ADD COLUMN IF NOT EXISTS rootEntityVersionId Nullable(String)`,
+  addColumn(TABLE_SCORE_EVENTS, 'entityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_SCORE_EVENTS, 'parentEntityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_SCORE_EVENTS, 'rootEntityVersionId', 'Nullable(String)'),
   // Feedback
-  `ALTER TABLE ${TABLE_FEEDBACK_EVENTS} ADD COLUMN IF NOT EXISTS entityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_FEEDBACK_EVENTS} ADD COLUMN IF NOT EXISTS parentEntityVersionId Nullable(String)`,
-  `ALTER TABLE ${TABLE_FEEDBACK_EVENTS} ADD COLUMN IF NOT EXISTS rootEntityVersionId Nullable(String)`,
+  addColumn(TABLE_FEEDBACK_EVENTS, 'entityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_FEEDBACK_EVENTS, 'parentEntityVersionId', 'Nullable(String)'),
+  addColumn(TABLE_FEEDBACK_EVENTS, 'rootEntityVersionId', 'Nullable(String)'),
   // Metric skip indexes — additive, instant DDL. Existing parts keep no index
   // until merged or `MATERIALIZE INDEX` is run; new parts are bloom-filtered
   // immediately. With normal retention turning over the table, the index
   // converges to full coverage without an explicit backfill.
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_traceId traceId TYPE bloom_filter(0.01) GRANULARITY 2`,
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_threadId threadId TYPE bloom_filter(0.01) GRANULARITY 2`,
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_resourceId resourceId TYPE bloom_filter(0.01) GRANULARITY 2`,
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_userId userId TYPE bloom_filter(0.01) GRANULARITY 2`,
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_organizationId organizationId TYPE bloom_filter(0.01) GRANULARITY 2`,
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_experimentId experimentId TYPE bloom_filter(0.01) GRANULARITY 2`,
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_runId runId TYPE bloom_filter(0.01) GRANULARITY 2`,
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_sessionId sessionId TYPE bloom_filter(0.01) GRANULARITY 2`,
-  `ALTER TABLE ${TABLE_METRIC_EVENTS} ADD INDEX IF NOT EXISTS idx_requestId requestId TYPE bloom_filter(0.01) GRANULARITY 2`,
+  addBloomIndex(TABLE_METRIC_EVENTS, 'idx_traceId', 'traceId'),
+  addBloomIndex(TABLE_METRIC_EVENTS, 'idx_threadId', 'threadId'),
+  addBloomIndex(TABLE_METRIC_EVENTS, 'idx_resourceId', 'resourceId'),
+  addBloomIndex(TABLE_METRIC_EVENTS, 'idx_userId', 'userId'),
+  addBloomIndex(TABLE_METRIC_EVENTS, 'idx_organizationId', 'organizationId'),
+  addBloomIndex(TABLE_METRIC_EVENTS, 'idx_experimentId', 'experimentId'),
+  addBloomIndex(TABLE_METRIC_EVENTS, 'idx_runId', 'runId'),
+  addBloomIndex(TABLE_METRIC_EVENTS, 'idx_sessionId', 'sessionId'),
+  addBloomIndex(TABLE_METRIC_EVENTS, 'idx_requestId', 'requestId'),
 ];
 
 /**
@@ -826,13 +849,19 @@ const SIGNAL_TO_TABLES: Record<keyof RetentionConfig, string[]> = {
 };
 
 /**
- * Generates `ALTER TABLE ... MODIFY TTL` statements for the given retention config.
- * Returns empty array if no retention is configured.
- *
- * Uses `MODIFY TTL` so re-running init is idempotent (overwrites any previous TTL).
+ * Structured retention plan entry. Init uses these to skip `MODIFY TTL`
+ * statements whose effect is already in place (avoiding metadata churn on
+ * Replicated/Shared MergeTree tables).
  */
-export function buildRetentionDDL(retention: RetentionConfig): string[] {
-  const statements: string[] = [];
+export interface RetentionEntry {
+  table: string;
+  column: string;
+  days: number;
+  sql: string;
+}
+
+export function buildRetentionEntries(retention: RetentionConfig): RetentionEntry[] {
+  const entries: RetentionEntry[] = [];
 
   for (const [signal, days] of Object.entries(retention)) {
     const safeDays = Math.floor(Number(days));
@@ -844,9 +873,38 @@ export function buildRetentionDDL(retention: RetentionConfig): string[] {
     for (const table of tables) {
       const col = SIGNAL_TTL_COLUMNS[table];
       if (!col) continue;
-      statements.push(`ALTER TABLE ${table} MODIFY TTL ${col} + INTERVAL ${safeDays} DAY`);
+      entries.push({
+        table,
+        column: col,
+        days: safeDays,
+        sql: `ALTER TABLE ${table} MODIFY TTL ${col} + INTERVAL ${safeDays} DAY`,
+      });
     }
   }
 
-  return statements;
+  return entries;
+}
+
+/**
+ * Generates `ALTER TABLE ... MODIFY TTL` statements for the given retention config.
+ * Returns empty array if no retention is configured.
+ *
+ * Uses `MODIFY TTL` so re-running init is idempotent (overwrites any previous TTL).
+ */
+export function buildRetentionDDL(retention: RetentionConfig): string[] {
+  return buildRetentionEntries(retention).map(e => e.sql);
+}
+
+/**
+ * Parses a ClickHouse `TTL` expression of the form
+ *   `TTL <col> + INTERVAL <N> DAY`     (input form)
+ *   `TTL <col> + toIntervalDay(<N>)`   (normalized form in system.tables)
+ * Returns `{ column, days }` if matched, otherwise null.
+ */
+export function parseTtlExpression(expr: string): { column: string; days: number } | null {
+  const match = expr.match(/TTL\s+(\w+)\s*\+\s*(?:toIntervalDay\((\d+)\)|INTERVAL\s+(\d+)\s+DAY)/i);
+  if (!match) return null;
+  const days = Number(match[2] ?? match[3]);
+  if (!Number.isFinite(days)) return null;
+  return { column: match[1]!, days };
 }

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -4088,6 +4088,13 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       expect(parseTtlExpression(createTable)).toEqual({ column: 'endedAt', days: 30 });
     });
 
+    it('parseTtlExpression handles backtick-quoted column identifiers', () => {
+      // ClickHouse's `system.tables.create_table_query` often wraps identifiers
+      // in backticks, e.g. `TTL `endedAt` + toIntervalDay(30)`.
+      expect(parseTtlExpression('TTL `endedAt` + toIntervalDay(30)')).toEqual({ column: 'endedAt', days: 30 });
+      expect(parseTtlExpression('TTL `timestamp` + INTERVAL 7 DAY')).toEqual({ column: 'timestamp', days: 7 });
+    });
+
     it('parseTtlExpression returns null when no TTL clause is present', () => {
       expect(parseTtlExpression('ORDER BY (traceId, endedAt)')).toBeNull();
       expect(parseTtlExpression('')).toBeNull();

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -13,7 +13,7 @@
 import { createClient } from '@clickhouse/client';
 import { EntityType, SpanType } from '@mastra/core/observability';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildRetentionDDL } from './ddl';
+import { ALL_MIGRATIONS, buildRetentionDDL, buildRetentionEntries, parseTtlExpression } from './ddl';
 import { ObservabilityStorageClickhouseVNext } from '.';
 
 vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
@@ -4059,6 +4059,40 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       expect(stmts[0]).toBe('ALTER TABLE mastra_log_events MODIFY TTL timestamp + INTERVAL 7 DAY');
     });
 
+    // --- Unit tests for buildRetentionEntries ---
+
+    it('buildRetentionEntries returns structured entries whose sql matches buildRetentionDDL', () => {
+      const config = { tracing: 30, logs: 7, metrics: 14 };
+      const entries = buildRetentionEntries(config);
+      const ddl = buildRetentionDDL(config);
+      expect(entries).toHaveLength(ddl.length);
+      expect(entries.map(e => e.sql)).toEqual(ddl);
+      for (const entry of entries) {
+        expect(entry.sql).toContain(`ALTER TABLE ${entry.table}`);
+        expect(entry.sql).toContain(`${entry.column} + INTERVAL ${entry.days} DAY`);
+      }
+    });
+
+    // --- Unit tests for parseTtlExpression ---
+
+    it('parseTtlExpression parses normalized toIntervalDay form', () => {
+      expect(parseTtlExpression('TTL endedAt + toIntervalDay(30)')).toEqual({ column: 'endedAt', days: 30 });
+    });
+
+    it('parseTtlExpression parses INTERVAL N DAY form', () => {
+      expect(parseTtlExpression('TTL timestamp + INTERVAL 7 DAY')).toEqual({ column: 'timestamp', days: 7 });
+    });
+
+    it('parseTtlExpression extracts TTL from a full CREATE TABLE statement', () => {
+      const createTable = `CREATE TABLE mastra_span_events (...) ENGINE = ReplacingMergeTree PARTITION BY toDate(endedAt) ORDER BY (traceId) TTL endedAt + toIntervalDay(30) SETTINGS index_granularity = 8192`;
+      expect(parseTtlExpression(createTable)).toEqual({ column: 'endedAt', days: 30 });
+    });
+
+    it('parseTtlExpression returns null when no TTL clause is present', () => {
+      expect(parseTtlExpression('ORDER BY (traceId, endedAt)')).toBeNull();
+      expect(parseTtlExpression('')).toBeNull();
+    });
+
     // --- Integration test: retention is applied during init ---
 
     it('init applies retention TTL to tables', async () => {
@@ -4113,6 +4147,181 @@ describe('ObservabilityStorageClickhouseVNext', () => {
         for (const table of signalTables) {
           await client.command({ query: `ALTER TABLE ${table} REMOVE TTL` });
         }
+        await client.close();
+      }
+    });
+  });
+
+  // ==========================================================================
+  // init() idempotence
+  //
+  // Regression coverage for the metadata-version churn that hung agent streams
+  // when ClickHouse observability was configured. On Replicated/Shared
+  // MergeTree, every ALTER bumps the table's metadata version even when the
+  // change is a no-op, so init() must skip ALTERs whose target is already in
+  // place to avoid replica catch-up races on every process boot.
+  // ==========================================================================
+
+  describe('init idempotence', () => {
+    // --- Unit tests for ALL_MIGRATIONS shape ---
+
+    it('ALL_MIGRATIONS entries carry table + name consistent with their SQL', () => {
+      expect(ALL_MIGRATIONS.length).toBeGreaterThan(0);
+      for (const entry of ALL_MIGRATIONS) {
+        expect(entry.sql).toContain(`ALTER TABLE ${entry.table}`);
+        expect(entry.sql).toContain(entry.name);
+        if (entry.kind === 'column') {
+          expect(entry.sql).toContain('ADD COLUMN IF NOT EXISTS');
+        } else {
+          expect(entry.sql).toContain('ADD INDEX IF NOT EXISTS');
+        }
+      }
+    });
+
+    it('ALL_MIGRATIONS entry names are unique within (table, kind)', () => {
+      const seen = new Set<string>();
+      for (const entry of ALL_MIGRATIONS) {
+        const key = `${entry.kind}:${entry.table}:${entry.name}`;
+        expect(seen.has(key), `duplicate migration entry ${key}`).toBe(false);
+        seen.add(key);
+      }
+    });
+
+    // --- Integration tests: init() must not re-issue applied ALTERs ---
+
+    it('re-running init against a current schema emits zero ALTER statements', async () => {
+      const client = createClient({
+        url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+        username: process.env.CLICKHOUSE_USERNAME || 'default',
+        password: process.env.CLICKHOUSE_PASSWORD || 'password',
+      });
+
+      try {
+        // First init brings the DB to the current schema.
+        const first = new ObservabilityStorageClickhouseVNext({ client });
+        await first.init();
+
+        // Wrap client.command so we can observe the second init's DDL traffic.
+        const originalCommand = client.command.bind(client);
+        const commands: string[] = [];
+        const spy = vi.spyOn(client, 'command').mockImplementation(async args => {
+          commands.push((args as { query: string }).query);
+          return originalCommand(args);
+        });
+
+        try {
+          const second = new ObservabilityStorageClickhouseVNext({ client });
+          await second.init();
+
+          const alters = commands.filter(q => /^\s*ALTER\s+TABLE/i.test(q));
+          expect(alters, `expected no ALTERs, got:\n${alters.join('\n')}`).toEqual([]);
+        } finally {
+          spy.mockRestore();
+        }
+      } finally {
+        await client.close();
+      }
+    });
+
+    it('changing retention only emits MODIFY TTL for tables whose value actually differs', async () => {
+      const client = createClient({
+        url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+        username: process.env.CLICKHOUSE_USERNAME || 'default',
+        password: process.env.CLICKHOUSE_PASSWORD || 'password',
+      });
+
+      const signalTables = [
+        'mastra_span_events',
+        'mastra_trace_roots',
+        'mastra_trace_branches',
+        'mastra_log_events',
+        'mastra_metric_events',
+        'mastra_score_events',
+        'mastra_feedback_events',
+      ];
+
+      try {
+        // Establish baseline retention.
+        const first = new ObservabilityStorageClickhouseVNext({
+          client,
+          retention: { tracing: 30, logs: 7, metrics: 14 },
+        });
+        await first.init();
+
+        // Spy on the second init's DDL traffic.
+        const originalCommand = client.command.bind(client);
+        const commands: string[] = [];
+        const spy = vi.spyOn(client, 'command').mockImplementation(async args => {
+          commands.push((args as { query: string }).query);
+          return originalCommand(args);
+        });
+
+        try {
+          // Change only `logs`; leave tracing and metrics unchanged.
+          const second = new ObservabilityStorageClickhouseVNext({
+            client,
+            retention: { tracing: 30, logs: 21, metrics: 14 },
+          });
+          await second.init();
+
+          const ttlAlters = commands.filter(q => /MODIFY TTL/i.test(q));
+          expect(ttlAlters).toHaveLength(1);
+          expect(ttlAlters[0]).toContain('mastra_log_events');
+          expect(ttlAlters[0]).toContain('21 DAY');
+        } finally {
+          spy.mockRestore();
+        }
+      } finally {
+        // Clean up TTLs so other tests start from a clean state.
+        for (const table of signalTables) {
+          await client.command({ query: `ALTER TABLE ${table} REMOVE TTL` }).catch(() => {});
+        }
+        await client.close();
+      }
+    });
+
+    it('init still applies an ALTER for a column that was manually dropped', async () => {
+      const client = createClient({
+        url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+        username: process.env.CLICKHOUSE_USERNAME || 'default',
+        password: process.env.CLICKHOUSE_PASSWORD || 'password',
+      });
+
+      // Pick a migration we know is additive and safe to drop/re-add.
+      const target = ALL_MIGRATIONS.find(
+        m => m.kind === 'column' && m.table === 'mastra_log_events' && m.name === 'entityVersionId',
+      );
+      expect(target).toBeDefined();
+
+      try {
+        await new ObservabilityStorageClickhouseVNext({ client }).init();
+        await client.command({
+          query: `ALTER TABLE ${target!.table} DROP COLUMN IF EXISTS ${target!.name}`,
+        });
+
+        const originalCommand = client.command.bind(client);
+        const commands: string[] = [];
+        const spy = vi.spyOn(client, 'command').mockImplementation(async args => {
+          commands.push((args as { query: string }).query);
+          return originalCommand(args);
+        });
+
+        try {
+          await new ObservabilityStorageClickhouseVNext({ client }).init();
+          const matched = commands.filter(q => q.includes(`ALTER TABLE ${target!.table}`) && q.includes(target!.name));
+          expect(matched).toHaveLength(1);
+        } finally {
+          spy.mockRestore();
+        }
+
+        // Verify column is back so subsequent tests see the expected schema.
+        const colResult = await client.query({
+          query: `SELECT name FROM system.columns WHERE database = currentDatabase() AND table = {table:String} AND name = {name:String}`,
+          query_params: { table: target!.table, name: target!.name },
+          format: 'JSONEachRow',
+        });
+        expect(((await colResult.json()) as unknown[]).length).toBe(1);
+      } finally {
         await client.close();
       }
     });

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
@@ -96,9 +96,10 @@ import {
   ALL_TABLE_NAMES,
   MV_DISCOVERY_VALUES,
   MV_DISCOVERY_PAIRS,
-  buildRetentionDDL,
+  buildRetentionEntries,
+  parseTtlExpression,
 } from './ddl';
-import type { RetentionConfig } from './ddl';
+import type { MigrationEntry, RetentionEntry, RetentionConfig } from './ddl';
 export type { RetentionConfig } from './ddl';
 
 /** Extended config for v-next observability, adding per-signal retention. */
@@ -146,6 +147,104 @@ function buildSignalMigrationRequiredMessage(args: {
   );
 }
 
+/**
+ * Returns migrations whose target column/index does not yet exist. Falls back
+ * to running every migration if introspection fails — preserves correctness on
+ * older ClickHouse versions or restricted-permission users.
+ */
+async function filterAppliedMigrations(
+  client: ClickHouseClient,
+  migrations: readonly MigrationEntry[],
+): Promise<readonly MigrationEntry[]> {
+  if (migrations.length === 0) return migrations;
+
+  const tables = [...new Set(migrations.map(m => m.table))];
+
+  let existingColumns: Map<string, Set<string>>;
+  let existingIndices: Map<string, Set<string>>;
+  try {
+    [existingColumns, existingIndices] = await Promise.all([
+      queryNamesByTable(
+        client,
+        `SELECT table, name FROM system.columns WHERE database = currentDatabase() AND table IN ({tables:Array(String)})`,
+        tables,
+      ),
+      queryNamesByTable(
+        client,
+        `SELECT table, name FROM system.data_skipping_indices WHERE database = currentDatabase() AND table IN ({tables:Array(String)})`,
+        tables,
+      ),
+    ]);
+  } catch {
+    return migrations;
+  }
+
+  return migrations.filter(m => {
+    const present = m.kind === 'column' ? existingColumns.get(m.table) : existingIndices.get(m.table);
+    // If we don't have introspection data for this table, run the migration
+    // (table may not exist yet — preceding CREATE TABLE IF NOT EXISTS handles it).
+    if (!present) return true;
+    return !present.has(m.name);
+  });
+}
+
+/**
+ * Returns retention entries whose `MODIFY TTL` would actually change the
+ * table's TTL. Falls back to running every entry if introspection fails.
+ */
+async function filterAppliedRetention(
+  client: ClickHouseClient,
+  entries: readonly RetentionEntry[],
+): Promise<readonly RetentionEntry[]> {
+  if (entries.length === 0) return entries;
+
+  const tables = [...new Set(entries.map(e => e.table))];
+
+  let createQueries: Map<string, string>;
+  try {
+    const result = await client.query({
+      query: `SELECT name, create_table_query FROM system.tables WHERE database = currentDatabase() AND name IN ({tables:Array(String)})`,
+      query_params: { tables },
+      format: 'JSONEachRow',
+    });
+    const rows = (await result.json()) as Array<{ name: string; create_table_query: string }>;
+    createQueries = new Map(rows.map(r => [r.name, r.create_table_query ?? '']));
+  } catch {
+    return entries;
+  }
+
+  return entries.filter(e => {
+    const createQuery = createQueries.get(e.table);
+    if (!createQuery) return true;
+    const current = parseTtlExpression(createQuery);
+    if (!current) return true;
+    return current.column !== e.column || current.days !== e.days;
+  });
+}
+
+async function queryNamesByTable(
+  client: ClickHouseClient,
+  query: string,
+  tables: string[],
+): Promise<Map<string, Set<string>>> {
+  const result = await client.query({
+    query,
+    query_params: { tables },
+    format: 'JSONEachRow',
+  });
+  const rows = (await result.json()) as Array<{ table: string; name: string }>;
+  const out = new Map<string, Set<string>>();
+  for (const row of rows) {
+    let set = out.get(row.table);
+    if (!set) {
+      set = new Set<string>();
+      out.set(row.table, set);
+    }
+    set.add(row.name);
+  }
+  return out;
+}
+
 export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
   readonly #client: ClickHouseClient;
   readonly #retention?: RetentionConfig;
@@ -181,17 +280,24 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
         await this.#client.command({ query: ddl });
       }
 
-      // Additive migrations for existing databases (add new columns)
-      for (const migration of ALL_MIGRATIONS) {
-        await this.#client.command({ query: migration });
+      // Additive migrations for existing databases (add new columns/indexes).
+      // Filter out ALTERs whose target already exists: on Replicated/Shared
+      // MergeTree, every issued ALTER bumps the table's metadata version
+      // even when `IF NOT EXISTS` is a no-op, causing replica-lag retry
+      // errors on every boot when multiple replicas/pods race.
+      const pendingMigrations = await filterAppliedMigrations(this.#client, ALL_MIGRATIONS);
+      for (const migration of pendingMigrations) {
+        await this.#client.command({ query: migration.sql });
       }
 
       // Apply retention TTL if configured (per design doc: per-signal, day increments).
-      // Uses ALTER TABLE ... MODIFY TTL so re-running init is idempotent.
+      // Skip statements whose current TTL already matches: `MODIFY TTL` bumps the
+      // metadata version unconditionally, so re-issuing it on every boot is the
+      // primary source of replica-catch-up races in deployments with retention.
       if (this.#retention) {
-        const ttlStatements = buildRetentionDDL(this.#retention);
-        for (const stmt of ttlStatements) {
-          await this.#client.command({ query: stmt });
+        const pendingRetention = await filterAppliedRetention(this.#client, buildRetentionEntries(this.#retention));
+        for (const entry of pendingRetention) {
+          await this.#client.command({ query: entry.sql });
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Description

Fixed intermittent agent hangs when ClickHouse observability storage was configured. On Replicated/Shared MergeTree tables, every `ALTER` statement bumps the table's metadata version even when the change is a no-op (e.g., `ADD COLUMN IF NOT EXISTS` on an existing column). Re-issuing these statements on every process boot caused replica catch-up races, leading to "metadata version on replica is N, while common metadata is N+1" errors. When init failed, the storage proxy cached the rejected promise, causing all subsequent storage calls to hang.

**Changes:**
- Refactored `ALL_MIGRATIONS` from raw SQL strings to structured `MigrationEntry` objects with `kind`, `table`, `name`, and `sql` fields
- Added helper functions `addColumn()` and `addBloomIndex()` to generate migration entries
- Refactored `buildRetentionDDL()` → `buildRetentionEntries()` to return structured `RetentionEntry` objects instead of raw SQL
- Added `parseTtlExpression()` to extract column and days from ClickHouse TTL expressions (handles both input and normalized forms)
- Added `filterAppliedMigrations()` to introspect `system.columns` and `system.data_skipping_indices` and skip migrations whose target already exists
- Added `filterAppliedRetention()` to introspect `system.tables.create_table_query` and skip `MODIFY TTL` statements that wouldn't change the current TTL
- Updated init logic to call these filter functions before executing ALTERs, reducing metadata churn to zero on steady-state databases
- Falls back to running all statements if introspection fails (preserves correctness on older ClickHouse versions or restricted-permission users)

## Related issue(s)

Fixes: https://github.com/mastra-ai/mastra/issues/16370

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

https://claude.ai/code/session_01VWuXdMjr4kqeyZgkachJqe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The PR makes ClickHouse startup smarter: instead of re-running schema changes that already exist (like adding a column or index), it checks the database and only runs what's missing, preventing replica confusion and startup hangs.

---

## Summary

This PR prevents intermittent agent hangs during ClickHouse observability storage initialization by introspecting ClickHouse system metadata and skipping no-op ALTER statements that would otherwise increment table metadata versions on Replicated/SharedMergeTree tables.

Problem
- Re-applying ALTERs such as ADD COLUMN IF NOT EXISTS, ADD INDEX IF NOT EXISTS, and MODIFY TTL at process boot still increments metadata versions even when the change is a no-op. This can produce replica "metadata version" mismatch errors, cause init to fail, cache rejected promises in the storage proxy, and lead to hung storage calls.

Solution
- Replace raw SQL migration list with structured MigrationEntry objects (kind, table, name, sql) and add helpers addColumn() and addBloomIndex() to generate them.
- Refactor retention DDL generation to buildRetentionEntries() returning RetentionEntry objects (table, column, days, sql) and keep buildRetentionDDL() delegating to .map(e => e.sql).
- Implement parseTtlExpression() to extract { column, days } from ClickHouse TTL expressions; it handles both input forms (INTERVAL N DAY) and ClickHouse-normalized forms (toIntervalDay(N)), and now accepts backtick-quoted identifiers (e.g., `endedAt`) so parsing succeeds when create_table_query emits quoted columns.
- Add filterAppliedMigrations() to query system.columns and system.data_skipping_indices and skip migrations whose target columns or skipping indices already exist.
- Add filterAppliedRetention() to inspect system.tables.create_table_query and skip MODIFY TTL statements that would not change the current TTL.
- Update init logic to run these filters before executing ALTERs; if introspection fails (older ClickHouse or restricted permissions), fall back to executing all statements to preserve correctness.
- Tests: unit tests for parseTtlExpression and buildRetentionEntries; integration tests verifying init idempotence (zero ALTERs on re-run), selective MODIFY TTL behavior, and re-applying migrations when columns are manually dropped.
- Changelog: .changeset entry describing the fix and release notes.

Result
- Eliminates unnecessary ALTERs on steady-state databases, reducing metadata churn to zero in typical cases, avoiding replica races and startup hangs while preserving correctness when introspection is unavailable.

Type: bug fix, performance improvement. Status: open.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16420)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->