### PR TITLE
refactor(playground-ui): use ButtonsGroup primitives in PropertyFilterApplied

### DIFF
--- a/.changeset/dry-geese-rescue.md
+++ b/.changeset/dry-geese-rescue.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Filter pills (`PropertyFilterApplied`) now match the rest of the design system — single 1px border, consistent rounded segments, no custom styling. Labels stay on one line and no longer compress when long values are present.
+
+`ButtonsGroupText` segments also no longer wrap to multiple lines or shrink under flex pressure, which makes them safer to drop into any tight layout.

--- a/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx
+++ b/packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx
@@ -111,7 +111,7 @@ ButtonsGroupSeparator.displayName = 'ButtonsGroupSeparator';
 const buttonsGroupTextVariants = cva(
   cn(
     'inline-flex items-center justify-center bg-surface3 border border-border1 text-neutral5 select-none',
-    'rounded-full gap-[.75em] px-[1em]',
+    'rounded-full gap-[.75em] px-[1em] whitespace-nowrap shrink-0',
     '[&>svg]:w-[1.1em] [&>svg]:h-[1.1em] [&>svg]:opacity-50',
   ),
   {

--- a/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-applied.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-applied.tsx
@@ -2,12 +2,12 @@ import { LockIcon, XIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { Button } from '../Button';
+import { ButtonsGroup, ButtonsGroupText } from '../ButtonsGroup';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../Tooltip';
 import { PickMultiPanel } from './pick-multi-panel';
 import type { PropertyFilterField, PropertyFilterToken } from './types';
 import { Input } from '@/ds/components/Input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/ds/components/Popover/popover';
-import { formElementSizes } from '@/ds/primitives/form-element';
 
 export type PropertyFilterAppliedProps = {
   fields: PropertyFilterField[];
@@ -35,15 +35,6 @@ function stringifyTokenValue(value: string | string[]) {
   return value;
 }
 
-const PILL_CLASS = 'inline-flex';
-const SHARED_LABEL_OPERATOR_CLASSES = `${formElementSizes.md} border-y-2 border-border1 px-[.75em] text-neutral3 whitespace-nowrap flex items-center`;
-const LABEL_CLASS = `${SHARED_LABEL_OPERATOR_CLASSES} text-ui-md rounded-l-lg border-l-2 border-r-1`;
-const OPERATOR_CLASS = `${SHARED_LABEL_OPERATOR_CLASSES} text-ui-md `;
-const REMOVE_CLASS = 'rounded-tl-none rounded-bl-none border-l-transparent';
-const INPUT_CLASS = 'rounded-none';
-const VALUE_BUTTON_CLASS = 'rounded-none';
-const LOCKED_VALUE_CLASS = `${SHARED_LABEL_OPERATOR_CLASSES} text-ui-md text-neutral5 px-2.5 max-w-[20rem] truncate`;
-const LOCKED_ICON_CLASS = `${SHARED_LABEL_OPERATOR_CLASSES} text-ui-md rounded-r-lg border-r-2 border-l-1 gap-1.5 text-neutral3`;
 const DEFAULT_LOCKED_TOOLTIP = 'This filter is set by the current context and cannot be removed here.';
 
 function lookupOptionLabel(field: PropertyFilterField, value: string | string[]): string {
@@ -71,20 +62,20 @@ function LockedTokenPill({ field, value, tooltipContent }: LockedTokenPillProps)
     <TooltipProvider delayDuration={150}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div
-            className={`${PILL_CLASS} cursor-not-allowed select-none`}
+          <ButtonsGroup
+            spacing="close"
             data-locked-field-id={field.id}
             data-property-filter-pill="locked"
             tabIndex={0}
             aria-label={lockA11yLabel}
           >
-            <span className={LABEL_CLASS}>{field.label}</span>
-            <span className={OPERATOR_CLASS}>is</span>
-            <span className={LOCKED_VALUE_CLASS}>{display}</span>
-            <span className={LOCKED_ICON_CLASS} aria-hidden>
-              <LockIcon className="h-3.5 w-3.5" />
-            </span>
-          </div>
+            <ButtonsGroupText size="md">{field.label}</ButtonsGroupText>
+            <ButtonsGroupText size="md">is</ButtonsGroupText>
+            <ButtonsGroupText size="md">{display}</ButtonsGroupText>
+            <ButtonsGroupText size="md">
+              <LockIcon />
+            </ButtonsGroupText>
+          </ButtonsGroup>
         </TooltipTrigger>
         <TooltipContent>{tooltipContent}</TooltipContent>
       </Tooltip>
@@ -118,16 +109,15 @@ function TextTokenPill({ field, value, onChange, onRemove, disabled, autoFocus }
   }, [autoFocus]);
 
   return (
-    <div className={PILL_CLASS}>
-      <span className={LABEL_CLASS}>{field.label}</span>
-      <span className={OPERATOR_CLASS}>is</span>
+    <ButtonsGroup spacing="close">
+      <ButtonsGroupText size="md">{field.label}</ButtonsGroupText>
+      <ButtonsGroupText size="md">is</ButtonsGroupText>
       <Input
         ref={inputRef}
         size="md"
         disabled={disabled}
         value={draft}
         placeholder={field.placeholder ?? `Enter ${field.label}`}
-        className={INPUT_CLASS}
         onChange={e => {
           const next = e.target.value;
           setDraft(next);
@@ -151,14 +141,13 @@ function TextTokenPill({ field, value, onChange, onRemove, disabled, autoFocus }
         type="button"
         disabled={disabled}
         aria-label={`Remove ${field.label} filter`}
-        className={REMOVE_CLASS}
         size="md"
         onMouseDown={e => e.preventDefault()}
         onClick={onRemove}
       >
         <XIcon />
       </Button>
-    </div>
+    </ButtonsGroup>
   );
 }
 
@@ -175,18 +164,12 @@ function PickMultiTokenPill({ field, token, tokens, onChange, onRemove, disabled
   const [open, setOpen] = useState(false);
 
   return (
-    <div className={PILL_CLASS}>
-      <span className={LABEL_CLASS}>{field.label}</span>
-      <span className={OPERATOR_CLASS}>is</span>
+    <ButtonsGroup spacing="close">
+      <ButtonsGroupText size="md">{field.label}</ButtonsGroupText>
+      <ButtonsGroupText size="md">is</ButtonsGroupText>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button
-            type="button"
-            disabled={disabled}
-            size="md"
-            className={VALUE_BUTTON_CLASS}
-            // className="px-2.5 py-1.5 max-w-[20rem] truncate text-left hover:bg-surface5 hover:text-neutral6 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
+          <Button type="button" disabled={disabled} size="md">
             {stringifyTokenValue(token.value)}
           </Button>
         </PopoverTrigger>
@@ -198,13 +181,12 @@ function PickMultiTokenPill({ field, token, tokens, onChange, onRemove, disabled
         type="button"
         disabled={disabled}
         aria-label={`Remove ${field.label} filter`}
-        className={REMOVE_CLASS}
         size="md"
         onClick={onRemove}
       >
         <XIcon />
       </Button>
-    </div>
+    </ButtonsGroup>
   );
 }
 
@@ -295,21 +277,20 @@ export function PropertyFilterApplied({
         }
 
         return (
-          <div key={`${token.fieldId}-${index}`} className={PILL_CLASS}>
-            <span className={LABEL_CLASS}>{field.label}</span>
-            <span className={OPERATOR_CLASS}>is</span>
-            <span className="px-2.5 py-1.5 max-w-[20rem] truncate">{stringifyTokenValue(token.value)}</span>
+          <ButtonsGroup spacing="close" key={`${token.fieldId}-${index}`}>
+            <ButtonsGroupText size="md">{field.label}</ButtonsGroupText>
+            <ButtonsGroupText size="md">is</ButtonsGroupText>
+            <ButtonsGroupText size="md">{stringifyTokenValue(token.value)}</ButtonsGroupText>
             <Button
               type="button"
               disabled={disabled}
               size="md"
               aria-label={`Remove ${field.label} filter`}
-              className={REMOVE_CLASS}
               onClick={() => removeTokenAt(index)}
             >
               <XIcon />
             </Button>
-          </div>
+          </ButtonsGroup>
         );
       })}
     </div>


### PR DESCRIPTION
## Summary
- Replace bespoke Tailwind class constants + className overrides on `Input`/`Button` inside `PropertyFilterApplied` with `ButtonsGroup` (`spacing="close"`) + `ButtonsGroupText` cells. Pills now share the same border/radius/shrink behavior as the rest of the DS.
- Harden `ButtonsGroupText` itself with `whitespace-nowrap` and `shrink-0` so segment labels never wrap to two lines or get compressed under flex pressure.

<img width="693" height="243" alt="CleanShot 2026-05-11 at 16 38 30" src="https://github.com/user-attachments/assets/e0498a3c-b39d-41a1-9765-64a40593ffb7" />

## Why
The pill component was carrying nine hardcoded Tailwind constants (`PILL_CLASS`, `SHARED_LABEL_OPERATOR_CLASSES`, `LABEL_CLASS`, `OPERATOR_CLASS`, `REMOVE_CLASS`, `INPUT_CLASS`, `VALUE_BUTTON_CLASS`, `LOCKED_VALUE_CLASS`, `LOCKED_ICON_CLASS`) and was overriding `className` on `Input` and `Button` to fake a segmented look. The DS already exposes `ButtonsGroup` for exactly this use case — using it removes the overrides and homogenizes the visual with the rest of the design system.

## Visual change
Pills move from a custom 2px outer border + 1px internal dividers to the DS standard single 1px border with `rounded-full` segmented spacing. All existing public behaviors (editable text token, pick-multi popover, locked pill with tooltip, × removal) are preserved.

## Test plan
- [x] `pnpm test` in `packages/playground-ui` — 132 tests pass (incl. `property-filter-applied.test.tsx` and `buttons-group` stories)
- [x] `pnpm tsc --noEmit` — clean
- [ ] Manually verify pills in `/agents/:id/traces`, `/traces`, `/logs` toolbars (text token edit, pick-multi popover, locked pill tooltip, × remove)
- [ ] Verify long values don't break layout (`whitespace-nowrap` + `shrink-0` on `ButtonsGroupText`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR replaces custom-made filter "pills" with standard design-system button groups so they look and behave consistently with the rest of the app, while keeping all existing functionality.

## What Changed

- Refactored PropertyFilterApplied to use ds ButtonsGroup and ButtonsGroupText primitives instead of bespoke Tailwind constants and className overrides.
- Hardened ButtonsGroupText by adding whitespace-nowrap and shrink-0 so segment labels never wrap or get flex-compressed.
- Removed local pill style constants and className hacks; visuals follow the DS standard (single 1px border, rounded-full segmented spacing) instead of the previous custom 2px outer border + internal dividers.

## Behavior Preservation

All public behaviors are preserved:
- Editable text tokens (draft state, Enter/Escape handling, live onChange)
- Pick-multi popover behavior
- Locked pill with tooltip and data-* attributes
- × removal action

## Files Modified

- .changeset/dry-geese-rescue.md — changeset describing migration to ButtonsGroup
- packages/playground-ui/src/ds/components/ButtonsGroup/buttons-group.tsx — added whitespace-nowrap and shrink-0 to ButtonsGroupText base styles
- packages/playground-ui/src/ds/components/PropertyFilter/property-filter-applied.tsx — refactored LockedTokenPill, TextTokenPill, PickMultiTokenPill, and fallback to use ButtonsGroup; removed local pill class constants and formElementSizes import

## Tests & Verification

- pnpm test in packages/playground-ui — 132 tests pass (includes property-filter-applied.test.tsx and buttons-group stories).
- pnpm tsc --noEmit — clean.
- Manual checks pending: pill behavior verification in /agents/:id/traces, /traces, and /logs toolbars (text-token edit, pick-multi popover, locked-pill tooltip, × remove) and long-value layout handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16426)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->