### PR TITLE
fix evented workflows timetravel conditional step

### DIFF
--- a/.changeset/legal-forks-decide.md
+++ b/.changeset/legal-forks-decide.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed `timeTravel()` into a `.branch()` step on evented workflows leaking an empty result for the branches that were not selected. The aggregated branch output now only includes the branch that ran, matching the default workflow engine.
+Fixed `timeTravel()` on evented workflows so jumping to a `.branch()` step no longer returns empty results for branches that did not run. Branch results now include only the branch that ran, matching the default workflow engine.

--- a/.changeset/legal-forks-decide.md
+++ b/.changeset/legal-forks-decide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `timeTravel()` into a `.branch()` step on evented workflows leaking an empty result for the branches that were not selected. The aggregated branch output now only includes the branch that ran, matching the default workflow engine.

--- a/packages/core/src/workflows/evented/evented-workflow.test.ts
+++ b/packages/core/src/workflows/evented/evented-workflow.test.ts
@@ -79,9 +79,6 @@ createWorkflowTestSuite({
     resumeNested: true, // Nested resume works but input value from previous step lost (26 vs 27)
     resumeDountil: true,
 
-    // Time travel - different result structure
-    timeTravelConditional: true,
-
     // Streaming - legacy API timeout issue
     streamingSuspendResumeLegacy: true,
 
@@ -97,9 +94,6 @@ createWorkflowTestSuite({
 
     // Callback - state test uses stateSchema/setState (WIP in evented)
     callbackStateOnError: true,
-
-    // Time travel - conditional perStep inherits timeTravelConditional issues
-    timeTravelConditionalPerStep: true,
 
     // Resume error tests - evented engine error behavior may differ
     resumeNotSuspendedWorkflow: true,

--- a/packages/core/src/workflows/utils.ts
+++ b/packages/core/src/workflows/utils.ts
@@ -295,7 +295,8 @@ export const createTimeTravelExecutionParams = (params: {
       break;
     }
     const stepIds = getStepIds(entry);
-    if (stepIds.includes(firstStepId)) {
+    const isTargetEntry = stepIds.includes(firstStepId);
+    if (isTargetEntry) {
       const innerExecutionPath = stepIds?.length > 1 ? [stepIds?.findIndex(s => s === firstStepId)] : [];
       //parallel and loop steps will have more than one step id,
       // and if the step is one of those, we need the index for the execution path
@@ -353,7 +354,15 @@ export const createTimeTravelExecutionParams = (params: {
     stepIds.forEach(stepId => {
       let result;
       const stepContext = context?.[stepId] ?? snapshotContext[stepId];
-      const defaultStepStatus = steps?.includes(stepId) ? 'running' : 'success';
+      // Siblings of the time-travel target inside a conditional were not selected by the
+      // branch's condition, so they should be reported as skipped rather than as a fake
+      // success (otherwise their empty output leaks into the conditional's aggregated result).
+      const isUnselectedConditionalSibling = isTargetEntry && entry.type === 'conditional' && !steps?.includes(stepId);
+      const defaultStepStatus = steps?.includes(stepId)
+        ? 'running'
+        : isUnselectedConditionalSibling
+          ? 'skipped'
+          : 'success';
       const status = ['failed', 'canceled'].includes(stepContext?.status)
         ? defaultStepStatus
         : (stepContext?.status ?? defaultStepStatus);


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->
Fixed `timeTravel()` into a `.branch()` step on evented workflows leaking an empty result for the branches that were not selected. The aggregated branch output now only includes the branch that ran, matching the default workflow engine.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

When you jump back in time inside a workflow that splits into branches, the system used to show empty results for branches that weren't taken. This PR fixes that so only the branch that actually ran is included in the time-traveled output.

## Changes Overview

Fixes a bug in evented workflows where calling timeTravel() into a .branch() step could leak empty results for non-selected branches; aggregated branch output now includes only the branch that ran (matching the default workflow engine).

## Key Changes

### Changeset
- .changeset/legal-forks-decide.md: Bumps @mastra/core (patch) and documents the timeTravel() fix for evented workflows.

### Tests
- packages/core/src/workflows/evented/evented-workflow.test.ts: Removed skip entries for `timeTravelConditional` and `timeTravelConditionalPerStep`, enabling those time-travel conditional tests for the evented engine.

### Core Logic Fix
- packages/core/src/workflows/utils.ts: Updated `createTimeTravelExecutionParams` to:
  - Determine whether the current graph entry is the time-travel target (`isTargetEntry`) when constructing the execution path.
  - Mark unselected sibling steps inside conditional branches as `skipped` (instead of `success`), preventing their empty outputs from being included in conditional aggregate results.

## Impact

Evented workflows now return aggregated branch outputs that include only the branch that executed during time travel, making behavior consistent with the default workflow engine.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16428)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16428)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->