### PR TITLE
docs(inngest): document INNGEST_DEV env var

### DIFF
--- a/docs/src/content/en/guides/deployment/inngest.mdx
+++ b/docs/src/content/en/guides/deployment/inngest.mdx
@@ -61,6 +61,31 @@ export const inngest = new Inngest({
 })
 ```
 
+#### Selecting dev or cloud mode with `INNGEST_DEV`
+
+The Inngest SDK runs in one of two modes: dev or cloud. From v4 onward, the SDK defaults to cloud mode and requires `INNGEST_EVENT_KEY` and `INNGEST_SIGNING_KEY`. The examples above set the mode in code with `isDev: true`. As an alternative, set the [`INNGEST_DEV` environment variable](https://www.inngest.com/docs/sdk/environment-variables#inngest-dev) so the same client code works across environments:
+
+- `INNGEST_DEV=1`: force dev mode. The SDK talks to a local Inngest Dev Server and disables signature verification.
+- `INNGEST_DEV=0`: force cloud mode. The SDK talks to Inngest Cloud and requires event and signing keys.
+- `INNGEST_DEV=<url>`: force dev mode and point the SDK at the Dev Server at `<url>`, for example `http://localhost:8288`.
+- Unset: defaults to cloud mode.
+
+When `INNGEST_DEV` is set, you can drop `isDev` and `baseUrl` from the client:
+
+```ts title="src/mastra/inngest/index.ts"
+import { Inngest } from 'inngest'
+
+export const inngest = new Inngest({
+  id: 'mastra',
+})
+```
+
+:::warning
+Do not set `INNGEST_DEV` in production. It disables signature verification, which is required to securely receive events from Inngest Cloud.
+:::
+
+The `isDev` option on `new Inngest()` overrides `INNGEST_DEV` when both are set.
+
 ### Creating steps
 
 Define the individual steps that will compose your workflow:


### PR DESCRIPTION
Adds a short subsection to the Inngest deployment guide explaining the `INNGEST_DEV` environment variable, so users can pick dev vs cloud mode without changing client code between environments.

Before, the guide only showed switching via `isDev: true` in the `new Inngest()` options. Now it also covers the env var, the four states it can take (`1`, `0`, `<url>`, unset), and notes that the in-code `isDev` overrides it. Includes a warning not to set it in production since it disables signature verification.

Docs-only, no code changes, so no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds documentation explaining a special setting (`INNGEST_DEV`) that lets developers choose whether their Inngest application runs in development or production mode just by changing an environment variable, instead of having to modify their code.

## Changes

### Documentation Updates

Added a new subsection to the Inngest deployment guide documenting the `INNGEST_DEV` environment variable:

- **Purpose**: Allows switching Inngest SDK between dev and cloud modes via environment configuration
- **Supported values**: 
  - `1` - enables dev mode
  - `0` - disables dev mode  
  - URL string - sets a custom base URL
  - Unset - uses default behavior
- **Override behavior**: The in-code `isDev` option passed to `new Inngest()` takes precedence over the environment variable
- **Production warning**: Explicitly cautions against setting `INNGEST_DEV` in production as it disables signature verification

**Files modified**: `docs/src/content/en/guides/deployment/inngest.mdx` (+25 lines)

This is a documentation-only change with no code modifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16432)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->