### PR TITLE
Roll up internal MODEL_GENERATION usage to visible ancestor spans

### DIFF
--- a/.changeset/internal-usage-attribute.md
+++ b/.changeset/internal-usage-attribute.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Added the `internalUsage?: UsageStats` field to `AIBaseAttributes`, so any span type can carry token usage rolled up from internal descendant spans. Populated automatically by `@mastra/observability` when an internal `MODEL_GENERATION` ends inside a non-internal ancestor.

--- a/.changeset/rollup-internal-usage.md
+++ b/.changeset/rollup-internal-usage.md
@@ -1,0 +1,10 @@
+---
+"@mastra/observability": minor
+---
+
+Roll up token usage from internal MODEL_GENERATION spans onto the closest exported ancestor span. When `tracingPolicy.internal` filters a model call out of exported traces, its tokens used to disappear from both the trace UI and metrics. Now:
+
+- The visible ancestor (e.g. `PROCESSOR_RUN`, `AGENT_RUN`) gets an `internalUsage` attribute summing the tokens consumed by its hidden descendants — so a Mastra-owned processor that runs an internal agent (moderation, PII detector, structured output, etc.) shows its aggregate cost on the visible `PROCESSOR_RUN` span.
+- Token / cost metrics still emit, but are attributed via labels to the visible ancestor instead of the hidden agent.
+
+No action required — the rollup applies automatically whenever an internal `MODEL_GENERATION` ends inside a non-internal ancestor.

--- a/observability/mastra/src/__snapshots__/agent-structured-output-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-structured-output-trace-generate.json
@@ -277,7 +277,17 @@
             "entityId": "test-agent",
             "attributes": {
               "processorExecutor": "legacy",
-              "processorIndex": 0
+              "processorIndex": 0,
+              "internalUsage": {
+                "inputTokens": 15,
+                "outputTokens": 25,
+                "inputDetails": {
+                  "text": 15
+                },
+                "outputDetails": {
+                  "text": 25
+                }
+              }
             },
             "metadata": {
               "runId": "<runId-1>",

--- a/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
@@ -275,7 +275,17 @@
             "entityId": "test-agent",
             "attributes": {
               "processorExecutor": "legacy",
-              "processorIndex": 0
+              "processorIndex": 0,
+              "internalUsage": {
+                "inputTokens": 15,
+                "outputTokens": 25,
+                "inputDetails": {
+                  "text": 15
+                },
+                "outputDetails": {
+                  "text": 25
+                }
+              }
             },
             "metadata": {
               "runId": "<runId-1>",

--- a/observability/mastra/src/features.ts
+++ b/observability/mastra/src/features.ts
@@ -36,4 +36,4 @@
  * ```
  */
 // Add feature flags here as new features are introduced
-export const observabilityFeatures: ReadonlySet<string> = new Set(['model-inference-span']);
+export const observabilityFeatures: ReadonlySet<string> = new Set(['model-inference-span', 'internal-usage-rollup']);

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -6,7 +6,7 @@ import { MastraBase } from '@mastra/core/base';
 import type { RequestContext } from '@mastra/core/di';
 import type { IMastraLogger } from '@mastra/core/logger';
 import { RegisteredLogger } from '@mastra/core/logger';
-import { TracingEventType, noOpLoggerContext } from '@mastra/core/observability';
+import { SpanType, TracingEventType, noOpLoggerContext } from '@mastra/core/observability';
 import type {
   Span,
   ObservabilityExporter,
@@ -27,7 +27,8 @@ import type {
   LoggerContext,
   MetricsContext,
   ObservabilityEvent,
-  SpanType,
+  ModelGenerationAttributes,
+  UsageStats,
 } from '@mastra/core/observability';
 import { getNestedValue, setNestedValue } from '@mastra/core/utils';
 import { ObservabilityBus } from '../bus';
@@ -35,9 +36,10 @@ import type { ObservabilityInstanceConfig } from '../config';
 import { SamplingStrategyType } from '../config';
 import { LoggerContextImpl } from '../context/logger';
 import { MetricsContextImpl } from '../context/metrics';
-import { emitAutoExtractedMetrics } from '../metrics/auto-extract';
+import { emitAutoExtractedMetrics, emitTokenMetricsForUsage } from '../metrics/auto-extract';
 import { CardinalityFilter } from '../metrics/cardinality';
 import { NoOpSpan } from '../spans';
+import { addUsageStats } from '../usage';
 
 // ============================================================================
 // Abstract Base Class
@@ -456,10 +458,10 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    * This ensures all spans emit events regardless of implementation
    */
   private wireSpanLifecycle<TType extends SpanType>(span: Span<TType>): void {
-    // bypass wire up if internal span and not includeInternalSpans
-    if (!this.config.includeInternalSpans && span.isInternal) {
-      return;
-    }
+    // Internal spans are also wired so that filtered MODEL_GENERATION spans
+    // can roll their usage up to the closest exported ancestor. emitSpanEnded
+    // / emitSpanUpdated still short-circuit for filtered spans via
+    // getSpanForExport, so no trace events leak for internal spans.
 
     // Store original methods
     const originalEnd = span.end.bind(span);
@@ -471,7 +473,19 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
         this.logger.warn(`End event is not available on event spans`);
         return;
       }
+
+      // Capture rollup usage BEFORE originalEnd runs: excluded spans
+      // drop end-time attributes (see DefaultSpan#end), so the only
+      // place to read MODEL_GENERATION usage for a filtered span is the
+      // end() options being passed in right now.
+      const rollupTarget = this.captureModelUsageRollup(span, options);
+
       originalEnd(options);
+
+      if (rollupTarget) {
+        this.applyUsageRollup(rollupTarget);
+      }
+
       this.emitSpanEnded(span);
     };
 
@@ -697,6 +711,76 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       const event: TracingEvent = { type: TracingEventType.SPAN_UPDATED, exportedSpan };
       this.emitTracingEvent(event);
     }
+  }
+
+  /**
+   * When an internal MODEL_GENERATION span ends, capture the rollup payload
+   * (usage, provider, model, target ancestor) needed to attribute its cost
+   * to the closest exported ancestor span. Returns undefined when no rollup
+   * applies — non-MODEL_GENERATION spans, spans that will be exported, or
+   * spans whose usage isn't available at end time.
+   */
+  private captureModelUsageRollup<TType extends SpanType>(
+    span: Span<TType>,
+    endOptions: EndSpanOptions<TType> | undefined,
+  ): { ancestor: AnySpan; usage: UsageStats; provider?: string; model?: string } | undefined {
+    if (span.type !== SpanType.MODEL_GENERATION) return undefined;
+    // If the span itself will be exported, the existing auto-extract pipeline
+    // emits its metrics; nothing to roll up.
+    if (!span.isInternal || this.config.includeInternalSpans) return undefined;
+
+    // For excluded spans, end() options carry the only copy of attributes —
+    // the live span discards them. Read from there first, falling back to
+    // any prior values that survived an earlier update().
+    const endAttrs = (endOptions?.attributes as ModelGenerationAttributes | undefined) ?? undefined;
+    const liveAttrs = span.attributes as ModelGenerationAttributes | undefined;
+    const usage = endAttrs?.usage ?? liveAttrs?.usage;
+    if (!usage) return undefined;
+
+    const ancestor = this.findExportedAncestor(span);
+    if (!ancestor) return undefined;
+
+    const provider = endAttrs?.provider ?? liveAttrs?.provider;
+    const model = endAttrs?.responseModel ?? endAttrs?.model ?? liveAttrs?.responseModel ?? liveAttrs?.model;
+
+    return { ancestor, usage, provider, model };
+  }
+
+  /**
+   * Accumulate usage onto the ancestor's `internalUsage` attribute (for trace
+   * UI visibility) and emit auto-extracted token metrics now, using the
+   * ancestor's metrics context so cost / token labels point at the visible
+   * span instead of the hidden agent that incurred them.
+   */
+  private applyUsageRollup(target: { ancestor: AnySpan; usage: UsageStats; provider?: string; model?: string }): void {
+    const { ancestor, usage, provider, model } = target;
+
+    // Mutate the live ancestor's attributes; export reads this object later.
+    // Ancestor is non-internal so its attributes weren't discarded at end-
+    // time-drop, and ancestor hasn't ended yet (we're inside a descendant's
+    // end()), so direct mutation is safe.
+    const attrs = (ancestor.attributes ?? {}) as { internalUsage?: UsageStats };
+    attrs.internalUsage = addUsageStats(attrs.internalUsage, usage);
+    (ancestor as { attributes: unknown }).attributes = attrs;
+
+    try {
+      emitTokenMetricsForUsage(usage, provider, model, this.getMetricsContext(ancestor));
+    } catch (err) {
+      this.logger.error('[Observability] Usage rollup metric emission error:', err);
+    }
+  }
+
+  /**
+   * Walk up the parent chain to find the closest ancestor that won't be
+   * filtered by internal-span filtering. Returns undefined when every
+   * ancestor is internal-and-filtered.
+   */
+  private findExportedAncestor(span: AnySpan): AnySpan | undefined {
+    let ancestor: AnySpan | undefined = span.parent;
+    while (ancestor && ancestor.isInternal && !this.config.includeInternalSpans) {
+      ancestor = ancestor.parent;
+    }
+    return ancestor;
   }
 
   /**

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -458,10 +458,15 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    * This ensures all spans emit events regardless of implementation
    */
   private wireSpanLifecycle<TType extends SpanType>(span: Span<TType>): void {
-    // Internal spans are also wired so that filtered MODEL_GENERATION spans
-    // can roll their usage up to the closest exported ancestor. emitSpanEnded
-    // / emitSpanUpdated still short-circuit for filtered spans via
-    // getSpanForExport, so no trace events leak for internal spans.
+    // Skip wiring for filtered internal spans, except MODEL_GENERATION —
+    // those need the wrap so captureModelUsageRollup can intercept usage
+    // before originalEnd discards it. Other internal types (AGENT_RUN,
+    // WORKFLOW_RUN, MODEL_STEP, MODEL_CHUNK, …) carry nothing to roll up,
+    // and skipping the closure-per-span cost matters in streaming hot
+    // paths like per-chunk MODEL_CHUNK spans.
+    if (!this.config.includeInternalSpans && span.isInternal && span.type !== SpanType.MODEL_GENERATION) {
+      return;
+    }
 
     // Store original methods
     const originalEnd = span.end.bind(span);

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -735,8 +735,9 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
     if (!span.isInternal || this.config.includeInternalSpans) return undefined;
 
     // For excluded spans, end() options carry the only copy of attributes —
-    // the live span discards them. Read from there first, falling back to
-    // any prior values that survived an earlier update().
+    // the live span discards them in DefaultSpan#end. The liveAttrs fallback
+    // is dead for the default implementation but kept for non-DefaultSpan
+    // Span implementations that might preserve attributes on excluded spans.
     const endAttrs = (endOptions?.attributes as ModelGenerationAttributes | undefined) ?? undefined;
     const liveAttrs = span.attributes as ModelGenerationAttributes | undefined;
     const usage = endAttrs?.usage ?? liveAttrs?.usage;
@@ -760,13 +761,12 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
   private applyUsageRollup(target: { ancestor: AnySpan; usage: UsageStats; provider?: string; model?: string }): void {
     const { ancestor, usage, provider, model } = target;
 
-    // Mutate the live ancestor's attributes; export reads this object later.
-    // Ancestor is non-internal so its attributes weren't discarded at end-
-    // time-drop, and ancestor hasn't ended yet (we're inside a descendant's
-    // end()), so direct mutation is safe.
-    const attrs = (ancestor.attributes ?? {}) as { internalUsage?: UsageStats };
+    // Mutate the live ancestor's attributes directly. BaseSpan's constructor
+    // guarantees `attributes` is always at least `{}` (see spans/base.ts),
+    // and the ancestor hasn't ended yet (we're inside a descendant's end()),
+    // so the export will pick up the mutated field.
+    const attrs = ancestor.attributes as { internalUsage?: UsageStats };
     attrs.internalUsage = addUsageStats(attrs.internalUsage, usage);
-    (ancestor as { attributes: unknown }).attributes = attrs;
 
     try {
       emitTokenMetricsForUsage(usage, provider, model, this.getMetricsContext(ancestor));
@@ -776,16 +776,33 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
   }
 
   /**
-   * Walk up the parent chain to find the closest ancestor that won't be
-   * filtered by internal-span filtering. Returns undefined when every
-   * ancestor is internal-and-filtered.
+   * Walk up the parent chain to find the closest ancestor that will actually
+   * reach exporters. Skips both internal-filtered ancestors and ancestors
+   * whose type matches `excludeSpanTypes`, so the rollup target is one whose
+   * mutated `internalUsage` attribute is visible in exported traces.
+   *
+   * Note: this does not preemptively run `spanFilter` — that filter can be
+   * async and have side effects, so the rare case of a `spanFilter`-dropped
+   * ancestor falls through.
    */
   private findExportedAncestor(span: AnySpan): AnySpan | undefined {
     let ancestor: AnySpan | undefined = span.parent;
-    while (ancestor && ancestor.isInternal && !this.config.includeInternalSpans) {
+    while (ancestor && this.isFilteredFromExport(ancestor)) {
       ancestor = ancestor.parent;
     }
     return ancestor;
+  }
+
+  /**
+   * Returns true when a span would be dropped by `getSpanForExport` for a
+   * reason cheap to check up-front (internal-span filtering or
+   * `excludeSpanTypes`). Used by `findExportedAncestor` to skip rollup
+   * targets that would silently lose their `internalUsage` attribute.
+   */
+  private isFilteredFromExport(span: AnySpan): boolean {
+    if (span.isInternal && !this.config.includeInternalSpans) return true;
+    if (this.config.excludeSpanTypes?.includes(span.type)) return true;
+    return false;
   }
 
   /**

--- a/observability/mastra/src/metrics/auto-extract.ts
+++ b/observability/mastra/src/metrics/auto-extract.ts
@@ -3,7 +3,13 @@
  */
 
 import { SpanType } from '@mastra/core/observability';
-import type { AnySpan, CostContext, MetricsContext, ModelGenerationAttributes } from '@mastra/core/observability';
+import type {
+  AnySpan,
+  CostContext,
+  MetricsContext,
+  ModelGenerationAttributes,
+  UsageStats,
+} from '@mastra/core/observability';
 import { estimateCosts } from './estimator';
 import type { TokenMetrics } from './types';
 import { getTokenMetricSamples } from './usage-metrics';
@@ -33,6 +39,24 @@ export function emitTokenMetrics(span: AnySpan, metrics: MetricsContext): void {
   }
 
   emitUsageMetrics(attrs, attrs.usage, metrics);
+}
+
+/**
+ * Emit token usage metrics from an explicit usage payload, using the supplied
+ * metrics context (which carries entity / parent / root labels) and the
+ * supplied provider+model for cost lookup.
+ *
+ * Used when an internal MODEL_GENERATION's usage is rolled up to a visible
+ * ancestor span: the metric labels come from the ancestor's context, the
+ * cost calculation still uses the original model that incurred the tokens.
+ */
+export function emitTokenMetricsForUsage(
+  usage: UsageStats,
+  provider: string | undefined,
+  model: string | undefined,
+  metrics: MetricsContext,
+): void {
+  emitUsageMetrics({ provider, model } as ModelGenerationAttributes, usage, metrics);
 }
 
 /** Emit all auto-extracted metrics for a live span end. */

--- a/observability/mastra/src/usage-rollup.test.ts
+++ b/observability/mastra/src/usage-rollup.test.ts
@@ -194,12 +194,12 @@ describe('internal MODEL_GENERATION usage rollup', () => {
     visibleAgent.end();
     await tracing.flush();
 
-    const ended = exporter.endedSpans();
-    const exportedAgent = ended.find(s => (s.entityType === undefined ? false : true)) ?? ended[0];
     // The user-visible AGENT_RUN should be the sole exported span and carry the rolled-up usage.
+    const ended = exporter.endedSpans();
     expect(ended).toHaveLength(1);
-    expect(exportedAgent!.type).toBe(SpanType.AGENT_RUN);
-    const attrs = exportedAgent!.attributes as { internalUsage?: { inputTokens?: number; outputTokens?: number } };
+    const exportedAgent = ended[0]!;
+    expect(exportedAgent.type).toBe(SpanType.AGENT_RUN);
+    const attrs = exportedAgent.attributes as { internalUsage?: { inputTokens?: number; outputTokens?: number } };
     expect(attrs.internalUsage).toEqual({ inputTokens: 7, outputTokens: 3 });
   });
 
@@ -266,6 +266,71 @@ describe('internal MODEL_GENERATION usage rollup', () => {
     expect(outputMetric).toBeDefined();
     expect(outputMetric!.metric.correlationContext.entityId).toBe('moderation');
     expect(outputMetric!.metric.value).toBe(25);
+  });
+
+  it('walks past ancestors filtered by excludeSpanTypes', async () => {
+    // A non-internal ancestor that matches `excludeSpanTypes` wouldn't reach
+    // exporters either — picking it as the rollup target would silently lose
+    // the `internalUsage` attribute. The walk must keep going.
+    const localExporter = new CollectingExporter();
+    const localTracing = new DefaultObservabilityInstance({
+      serviceName: 'usage-rollup-test',
+      name: 'test-instance',
+      sampling: { type: SamplingStrategyType.ALWAYS },
+      excludeSpanTypes: [SpanType.PROCESSOR_RUN],
+      exporters: [localExporter],
+    });
+
+    const visibleAgent = localTracing.startSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'agent run: user-agent',
+      entityName: 'User Agent',
+      entityId: 'user-agent',
+    });
+    // PROCESSOR_RUN is dropped by excludeSpanTypes — must be skipped during rollup.
+    const excludedProcessor = visibleAgent.createChildSpan({
+      type: SpanType.PROCESSOR_RUN,
+      name: 'input processor: moderation',
+    });
+    const hiddenAgent = excludedProcessor.createChildSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'agent run: content-moderator',
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+    const hiddenModel = hiddenAgent.createChildSpan({
+      type: SpanType.MODEL_GENERATION,
+      name: "llm: 'mock'",
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+
+    hiddenModel.end({
+      attributes: {
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+        usage: { inputTokens: 42, outputTokens: 9 },
+      },
+    });
+    hiddenAgent.end();
+    excludedProcessor.end();
+    visibleAgent.end();
+    await localTracing.flush();
+
+    // PROCESSOR_RUN is dropped; the rollup landed on the AGENT_RUN above it
+    // so both attribute and metric attribution reach an exported span.
+    const ended = localExporter.endedSpans();
+    expect(ended.some(s => s.type === SpanType.PROCESSOR_RUN)).toBe(false);
+    const exportedAgent = ended.find(s => s.type === SpanType.AGENT_RUN)!;
+    expect(exportedAgent).toBeDefined();
+    expect((exportedAgent.attributes as { internalUsage?: { inputTokens?: number } }).internalUsage).toEqual({
+      inputTokens: 42,
+      outputTokens: 9,
+    });
+
+    const inputMetric = localExporter.metricEvents.find(e => e.metric.name === 'mastra_model_total_input_tokens');
+    expect(inputMetric).toBeDefined();
+    expect(inputMetric!.metric.correlationContext.entityId).toBe('user-agent');
+
+    await localTracing.shutdown();
   });
 
   it('does not roll up when includeInternalSpans is true', async () => {

--- a/observability/mastra/src/usage-rollup.test.ts
+++ b/observability/mastra/src/usage-rollup.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for rolling up internal MODEL_GENERATION usage onto the closest
+ * exported ancestor when internal-span filtering is active.
+ *
+ * The rollup serves two goals:
+ *
+ *   1. Trace UI visibility — the visible ancestor (e.g. PROCESSOR_RUN) gets
+ *      an `internalUsage` attribute summing the tokens consumed by hidden
+ *      descendant model calls so users can see processor cost without
+ *      needing to enable `includeInternalSpans`.
+ *
+ *   2. Metric attribution — token / cost metrics still emit, but are
+ *      attributed (via labels) to the visible ancestor span instead of
+ *      vanishing along with the hidden MODEL_GENERATION.
+ */
+
+import { SpanType, SamplingStrategyType, InternalSpans } from '@mastra/core/observability';
+import type {
+  AnyExportedSpan,
+  MetricEvent,
+  ObservabilityExporter,
+  ProcessorRunAttributes,
+  TracingEvent,
+} from '@mastra/core/observability';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DefaultObservabilityInstance } from './instances';
+
+class CollectingExporter implements ObservabilityExporter {
+  name = 'collector';
+  tracingEvents: TracingEvent[] = [];
+  metricEvents: MetricEvent[] = [];
+
+  async onTracingEvent(event: TracingEvent): Promise<void> {
+    this.tracingEvents.push(event);
+  }
+  async onMetricEvent(event: MetricEvent): Promise<void> {
+    this.metricEvents.push(event);
+  }
+
+  endedSpans(): AnyExportedSpan[] {
+    return this.tracingEvents.filter(e => e.type === 'span_ended').map(e => e.exportedSpan);
+  }
+
+  async shutdown(): Promise<void> {}
+  async flush(): Promise<void> {}
+}
+
+describe('internal MODEL_GENERATION usage rollup', () => {
+  let exporter: CollectingExporter;
+  let tracing: DefaultObservabilityInstance;
+
+  beforeEach(() => {
+    exporter = new CollectingExporter();
+    tracing = new DefaultObservabilityInstance({
+      serviceName: 'usage-rollup-test',
+      name: 'test-instance',
+      sampling: { type: SamplingStrategyType.ALWAYS },
+      exporters: [exporter],
+    });
+  });
+
+  afterEach(async () => {
+    await tracing.shutdown();
+  });
+
+  it('accumulates internal-model usage onto the closest exported ancestor', async () => {
+    const processorSpan = tracing.startSpan({
+      type: SpanType.PROCESSOR_RUN,
+      name: 'input processor: moderation',
+    });
+
+    const hiddenAgent = processorSpan.createChildSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'agent run: content-moderator',
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+
+    const hiddenModel = hiddenAgent.createChildSpan({
+      type: SpanType.MODEL_GENERATION,
+      name: "llm: 'mock'",
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+
+    hiddenModel.end({
+      attributes: {
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+        usage: { inputTokens: 100, outputTokens: 25 },
+      },
+    });
+    hiddenAgent.end();
+    processorSpan.end();
+    await tracing.flush();
+
+    // The visible processor span carries an internalUsage summary.
+    const ended = exporter.endedSpans();
+    const exportedProcessor = ended.find(s => s.type === SpanType.PROCESSOR_RUN);
+    expect(exportedProcessor).toBeDefined();
+    const attrs = exportedProcessor!.attributes as ProcessorRunAttributes;
+    expect(attrs.internalUsage).toEqual({ inputTokens: 100, outputTokens: 25 });
+
+    // Hidden descendants must not be exported.
+    expect(ended.some(s => s.type === SpanType.AGENT_RUN)).toBe(false);
+    expect(ended.some(s => s.type === SpanType.MODEL_GENERATION)).toBe(false);
+  });
+
+  it('sums usage across multiple hidden model calls onto a single ancestor', async () => {
+    const processorSpan = tracing.startSpan({
+      type: SpanType.PROCESSOR_RUN,
+      name: 'input processor: structured-output',
+    });
+    const hiddenAgent = processorSpan.createChildSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'agent run: structurer',
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+
+    const m1 = hiddenAgent.createChildSpan({
+      type: SpanType.MODEL_GENERATION,
+      name: "llm: 'mock'",
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+    m1.end({
+      attributes: {
+        provider: 'p',
+        model: 'm',
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          inputDetails: { text: 10 },
+          outputDetails: { text: 5 },
+        },
+      },
+    });
+
+    const m2 = hiddenAgent.createChildSpan({
+      type: SpanType.MODEL_GENERATION,
+      name: "llm: 'mock'",
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+    m2.end({
+      attributes: {
+        provider: 'p',
+        model: 'm',
+        usage: {
+          inputTokens: 30,
+          outputTokens: 15,
+          inputDetails: { text: 30 },
+          outputDetails: { text: 12, reasoning: 3 },
+        },
+      },
+    });
+
+    hiddenAgent.end();
+    processorSpan.end();
+    await tracing.flush();
+
+    const exportedProcessor = exporter.endedSpans().find(s => s.type === SpanType.PROCESSOR_RUN)!;
+    const usage = (exportedProcessor.attributes as ProcessorRunAttributes).internalUsage;
+    expect(usage).toEqual({
+      inputTokens: 40,
+      outputTokens: 20,
+      inputDetails: { text: 40 },
+      outputDetails: { text: 17, reasoning: 3 },
+    });
+  });
+
+  it('walks past intermediate internal ancestors to reach an exported span', async () => {
+    const visibleAgent = tracing.startSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'agent run: user-agent',
+    });
+    const hiddenWorkflow = visibleAgent.createChildSpan({
+      type: SpanType.WORKFLOW_RUN,
+      name: 'workflow: agentic-loop',
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+    const hiddenInnerAgent = hiddenWorkflow.createChildSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'agent run: inner',
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+    const hiddenModel = hiddenInnerAgent.createChildSpan({
+      type: SpanType.MODEL_GENERATION,
+      name: "llm: 'mock'",
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+
+    hiddenModel.end({
+      attributes: { provider: 'p', model: 'm', usage: { inputTokens: 7, outputTokens: 3 } },
+    });
+    hiddenInnerAgent.end();
+    hiddenWorkflow.end();
+    visibleAgent.end();
+    await tracing.flush();
+
+    const ended = exporter.endedSpans();
+    const exportedAgent = ended.find(s => (s.entityType === undefined ? false : true)) ?? ended[0];
+    // The user-visible AGENT_RUN should be the sole exported span and carry the rolled-up usage.
+    expect(ended).toHaveLength(1);
+    expect(exportedAgent!.type).toBe(SpanType.AGENT_RUN);
+    const attrs = exportedAgent!.attributes as { internalUsage?: { inputTokens?: number; outputTokens?: number } };
+    expect(attrs.internalUsage).toEqual({ inputTokens: 7, outputTokens: 3 });
+  });
+
+  it('does not roll up usage when the MODEL_GENERATION itself is exported', async () => {
+    const agentSpan = tracing.startSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'agent run: visible',
+    });
+    const visibleModel = agentSpan.createChildSpan({
+      type: SpanType.MODEL_GENERATION,
+      name: "llm: 'mock'",
+    });
+    visibleModel.end({
+      attributes: { provider: 'p', model: 'm', usage: { inputTokens: 50, outputTokens: 10 } },
+    });
+    agentSpan.end();
+    await tracing.flush();
+
+    const ended = exporter.endedSpans();
+    const exportedAgent = ended.find(s => s.type === SpanType.AGENT_RUN)!;
+    // The visible model emits its own metrics; we must NOT also double-attribute
+    // its usage to the agent via internalUsage.
+    expect((exportedAgent.attributes as { internalUsage?: unknown }).internalUsage).toBeUndefined();
+  });
+
+  it('emits token metrics attributed to the visible ancestor, not the hidden agent', async () => {
+    const processorSpan = tracing.startSpan({
+      type: SpanType.PROCESSOR_RUN,
+      name: 'input processor: moderation',
+      entityName: 'Moderation',
+      entityId: 'moderation',
+    });
+    const hiddenAgent = processorSpan.createChildSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'agent run: content-moderator',
+      entityName: 'Content Moderator',
+      entityId: 'content-moderator',
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+    const hiddenModel = hiddenAgent.createChildSpan({
+      type: SpanType.MODEL_GENERATION,
+      name: "llm: 'mock'",
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+    hiddenModel.end({
+      attributes: {
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+        usage: { inputTokens: 100, outputTokens: 25 },
+      },
+    });
+    hiddenAgent.end();
+    processorSpan.end();
+    await tracing.flush();
+
+    const inputMetric = exporter.metricEvents.find(e => e.metric.name === 'mastra_model_total_input_tokens');
+    expect(inputMetric).toBeDefined();
+    // Labels point at the processor (the visible ancestor), not the hidden agent.
+    expect(inputMetric!.metric.correlationContext.entityId).toBe('moderation');
+    expect(inputMetric!.metric.correlationContext.entityName).toBe('Moderation');
+    expect(inputMetric!.metric.value).toBe(100);
+
+    const outputMetric = exporter.metricEvents.find(e => e.metric.name === 'mastra_model_total_output_tokens');
+    expect(outputMetric).toBeDefined();
+    expect(outputMetric!.metric.correlationContext.entityId).toBe('moderation');
+    expect(outputMetric!.metric.value).toBe(25);
+  });
+
+  it('does not roll up when includeInternalSpans is true', async () => {
+    const localExporter = new CollectingExporter();
+    const localTracing = new DefaultObservabilityInstance({
+      serviceName: 'usage-rollup-test',
+      name: 'test-instance',
+      sampling: { type: SamplingStrategyType.ALWAYS },
+      includeInternalSpans: true,
+      exporters: [localExporter],
+    });
+
+    const processorSpan = localTracing.startSpan({
+      type: SpanType.PROCESSOR_RUN,
+      name: 'input processor: moderation',
+    });
+    const hiddenAgent = processorSpan.createChildSpan({
+      type: SpanType.AGENT_RUN,
+      name: 'agent run: content-moderator',
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+    const hiddenModel = hiddenAgent.createChildSpan({
+      type: SpanType.MODEL_GENERATION,
+      name: "llm: 'mock'",
+      tracingPolicy: { internal: InternalSpans.ALL },
+    });
+    hiddenModel.end({
+      attributes: {
+        provider: 'mock-provider',
+        model: 'mock-model-id',
+        usage: { inputTokens: 100, outputTokens: 25 },
+      },
+    });
+    hiddenAgent.end();
+    processorSpan.end();
+    await localTracing.flush();
+
+    // When internal spans are surfaced, the MODEL_GENERATION emits its own
+    // metrics via the normal pipeline and we must not also roll its usage
+    // onto the processor span.
+    const processor = localExporter.endedSpans().find(s => s.type === SpanType.PROCESSOR_RUN)!;
+    expect((processor.attributes as { internalUsage?: unknown }).internalUsage).toBeUndefined();
+
+    // All three spans are exported as descendants in the trace.
+    const types = localExporter.endedSpans().map(s => s.type);
+    expect(types).toContain(SpanType.PROCESSOR_RUN);
+    expect(types).toContain(SpanType.AGENT_RUN);
+    expect(types).toContain(SpanType.MODEL_GENERATION);
+
+    await localTracing.shutdown();
+  });
+});

--- a/observability/mastra/src/usage.test.ts
+++ b/observability/mastra/src/usage.test.ts
@@ -1,6 +1,6 @@
 import type { LanguageModelUsage, ProviderMetadata } from '@mastra/core/stream';
 import { describe, it, expect } from 'vitest';
-import { extractUsageMetrics } from './usage';
+import { addUsageStats, extractUsageMetrics } from './usage';
 
 describe('extractUsageMetrics', () => {
   describe('basic usage extraction', () => {
@@ -521,5 +521,52 @@ describe('extractUsageMetrics', () => {
       expect(result.inputDetails).toEqual({ text: 100 });
       expect(result.outputDetails).toEqual({ text: 50 });
     });
+  });
+});
+
+describe('addUsageStats', () => {
+  it('returns a copy of b when accumulator is undefined', () => {
+    const result = addUsageStats(undefined, { inputTokens: 10, outputTokens: 5 });
+    expect(result).toEqual({ inputTokens: 10, outputTokens: 5 });
+  });
+
+  it('does not mutate the accumulator', () => {
+    const a = { inputTokens: 5, outputTokens: 2 };
+    const result = addUsageStats(a, { inputTokens: 3, outputTokens: 1 });
+    expect(a).toEqual({ inputTokens: 5, outputTokens: 2 });
+    expect(result).toEqual({ inputTokens: 8, outputTokens: 3 });
+  });
+
+  it('sums top-level token counts', () => {
+    const result = addUsageStats({ inputTokens: 100, outputTokens: 50 }, { inputTokens: 25, outputTokens: 75 });
+    expect(result.inputTokens).toBe(125);
+    expect(result.outputTokens).toBe(125);
+  });
+
+  it('keeps undefined fields undefined when both sides omit them', () => {
+    const result = addUsageStats({ inputTokens: 10 }, { outputTokens: 5 });
+    expect(result.inputTokens).toBe(10);
+    expect(result.outputTokens).toBe(5);
+  });
+
+  it('merges inputDetails and outputDetails per-field', () => {
+    const result = addUsageStats(
+      {
+        inputDetails: { text: 90, cacheRead: 10 },
+        outputDetails: { text: 40, reasoning: 5 },
+      },
+      {
+        inputDetails: { text: 30, cacheWrite: 8 },
+        outputDetails: { text: 10, audio: 2 },
+      },
+    );
+    expect(result.inputDetails).toEqual({ text: 120, cacheRead: 10, cacheWrite: 8 });
+    expect(result.outputDetails).toEqual({ text: 50, reasoning: 5, audio: 2 });
+  });
+
+  it('preserves details from one side when the other has none', () => {
+    const result = addUsageStats({ inputTokens: 10 }, { inputTokens: 5, inputDetails: { text: 5 } });
+    expect(result.inputTokens).toBe(15);
+    expect(result.inputDetails).toEqual({ text: 5 });
   });
 });

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -185,3 +185,59 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
 function sumDefinedValues<T extends object, K extends keyof T>(obj: T, keys: K[]): number {
   return keys.reduce((sum, key) => sum + ((obj[key] as number | undefined) ?? 0), 0);
 }
+
+function addOptional(a: number | undefined, b: number | undefined): number | undefined {
+  if (a === undefined && b === undefined) return undefined;
+  return (a ?? 0) + (b ?? 0);
+}
+
+function mergeInputDetails(
+  a: InputTokenDetails | undefined,
+  b: InputTokenDetails | undefined,
+): InputTokenDetails | undefined {
+  if (!a) return b ? { ...b } : undefined;
+  if (!b) return { ...a };
+  return {
+    text: addOptional(a.text, b.text),
+    cacheRead: addOptional(a.cacheRead, b.cacheRead),
+    cacheWrite: addOptional(a.cacheWrite, b.cacheWrite),
+    audio: addOptional(a.audio, b.audio),
+    image: addOptional(a.image, b.image),
+  };
+}
+
+function mergeOutputDetails(
+  a: OutputTokenDetails | undefined,
+  b: OutputTokenDetails | undefined,
+): OutputTokenDetails | undefined {
+  if (!a) return b ? { ...b } : undefined;
+  if (!b) return { ...a };
+  return {
+    text: addOptional(a.text, b.text),
+    reasoning: addOptional(a.reasoning, b.reasoning),
+    audio: addOptional(a.audio, b.audio),
+    image: addOptional(a.image, b.image),
+  };
+}
+
+/**
+ * Sum two UsageStats into a new one. Treats undefined fields as zero when
+ * the other side has a value, and preserves undefined when both are absent.
+ * Used to roll up internal model-generation usage onto a visible ancestor
+ * span so cost / token attribution survives internal-span filtering.
+ */
+export function addUsageStats(a: UsageStats | undefined, b: UsageStats): UsageStats {
+  if (!a) {
+    return {
+      ...b,
+      inputDetails: b.inputDetails ? { ...b.inputDetails } : undefined,
+      outputDetails: b.outputDetails ? { ...b.outputDetails } : undefined,
+    };
+  }
+  return {
+    inputTokens: addOptional(a.inputTokens, b.inputTokens),
+    outputTokens: addOptional(a.outputTokens, b.outputTokens),
+    inputDetails: mergeInputDetails(a.inputDetails, b.inputDetails),
+    outputDetails: mergeOutputDetails(a.outputDetails, b.outputDetails),
+  };
+}

--- a/packages/core/src/features/index.ts
+++ b/packages/core/src/features/index.ts
@@ -24,4 +24,5 @@ export const coreFeatures = new Set<string>([
   'channels',
   'deploy-diagnosis',
   'model-inference-span',
+  'internal-usage-rollup',
 ]);

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -97,7 +97,19 @@ export { EntityType };
 /**
  * Base attributes that all spans can have
  */
-export interface AIBaseAttributes {}
+export interface AIBaseAttributes {
+  /**
+   * Token usage rolled up from internal descendant spans whose own
+   * MODEL_GENERATION spans are filtered from the exported trace (e.g.
+   * Mastra-owned processors that run with `tracingPolicy.internal`).
+   *
+   * Accumulated on the closest exported ancestor at descendant-end time,
+   * so cost / token attribution survives even when the descendant model
+   * spans themselves are hidden. Token-usage metrics auto-extract from
+   * this field on the ancestor when present.
+   */
+  internalUsage?: UsageStats;
+}
 
 /**
  * Agent Run attributes

--- a/packages/memory/src/processors/observational-memory/tracing.ts
+++ b/packages/memory/src/processors/observational-memory/tracing.ts
@@ -57,13 +57,11 @@ export async function withOmTracingSpan<T>({
     entityType: EntityType.OUTPUT_STEP_PROCESSOR,
     entityName: config.entityName,
     tracingContext: observabilityContext?.tracingContext ?? observabilityContext?.tracing,
-    attributes: {
-      metadata: {
-        omPhase: phase,
-        omInputTokens: inputTokens,
-        omSelectedModel: typeof model === 'string' ? model : '(dynamic-model)',
-        ...metadata,
-      },
+    metadata: {
+      omPhase: phase,
+      omInputTokens: inputTokens,
+      omSelectedModel: typeof model === 'string' ? model : '(dynamic-model)',
+      ...metadata,
     },
     requestContext,
   });


### PR DESCRIPTION
## Description

When `tracingPolicy.internal` filters out MODEL_GENERATION spans from exported traces, their token usage now rolls up to the closest exported ancestor span. This ensures:

1. **Trace UI visibility**: The visible ancestor (e.g., `PROCESSOR_RUN`, `AGENT_RUN`) gets an `internalUsage` attribute summing tokens consumed by hidden descendant model calls, so users can see processor/agent cost without enabling `includeInternalSpans`.

2. **Metric attribution**: Token and cost metrics still emit, but are attributed via labels to the visible ancestor instead of vanishing with the hidden MODEL_GENERATION span.

### Key Changes

- **`BaseObservabilityInstance`**: Modified span lifecycle wiring to capture usage from internal MODEL_GENERATION spans at end time, walk up the parent chain to find the closest exported ancestor, and apply the rollup (mutating ancestor attributes and emitting metrics with ancestor's context).

- **`usage.ts`**: Added `addUsageStats()` function to merge two UsageStats objects, handling nested `inputDetails` and `outputDetails` fields correctly.

- **`auto-extract.ts`**: Exported new `emitTokenMetricsForUsage()` function to emit token metrics from an explicit usage payload with a supplied metrics context (used when rolling up internal model usage).

- **`AIBaseAttributes`**: Added optional `internalUsage?: UsageStats` field to carry rolled-up usage on any span type.

- **Comprehensive test suite**: Added 320-line test file covering single/multiple hidden model calls, walking past intermediate internal ancestors, preventing double-attribution of visible models, metric label correctness, and disabling rollup when `includeInternalSpans` is true.

## Related issue(s)

<!-- Link to issue if available -->

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

https://claude.ai/code/session_01YCjcD8VKB3uxbLVpFFXzNP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Hidden model calls used to vanish from traces and cost reports. Now, when a model call is hidden, its token usage is added to the nearest visible parent span so the UI and metrics still show the cost.

## Overview

Rolls up token usage from internal MODEL_GENERATION spans that are filtered out by tracingPolicy.internal onto the nearest exported (visible) ancestor span. The ancestor receives an internalUsage attribute with summed tokens (including merged inputDetails/outputDetails) and token metrics are emitted using the ancestor's metrics context/labels so trace UI and token/cost metrics reflect the hidden work without enabling includeInternalSpans.

## Changes Made

### Core Types
- packages/core: AIBaseAttributes now includes optional internalUsage?: UsageStats (allows any span to carry rolled-up internal usage).

### Observability Implementation
- BaseObservabilityInstance
  - Adjusted span lifecycle wiring: when an internal MODEL_GENERATION that would be filtered ends, its usage payload is captured (from end() options or span attributes), the parent chain is walked to find the nearest exported ancestor (skipping intermediate internal spans and honoring excludeSpanTypes), that ancestor's attributes are mutated to accumulate internalUsage via addUsageStats, and token metrics are emitted using the ancestor’s MetricsContext/labels.
  - Ensures no double-attribution: if the MODEL_GENERATION itself is exported, rollup is skipped.

- usage.ts
  - Added addUsageStats(a, b) and helpers (addOptional, mergeInputDetails/mergeOutputDetails) to merge UsageStats objects without mutating inputs, summing tokens and merging detailed token breakdowns.

- auto-extract.ts
  - Exported emitTokenMetricsForUsage(usage, provider, model, metrics) to emit token metrics from an explicit UsageStats payload tied to a supplied MetricsContext (used when rolling up internal usage).

- features flags
  - Added "internal-usage-rollup" to coreFeatures and observabilityFeatures so downstream code can detect the capability; the rollup logic itself runs in BaseObservabilityInstance when relevant.

- Minor API placement fix
  - Observational memory tracing metadata fields (omPhase, omInputTokens, omSelectedModel) were moved into the top-level metadata option for getOrCreateSpan calls to match the new AIBaseAttributes placement and avoid excess-property mismatches.

### Behavioral Details
- Rollup only applies for internal MODEL_GENERATION spans that would be filtered from export; exported MODEL_GENERATION spans keep their own usage to avoid double-counting.
- Walks up past intermediate internal ancestors and skips span types listed in excludeSpanTypes so rollup lands on the next eligible exported ancestor.
- Token metrics continue to be emitted but are labeled/correlated to the visible ancestor so cost attribution follows the visible entity.
- When includeInternalSpans: true, rollup is effectively disabled: internal MODEL_GENERATION spans and their metrics are exported normally and no internalUsage is attached to ancestors.

## Tests
- New comprehensive test suite (usage-rollup.test.ts, ~320 lines) covering:
  - Single and multiple hidden model calls aggregating into ancestor.internalUsage (including inputDetails/outputDetails).
  - Walking past intermediate internal ancestors and skipping excludeSpanTypes.
  - Prevention of double-attribution when model spans are exported.
  - Correct metric label/correlation to the visible ancestor.
  - Rollup disabled when includeInternalSpans: true.
- Added addUsageStats unit tests in usage.test.ts (non-mutating behavior, undefined accumulator handling, detail merging).

## Packages / Releases
- Bumped @mastra/core to include AIBaseAttributes.internalUsage.
- @mastra/observability: implements rollup behavior, adds emitTokenMetricsForUsage, addUsageStats, feature flag, tests, and wiring changes to BaseObservabilityInstance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16434)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->