### PR TITLE
fix(client-js): tier-1 contract fixes for agent-builder and stored skills

### DIFF
--- a/.changeset/sdk-tier1-contract-fixes.md
+++ b/.changeset/sdk-tier1-contract-fixes.md
@@ -1,0 +1,27 @@
+---
+'@mastra/client-js': minor
+---
+
+Fix client-js bugs surfaced by the SDK ↔ server contract audit.
+
+- `MastraClient.getAgentBuilderActions()` previously requested `/agent-builder/` (trailing slash) and 404'd. Now hits `/agent-builder`.
+- `AgentBuilder.stream(params, runId)` now requires `runId`. The server route requires it; calls without it failed with a server-side validation error. The SDK now both types `runId` as required and guards at runtime.
+- `MastraClient.createStoredSkill(...)` now requires `description` in its parameter type. The server schema has always required it; the SDK type used to mark it optional, so omitting it produced a runtime 400 instead of a compile error.
+
+Migration:
+
+```ts
+// Before
+await agentBuilder.stream({ inputData });
+
+// After
+await agentBuilder.stream({ inputData }, runId);
+```
+
+```ts
+// Before
+await client.createStoredSkill({ name, instructions });
+
+// After
+await client.createStoredSkill({ name, description, instructions });
+```

--- a/client-sdks/client-js/src/client.test.ts
+++ b/client-sdks/client-js/src/client.test.ts
@@ -863,4 +863,58 @@ describe('MastraClient', () => {
       });
     });
   });
+
+  describe('Agent Builder Actions', () => {
+    let client: MastraClient;
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+      client = new MastraClient({ baseUrl: 'http://localhost:4111', retries: 0 });
+    });
+
+    it('getAgentBuilderActions should hit /agent-builder (no trailing slash)', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        json: async () => ({}),
+      });
+
+      await client.getAgentBuilderActions();
+
+      expect(global.fetch).toHaveBeenCalledWith('http://localhost:4111/api/agent-builder', expect.any(Object));
+    });
+  });
+
+  describe('Stored Skills', () => {
+    let client: MastraClient;
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+      client = new MastraClient({ baseUrl: 'http://localhost:4111', retries: 0 });
+    });
+
+    it('createStoredSkill should POST the required description and other fields', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        json: async () => ({}),
+      });
+
+      await client.createStoredSkill({
+        name: 'my-skill',
+        description: 'Does a thing',
+        instructions: 'Run the thing',
+      });
+
+      const [url, init] = (global.fetch as any).mock.calls[0];
+      expect(url).toBe('http://localhost:4111/api/stored/skills');
+      expect(init.method).toBe('POST');
+      const body = JSON.parse(init.body);
+      expect(body).toMatchObject({
+        name: 'my-skill',
+        description: 'Does a thing',
+        instructions: 'Run the thing',
+      });
+    });
+  });
 });

--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -547,7 +547,7 @@ export class MastraClient extends BaseResource {
    * @returns Promise containing map of action IDs to action details
    */
   public getAgentBuilderActions(): Promise<Record<string, WorkflowInfo>> {
-    return this.request('/agent-builder/');
+    return this.request('/agent-builder');
   }
 
   /**

--- a/client-sdks/client-js/src/resources/agent-builder.test.ts
+++ b/client-sdks/client-js/src/resources/agent-builder.test.ts
@@ -131,6 +131,20 @@ describe('AgentBuilder.runs', () => {
     expect(params.get('page')).toBe('10');
     expect(params.get('resourceId')).toBe('test-resource-456');
   });
+
+  it('stream should require a runId and serialize it as a query param', async () => {
+    await agentBuilder.stream({ inputData: { foo: 'bar' } }, 'run-stream-1');
+
+    expect(lastRequest.method).toBe('POST');
+    expect(lastRequest.url).toBe('/api/agent-builder/test-action-id/stream?runId=run-stream-1');
+  });
+
+  it('stream should throw when runId is missing', async () => {
+    await expect(
+      // @ts-expect-error: runId is now required, the cast intentionally exercises the runtime guard
+      agentBuilder.stream({ inputData: { foo: 'bar' } }, undefined),
+    ).rejects.toThrow(/runId is required/);
+  });
 });
 
 describe('AgentBuilder Streaming Methods (fetch-mocked)', () => {

--- a/client-sdks/client-js/src/resources/agent-builder.ts
+++ b/client-sdks/client-js/src/resources/agent-builder.ts
@@ -289,17 +289,19 @@ export class AgentBuilder extends BaseResource {
    */
   async stream(
     params: AgentBuilderActionRequest,
-    runId?: string,
+    runId: string,
   ): Promise<globalThis.ReadableStream<{ type: string; payload: any }>> {
-    const searchParams = new URLSearchParams();
-    if (runId) {
-      searchParams.set('runId', runId);
+    if (!runId) {
+      throw new Error('runId is required to stream an agent builder action');
     }
+
+    const searchParams = new URLSearchParams();
+    searchParams.set('runId', runId);
 
     const requestContext = parseClientRequestContext(params.requestContext);
     const { requestContext: _, ...actionParams } = params;
 
-    const url = `/agent-builder/${this.actionId}/stream${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
+    const url = `/agent-builder/${this.actionId}/stream?${searchParams.toString()}`;
     const response: Response = await this.request(url, {
       method: 'POST',
       body: { ...actionParams, requestContext },

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -1916,7 +1916,8 @@ export interface CreateStoredSkillParams {
   authorId?: string;
   metadata?: Record<string, unknown>;
   name: string;
-  description?: string;
+  /** Required by the server: description of what the skill does and when to use it. */
+  description: string;
   instructions: string;
   license?: string;
   files?: StoredSkillFileNode[];


### PR DESCRIPTION
## Summary

Three small fixes in `@mastra/client-js` for drift between the SDK and the server contract, found by the local SDK ↔ server audit. Tracked in #16292.

### 1. `MastraClient.getAgentBuilderActions()` URL
The SDK requested `GET /agent-builder/` (trailing slash). The server route is `GET /agent-builder`, so this 404'd. Dropped the trailing slash.

### 2. `AgentBuilder.stream(params, runId)` requires `runId`
The server's stream route requires `runId` (`runIdSchema`, not `optionalRunIdSchema` like `startAsync`). The SDK typed `runId` as optional and silently sent the request without it, which 400'd server-side.

- `runId` is now required at the type level
- a runtime guard throws `runId is required to stream an agent builder action` if it's missing

### 3. `CreateStoredSkillParams.description`
The server schema requires `description`. The SDK type marked it optional, so omitting it produced a runtime 400 instead of a compile error. Now required to match the server.

## Test plan

- New unit tests:
  - `client.test.ts`: `getAgentBuilderActions` asserts URL is `/api/agent-builder` (no trailing slash); `createStoredSkill` asserts the POST body carries the required `description`
  - `agent-builder.test.ts`: `stream` asserts the URL serializes `runId` and that the runtime guard rejects when `runId` is missing
- `pnpm vitest run` in `client-sdks/client-js`: 429/431 (the two failures are pre-existing vNext flakes on `main`, unrelated)
- `pnpm tsc --noEmit` clean in `client-sdks/client-js` and `packages/playground` (verifies the `createStoredSkill.description` tightening doesn't break in-tree callers)
- `pnpm lint` clean
- Local e2e against a real `mastra dev` server (single agent, libsql storage):
  - `GET /api/agent-builder` → 200; `GET /api/agent-builder/` → 404 (confirms the trailing-slash bug existed and is fixed; SDK wire URL verified as `/api/agent-builder`)
  - `POST /api/agent-builder/:actionId/stream` without `runId` → 400 `Invalid query parameters: runId expected string, received undefined`; with `runId` → request reaches action lookup. SDK rejects `undefined`/`""` `runId` before the wire call and serializes `?runId=...` correctly.
  - `POST /api/stored/skills` without `description` → 400 `description: expected string, received undefined`; with `description` → 200 and value round-trips. SDK type tightening turns this into a compile-time error.
  - 7/7 scenarios passed.

Refs #16292


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes three bugs in the JavaScript SDK where the code didn't match what the server expected: it removes an accidental extra slash from one endpoint URL, makes sure a required ID parameter (`runId`) is actually treated as required instead of optional, and makes sure a required field (`description`) is marked as required in the TypeScript types. These fixes prevent 404 and 400 errors when developers try to use the agent builder features.

## Overview

This PR contains three targeted contract fixes in `@mastra/client-js` to resolve discrepancies between SDK types/behavior and server requirements discovered during an SDK ↔ server audit:

### Fix 1: Remove trailing slash from `getAgentBuilderActions()` endpoint

**Issue:** The endpoint was requesting `GET /agent-builder/` (with trailing slash), which returned 404s.  
**Solution:** Changed to `GET /agent-builder` (no trailing slash) to match the actual server route.

### Fix 2: Make `runId` required for `AgentBuilder.stream()`

**Issue:** The `runId` parameter was optional in SDK types, but the server route required it, causing validation failures.  
**Solution:** 
- Updated method signature from `stream(params, runId?: string)` to `stream(params, runId: string)`
- Added runtime guard that throws `Error('runId is required to stream an agent builder action')` if `runId` is not provided

### Fix 3: Require `description` in `CreateStoredSkillParams`

**Issue:** The `description` field was optional in the SDK type, but the server schema required it, causing runtime 400 errors.  
**Solution:** Changed `description?: string` to `description: string` in the `CreateStoredSkillParams` interface.

## Testing

- **Unit tests added:**
  - `client.test.ts`: Verifies `getAgentBuilderActions()` uses `/api/agent-builder` endpoint and `createStoredSkill()` POST includes required `description`
  - `agent-builder.test.ts`: Verifies `stream()` serializes `runId` parameter and runtime guard rejects missing `runId`
- **Test results:** 429/431 passing (pre-existing vNext flakes noted on main)
- **Type checking:** `pnpm tsc --noEmit` clean in both `client-sdks/client-js` and `packages/playground`
- **Linting:** `pnpm lint` clean

## Files Changed

- `.changeset/sdk-tier1-contract-fixes.md` — Changeset documentation
- `client-sdks/client-js/src/client.ts` — Fixed endpoint URL
- `client-sdks/client-js/src/client.test.ts` — Added tests for endpoint and request body
- `client-sdks/client-js/src/resources/agent-builder.ts` — Made `runId` required with runtime validation
- `client-sdks/client-js/src/resources/agent-builder.test.ts` — Added tests for `runId` handling
- `client-sdks/client-js/src/types.ts` — Made `description` required in `CreateStoredSkillParams`

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16439)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
