### PR TITLE
feat(memory): env-gated debug-trace spans for OM hot-path internals

### DIFF
--- a/.changeset/om-debug-trace.md
+++ b/.changeset/om-debug-trace.md
@@ -1,0 +1,7 @@
+---
+'@mastra/memory': patch
+---
+
+Added env-gated debug-trace child spans around three hot-path Observational Memory internals: `step.prepare`, `getStatus`, and `getOrCreateRecord`. Off by default. Set `MASTRA_OM_DEBUG_TRACE=1` to opt in.
+
+When unset the wrapper is a direct passthrough with no span construction overhead. When set, the wrappers emit child spans of the current OM `om.observer` / `om.reflector` span (or whatever current span is in `AsyncLocalStorage`), so bisecting a slow agentic-loop step from OM internals only requires flipping the env var and looking at the trace tree.

--- a/.changeset/om-debug-trace.md
+++ b/.changeset/om-debug-trace.md
@@ -7,8 +7,8 @@ Added opt-in debug tracing for Observational Memory's hot-path internals, useful
 Off by default. Set `MASTRA_OM_DEBUG_TRACE=1` (or `true`) to opt in. When the env var is unset, behavior is unchanged — the wrapper is a direct passthrough with no span construction overhead.
 
 ```bash
-# Show which OM internal (per-step prepare, record lookup, status check)
-# is paying the cost in your agent's trace.
+# Show which OM internal (per-step prepare, turn-end flush, record
+# lookup, status check) is paying the cost in your agent's trace.
 MASTRA_OM_DEBUG_TRACE=1 pnpm start
 ```
 

--- a/.changeset/om-debug-trace.md
+++ b/.changeset/om-debug-trace.md
@@ -2,6 +2,14 @@
 '@mastra/memory': patch
 ---
 
-Added env-gated debug-trace child spans around three hot-path Observational Memory internals: `step.prepare`, `getStatus`, and `getOrCreateRecord`. Off by default. Set `MASTRA_OM_DEBUG_TRACE=1` to opt in.
+Added opt-in debug tracing for Observational Memory's hot-path internals, useful for bisecting slow agentic-loop steps from the trace tree.
 
-When unset the wrapper is a direct passthrough with no span construction overhead. When set, the wrappers emit child spans of the current OM `om.observer` / `om.reflector` span (or whatever current span is in `AsyncLocalStorage`), so bisecting a slow agentic-loop step from OM internals only requires flipping the env var and looking at the trace tree.
+Off by default. Set `MASTRA_OM_DEBUG_TRACE=1` (or `true`) to opt in. When the env var is unset, behavior is unchanged — the wrapper is a direct passthrough with no span construction overhead.
+
+```bash
+# Show which OM internal (per-step prepare, record lookup, status check)
+# is paying the cost in your agent's trace.
+MASTRA_OM_DEBUG_TRACE=1 pnpm start
+```
+
+The new spans nest under the existing `om.observer` / `om.reflector` spans (or whatever current span is in scope), so the trace tree resolves which Observational Memory call is responsible without further code changes.

--- a/packages/memory/src/processors/observational-memory/__tests__/debug-trace.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/debug-trace.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OM_DEBUG_TRACE_ENV, withOmDebugSpan } from '../debug-trace';
+
+describe('withOmDebugSpan', () => {
+  const originalEnv = process.env[OM_DEBUG_TRACE_ENV];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[OM_DEBUG_TRACE_ENV];
+    } else {
+      process.env[OM_DEBUG_TRACE_ENV] = originalEnv;
+    }
+  });
+
+  describe('when MASTRA_OM_DEBUG_TRACE is unset', () => {
+    beforeEach(() => {
+      delete process.env[OM_DEBUG_TRACE_ENV];
+    });
+
+    it('returns the callback result without creating a span', async () => {
+      const fn = vi.fn().mockResolvedValue('result');
+      const currentSpan = { createChildSpan: vi.fn() };
+
+      const result = await withOmDebugSpan('om.step.prepare', { tracingContext: { currentSpan } } as any, fn);
+
+      expect(result).toBe('result');
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(currentSpan.createChildSpan).not.toHaveBeenCalled();
+    });
+
+    it('propagates rejections without touching span APIs', async () => {
+      const err = new Error('boom');
+      await expect(withOmDebugSpan('om.getStatus', undefined, () => Promise.reject(err))).rejects.toBe(err);
+    });
+  });
+
+  describe('when MASTRA_OM_DEBUG_TRACE=1', () => {
+    beforeEach(() => {
+      process.env[OM_DEBUG_TRACE_ENV] = '1';
+    });
+
+    it('runs the callback directly when there is no current span', async () => {
+      const fn = vi.fn().mockResolvedValue(42);
+      const result = await withOmDebugSpan('om.getOrCreateRecord', undefined, fn);
+      expect(result).toBe(42);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates a child span and ends it on success', async () => {
+      const child = {
+        executeInContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+        end: vi.fn(),
+        error: vi.fn(),
+      };
+      const currentSpan = { createChildSpan: vi.fn().mockReturnValue(child) };
+
+      const result = await withOmDebugSpan('om.step.prepare', { tracingContext: { currentSpan } } as any, () =>
+        Promise.resolve('ok'),
+      );
+
+      expect(result).toBe('ok');
+      expect(currentSpan.createChildSpan).toHaveBeenCalledTimes(1);
+      expect(currentSpan.createChildSpan.mock.calls[0][0].name).toBe('om.step.prepare');
+      expect(child.executeInContext).toHaveBeenCalledTimes(1);
+      expect(child.end).toHaveBeenCalledTimes(1);
+      expect(child.error).not.toHaveBeenCalled();
+    });
+
+    it('records error with endSpan: true when the callback throws', async () => {
+      const child = {
+        executeInContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+        end: vi.fn(),
+        error: vi.fn(),
+      };
+      const currentSpan = { createChildSpan: vi.fn().mockReturnValue(child) };
+
+      const err = new Error('downstream');
+      await expect(
+        withOmDebugSpan('om.getStatus', { tracingContext: { currentSpan } } as any, () => Promise.reject(err)),
+      ).rejects.toBe(err);
+
+      expect(child.error).toHaveBeenCalledTimes(1);
+      expect(child.error.mock.calls[0][0].error).toBe(err);
+      expect(child.error.mock.calls[0][0].endSpan).toBe(true);
+      expect(child.end).not.toHaveBeenCalled();
+    });
+
+    it('also accepts the literal "true" as the opt-in value', async () => {
+      process.env[OM_DEBUG_TRACE_ENV] = 'true';
+      const child = {
+        executeInContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+        end: vi.fn(),
+        error: vi.fn(),
+      };
+      const currentSpan = { createChildSpan: vi.fn().mockReturnValue(child) };
+
+      await withOmDebugSpan('om.step.prepare', { tracingContext: { currentSpan } } as any, () => Promise.resolve());
+      expect(currentSpan.createChildSpan).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/memory/src/processors/observational-memory/debug-trace.ts
+++ b/packages/memory/src/processors/observational-memory/debug-trace.ts
@@ -1,0 +1,59 @@
+import type { ObservabilityContext } from '@mastra/core/observability';
+import { EntityType, resolveCurrentSpan, SpanType } from '@mastra/core/observability';
+
+/**
+ * Env var that opts into deep OM instrumentation child spans for hot-path
+ * internals (`step.prepare`, `getStatus`, `getOrCreateRecord`). Off by default.
+ *
+ * Set to `1` or `true` to enable. When unset, `withOmDebugSpan` is a pass-through
+ * with no span construction overhead.
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/15677
+ */
+export const OM_DEBUG_TRACE_ENV = 'MASTRA_OM_DEBUG_TRACE';
+
+function isOmDebugTraceEnabled(): boolean {
+  const v = process.env[OM_DEBUG_TRACE_ENV];
+  return v === '1' || v === 'true';
+}
+
+/**
+ * Wrap an OM internal call with a debug-trace child span when
+ * `MASTRA_OM_DEBUG_TRACE` is set. When unset, returns `fn()` directly with no
+ * observability overhead.
+ *
+ * The span attaches to `observabilityContext.tracingContext.currentSpan` if
+ * provided, otherwise falls back to the AsyncLocalStorage-resolved current
+ * span. Calls inside the `fn` callback inherit this span as parent via
+ * `executeInContext`, so nested instrumented OM ops nest correctly without
+ * threading context through every call site.
+ */
+export async function withOmDebugSpan<T>(
+  name: string,
+  observabilityContext: ObservabilityContext | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!isOmDebugTraceEnabled()) return fn();
+
+  const parent = observabilityContext?.tracingContext?.currentSpan ?? resolveCurrentSpan();
+  if (!parent) return fn();
+
+  const span = parent.createChildSpan({
+    type: SpanType.MEMORY_OPERATION,
+    name,
+    entityType: EntityType.MEMORY,
+    entityName: 'ObservationalMemory',
+    attributes: {},
+  });
+
+  if (!span) return fn();
+
+  try {
+    const result = await span.executeInContext(() => fn());
+    span.end({});
+    return result;
+  } catch (error) {
+    span.error({ error: error instanceof Error ? error : new Error(String(error)) });
+    throw error;
+  }
+}

--- a/packages/memory/src/processors/observational-memory/debug-trace.ts
+++ b/packages/memory/src/processors/observational-memory/debug-trace.ts
@@ -53,7 +53,7 @@ export async function withOmDebugSpan<T>(
     span.end({});
     return result;
   } catch (error) {
-    span.error({ error: error instanceof Error ? error : new Error(String(error)) });
+    span.error({ error: error instanceof Error ? error : new Error(String(error)), endSpan: true });
     throw error;
   }
 }

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -1,6 +1,7 @@
 import { getThreadOMMetadata } from '@mastra/core/memory';
 
 import { omDebug } from '../debug';
+import { withOmDebugSpan } from '../debug-trace';
 import { filterObservedMessages } from '../message-utils';
 import { getLastActivityFromMessages, getLatestStepParts } from '../observational-memory';
 import { resolveRetentionFloor } from '../thresholds';
@@ -43,6 +44,10 @@ export class ObservationStep {
    * builds system message, filters observed.
    */
   async prepare(): Promise<StepContext> {
+    return withOmDebugSpan('om.step.prepare', this.turn.observabilityContext, () => this._prepareImpl());
+  }
+
+  private async _prepareImpl(): Promise<StepContext> {
     if (this._prepared) throw new Error(`Step ${this.stepNumber} already prepared`);
 
     const { threadId, resourceId, messageList } = this.turn;

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -127,11 +127,13 @@ export class ObservationStep {
     );
 
     // ── Check thresholds + buffer trigger (all steps) ──────────
-    let statusSnapshot = await om.getStatus({
-      threadId,
-      resourceId,
-      messages: messageList.get.all.db(),
-    });
+    let statusSnapshot = await withOmDebugSpan('om.getStatus', this.turn.observabilityContext, () =>
+      om.getStatus({
+        threadId,
+        resourceId,
+        messages: messageList.get.all.db(),
+      }),
+    );
 
     // Trigger buffering if interval boundary crossed (fire-and-forget, all steps)
     if (statusSnapshot.shouldBuffer && !hasIncompleteToolCalls) {
@@ -243,11 +245,13 @@ export class ObservationStep {
       }
 
       // Re-fetch status after observation/cleanup for the snapshot
-      statusSnapshot = await om.getStatus({
-        threadId,
-        resourceId,
-        messages: messageList.get.all.db(),
-      });
+      statusSnapshot = await withOmDebugSpan('om.getStatus', this.turn.observabilityContext, () =>
+        om.getStatus({
+          threadId,
+          resourceId,
+          messages: messageList.get.all.db(),
+        }),
+      );
     }
 
     // ── Refresh cross-thread context (resource scope) ──────────
@@ -314,11 +318,13 @@ export class ObservationStep {
     await om.waitForBuffering(threadId, resourceId);
 
     // Re-check status with fresh state
-    const freshStatus = await om.getStatus({
-      threadId,
-      resourceId,
-      messages: messageList.get.all.db(),
-    });
+    const freshStatus = await withOmDebugSpan('om.getStatus', this.turn.observabilityContext, () =>
+      om.getStatus({
+        threadId,
+        resourceId,
+        messages: messageList.get.all.db(),
+      }),
+    );
 
     if (!freshStatus.shouldObserve) {
       return { succeeded: false, record: freshStatus.record };

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -4,6 +4,7 @@ import type { ProcessorStreamWriter } from '@mastra/core/processors';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { ObservationalMemoryRecord } from '@mastra/core/storage';
 
+import { withOmDebugSpan } from '../debug-trace';
 import type { ObservationalMemory } from '../observational-memory';
 import type { MemoryContextProvider } from '../processor';
 import type { ObservationModelContext } from '../types';
@@ -165,6 +166,10 @@ export class ObservationTurn {
    * Finalize the turn: save any remaining messages and return the latest record state.
    */
   async end(): Promise<TurnResult> {
+    return withOmDebugSpan('om.turn.end', this.observabilityContext, () => this._endImpl());
+  }
+
+  private async _endImpl(): Promise<TurnResult> {
     if (this._ended) throw new Error('Turn already ended');
     this._ended = true;
 

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -179,6 +179,7 @@ function parseActivationTTL(value: number | string | undefined, fieldPath: strin
 
 import { addRelativeTimeToObservations } from './date-utils';
 import { omDebug, omError } from './debug';
+import { withOmDebugSpan } from './debug-trace';
 import { createBufferingStartMarker, createActivationMarker } from './markers';
 import {
   findLastCompletedObservationBoundary,
@@ -1015,27 +1016,29 @@ export class ObservationalMemory {
    * Returns the existing record if one exists, otherwise initializes a new one.
    */
   async getOrCreateRecord(threadId: string, resourceId?: string): Promise<ObservationalMemoryRecord> {
-    const ids = this.getStorageIds(threadId, resourceId);
-    let record = await this.storage.getObservationalMemory(ids.threadId, ids.resourceId);
+    return withOmDebugSpan('om.getOrCreateRecord', undefined, async () => {
+      const ids = this.getStorageIds(threadId, resourceId);
+      let record = await this.storage.getObservationalMemory(ids.threadId, ids.resourceId);
 
-    if (!record) {
-      // Capture the timezone used for Observer date formatting
-      const observedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (!record) {
+        // Capture the timezone used for Observer date formatting
+        const observedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-      record = await this.storage.initializeObservationalMemory({
-        threadId: ids.threadId,
-        resourceId: ids.resourceId,
-        scope: this.scope,
-        config: {
-          observation: this.observationConfig,
-          reflection: this.reflectionConfig,
+        record = await this.storage.initializeObservationalMemory({
+          threadId: ids.threadId,
+          resourceId: ids.resourceId,
           scope: this.scope,
-        },
-        observedTimezone,
-      });
-    }
+          config: {
+            observation: this.observationConfig,
+            reflection: this.reflectionConfig,
+            scope: this.scope,
+          },
+          observedTimezone,
+        });
+      }
 
-    return record;
+      return record;
+    });
   }
 
   // ════════════════════════════════════════════════════════════════════════════
@@ -2631,6 +2634,25 @@ ${formattedMessages}
    * ```
    */
   async getStatus(opts: { threadId: string; resourceId?: string; messages?: MastraDBMessage[] }): Promise<{
+    record: ObservationalMemoryRecord;
+    pendingTokens: number;
+    threshold: number;
+    effectiveObservationTokensThreshold: number;
+    unbufferedPendingTokens: number;
+    shouldObserve: boolean;
+    shouldBuffer: boolean;
+    shouldReflect: boolean;
+    bufferedChunkCount: number;
+    bufferedChunkTokens: number;
+    canActivate: boolean;
+    asyncObservationEnabled: boolean;
+    asyncReflectionEnabled: boolean;
+    scope: 'resource' | 'thread';
+  }> {
+    return withOmDebugSpan('om.getStatus', undefined, () => this._getStatusImpl(opts));
+  }
+
+  private async _getStatusImpl(opts: { threadId: string; resourceId?: string; messages?: MastraDBMessage[] }): Promise<{
     record: ObservationalMemoryRecord;
     pendingTokens: number;
     threshold: number;

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -6,6 +6,7 @@ import type { ObservationalMemoryRecord } from '@mastra/core/storage';
 
 import { OBSERVATION_CONTINUATION_HINT } from './constants';
 import { omDebug } from './debug';
+import { withOmDebugSpan } from './debug-trace';
 import type { ObservationTurn } from './observation-turn/index';
 import type { ObservationalMemory } from './observational-memory';
 import { isOmReproCaptureEnabled, safeCaptureJson, writeProcessInputStepReproCapture } from './repro-capture';
@@ -242,7 +243,9 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
         // isBufferingObservation set by fire-and-forget buffer()) are visible.
         // The cached this.turn.record is stale in production DBs where each
         // query returns a new row object.
-        const freshRecord = await this.engine.getOrCreateRecord(threadId, resourceId);
+        const freshRecord = await withOmDebugSpan('om.getOrCreateRecord', observabilityContext, () =>
+          this.engine.getOrCreateRecord(threadId, resourceId),
+        );
         await this.engine.emitProgress({
           record: freshRecord,
           stepNumber,


### PR DESCRIPTION
## Description

Wraps three Observational Memory hot-path internals (`step.prepare`, `getStatus`, `getOrCreateRecord`) with a passthrough helper that emits a child span only when `MASTRA_OM_DEBUG_TRACE` is set. The child attaches to the current `om.observer` / `om.reflector` span (or whatever current span is resolved from `AsyncLocalStorage`), so descendant ops nest without threading observability context through every call site.

Off by default. Set `MASTRA_OM_DEBUG_TRACE=1` (or `true`) to opt in.

```bash
MASTRA_OM_DEBUG_TRACE=1 pnpm start
```

The motivation in #15677 was that bisecting an OM-attributed slow step from the issue side meant guessing whether the cost was in token-counting, in the storage round-trip, or in the metadata read inside `step.prepare`. With the env flag on, the trace tree resolves it in one look.

## Related Issue(s)

Closes #15677

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have addressed all Coderabbit comments on this PR

### Notes

- New file: `packages/memory/src/processors/observational-memory/debug-trace.ts` — the `withOmDebugSpan(name, observabilityContext, fn)` helper and `OM_DEBUG_TRACE_ENV` const.
- Wrappers added at:
  - `ObservationStep.prepare` (the most useful one — covers `getThreadOMMetadata`, the per-step token count, and the buffered-chunks scan)
  - `ObservationalMemory.getStatus` (the public entry point hit from `processInputStep`)
  - `ObservationalMemory.getOrCreateRecord` (the lazy-create round-trip)
- Helper resolves the parent span via `observabilityContext.tracingContext.currentSpan` if provided, else falls back to `resolveCurrentSpan()` from `@mastra/core/observability`. Returns `fn()` directly when the env var is unset, with no span construction overhead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Adds an optional debug mode (set MASTRA_OM_DEBUG_TRACE=1 or "true") that, when turned on, records small timing spans around key Observational Memory internals so you can see which part is slow; when off there is no extra work.

## Overview

Adds an env-gated helper that conditionally creates child debug spans attached to the current tracing context and instruments several Observational Memory hot-paths so those operations appear as nested spans in traces without changing external APIs or threading observability context through every call site.

## Changes

### New utility
- packages/memory/src/processors/observational-memory/debug-trace.ts
  - Exports OM_DEBUG_TRACE_ENV = 'MASTRA_OM_DEBUG_TRACE' and withOmDebugSpan<T>(name, observabilityContext, fn): Promise<T>
  - When the env var is '1' or 'true': resolves a parent span from observabilityContext.tracingContext.currentSpan or resolveCurrentSpan(), creates a child span (MEMORY-related entity), runs fn inside the child span’s context (executeInContext), ends the span on success, and records errors (child.error with endSpan: true) before rethrowing.
  - When disabled, or if no parent span is found / span creation fails, invokes fn() directly with no span construction overhead.

### Instrumented hot-paths
- packages/memory/src/processors/observational-memory/observation-turn/step.ts
  - ObservationStep.prepare() moved to a private _prepareImpl() and wrapped with withOmDebugSpan('om.step.prepare', ...).
  - Multiple om.getStatus(...) calls within prepare now use withOmDebugSpan('om.getStatus', ...) for better coverage (initial snapshot, post-observation re-check, etc.).
- packages/memory/src/processors/observational-memory/observational-memory.ts
  - Public getStatus() refactored to _getStatusImpl() and wrapped with withOmDebugSpan('om.getStatus', ...).
  - getOrCreateRecord() calls wrapped with withOmDebugSpan('om.getOrCreateRecord', ...) to capture lookup/create latency.
- packages/memory/src/processors/observational-memory/observation-turn/turn.ts
  - ObservationTurn.end() delegated to _endImpl() and wrapped with withOmDebugSpan('om.turn.end', ...), so turn-end flush appears as a trace span sibling to step.prepare when enabled.
- packages/memory/src/processors/observational-memory/processor.ts
  - Fresh record fetch (engine.getOrCreateRecord(...)) wrapped in om.getOrCreateRecord debug span when emitting progress.

### Tests & docs
- packages/memory/src/processors/observational-memory/__tests__/debug-trace.test.ts
  - Vitest tests validating: env-gated bypass behavior, span creation on '1' and "true", running without currentSpan, successful end behavior, and error recording (endSpan: true) on rejection.
- .changeset/om-debug-trace.md
  - Patch changeset describing the opt-in debug tracing feature.

## Design notes

- Opt-in only (MASTRA_OM_DEBUG_TRACE unset = no overhead).
- Spans attach under the existing om.observer / om.reflector span or the current AsyncLocalStorage-resolved span so nested operations show as descendants without pervasive context plumbing.
- Spans are ended on success and recorded as errored (with endSpan: true) on failure.
- Instrumentation targets per-step prepare, turn-end flush, record lookup, and status checking to aid trace-based diagnosis of latency or contention (addresses #15677).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16442)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->