### PR TITLE
docs(workspace): fix E2BSandbox reference — add missing options, correct ProviderStatus, add Azure Blob

### DIFF
--- a/docs/src/content/en/reference/workspace/e2b-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/e2b-sandbox.mdx
@@ -99,6 +99,19 @@ const agent = new Agent({
     description: 'Access token for authentication. Falls back to E2B_ACCESS_TOKEN env var.',
     isOptional: true,
   },
+  {
+    name: 'metadata',
+    type: 'Record<string, unknown>',
+    description: 'Custom metadata attached to the sandbox instance.',
+    isOptional: true,
+  },
+  {
+    name: 'instructions',
+    type: 'string | ((opts: { defaultInstructions: string; requestContext?: RequestContext }) => string)',
+    description:
+      'Custom instructions returned by `getInstructions()`. A string fully replaces the defaults; a function receives the defaults and can extend or customise them per-request. Pass an empty string to suppress instructions entirely.',
+    isOptional: true,
+  },
 ]}
 />
 
@@ -124,12 +137,7 @@ const agent = new Agent({
   {
     name: 'status',
     type: 'ProviderStatus',
-    description: "'pending' | 'initializing' | 'ready' | 'error'",
-  },
-  {
-    name: 'supportsMounting',
-    type: 'boolean',
-    description: 'Always true - E2B sandboxes support mounting cloud filesystems',
+    description: "'pending' | 'initializing' | 'ready' | 'starting' | 'running' | 'stopping' | 'stopped' | 'destroying' | 'destroyed' | 'error'",
   },
   {
     name: 'processes',
@@ -173,7 +181,7 @@ See [`SandboxProcessManager` reference](/reference/workspace/process-manager) fo
 
 ## Mounting cloud storage
 
-E2B sandboxes can mount S3 or GCS filesystems, making cloud storage accessible as local directories inside the sandbox. This is useful for:
+E2B sandboxes can mount S3, GCS, and Azure Blob filesystems, making cloud storage accessible as local directories inside the sandbox. This is useful for:
 
 - Processing large datasets stored in cloud buckets
 - Writing output files directly to cloud storage
@@ -215,6 +223,7 @@ E2B sandboxes use FUSE (Filesystem in Userspace) to mount cloud storage:
 
 - **S3/R2**: Mounted via [s3fs-fuse](https://github.com/s3fs-fuse/s3fs-fuse)
 - **GCS**: Mounted via [gcsfuse](https://github.com/GoogleCloudPlatform/gcsfuse)
+- **Azure Blob**: Mounted via [blobfuse2](https://github.com/Azure/azure-storage-fuse)
 
 The E2B sandbox automatically installs the required FUSE tools when mounting is used. For best performance, pre-build a custom template with the tools installed.
 
@@ -305,4 +314,5 @@ This is optional—`gcsfuse` is installed automatically at mount time if not pre
 - [LocalSandbox reference](/reference/workspace/local-sandbox)
 - [S3Filesystem reference](/reference/workspace/s3-filesystem)
 - [GCSFilesystem reference](/reference/workspace/gcs-filesystem)
+- [Azure Blob Filesystem reference](/reference/workspace/azure-blob-filesystem)
 - [Workspace overview](/docs/workspace/overview)

--- a/docs/src/content/en/reference/workspace/e2b-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/e2b-sandbox.mdx
@@ -109,7 +109,7 @@ const agent = new Agent({
     name: 'instructions',
     type: 'string | ((opts: { defaultInstructions: string; requestContext?: RequestContext }) => string)',
     description:
-      'Custom instructions returned by `getInstructions()`. A string fully replaces the defaults; a function receives the defaults and can extend or customise them per-request. Pass an empty string to suppress instructions entirely.',
+      'Custom instructions returned by `getInstructions()`. A string fully replaces the defaults; a function receives the defaults and can extend or customize them per-request. Pass an empty string to suppress instructions entirely.',
     isOptional: true,
   },
 ]}


### PR DESCRIPTION
## What

Fixes four accuracy issues in the E2BSandbox reference page.

**1. Missing constructor params** — `metadata` and `instructions` options both exist in `E2BSandboxOptions` (source: `workspaces/e2b/src/sandbox/index.ts`) but were absent from the reference table. The `instructions` param is especially significant as it allows full customisation of the sandbox agent instructions.

**2. Wrong `status` type** — The properties table showed only 4 `ProviderStatus` values (`pending | initializing | ready | error`) but the actual type (source: `packages/core/src/workspace/lifecycle.ts`) has 10: adds `starting`, `running`, `stopping`, `stopped`, `destroying`, `destroyed`.

**3. Non-existent `supportsMounting` property** — Listed as a class property but `E2BSandbox` has no such field. Mount support is determined by the presence of `mount()`, not a boolean property.

**4. Azure Blob mount support undocumented** — The E2B package exports `mountAzure` (via `workspaces/e2b/src/sandbox/mounts/azure.ts`, using blobfuse2) and handles `azure-blob` in the `mount()` switch, but the docs only mentioned S3 and GCS.

## Scope

Docs-only (`docs/src/content/en/reference/workspace/e2b-sandbox.mdx`), no code changes, no changeset needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes the E2BSandbox instruction manual: it adds two missing constructor options, corrects the full set of lifecycle statuses, removes a wrongly-documented boolean, and documents Azure Blob mounting support that was already implemented.

## Changes

**File modified:** `docs/src/content/en/reference/workspace/e2b-sandbox.mdx`

**Documentation updates:**
- **Constructor options:** Added `metadata` (Record<string, unknown>) and `instructions` (string | (opts: { defaultInstructions: string; requestContext?: RequestContext }) => string) to the constructor options table. `instructions` lets you supply a string or a function that receives default instructions (and optional request context) to customize or suppress instructions.
- **Status property:** Expanded the documented `status` type from the short set to the full lifecycle union: `pending | initializing | starting | running | ready | stopping | stopped | destroying | destroyed | error`.
- **Removed inaccuracy:** Removed the incorrectly documented `supportsMounting` boolean; mounting capability is determined by the presence of a `mount()` method.
- **Azure Blob support:** Extended the "Mounting cloud storage" section to include Azure Blob mounts (via blobfuse2) alongside S3 (s3fs-fuse) and GCS (gcsfuse). Added an Azure Blob Filesystem reference link.
  
**Scope:** Documentation-only change; no code modifications or changeset required.

**Changes:** +17 lines, -7 lines
<!-- end of auto-generated comment: release notes by coderabbit.ai -->