### PR TITLE
fix(core): normalize `toModelOutput` media types for AI SDK provider compatibility

### DIFF
--- a/.changeset/fifty-doors-go.md
+++ b/.changeset/fifty-doors-go.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed toModelOutput media type normalization for AI SDK provider compatibility. Tools returning type: 'media' image content (e.g. screenshot tools) are now correctly converted to type: 'image-data' before being sent to the model, matching what AI SDK providers like Anthropic expect at runtime.
+Fixed tool result media content not reaching the model. Tools using `toModelOutput` to return images or files (e.g. screenshot tools) now work correctly with all AI SDK providers (Anthropic, OpenAI, Google).

--- a/.changeset/fifty-doors-go.md
+++ b/.changeset/fifty-doors-go.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed toModelOutput media type normalization for AI SDK provider compatibility. Tools returning type: 'media' image content (e.g. screenshot tools) are now correctly converted to type: 'image-data' before being sent to the model, matching what AI SDK providers like Anthropic expect at runtime.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -1061,6 +1061,55 @@ describe('createLLMMappingStep toModelOutput', () => {
     );
   });
 
+  it('should not throw when toModelOutput returns malformed content entries', async () => {
+    const toModelOutputMock = vi.fn(() => ({
+      type: 'content',
+      value: [null, undefined, 'not-an-object', { type: 'media', data: 'abc', mediaType: 'image/png' }],
+    }));
+
+    const llmMappingStep = createLLMMappingStep(
+      {
+        models: {} as any,
+        controller,
+        messageList,
+        runId: 'test-run',
+        _internal: { generateId: () => 'test-message-id' },
+        tools: {
+          screenshot: {
+            execute: async () => ({ base64: 'abc' }),
+            toModelOutput: toModelOutputMock,
+            inputSchema: z.object({}),
+          },
+        },
+      } as any,
+      llmExecutionStep,
+    );
+
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'screenshot',
+        args: {},
+        result: { base64: 'abc' },
+      },
+    ];
+
+    await expect(llmMappingStep.execute(createExecuteParams(inputData))).resolves.not.toThrow();
+
+    expect(messageList.updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerMetadata: expect.objectContaining({
+          mastra: expect.objectContaining({
+            modelOutput: {
+              type: 'content',
+              value: [null, undefined, 'not-an-object', { type: 'image-data', data: 'abc', mediaType: 'image/png' }],
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
   it('should NOT call toModelOutput for tools without it defined', async () => {
     const llmMappingStep = createLLMMappingStep(
       {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -1004,6 +1004,63 @@ describe('createLLMMappingStep toModelOutput', () => {
     );
   });
 
+  it('should normalize media parts in toModelOutput to image-data/file-data', async () => {
+    const toModelOutputMock = vi.fn(() => ({
+      type: 'content',
+      value: [
+        { type: 'media', data: 'base64png', mediaType: 'image/png' },
+        { type: 'media', data: 'base64pdf', mediaType: 'application/pdf' },
+        { type: 'text', text: 'caption' },
+      ],
+    }));
+
+    const llmMappingStep = createLLMMappingStep(
+      {
+        models: {} as any,
+        controller,
+        messageList,
+        runId: 'test-run',
+        _internal: { generateId: () => 'test-message-id' },
+        tools: {
+          screenshot: {
+            execute: async () => ({ base64: 'abc' }),
+            toModelOutput: toModelOutputMock,
+            inputSchema: z.object({}),
+          },
+        },
+      } as any,
+      llmExecutionStep,
+    );
+
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'screenshot',
+        args: {},
+        result: { base64: 'abc' },
+      },
+    ];
+
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    expect(messageList.updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerMetadata: expect.objectContaining({
+          mastra: expect.objectContaining({
+            modelOutput: {
+              type: 'content',
+              value: [
+                { type: 'image-data', data: 'base64png', mediaType: 'image/png' },
+                { type: 'file-data', data: 'base64pdf', mediaType: 'application/pdf' },
+                { type: 'text', text: 'caption' },
+              ],
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
   it('should NOT call toModelOutput for tools without it defined', async () => {
     const llmMappingStep = createLLMMappingStep(
       {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -16,31 +16,6 @@ import { createStep } from '../../../workflows';
 import type { OuterLLMRun } from '../../types';
 import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
 
-/**
- * Normalize modelOutput from toModelOutput() so that `type: 'media'` parts are
- * converted to `type: 'image-data'` or `type: 'file-data'` as the AI SDK
- * provider layer expects. AI SDK performs this same normalization internally in
- * `mapToolResultOutput`, but Mastra calls toModelOutput directly and stores
- * the result, so we need to replicate this mapping.
- */
-function normalizeModelOutput(output: unknown): unknown {
-  if (output == null || typeof output !== 'object') return output;
-
-  const obj = output as Record<string, unknown>;
-  if (obj.type !== 'content' || !Array.isArray(obj.value)) return output;
-
-  return {
-    ...obj,
-    value: (obj.value as Array<Record<string, unknown>>).map(item => {
-      if (item.type !== 'media') return item;
-      if (typeof item.mediaType === 'string' && item.mediaType.startsWith('image/')) {
-        return { type: 'image-data', data: item.data, mediaType: item.mediaType };
-      }
-      return { type: 'file-data', data: item.data, mediaType: item.mediaType };
-    }),
-  };
-}
-
 export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = undefined>(
   { models, _internal, ...rest }: OuterLLMRun<Tools, OUTPUT>,
   llmExecutionStep: any,
@@ -143,6 +118,31 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
        * When toModelOutput is defined, the transform runs under a MAPPING child span so
        * traces can distinguish "never invoked" from "ran no-op" from "ran transforming."
        */
+      /**
+       * Normalize modelOutput from toModelOutput() so that `type: 'media'` parts
+       * are converted to `type: 'image-data'` or `type: 'file-data'` as AI SDK
+       * providers expect. AI SDK does this internally in `mapToolResultOutput`,
+       * but Mastra calls toModelOutput directly and stores the result, bypassing
+       * that normalization.
+       */
+      function normalizeModelOutput(output: unknown): unknown {
+        if (output == null || typeof output !== 'object') return output;
+
+        const obj = output as Record<string, unknown>;
+        if (obj.type !== 'content' || !Array.isArray(obj.value)) return output;
+
+        return {
+          ...obj,
+          value: (obj.value as Array<Record<string, unknown>>).map(item => {
+            if (item.type !== 'media') return item;
+            if (typeof item.mediaType === 'string' && item.mediaType.startsWith('image/')) {
+              return { type: 'image-data', data: item.data, mediaType: item.mediaType };
+            }
+            return { type: 'file-data', data: item.data, mediaType: item.mediaType };
+          }),
+        };
+      }
+
       async function getProviderMetadataWithModelOutput(toolCall: {
         toolName: string;
         toolCallId?: string;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -17,27 +17,35 @@ import type { OuterLLMRun } from '../../types';
 import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
 
 /**
+ * The return type of `toModelOutput()` as defined by `@ai-sdk/provider`
+ * (`LanguageModelV2ToolResultOutput`). This is a discriminated union on `type` —
+ * only the `content` variant can contain `type: 'media'` parts that need normalizing.
+ */
+type ModelOutput =
+  | { type: 'text'; value: string }
+  | { type: 'json'; value: unknown }
+  | { type: 'error-text'; value: string }
+  | { type: 'error-json'; value: unknown }
+  | { type: 'content'; value: Array<{ type: string; [key: string]: unknown }> };
+
+/**
  * Normalize modelOutput from toModelOutput() so that `type: 'media'` parts are
  * converted to `type: 'image-data'` or `type: 'file-data'` as the AI SDK
  * provider layer expects. AI SDK performs this same normalization internally in
- * `resolveToolResultOutput`, but Mastra calls toModelOutput directly and stores
+ * `mapToolResultOutput`, but Mastra calls toModelOutput directly and stores
  * the result, so we need to replicate this mapping.
  */
 function normalizeModelOutput(output: unknown): unknown {
-  if (
-    output == null ||
-    typeof output !== 'object' ||
-    (output as any).type !== 'content' ||
-    !Array.isArray((output as any).value)
-  ) {
-    return output;
-  }
-  const value = (output as any).value as Array<Record<string, unknown>>;
+  if (output == null || typeof output !== 'object') return output;
+
+  const typed = output as ModelOutput;
+  if (typed.type !== 'content' || !Array.isArray(typed.value)) return output;
+
   return {
-    ...(output as any),
-    value: value.map(item => {
+    ...typed,
+    value: typed.value.map(item => {
       if (item.type !== 'media') return item;
-      if (typeof item.mediaType === 'string' && (item.mediaType as string).startsWith('image/')) {
+      if (typeof item.mediaType === 'string' && item.mediaType.startsWith('image/')) {
         return { type: 'image-data', data: item.data, mediaType: item.mediaType };
       }
       return { type: 'file-data', data: item.data, mediaType: item.mediaType };

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2ToolResultOutput, ToolSet } from '@internal/ai-sdk-v5';
+import type { ToolSet } from '@internal/ai-sdk-v5';
 import { z } from 'zod/v4';
 import { sanitizeToolName } from '../../../agent/message-list/utils/tool-name';
 import { createObservabilityContext, EntityType, SpanType } from '../../../observability';
@@ -26,17 +26,17 @@ import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
 function normalizeModelOutput(output: unknown): unknown {
   if (output == null || typeof output !== 'object') return output;
 
-  const typed = output as LanguageModelV2ToolResultOutput;
-  if (typed.type !== 'content' || !Array.isArray(typed.value)) return output;
+  const obj = output as Record<string, unknown>;
+  if (obj.type !== 'content' || !Array.isArray(obj.value)) return output;
 
   return {
-    ...typed,
-    value: typed.value.map(item => {
+    ...obj,
+    value: (obj.value as Array<Record<string, unknown>>).map(item => {
       if (item.type !== 'media') return item;
       if (typeof item.mediaType === 'string' && item.mediaType.startsWith('image/')) {
-        return { type: 'image-data' as const, data: item.data, mediaType: item.mediaType };
+        return { type: 'image-data', data: item.data, mediaType: item.mediaType };
       }
-      return { type: 'file-data' as const, data: item.data, mediaType: item.mediaType };
+      return { type: 'file-data', data: item.data, mediaType: item.mediaType };
     }),
   };
 }

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -154,7 +154,6 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
         )?.[toolCall.toolName] ?? rest.tools?.[toolCall.toolName]) as
           | { toModelOutput?: (output: unknown) => unknown }
           | undefined;
-
         let modelOutput: unknown;
         if (tool?.toModelOutput && toolCall.result != null) {
           const parentSpan = observabilityContext?.tracingContext?.currentSpan;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -133,12 +133,14 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
 
         return {
           ...obj,
-          value: (obj.value as Array<Record<string, unknown>>).map(item => {
-            if (item.type !== 'media') return item;
-            if (typeof item.mediaType === 'string' && item.mediaType.startsWith('image/')) {
-              return { type: 'image-data', data: item.data, mediaType: item.mediaType };
+          value: (obj.value as unknown[]).map(item => {
+            if (item == null || typeof item !== 'object') return item;
+            const part = item as Record<string, unknown>;
+            if (part.type !== 'media') return part;
+            if (typeof part.mediaType === 'string' && part.mediaType.startsWith('image/')) {
+              return { type: 'image-data', data: part.data, mediaType: part.mediaType };
             }
-            return { type: 'file-data', data: item.data, mediaType: item.mediaType };
+            return { type: 'file-data', data: part.data, mediaType: part.mediaType };
           }),
         };
       }

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -16,6 +16,35 @@ import { createStep } from '../../../workflows';
 import type { OuterLLMRun } from '../../types';
 import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
 
+/**
+ * Normalize modelOutput from toModelOutput() so that `type: 'media'` parts are
+ * converted to `type: 'image-data'` or `type: 'file-data'` as the AI SDK
+ * provider layer expects. AI SDK performs this same normalization internally in
+ * `resolveToolResultOutput`, but Mastra calls toModelOutput directly and stores
+ * the result, so we need to replicate this mapping.
+ */
+function normalizeModelOutput(output: unknown): unknown {
+  if (
+    output == null ||
+    typeof output !== 'object' ||
+    (output as any).type !== 'content' ||
+    !Array.isArray((output as any).value)
+  ) {
+    return output;
+  }
+  const value = (output as any).value as Array<Record<string, unknown>>;
+  return {
+    ...(output as any),
+    value: value.map(item => {
+      if (item.type !== 'media') return item;
+      if (typeof item.mediaType === 'string' && (item.mediaType as string).startsWith('image/')) {
+        return { type: 'image-data', data: item.data, mediaType: item.mediaType };
+      }
+      return { type: 'file-data', data: item.data, mediaType: item.mediaType };
+    }),
+  };
+}
+
 export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = undefined>(
   { models, _internal, ...rest }: OuterLLMRun<Tools, OUTPUT>,
   llmExecutionStep: any,
@@ -129,6 +158,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
         )?.[toolCall.toolName] ?? rest.tools?.[toolCall.toolName]) as
           | { toModelOutput?: (output: unknown) => unknown }
           | undefined;
+
         let modelOutput: unknown;
         if (tool?.toModelOutput && toolCall.result != null) {
           const parentSpan = observabilityContext?.tracingContext?.currentSpan;
@@ -146,6 +176,8 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           });
           try {
             modelOutput = await tool.toModelOutput(toolCall.result);
+            // Normalize media parts to image-data/file-data as AI SDK expects
+            modelOutput = normalizeModelOutput(modelOutput);
             mappingSpan?.end({ output: modelOutput });
           } catch (err) {
             mappingSpan?.error({ error: err as Error, endSpan: true });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -1,4 +1,4 @@
-import type { ToolSet } from '@internal/ai-sdk-v5';
+import type { LanguageModelV2ToolResultOutput, ToolSet } from '@internal/ai-sdk-v5';
 import { z } from 'zod/v4';
 import { sanitizeToolName } from '../../../agent/message-list/utils/tool-name';
 import { createObservabilityContext, EntityType, SpanType } from '../../../observability';
@@ -17,18 +17,6 @@ import type { OuterLLMRun } from '../../types';
 import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
 
 /**
- * The return type of `toModelOutput()` as defined by `@ai-sdk/provider`
- * (`LanguageModelV2ToolResultOutput`). This is a discriminated union on `type` —
- * only the `content` variant can contain `type: 'media'` parts that need normalizing.
- */
-type ModelOutput =
-  | { type: 'text'; value: string }
-  | { type: 'json'; value: unknown }
-  | { type: 'error-text'; value: string }
-  | { type: 'error-json'; value: unknown }
-  | { type: 'content'; value: Array<{ type: string; [key: string]: unknown }> };
-
-/**
  * Normalize modelOutput from toModelOutput() so that `type: 'media'` parts are
  * converted to `type: 'image-data'` or `type: 'file-data'` as the AI SDK
  * provider layer expects. AI SDK performs this same normalization internally in
@@ -38,7 +26,7 @@ type ModelOutput =
 function normalizeModelOutput(output: unknown): unknown {
   if (output == null || typeof output !== 'object') return output;
 
-  const typed = output as ModelOutput;
+  const typed = output as LanguageModelV2ToolResultOutput;
   if (typed.type !== 'content' || !Array.isArray(typed.value)) return output;
 
   return {
@@ -46,9 +34,9 @@ function normalizeModelOutput(output: unknown): unknown {
     value: typed.value.map(item => {
       if (item.type !== 'media') return item;
       if (typeof item.mediaType === 'string' && item.mediaType.startsWith('image/')) {
-        return { type: 'image-data', data: item.data, mediaType: item.mediaType };
+        return { type: 'image-data' as const, data: item.data, mediaType: item.mediaType };
       }
-      return { type: 'file-data', data: item.data, mediaType: item.mediaType };
+      return { type: 'file-data' as const, data: item.data, mediaType: item.mediaType };
     }),
   };
 }


### PR DESCRIPTION
## Summary

Fixes tools with `toModelOutput` that return image content (like screenshot tools) not being visible to the model.

## Problem

`toModelOutput` returns `{ type: 'media', mediaType: 'image/png', data: ... }` which matches the `@ai-sdk/provider` TypeScript types (`LanguageModelV2ToolResultOutput`). However, AI SDK providers at runtime expect `type: 'image-data'` — and silently drop any unrecognized content part type.

AI SDK normally normalizes `media` → `image-data` internally in `mapToolResultOutput`, but Mastra calls `toModelOutput` directly via `getProviderMetadataWithModelOutput` and stores the result in `providerMetadata.mastra.modelOutput`, bypassing that normalization step.

### Affected providers

| Provider | `type: 'image-data'` (normalized) | `type: 'media'` (unnormalized) |
|---|---|---|
| **Anthropic** | Native `image` block | Silently dropped |
| **Google/Gemini** | `inlineData` | Silently dropped |
| **OpenAI (Responses API)** | `input_image` with data URI | Dropped + warning |
| **OpenAI (Chat Completions)** | `input_image` with data URI | Dropped + warning |
| **OpenAI-compatible** | `JSON.stringify` (no image support) | Same — no difference |

Any tool using `toModelOutput` to return image/file content was affected across all major providers.

## Fix

Add `normalizeModelOutput()` in `llm-mapping-step.ts` that runs immediately after `tool.toModelOutput()` and converts:
- `type: 'media'` with image MIME → `type: 'image-data'`
- `type: 'media'` with non-image MIME → `type: 'file-data'`

This mirrors the same mapping AI SDK does in its `mapToolResultOutput` function.

## Test Plan

- Existing `llm-mapping-step.test.ts` tests pass (26/26)
- Typecheck clean
- Manually verified: screenshot tool images now visible to Claude models via Anthropic provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Tools were giving images/files to the AI in a format the AI providers didn't understand, so those images/files were dropped. This change converts the tool output into the format providers expect so images/files actually reach the model.

## Overview

Fixes a compatibility bug where tool results returned by toModelOutput() using Mastra's internal media shape (e.g., { type: 'media', mediaType: 'image/png', data: ... }) were not recognized by AI SDK providers and were silently dropped. The PR normalizes tool outputs immediately after toModelOutput() so they match provider-expected types (image-data/file-data), preserving media parts across Anthropic, Google/Gemini, OpenAI (Responses/Chat), and OpenAI-compatible providers.

## Changes

packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
- Add normalizeModelOutput() helper and run it right after tool.toModelOutput(toolCall.result).
- convert any part with type: 'media' into:
  - type: 'image-data' when mediaType starts with 'image/'
  - type: 'file-data' for other media types
- Preserve data and mediaType fields and avoid unsafe runtime assertions by narrowing at runtime.
- Persist the normalized value into providerMetadata.mastra.modelOutput so Mastra no longer bypasses AI SDK normalization.

packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
- Add unit tests:
  - Normalizes media parts from toModelOutput into image-data and file-data while preserving non-media parts.
  - Handles malformed content.value entries robustly (null/undefined/non-objects) without throwing, ensuring only valid media entries are normalized.

.changeset/fifty-doors-go.md
- Add changeset metadata for a patch release of @mastra/core describing the media normalization fix.

## Testing

- Existing tests pass (llm-mapping-step tests: 26/26).
- TypeScript typecheck clean.
- Manual verification: screenshot tool images are visible to Claude via the Anthropic provider.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16449)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->