### PR TITLE
fix: support old core worker lifecycle

### DIFF
--- a/packages/deployer/src/server/__tests__/node-server-host.test.ts
+++ b/packages/deployer/src/server/__tests__/node-server-host.test.ts
@@ -89,6 +89,7 @@ describe('createNodeServer host binding', () => {
       getServerMiddleware: vi.fn(() => []),
       getLogger: vi.fn(() => logger),
       startWorkers: vi.fn(),
+      startEventEngine: vi.fn(),
       listAgents: vi.fn(() => []),
       setMastraServer: vi.fn(),
     } as unknown as Mastra;
@@ -122,5 +123,25 @@ describe('createNodeServer host binding', () => {
       hostname: '0.0.0.0',
     });
     expect(logger.info).toHaveBeenCalledWith('Mastra API running', { url: 'http://0.0.0.0:4111/api' });
+  });
+
+  it('starts workers with the current lifecycle API', async () => {
+    await createNodeServer(mockMastra, { tools: {} });
+
+    expect(mockMastra.startWorkers).toHaveBeenCalledOnce();
+    expect(mockMastra.startEventEngine).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the deprecated event engine API for older core versions', async () => {
+    const startEventEngine = vi.fn();
+    const oldCoreMastra = {
+      ...mockMastra,
+      startWorkers: undefined,
+      startEventEngine,
+    } as unknown as Mastra;
+
+    await createNodeServer(oldCoreMastra, { tools: {} });
+
+    expect(startEventEngine).toHaveBeenCalledOnce();
   });
 });

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -551,7 +551,17 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
   // MUST be called after serve() returns per @hono/node-ws requirements
   injectWebSocket?.(server);
 
-  await mastra.startWorkers();
+  // Backwards compatibility for projects running a newer deployer/CLI with an older @mastra/core.
+  // TODO(v2): call `mastra.startWorkers()` unconditionally once old core versions are unsupported.
+  const workerLifecycle = mastra as unknown as {
+    startWorkers?: () => Promise<void>;
+    startEventEngine: () => Promise<void>;
+  };
+  if (typeof workerLifecycle.startWorkers === 'function') {
+    await workerLifecycle.startWorkers();
+  } else {
+    await workerLifecycle.startEventEngine();
+  }
 
   return server;
 }


### PR DESCRIPTION
This keeps the node deployer compatible with projects that are running a newer deployer/CLI against an older `@mastra/core`.

Before, the server always called the new worker lifecycle API:

```ts
await mastra.startWorkers();
```

Now it prefers the new API, but falls back to the old event engine API when `startWorkers` is not available:

```ts
if (typeof workerLifecycle.startWorkers === 'function') {
  await workerLifecycle.startWorkers();
} else {
  await workerLifecycle.startEventEngine();
}
```

I added focused tests for both paths. Verified with the deployer node server tests and `@mastra/deployer` build.

  The issue came from PR #16309:                                                                                                                                  
                                                                                                                                                                  
  feat: standalone workers + push-capable PubSub + Redis Streams broker                                                                                           
                                                                                                                                                                  
  It changed the deployer server startup from the old lifecycle call:                                                                                             
                                                                                                                                                                  
  ```ts                                                                                                                                                           
    await mastra.startEventEngine();                                                                                                                              
  ```                                                                                                                                                             
                                                                                                                                                                  
  to the new one:                                                                                                                                                 
                                                                                                                                                                  
  ```ts                                                                                                                                                           
    await mastra.startWorkers();                                                                                                                                  
  ```                                                                                                                                                             
                                                                                                                                                                  
  Specifically, the crash came from packages/deployer/src/server/index.ts calling mastra.startWorkers() unconditionally. That works with the new @mastra/core,    
  but fails in the skew case you tested: newer linked CLI/deployer + published older core (1.32.1), where startWorkers doesn’t exist.                             


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the new version of Mastra's deployer able to work with older versions of Mastra. When the deployer starts up, it tries to use the new way of starting workers (`startWorkers`), but if that doesn't exist (because you have an older Mastra version), it falls back to using the old way (`startEventEngine`). This ensures you can upgrade the deployer without being forced to upgrade Mastra at the same time.

## Changes

### `packages/deployer/src/server/index.ts`
Updated `createNodeServer` to implement backwards-compatible worker lifecycle handling. Instead of always calling `mastra.startWorkers()`, the implementation now detects whether `startWorkers` is available on the `Mastra` instance. If present, it calls the newer API; otherwise, it falls back to calling `startEventEngine()`. This allows the deployer to work with both newer and older versions of @mastra/core. WebSocket injection logic remains unchanged.

### `packages/deployer/src/server/__tests__/node-server-host.test.ts`
Added test coverage for the backwards-compatible lifecycle:
- Mocks `startEventEngine` on the `Mastra` instance
- Verifies that when `startWorkers` is available, the server calls it and does not invoke `startEventEngine`
- Verifies that when `startWorkers` is missing (simulating an older core version), the server correctly falls back to calling `startEventEngine`
- Existing tests for hostname resolution remain unchanged

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16450)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->