### PR TITLE
fix(core): update CommonJS TypeScript resolution for workflows and ad…

### DIFF
--- a/.changeset/fix-core-workflows-commonjs-types.md
+++ b/.changeset/fix-core-workflows-commonjs-types.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed CommonJS TypeScript resolution for `@mastra/core/workflows` in `moduleResolution: "nodenext"` projects.
+
+Static imports from `@mastra/core/workflows` now resolve through a CommonJS declaration file for the `require` export condition, which avoids `TS1479` in CommonJS consumers.

--- a/packages/_types-builder/src/index.js
+++ b/packages/_types-builder/src/index.js
@@ -96,10 +96,12 @@ export async function generateTypes(rootDir, bundledPackages = new Set()) {
       });
 
       if (!modified) {
+        await fs.writeFile(fullPath.replace(/\.d\.ts$/, '.d.cts'), code);
         continue;
       }
 
       await fs.writeFile(fullPath, code);
+      await fs.writeFile(fullPath.replace(/\.d\.ts$/, '.d.cts'), code);
     }
   } catch (err) {
     // TypeScript errors are already printed to console via stdio: 'inherit'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -487,7 +487,7 @@
         "default": "./dist/workflows/index.js"
       },
       "require": {
-        "types": "./dist/workflows/index.d.ts",
+        "types": "./dist/workflows/index.d.cts",
         "default": "./dist/workflows/index.cjs"
       }
     },


### PR DESCRIPTION
…d support for .d.cts files

## Description

Fixed CommonJS type resolution for @mastra/core/workflows.

This updates the core package build so it emits .d.cts declaration files
alongside generated .d.ts files, and repoints the ./workflows require.types
export to the CommonJS declaration target. That prevents TS1479 in CommonJS
consumers using moduleResolution: "nodenext" when statically importing
@mastra/core/workflows.

## Related issue(s)

Fixes #16441

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When TypeScript developers use modern settings to check their code, importing a package that's set up as an ES Module sometimes breaks for projects that use older JavaScript style (CommonJS). This PR fixes that by creating a special file that tells TypeScript "when you're in CommonJS mode, use this file instead" - similar to having different instruction manuals for different customers.

## Changes

### Type Builder Enhancement
Updated the type generation script (`packages/_types-builder/src/index.js`) to generate `.d.cts` (CommonJS declaration) files alongside the existing `.d.ts` (ES Module declaration) files. This ensures that for every `.d.ts` file created in the `dist/` directory, a corresponding `.d.cts` file is also generated, providing proper type hints for CommonJS consumers.

### Package Export Configuration
Modified `packages/core/package.json` to update the `./workflows` subpath export configuration. The CommonJS (`require`) export now correctly points to `./dist/workflows/index.d.cts` for type declarations instead of the ES Module `.d.ts` file. This prevents TypeScript errors (TS1479) when CommonJS projects using `moduleResolution: "nodenext"` statically import `@mastra/core/workflows`.

### Changeset Documentation
Added a changeset entry documenting this fix for the `@mastra/core` package at the patch version level, recording the CommonJS TypeScript resolution improvements.

## Impact
Resolves TS1479 errors for CommonJS consumers of `@mastra/core/workflows` that use TypeScript's `nodenext` module resolution setting, ensuring proper type declaration handling across both ES Module and CommonJS import styles.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16451)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->