### PR TITLE
feat(core): compute `toModelOutput` before `tool-result` chunk emission and forward `providerMetadata` through harness

### DIFF
--- a/.changeset/core-harness-modeloutput.md
+++ b/.changeset/core-harness-modeloutput.md
@@ -2,4 +2,11 @@
 '@mastra/core': patch
 ---
 
-Compute a tool's `toModelOutput` before emitting the streaming `tool-result` chunk so its value is available on `chunk.payload.providerMetadata.mastra.modelOutput`. Forward `providerMetadata` through the harness `tool_end` event and on `tool_result` content (both for streaming and history replay) so harness UIs can read `providerMetadata.mastra.modelOutput` (or any other provider metadata) without re-running the tool.
+Harness consumers can now read a tool's `toModelOutput` result directly from `tool_result` content and `tool_end` events without re-running the tool. The harness now forwards the full `providerMetadata` (including `mastra.modelOutput`) on streaming chunks, replayed history, and `tool_end` events — so UIs can render rich tool output (e.g. screenshot images) inline.
+
+```ts
+harness.on('tool_end', event => {
+  const modelOutput = event.providerMetadata?.mastra?.modelOutput;
+  // e.g. { type: 'content', value: [{ type: 'image-data', mediaType: 'image/png', data: '...' }] }
+});
+```

--- a/.changeset/core-harness-modeloutput.md
+++ b/.changeset/core-harness-modeloutput.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Expose tool `toModelOutput` content on streaming `tool-result` chunks and harness `tool_end` events. The `modelOutput` (e.g. screenshot image parts produced by a tool's `toModelOutput`) is now available on `chunk.payload.providerMetadata.mastra.modelOutput` and forwarded to harness consumers via `tool_end.modelOutput` and `tool_result.modelOutput`, including in history replay. This lets harness UIs (such as the mastracode TUI) render rich tool output inline without re-running the tool.
+Compute a tool's `toModelOutput` before emitting the streaming `tool-result` chunk so its value is available on `chunk.payload.providerMetadata.mastra.modelOutput`. Forward `providerMetadata` through the harness `tool_end` event and on `tool_result` content (both for streaming and history replay) so harness UIs can read `providerMetadata.mastra.modelOutput` (or any other provider metadata) without re-running the tool.

--- a/.changeset/core-harness-modeloutput.md
+++ b/.changeset/core-harness-modeloutput.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Expose tool `toModelOutput` content on streaming `tool-result` chunks and harness `tool_end` events. The `modelOutput` (e.g. screenshot image parts produced by a tool's `toModelOutput`) is now available on `chunk.payload.providerMetadata.mastra.modelOutput` and forwarded to harness consumers via `tool_end.modelOutput` and `tool_result.modelOutput`, including in history replay. This lets harness UIs (such as the mastracode TUI) render rich tool output inline without re-running the tool.

--- a/.changeset/core-harness-modeloutput.md
+++ b/.changeset/core-harness-modeloutput.md
@@ -2,7 +2,9 @@
 '@mastra/core': patch
 ---
 
-Harness consumers can now read a tool's `toModelOutput` result directly from `tool_result` content and `tool_end` events without re-running the tool. The harness now forwards the full `providerMetadata` (including `mastra.modelOutput`) on streaming chunks, replayed history, and `tool_end` events — so UIs can render rich tool output (e.g. screenshot images) inline.
+A tool's `toModelOutput` result is now computed before the `tool-result` chunk is emitted, so it travels with the chunk on `providerMetadata.mastra.modelOutput`. Previously `toModelOutput` only ran later when the message list was updated, meaning live stream consumers couldn't see it without re-running the tool.
+
+The harness now forwards that `providerMetadata` on `tool_result` content (both streaming and replayed history) and on `tool_end` events, so UIs can render rich tool output (e.g. screenshot images) inline.
 
 ```ts
 harness.on('tool_end', event => {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1757,7 +1757,7 @@ export class Harness<TState = {}> {
             const inv = part.toolInvocation;
             content.push({ type: 'tool_call', id: inv.toolCallId, name: inv.toolName, args: inv.args });
             if (inv.state === 'result' && inv.result !== undefined) {
-              const partProviderMetadata = part.providerMetadata as Record<string, any> | undefined;
+              const partProviderMetadata = part.providerMetadata as Record<string, unknown> | undefined;
               content.push({
                 type: 'tool_result',
                 id: inv.toolCallId,
@@ -1778,7 +1778,7 @@ export class Harness<TState = {}> {
           break;
         case 'tool-result':
           if (part.toolCallId && part.toolName) {
-            const resultProviderMetadata = part.providerMetadata as Record<string, any> | undefined;
+            const resultProviderMetadata = part.providerMetadata as Record<string, unknown> | undefined;
             content.push({
               type: 'tool_result',
               id: part.toolCallId,
@@ -2018,7 +2018,7 @@ export class Harness<TState = {}> {
 
         case 'tool-result': {
           const toolResult = chunk.payload;
-          const providerMetadata = toolResult.providerMetadata as Record<string, any> | undefined;
+          const providerMetadata = toolResult.providerMetadata as Record<string, unknown> | undefined;
           currentMessage.content.push({
             type: 'tool_result',
             id: toolResult.toolCallId,

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1757,14 +1757,14 @@ export class Harness<TState = {}> {
             const inv = part.toolInvocation;
             content.push({ type: 'tool_call', id: inv.toolCallId, name: inv.toolName, args: inv.args });
             if (inv.state === 'result' && inv.result !== undefined) {
-              const partModelOutput = (part.providerMetadata as Record<string, any>)?.mastra?.modelOutput;
+              const partProviderMetadata = part.providerMetadata as Record<string, any> | undefined;
               content.push({
                 type: 'tool_result',
                 id: inv.toolCallId,
                 name: inv.toolName,
                 result: inv.result,
                 isError: inv.isError ?? false,
-                ...(partModelOutput != null ? { modelOutput: partModelOutput } : {}),
+                ...(partProviderMetadata ? { providerMetadata: partProviderMetadata } : {}),
               });
             }
           } else if (part.toolCallId && part.toolName) {
@@ -1778,14 +1778,14 @@ export class Harness<TState = {}> {
           break;
         case 'tool-result':
           if (part.toolCallId && part.toolName) {
-            const resultModelOutput = (part.providerMetadata as Record<string, any>)?.mastra?.modelOutput;
+            const resultProviderMetadata = part.providerMetadata as Record<string, any> | undefined;
             content.push({
               type: 'tool_result',
               id: part.toolCallId,
               name: part.toolName,
               result: part.result,
               isError: part.isError ?? false,
-              ...(resultModelOutput != null ? { modelOutput: resultModelOutput } : {}),
+              ...(resultProviderMetadata ? { providerMetadata: resultProviderMetadata } : {}),
             });
           }
           break;
@@ -2018,21 +2018,21 @@ export class Harness<TState = {}> {
 
         case 'tool-result': {
           const toolResult = chunk.payload;
-          const modelOutput = (toolResult.providerMetadata as Record<string, any>)?.mastra?.modelOutput;
+          const providerMetadata = toolResult.providerMetadata as Record<string, any> | undefined;
           currentMessage.content.push({
             type: 'tool_result',
             id: toolResult.toolCallId,
             name: toolResult.toolName,
             result: getDisplayTransform(chunk.metadata, 'output-available', toolResult.result),
             isError: toolResult.isError ?? false,
-            ...(modelOutput != null ? { modelOutput } : {}),
+            ...(providerMetadata ? { providerMetadata } : {}),
           });
           this.emit({
             type: 'tool_end',
             toolCallId: toolResult.toolCallId,
             result: getDisplayTransform(chunk.metadata, 'output-available', toolResult.result),
             isError: toolResult.isError ?? false,
-            ...(modelOutput != null ? { modelOutput } : {}),
+            ...(providerMetadata ? { providerMetadata } : {}),
           });
           this.emit({ type: 'message_update', message: { ...currentMessage } });
           break;

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1757,12 +1757,14 @@ export class Harness<TState = {}> {
             const inv = part.toolInvocation;
             content.push({ type: 'tool_call', id: inv.toolCallId, name: inv.toolName, args: inv.args });
             if (inv.state === 'result' && inv.result !== undefined) {
+              const partModelOutput = (part.providerMetadata as Record<string, any>)?.mastra?.modelOutput;
               content.push({
                 type: 'tool_result',
                 id: inv.toolCallId,
                 name: inv.toolName,
                 result: inv.result,
                 isError: inv.isError ?? false,
+                ...(partModelOutput != null ? { modelOutput: partModelOutput } : {}),
               });
             }
           } else if (part.toolCallId && part.toolName) {
@@ -1776,12 +1778,14 @@ export class Harness<TState = {}> {
           break;
         case 'tool-result':
           if (part.toolCallId && part.toolName) {
+            const resultModelOutput = (part.providerMetadata as Record<string, any>)?.mastra?.modelOutput;
             content.push({
               type: 'tool_result',
               id: part.toolCallId,
               name: part.toolName,
               result: part.result,
               isError: part.isError ?? false,
+              ...(resultModelOutput != null ? { modelOutput: resultModelOutput } : {}),
             });
           }
           break;
@@ -2014,18 +2018,21 @@ export class Harness<TState = {}> {
 
         case 'tool-result': {
           const toolResult = chunk.payload;
+          const modelOutput = (toolResult.providerMetadata as Record<string, any>)?.mastra?.modelOutput;
           currentMessage.content.push({
             type: 'tool_result',
             id: toolResult.toolCallId,
             name: toolResult.toolName,
             result: getDisplayTransform(chunk.metadata, 'output-available', toolResult.result),
             isError: toolResult.isError ?? false,
+            ...(modelOutput != null ? { modelOutput } : {}),
           });
           this.emit({
             type: 'tool_end',
             toolCallId: toolResult.toolCallId,
             result: getDisplayTransform(chunk.metadata, 'output-available', toolResult.result),
             isError: toolResult.isError ?? false,
+            ...(modelOutput != null ? { modelOutput } : {}),
           });
           this.emit({ type: 'message_update', message: { ...currentMessage } });
           break;

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -739,7 +739,13 @@ export type HarnessEvent =
       resumeSchema?: string;
     }
   | { type: 'tool_update'; toolCallId: string; partialResult: unknown }
-  | { type: 'tool_end'; toolCallId: string; result: unknown; isError: boolean; modelOutput?: unknown }
+  | {
+      type: 'tool_end';
+      toolCallId: string;
+      result: unknown;
+      isError: boolean;
+      providerMetadata?: Record<string, any>;
+    }
   | { type: 'tool_input_start'; toolCallId: string; toolName: string }
   | { type: 'tool_input_delta'; toolCallId: string; argsTextDelta: string; toolName?: string }
   | { type: 'tool_input_end'; toolCallId: string }
@@ -936,7 +942,14 @@ export type HarnessMessageContent =
   | { type: 'text'; text: string }
   | { type: 'thinking'; thinking: string }
   | { type: 'tool_call'; id: string; name: string; args: unknown }
-  | { type: 'tool_result'; id: string; name: string; result: unknown; isError: boolean; modelOutput?: unknown }
+  | {
+      type: 'tool_result';
+      id: string;
+      name: string;
+      result: unknown;
+      isError: boolean;
+      providerMetadata?: Record<string, any>;
+    }
   | {
       type: 'system_reminder';
       message: string;

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -739,7 +739,7 @@ export type HarnessEvent =
       resumeSchema?: string;
     }
   | { type: 'tool_update'; toolCallId: string; partialResult: unknown }
-  | { type: 'tool_end'; toolCallId: string; result: unknown; isError: boolean }
+  | { type: 'tool_end'; toolCallId: string; result: unknown; isError: boolean; modelOutput?: unknown }
   | { type: 'tool_input_start'; toolCallId: string; toolName: string }
   | { type: 'tool_input_delta'; toolCallId: string; argsTextDelta: string; toolName?: string }
   | { type: 'tool_input_end'; toolCallId: string }
@@ -936,7 +936,7 @@ export type HarnessMessageContent =
   | { type: 'text'; text: string }
   | { type: 'thinking'; thinking: string }
   | { type: 'tool_call'; id: string; name: string; args: unknown }
-  | { type: 'tool_result'; id: string; name: string; result: unknown; isError: boolean }
+  | { type: 'tool_result'; id: string; name: string; result: unknown; isError: boolean; modelOutput?: unknown }
   | {
       type: 'system_reminder';
       message: string;

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -744,7 +744,7 @@ export type HarnessEvent =
       toolCallId: string;
       result: unknown;
       isError: boolean;
-      providerMetadata?: Record<string, any>;
+      providerMetadata?: Record<string, unknown>;
     }
   | { type: 'tool_input_start'; toolCallId: string; toolName: string }
   | { type: 'tool_input_delta'; toolCallId: string; argsTextDelta: string; toolName?: string }
@@ -948,7 +948,7 @@ export type HarnessMessageContent =
       name: string;
       result: unknown;
       isError: boolean;
-      providerMetadata?: Record<string, any>;
+      providerMetadata?: Record<string, unknown>;
     }
   | {
       type: 'system_reminder';

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -1002,6 +1002,25 @@ describe('createLLMMappingStep toModelOutput', () => {
         }),
       }),
     );
+
+    // The emitted tool-result chunk should also carry modelOutput on providerMetadata
+    // so harness consumers (e.g. mastracode TUI) can read it without going through the messageList.
+    expect(controller.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-result',
+        payload: expect.objectContaining({
+          toolCallId: 'call-1',
+          providerMetadata: expect.objectContaining({
+            mastra: expect.objectContaining({
+              modelOutput: {
+                type: 'text',
+                value: 'Transformed: {"temperature":72,"conditions":"sunny"}',
+              },
+            }),
+          }),
+        }),
+      }),
+    );
   });
 
   it('should normalize media parts in toModelOutput to image-data/file-data', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -311,13 +311,13 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
             for (const toolCall of successfulResults) {
               // Compute modelOutput before emitting the chunk so consumers (e.g. harness)
               // can access it on the chunk's providerMetadata.mastra.modelOutput.
+              // getProviderMetadataWithModelOutput already returns the fully-merged providerMetadata.
               const providerMetadata = !toolCall.providerExecuted
                 ? await getProviderMetadataWithModelOutput(toolCall)
                 : undefined;
-
-              const chunkProviderMetadata = providerMetadata
-                ? ({ ...toolCall.providerMetadata, ...providerMetadata } as ProviderMetadata)
-                : (toolCall.providerMetadata as ProviderMetadata | undefined);
+              const chunkProviderMetadata = (providerMetadata ?? toolCall.providerMetadata) as
+                | ProviderMetadata
+                | undefined;
 
               const chunk = await transformToolChunk(
                 {
@@ -405,13 +405,11 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
 
           // Compute modelOutput before emitting the chunk so consumers (e.g. harness)
           // can access it on the chunk's providerMetadata.mastra.modelOutput.
+          // getProviderMetadataWithModelOutput already returns the fully-merged providerMetadata.
           const providerMetadata = !toolCall.providerExecuted
             ? await getProviderMetadataWithModelOutput(toolCall)
             : undefined;
-
-          const chunkProviderMetadata = providerMetadata
-            ? ({ ...toolCall.providerMetadata, ...providerMetadata } as ProviderMetadata)
-            : (toolCall.providerMetadata as ProviderMetadata | undefined);
+          const chunkProviderMetadata = (providerMetadata ?? toolCall.providerMetadata) as ProviderMetadata | undefined;
 
           const chunk = await transformToolChunk(
             {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -309,6 +309,16 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           const successfulResults = inputData.filter(tc => tc.result !== undefined);
           if (successfulResults.length) {
             for (const toolCall of successfulResults) {
+              // Compute modelOutput before emitting the chunk so consumers (e.g. harness)
+              // can access it on the chunk's providerMetadata.mastra.modelOutput.
+              const providerMetadata = !toolCall.providerExecuted
+                ? await getProviderMetadataWithModelOutput(toolCall)
+                : undefined;
+
+              const chunkProviderMetadata = providerMetadata
+                ? ({ ...toolCall.providerMetadata, ...providerMetadata } as ProviderMetadata)
+                : (toolCall.providerMetadata as ProviderMetadata | undefined);
+
               const chunk = await transformToolChunk(
                 {
                   type: 'tool-result',
@@ -319,7 +329,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
                     toolCallId: toolCall.toolCallId,
                     toolName: toolCall.toolName,
                     result: toolCall.result,
-                    providerMetadata: toolCall.providerMetadata,
+                    providerMetadata: chunkProviderMetadata,
                     providerExecuted: toolCall.providerExecuted,
                   },
                 },
@@ -332,7 +342,6 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
               if (!toolCall.providerExecuted) {
                 // Update tool invocations from state:'call' to state:'result' for successful client tools.
                 // Provider-executed tools are handled by llm-execution-step.
-                const providerMetadata = await getProviderMetadataWithModelOutput(toolCall);
                 rest.messageList.updateToolInvocation({
                   type: 'tool-invocation' as const,
                   toolInvocation: {
@@ -394,6 +403,16 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           // by processOutputStream's 'tool-result' case in llm-execution-step.
           if (toolCall.result === undefined) continue;
 
+          // Compute modelOutput before emitting the chunk so consumers (e.g. harness)
+          // can access it on the chunk's providerMetadata.mastra.modelOutput.
+          const providerMetadata = !toolCall.providerExecuted
+            ? await getProviderMetadataWithModelOutput(toolCall)
+            : undefined;
+
+          const chunkProviderMetadata = providerMetadata
+            ? ({ ...toolCall.providerMetadata, ...providerMetadata } as ProviderMetadata)
+            : (toolCall.providerMetadata as ProviderMetadata | undefined);
+
           const chunk = await transformToolChunk(
             {
               type: 'tool-result',
@@ -404,7 +423,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
                 toolCallId: toolCall.toolCallId,
                 toolName: toolCall.toolName,
                 result: toolCall.result,
-                providerMetadata: toolCall.providerMetadata as ProviderMetadata | undefined,
+                providerMetadata: chunkProviderMetadata,
                 providerExecuted: toolCall.providerExecuted,
               },
             },
@@ -418,7 +437,6 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           // Exclude provider-executed tools — these are handled by llm-execution-step
           // (same-turn results are stored directly, deferred results are resolved via updateToolInvocation).
           if (!toolCall.providerExecuted) {
-            const providerMetadata = await getProviderMetadataWithModelOutput(toolCall);
             rest.messageList.updateToolInvocation({
               type: 'tool-invocation' as const,
               toolInvocation: {


### PR DESCRIPTION
## Summary

Two related changes that together let harness consumers (such as the mastracode TUI) read a tool's `toModelOutput` result without re-running the tool:

1. **Compute `toModelOutput` before emitting the streaming `tool-result` chunk.** Previously it was only computed *after* the chunk was already on the wire, when updating the message list. This meant the streaming chunk never carried `mastra.modelOutput` — only the persisted message did.
2. **Forward `providerMetadata` through the harness `tool_end` event and `tool_result` content** (both streaming and history replay), so consumers can read it directly off the harness surface.

## What changes

### Core behavior change: hoist `getProviderMetadataWithModelOutput`

`packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts`

- Compute `getProviderMetadataWithModelOutput(toolCall)` **before** the streaming `tool-result` chunk is emitted, then thread the merged metadata into `chunk.payload.providerMetadata`.
- The same value is reused when updating the message list, so it's computed once per tool call (previously the hoist would have doubled the work; now it's deduplicated).
- Both the "successful-results-on-error-turn" path and the main `inputData` loop are updated.
- `providerExecuted` tools are skipped (matches the pre-existing message-list path behavior).

### Harness plumbing

`packages/core/src/harness/types.ts`

- Add optional `providerMetadata?: Record<string, unknown>` to the `tool_end` event and to the `tool_result` content variant on harness messages.

`packages/core/src/harness/harness.ts`

- Streaming path: when consuming a `tool-result` chunk, forward `payload.providerMetadata` on the pushed `tool_result` content part and the emitted `tool_end` event.
- History replay (`convertToHarnessMessage`): pass `part.providerMetadata` through for both `tool-invocation` (state `'result'`) and `tool-result` parts so reloaded threads carry the same data.

`modelOutput` already lives at `providerMetadata.mastra.modelOutput` — the same location `message-list.ts`'s `storedModelOutputs` reads from. Forwarding `providerMetadata` directly avoids creating a second source of truth and lets consumers read any future `mastra.*` fields without another core change.

## Why

Tools can already produce structured `toModelOutput` content (e.g. `{ type: 'content', value: [{ type: 'media', mediaType: 'image/png', data: '<base64>' }] }`). That content already reaches the model (PR #16449 normalizes it for AI SDK providers), but harness consumers never saw it on the streaming path — they only got the raw `result` value. With the hoist + harness forwarding, harness UIs can read `providerMetadata.mastra.modelOutput` and render the same multi-modal output the model sees, in real time.

## Test plan

- New assertion in `llm-mapping-step.test.ts`: after `toModelOutput` runs, `controller.enqueue` is called with a `tool-result` chunk whose `payload.providerMetadata.mastra.modelOutput` equals the `toModelOutput` return value.
- `pnpm --filter ./packages/core test -- --run llm-mapping-step harness` — 271/271 pass.
- `pnpm --filter ./packages/core check` — clean.

## Risk

Low. The behavior change is additive:

- The hoist moves a computation earlier in the same function — its output is now reused instead of recomputed. Tools without `toModelOutput` are unaffected (the helper returns `undefined` and the chunk falls back to the original `providerMetadata`).
- `providerMetadata` is only added as an optional field on the harness `tool_end` event and `tool_result` content variant.
- Existing message-list update logic for `toModelOutput` is preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a tool produces rich output (like an image), the UI can now show that output immediately while streaming instead of running the tool again — this PR sends the tool's rendered model-output together with streaming and harness events.

## Overview

Forward providerMetadata (including mastra.modelOutput computed from a tool's toModelOutput) on streaming tool-result chunks, harness tool_end events, and replayed history so harness consumers can render rich tool outputs inline without re-executing the tool.

## Changes

packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
- Compute getProviderMetadataWithModelOutput(toolCall) before emitting streaming `tool-result` chunks and reuse it for both normal and successful-results-on-error paths.
- Merge the returned metadata into `chunk.payload.providerMetadata` so `providerMetadata.mastra.modelOutput` is present on streamed `tool-result` chunks.
- Avoid redundant recomputation when updating messageList (use precomputed metadata).

packages/core/src/harness/types.ts
- Add optional `providerMetadata?: Record<string, unknown>` to the `tool_end` event and to the `tool_result` content variant on harness messages (tightened to `Record<string, unknown>`).

packages/core/src/harness/harness.ts
- Streaming: when handling `tool-result` chunks, forward `payload.providerMetadata` onto the pushed `tool_result` content part and the emitted `tool_end` event.
- History replay (`convertToHarnessMessage`): pass `part.providerMetadata` through for `tool-invocation` (state 'result') and `tool-result` parts so reloaded threads retain provider metadata.

packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
- Extend tests to assert that emitted streaming `tool-result` chunks include `providerMetadata.mastra.modelOutput`.

.changeset/core-harness-modeloutput.md
- Adds user-facing changeset documenting that harness consumers can access a tool's toModelOutput via providerMetadata forwarded on stream and in tool_end/tool_result.

## Key Design Notes

- modelOutput remains authoritative at providerMetadata.mastra.modelOutput (matches message-list storedModelOutputs); no second source of truth introduced.
- Additive, optional change — tools without toModelOutput are unaffected; risk is low.
- Types tightened to `Record<string, unknown>` for providerMetadata; relevant core and harness tests pass and type checks are clean.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16457)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->