### PR TITLE
Add react-query to vite config dedupe

### DIFF
--- a/.changeset/fix-playground-react-query-dedupe.md
+++ b/.changeset/fix-playground-react-query-dedupe.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed a Studio crash that surfaced as `No QueryClient set, use QueryClientProvider to set one` (most visibly on the Metrics page) when the workspace ended up with more than one React version installed. Multiple React copies caused `@tanstack/react-query` to be duplicated in the playground bundle, which split the QueryClient context between provider and consumers. The Vite build now dedupes `@tanstack/react-query`, so a single QueryClient context is shared across the bundle regardless of how many React copies pnpm produces.

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -215,7 +215,7 @@ export default defineConfig(({ mode }) => {
     plugins: [stubNodeBuiltinsPlugin, tailwindcss(), react(), routesManifestPlugin()],
     base: './',
     resolve: {
-      dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react-resizable-panels'],
+      dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react-resizable-panels', '@tanstack/react-query'],
       alias: {
         '@': path.resolve(__dirname, './src'),
         '@internal-temp': path.resolve(__dirname, './src/vendor/@mastra'),


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When the playground builds its code, sometimes multiple copies of a library called react-query get bundled together by mistake, which breaks things. This PR tells the build system to only use one copy of react-query so everything works properly.

## Overview
This PR fixes a Studio crash in the playground by deduplicating `@tanstack/react-query` in the Vite build configuration. The issue occurred when multiple React versions were installed, causing `@tanstack/react-query` to be duplicated in the bundle, which split the QueryClient context and resulted in "No QueryClient set" errors.

## Changes Made

### `.changeset/fix-playground-react-query-dedupe.md`
- Added a changeset documenting a patch version bump for the `@internal/playground` package
- Documents the fix for the Studio crash caused by duplicated `@tanstack/react-query`

### `packages/playground/vite.config.ts`
- Updated the Vite `resolve.dedupe` configuration to include `@tanstack/react-query`
- Ensures only one instance of `@tanstack/react-query` is included in the build output

## Impact
- Resolves the "No QueryClient set" error in the playground when multiple React versions are present
- Maintains consistent QueryClient context across the entire playground bundle

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16469)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->