### PR TITLE
fix(playground): route favorite skill clicks based on ownership

### DIFF
--- a/.changeset/light-games-cut.md
+++ b/.changeset/light-games-cut.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed favorite skill click in Agent Builder so that owners are taken to the skill editor and non-owners are taken to the read-only skill view.

--- a/packages/playground/src/pages/agent-builder/favorite/__tests__/favorite-page.test.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/__tests__/favorite-page.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import AgentBuilderFavoritePage from '..';
 import { LinkComponentProvider } from '@/lib/framework';
@@ -58,9 +59,11 @@ function renderPage() {
     <MastraReactProvider baseUrl={BASE_URL}>
       <QueryClientProvider client={queryClient}>
         <LinkComponentProvider Link={StubLink as never} navigate={() => {}} paths={noopPaths}>
-          <TooltipProvider>
-            <AgentBuilderFavoritePage />
-          </TooltipProvider>
+          <MemoryRouter>
+            <TooltipProvider>
+              <AgentBuilderFavoritePage />
+            </TooltipProvider>
+          </MemoryRouter>
         </LinkComponentProvider>
       </QueryClientProvider>
     </MastraReactProvider>,

--- a/packages/playground/src/pages/agent-builder/favorite/index.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mastra/playground-ui';
 import { SparklesIcon, StarIcon } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
 import {
   AgentBuilderList,
   AgentBuilderListSkeleton,
@@ -21,22 +22,24 @@ import {
   SkillBuilderListSkeleton,
 } from '@/domains/agent-builder/components/skill-builder-list/skill-builder-list';
 import { useBuilderAgentFeatures } from '@/domains/agent-builder/hooks/use-builder-agent-features';
-import { SkillEditDialog } from '@/domains/agents/components/agent-cms-pages/skill-edit-dialog';
 import { useStoredAgents } from '@/domains/agents/hooks/use-stored-agents';
 import { useStoredSkills } from '@/domains/agents/hooks/use-stored-skills';
 import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
-import { usePermissions } from '@/domains/auth/hooks/use-permissions';
 
 type Tab = 'agents' | 'skills';
 
 export default function AgentBuilderFavoritePage() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState('');
   const [tab, setTab] = useState<Tab>('agents');
-  const [selectedSkill, setSelectedSkill] = useState<StoredSkillResponse | null>(null);
   const features = useBuilderAgentFeatures();
   const { data: currentUser } = useCurrentUser();
-  const { hasPermission, rbacEnabled } = usePermissions();
-  const canWriteSkills = !rbacEnabled || hasPermission('stored-skills:write');
+
+  const handleSkillClick = (skill: StoredSkillResponse) => {
+    const isOwner = !skill.authorId || currentUser?.id === skill.authorId;
+    const destination = isOwner ? 'edit' : 'view';
+    void navigate(`/agent-builder/skills/${skill.id}/${destination}`, { viewTransition: true });
+  };
 
   const agentListParams = useMemo<ListStoredAgentsParams>(
     () => ({
@@ -118,9 +121,7 @@ export default function AgentBuilderFavoritePage() {
         </div>
       );
     }
-    return (
-      <SkillBuilderList skills={skills} search={search} onSkillClick={canWriteSkills ? setSelectedSkill : undefined} />
-    );
+    return <SkillBuilderList skills={skills} search={search} onSkillClick={handleSkillClick} />;
   })();
 
   return (
@@ -168,16 +169,6 @@ export default function AgentBuilderFavoritePage() {
 
         {body}
       </PageLayout>
-
-      {selectedSkill && (
-        <SkillEditDialog
-          isOpen={!!selectedSkill}
-          onClose={() => setSelectedSkill(null)}
-          skill={selectedSkill}
-          currentUserId={currentUser?.id}
-          isAdmin={canWriteSkills}
-        />
-      )}
     </>
   );
 }


### PR DESCRIPTION
The favorite list previously opened a modal edit dialog for any user with write permission, which hid the public/read-only view from non-owners. Route to /edit for the skill's owner and /view for everyone else, mirroring the pattern used by the library page.

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
