### PR TITLE
fix(koa): guard dispatcher-reuse against non-Koa app-like targets

### DIFF
--- a/.changeset/ten-hats-slide.md
+++ b/.changeset/ten-hats-slide.md
@@ -1,0 +1,25 @@
+---
+'@mastra/koa': patch
+---
+
+Fixed `TypeError: Cannot read properties of undefined (reading 'length')` thrown during `MastraServer.init()` when a subclass forwards a non-Koa app-like object (for example a `koa-router` instance, a mounted sub-app, or a custom wrapper) to `super.registerRoute(app, route, opts)`. The dispatcher-reuse optimization introduced in 1.5.0 now requires the target to expose an `app.middleware` array; otherwise it falls back to registering a fresh dispatcher per route via `app.use`, matching the pre-1.5.0 per-route behavior.
+
+**Example (subclass that previously crashed):**
+
+```ts
+import { MastraServer } from '@mastra/koa';
+import Router from 'koa-router';
+
+class CustomKoaMastraServer extends MastraServer {
+  private router = new Router();
+
+  async registerCustomApiRoutes() {
+    const routes = this.mastra.getServer()?.apiRoutes ?? [];
+    for (const route of routes) {
+      // The router has no `middleware` array — this used to throw at init.
+      await super.registerRoute(this.router as any, route, { prefix: this.prefix });
+    }
+    this.app.use(this.router.routes());
+  }
+}
+```

--- a/server-adapters/koa/src/__tests__/koa-adapter.test.ts
+++ b/server-adapters/koa/src/__tests__/koa-adapter.test.ts
@@ -349,6 +349,156 @@ describe('Koa Server Adapter', () => {
       expect(secondResponse.status).toBe(200);
       await expect(secondResponse.json()).resolves.toEqual({ route: 'second' });
     });
+
+    // Regression: subclasses sometimes forward an app-like object (e.g. a
+    // koa-router instance or a mounted sub-app) to super.registerRoute().
+    // Before the fix, getRouteDispatcherGroup unconditionally read
+    // `app.middleware.length` and threw `TypeError: Cannot read properties of
+    // undefined (reading 'length')` during init.
+    describe('non-Koa app-like targets', () => {
+      const buildRouterLike = () => {
+        const used: Koa.Middleware[] = [];
+        const routerLike = {
+          use(mw: Koa.Middleware) {
+            used.push(mw);
+            return routerLike;
+          },
+        };
+        return { routerLike, used };
+      };
+
+      it('does not throw when app.middleware is missing entirely', async () => {
+        const koaApp = new Koa();
+        const adapter = new MastraServer({ app: koaApp, mastra: new Mastra({}) });
+        const { routerLike, used } = buildRouterLike();
+
+        await expect(
+          adapter.registerRoute(
+            routerLike as unknown as Koa,
+            {
+              method: 'GET',
+              path: '/ping',
+              responseType: 'json',
+              handler: async () => ({ ok: true }),
+            },
+            { prefix: '' },
+          ),
+        ).resolves.toBeUndefined();
+
+        expect(used).toHaveLength(1);
+        expect(used[0].name).toBe('mastraRouteDispatcher');
+      });
+
+      it('does not reuse a dispatcher when app.middleware is present but not an array', async () => {
+        const koaApp = new Koa();
+        const adapter = new MastraServer({ app: koaApp, mastra: new Mastra({}) });
+        const { routerLike, used } = buildRouterLike();
+        // Some wrappers expose `middleware` as a non-array (e.g. an object map).
+        // Without the Array.isArray() guard, the reuse-cache path would either
+        // crash on `.length` or silently cache a bogus `stackLengthAfterRegistration`
+        // and start incorrectly reusing the dispatcher across calls.
+        (routerLike as any).middleware = { not: 'an array' };
+
+        await adapter.registerRoute(
+          routerLike as unknown as Koa,
+          {
+            method: 'GET',
+            path: '/x',
+            responseType: 'json',
+            handler: async () => ({ route: 'x' }),
+          },
+          { prefix: '' },
+        );
+
+        await adapter.registerRoute(
+          routerLike as unknown as Koa,
+          {
+            method: 'GET',
+            path: '/y',
+            responseType: 'json',
+            handler: async () => ({ route: 'y' }),
+          },
+          { prefix: '' },
+        );
+
+        expect(used).toHaveLength(2);
+        expect(used.every(mw => mw.name === 'mastraRouteDispatcher')).toBe(true);
+      });
+
+      it('registers a fresh dispatcher per route on non-Koa targets (no reuse)', async () => {
+        const koaApp = new Koa();
+        const adapter = new MastraServer({ app: koaApp, mastra: new Mastra({}) });
+        const { routerLike, used } = buildRouterLike();
+
+        await adapter.registerRoute(
+          routerLike as unknown as Koa,
+          {
+            method: 'GET',
+            path: '/a',
+            responseType: 'json',
+            handler: async () => ({ route: 'a' }),
+          },
+          { prefix: '' },
+        );
+
+        await adapter.registerRoute(
+          routerLike as unknown as Koa,
+          {
+            method: 'GET',
+            path: '/b',
+            responseType: 'json',
+            handler: async () => ({ route: 'b' }),
+          },
+          { prefix: '' },
+        );
+
+        // Without `app.middleware`, reuse is impossible — each registration
+        // must produce its own dispatcher middleware on the target.
+        expect(used).toHaveLength(2);
+        expect(used.every(mw => mw.name === 'mastraRouteDispatcher')).toBe(true);
+        expect(used[0]).not.toBe(used[1]);
+      });
+
+      it('serves the route end-to-end when the router-like target is mounted on a real Koa app', async () => {
+        const koaApp = new Koa();
+        koaApp.use(bodyParser());
+
+        const adapter = new MastraServer({ app: koaApp, mastra: new Mastra({}) });
+        adapter.registerContextMiddleware();
+
+        // routerLike forwards `.use` straight onto the real Koa app, mimicking
+        // a mount/wrapper pattern where the dispatcher ultimately runs inside
+        // the parent app's middleware stack.
+        const routerLike = {
+          use: (mw: Koa.Middleware) => {
+            koaApp.use(mw);
+            return routerLike;
+          },
+        };
+
+        await adapter.registerRoute(
+          routerLike as unknown as Koa,
+          {
+            method: 'GET',
+            path: '/mounted',
+            responseType: 'json',
+            handler: async () => ({ route: 'mounted' }),
+          },
+          { prefix: '' },
+        );
+
+        server = await new Promise(resolve => {
+          const s = koaApp.listen(0, () => resolve(s));
+        });
+
+        const address = server.address();
+        const port = typeof address === 'object' && address ? address.port : 0;
+
+        const response = await fetch(`http://localhost:${port}/mounted`);
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({ route: 'mounted' });
+      });
+    });
   });
 
   describe('Stream Data Redaction', () => {

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -270,9 +270,21 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
   }
 
   private getRouteDispatcherGroup(app: Koa): RouteDispatcherGroup {
-    const activeGroup = this.activeRouteDispatchers.get(app);
-    if (activeGroup && app.middleware.length === activeGroup.stackLengthAfterRegistration) {
-      return activeGroup;
+    // The dispatcher-reuse optimization needs to observe app.middleware.length
+    // to detect when other middleware was registered between our route
+    // registrations (in which case we must start a new dispatcher group to
+    // preserve middleware ordering). Subclasses may pass an app-like object
+    // (e.g., a koa-router or a mounted sub-app) that only exposes `use` and
+    // has no `middleware` array. In that case, skip reuse and register a fresh
+    // dispatcher per call — equivalent to the pre-1.5.0 per-route behavior.
+    const middlewareStack = (app as { middleware?: unknown }).middleware;
+    const supportsReuse = Array.isArray(middlewareStack);
+
+    if (supportsReuse) {
+      const activeGroup = this.activeRouteDispatchers.get(app);
+      if (activeGroup && middlewareStack.length === activeGroup.stackLengthAfterRegistration) {
+        return activeGroup;
+      }
     }
 
     const group: RouteDispatcherGroup = {
@@ -280,8 +292,12 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       stackLengthAfterRegistration: 0,
     };
     app.use(this.createRouteDispatcherMiddleware(group));
-    group.stackLengthAfterRegistration = app.middleware.length;
-    this.activeRouteDispatchers.set(app, group);
+
+    if (supportsReuse) {
+      group.stackLengthAfterRegistration = (app as { middleware: unknown[] }).middleware.length;
+      this.activeRouteDispatchers.set(app, group);
+    }
+
     return group;
   }
 


### PR DESCRIPTION
`@mastra/koa@1.5.0` introduced a dispatcher-reuse optimization that unconditionally reads `app.middleware.length` in `getRouteDispatcherGroup`. Subclasses that forward a non-Koa app-like object (e.g. a `koa-router`, a mounted sub-app, or a custom wrapper) to `super.registerRoute(app, route, opts)` hit `undefined.length` and crash at `MastraServer.init()` with `TypeError: Cannot read properties of undefined (reading 'length')`.

This guards reuse on `Array.isArray(app.middleware)` and falls back to registering a fresh dispatcher per route via `app.use` when the array isn't there — the same per-route behavior the adapter had before 1.5.0. Real Koa apps keep the optimization unchanged.

Before:

```ts
class CustomKoaMastraServer extends MastraServer {
  async registerCustomApiRoutes() {
    for (const route of this.mastra.getServer()?.apiRoutes ?? []) {
      await super.registerRoute(this.router as any, route, { prefix: this.prefix });
      // 💥 TypeError: Cannot read properties of undefined (reading 'length')
    }
  }
}
```

After: the same subclass initializes cleanly and routes register on the forwarded target via `.use()`.

Covered by four new tests in `Route dispatcher > non-Koa app-like targets` — each one was verified to fail against the unguarded implementation and pass with the fix. Full koa adapter suite: 2,188/2,188 passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR fixes a crash that happens when Koa server code tries to reuse optimization shortcuts for router-like objects that don't have all the expected properties. By checking if the property exists before using it, the code now gracefully falls back to the slower (but safe) approach for these unusual objects, while keeping the optimization for normal Koa apps.

## Summary

This PR fixes a `TypeError` in `@mastra/koa@1.5.0` that occurs during `MastraServer.init()` when a subclass forwards a non-Koa app-like object (such as a koa-router instance, mounted sub-app, or custom wrapper) to the `registerRoute` method. The dispatcher-reuse optimization introduced in 1.5.0 unconditionally accessed `app.middleware.length`, which failed when `app.middleware` was undefined or not an array.

## Changes

**server-adapters/koa/src/index.ts**
- Updated `getRouteDispatcherGroup()` to guard the dispatcher-reuse optimization by checking `Array.isArray(app.middleware)` before attempting to reuse an existing dispatcher group
- Falls back to registering a fresh dispatcher per route via `app.use()` when the optimization is unavailable, matching the pre-1.5.0 behavior
- Real Koa apps with a proper `middleware` array retain the optimization

**server-adapters/koa/src/__tests__/koa-adapter.test.ts**
- Added four new test cases under "Route dispatcher > non-Koa app-like targets" covering:
  - No crash when `middleware` is missing
  - Correct handling when `middleware` exists but is not an array
  - Fresh dispatcher creation per route when reuse is impossible
  - End-to-end request handling with router-like targets mounted in a real Koa app

**.changeset/ten-hats-slide.md**
- Documents the patch-level fix with an illustrative TypeScript example demonstrating the previous crash and the corrected behavior

## Verification

The full koa adapter test suite reports 2,188/2,188 tests passing. All four new tests were verified to fail on the unguarded implementation and pass with the fix applied.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16484)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->