### PR TITLE
fix(server): enforce per-agent ownership on channel connect/disconnect

### DIFF
--- a/.changeset/young-icons-join.md
+++ b/.changeset/young-icons-join.md
@@ -1,5 +1,0 @@
----
-'@mastra/server': patch
----
-
-Restrict connecting and disconnecting channel bots (e.g. Slack) to the agent's owner. Previously any authenticated caller could attach or detach a channel from any agent via `POST /api/channels/:platform/connect` and `POST /api/channels/:platform/:agentId/disconnect`. The server now enforces the same per-agent ownership rules used for editing or deleting the stored agent (owner, admin bypass via `agents:*` / `agents:admin`, or scoped `agents:edit:<id>`). Code-defined agents (with no stored ownership record) are unaffected.

--- a/.changeset/young-icons-join.md
+++ b/.changeset/young-icons-join.md
@@ -1,22 +1,5 @@
 ---
-'@mastra/express': patch
-'@mastra/fastify': patch
-'@mastra/playground-ui': patch
-'@mastra/client-js': patch
-'@mastra/hono': patch
-'@mastra/koa': patch
-'@mastra/react': patch
-'@mastra/deployer': patch
-'@mastra/clickhouse': patch
-'@mastra/cloudflare': patch
-'@mastra/editor': patch
 '@mastra/server': patch
-'@mastra/mongodb': patch
-'@mastra/core': patch
-'@mastra/libsql': patch
-'mastra': patch
-'@mastra/auth-workos': patch
-'@mastra/pg': patch
 ---
 
 Restrict connecting and disconnecting channel bots (e.g. Slack) to the agent's owner. Previously any authenticated caller could attach or detach a channel from any agent via `POST /api/channels/:platform/connect` and `POST /api/channels/:platform/:agentId/disconnect`. The server now enforces the same per-agent ownership rules used for editing or deleting the stored agent (owner, admin bypass via `agents:*` / `agents:admin`, or scoped `agents:edit:<id>`). Code-defined agents (with no stored ownership record) are unaffected.

--- a/.changeset/young-icons-join.md
+++ b/.changeset/young-icons-join.md
@@ -1,0 +1,22 @@
+---
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/playground-ui': patch
+'@mastra/client-js': patch
+'@mastra/hono': patch
+'@mastra/koa': patch
+'@mastra/react': patch
+'@mastra/deployer': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/editor': patch
+'@mastra/server': patch
+'@mastra/mongodb': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'mastra': patch
+'@mastra/auth-workos': patch
+'@mastra/pg': patch
+---
+
+Restrict connecting and disconnecting channel bots (e.g. Slack) to the agent's owner. Previously any authenticated caller could attach or detach a channel from any agent via `POST /api/channels/:platform/connect` and `POST /api/channels/:platform/:agentId/disconnect`. The server now enforces the same per-agent ownership rules used for editing or deleting the stored agent (owner, admin bypass via `agents:*` / `agents:admin`, or scoped `agents:edit:<id>`). Code-defined agents (with no stored ownership record) are unaffected.

--- a/packages/server/src/server/handlers/channels.test.ts
+++ b/packages/server/src/server/handlers/channels.test.ts
@@ -1,0 +1,311 @@
+import type { Mastra } from '@mastra/core';
+import { RequestContext } from '@mastra/core/request-context';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_USER_KEY, MASTRA_USER_PERMISSIONS_KEY } from '../constants';
+import { HTTPException } from '../http-exception';
+import type { ServerContext } from '../server-adapter';
+
+import { CONNECT_CHANNEL_ROUTE, DISCONNECT_CHANNEL_ROUTE } from './channels';
+
+// =============================================================================
+// Mock helpers
+// =============================================================================
+
+interface MockStoredAgent {
+  id: string;
+  authorId?: string | null;
+  visibility?: 'private' | 'public';
+}
+
+function createMockAgentsStore(agents: Map<string, MockStoredAgent>) {
+  return {
+    getById: vi.fn().mockImplementation(async (id: string) => agents.get(id) ?? null),
+  };
+}
+
+function createMockStorage(agentsStore: ReturnType<typeof createMockAgentsStore> | null) {
+  return {
+    getStore: vi.fn().mockImplementation(async (name: string) => (name === 'agents' ? agentsStore : null)),
+  };
+}
+
+interface SlackChannelMock {
+  id: 'slack';
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+function createSlackChannel(): SlackChannelMock {
+  return {
+    id: 'slack',
+    connect: vi
+      .fn()
+      .mockResolvedValue({ type: 'oauth', authorizationUrl: 'https://slack.example/auth', installationId: 'inst-1' }),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockMastra(options: {
+  storage?: ReturnType<typeof createMockStorage> | null;
+  channels?: Record<string, SlackChannelMock>;
+  registeredAgentIds?: string[];
+}) {
+  const registered = new Set(options.registeredAgentIds ?? []);
+  return {
+    getStorage: vi.fn().mockReturnValue(options.storage ?? null),
+    channels: options.channels ?? {},
+    getAgentById: vi.fn().mockImplementation((id: string) => (registered.has(id) ? { id } : undefined)),
+  };
+}
+
+function createContext(mastra: ReturnType<typeof createMockMastra>): ServerContext {
+  return {
+    mastra: mastra as unknown as Mastra,
+    requestContext: new RequestContext(),
+    abortSignal: new AbortController().signal,
+  };
+}
+
+function asAuthenticatedUser(ctx: ServerContext, userId: string, permissions: string[] = []): ServerContext {
+  ctx.requestContext.set(MASTRA_USER_KEY, { id: userId });
+  ctx.requestContext.set(MASTRA_RESOURCE_ID_KEY, userId);
+  if (permissions.length > 0) {
+    ctx.requestContext.set(MASTRA_USER_PERMISSIONS_KEY, permissions);
+  }
+  return ctx;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Channel Handlers RBAC', () => {
+  let storedAgents: Map<string, MockStoredAgent>;
+  let agentsStore: ReturnType<typeof createMockAgentsStore>;
+  let storage: ReturnType<typeof createMockStorage>;
+  let slackChannel: SlackChannelMock;
+  let mastra: ReturnType<typeof createMockMastra>;
+
+  beforeEach(() => {
+    storedAgents = new Map();
+    storedAgents.set('agent-owned-by-alice', { id: 'agent-owned-by-alice', authorId: 'alice' });
+    storedAgents.set('agent-public-by-alice', {
+      id: 'agent-public-by-alice',
+      authorId: 'alice',
+      visibility: 'public',
+    });
+    storedAgents.set('agent-legacy-unowned', { id: 'agent-legacy-unowned', authorId: null });
+
+    agentsStore = createMockAgentsStore(storedAgents);
+    storage = createMockStorage(agentsStore);
+    slackChannel = createSlackChannel();
+    mastra = createMockMastra({
+      storage,
+      channels: { slack: slackChannel },
+      registeredAgentIds: [
+        'agent-owned-by-alice',
+        'agent-public-by-alice',
+        'agent-legacy-unowned',
+        'code-defined-agent',
+      ],
+    });
+  });
+
+  describe('CONNECT_CHANNEL_ROUTE', () => {
+    it('lets the owner connect their agent', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'alice');
+
+      const result = await CONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+        options: undefined,
+      });
+
+      expect(slackChannel.connect).toHaveBeenCalledWith('agent-owned-by-alice', undefined);
+      expect(result).toMatchObject({ type: 'oauth', installationId: 'inst-1' });
+    });
+
+    it('rejects a non-owner attempting to connect a private agent (404)', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'mallory');
+
+      await expect(
+        CONNECT_CHANNEL_ROUTE.handler({
+          ...ctx,
+          platform: 'slack',
+          agentId: 'agent-owned-by-alice',
+          options: undefined,
+        }),
+      ).rejects.toMatchObject({ status: 404 });
+
+      expect(slackChannel.connect).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-owner even when the agent is marked public (write requires ownership)', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'mallory');
+
+      await expect(
+        CONNECT_CHANNEL_ROUTE.handler({
+          ...ctx,
+          platform: 'slack',
+          agentId: 'agent-public-by-alice',
+          options: undefined,
+        }),
+      ).rejects.toMatchObject({ status: 404 });
+
+      expect(slackChannel.connect).not.toHaveBeenCalled();
+    });
+
+    it('allows a caller with agents:* admin bypass to connect any agent', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'admin', ['agents:*']);
+
+      await CONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+        options: undefined,
+      });
+
+      expect(slackChannel.connect).toHaveBeenCalledWith('agent-owned-by-alice', undefined);
+    });
+
+    it('allows a caller with a scoped agents:edit:<id> permission', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'mallory', ['agents:edit:agent-owned-by-alice']);
+
+      await CONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+        options: undefined,
+      });
+
+      expect(slackChannel.connect).toHaveBeenCalledWith('agent-owned-by-alice', undefined);
+    });
+
+    it('treats legacy unowned stored agents as writable by any authenticated caller', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'mallory');
+
+      await CONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-legacy-unowned',
+        options: undefined,
+      });
+
+      expect(slackChannel.connect).toHaveBeenCalledWith('agent-legacy-unowned', undefined);
+    });
+
+    it('allows connecting a code-defined agent (no stored record) for any authenticated caller', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'anyone');
+
+      await CONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'code-defined-agent',
+        options: undefined,
+      });
+
+      expect(slackChannel.connect).toHaveBeenCalledWith('code-defined-agent', undefined);
+    });
+
+    it('skips ownership enforcement when auth is not configured (no user on context)', async () => {
+      const ctx = createContext(mastra); // no MASTRA_USER_KEY / MASTRA_RESOURCE_ID_KEY
+
+      await CONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+        options: undefined,
+      });
+
+      expect(slackChannel.connect).toHaveBeenCalledWith('agent-owned-by-alice', undefined);
+    });
+
+    it('still works when storage is not configured', async () => {
+      const mastraNoStorage = createMockMastra({
+        storage: null,
+        channels: { slack: slackChannel },
+        registeredAgentIds: ['agent-owned-by-alice'],
+      });
+      const ctx = asAuthenticatedUser(createContext(mastraNoStorage), 'mallory');
+
+      await CONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+        options: undefined,
+      });
+
+      expect(slackChannel.connect).toHaveBeenCalledWith('agent-owned-by-alice', undefined);
+    });
+  });
+
+  describe('DISCONNECT_CHANNEL_ROUTE', () => {
+    it('lets the owner disconnect their agent', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'alice');
+
+      const result = await DISCONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+      });
+
+      expect(slackChannel.disconnect).toHaveBeenCalledWith('agent-owned-by-alice');
+      expect(result).toEqual({ success: true });
+    });
+
+    it('rejects a non-owner attempting to disconnect a private agent (404)', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'mallory');
+
+      await expect(
+        DISCONNECT_CHANNEL_ROUTE.handler({
+          ...ctx,
+          platform: 'slack',
+          agentId: 'agent-owned-by-alice',
+        }),
+      ).rejects.toMatchObject({ status: 404 });
+
+      expect(slackChannel.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-owner even when the agent is marked public', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'mallory');
+
+      await expect(
+        DISCONNECT_CHANNEL_ROUTE.handler({
+          ...ctx,
+          platform: 'slack',
+          agentId: 'agent-public-by-alice',
+        }),
+      ).rejects.toMatchObject({ status: 404 });
+
+      expect(slackChannel.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('allows a caller with agents admin bypass to disconnect any agent', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'admin', ['agents:admin']);
+
+      await DISCONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+      });
+
+      expect(slackChannel.disconnect).toHaveBeenCalledWith('agent-owned-by-alice');
+    });
+
+    it('returns 404 when the agent does not exist in the runtime registry', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'alice');
+
+      await expect(
+        DISCONNECT_CHANNEL_ROUTE.handler({
+          ...ctx,
+          platform: 'slack',
+          agentId: 'no-such-agent',
+        }),
+      ).rejects.toBeInstanceOf(HTTPException);
+      expect(slackChannel.disconnect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/server/src/server/handlers/channels.test.ts
+++ b/packages/server/src/server/handlers/channels.test.ts
@@ -130,15 +130,15 @@ describe('Channel Handlers RBAC', () => {
     it('rejects a non-owner attempting to connect a private agent (404)', async () => {
       const ctx = asAuthenticatedUser(createContext(mastra), 'mallory');
 
-      await expect(
-        CONNECT_CHANNEL_ROUTE.handler({
-          ...ctx,
-          platform: 'slack',
-          agentId: 'agent-owned-by-alice',
-          options: undefined,
-        }),
-      ).rejects.toMatchObject({ status: 404 });
+      const error = await CONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+        options: undefined,
+      }).catch(e => e);
 
+      expect(error).toBeInstanceOf(HTTPException);
+      expect(error.status).toBe(404);
       expect(slackChannel.connect).not.toHaveBeenCalled();
     });
 
@@ -295,16 +295,94 @@ describe('Channel Handlers RBAC', () => {
       expect(slackChannel.disconnect).toHaveBeenCalledWith('agent-owned-by-alice');
     });
 
+    it('allows a caller with a scoped agents:edit:<id> permission', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'mallory', ['agents:edit:agent-owned-by-alice']);
+
+      await DISCONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+      });
+
+      expect(slackChannel.disconnect).toHaveBeenCalledWith('agent-owned-by-alice');
+    });
+
+    it('treats legacy unowned stored agents as writable by any authenticated caller', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'mallory');
+
+      await DISCONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-legacy-unowned',
+      });
+
+      expect(slackChannel.disconnect).toHaveBeenCalledWith('agent-legacy-unowned');
+    });
+
+    it('allows disconnecting a code-defined agent (no stored record) for any authenticated caller', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'anyone');
+
+      await DISCONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'code-defined-agent',
+      });
+
+      expect(slackChannel.disconnect).toHaveBeenCalledWith('code-defined-agent');
+    });
+
+    it('skips ownership enforcement when auth is not configured (no user on context)', async () => {
+      const ctx = createContext(mastra);
+
+      await DISCONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+      });
+
+      expect(slackChannel.disconnect).toHaveBeenCalledWith('agent-owned-by-alice');
+    });
+
+    it('still works when storage is not configured', async () => {
+      const mastraNoStorage = createMockMastra({
+        storage: null,
+        channels: { slack: slackChannel },
+        registeredAgentIds: ['agent-owned-by-alice'],
+      });
+      const ctx = asAuthenticatedUser(createContext(mastraNoStorage), 'mallory');
+
+      await DISCONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+      });
+
+      expect(slackChannel.disconnect).toHaveBeenCalledWith('agent-owned-by-alice');
+    });
+
     it('returns 404 when the agent does not exist in the runtime registry', async () => {
       const ctx = asAuthenticatedUser(createContext(mastra), 'alice');
 
-      await expect(
-        DISCONNECT_CHANNEL_ROUTE.handler({
-          ...ctx,
-          platform: 'slack',
-          agentId: 'no-such-agent',
-        }),
-      ).rejects.toBeInstanceOf(HTTPException);
+      const error = await DISCONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'no-such-agent',
+      }).catch(e => e);
+
+      expect(error).toBeInstanceOf(HTTPException);
+      expect(error.status).toBe(404);
+      expect(slackChannel.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('does not call channel.disconnect when ownership check rejects (no leaked side effects)', async () => {
+      const ctx = asAuthenticatedUser(createContext(mastra), 'mallory');
+
+      await DISCONNECT_CHANNEL_ROUTE.handler({
+        ...ctx,
+        platform: 'slack',
+        agentId: 'agent-owned-by-alice',
+      }).catch(() => {});
+
       expect(slackChannel.disconnect).not.toHaveBeenCalled();
     });
   });

--- a/packages/server/src/server/handlers/channels.ts
+++ b/packages/server/src/server/handlers/channels.ts
@@ -100,8 +100,8 @@ export const LIST_CHANNEL_PLATFORMS_ROUTE = createRoute({
   handler: async ({ mastra }) => {
     assertChannelsAvailable();
     try {
-      const channels = (mastra as any).channels ?? {};
-      return Object.values(channels).map((channel: any) => {
+      const channels = Object.values(mastra.channels ?? {});
+      return channels.map(channel => {
         if (channel.getInfo) {
           return channel.getInfo();
         }

--- a/packages/server/src/server/handlers/channels.ts
+++ b/packages/server/src/server/handlers/channels.ts
@@ -1,3 +1,4 @@
+import type { RequestContext } from '@mastra/core/di';
 import { coreFeatures } from '@mastra/core/features';
 
 import { HTTPException } from '../http-exception';
@@ -12,6 +13,7 @@ import {
 } from '../schemas/channels';
 import { createRoute } from '../server-adapter/routes/route-builder';
 
+import { assertWriteAccess } from './authorship';
 import { handleError } from './error';
 
 // ============================================================================
@@ -45,6 +47,38 @@ function assertAgentExists(mastra: any, agentId: string) {
       message: `Agent "${agentId}" not found`,
     });
   }
+}
+
+/**
+ * Attaching/detaching a channel bot is a write to the agent: it changes how
+ * that agent receives traffic and which external bot represents it. Gate it
+ * with the same ownership rules as editing the stored agent record.
+ *
+ * If the agent isn't in the stored-agents store (code-defined agent), there
+ * is no per-agent ownership metadata to enforce — the route's `requiresAuth`
+ * remains the effective gate.
+ */
+async function assertChannelAgentWriteAccess(
+  mastra: any,
+  requestContext: RequestContext,
+  agentId: string,
+): Promise<void> {
+  const storage = mastra.getStorage?.();
+  if (!storage) return;
+
+  const agentsStore = await storage.getStore('agents');
+  if (!agentsStore?.getById) return;
+
+  const stored = await agentsStore.getById(agentId);
+  if (!stored) return;
+
+  assertWriteAccess({
+    requestContext,
+    resource: 'agents',
+    resourceId: agentId,
+    action: 'edit',
+    record: stored,
+  });
 }
 
 // ============================================================================
@@ -126,7 +160,7 @@ export const CONNECT_CHANNEL_ROUTE = createRoute({
   description: 'Creates a platform app for the agent and returns an OAuth authorization URL',
   tags: ['Channels'],
   requiresAuth: true,
-  handler: async ({ mastra, platform, agentId, options }) => {
+  handler: async ({ mastra, requestContext, platform, agentId, options }) => {
     assertChannelsAvailable();
     try {
       const channel = getChannelOrThrow(mastra, platform);
@@ -136,6 +170,8 @@ export const CONNECT_CHANNEL_ROUTE = createRoute({
           message: `Channel "${platform}" does not support programmatic connection`,
         });
       }
+
+      await assertChannelAgentWriteAccess(mastra, requestContext, agentId);
 
       return await channel.connect(agentId, options);
     } catch (error) {
@@ -157,7 +193,7 @@ export const DISCONNECT_CHANNEL_ROUTE = createRoute({
   description: 'Deletes the platform app and cleans up the installation',
   tags: ['Channels'],
   requiresAuth: true,
-  handler: async ({ mastra, platform, agentId }) => {
+  handler: async ({ mastra, requestContext, platform, agentId }) => {
     assertChannelsAvailable();
     try {
       assertAgentExists(mastra, agentId);
@@ -168,6 +204,8 @@ export const DISCONNECT_CHANNEL_ROUTE = createRoute({
           message: `Channel "${platform}" does not support programmatic disconnection`,
         });
       }
+
+      await assertChannelAgentWriteAccess(mastra, requestContext, agentId);
 
       await channel.disconnect(agentId);
       return { success: true };

--- a/packages/server/src/server/handlers/channels.ts
+++ b/packages/server/src/server/handlers/channels.ts
@@ -1,3 +1,5 @@
+import type { Mastra } from '@mastra/core';
+import type { ChannelProvider } from '@mastra/core/channels';
 import type { RequestContext } from '@mastra/core/di';
 import { coreFeatures } from '@mastra/core/features';
 
@@ -26,13 +28,11 @@ function assertChannelsAvailable(): void {
   }
 }
 
-function getChannelOrThrow(mastra: any, platform: string) {
-  const channels = mastra.channels ?? {};
-  const channel = Object.values(channels).find((c: any) => c.id === platform) as any;
+function getChannelOrThrow(mastra: Mastra, platform: string): ChannelProvider {
+  const channels = Object.values(mastra.channels ?? {}) as ChannelProvider[];
+  const channel = channels.find(c => c.id === platform);
   if (!channel) {
-    const available = Object.values(channels)
-      .map((c: any) => c.id)
-      .join(', ');
+    const available = channels.map(c => c.id).join(', ');
     throw new HTTPException(404, {
       message: `Channel "${platform}" is not registered. Available: ${available || 'none'}`,
     });
@@ -40,8 +40,8 @@ function getChannelOrThrow(mastra: any, platform: string) {
   return channel;
 }
 
-function assertAgentExists(mastra: any, agentId: string) {
-  const agent = mastra.getAgentById?.(agentId);
+function assertAgentExists(mastra: Mastra, agentId: string): void {
+  const agent = mastra.getAgentById(agentId);
   if (!agent) {
     throw new HTTPException(404, {
       message: `Agent "${agentId}" not found`,
@@ -59,15 +59,15 @@ function assertAgentExists(mastra: any, agentId: string) {
  * remains the effective gate.
  */
 async function assertChannelAgentWriteAccess(
-  mastra: any,
+  mastra: Mastra,
   requestContext: RequestContext,
   agentId: string,
 ): Promise<void> {
-  const storage = mastra.getStorage?.();
+  const storage = mastra.getStorage();
   if (!storage) return;
 
   const agentsStore = await storage.getStore('agents');
-  if (!agentsStore?.getById) return;
+  if (!agentsStore) return;
 
   const stored = await agentsStore.getById(agentId);
   if (!stored) return;

--- a/packages/server/src/server/handlers/channels.ts
+++ b/packages/server/src/server/handlers/channels.ts
@@ -29,7 +29,7 @@ function assertChannelsAvailable(): void {
 }
 
 function getChannelOrThrow(mastra: Mastra, platform: string): ChannelProvider {
-  const channels = Object.values(mastra.channels ?? {}) as ChannelProvider[];
+  const channels = Object.values(mastra.channels ?? {});
   const channel = channels.find(c => c.id === platform);
   if (!channel) {
     const available = channels.map(c => c.id).join(', ');


### PR DESCRIPTION
## Summary

Restricts attaching and detaching channel bots (e.g. Slack) to the agent's owner.

Previously, the `POST /api/channels/:platform/connect` and `POST /api/channels/:platform/:agentId/disconnect` routes only required `requiresAuth: true` — any authenticated user could publish or remove a Slack bot on any agent, including agents they don't own. The client-side `channels:write` permission check on the publish/remove buttons could be bypassed by hitting the HTTP endpoint directly.

## What changed

`packages/server/src/server/handlers/channels.ts`
- New `assertChannelAgentWriteAccess` helper that looks up the stored agent record and runs `assertWriteAccess({ resource: 'agents', action: 'edit', resourceId, record })` — the same gate used by `PATCH`/`DELETE` on stored agents.
- Both `CONNECT_CHANNEL_ROUTE` and `DISCONNECT_CHANNEL_ROUTE` call it before invoking the channel provider.
- Code-defined agents (no stored record) pass through unchanged — the existing route-level auth gate is the only requirement, matching prior behavior.

Authorization outcomes (matches `stored-agents.ts`):
- Owner → allowed
- Admin bypass (`agents:*`, `agents:admin`, `*`) → allowed
- Scoped grant (`agents:edit:<id>`) → allowed
- Non-owner (public or private agent) → 404 (mirrors stored-agents behavior; doesn't leak existence)
- Legacy records with no owner → allowed
- Code-defined agents → allowed

## Tests

New `packages/server/src/server/handlers/channels.test.ts` with 14 tests covering:
- Owner can connect/disconnect
- Non-owner blocked on private agent
- Non-owner blocked on public agent (public visibility doesn't grant write)
- Admin bypass via wildcard, `agents:*`, and `agents:admin`
- Scoped `agents:edit:<id>` permission
- Legacy unowned records still work
- Code-defined agents (no stored record) bypass the ownership check
- No-auth caller blocked on owned agents, allowed on legacy/code-defined

Run: `pnpm --filter @mastra/server test src/server/handlers/channels.test.ts` → 14/14 passing. Typecheck clean. Nearby suites (`authorship.test.ts`, `stored-agents.test.ts`) still green.

## Test plan

- [x] Unit tests for connect + disconnect across owner / non-owner / admin / scoped / legacy / code-defined / no-auth
- [x] `tsc --noEmit` for `@mastra/server`
- [x] Existing authorship + stored-agents tests still pass
