### PR TITLE
ci: exclude first-party packages from minimumReleaseAge gate

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,14 @@ blockExoticSubdeps: true
 trustPolicy: no-downgrade
 trustPolicyIgnoreAfter: 43200 # 30 days
 minimumReleaseAge: 1440 # 1 day
+minimumReleaseAgeExclude:
+  # Exclude our own published packages so snapshot/canary e2e flows can install
+  # versions immediately after publishing in CI. The minimumReleaseAge gate is
+  # intended as a supply-chain defense for third-party dependencies.
+  - '@mastra/*'
+  - '@internal/*'
+  - 'mastra'
+  - 'create-mastra'
 trustPolicyExclude:
   # Security fix for GHSA middleware-based route protection bypass (CVE).
   # 3.47.4 is published with provenance attestation rather than trusted publisher,


### PR DESCRIPTION
## Description

The `minimumReleaseAge: 1440` setting added to `pnpm-workspace.yaml` in #16462 (as a supply-chain defense ahead of the pnpm v11 default) also applies to our **own** snapshot/canary publishes. E2E flows that publish a temporary `0.0.0-…-snapshot` version and then immediately try to install it fail with:

```
ERR_PNPM_NO_MATURE_MATCHING_VERSION  No matching version found for @mastra/loggers@0.0.0-…-snapshot
The package was released just now and you have a minimumReleaseAge of 1440 minutes set.
```

Affected workflows on main:
- `E2E Tests / create-mastra` (pnpm dlx create-mastra@…-snapshot)
- `E2E Tests / no-bundling`
- `E2E Tests / monorepo`
- `E2E Tests / deployers`

## Fix

Add `minimumReleaseAgeExclude` listing first-party package patterns. The supply-chain defense remains in effect for all third-party dependencies; only our own packages bypass the 1-day wait.

```yaml
minimumReleaseAgeExclude:
  - '@mastra/*'
  - '@internal/*'
  - 'mastra'
  - 'create-mastra'
```

Setting reference: https://pnpm.io/settings#minimumreleaseageexclude (available since pnpm 10.10).

## Test plan

- CI `E2E Tests` job should no longer fail with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` for `@mastra/*` / `@internal/*` / `mastra` / `create-mastra` snapshot versions.
- Third-party packages still gated by the 1-day `minimumReleaseAge`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Think of the project like a package store with a safety rule: "Don't sell anything that just arrived today—wait a day to make sure it's safe." The problem was this rule was also stopping the store from using its own fresh products. The fix tells the store: "Apply this safety rule to packages from other suppliers, but trust our own products and use them right away."

## Overview

This PR resolves a CI issue where pnpm's `minimumReleaseAge: 1440` setting (which enforces a 1-day maturity gate for package installation) was incorrectly blocking the installation of the project's own snapshot and canary builds during E2E tests. The fix adds a `minimumReleaseAgeExclude` configuration to `pnpm-workspace.yaml` that exempts first-party packages from this gate, while preserving the supply-chain security protection for third-party dependencies.

## Changes

**pnpm-workspace.yaml**: Added `minimumReleaseAgeExclude` configuration with the following excluded package patterns:
- `@mastra/*` (scoped packages)
- `@internal/*` (internal scoped packages)
- `mastra` (main package)
- `create-mastra` (create-mastra package)

This allows snapshot and canary builds to be installed immediately after publishing, unblocking E2E test flows (create-mastra, no-bundling, monorepo, deployers) that were previously failing with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`.

## Impact

- **Bug Fix**: Resolves CI failures for snapshot/canary E2E flows that publish and immediately install temporary 0.0.0-…-snapshot versions
- **Security Preserved**: Third-party dependencies remain subject to the 1-day maturity requirement
- **Non-breaking**: This is a configuration-only change with no impact on public APIs or breaking changes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16495)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->