### PR TITLE
fix(observability): support platform token env fallback

### DIFF
--- a/.changeset/platform-observability-token-env.md
+++ b/.changeset/platform-observability-token-env.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Support `MASTRA_PLATFORM_ACCESS_TOKEN` as the preferred environment variable for `MastraPlatformExporter`, while retaining `MASTRA_CLOUD_ACCESS_TOKEN` as a fallback for backward compatibility.

--- a/observability/mastra/src/exporters/mastra-platform.test.ts
+++ b/observability/mastra/src/exporters/mastra-platform.test.ts
@@ -845,6 +845,113 @@ describe('MastraPlatformExporter', () => {
       await authExporter.shutdown();
     });
 
+    it('should use MASTRA_CLOUD_ACCESS_TOKEN from the environment', async () => {
+      const envToken = createTestJWT({ teamId: 'cloud-env-token', projectId: 'auth-project' });
+      vi.stubEnv('MASTRA_CLOUD_ACCESS_TOKEN', envToken);
+
+      const authExporter = new MastraPlatformExporter({
+        endpoint: 'http://localhost:3000',
+      });
+
+      try {
+        await authExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+
+        await authExporter.flush();
+
+        const requestOptions = mockFetchWithRetry.mock.calls[0][1] as RequestInit;
+        const headers = requestOptions.headers as Record<string, string>;
+
+        expect(headers.Authorization).toBe(`Bearer ${envToken}`);
+      } finally {
+        await authExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should use MASTRA_PLATFORM_ACCESS_TOKEN from the environment', async () => {
+      const envToken = createTestJWT({ teamId: 'platform-env-token', projectId: 'auth-project' });
+      vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', envToken);
+
+      const authExporter = new MastraPlatformExporter({
+        endpoint: 'http://localhost:3000',
+      });
+
+      try {
+        await authExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+
+        await authExporter.flush();
+
+        const requestOptions = mockFetchWithRetry.mock.calls[0][1] as RequestInit;
+        const headers = requestOptions.headers as Record<string, string>;
+
+        expect(headers.Authorization).toBe(`Bearer ${envToken}`);
+      } finally {
+        await authExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should prefer MASTRA_PLATFORM_ACCESS_TOKEN over MASTRA_CLOUD_ACCESS_TOKEN', async () => {
+      const cloudToken = createTestJWT({ teamId: 'cloud-env-token', projectId: 'auth-project' });
+      const platformToken = createTestJWT({ teamId: 'platform-env-token', projectId: 'auth-project' });
+      vi.stubEnv('MASTRA_CLOUD_ACCESS_TOKEN', cloudToken);
+      vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', platformToken);
+
+      const authExporter = new MastraPlatformExporter({
+        endpoint: 'http://localhost:3000',
+      });
+
+      try {
+        await authExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+
+        await authExporter.flush();
+
+        const requestOptions = mockFetchWithRetry.mock.calls[0][1] as RequestInit;
+        const headers = requestOptions.headers as Record<string, string>;
+
+        expect(headers.Authorization).toBe(`Bearer ${platformToken}`);
+      } finally {
+        await authExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should fall back to MASTRA_CLOUD_ACCESS_TOKEN when MASTRA_PLATFORM_ACCESS_TOKEN is empty', async () => {
+      const cloudToken = createTestJWT({ teamId: 'cloud-env-token', projectId: 'auth-project' });
+      vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
+      vi.stubEnv('MASTRA_CLOUD_ACCESS_TOKEN', cloudToken);
+
+      const authExporter = new MastraPlatformExporter({
+        endpoint: 'http://localhost:3000',
+      });
+
+      try {
+        await authExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+
+        await authExporter.flush();
+
+        const requestOptions = mockFetchWithRetry.mock.calls[0][1] as RequestInit;
+        const headers = requestOptions.headers as Record<string, string>;
+
+        expect(headers.Authorization).toBe(`Bearer ${cloudToken}`);
+      } finally {
+        await authExporter.shutdown();
+        vi.unstubAllEnvs();
+      }
+    });
+
     it('should handle multiple spans in batch', async () => {
       const exportedSpans = [
         { ...mockSpan, id: 'span-1' },

--- a/observability/mastra/src/exporters/mastra-platform.ts
+++ b/observability/mastra/src/exporters/mastra-platform.ts
@@ -232,7 +232,8 @@ export class MastraPlatformExporter extends BaseExporter {
       throw createInvalidProjectIdError(config.projectId);
     }
 
-    const accessToken = config.accessToken ?? process.env.MASTRA_CLOUD_ACCESS_TOKEN;
+    const accessToken =
+      config.accessToken || process.env.MASTRA_PLATFORM_ACCESS_TOKEN || process.env.MASTRA_CLOUD_ACCESS_TOKEN;
     // Treat an empty MASTRA_PROJECT_ID as unset so deployments that always
     // export the variable (e.g. CI templates) don't have to special-case it.
     const envProjectId = process.env.MASTRA_PROJECT_ID === '' ? undefined : process.env.MASTRA_PROJECT_ID;
@@ -242,7 +243,7 @@ export class MastraPlatformExporter extends BaseExporter {
     }
     const projectId = rawProjectId;
     if (!accessToken) {
-      this.setDisabled('MASTRA_CLOUD_ACCESS_TOKEN environment variable not set.', 'debug');
+      this.setDisabled('MASTRA_PLATFORM_ACCESS_TOKEN environment variable not set.', 'debug');
     }
 
     const tracesEndpointOverride = config.tracesEndpoint ?? process.env.MASTRA_CLOUD_TRACES_ENDPOINT;

--- a/observability/mastra/src/registry.test.ts
+++ b/observability/mastra/src/registry.test.ts
@@ -1021,6 +1021,7 @@ describe('Observability Registry', () => {
       // keeps Vitest's env restoration intact so the suite-level afterEach
       // can roll it back without leaking the test value into later tests.
       vi.stubEnv('MASTRA_CLOUD_ACCESS_TOKEN', '');
+      vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
 
       const logger = new ConsoleLogger({ level: LogLevel.DEBUG });
 
@@ -1034,7 +1035,7 @@ describe('Observability Registry', () => {
       // Verify debug message was logged with exporter name
       expect(infoSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          'mastra-platform-exporter disabled: MASTRA_CLOUD_ACCESS_TOKEN environment variable not set',
+          'mastra-platform-exporter disabled: MASTRA_PLATFORM_ACCESS_TOKEN environment variable not set',
         ),
       );
 


### PR DESCRIPTION
## Summary
- Allow MastraPlatformExporter to use MASTRA_PLATFORM_ACCESS_TOKEN when present, falling back to MASTRA_CLOUD_ACCESS_TOKEN
- Keep explicit accessToken config precedence over environment variables
- Update observability tests and the missing-token debug expectation

## Test plan
- pnpm --filter @mastra/observability exec vitest run src/exporters/mastra-platform.test.ts src/registry.test.ts
- pnpm --filter @mastra/observability build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the observability exporter look for a second environment variable (MASTRA_PLATFORM_ACCESS_TOKEN) to authenticate with the cloud and prefer it over the older MASTRA_CLOUD_ACCESS_TOKEN when no explicit token is configured.

## Changes

### Core Changes

**observability/mastra/src/exporters/mastra-platform.ts**
- Resolve `accessToken` from, in order: `config.accessToken`, `MASTRA_PLATFORM_ACCESS_TOKEN`, then `MASTRA_CLOUD_ACCESS_TOKEN`.
- Update the debug message shown when no token is available to mention both `MASTRA_PLATFORM_ACCESS_TOKEN` and `MASTRA_CLOUD_ACCESS_TOKEN`.

### Test Updates

**observability/mastra/src/exporters/mastra-platform.test.ts**
- Added four integration tests verifying Authorization header selection when no explicit token is configured:
  - Uses `MASTRA_CLOUD_ACCESS_TOKEN` when only the cloud token is set.
  - Uses `MASTRA_PLATFORM_ACCESS_TOKEN` when only the platform token is set.
  - Prefers `MASTRA_PLATFORM_ACCESS_TOKEN` when both env vars are present.
  - Falls back to `MASTRA_CLOUD_ACCESS_TOKEN` when `MASTRA_PLATFORM_ACCESS_TOKEN` is set to an empty string.
- Each test stubs environment variables with `vi.stubEnv`, exports a span, flushes to trigger the HTTP call, asserts the mocked request's `Authorization` header, and restores state in a `finally` block.

**observability/mastra/src/registry.test.ts**
- The missing-token test now stubs both `MASTRA_CLOUD_ACCESS_TOKEN` and `MASTRA_PLATFORM_ACCESS_TOKEN` (the latter as empty) and updates the expected DEBUG message to reference both environment variable names.

### Changeset

**.changeset/platform-observability-token-env.md**
- Added a patch changeset documenting support for `MASTRA_PLATFORM_ACCESS_TOKEN` while retaining `MASTRA_CLOUD_ACCESS_TOKEN` as a fallback.

## Notes
- No public API changes.
- Test plan:
  - pnpm --filter @mastra/observability exec vitest run src/exporters/mastra-platform.test.ts src/registry.test.ts
  - pnpm --filter @mastra/observability build

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16500)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->