### PR TITLE
Pair observability prompt with CLI auth flow

### DIFF
--- a/.changeset/cli-observability-auth-prompt.md
+++ b/.changeset/cli-observability-auth-prompt.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Start the Mastra Platform auth flow immediately after users opt in to observability during `create mastra` and `mastra init`, then reuse that token when provisioning the observability project.

--- a/packages/cli/src/commands/actions/init-project.ts
+++ b/packages/cli/src/commands/actions/init-project.ts
@@ -44,6 +44,7 @@ export const initProject = async (args: InitArgs) => {
           mcpServer: result?.mcpServer,
           versionTag,
           observability: result?.observability,
+          observabilityToken: result?.observabilityToken,
         });
         return;
       }

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -95,6 +95,7 @@ export const create = async (args: {
       observability: args.observability ?? result?.observability,
       observabilityProject: args.observabilityProject,
       observabilityMode: 'create',
+      observabilityToken: result?.observabilityToken,
     });
     postCreate({ projectName });
     return;

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -227,7 +227,7 @@ export const init = async ({
 
   Empty ${color.cyan('MASTRA_PLATFORM_ACCESS_TOKEN')} and ${color.cyan('MASTRA_PROJECT_ID')} placeholders were added to your ${color.cyan('.env')} file.
 
-  1. Visit ${color.cyan('https://projects.mastra.ai')} to create a project and mint an access token.
+  1. Visit ${color.cyan('https://projects.mastra.ai')} to create a project and an access token.
   2. Paste the token into ${color.cyan('MASTRA_PLATFORM_ACCESS_TOKEN')} and the project id into ${color.cyan('MASTRA_PROJECT_ID')}.`,
         );
       }

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -37,6 +37,7 @@ export const init = async ({
   observability,
   observabilityProject,
   observabilityMode = 'pick',
+  observabilityToken,
 }: {
   directory?: string;
   components: Component[];
@@ -49,6 +50,7 @@ export const init = async ({
   initGit?: boolean;
   observability?: boolean;
   observabilityProject?: string;
+  observabilityToken?: string;
   /**
    * `'create'` skips the picker and always provisions a new platform project
    * named after the local one (used by `create-mastra`). `'pick'` shows the
@@ -202,6 +204,7 @@ export const init = async ({
           defaultProjectName,
           observabilityProject,
           mode: observabilityMode,
+          token: observabilityToken,
         });
         await writeObservabilityEnv({
           token: result.token,

--- a/packages/cli/src/commands/init/observability-provision.test.ts
+++ b/packages/cli/src/commands/init/observability-provision.test.ts
@@ -49,6 +49,29 @@ describe('provisionObservabilityProject', () => {
     resolveCurrentOrgMock.mockResolvedValue({ orgId: 'org_test', orgName: 'Test Org' });
   });
 
+  test('uses a provided platform token instead of starting auth again', async () => {
+    platformFetchMock
+      .mockResolvedValueOnce(jsonResponse({ projects: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          project: { id: 'p1', slug: 'my-app', name: 'my-app', organizationId: 'org_test' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          token: { id: 'k1', name: 'mastra observability – my-app' },
+          secret: 'sk_secret_value',
+        }),
+      );
+
+    textMock.mockResolvedValueOnce('my-app' as never);
+
+    await provisionObservabilityProject({ defaultProjectName: 'my-app', token: 'prompt-token' });
+
+    expect(getTokenMock).not.toHaveBeenCalled();
+    expect(resolveCurrentOrgMock).toHaveBeenCalledWith('prompt-token', { forcePrompt: true });
+  });
+
   test('creates a new project when the org has none, defaulting to package name', async () => {
     platformFetchMock
       .mockResolvedValueOnce(jsonResponse({ projects: [] }))

--- a/packages/cli/src/commands/init/observability-provision.ts
+++ b/packages/cli/src/commands/init/observability-provision.ts
@@ -49,6 +49,7 @@ export async function provisionObservabilityProject({
   defaultProjectName,
   observabilityProject,
   mode = 'pick',
+  token: providedToken,
 }: {
   defaultProjectName?: string;
   /**
@@ -64,8 +65,10 @@ export async function provisionObservabilityProject({
    * attach to an existing project or create a new one.
    */
   mode?: 'create' | 'pick';
+  /** Platform auth token already acquired during the observability opt-in prompt. */
+  token?: string;
 } = {}): Promise<ObservabilityProvisionResult> {
-  const token = await getToken();
+  const token = providedToken ?? (await getToken());
   const { orgId, orgName } = await resolveCurrentOrg(token, { forcePrompt: true });
 
   let project: ObservabilityProject;

--- a/packages/cli/src/commands/init/utils.test.ts
+++ b/packages/cli/src/commands/init/utils.test.ts
@@ -9,7 +9,44 @@ vi.mock('node:fs/promises', async () => {
   };
 });
 
-const { writeObservabilityEnv } = await import('./utils');
+vi.mock('@clack/prompts', () => ({
+  select: vi.fn(),
+  isCancel: (v: unknown) => typeof v === 'symbol',
+}));
+
+vi.mock('../auth/credentials.js', () => ({
+  getToken: vi.fn(),
+}));
+
+const { promptForObservability, writeObservabilityEnv } = await import('./utils');
+const prompts = await import('@clack/prompts');
+const { getToken } = await import('../auth/credentials.js');
+
+const selectMock = vi.mocked(prompts.select);
+const getTokenMock = vi.mocked(getToken);
+
+describe('promptForObservability', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTokenMock.mockResolvedValue('platform-token');
+  });
+
+  test('starts platform auth immediately when observability is enabled', async () => {
+    selectMock.mockResolvedValueOnce('yes' as never);
+
+    await expect(promptForObservability()).resolves.toEqual({ enabled: true, token: 'platform-token' });
+
+    expect(getTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not start platform auth when observability is skipped', async () => {
+    selectMock.mockResolvedValueOnce('no' as never);
+
+    await expect(promptForObservability()).resolves.toEqual({ enabled: false });
+
+    expect(getTokenMock).not.toHaveBeenCalled();
+  });
+});
 
 describe('writeObservabilityEnv', () => {
   const cwd = '/mock-project';

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -11,6 +11,7 @@ import yoctoSpinner from 'yocto-spinner';
 
 import { DepsService } from '../../services/service.deps';
 import { FileService } from '../../services/service.file';
+import { getToken } from '../auth/credentials.js';
 import {
   cursorGlobalMCPConfigPath,
   windsurfGlobalMCPConfigPath,
@@ -25,6 +26,28 @@ export const COMPONENTS = ['agents', 'workflows', 'tools', 'scorers'] as const;
 
 export type LLMProvider = (typeof LLMProvider)[number];
 export type Component = (typeof COMPONENTS)[number];
+
+export interface ObservabilityPromptResult {
+  enabled?: boolean;
+  token?: string;
+}
+
+export async function promptForObservability(): Promise<ObservabilityPromptResult> {
+  const choice = await p.select({
+    message: 'Enable Mastra Observability? (will open auth flow)',
+    options: [
+      { value: 'yes', label: 'Yes' },
+      { value: 'no', label: 'No' },
+    ],
+    initialValue: 'yes',
+  });
+
+  if (p.isCancel(choice)) return {};
+  if (choice !== 'yes') return { enabled: false };
+
+  const token = await getToken();
+  return { enabled: true, token };
+}
 
 /**
  * Type-guard to check if a value is a valid LLMProvider
@@ -751,18 +774,7 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
       },
       observability: async () => {
         if (skip?.observability) return undefined;
-
-        const choice = await p.select({
-          message: 'Enable Mastra Observability? (will open auth flow)',
-          options: [
-            { value: 'yes', label: 'Yes' },
-            { value: 'no', label: 'No' },
-          ],
-          initialValue: 'yes',
-        });
-
-        if (p.isCancel(choice)) return undefined;
-        return choice === 'yes';
+        return promptForObservability();
       },
       configureMastraToolingForAgents: async () => {
         if (skip?.skills && skip?.mcpServer) return { skills: undefined, mcpServer: undefined };
@@ -957,10 +969,12 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
     },
   );
 
-  // Flatten the configureMastraToolingForAgents return value
-  const { configureMastraToolingForAgents, ...rest } = mastraProject;
+  // Flatten grouped prompt return values
+  const { configureMastraToolingForAgents, observability, ...rest } = mastraProject;
   return {
     ...rest,
+    observability: observability?.enabled,
+    observabilityToken: observability?.token,
     skills: configureMastraToolingForAgents?.skills as string[] | undefined,
     mcpServer: configureMastraToolingForAgents?.mcpServer as Editor | undefined,
   };


### PR DESCRIPTION
## Summary
- start the platform login/token flow immediately after users opt in to observability during create/init prompts
- reuse that authenticated state later when provisioning the observability project
- add prompt-level coverage to ensure auth only starts for the yes path

## Test plan
- pnpm --filter mastra exec vitest run src/commands/init/utils.test.ts src/commands/init/observability-provision.test.ts
- pnpm --filter mastra typecheck
- pnpm --filter mastra build:lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

When you answer "yes" to "Do you want monitoring?", the CLI now immediately logs you into the platform so it's ready to set up monitoring right away, instead of asking for credentials later.

---

## Changes Overview

### packages/cli/src/commands/init/utils.ts
- Added export: `promptForObservability()` — prompts the user and, if they opt in, immediately runs the platform auth flow via `getToken()` and returns `{ enabled: true, token }`.
- Added `ObservabilityPromptResult` type: `{ enabled?: boolean; token?: string }`.
- Refactored `interactivePrompt` to delegate the observability step to `promptForObservability()` and to include `observability` and `observabilityToken` when flattening results.

### packages/cli/src/commands/init/utils.test.ts
- Added tests for `promptForObservability()` with mocks for `@clack/prompts` and `../auth/credentials.js`.
- Test cases:
  - When select returns "yes": resolves to `{ enabled: true, token: 'platform-token' }` and calls `getToken`.
  - When select returns "no": resolves to `{ enabled: false }` and does not call `getToken`.
- Consolidated async imports/setup for observability-related tests.

### packages/cli/src/commands/init/observability-provision.ts
- Updated `provisionObservabilityProject` signature to accept an optional `token` parameter.
- If `token` is provided, uses it instead of calling `getToken()`; otherwise falls back to `await getToken()`.

### packages/cli/src/commands/init/observability-provision.test.ts
- Added a test verifying that when a token is passed into provisioning, `getToken` is not called and the provision flow uses the provided token (calls `resolveCurrentOrg` with the token and `{ forcePrompt: true }`).

### packages/cli/src/commands/actions/init-project.ts and packages/cli/src/commands/create/create.ts
- Thread `observabilityToken` from the interactive prompt result into `init(...)` so the token obtained at prompt time is reused during provisioning.

### packages/cli/src/commands/init/init.ts
- `init` now accepts an optional `observabilityToken` option and forwards it to `provisionObservabilityProject({ token: observabilityToken })`.

### .changeset/cli-observability-auth-prompt.md
- New changeset documenting the behavior: start platform auth immediately when users opt into observability during create/init and reuse the token for provisioning.

---

## Impact

- User experience: authentication is paired with the observability opt-in prompt, eliminating a later credential prompt and enabling a smoother provisioning flow.
- Behavior: the token obtained at opt-in is reused for observability project provisioning; code paths that previously always called `getToken()` now accept and prefer a supplied token.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16502)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->