### PR TITLE
chore(docs): add Coinbase Agentic Wallet MCP entry

### DIFF
--- a/docs/src/content/en/docs/mcp/coinbase-agentic-wallet.mdx
+++ b/docs/src/content/en/docs/mcp/coinbase-agentic-wallet.mdx
@@ -7,7 +7,7 @@ packages:
 
 # Coinbase Agentic Wallet MCP
 
-The [Coinbase Agentic Wallet MCP server](https://docs.cdp.coinbase.com/agentic-wallet/mcp/welcome) lets agents discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet -- no API keys, no manual onramp, no seed phrases.
+The [Coinbase Agentic Wallet MCP server](https://docs.cdp.coinbase.com/agentic-wallet/mcp/welcome) lets agents discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet. Funding happens through the built-in Coinbase Onramp when needed, with no API keys or seed phrases to manage.
 
 ## Configure `MCPClient`
 
@@ -52,7 +52,7 @@ export const paymentsAgent = new Agent({
     You can search the x402 bazaar, inspect payment requirements,
     and pay for HTTP APIs in USDC.
   `,
-  model: 'openai/gpt-5-mini',
+  model: 'openai/gpt-5.4',
   tools: await coinbaseMcp.listTools(),
 })
 ```

--- a/docs/src/content/en/docs/mcp/coinbase-agentic-wallet.mdx
+++ b/docs/src/content/en/docs/mcp/coinbase-agentic-wallet.mdx
@@ -1,0 +1,71 @@
+---
+title: "Coinbase Agentic Wallet MCP | MCP"
+description: Connect Mastra agents to the Coinbase Agentic Wallet MCP server to autonomously discover and pay for x402 APIs in USDC.
+packages:
+  - "@mastra/mcp"
+---
+
+# Coinbase Agentic Wallet MCP
+
+The [Coinbase Agentic Wallet MCP server](https://docs.cdp.coinbase.com/agentic-wallet/mcp/welcome) lets agents discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet -- no API keys, no manual onramp, no seed phrases.
+
+## Configure `MCPClient`
+
+Install the Coinbase MCP bundle once:
+
+```bash
+npx @coinbase/payments-mcp install --client other
+```
+
+Then point `MCPClient` at the generated stdio bundle:
+
+```typescript title="src/mastra/mcp/coinbase-mcp.ts"
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import { MCPClient } from '@mastra/mcp'
+
+const coinbaseMcpBundle = join(homedir(), '.payments-mcp', 'bundle.js')
+
+export const coinbaseMcp = new MCPClient({
+  id: 'coinbase-agentic-wallet',
+  servers: {
+    coinbase: {
+      command: 'node',
+      args: [coinbaseMcpBundle],
+    },
+  },
+})
+```
+
+## Use with an agent
+
+```typescript title="src/mastra/agents/payments-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { coinbaseMcp } from '../mcp/coinbase-mcp'
+
+export const paymentsAgent = new Agent({
+  id: 'payments-agent',
+  name: 'Payments Agent',
+  description: 'Discovers and pays for x402 APIs autonomously',
+  instructions: `
+    You can search the x402 bazaar, inspect payment requirements,
+    and pay for HTTP APIs in USDC.
+  `,
+  model: 'openai/gpt-5-mini',
+  tools: await coinbaseMcp.listTools(),
+})
+```
+
+## Sign in
+
+On first run, the MCP server opens a companion window for email and OTP sign-in. This creates a Coinbase-managed embedded wallet, so you do not need to manage a seed phrase. Fund the wallet through the built-in Coinbase Onramp.
+
+## What the agent can do
+
+- Search the x402 bazaar for paid APIs by topic
+- Inspect a service's price and payment requirements
+- Pay for an HTTP API request in USDC
+- Check wallet address and balance
+
+See the [Agentic Wallet MCP tool reference](https://docs.cdp.coinbase.com/agentic-wallet/mcp/mcp-tools/overview) for the full tool catalog and supported chains.

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -332,6 +332,11 @@ const sidebars = {
           id: 'mcp/mcp-apps',
           label: 'MCP Apps',
         },
+        {
+          type: 'doc',
+          id: 'mcp/coinbase-agentic-wallet',
+          label: 'Coinbase Agentic Wallet',
+        },
       ],
     },
     {


### PR DESCRIPTION
## Description

Fixes #16503.

Adds an MCP docs page for Coinbase Agentic Wallet, covering the one-time installer step, `MCPClient` configuration against the installed stdio bundle, agent wiring, sign-in, and the discover-and-pay x402 flow.

Lets agents discover and pay for HTTP APIs autonomously via the x402 protocol, using a Coinbase-managed embedded wallet -- no API keys, no manual onramp, no seed phrases.

## Related issue(s)

Fixes #16503

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Testing

- `pnpm install --frozen-lockfile=false`
- `pnpm --filter mastra-docs build`
- `pnpm changeset-cli status --since upstream/main`

Notes: install completed with existing workspace warnings about a changesets patch/bin link and ignored build scripts. The docs build completed successfully and reported existing broken-anchor warnings unrelated to this page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a help page that shows how to connect Mastra agents to a Coinbase-managed wallet so agents can find and pay for paid web APIs automatically, without needing API keys or secret seed phrases.

## Changes

- New documentation page "Coinbase Agentic Wallet MCP" that explains how to install the Coinbase MCP stdio bundle, configure an MCPClient to run it, and wire the bundle's tools into a Mastra agent.
  - Includes an installation command: `npx @coinbase/payments-mcp install --client other`
  - Shows an MCPClient example pointing at the generated stdio bundle (`~/.payments-mcp/bundle.js`)
  - Shows agent wiring example using `tools: await coinbaseMcp.listTools()`
  - Documents the first-run sign-in (email + OTP) which creates a Coinbase-managed embedded wallet and uses Coinbase Onramp for funding
  - Lists agent capabilities: x402 discovery/search, inspect pricing/requirements, pay in USDC, check wallet address/balance, with a link to the full tool catalog
- Sidebar update to add the new MCP doc under the MCP docs navigation.

## Files changed
- docs/src/content/en/docs/mcp/coinbase-agentic-wallet.mdx (+71 lines): New documentation page with install, configuration, agent examples, and sign-in/usage guidance.
- docs/src/content/en/docs/sidebars.js (+5 lines): Added "Coinbase Agentic Wallet" entry to the docs sidebar.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16504)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->