### PR TITLE
ci: exclude first-party packages from minimumReleaseAge in snapshot E2E jobs

### DIFF
--- a/.github/workflows/secrets.e2e.yml
+++ b/.github/workflows/secrets.e2e.yml
@@ -119,6 +119,12 @@ jobs:
         run: pnpm test
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # The harness publishes a snapshot to a local registry then installs it
+          # from a generated project outside the workspace, so the workspace's
+          # `minimumReleaseAgeExclude` setting does not apply. Bypass the gate
+          # for our own first-party snapshots only; third-party deps are still
+          # subject to the maturity gate.
+          NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE: '@mastra/* @internal/* mastra create-mastra'
 
   e2e-no-bundling:
     name: E2E no-bundling
@@ -169,6 +175,8 @@ jobs:
         run: pnpm test
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # See e2e-monorepo for rationale.
+          NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE: '@mastra/* @internal/* mastra create-mastra'
 
   e2e-create-mastra:
     name: E2E create-mastra
@@ -213,6 +221,9 @@ jobs:
       - name: Test
         working-directory: ./e2e-tests/create-mastra
         run: pnpm test
+        env:
+          # See e2e-monorepo for rationale.
+          NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE: '@mastra/* @internal/* mastra create-mastra'
 
   e2e-commonjs:
     name: E2E CommonJS
@@ -301,6 +312,9 @@ jobs:
       - name: Test
         working-directory: ./e2e-tests/deployers
         run: pnpm test
+        env:
+          # See e2e-monorepo for rationale.
+          NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE: '@mastra/* @internal/* mastra create-mastra'
 
   e2e-type-check:
     name: E2E Type check


### PR DESCRIPTION
## Problem

#16462 added `minimumReleaseAge: 1440` to `pnpm-workspace.yaml` ahead of pnpm v11 default, as a supply-chain defense against newly-published malicious third-party packages.

#16495 added `minimumReleaseAgeExclude` to exempt our own packages (`@mastra/*`, `@internal/*`, `mastra`, `create-mastra`) so the gate did not block our snapshot/canary E2E flows.

That fixed the in-workspace case but the snapshot E2E jobs are still failing:

```
ERR_PNPM_NO_MATURE_MATCHING_VERSION  Version 0.0.0-no-bundling-test-…-snapshot
(released just now) of @mastra/loggers does not meet the minimumReleaseAge constraint
```

The reason: these jobs publish a snapshot to a **local registry**, then install it inside a **freshly generated project under `/tmp/…`**. That generated project is outside the workspace and has no `pnpm-workspace.yaml`, so the workspace-level `minimumReleaseAgeExclude` setting does not apply.

Affected jobs:

- `E2E monorepo`
- `E2E no-bundling`
- `E2E create-mastra`
- `E2E deployers`

## Fix

Set `NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE='@mastra/* @internal/* mastra create-mastra'` on each affected job Test step. This mirrors the workspace-level `minimumReleaseAgeExclude` but applies inside the generated `/tmp/…` project where the workspace config does not reach.

## Why this is the right scope

The `minimumReleaseAge` defense exists to prevent CI/dev installs from immediately picking up malicious third-party publishes before the ecosystem can detect them. The exclude env keeps that defense intact for third-party deps while letting our own freshly-built snapshots install:

- Only our **own first-party packages** (`@mastra/*`, `@internal/*`, `mastra`, `create-mastra`) are exempted
- **Third-party transitive deps** pulled in by the generated `/tmp/…` project still go through the 1-day gate — a newly published malicious npm package would still be blocked
- The exclude env is scoped to the `Test` step of these four jobs; every other `pnpm install` in CI (workspace bootstrap, lint, etc.) is unaffected
- The whole `/tmp/…` project is discarded at job end

Compared to alternatives:

- **`NPM_CONFIG_MINIMUM_RELEASE_AGE=0`** would also bypass the gate for every third-party package the generated project transitively installs, weakening supply-chain defense on the CI runner.
- **Patching the `mastra build` output template** to ship `minimumReleaseAgeExclude` to every generated user project would leak CI-test concerns into production code.
- **Dropping `minimumReleaseAge` entirely** would undo #16462 supply-chain defense for real workspace installs.

## Test plan

- `E2E Tests` on this PR should no longer fail with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` for our own snapshot versions.
- Workspace bootstrap, `Build`, and `Install dependencies` steps still run with the gate in effect, so third-party packages newer than 24h are still blocked everywhere else, including inside the generated `/tmp/…` project.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>
