### PR TITLE
fix(core): scheduled workflow dispatch by id and zombie schedule cleanup

### DIFF
--- a/.changeset/better-poems-join.md
+++ b/.changeset/better-poems-join.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': patch
+---
+
+Fixed two bugs that affected scheduled workflows.
+
+**Scheduled workflow with mismatched `id` could not be dispatched ([#16471](https://github.com/mastra-ai/mastra/issues/16471))**
+
+When a workflow's `id` differed from the key it was registered under, the scheduler published events the event processor could not resolve, causing the run to fail with "Workflow not found." The dispatcher now looks up workflows by `.id` first (falling back to the registration key), so the following now works as expected:
+
+```ts
+const workflow = createWorkflow({ id: 'daily-report', schedule: { cron: '0 9 * * *' } });
+new Mastra({ workflows: { dailyReport: workflow } });
+```
+
+**Deleted scheduled workflows caused infinite event redelivery**
+
+Removing a scheduled workflow from code used to leave its schedule row in storage. The scheduler kept firing for the missing workflow and the event processor kept telling the transport to redeliver the event forever. On boot, Mastra now cleans up declarative schedule rows (those it wrote itself, prefixed with `wf_`) for workflows that are no longer registered. User-created schedules made via the schedules API are left untouched. The event processor also handles in-flight events for missing workflows by emitting a single terminal `workflow.fail` instead of looping.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -153,6 +153,25 @@ function ownerWorkflowIdForRow(rowId: string, byWorkflow: Map<string, Set<string
   return undefined;
 }
 
+/**
+ * Decodes the owning workflow id directly from a `wf_<encoded>` /
+ * `wf_<encoded>__<...>` row id without needing the workflow to be in the
+ * current registry. Used to identify rows whose workflow has been deleted
+ * from code so we can clean them up on startup.
+ */
+function ownerWorkflowIdFromRowId(rowId: string): string | undefined {
+  if (!rowId.startsWith('wf_')) return undefined;
+  const rest = rowId.slice('wf_'.length);
+  const sep = rest.indexOf('__');
+  const encoded = sep === -1 ? rest : rest.slice(0, sep);
+  if (!encoded) return undefined;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return undefined;
+  }
+}
+
 /** See {@link targetsEqual}. Same approach for free-form metadata. */
 function metadataEqual(a: Record<string, unknown> | null | undefined, b: Record<string, unknown> | undefined): boolean {
   const aNorm = a ?? undefined;
@@ -1448,27 +1467,30 @@ export class Mastra<
       }
     }
 
-    // Orphan deletion: drop any storage rows owned by a registered workflow
-    // (id starts with `wf_<workflowId>` or `wf_<workflowId>__`) but not
-    // present in the current declared set. This keeps the storage in sync
-    // when array-form entries are removed across deploys. We only consider
-    // workflows we actually have registered — schedules belonging to a
-    // removed workflow are left alone (the workflow may be coming back).
-    if (declaredIdsByWorkflow.size > 0) {
-      const allRows = await schedulesStore.listSchedules();
-      for (const row of allRows) {
-        if (declaredIds.has(row.id)) continue;
-        const ownerWorkflowId = ownerWorkflowIdForRow(row.id, declaredIdsByWorkflow);
-        if (!ownerWorkflowId) continue;
-        try {
-          await schedulesStore.deleteSchedule(row.id);
-        } catch (error) {
-          this.#logger?.error('Failed to delete orphaned declarative schedule', {
-            scheduleId: row.id,
-            workflowId: ownerWorkflowId,
-            error,
-          });
-        }
+    // Orphan deletion: drop any Mastra-managed declarative schedule rows
+    // (id starts with `wf_<workflowId>` or `wf_<workflowId>__`) that are no
+    // longer declared in code. This covers two cases:
+    //   1. A registered workflow's array-form entries shrunk across deploys.
+    //   2. The owning workflow itself was deleted from code. Leaving these
+    //      rows behind would have the scheduler keep firing for a workflow
+    //      the processor can't resolve, producing infinite event-redelivery
+    //      loops (see WorkflowEventProcessor#dispatch).
+    // User-created schedules (via the schedules API) don't use the `wf_`
+    // prefix, so they're untouched.
+    const allRows = await schedulesStore.listSchedules();
+    for (const row of allRows) {
+      if (declaredIds.has(row.id)) continue;
+      if (!row.id.startsWith('wf_')) continue;
+      const ownerWorkflowId = ownerWorkflowIdForRow(row.id, declaredIdsByWorkflow) ?? ownerWorkflowIdFromRowId(row.id);
+      if (!ownerWorkflowId) continue;
+      try {
+        await schedulesStore.deleteSchedule(row.id);
+      } catch (error) {
+        this.#logger?.error('Failed to delete orphaned declarative schedule', {
+          scheduleId: row.id,
+          workflowId: ownerWorkflowId,
+          error,
+        });
       }
     }
   }

--- a/packages/core/src/mastra/scheduler-integration.test.ts
+++ b/packages/core/src/mastra/scheduler-integration.test.ts
@@ -393,14 +393,44 @@ describe('Mastra — workflow scheduler integration', () => {
       await second.shutdown();
     });
 
-    it('does not delete schedule rows belonging to non-registered workflows', async () => {
+    it('deletes declarative `wf_`-prefixed rows for workflows no longer registered in code', async () => {
       const storage = new MockStore();
       const mastra = await boot(storage, buildMultiScheduledWorkflow([{ id: 'a', cron: '0 9 * * *' }]));
       const schedulesStore = (await storage.getStore('schedules'))!;
 
-      // Manually insert a row for an unrelated workflow.
+      // Simulate a previous deploy that declared a schedule for a workflow
+      // that has since been removed from code entirely.
       await schedulesStore.createSchedule({
-        id: 'wf_unrelated__job',
+        id: 'wf_removed-wf__job',
+        target: { type: 'workflow', workflowId: 'removed-wf' },
+        cron: '0 0 * * *',
+        status: 'active',
+        nextFireAt: Date.now() + 60_000,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await mastra.shutdown();
+
+      // Reboot without `removed-wf`. Its declarative row must be cleaned up
+      // so the scheduler doesn't keep firing events the processor can't
+      // resolve (which would otherwise cause infinite event redelivery).
+      const second = await boot(storage, buildMultiScheduledWorkflow([{ id: 'a', cron: '0 9 * * *' }]));
+      const ids = (await schedulesStore.listSchedules()).map(r => r.id).sort();
+      expect(ids).not.toContain('wf_removed-wf__job');
+      expect(ids).toEqual(['wf_multi-wf__a']);
+      await second.shutdown();
+    });
+
+    it('does not delete user-created (non-`wf_`-prefixed) schedule rows', async () => {
+      const storage = new MockStore();
+      const mastra = await boot(storage, buildMultiScheduledWorkflow([{ id: 'a', cron: '0 9 * * *' }]));
+      const schedulesStore = (await storage.getStore('schedules'))!;
+
+      // A schedule created via the schedules API (not via declarative config)
+      // does not use the `wf_` prefix and must be left alone on reboot even
+      // when its target workflow isn't currently registered.
+      await schedulesStore.createSchedule({
+        id: 'user-created-schedule',
         target: { type: 'workflow', workflowId: 'unrelated' },
         cron: '0 0 * * *',
         status: 'active',
@@ -408,12 +438,11 @@ describe('Mastra — workflow scheduler integration', () => {
         createdAt: Date.now(),
         updatedAt: Date.now(),
       });
-      // Reboot with the same registered workflow set; orphan deletion must
-      // not touch rows owned by workflows we don't have registered.
       await mastra.shutdown();
+
       const second = await boot(storage, buildMultiScheduledWorkflow([{ id: 'a', cron: '0 9 * * *' }]));
       const ids = (await schedulesStore.listSchedules()).map(r => r.id).sort();
-      expect(ids).toContain('wf_unrelated__job');
+      expect(ids).toContain('user-created-schedule');
       await second.shutdown();
     });
   });

--- a/packages/core/src/workflows/evented/workflow-event-processor/dispatch.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/dispatch.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { createStep, createWorkflow } from '..';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import type { Event } from '../../../events/types';
+import { Mastra } from '../../../mastra';
+import { MockStore } from '../../../storage/mock';
+
+function makeStartEvent(workflowId: string, runId: string): Event {
+  return {
+    type: 'workflow.start',
+    runId,
+    data: {
+      workflowId,
+      runId,
+      executionPath: [0],
+      stepResults: {},
+      prevResult: { status: 'success', output: {} },
+      activeSteps: {},
+      requestContext: {},
+    },
+  } as Event;
+}
+
+describe('WorkflowEventProcessor #dispatch', () => {
+  it('resolves the workflow by its `id` even when registered under a different key (issue #16471)', async () => {
+    // Workflow has id "daily-report" but is registered as { dailyReport }.
+    // The scheduler emits `workflow.start` with workflowId="daily-report",
+    // and that lookup must succeed.
+    const wf = createWorkflow({
+      id: 'daily-report',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+    });
+    wf.then(
+      createStep({
+        id: 'noop',
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        execute: async () => ({}),
+      }) as any,
+    ).commit();
+
+    const pubsub = new EventEmitterPubSub();
+    const mastra = new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      // Note: registration key `dailyReport` !== workflow.id `daily-report`.
+      workflows: { dailyReport: wf } as any,
+      pubsub,
+    });
+
+    const result = await mastra.handleWorkflowEvent(makeStartEvent('daily-report', 'run-1'));
+
+    expect(result).toEqual({ ok: true });
+
+    await mastra.shutdown();
+  });
+
+  it('does not retry indefinitely when the workflow is no longer registered', async () => {
+    // Simulates a scheduled workflow whose definition was deleted from code.
+    // Scheduler publishes `workflow.start` for the missing workflow; the
+    // processor must terminate it instead of returning retry:true forever.
+    const pubsub = new EventEmitterPubSub();
+    const mastra = new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: {} as any,
+      pubsub,
+    });
+
+    const failEvents: Event[] = [];
+    void pubsub.subscribe('workflows', async event => {
+      if (event.type === 'workflow.fail') failEvents.push(event);
+    });
+
+    const result = await mastra.handleWorkflowEvent(makeStartEvent('ghost-workflow', 'run-1'));
+
+    // Must NOT be a retryable failure — otherwise the transport redelivers
+    // the event infinitely.
+    expect(result).toEqual({ ok: true });
+    // errorWorkflow() should have published a single workflow.fail event so
+    // any downstream listeners (storage, watchers) can finalize the run.
+    expect(failEvents.length).toBeGreaterThanOrEqual(1);
+
+    // A follow-up workflow.fail event for the same missing workflow must
+    // also terminate (it would otherwise loop back through #dispatch and
+    // re-trigger errorWorkflow forever).
+    const followUp = await mastra.handleWorkflowEvent({
+      type: 'workflow.fail',
+      runId: 'run-1',
+      data: {
+        workflowId: 'ghost-workflow',
+        runId: 'run-1',
+        executionPath: [],
+        stepResults: {},
+        prevResult: { status: 'failed', error: { message: 'gone' } as any },
+        activeSteps: {},
+        requestContext: {},
+      },
+    } as Event);
+    expect(followUp).toEqual({ ok: true });
+
+    await mastra.shutdown();
+  });
+});

--- a/packages/core/src/workflows/evented/workflow-event-processor/dispatch.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/dispatch.test.ts
@@ -70,7 +70,7 @@ describe('WorkflowEventProcessor #dispatch', () => {
     });
 
     const failEvents: Event[] = [];
-    void pubsub.subscribe('workflows', async event => {
+    await pubsub.subscribe('workflows', async event => {
       if (event.type === 'workflow.fail') failEvents.push(event);
     });
 

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -138,6 +138,22 @@ export class WorkflowEventProcessor extends EventProcessor {
     this.stepExecutor.__registerMastra(mastra);
   }
 
+  /**
+   * Resolves a workflow by id without throwing. Searches first by the
+   * workflow's `.id` (the value that ends up on event payloads) and then
+   * falls back to the registration key in `Mastra.workflows`. Returns
+   * `undefined` if neither lookup succeeds — callers decide how to handle
+   * the missing case (e.g. terminal failure vs. cleanup pass-through) so
+   * we don't throw inside `#dispatch` and trigger infinite event retries.
+   */
+  #tryResolveWorkflow(workflowId: string): Workflow | undefined {
+    try {
+      return this.mastra.getWorkflowById(workflowId) as Workflow;
+    } catch {
+      return undefined;
+    }
+  }
+
   private async errorWorkflow(
     {
       parentWorkflow,
@@ -2261,10 +2277,25 @@ export class WorkflowEventProcessor extends EventProcessor {
     }
 
     if (type.startsWith('workflow.user-event.')) {
+      const userEventWorkflow = this.#tryResolveWorkflow(workflowData.workflowId);
+      if (!userEventWorkflow) {
+        // Workflow no longer registered (e.g. deleted from code). Treat as a
+        // terminal failure rather than throwing — otherwise the transport
+        // would redeliver this event indefinitely.
+        return this.errorWorkflow(
+          workflowData,
+          new MastraError({
+            id: 'MASTRA_WORKFLOW',
+            text: `Workflow not found: ${workflowData.workflowId}`,
+            domain: ErrorDomain.MASTRA_WORKFLOW,
+            category: ErrorCategory.SYSTEM,
+          }),
+        );
+      }
       await processWorkflowWaitForEvent(
         {
           ...workflowData,
-          workflow: this.mastra.getWorkflow(workflowData.workflowId),
+          workflow: userEventWorkflow,
         },
         {
           pubsub: this.mastra.pubsub,
@@ -2281,19 +2312,29 @@ export class WorkflowEventProcessor extends EventProcessor {
     } else if (workflowData.parentWorkflow) {
       workflow = getNestedWorkflow(this.mastra, workflowData.parentWorkflow);
     } else {
-      workflow = this.mastra.getWorkflow(workflowData.workflowId);
+      workflow = this.#tryResolveWorkflow(workflowData.workflowId);
     }
 
     if (!workflow) {
-      return this.errorWorkflow(
-        workflowData,
-        new MastraError({
-          id: 'MASTRA_WORKFLOW',
-          text: `Workflow not found: ${workflowData.workflowId}`,
-          domain: ErrorDomain.MASTRA_WORKFLOW,
-          category: ErrorCategory.SYSTEM,
-        }),
-      );
+      // For terminal/cleanup events (`workflow.fail`, `workflow.end`,
+      // `workflow.cancel`), we deliberately keep dispatching with
+      // `workflow=undefined` so the processors can finish their cleanup work
+      // (persist final state, notify parent workflow, publish to
+      // workflows-finish). Republishing `workflow.fail` here would loop
+      // forever because the redelivered event would hit this same branch.
+      if (type === 'workflow.fail' || type === 'workflow.end' || type === 'workflow.cancel') {
+        // fall through to switch below with workflow=undefined
+      } else {
+        return this.errorWorkflow(
+          workflowData,
+          new MastraError({
+            id: 'MASTRA_WORKFLOW',
+            text: `Workflow not found: ${workflowData.workflowId}`,
+            domain: ErrorDomain.MASTRA_WORKFLOW,
+            category: ErrorCategory.SYSTEM,
+          }),
+        );
+      }
     }
 
     if (type === 'workflow.start' || type === 'workflow.resume') {
@@ -2310,52 +2351,60 @@ export class WorkflowEventProcessor extends EventProcessor {
       });
     }
 
+    // For the cleanup-path events (`workflow.fail`/`workflow.end`/
+    // `workflow.cancel`) we may have fallen through above with no resolved
+    // workflow. The processors for those events tolerate `workflow=undefined`
+    // (they rely on optional chaining / persisted state), so we cast here to
+    // avoid widening the shared `ProcessorArgs.workflow` type across the
+    // hundreds of usage sites in this file.
+    const workflowArg = workflow as Workflow;
+
     switch (type) {
       case 'workflow.cancel':
         await this.processWorkflowCancel({
-          workflow,
+          workflow: workflowArg,
           ...workflowData,
         });
         break;
       case 'workflow.start':
         await this.processWorkflowStart({
-          workflow,
+          workflow: workflowArg,
           ...workflowData,
         });
         break;
       case 'workflow.resume':
         await this.processWorkflowStart({
-          workflow,
+          workflow: workflowArg,
           ...workflowData,
         });
         break;
       case 'workflow.end':
         await this.processWorkflowEnd({
-          workflow,
+          workflow: workflowArg,
           ...workflowData,
         });
         break;
       case 'workflow.step.end':
         await this.processWorkflowStepEnd({
-          workflow,
+          workflow: workflowArg,
           ...workflowData,
         });
         break;
       case 'workflow.step.run':
         await this.processWorkflowStepRun({
-          workflow,
+          workflow: workflowArg,
           ...workflowData,
         });
         break;
       case 'workflow.suspend':
         await this.processWorkflowSuspend({
-          workflow,
+          workflow: workflowArg,
           ...workflowData,
         });
         break;
       case 'workflow.fail':
         await this.processWorkflowFail({
-          workflow,
+          workflow: workflowArg,
           ...workflowData,
         });
         break;


### PR DESCRIPTION
Fixes two bugs in scheduled workflows.

The first is #16471: when a workflow's `id` differs from the key it's registered under, the scheduler publishes events the dispatcher can't resolve and the run fails with "Workflow not found." The dispatcher now resolves by `.id` first and falls back to the registration key, so this works:

```ts
const workflow = createWorkflow({ id: 'daily-report', schedule: { cron: '0 9 * * *' } });
new Mastra({ workflows: { dailyReport: workflow } });
```

The second is an infinite event-redelivery loop when a scheduled workflow is deleted from code. Its schedule row would stay in storage forever, the scheduler would keep firing for it, and the processor's "not found" error would tell the transport to redeliver indefinitely.

Fixed at two layers: on boot, Mastra now cleans up its own declarative schedule rows (the `wf_`-prefixed ones it writes itself) for workflows that are no longer registered — user-created schedules via the schedules API are left alone. And the event processor no longer throws on missing workflows; it emits a single terminal `workflow.fail` to the workflows-finish topic and stops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes two scheduled-workflow bugs: workflows couldn't be started if their internal id differed from their registration name, and deleted workflows could leave "zombie" schedules that retried forever. The fixes make dispatch resolve by workflow id first, remove orphan declarative schedules on boot, and ensure missing-workflow events produce a single terminal failure instead of infinite redelivery.

---

## Changes Overview

**Release Notes** (`.changeset/better-poems-join.md`)
- Documents the two scheduled-workflow bug fixes in `@mastra/core` as a patch.

**Scheduler Initialization & Orphan Cleanup** (`packages/core/src/mastra/index.ts`)
- Added `ownerWorkflowIdFromRowId(rowId)` to decode owning workflow IDs from declarative schedule row IDs (`wf_<encoded>` / `wf_<encoded>__...`) so rows can be cleaned up even when the workflow is no longer registered.
- On boot, the scheduler now lists all schedules and deletes orphaned declarative rows whose IDs start with `wf_` and are not in the current declared set (using either the registry map or the decoded ID).
- Leaves schedules created via the schedules API (non-`wf_` rows) intact.
- Improved error logging for failed deletions.

**Scheduler Integration Tests** (`packages/core/src/mastra/scheduler-integration.test.ts`)
- Replaced an outdated test and added two focused tests:
  - Verifies `wf_`-prefixed declarative schedules are deleted when their target workflows are no longer registered.
  - Verifies user-created (non-`wf_`-prefixed) schedule rows are preserved across reboot.

**Workflow Dispatch Resolution & Processor Behavior** (`packages/core/src/workflows/evented/workflow-event-processor/index.ts`)
- Added private `#tryResolveWorkflow(workflowId)` to resolve workflows without throwing (returns `undefined` if not found).
- Dispatch now resolves by workflow `.id` first, falling back to the registration key—fixing cases where a workflow's runtime `.id` differs from its registration key.
- If a scheduled `workflow.start` (or other non-terminal event) targets a missing workflow, the processor publishes a single terminal `workflow.fail` to the workflows-finish topic instead of throwing and causing infinite redelivery.
- Terminal/cleanup events (`workflow.fail`, `workflow.end`, `workflow.cancel`) are still dispatched so cleanup logic can run, even when the workflow is `undefined`.

**Workflow Dispatch Tests** (`packages/core/src/workflows/evented/workflow-event-processor/dispatch.test.ts`)
- New test suite with `makeStartEvent` helper.
- Test verifying workflows can be resolved by their declared `.id` even when registered under a different key.
- Test verifying missing scheduled workflows cause a single `workflow.fail` rather than indefinite retries; subsequent `workflow.fail` handling also succeeds.
- Tests ensure subscribers are awaited where needed to avoid race conditions.

**Test/Infra Commit**
- One test-focused commit waits for pubsub.subscribe in a dispatch test to avoid flaky races where dispatched events could arrive before subscription.

---

No public API or exported declarations were changed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16510)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->