### PR TITLE
fix(cli): show logged-in user during auth login and create

### DIFF
--- a/.changeset/grumpy-cases-win.md
+++ b/.changeset/grumpy-cases-win.md
@@ -1,0 +1,7 @@
+---
+'mastra': patch
+---
+
+Improved `mastra auth login` to skip the browser flow when an existing token is still valid (or can be refreshed) and surface the logged-in user's email.
+
+The `mastra create` observability prompt also prints the logged-in user when authentication resolves from cached credentials, so you can confirm which account you're about to enable observability for.

--- a/packages/cli/src/commands/auth/auth.test.ts
+++ b/packages/cli/src/commands/auth/auth.test.ts
@@ -30,6 +30,8 @@ const mockLoadCredentials = vi.fn();
 const mockGetCurrentOrgId = vi.fn().mockResolvedValue('org-1');
 const mockSetCurrentOrgId = vi.fn().mockResolvedValue(undefined);
 const mockClearCredentials = vi.fn().mockResolvedValue(undefined);
+const mockVerifyToken = vi.fn().mockResolvedValue(false);
+const mockTryRefreshToken = vi.fn().mockResolvedValue(null);
 const mockLogin = vi.fn().mockResolvedValue({
   token: 'new-token',
   user: { id: 'u1', email: 'user@test.com', firstName: 'A', lastName: 'B' },
@@ -42,6 +44,8 @@ vi.mock('./credentials.js', () => ({
   getCurrentOrgId: mockGetCurrentOrgId,
   setCurrentOrgId: mockSetCurrentOrgId,
   clearCredentials: mockClearCredentials,
+  verifyToken: mockVerifyToken,
+  tryRefreshToken: mockTryRefreshToken,
   login: mockLogin,
 }));
 
@@ -61,6 +65,8 @@ beforeEach(() => {
   vi.resetAllMocks();
   mockGetToken.mockResolvedValue('test-token');
   mockGetCurrentOrgId.mockResolvedValue('org-1');
+  mockVerifyToken.mockResolvedValue(false);
+  mockTryRefreshToken.mockResolvedValue(null);
   mockFetchOrgs.mockResolvedValue([
     { id: 'org-1', name: 'Test Org', role: 'admin', isCurrent: true },
     { id: 'org-2', name: 'Other Org', role: 'member', isCurrent: false },
@@ -77,7 +83,59 @@ afterEach(() => {
 /* ------------------------------------------------------------------ */
 
 describe('loginAction', () => {
-  it('calls login()', async () => {
+  it('calls login() when no existing credentials', async () => {
+    mockLoadCredentials.mockResolvedValue(null);
+    const { loginAction } = await import('./login.js');
+    await loginAction();
+    expect(mockLogin).toHaveBeenCalled();
+  });
+
+  it('skips login() and prints user when existing token is still valid', async () => {
+    mockLoadCredentials.mockResolvedValue({
+      token: 'tok',
+      user: { id: 'u1', email: 'existing@test.com', firstName: 'A', lastName: 'B' },
+      organizationId: 'org-1',
+    });
+    mockVerifyToken.mockResolvedValue(true);
+
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { loginAction } = await import('./login.js');
+    await loginAction();
+
+    expect(mockLogin).not.toHaveBeenCalled();
+    const output = spy.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('Already logged in as existing@test.com');
+    spy.mockRestore();
+  });
+
+  it('skips login() when refresh succeeds for an expired token', async () => {
+    mockLoadCredentials.mockResolvedValue({
+      token: 'expired',
+      refreshToken: 'r',
+      user: { id: 'u1', email: 'existing@test.com', firstName: 'A', lastName: 'B' },
+      organizationId: 'org-1',
+    });
+    mockVerifyToken.mockResolvedValue(false);
+    mockTryRefreshToken.mockResolvedValue('new-tok');
+
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { loginAction } = await import('./login.js');
+    await loginAction();
+
+    expect(mockLogin).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('falls back to login() when verify and refresh both fail', async () => {
+    mockLoadCredentials.mockResolvedValue({
+      token: 'expired',
+      refreshToken: 'r',
+      user: { id: 'u1', email: 'existing@test.com', firstName: 'A', lastName: 'B' },
+      organizationId: 'org-1',
+    });
+    mockVerifyToken.mockResolvedValue(false);
+    mockTryRefreshToken.mockResolvedValue(null);
+
     const { loginAction } = await import('./login.js');
     await loginAction();
     expect(mockLogin).toHaveBeenCalled();

--- a/packages/cli/src/commands/auth/credentials.ts
+++ b/packages/cli/src/commands/auth/credentials.ts
@@ -88,6 +88,19 @@ function openBrowser(url: string) {
   }
 }
 
+export async function verifyToken(token: string): Promise<boolean> {
+  // Use plain fetch — NOT authenticatedFetch — to avoid its 401 interceptor
+  // triggering a redundant refresh cycle.
+  try {
+    const res = await fetch(`${MASTRA_PLATFORM_API_URL}/v1/auth/verify`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 export async function tryRefreshToken(creds: Credentials): Promise<string | null> {
   if (!creds.refreshToken) return null;
 
@@ -266,16 +279,7 @@ export async function getToken(): Promise<string> {
   }
 
   // Try a quick verify to see if the token is still valid.
-  // Use plain fetch to avoid authenticatedFetch's 401 interceptor
-  // which would trigger a redundant refresh cycle.
-  try {
-    const res = await fetch(`${MASTRA_PLATFORM_API_URL}/v1/auth/verify`, {
-      headers: { Authorization: `Bearer ${creds.token}` },
-    });
-    if (res.ok) return creds.token;
-  } catch {
-    // Network error — try refresh
-  }
+  if (await verifyToken(creds.token)) return creds.token;
 
   // Token might be expired — attempt refresh
   const refreshed = await tryRefreshToken(creds);

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -1,6 +1,14 @@
-import { login, clearCredentials } from './credentials.js';
+import { login, clearCredentials, loadCredentials, verifyToken, tryRefreshToken } from './credentials.js';
 
 export async function loginAction() {
+  const existing = await loadCredentials();
+  if (existing) {
+    const stillValid = (await verifyToken(existing.token)) || Boolean(await tryRefreshToken(existing));
+    if (stillValid) {
+      console.info(`\nAlready logged in as ${existing.user.email}\n`);
+      return;
+    }
+  }
   await login();
 }
 

--- a/packages/cli/src/commands/init/utils.test.ts
+++ b/packages/cli/src/commands/init/utils.test.ts
@@ -53,11 +53,13 @@ describe('promptForObservability', () => {
 
   test('prints logged-in user when creds existed before getToken()', async () => {
     selectMock.mockResolvedValueOnce('yes' as never);
-    loadCredentialsMock.mockResolvedValueOnce({
+    const creds = {
       token: 'tok',
       user: { id: 'u1', email: 'existing@test.com', firstName: 'A', lastName: 'B' },
       organizationId: 'org-1',
-    } as never);
+    } as never;
+    loadCredentialsMock.mockResolvedValueOnce(creds);
+    loadCredentialsMock.mockResolvedValueOnce(creds);
 
     await promptForObservability();
 
@@ -71,6 +73,26 @@ describe('promptForObservability', () => {
     await promptForObservability();
 
     expect(vi.mocked(prompts.log.info)).not.toHaveBeenCalled();
+  });
+
+  test('prints the post-auth user when stale creds force a fresh login as a different account', async () => {
+    selectMock.mockResolvedValueOnce('yes' as never);
+    // Pre-auth: stale creds for an old user
+    loadCredentialsMock.mockResolvedValueOnce({
+      token: 'stale',
+      user: { id: 'u1', email: 'old@test.com', firstName: 'A', lastName: 'B' },
+      organizationId: 'org-1',
+    } as never);
+    // Post-auth: new creds written by login() for a different user
+    loadCredentialsMock.mockResolvedValueOnce({
+      token: 'new',
+      user: { id: 'u2', email: 'new@test.com', firstName: 'C', lastName: 'D' },
+      organizationId: 'org-2',
+    } as never);
+
+    await promptForObservability();
+
+    expect(vi.mocked(prompts.log.info)).toHaveBeenCalledWith('Logged in as new@test.com');
   });
 });
 

--- a/packages/cli/src/commands/init/utils.test.ts
+++ b/packages/cli/src/commands/init/utils.test.ts
@@ -12,23 +12,27 @@ vi.mock('node:fs/promises', async () => {
 vi.mock('@clack/prompts', () => ({
   select: vi.fn(),
   isCancel: (v: unknown) => typeof v === 'symbol',
+  log: { info: vi.fn() },
 }));
 
 vi.mock('../auth/credentials.js', () => ({
   getToken: vi.fn(),
+  loadCredentials: vi.fn(),
 }));
 
 const { promptForObservability, writeObservabilityEnv } = await import('./utils');
 const prompts = await import('@clack/prompts');
-const { getToken } = await import('../auth/credentials.js');
+const { getToken, loadCredentials } = await import('../auth/credentials.js');
 
 const selectMock = vi.mocked(prompts.select);
 const getTokenMock = vi.mocked(getToken);
+const loadCredentialsMock = vi.mocked(loadCredentials);
 
 describe('promptForObservability', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getTokenMock.mockResolvedValue('platform-token');
+    loadCredentialsMock.mockResolvedValue(null);
   });
 
   test('starts platform auth immediately when observability is enabled', async () => {
@@ -45,6 +49,28 @@ describe('promptForObservability', () => {
     await expect(promptForObservability()).resolves.toEqual({ enabled: false });
 
     expect(getTokenMock).not.toHaveBeenCalled();
+  });
+
+  test('prints logged-in user when creds existed before getToken()', async () => {
+    selectMock.mockResolvedValueOnce('yes' as never);
+    loadCredentialsMock.mockResolvedValueOnce({
+      token: 'tok',
+      user: { id: 'u1', email: 'existing@test.com', firstName: 'A', lastName: 'B' },
+      organizationId: 'org-1',
+    } as never);
+
+    await promptForObservability();
+
+    expect(vi.mocked(prompts.log.info)).toHaveBeenCalledWith('Logged in as existing@test.com');
+  });
+
+  test('does not print logged-in user when creds were created by login()', async () => {
+    selectMock.mockResolvedValueOnce('yes' as never);
+    loadCredentialsMock.mockResolvedValueOnce(null);
+
+    await promptForObservability();
+
+    expect(vi.mocked(prompts.log.info)).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -11,7 +11,7 @@ import yoctoSpinner from 'yocto-spinner';
 
 import { DepsService } from '../../services/service.deps';
 import { FileService } from '../../services/service.file';
-import { getToken } from '../auth/credentials.js';
+import { getToken, loadCredentials } from '../auth/credentials.js';
 import {
   cursorGlobalMCPConfigPath,
   windsurfGlobalMCPConfigPath,
@@ -45,7 +45,12 @@ export async function promptForObservability(): Promise<ObservabilityPromptResul
   if (p.isCancel(choice)) return {};
   if (choice !== 'yes') return { enabled: false };
 
+  // Only surface the logged-in user when creds already existed before getToken().
+  // If they didn't, getToken() ran the browser login() flow which prints its own
+  // "Logged in as <email>" message — printing again here would duplicate it.
+  const preExisting = await loadCredentials();
   const token = await getToken();
+  if (preExisting) p.log.info(`Logged in as ${preExisting.user.email}`);
   return { enabled: true, token };
 }
 

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -48,9 +48,14 @@ export async function promptForObservability(): Promise<ObservabilityPromptResul
   // Only surface the logged-in user when creds already existed before getToken().
   // If they didn't, getToken() ran the browser login() flow which prints its own
   // "Logged in as <email>" message — printing again here would duplicate it.
-  const preExisting = await loadCredentials();
+  // Re-read creds after getToken() so the email reflects the actual logged-in
+  // account, even when stale creds forced a browser re-login as a different user.
+  const hadCachedCreds = (await loadCredentials()) !== null;
   const token = await getToken();
-  if (preExisting) p.log.info(`Logged in as ${preExisting.user.email}`);
+  if (hadCachedCreds) {
+    const creds = await loadCredentials();
+    if (creds) p.log.info(`Logged in as ${creds.user.email}`);
+  }
   return { enabled: true, token };
 }
 


### PR DESCRIPTION
`mastra auth login` and the auth step of `mastra create` now print which account you're logged in as. Previously `auth login` re-ran the full browser flow every time with no confirmation of the resulting account, and `create` silently resolved cached credentials without telling you which account observability would be enabled for.

```
$ mastra auth login

Already logged in as you@example.com
```

```
$ mastra create
...
◇  Enable Mastra Observability? (will open auth flow)
│  Yes
│
◇  Logged in as you@example.com
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you run `mastra auth login` or `mastra create`, the CLI now tells you which user account you're logged in as. If you're already logged in, it skips the browser login step and just confirms your identity. This prevents confusion about which account is being used, especially when dealing with multiple accounts.

## Overview

This PR improves authentication transparency in the Mastra CLI by displaying the logged-in user's email address during authentication flows and optimizing the login process to reuse valid cached credentials.

## Key Changes

### **Authentication Reuse & Login Optimization** (`auth/login.ts`)
- `loginAction()` now checks for previously saved credentials before initiating the browser login flow
- If cached credentials exist and are still valid (verified via token check or refresh), it logs "Already logged in as {email}" and exits early, avoiding unnecessary browser-based re-authentication
- Maintains the existing login behavior (with browser flow messaging) only when no cached credentials exist

### **Token Verification Helper** (`auth/credentials.ts`)
- New exported function `verifyToken(token: string): Promise<boolean>` validates a token against the platform's `/v1/auth/verify` endpoint
- Uses plain `fetch` instead of authenticated interceptors to avoid recursive refresh loops
- Updated `getToken()` to leverage this helper for quicker token validity checks

### **Observability Prompt Enhancement** (`init/utils.ts`)
- `promptForObservability()` now detects whether credentials were cached before calling `getToken()`
- After authentication resolves, re-reads credentials to capture the actual logged-in user's email (correcting for scenarios where stale credentials triggered a fresh login as a different user)
- Conditionally logs "Logged in as {email}" only if cached credentials existed beforehand, preventing duplicate messaging from the browser login flow's own output
- Added `loadCredentials` to imports to support this detection

### **Test Coverage** (`auth/auth.test.ts`, `init/utils.test.ts`)
- Expanded `loginAction` tests to cover four scenarios: fresh login, valid cached token, refresh-after-verification failure, and fallback to browser login
- Added assertions for console output verification
- Extended `promptForObservability` tests to validate conditional email logging based on credential cache state and post-authentication credential re-reading

## Impact

- **Improved UX**: Users now see confirmation of their logged-in account during authentication, eliminating ambiguity about which credentials are active
- **Optimized Flow**: Eliminates redundant browser login flows when valid cached credentials exist
- **Account Safety**: Ensures the displayed email always reflects the actual authenticated user, even if stale cached credentials forced a re-login as a different account

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16512)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->