### PR TITLE
fix(playground): keep Agent Builder edit configure pane open across autosave

### DIFF
--- a/.changeset/fine-apples-help.md
+++ b/.changeset/fine-apples-help.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Agent Builder edit page closing the configure detail pane after autosave. The readiness check now uses React Query's `isLoading` (initial load only) instead of `isPending`, so background refetches triggered by autosave no longer remount the page and reset the open detail pane.

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/edit-msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/edit-msw.test.tsx
@@ -213,4 +213,47 @@ describe('AgentBuilderAgentEdit MSW integration — visibility immediate-persist
       expect(screen.queryByTestId('agent-builder-visibility-confirm-dialog')).toBeNull();
     });
   });
+
+  it('keeps the configure detail pane mounted after an autosave round-trip', async () => {
+    let patchCount = 0;
+    server.use(
+      ...baseHandlers(),
+      http.patch(`${BASE_URL}/api/stored/agents/agent-123`, async ({ request }) => {
+        patchCount += 1;
+        const body = (await request.json()) as Partial<typeof storedAgent>;
+        return HttpResponse.json({ ...storedAgent, ...body });
+      }),
+    );
+
+    renderPage();
+
+    // Open the instructions detail pane.
+    const openInstructions = await screen.findByTestId('agent-preview-edit-system-prompt');
+    fireEvent.click(openInstructions);
+
+    // Detail pane must be mounted before we trigger the autosave.
+    expect(await screen.findByTestId('instructions-detail-close')).toBeTruthy();
+
+    // Edit the name to trigger autosave (debounced 600ms).
+    const nameInput = (await screen.findByTestId('agent-configure-name')) as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'MSW Agent Renamed' } });
+
+    // Autosave fires after debounce and PATCHes the stored agent. The success path
+    // invalidates ['stored-agent', id] and friends, causing background refetches.
+    await waitFor(
+      () => {
+        expect(patchCount).toBeGreaterThan(0);
+      },
+      { timeout: 3000 },
+    );
+
+    // Let the invalidation-triggered refetches settle.
+    await waitFor(() => {
+      expect(screen.queryByTestId('agent-builder-autosave-saved')).toBeTruthy();
+    });
+
+    // Regression guard: the ready gate must not flip back to the skeleton on
+    // refetch, so the configure detail pane must remain mounted.
+    expect(screen.queryByTestId('instructions-detail-close')).toBeTruthy();
+  });
 });

--- a/packages/playground/src/pages/agent-builder/agents/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/edit.tsx
@@ -46,10 +46,10 @@ export default function AgentBuilderAgentEdit() {
   const features = useBuilderAgentFeatures();
   const initialUserMessage = useStarterUserMessage();
   const { data: storedAgent, isLoading: isStoredAgentLoading } = useStoredAgent(id, { status: 'draft' });
-  const { data: toolsData, isPending: isToolsPending } = useTools({ enabled: features.tools });
-  const { data: agentsData, isPending: isAgentsPending } = useAgents({ enabled: features.agents });
-  const { data: workflowsData, isPending: isWorkflowsPending } = useWorkflows({ enabled: features.workflows });
-  const { data: storedSkillsResponse, isPending: isSkillsPending } = useStoredSkills(undefined, {
+  const { data: toolsData, isLoading: isToolsLoading } = useTools({ enabled: features.tools });
+  const { data: agentsData, isLoading: isAgentsLoading } = useAgents({ enabled: features.agents });
+  const { data: workflowsData, isLoading: isWorkflowsLoading } = useWorkflows({ enabled: features.workflows });
+  const { data: storedSkillsResponse, isLoading: isSkillsLoading } = useStoredSkills(undefined, {
     enabled: features.skills,
   });
   const { data: workspacesData } = useStoredWorkspaces();
@@ -60,10 +60,10 @@ export default function AgentBuilderAgentEdit() {
     Boolean(id) &&
     !isStoredAgentLoading &&
     !isOwnershipLoading &&
-    (!features.tools || !isToolsPending) &&
-    (!features.skills || !isSkillsPending) &&
-    (!features.agents || !isAgentsPending) &&
-    (!features.workflows || !isWorkflowsPending);
+    (!features.tools || !isToolsLoading) &&
+    (!features.skills || !isSkillsLoading) &&
+    (!features.agents || !isAgentsLoading) &&
+    (!features.workflows || !isWorkflowsLoading);
 
   const availableWorkspaces = useMemo<AvailableWorkspace[]>(
     () =>


### PR DESCRIPTION
Editing an agent in the Agent Builder caused the configure detail pane (instructions, tools, skills) to close on every autosave. The page's ready gate used React Query's `isPending`, which can flip true again on background refetches with no cached data — autosave invalidates the stored-agent query, the gate briefly became false, the whole edit tree unmounted, and `WorkspaceLayout` / `activeDetail` reset.

Swapped the gate to `isLoading`, which only covers the initial load and stays false through background refetches, so the edit tree survives autosave-driven invalidations.

```ts
// before
const { data: toolsData, isPending: isToolsPending } = useTools({ enabled: features.tools });
const isReady = ... && (!features.tools || !isToolsPending) && ...;

// after
const { data: toolsData, isLoading: isToolsLoading } = useTools({ enabled: features.tools });
const isReady = ... && (!features.tools || !isToolsLoading) && ...;
```

Added an MSW regression test that opens the instructions pane, edits the name to trigger autosave, waits for the PATCH and `agent-builder-autosave-saved`, then asserts `instructions-detail-close` is still mounted.
