### PR TITLE
fix(core): infer createTool execute inputData type from Zod schema

### DIFF
--- a/.changeset/stale-pigs-retire.md
+++ b/.changeset/stale-pigs-retire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `createTool`'s `execute` callback `inputData` parameter being typed as `any` instead of the inferred schema type when using Zod schemas. TypeScript now correctly infers the input type without requiring explicit annotation.

--- a/packages/core/src/tools/createtool-inputdata-types.test-d.ts
+++ b/packages/core/src/tools/createtool-inputdata-types.test-d.ts
@@ -1,0 +1,80 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod/v4';
+import z3 from 'zod/v3';
+import { createTool } from './tool';
+
+/**
+ * Type tests for issue #16528:
+ * `createTool`'s `execute` callback `inputData` parameter should be typed
+ * as the inferred schema type, not `any`.
+ *
+ * Before the fix, TypeScript deferred `InferSchema<TInputSchema>` as a
+ * conditional type when `inputSchema` and `execute` were resolved in the
+ * same object literal, causing `inputData` to fall back to `any`.
+ *
+ * The fix adds Zod v4 and v3 overloads that bind `TInput` directly from
+ * `ZodType<TInput>`, so the type is available when TypeScript processes
+ * the `execute` callback.
+ */
+describe('createTool inputData type inference (issue #16528)', () => {
+  it('should infer inputData type from zod v4 inputSchema — not any', () => {
+    createTool({
+      id: 'test',
+      description: 'test',
+      inputSchema: z.object({ name: z.string(), age: z.number() }),
+      execute: async inputData => {
+        expectTypeOf(inputData).toEqualTypeOf<{ name: string; age: number }>();
+        return {};
+      },
+    });
+  });
+
+  it('should infer inputData type from zod v3 inputSchema — not any', () => {
+    createTool({
+      id: 'test',
+      description: 'test',
+      inputSchema: z3.object({ name: z3.string(), age: z3.number() }),
+      execute: async inputData => {
+        expectTypeOf(inputData).toEqualTypeOf<{ name: string; age: number }>();
+        return {};
+      },
+    });
+  });
+
+  it('should infer inputData with optional fields correctly (zod v4)', () => {
+    createTool({
+      id: 'test',
+      description: 'test',
+      inputSchema: z.object({ name: z.string(), email: z.string().optional() }),
+      execute: async inputData => {
+        expectTypeOf(inputData).toEqualTypeOf<{ name: string; email?: string | undefined }>();
+        return {};
+      },
+    });
+  });
+
+  it('should infer inputData with enum fields correctly (zod v4)', () => {
+    createTool({
+      id: 'test',
+      description: 'test',
+      inputSchema: z.object({ op: z.enum(['add', 'sub']), a: z.number(), b: z.number() }),
+      execute: async inputData => {
+        expectTypeOf(inputData).toEqualTypeOf<{ op: 'add' | 'sub'; a: number; b: number }>();
+        return {};
+      },
+    });
+  });
+
+  it('should infer outputData type from zod v4 outputSchema', () => {
+    createTool({
+      id: 'test',
+      description: 'test',
+      inputSchema: z.object({ name: z.string() }),
+      outputSchema: z.object({ greeting: z.string() }),
+      execute: async inputData => {
+        expectTypeOf(inputData).toEqualTypeOf<{ name: string }>();
+        return { greeting: `Hello ${inputData.name}` };
+      },
+    });
+  });
+});

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -1,3 +1,5 @@
+import type { ZodSchema as ZodSchemaV3 } from 'zod/v3';
+import type { ZodType as ZodTypeV4 } from 'zod/v4';
 import type { Mastra } from '../mastra';
 import { RequestContext } from '../request-context';
 import { toStandardSchema } from '../schema';
@@ -537,6 +539,80 @@ type CreateToolOpts<
   suspendSchema?: TSuspendSchema;
   resumeSchema?: TResumeSchema;
 };
+
+// Overload opts for Zod v4 schemas: TInput/TOutput bound directly, bypassing deferred conditional types
+type CreateToolOptsZodV4<
+  TId extends string,
+  TInput,
+  TOutput,
+  TSuspend,
+  TResume,
+  TRequestContext,
+  TContext extends ToolExecutionContext<TSuspend, TResume, TRequestContext>,
+> = Omit<
+  ToolAction<TInput, TOutput, TSuspend, TResume, TContext, TId, TRequestContext>,
+  'inputSchema' | 'outputSchema' | 'suspendSchema' | 'resumeSchema'
+> & {
+  inputSchema: ZodTypeV4<TInput, any>;
+  outputSchema?: ZodTypeV4<TOutput, any>;
+  suspendSchema?: ZodTypeV4<TSuspend, any>;
+  resumeSchema?: ZodTypeV4<TResume, any>;
+};
+
+// Overload opts for Zod v3 schemas: TInput/TOutput bound directly, bypassing deferred conditional types
+type CreateToolOptsZodV3<
+  TId extends string,
+  TInput,
+  TOutput,
+  TSuspend,
+  TResume,
+  TRequestContext,
+  TContext extends ToolExecutionContext<TSuspend, TResume, TRequestContext>,
+> = Omit<
+  ToolAction<TInput, TOutput, TSuspend, TResume, TContext, TId, TRequestContext>,
+  'inputSchema' | 'outputSchema' | 'suspendSchema' | 'resumeSchema'
+> & {
+  inputSchema: ZodSchemaV3<TInput, any, any>;
+  outputSchema?: ZodSchemaV3<TOutput, any, any>;
+  suspendSchema?: ZodSchemaV3<TSuspend, any, any>;
+  resumeSchema?: ZodSchemaV3<TResume, any, any>;
+};
+
+// Overload 1: Zod v4 inputSchema — TInput inferred directly without conditional type deferral
+export function createTool<
+  TId extends string = string,
+  TInput = unknown,
+  TOutput = unknown,
+  TSuspend = unknown,
+  TResume = unknown,
+  TRequestContext extends Record<string, any> | unknown = unknown,
+  TContext extends ToolExecutionContext<TSuspend, TResume, TRequestContext> = ToolExecutionContext<
+    TSuspend,
+    TResume,
+    TRequestContext
+  >,
+>(
+  opts: CreateToolOptsZodV4<TId, TInput, TOutput, TSuspend, TResume, TRequestContext, TContext>,
+): Tool<TInput, TOutput, TSuspend, TResume, TContext, TId, TRequestContext>;
+
+// Overload 2: Zod v3 inputSchema — TInput inferred directly without conditional type deferral
+export function createTool<
+  TId extends string = string,
+  TInput = unknown,
+  TOutput = unknown,
+  TSuspend = unknown,
+  TResume = unknown,
+  TRequestContext extends Record<string, any> | unknown = unknown,
+  TContext extends ToolExecutionContext<TSuspend, TResume, TRequestContext> = ToolExecutionContext<
+    TSuspend,
+    TResume,
+    TRequestContext
+  >,
+>(
+  opts: CreateToolOptsZodV3<TId, TInput, TOutput, TSuspend, TResume, TRequestContext, TContext>,
+): Tool<TInput, TOutput, TSuspend, TResume, TContext, TId, TRequestContext>;
+
+// Overload 3: generic fallback for all other schema types (JSONSchema7, AI SDK Schema, etc.)
 export function createTool<
   TId extends string = string,
   TInputSchema extends SchemaLike = undefined,
@@ -556,6 +632,9 @@ export function createTool<
   TContext,
   TId,
   TRequestContext
-> {
+>;
+
+// Implementation — compatible with all overloads above
+export function createTool(opts: any): any {
   return new Tool(opts);
 }


### PR DESCRIPTION
## Summary

Closes #16528

- Add Zod v4 and v3 overloads to `createTool` that bind `TInput` directly from `ZodType<TInput, any>` / `ZodSchemaV3<TInput, any, any>`
- The new overloads bypass the deferred conditional type `InferSchema<TInputSchema>` that causes `inputData` to fall back to `any`
- Add type test file `createtool-inputdata-types.test-d.ts` with `expectTypeOf(...).toEqualTypeOf<>()` assertions to prevent regression

## Root cause

When both `inputSchema` and `execute` are in the same object literal passed to `createTool`, TypeScript cannot resolve the conditional type `InferSchema<TInputSchema>` as a contextual type for the `execute` callback parameter because `TInputSchema` is still an unresolved type variable. This causes `inputData` to fall back to `any`.

## Fix

Add two overloads (Zod v4 and v3) where `TInput` is a direct type parameter inferred from `ZodType<TInput, any>`. Since `TInput` appears directly — not inside a conditional type — TypeScript can resolve it eagerly and use it as the contextual type for `execute`'s first parameter.

```typescript
// Before fix: inputData is `any` — no TS error on nonexistent property
createTool({
  id: 'test',
  inputSchema: z.object({ name: z.string() }),
  execute: async (inputData) => {
    const x = inputData.this_does_not_exist; // no error!
    return {};
  },
});

// After fix: inputData is `{ name: string }` — TS error on nonexistent property
createTool({
  id: 'test',
  inputSchema: z.object({ name: z.string() }),
  execute: async (inputData) => {
    const name: string = inputData.name; // ✅ typed correctly
    const x = inputData.nonExistent;     // ✅ TS2339 error now
    return {};
  },
});
```

The workaround of explicitly annotating `inputData: z.infer<typeof schema>` is no longer needed.

## Test plan

- [ ] New type test file `packages/core/src/tools/createtool-inputdata-types.test-d.ts` with 5 `expectTypeOf(...).toEqualTypeOf<>()` assertions verifying Zod v4 and v3 schemas produce exact types (not `any`)
- [ ] Existing `createtool-types.test.ts` tests (12 tests) still pass
- [ ] No new TypeScript errors introduced in `packages/core/src/tools/tool.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When you used a TypeScript tool called `createTool` with a schema (a description of what type of data you expect), the code inside the tool couldn't tell what type of data it was getting—it just saw it as "anything" (`any`). This PR fixes that by teaching TypeScript to look at the schema and automatically figure out what type of data the tool is actually receiving, so you get helpful error messages if you try to use the wrong type.

## Changes

### Core Typing Fix

Added two TypeScript function overloads to `createTool` in `packages/core/src/tools/tool.ts` that enable proper type inference for the `execute` callback's `inputData` parameter:

- **Zod v4 overload**: Accepts `inputSchema: ZodTypeV4<TInput, any>` and binds the generic type `TInput` directly from the schema, ensuring `inputData` is typed as `TInput`
- **Zod v3 overload**: Accepts `inputSchema: ZodSchemaV3<TInput, any, any>` with the same direct type binding approach

These overloads bypass the deferred conditional type resolution that was causing `inputData` to fall back to `any` when both `inputSchema` and `execute` were inferred simultaneously in the same object literal.

### Type Testing

Added `packages/core/src/tools/createtool-inputdata-types.test-d.ts` with TypeScript type assertions covering:
- Zod v4 and v3 schema input type inference
- Optional field handling in schemas
- Enum literal union type inference
- Output schema type inference

### Release Documentation

Added changeset entry documenting the fix as a patch release for `@mastra/core`.

## Impact

With this fix, TypeScript now correctly infers `inputData` types from Zod schemas without explicit type annotations, enabling full type checking within `execute` callbacks and preventing runtime type errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16530)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->