### PR TITLE
chore: add CodeRabbit local review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ when package splits unit integration or E2E coverage run narrowest suite first
 From root prefer specific scripts like pnpm build:core or pnpm --filter ./packages/name script
 Do not pnpm run setup pnpm build pnpm build:packages or repo wide test runs when package local is enough
 Building whole monorepo is slow and should be last resort
+Before pushing commits or opening PRs run the narrowest relevant local checks; if CodeRabbit CLI is installed and configured, run a local CodeRabbit review too
 some integration tests need pnpm i --ignore-workspace
 
 features and new packages need related docs updates


### PR DESCRIPTION
Adds a short line to `AGENTS.md` clarifying that agents should run the narrowest relevant local checks before pushing commits or opening PRs, and run a local CodeRabbit review when the CLI is installed and configured.

This keeps the existing package-local verification guidance intact and makes the CodeRabbit step conditional for environments where the CLI is not available.

Fixes #16533.

Tested with:

```bash
git diff --check
coderabbit review --type uncommitted --plain
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development guidelines to recommend running local checks before pushing commits or opening pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16534)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->