### PR TITLE
Fix Koa adapter crash when registerRoute called with non-standard host

### DIFF
--- a/.changeset/koa-register-route-missing-middleware.md
+++ b/.changeset/koa-register-route-missing-middleware.md
@@ -1,0 +1,5 @@
+---
+'@mastra/koa': patch
+---
+
+Fixed a startup crash in the Koa adapter when `registerRoute()` was called with a host that doesn't expose Koa's internal `middleware` array (for example a router, sub-app, or a subclass that calls `super.registerRoute()` with a custom wrapper). Previously this threw `TypeError: Cannot read properties of undefined (reading 'length')` during route registration, breaking apps that had registered custom routes after upgrading from `1.4.x`. The dispatcher-group cache now tolerates a missing `middleware` array and falls back to reusing the cached group.

--- a/.changeset/koa-register-route-missing-middleware.md
+++ b/.changeset/koa-register-route-missing-middleware.md
@@ -2,4 +2,4 @@
 '@mastra/koa': patch
 ---
 
-Fixed a startup crash in the Koa adapter when `registerRoute()` was called with a host that doesn't expose Koa's internal `middleware` array (for example a router, sub-app, or a subclass that calls `super.registerRoute()` with a custom wrapper). Previously this threw `TypeError: Cannot read properties of undefined (reading 'length')` during route registration, breaking apps that had registered custom routes after upgrading from `1.4.x`. The dispatcher-group cache now tolerates a missing `middleware` array and falls back to reusing the cached group.
+Fixed a startup crash when registering custom API routes on subclassed Koa adapters. Upgrading from 1.4.x to 1.5.x caused `TypeError: Cannot read properties of undefined (reading 'length')` during route registration.

--- a/server-adapters/koa/src/__tests__/koa-adapter.test.ts
+++ b/server-adapters/koa/src/__tests__/koa-adapter.test.ts
@@ -349,6 +349,46 @@ describe('Koa Server Adapter', () => {
       expect(secondResponse.status).toBe(200);
       await expect(secondResponse.json()).resolves.toEqual({ route: 'second' });
     });
+
+    it('does not crash when registerRoute is called with a host whose middleware stack is not exposed', async () => {
+      // Subclasses sometimes call super.registerRoute() with a wrapper instead of a raw
+      // Koa instance. The wrapper may not expose `middleware`. We should tolerate that
+      // rather than throwing `Cannot read properties of undefined (reading 'length')`.
+      const app = new Koa();
+      app.use(bodyParser());
+
+      const adapter = new MastraServer({
+        app,
+        mastra: new Mastra({}),
+      });
+
+      const hostWithoutMiddlewareArray = {
+        use: app.use.bind(app),
+      } as unknown as Koa;
+
+      await expect(
+        adapter.registerRoute(
+          hostWithoutMiddlewareArray,
+          {
+            method: 'POST',
+            path: '/chat',
+            responseType: 'json',
+            handler: async () => ({ ok: true }),
+          },
+          { prefix: '' },
+        ),
+      ).resolves.toBeUndefined();
+
+      server = await new Promise(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      const response = await fetch(`http://localhost:${port}/chat`, { method: 'POST' });
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true });
+    });
   });
 
   describe('Stream Data Redaction', () => {

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -270,8 +270,17 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
   }
 
   private getRouteDispatcherGroup(app: Koa): RouteDispatcherGroup {
+    // app.middleware is Koa's internal middleware stack. We sniff its length to detect
+    // when another middleware was added after our dispatcher so we can start a new group
+    // and preserve registration order. Subclasses or non-standard hosts may not expose it,
+    // in which case we fall back to reusing the cached group rather than crashing.
+    const middlewareCount = Array.isArray(app.middleware) ? app.middleware.length : undefined;
+
     const activeGroup = this.activeRouteDispatchers.get(app);
-    if (activeGroup && app.middleware.length === activeGroup.stackLengthAfterRegistration) {
+    if (
+      activeGroup &&
+      (middlewareCount === undefined || middlewareCount === activeGroup.stackLengthAfterRegistration)
+    ) {
       return activeGroup;
     }
 
@@ -280,7 +289,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       stackLengthAfterRegistration: 0,
     };
     app.use(this.createRouteDispatcherMiddleware(group));
-    group.stackLengthAfterRegistration = app.middleware.length;
+    group.stackLengthAfterRegistration = Array.isArray(app.middleware) ? app.middleware.length : 0;
     this.activeRouteDispatchers.set(app, group);
     return group;
   }


### PR DESCRIPTION
Closing in favor of #16484, which is a more correct fix — it avoids the reuse-cache entirely on non-Koa targets, preserving middleware ordering when `super.registerRoute()` is interleaved with other `app.use` calls on a router-like wrapper.