### PR TITLE
feat(mastracode): add Codex device login and MCP OAuth config

### DIFF
--- a/.changeset/tough-ants-greet.md
+++ b/.changeset/tough-ants-greet.md
@@ -2,4 +2,23 @@
 'mastracode': minor
 ---
 
-Added OpenAI Codex OAuth support to Mastra Code, including a device-code mode for headless or remote environments. HTTP MCP server config can now pass OAuth client metadata to `@mastra/mcp` and store per-server OAuth state without sharing tokens across projects.
+Improved OpenAI Codex OAuth support in Mastra Code, including a device-code mode for headless or remote environments. HTTP MCP server config can now pass OAuth client metadata to `@mastra/mcp` and store per-server OAuth state without sharing tokens across projects.
+
+Example:
+
+```sh
+export MASTRACODE_OPENAI_CODEX_AUTH_MODE=device
+```
+
+```json
+{
+  "mcpServers": {
+    "remote-api": {
+      "url": "https://mcp.example.com/mcp",
+      "oauth": {
+        "redirectUrl": "http://localhost:3000/oauth/callback"
+      }
+    }
+  }
+}
+```

--- a/.changeset/tough-ants-greet.md
+++ b/.changeset/tough-ants-greet.md
@@ -2,13 +2,9 @@
 'mastracode': minor
 ---
 
-Improved OpenAI Codex OAuth support in Mastra Code, including a device-code mode for headless or remote environments. HTTP MCP server config can now pass OAuth client metadata to `@mastra/mcp` and store per-server OAuth state without sharing tokens across projects.
+Improved OpenAI Codex OAuth support in Mastra Code. When you select the Codex provider in `/login` or during onboarding, Mastra Code now asks how to sign in — **Browser (local callback)** or **Device code (headless)** — so the device-code flow is discoverable without setting an env var. `MASTRACODE_OPENAI_CODEX_AUTH_MODE=device` still works as a preselect for scripted environments.
 
-Example:
-
-```sh
-export MASTRACODE_OPENAI_CODEX_AUTH_MODE=device
-```
+HTTP MCP server config can now pass OAuth client metadata to `@mastra/mcp` and store per-server OAuth state without sharing tokens across projects:
 
 ```json
 {

--- a/.changeset/tough-ants-greet.md
+++ b/.changeset/tough-ants-greet.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added OpenAI Codex OAuth support to Mastra Code, including a device-code mode for headless or remote environments. HTTP MCP server config can now pass OAuth client metadata to `@mastra/mcp` and store per-server OAuth state without sharing tokens across projects.

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -53,6 +53,12 @@ If you have an Anthropic Claude Max or OpenAI ChatGPT Plus subscription, you can
 
 OAuth credentials are stored in `auth.json` alongside the database in the app data directory. During onboarding, you can skip the OAuth step if you already have API keys configured.
 
+OpenAI OAuth uses the browser flow by default. Set `MASTRACODE_OPENAI_CODEX_AUTH_MODE=device` before running Mastra Code to use a device-code flow for headless or remote environments.
+
+```sh
+export MASTRACODE_OPENAI_CODEX_AUTH_MODE=device
+```
+
 ### Authentication priority for Anthropic
 
 When resolving Anthropic models, Mastra Code checks for credentials in this order:
@@ -118,7 +124,45 @@ Connect to a remote MCP server via URL. Requires a `url` field. The optional `he
 }
 ```
 
-Since `headers` only supports static values, use a stdio wrapper for dynamic authentication such as token refresh.
+#### HTTP OAuth
+
+HTTP servers can also use OAuth when the server supports MCP authorization. Add an `oauth` object with a `redirectUrl`. Mastra Code stores OAuth client data and tokens in the app data directory.
+
+Mastra Code passes this configuration to `@mastra/mcp` when connecting. The redirect URL must use HTTPS unless it is a loopback HTTP URL, and it must be handled by a callback endpoint that can complete the OAuth flow for that server.
+
+```json title=".mastracode/mcp.json"
+{
+  "mcpServers": {
+    "remote-api": {
+      "url": "https://mcp.example.com/mcp",
+      "oauth": {
+        "redirectUrl": "http://localhost:3000/oauth/callback",
+        "clientName": "Remote MCP",
+        "scopes": ["mcp:read", "mcp:write"]
+      }
+    }
+  }
+}
+```
+
+Use `clientId` and `clientSecret` when the MCP server requires a pre-registered OAuth client:
+
+```json title=".mastracode/mcp.json"
+{
+  "mcpServers": {
+    "remote-api": {
+      "url": "https://mcp.example.com/mcp",
+      "oauth": {
+        "redirectUrl": "http://localhost:3000/oauth/callback",
+        "clientId": "your-client-id",
+        "clientSecret": "your-client-secret"
+      }
+    }
+  }
+}
+```
+
+Do not commit real `clientSecret` values to a repository. Prefer a project-local or global config file that is not shared.
 
 #### Startup behavior
 

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -53,7 +53,12 @@ If you have an Anthropic Claude Max or OpenAI ChatGPT Plus subscription, you can
 
 OAuth credentials are stored in `auth.json` alongside the database in the app data directory. During onboarding, you can skip the OAuth step if you already have API keys configured.
 
-OpenAI OAuth uses the browser flow by default. Set `MASTRACODE_OPENAI_CODEX_AUTH_MODE=device` before running Mastra Code to use a device-code flow for headless or remote environments.
+When you select **ChatGPT Plus/Pro (Codex Subscription)** in `/login` or during onboarding, Mastra Code asks how you want to sign in:
+
+- **Browser (local callback)**: opens the browser and waits for the OAuth callback on localhost. This is the default.
+- **Device code (headless)**: shows a code to enter at `https://auth.openai.com/codex/device` — useful for SSH sessions, remote shells, or environments without a browser.
+
+To preselect the device-code flow (for example in scripts or remote shells where the prompt is inconvenient), set `MASTRACODE_OPENAI_CODEX_AUTH_MODE=device` before launching Mastra Code:
 
 ```sh
 export MASTRACODE_OPENAI_CODEX_AUTH_MODE=device

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -46,6 +46,10 @@ vi.mock('../../providers/openai-codex.js', () => ({
   },
 }));
 
+vi.mock('../../providers/github-copilot.js', () => ({
+  githubCopilotProvider: vi.fn(() => ({ __provider: 'github-copilot' })),
+}));
+
 // Mock @ai-sdk/anthropic
 vi.mock('@ai-sdk/anthropic', () => ({
   createAnthropic: vi.fn((_opts: Record<string, unknown>) => {
@@ -124,15 +128,18 @@ vi.mock('../../onboarding/settings.js', () => ({
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import { MastraGateway, ModelRouterLanguageModel } from '@mastra/core/llm';
-import { RequestContext } from '@mastra/core/request-context';
 import { wrapLanguageModel } from 'ai';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { opencodeClaudeMaxProvider, buildAnthropicOAuthFetch } from '../../providers/claude-max.js';
 import { openaiCodexProvider, buildOpenAICodexOAuthFetch } from '../../providers/openai-codex.js';
-import { resolveModel, getAnthropicApiKey, getOpenAIApiKey } from '../model.js';
+import { resolveModel, getDynamicModel, getAnthropicApiKey, getOpenAIApiKey } from '../model.js';
 
 function makeRequestContext({ threadId, resourceId }: { threadId?: string; resourceId?: string } = {}) {
-  const requestContext = new RequestContext();
+  const values = new Map<string, unknown>();
+  const requestContext = {
+    get: (key: string) => values.get(key),
+    set: (key: string, value: unknown) => values.set(key, value),
+  } as any;
   requestContext.set('harness', {
     threadId,
     resourceId,
@@ -301,6 +308,34 @@ describe('resolveModel', () => {
           'x-thread-id': 'thread-123',
           'x-resource-id': 'resource-456',
         },
+      });
+    });
+
+    it('remaps OpenAI GPT-5 models for Codex OAuth in dynamic model resolution', () => {
+      mockAuthStorageInstance.get.mockReturnValue({
+        type: 'oauth',
+        access: 'openai-oauth-access-token',
+        refresh: 'openai-oauth-refresh-token',
+        expires: Date.now() + 60_000,
+      });
+
+      const values = new Map<string, unknown>();
+      const requestContext = {
+        get: (key: string) => values.get(key),
+        set: (key: string, value: unknown) => values.set(key, value),
+      } as any;
+      requestContext.set('harness', {
+        state: {
+          currentModelId: 'openai/gpt-5.2',
+          thinkingLevel: 'high',
+        },
+      });
+
+      getDynamicModel({ requestContext });
+
+      expect(openaiCodexProvider).toHaveBeenCalledWith('gpt-5.2-codex', {
+        thinkingLevel: 'high',
+        headers: undefined,
       });
     });
   });

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -206,9 +206,7 @@ export function resolveModel(
     // OpenAI Codex OAuth: build model directly with middleware (bypasses ModelRouterLanguageModel)
     // Required because createCodexMiddleware injects instructions, store:false, and reasoningEffort
     if (normalizedModelId.startsWith('openai/') && openaiCred?.type === 'oauth') {
-      const resolvedModelId = options?.remapForCodexOAuth
-        ? remapOpenAIModelForCodexOAuth(normalizedModelId)
-        : normalizedModelId;
+      const resolvedModelId = remapOpenAIModelForCodexOAuth(normalizedModelId);
       const resolvedBareModelId = resolvedModelId.substring('openai/'.length);
       const requestedLevel: ThinkingLevel = options?.thinkingLevel ?? 'medium';
       const effectiveLevel = getEffectiveThinkingLevel(resolvedBareModelId, requestedLevel);
@@ -287,9 +285,7 @@ export function resolveModel(
     const storedCred = authStorage.get('openai-codex');
 
     if (storedCred?.type === 'oauth') {
-      const resolvedModelId = options?.remapForCodexOAuth
-        ? remapOpenAIModelForCodexOAuth(normalizedModelId)
-        : normalizedModelId;
+      const resolvedModelId = remapOpenAIModelForCodexOAuth(normalizedModelId);
       return openaiCodexProvider(resolvedModelId.substring(OPENAI_PREFIX.length), {
         thinkingLevel: options?.thinkingLevel,
         headers,
@@ -321,5 +317,5 @@ export function getDynamicModel({ requestContext }: { requestContext: RequestCon
 
   const thinkingLevel = harnessContext?.state?.thinkingLevel as ThinkingLevel | undefined;
 
-  return resolveModel(modelId, { thinkingLevel, requestContext });
+  return resolveModel(modelId, { thinkingLevel, remapForCodexOAuth: true, requestContext });
 }

--- a/mastracode/src/auth/index.ts
+++ b/mastracode/src/auth/index.ts
@@ -6,3 +6,4 @@ export * from './types.js';
 export * from './storage.js';
 export { anthropicOAuthProvider } from './providers/anthropic.js';
 export { githubCopilotOAuthProvider } from './providers/github-copilot.js';
+export { openaiCodexOAuthProvider } from './providers/openai-codex.js';

--- a/mastracode/src/auth/providers/openai-codex.test.ts
+++ b/mastracode/src/auth/providers/openai-codex.test.ts
@@ -416,3 +416,101 @@ describe('OpenAI Codex device OAuth', () => {
     expect(sleep).toHaveBeenCalledWith(1000);
   });
 });
+
+describe('openaiCodexOAuthProvider auth modes', () => {
+  const originalAuthMode = process.env.MASTRACODE_OPENAI_CODEX_AUTH_MODE;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalAuthMode === undefined) {
+      delete process.env.MASTRACODE_OPENAI_CODEX_AUTH_MODE;
+    } else {
+      process.env.MASTRACODE_OPENAI_CODEX_AUTH_MODE = originalAuthMode;
+    }
+  });
+
+  it('advertises browser and device auth modes', async () => {
+    const { openaiCodexOAuthProvider, OPENAI_CODEX_AUTH_MODES } = await import('./openai-codex.js');
+
+    expect(openaiCodexOAuthProvider.authModes).toBe(OPENAI_CODEX_AUTH_MODES);
+    expect(OPENAI_CODEX_AUTH_MODES.map(m => m.id)).toEqual(['browser', 'device']);
+  });
+
+  it('uses the device flow when callbacks.authMode is "device" even without the env var', async () => {
+    delete process.env.MASTRACODE_OPENAI_CODEX_AUTH_MODE;
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ device_auth_id: 'device-123', user_code: 'ABCD-EFGH', interval: '1' }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ authorization_code: 'auth-code', code_verifier: 'verifier' }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: jwt({ chatgpt_account_id: 'acct-device' }),
+            refresh_token: 'refresh-device',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { openaiCodexOAuthProvider } = await import('./openai-codex.js');
+    const onAuth = vi.fn();
+
+    await expect(
+      openaiCodexOAuthProvider.login({
+        onAuth,
+        onPrompt: async () => '',
+        authMode: 'device',
+      }),
+    ).resolves.toMatchObject({ accountId: 'acct-device', refresh: 'refresh-device' });
+
+    expect(onAuth).toHaveBeenCalledWith({
+      url: 'https://auth.openai.com/codex/device',
+      instructions: 'Enter code: ABCD-EFGH',
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://auth.openai.com/api/accounts/deviceauth/usercode',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('honors callbacks.authMode="browser" even when the env var requests device mode', async () => {
+    process.env.MASTRACODE_OPENAI_CODEX_AUTH_MODE = 'device';
+    const fetchMock = vi.fn().mockRejectedValue(new Error('unexpected fetch'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { openaiCodexOAuthProvider } = await import('./openai-codex.js');
+
+    // Browser flow needs a local callback server; the call may fail when the test
+    // environment cannot bind, but we only care that the device endpoint is *not* hit.
+    await openaiCodexOAuthProvider
+      .login({
+        onAuth: () => {
+          throw new Error('stop-after-onAuth');
+        },
+        onPrompt: async () => {
+          throw new Error('stop-after-onPrompt');
+        },
+        authMode: 'browser',
+      })
+      .catch(() => undefined);
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      'https://auth.openai.com/api/accounts/deviceauth/usercode',
+      expect.any(Object),
+    );
+  });
+});

--- a/mastracode/src/auth/providers/openai-codex.test.ts
+++ b/mastracode/src/auth/providers/openai-codex.test.ts
@@ -1,5 +1,5 @@
 import http from 'node:http';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const blockers: http.Server[] = [];
 
@@ -36,6 +36,12 @@ async function blockPort(port: number): Promise<void> {
 
 async function closeServer(server: http.Server): Promise<void> {
   await new Promise<void>(resolve => server.close(() => resolve()));
+}
+
+function jwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
 }
 
 describe('OpenAI Codex OAuth callback port selection', () => {
@@ -91,5 +97,322 @@ describe('OpenAI Codex OAuth callback port selection', () => {
     const { url } = await __testing.createAuthorizationFlow('http://localhost:1457/auth/callback', 'state');
 
     expect(new URL(url).searchParams.get('redirect_uri')).toBe('http://localhost:1457/auth/callback');
+  });
+
+  it('uses mastracode as the default OAuth originator', async () => {
+    const { __testing } = await import('./openai-codex.js');
+
+    const { url } = await __testing.createAuthorizationFlow('http://localhost:1455/auth/callback', 'state');
+
+    expect(new URL(url).searchParams.get('originator')).toBe('mastracode');
+  });
+
+  it('requests the official Codex OAuth scopes', async () => {
+    const { __testing } = await import('./openai-codex.js');
+
+    const { url } = await __testing.createAuthorizationFlow('http://localhost:1455/auth/callback', 'state');
+
+    expect(new URL(url).searchParams.get('scope')).toBe(
+      'openid profile email offline_access api.connectors.read api.connectors.invoke',
+    );
+  });
+});
+
+describe('OpenAI Codex OAuth account id extraction', () => {
+  it('extracts account id from id token before access token', async () => {
+    const { __testing } = await import('./openai-codex.js');
+
+    expect(
+      __testing.getAccountId({
+        idToken: jwt({ chatgpt_account_id: 'acct-id-token' }),
+        access: jwt({ chatgpt_account_id: 'acct-access-token' }),
+      }),
+    ).toBe('acct-id-token');
+  });
+
+  it('extracts account id from nested access token claims', async () => {
+    const { __testing } = await import('./openai-codex.js');
+
+    expect(
+      __testing.getAccountId({
+        access: jwt({ 'https://api.openai.com/auth': { chatgpt_account_id: 'acct-nested' } }),
+      }),
+    ).toBe('acct-nested');
+  });
+
+  it('does not use organization ids as ChatGPT account ids', async () => {
+    const { __testing } = await import('./openai-codex.js');
+
+    expect(
+      __testing.getAccountId({
+        access: jwt({ organizations: [{ id: 'org-123' }] }),
+      }),
+    ).toBeUndefined();
+  });
+
+  it('requires a ChatGPT account id for Codex credentials', async () => {
+    const { __testing } = await import('./openai-codex.js');
+
+    expect(() =>
+      __testing.requireAccountId({
+        access: jwt({ sub: 'user' }),
+      }),
+    ).toThrow('Failed to extract ChatGPT account id');
+  });
+
+  it('returns the previous account id when refreshed tokens do not include one', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: jwt({ sub: 'user' }),
+          refresh_token: 'refresh-new',
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { refreshOpenAICodexToken } = await import('./openai-codex.js');
+
+    await expect(refreshOpenAICodexToken('refresh-old', 'acct-previous')).resolves.toMatchObject({
+      access: expect.any(String),
+      refresh: 'refresh-new',
+      accountId: 'acct-previous',
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects refreshed tokens when no current or previous account id is available', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: jwt({ sub: 'user' }),
+          refresh_token: 'refresh-new',
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { refreshOpenAICodexToken } = await import('./openai-codex.js');
+
+    await expect(refreshOpenAICodexToken('refresh-old')).rejects.toThrow('Failed to extract ChatGPT account id');
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('OpenAI Codex device OAuth', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('exchanges device authorization for OAuth credentials', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            device_auth_id: 'device-123',
+            user_code: 'ABCD-EFGH',
+            interval: '1',
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_code: 'auth-code',
+            code_verifier: 'verifier',
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: jwt({ chatgpt_account_id: 'acct-device' }),
+            refresh_token: 'refresh-device',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const onAuth = vi.fn();
+    const { __testing } = await import('./openai-codex.js');
+
+    await expect(
+      __testing.loginOpenAICodexDevice({
+        onAuth,
+        sleep: async () => {},
+      }),
+    ).resolves.toMatchObject({
+      access: expect.any(String),
+      refresh: 'refresh-device',
+      accountId: 'acct-device',
+    });
+
+    expect(onAuth).toHaveBeenCalledWith({
+      url: 'https://auth.openai.com/codex/device',
+      instructions: 'Enter code: ABCD-EFGH',
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://auth.openai.com/api/accounts/deviceauth/usercode',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(String),
+      }),
+    );
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).toMatchObject({
+      client_id: expect.any(String),
+      originator: 'mastracode',
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'https://auth.openai.com/oauth/token',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(URLSearchParams),
+      }),
+    );
+    const tokenBody = fetchMock.mock.calls[2]?.[1]?.body as URLSearchParams;
+    expect(tokenBody.get('redirect_uri')).toBe('https://auth.openai.com/deviceauth/callback');
+  });
+
+  it('rejects device credentials without a ChatGPT account id', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            device_auth_id: 'device-123',
+            user_code: 'ABCD-EFGH',
+            interval: '1',
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_code: 'auth-code',
+            code_verifier: 'verifier',
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: jwt({ sub: 'user' }),
+            refresh_token: 'refresh-device',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const { __testing } = await import('./openai-codex.js');
+
+    await expect(
+      __testing.loginOpenAICodexDevice({
+        onAuth: vi.fn(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow('Failed to extract ChatGPT account id');
+  });
+
+  it('accepts the official usercode alias from device authorization responses', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            device_auth_id: 'device-123',
+            usercode: 'ABCD-EFGH',
+            interval: '1',
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_code: 'auth-code',
+            code_verifier: 'verifier',
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: jwt({ chatgpt_account_id: 'acct-device' }),
+            refresh_token: 'refresh-device',
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const onAuth = vi.fn();
+    const { __testing } = await import('./openai-codex.js');
+
+    await __testing.loginOpenAICodexDevice({
+      onAuth,
+      sleep: async () => {},
+    });
+
+    expect(onAuth).toHaveBeenCalledWith({
+      url: 'https://auth.openai.com/codex/device',
+      instructions: 'Enter code: ABCD-EFGH',
+    });
+  });
+
+  it('polls while device authorization is pending', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            device_auth_id: 'device-123',
+            user_code: 'ABCD-EFGH',
+            interval: '1',
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 403 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            authorization_code: 'auth-code',
+            code_verifier: 'verifier',
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: jwt({ chatgpt_account_id: 'acct-device' }),
+            refresh_token: 'refresh-device',
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const sleep = vi.fn(async () => {});
+    const { __testing } = await import('./openai-codex.js');
+
+    await __testing.loginOpenAICodexDevice({
+      onAuth: vi.fn(),
+      onProgress: vi.fn(),
+      sleep,
+    });
+
+    expect(sleep).toHaveBeenCalledWith(1000);
   });
 });

--- a/mastracode/src/auth/providers/openai-codex.test.ts
+++ b/mastracode/src/auth/providers/openai-codex.test.ts
@@ -442,16 +442,12 @@ describe('openaiCodexOAuthProvider auth modes', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({ device_auth_id: 'device-123', user_code: 'ABCD-EFGH', interval: '1' }),
-          { status: 200 },
-        ),
+        new Response(JSON.stringify({ device_auth_id: 'device-123', user_code: 'ABCD-EFGH', interval: '1' }), {
+          status: 200,
+        }),
       )
       .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({ authorization_code: 'auth-code', code_verifier: 'verifier' }),
-          { status: 200 },
-        ),
+        new Response(JSON.stringify({ authorization_code: 'auth-code', code_verifier: 'verifier' }), { status: 200 }),
       )
       .mockResolvedValueOnce(
         new Response(

--- a/mastracode/src/auth/providers/openai-codex.ts
+++ b/mastracode/src/auth/providers/openai-codex.ts
@@ -539,7 +539,9 @@ export async function loginOpenAICodex(options: {
   mode?: 'browser' | 'device';
 }): Promise<OAuthCredentials> {
   const envMode =
-    typeof process !== 'undefined' && process.env?.MASTRACODE_OPENAI_CODEX_AUTH_MODE === 'device' ? 'device' : undefined;
+    typeof process !== 'undefined' && process.env?.MASTRACODE_OPENAI_CODEX_AUTH_MODE === 'device'
+      ? 'device'
+      : undefined;
   const mode = options.mode ?? envMode ?? 'browser';
   if (mode === 'device') {
     return loginOpenAICodexDevice({

--- a/mastracode/src/auth/providers/openai-codex.ts
+++ b/mastracode/src/auth/providers/openai-codex.ts
@@ -11,6 +11,8 @@
 // NEVER convert to top-level imports - breaks browser/Vite builds (web-ui)
 let _randomBytes: ((size: number) => Buffer) | null = null;
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+let _cryptoPromise: Promise<typeof import('node:crypto')> | null = null;
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 let _httpPromise: Promise<typeof import('node:http')> | null = null;
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 let _http: typeof import('node:http') | null = null;
@@ -21,8 +23,9 @@ type HttpServer = {
   close: () => void;
 };
 if (typeof process !== 'undefined' && (process.versions?.node || process.versions?.bun)) {
-  import('node:crypto').then(m => {
+  _cryptoPromise = import('node:crypto').then(m => {
     _randomBytes = m.randomBytes;
+    return m;
   });
   _httpPromise = import('node:http').then(m => {
     _http = m;
@@ -34,11 +37,18 @@ import { generatePKCE } from '../pkce.js';
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from '../types.js';
 
 const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
-const AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize';
-const TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const ISSUER = 'https://auth.openai.com';
+const AUTHORIZE_URL = `${ISSUER}/oauth/authorize`;
+const TOKEN_URL = `${ISSUER}/oauth/token`;
+const DEVICE_USER_CODE_URL = `${ISSUER}/api/accounts/deviceauth/usercode`;
+const DEVICE_TOKEN_URL = `${ISSUER}/api/accounts/deviceauth/token`;
+const DEVICE_AUTHORIZE_URL = `${ISSUER}/codex/device`;
+const DEVICE_REDIRECT_URI = `${ISSUER}/deviceauth/callback`;
 const DEFAULT_CALLBACK_PORT = 1455;
 const FALLBACK_CALLBACK_PORT = 1457;
-const SCOPE = 'openid profile email offline_access';
+const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 3600;
+const DEVICE_AUTH_TIMEOUT_MS = 15 * 60 * 1000;
+const SCOPE = 'openid profile email offline_access api.connectors.read api.connectors.invoke';
 const JWT_CLAIM_PATH = 'https://api.openai.com/auth';
 
 const SUCCESS_HTML = `<!doctype html>
@@ -58,22 +68,22 @@ type TokenSuccess = {
   access: string;
   refresh: string;
   expires: number;
+  idToken?: string;
 };
 type TokenFailure = { type: 'failed' };
 type TokenResult = TokenSuccess | TokenFailure;
 
 type JwtPayload = {
+  chatgpt_account_id?: string;
   [JWT_CLAIM_PATH]?: {
     chatgpt_account_id?: string;
   };
   [key: string]: unknown;
 };
 
-function createState(): string {
-  if (!_randomBytes) {
-    throw new Error('OpenAI Codex OAuth is only available in Node.js environments');
-  }
-  return _randomBytes(16).toString('hex');
+async function createState(): Promise<string> {
+  const randomBytes = await getRandomBytes();
+  return randomBytes(16).toString('hex');
 }
 
 function parseAuthorizationInput(input: string): {
@@ -114,11 +124,61 @@ function decodeJwt(token: string): JwtPayload | null {
     const parts = token.split('.');
     if (parts.length !== 3) return null;
     const payload = parts[1] ?? '';
-    const decoded = atob(payload);
+    const padded = payload
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(Math.ceil(payload.length / 4) * 4, '=');
+    const decoded = atob(padded);
     return JSON.parse(decoded) as JwtPayload;
   } catch {
     return null;
   }
+}
+
+function extractAccountIdFromClaims(payload: JwtPayload | null | undefined): string | null {
+  if (!payload) return null;
+  const accountId = payload.chatgpt_account_id ?? payload[JWT_CLAIM_PATH]?.chatgpt_account_id;
+  return typeof accountId === 'string' && accountId.length > 0 ? accountId : null;
+}
+
+function getAccountId(tokens: { idToken?: string; access: string }, fallback?: string): string | undefined {
+  const fromIdToken = tokens.idToken ? extractAccountIdFromClaims(decodeJwt(tokens.idToken)) : null;
+  if (fromIdToken) return fromIdToken;
+
+  const fromAccessToken = extractAccountIdFromClaims(decodeJwt(tokens.access));
+  if (fromAccessToken) return fromAccessToken;
+
+  return fallback;
+}
+
+function requireAccountId(tokens: { idToken?: string; access: string }, fallback?: string): string {
+  const accountId = getAccountId(tokens, fallback);
+  if (!accountId) {
+    throw new Error('Failed to extract ChatGPT account id from OpenAI Codex token');
+  }
+  return accountId;
+}
+
+type TokenResponseJson = {
+  id_token?: string;
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+};
+
+function tokenResponseToResult(json: TokenResponseJson, logPrefix: string): TokenResult {
+  if (!json.access_token || !json.refresh_token) {
+    console.error(`[openai-codex] ${logPrefix} response missing fields:`, json);
+    return { type: 'failed' };
+  }
+
+  return {
+    type: 'success',
+    access: json.access_token,
+    refresh: json.refresh_token,
+    expires: Date.now() + (json.expires_in ?? DEFAULT_TOKEN_EXPIRES_IN_SECONDS) * 1000,
+    idToken: json.id_token,
+  };
 }
 
 async function exchangeAuthorizationCode(code: string, verifier: string, redirectUri: string): Promise<TokenResult> {
@@ -140,23 +200,7 @@ async function exchangeAuthorizationCode(code: string, verifier: string, redirec
     return { type: 'failed' };
   }
 
-  const json = (await response.json()) as {
-    access_token?: string;
-    refresh_token?: string;
-    expires_in?: number;
-  };
-
-  if (!json.access_token || !json.refresh_token || typeof json.expires_in !== 'number') {
-    console.error('[openai-codex] token response missing fields:', json);
-    return { type: 'failed' };
-  }
-
-  return {
-    type: 'success',
-    access: json.access_token,
-    refresh: json.refresh_token,
-    expires: Date.now() + json.expires_in * 1000,
-  };
+  return tokenResponseToResult((await response.json()) as TokenResponseJson, 'token');
 }
 
 async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
@@ -177,33 +221,27 @@ async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
       return { type: 'failed' };
     }
 
-    const json = (await response.json()) as {
-      access_token?: string;
-      refresh_token?: string;
-      expires_in?: number;
-    };
-
-    if (!json.access_token || !json.refresh_token || typeof json.expires_in !== 'number') {
-      console.error('[openai-codex] Token refresh response missing fields:', json);
-      return { type: 'failed' };
-    }
-
-    return {
-      type: 'success',
-      access: json.access_token,
-      refresh: json.refresh_token,
-      expires: Date.now() + json.expires_in * 1000,
-    };
+    return tokenResponseToResult((await response.json()) as TokenResponseJson, 'Token refresh');
   } catch (error) {
     console.error('[openai-codex] Token refresh error:', error);
     return { type: 'failed' };
   }
 }
 
+async function getRandomBytes() {
+  if (!_randomBytes && _cryptoPromise) {
+    _randomBytes = (await _cryptoPromise).randomBytes;
+  }
+  if (!_randomBytes) {
+    throw new Error('OpenAI Codex OAuth is only available in Node.js environments');
+  }
+  return _randomBytes;
+}
+
 async function createAuthorizationFlow(
   redirectUri: string,
   state: string,
-  originator: string = 'pi',
+  originator: string = 'mastracode',
 ): Promise<{ verifier: string; url: string }> {
   const { verifier, challenge } = await generatePKCE();
 
@@ -364,11 +402,107 @@ async function startLocalOAuthServer(
   });
 }
 
-function getAccountId(accessToken: string): string | null {
-  const payload = decodeJwt(accessToken);
-  const auth = payload?.[JWT_CLAIM_PATH];
-  const accountId = auth?.chatgpt_account_id;
-  return typeof accountId === 'string' && accountId.length > 0 ? accountId : null;
+async function loginOpenAICodexDevice(options: {
+  onAuth: (info: { url: string; instructions?: string }) => void;
+  onProgress?: (message: string) => void;
+  signal?: AbortSignal;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<OAuthCredentials> {
+  const response = await fetch(DEVICE_USER_CODE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': 'mastracode',
+    },
+    body: JSON.stringify({ client_id: CLIENT_ID, originator: 'mastracode' }),
+    signal: options.signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to initiate OpenAI Codex device authorization: ${response.status}`);
+  }
+
+  const deviceData = (await response.json()) as {
+    device_auth_id?: string;
+    user_code?: string;
+    usercode?: string;
+    interval?: string | number;
+  };
+
+  const userCode = deviceData.user_code ?? deviceData.usercode;
+
+  if (!deviceData.device_auth_id || !userCode) {
+    throw new Error('OpenAI Codex device authorization response missing required fields');
+  }
+
+  const intervalSeconds =
+    typeof deviceData.interval === 'number' ? deviceData.interval : Number.parseInt(deviceData.interval ?? '', 10) || 5;
+  const pollDelayMs = Math.max(intervalSeconds, 1) * 1000;
+  const sleep = options.sleep ?? (ms => new Promise<void>(resolve => setTimeout(resolve, ms)));
+  const startedAt = Date.now();
+
+  options.onAuth({
+    url: DEVICE_AUTHORIZE_URL,
+    instructions: `Enter code: ${userCode}`,
+  });
+
+  while (true) {
+    if (options.signal?.aborted) {
+      throw new Error('Login cancelled');
+    }
+    if (Date.now() - startedAt >= DEVICE_AUTH_TIMEOUT_MS) {
+      throw new Error('OpenAI Codex device authorization timed out after 15 minutes');
+    }
+
+    const pollResponse = await fetch(DEVICE_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': 'mastracode',
+      },
+      body: JSON.stringify({
+        device_auth_id: deviceData.device_auth_id,
+        user_code: userCode,
+      }),
+      signal: options.signal,
+    });
+
+    if (pollResponse.ok) {
+      const data = (await pollResponse.json()) as {
+        authorization_code?: string;
+        code_verifier?: string;
+      };
+
+      if (!data.authorization_code || !data.code_verifier) {
+        throw new Error('OpenAI Codex device token response missing required fields');
+      }
+
+      const tokenResult = await exchangeAuthorizationCode(
+        data.authorization_code,
+        data.code_verifier,
+        DEVICE_REDIRECT_URI,
+      );
+      if (tokenResult.type !== 'success') {
+        throw new Error('Token exchange failed');
+      }
+
+      const accountId = requireAccountId(tokenResult);
+      return {
+        access: tokenResult.access,
+        refresh: tokenResult.refresh,
+        expires: tokenResult.expires,
+        accountId,
+      };
+    }
+
+    if (pollResponse.status !== 403 && pollResponse.status !== 404) {
+      const text = await pollResponse.text().catch(() => '');
+      throw new Error(`OpenAI Codex device authorization failed: ${pollResponse.status}${text ? ` ${text}` : ''}`);
+    }
+
+    options.onProgress?.('Waiting for OpenAI Codex device authorization...');
+    await sleep(pollDelayMs);
+  }
 }
 
 /**
@@ -380,21 +514,36 @@ function getAccountId(accessToken: string): string | null {
  * @param options.onManualCodeInput - Optional promise that resolves with user-pasted code.
  *                                    Races with browser callback - whichever completes first wins.
  *                                    Useful for showing paste input immediately alongside browser flow.
- * @param options.originator - OAuth originator parameter (defaults to "pi")
+ * @param options.originator - OAuth originator parameter (defaults to "mastracode")
  */
 export async function loginOpenAICodex(options: {
   onAuth: (info: { url: string; instructions?: string }) => void;
   onPrompt: (prompt: OAuthPrompt) => Promise<string>;
   onProgress?: (message: string) => void;
   onManualCodeInput?: () => Promise<string>;
+  signal?: AbortSignal;
   originator?: string;
+  mode?: 'browser' | 'device';
 }): Promise<OAuthCredentials> {
-  const state = createState();
+  const mode = options.mode ?? (process.env.MASTRACODE_OPENAI_CODEX_AUTH_MODE === 'device' ? 'device' : 'browser');
+  if (mode === 'device') {
+    return loginOpenAICodexDevice({
+      onAuth: options.onAuth,
+      onProgress: options.onProgress,
+      signal: options.signal,
+    });
+  }
+
+  const state = await createState();
   const server = await startLocalOAuthServer(state);
   if (server.warning) {
     options.onProgress?.(server.warning);
   }
-  const { verifier, url } = await createAuthorizationFlow(server.redirectUri, state, options.originator);
+  const { verifier, url } = await createAuthorizationFlow(
+    server.redirectUri,
+    state,
+    options.originator ?? 'mastracode',
+  );
 
   options.onAuth({
     url,
@@ -482,10 +631,7 @@ export async function loginOpenAICodex(options: {
       throw new Error('Token exchange failed');
     }
 
-    const accountId = getAccountId(tokenResult.access);
-    if (!accountId) {
-      throw new Error('Failed to extract accountId from token');
-    }
+    const accountId = requireAccountId(tokenResult);
 
     return {
       access: tokenResult.access,
@@ -500,22 +646,27 @@ export async function loginOpenAICodex(options: {
 
 export const __testing = {
   createAuthorizationFlow,
+  decodeJwt,
+  extractAccountIdFromClaims,
+  getAccountId,
+  loginOpenAICodexDevice,
+  requireAccountId,
   startLocalOAuthServer,
 };
 
 /**
  * Refresh OpenAI Codex OAuth token
  */
-export async function refreshOpenAICodexToken(refreshToken: string): Promise<OAuthCredentials> {
+export async function refreshOpenAICodexToken(
+  refreshToken: string,
+  previousAccountId?: string,
+): Promise<OAuthCredentials> {
   const result = await refreshAccessToken(refreshToken);
   if (result.type !== 'success') {
     throw new Error('Failed to refresh OpenAI Codex token');
   }
 
-  const accountId = getAccountId(result.access);
-  if (!accountId) {
-    throw new Error('Failed to extract accountId from token');
-  }
+  const accountId = requireAccountId(result, previousAccountId);
 
   return {
     access: result.access,
@@ -536,11 +687,12 @@ export const openaiCodexOAuthProvider: OAuthProviderInterface = {
       onPrompt: callbacks.onPrompt,
       onProgress: callbacks.onProgress,
       onManualCodeInput: callbacks.onManualCodeInput,
+      signal: callbacks.signal,
     });
   },
 
   async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-    return refreshOpenAICodexToken(credentials.refresh);
+    return refreshOpenAICodexToken(credentials.refresh, credentials.accountId as string | undefined);
   },
 
   getApiKey(credentials: OAuthCredentials): string {

--- a/mastracode/src/auth/providers/openai-codex.ts
+++ b/mastracode/src/auth/providers/openai-codex.ts
@@ -34,7 +34,20 @@ if (typeof process !== 'undefined' && (process.versions?.node || process.version
 }
 
 import { generatePKCE } from '../pkce.js';
-import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from '../types.js';
+import type { AuthMode, OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from '../types.js';
+
+export const OPENAI_CODEX_AUTH_MODES: ReadonlyArray<AuthMode> = [
+  {
+    id: 'browser',
+    name: 'Browser (local callback)',
+    description: 'Opens the browser and waits for the OAuth callback on localhost.',
+  },
+  {
+    id: 'device',
+    name: 'Device code (headless)',
+    description: 'Shows a code to enter at openai.com — for SSH, remote, or no-browser environments.',
+  },
+];
 
 const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const ISSUER = 'https://auth.openai.com';
@@ -525,7 +538,9 @@ export async function loginOpenAICodex(options: {
   originator?: string;
   mode?: 'browser' | 'device';
 }): Promise<OAuthCredentials> {
-  const mode = options.mode ?? (process.env.MASTRACODE_OPENAI_CODEX_AUTH_MODE === 'device' ? 'device' : 'browser');
+  const envMode =
+    typeof process !== 'undefined' && process.env?.MASTRACODE_OPENAI_CODEX_AUTH_MODE === 'device' ? 'device' : undefined;
+  const mode = options.mode ?? envMode ?? 'browser';
   if (mode === 'device') {
     return loginOpenAICodexDevice({
       onAuth: options.onAuth,
@@ -680,14 +695,17 @@ export const openaiCodexOAuthProvider: OAuthProviderInterface = {
   id: 'openai-codex',
   name: 'ChatGPT Plus/Pro (Codex Subscription)',
   usesCallbackServer: true,
+  authModes: OPENAI_CODEX_AUTH_MODES,
 
   async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+    const mode = callbacks.authMode === 'device' || callbacks.authMode === 'browser' ? callbacks.authMode : undefined;
     return loginOpenAICodex({
       onAuth: callbacks.onAuth,
       onPrompt: callbacks.onPrompt,
       onProgress: callbacks.onProgress,
       onManualCodeInput: callbacks.onManualCodeInput,
       signal: callbacks.signal,
+      mode,
     });
   },
 

--- a/mastracode/src/auth/types.ts
+++ b/mastracode/src/auth/types.ts
@@ -22,12 +22,27 @@ export interface OAuthPrompt {
   allowEmpty?: boolean;
 }
 
+/**
+ * A selectable authentication mode for an OAuth provider.
+ * Providers that support multiple flows (e.g. browser callback vs. device code)
+ * advertise them via `OAuthProviderInterface.authModes`. The TUI shows a
+ * sub-selector when more than one mode is available so users don't need to
+ * discover the flow through environment variables.
+ */
+export interface AuthMode {
+  id: string;
+  name: string;
+  description?: string;
+}
+
 export interface OAuthLoginCallbacks {
   onAuth: (info: OAuthAuthInfo) => void;
   onPrompt: (prompt: OAuthPrompt) => Promise<string>;
   onProgress?: (message: string) => void;
   onManualCodeInput?: () => Promise<string>;
   signal?: AbortSignal;
+  /** Selected authentication mode id (matches one of `OAuthProviderInterface.authModes`). */
+  authMode?: string;
 }
 
 export interface OAuthProviderInterface {
@@ -36,6 +51,13 @@ export interface OAuthProviderInterface {
 
   /** Whether this provider uses a local callback server (vs manual code paste) */
   readonly usesCallbackServer?: boolean;
+
+  /**
+   * Optional list of selectable auth flows. When set with two or more entries,
+   * the TUI prompts the user to pick a mode before starting the login flow and
+   * forwards the choice via `OAuthLoginCallbacks.authMode`.
+   */
+  readonly authModes?: ReadonlyArray<AuthMode>;
 
   /** Run the login flow, return credentials to persist */
   login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>;

--- a/mastracode/src/mcp/__tests__/config.test.ts
+++ b/mastracode/src/mcp/__tests__/config.test.ts
@@ -138,6 +138,29 @@ describe('validateConfig', () => {
     });
   });
 
+  it('accepts IPv4 loopback range HTTP OAuth redirect URLs', () => {
+    const result = validateConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://mcp.example.com/sse',
+          oauth: { redirectUrl: 'http://127.0.0.2:3000/oauth/callback' },
+        },
+      },
+    });
+
+    expect(result.mcpServers!['remote']).toEqual({
+      url: 'https://mcp.example.com/sse',
+      headers: undefined,
+      oauth: {
+        redirectUrl: 'http://127.0.0.2:3000/oauth/callback',
+        clientName: undefined,
+        scopes: undefined,
+        clientId: undefined,
+        clientSecret: undefined,
+      },
+    });
+  });
+
   it('skips http server entry with invalid OAuth config', () => {
     const result = validateConfig({
       mcpServers: {

--- a/mastracode/src/mcp/__tests__/config.test.ts
+++ b/mastracode/src/mcp/__tests__/config.test.ts
@@ -86,6 +86,106 @@ describe('validateConfig', () => {
     });
   });
 
+  it('accepts http server entry with OAuth config', () => {
+    const result = validateConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://mcp.example.com/sse',
+          oauth: {
+            redirectUrl: 'http://localhost:3000/oauth/callback',
+            clientName: 'Mastra Code',
+            scopes: ['mcp:read', 'mcp:write'],
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+          },
+        },
+      },
+    });
+
+    expect(result.mcpServers!['remote']).toEqual({
+      url: 'https://mcp.example.com/sse',
+      headers: undefined,
+      oauth: {
+        redirectUrl: 'http://localhost:3000/oauth/callback',
+        clientName: 'Mastra Code',
+        scopes: ['mcp:read', 'mcp:write'],
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+      },
+    });
+  });
+
+  it('accepts loopback IPv6 HTTP OAuth redirect URLs', () => {
+    const result = validateConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://mcp.example.com/sse',
+          oauth: { redirectUrl: 'http://[::1]:3000/oauth/callback' },
+        },
+      },
+    });
+
+    expect(result.mcpServers!['remote']).toEqual({
+      url: 'https://mcp.example.com/sse',
+      headers: undefined,
+      oauth: {
+        redirectUrl: 'http://[::1]:3000/oauth/callback',
+        clientName: undefined,
+        scopes: undefined,
+        clientId: undefined,
+        clientSecret: undefined,
+      },
+    });
+  });
+
+  it('skips http server entry with invalid OAuth config', () => {
+    const result = validateConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://mcp.example.com/sse',
+          oauth: { redirectUrl: 'not a url' },
+        },
+      },
+    });
+
+    expect(result.mcpServers).toBeUndefined();
+    expect(result.skippedServers).toHaveLength(1);
+    expect(result.skippedServers![0]!.reason).toContain('Invalid OAuth redirectUrl');
+  });
+
+  it('skips http server entry with non-loopback HTTP OAuth redirect URL', () => {
+    const result = validateConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://mcp.example.com/sse',
+          oauth: { redirectUrl: 'http://oauth.example.com/callback' },
+        },
+      },
+    });
+
+    expect(result.mcpServers).toBeUndefined();
+    expect(result.skippedServers).toHaveLength(1);
+    expect(result.skippedServers![0]!.reason).toContain('must use HTTPS');
+  });
+
+  it('skips http server entry with invalid OAuth scopes', () => {
+    const result = validateConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://mcp.example.com/sse',
+          oauth: {
+            redirectUrl: 'http://localhost:3000/oauth/callback',
+            scopes: ['mcp:read', 42],
+          },
+        },
+      },
+    });
+
+    expect(result.mcpServers).toBeUndefined();
+    expect(result.skippedServers).toHaveLength(1);
+    expect(result.skippedServers![0]!.reason).toContain('"scopes" must be an array of strings');
+  });
+
   it('skips invalid entries and collects reasons', () => {
     const result = validateConfig({
       mcpServers: {

--- a/mastracode/src/mcp/__tests__/manager.test.ts
+++ b/mastracode/src/mcp/__tests__/manager.test.ts
@@ -212,8 +212,8 @@ describe('createMcpManager', () => {
 
       const firstStoragePath = MockedMCPOAuthClientProvider.mock.calls[0]?.[0]?.storage?.filePath;
       const secondStoragePath = MockedMCPOAuthClientProvider.mock.calls[1]?.[0]?.storage?.filePath;
-      expect(firstStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{32}\.json$/));
-      expect(secondStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{32}\.json$/));
+      expect(firstStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{16}\.json$/));
+      expect(secondStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{16}\.json$/));
       expect(firstStoragePath).not.toBe(secondStoragePath);
     });
 

--- a/mastracode/src/mcp/__tests__/manager.test.ts
+++ b/mastracode/src/mcp/__tests__/manager.test.ts
@@ -1,16 +1,22 @@
-import { MCPClient } from '@mastra/mcp';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { loadMcpConfig } from '../config.js';
 import { createMcpManager } from '../manager.js';
 import type { McpConfig, McpHttpServerConfig, McpStdioServerConfig } from '../types.js';
 
-// Mock @mastra/mcp before importing manager
-vi.mock('@mastra/mcp', () => {
+const mcpMocks = vi.hoisted(() => {
   const MCPClient = vi.fn(function (this: any) {
     // individual tests override listToolsets/disconnect via mockImplementation
   });
-  return { MCPClient };
+  const MCPOAuthClientProvider = vi.fn(function (this: any, options: any) {
+    this.options = options;
+  });
+  return { MCPClient, MCPOAuthClientProvider };
+});
+
+// Mock @mastra/mcp before importing manager
+vi.mock('@mastra/mcp', () => {
+  return mcpMocks;
 });
 
 // Mock config module to control what loadMcpConfig returns
@@ -23,7 +29,8 @@ vi.mock('../config.js', async importOriginal => {
 });
 
 const mockedLoadMcpConfig = vi.mocked(loadMcpConfig);
-const MockedMCPClient = vi.mocked(MCPClient);
+const MockedMCPClient = vi.mocked(mcpMocks.MCPClient);
+const MockedMCPOAuthClientProvider = vi.mocked(mcpMocks.MCPOAuthClientProvider);
 
 function setupConfig(config: McpConfig) {
   mockedLoadMcpConfig.mockReturnValue(config);
@@ -138,6 +145,76 @@ describe('createMcpManager', () => {
       const serverDef = call.servers['remote'] as any;
       expect(serverDef.url).toBeInstanceOf(URL);
       expect(serverDef.requestInit).toBeUndefined();
+    });
+
+    it('builds http server def with OAuth authProvider', async () => {
+      const httpConfig: McpHttpServerConfig = {
+        url: 'https://mcp.example.com/mcp',
+        oauth: {
+          redirectUrl: 'http://localhost:3000/oauth/callback',
+          clientName: 'Remote MCP',
+          scopes: ['mcp:read', 'mcp:write'],
+          clientId: 'client-id',
+          clientSecret: 'client-secret',
+        },
+      };
+      setupConfig({ mcpServers: { remote: httpConfig } });
+
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listToolsetsWithErrors = vi.fn().mockResolvedValue({ toolsets: { remote: {} }, errors: {} });
+        this.disconnect = vi.fn().mockResolvedValue(undefined);
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const call = MockedMCPClient.mock.calls[0]![0]!;
+      const serverDef = call.servers['remote'] as any;
+      expect(serverDef.authProvider).toBeInstanceOf(mcpMocks.MCPOAuthClientProvider);
+      expect(MockedMCPOAuthClientProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          redirectUrl: 'http://localhost:3000/oauth/callback',
+          clientMetadata: {
+            redirect_uris: ['http://localhost:3000/oauth/callback'],
+            client_name: 'Remote MCP',
+            grant_types: ['authorization_code', 'refresh_token'],
+            response_types: ['code'],
+            scope: 'mcp:read mcp:write',
+          },
+          clientInformation: {
+            client_id: 'client-id',
+            client_secret: 'client-secret',
+          },
+          storage: expect.anything(),
+        }),
+      );
+    });
+
+    it('uses separate OAuth token storage for the same server name in different projects', async () => {
+      const httpConfig: McpHttpServerConfig = {
+        url: 'https://mcp.example.com/mcp',
+        oauth: {
+          redirectUrl: 'http://localhost:3000/oauth/callback',
+          clientName: 'Remote MCP',
+          scopes: ['mcp:read'],
+          clientId: 'client-id',
+        },
+      };
+      setupConfig({ mcpServers: { remote: httpConfig } });
+
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listToolsetsWithErrors = vi.fn().mockResolvedValue({ toolsets: { remote: {} }, errors: {} });
+        this.disconnect = vi.fn().mockResolvedValue(undefined);
+      } as any);
+
+      await createMcpManager('/tmp/project-a').init();
+      await createMcpManager('/tmp/project-b').init();
+
+      const firstStoragePath = MockedMCPOAuthClientProvider.mock.calls[0]?.[0]?.storage?.filePath;
+      const secondStoragePath = MockedMCPOAuthClientProvider.mock.calls[1]?.[0]?.storage?.filePath;
+      expect(firstStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{32}\.json$/));
+      expect(secondStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{32}\.json$/));
+      expect(firstStoragePath).not.toBe(secondStoragePath);
     });
 
     it('creates one MCPClient with all servers', async () => {

--- a/mastracode/src/mcp/config.ts
+++ b/mastracode/src/mcp/config.ts
@@ -152,7 +152,9 @@ function parseOAuthConfig(raw: unknown): { config?: McpHttpOAuthConfig; reason?:
   try {
     const redirectUrl = new URL(obj.redirectUrl);
     const isLoopback =
-      redirectUrl.hostname === 'localhost' || redirectUrl.hostname === '127.0.0.1' || redirectUrl.hostname === '[::1]';
+      redirectUrl.hostname === 'localhost' ||
+      redirectUrl.hostname.startsWith('127.') ||
+      redirectUrl.hostname === '[::1]';
     if (redirectUrl.protocol !== 'https:' && !(redirectUrl.protocol === 'http:' && isLoopback)) {
       return { reason: 'Invalid OAuth redirectUrl: must use HTTPS unless it is a loopback HTTP URL' };
     }

--- a/mastracode/src/mcp/config.ts
+++ b/mastracode/src/mcp/config.ts
@@ -11,7 +11,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { McpConfig, McpServerConfig, McpSkippedServer } from './types.js';
+import type { McpConfig, McpHttpOAuthConfig, McpServerConfig, McpSkippedServer } from './types.js';
 
 export function loadMcpConfig(projectDir: string): McpConfig {
   const claudeConfig = loadClaudeSettings(projectDir);
@@ -113,10 +113,16 @@ export function validateConfig(raw: unknown): McpConfig {
       };
     } else if (classification.kind === 'http') {
       const e = entry as Record<string, unknown>;
+      const oauthResult = parseOAuthConfig(e.oauth);
+      if (oauthResult.reason) {
+        skippedServers.push({ name, reason: oauthResult.reason });
+        continue;
+      }
       servers[name] = {
         url: e.url as string,
         headers:
           typeof e.headers === 'object' && e.headers !== null ? (e.headers as Record<string, string>) : undefined,
+        oauth: oauthResult.config,
       };
     } else {
       skippedServers.push({ name, reason: classification.reason! });
@@ -131,6 +137,42 @@ export function validateConfig(raw: unknown): McpConfig {
     result.skippedServers = skippedServers;
   }
   return result;
+}
+
+function parseOAuthConfig(raw: unknown): { config?: McpHttpOAuthConfig; reason?: string } {
+  if (raw === undefined) return {};
+  if (!raw || typeof raw !== 'object') {
+    return { reason: 'Invalid OAuth config: expected an object' };
+  }
+
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.redirectUrl !== 'string') {
+    return { reason: 'Invalid OAuth config: missing required field "redirectUrl"' };
+  }
+  try {
+    const redirectUrl = new URL(obj.redirectUrl);
+    const isLoopback =
+      redirectUrl.hostname === 'localhost' || redirectUrl.hostname === '127.0.0.1' || redirectUrl.hostname === '[::1]';
+    if (redirectUrl.protocol !== 'https:' && !(redirectUrl.protocol === 'http:' && isLoopback)) {
+      return { reason: 'Invalid OAuth redirectUrl: must use HTTPS unless it is a loopback HTTP URL' };
+    }
+  } catch {
+    return { reason: `Invalid OAuth redirectUrl: "${obj.redirectUrl}"` };
+  }
+
+  if (obj.scopes !== undefined && (!Array.isArray(obj.scopes) || obj.scopes.some(scope => typeof scope !== 'string'))) {
+    return { reason: 'Invalid OAuth config: "scopes" must be an array of strings' };
+  }
+
+  return {
+    config: {
+      redirectUrl: obj.redirectUrl,
+      clientName: typeof obj.clientName === 'string' ? obj.clientName : undefined,
+      scopes: obj.scopes as string[] | undefined,
+      clientId: typeof obj.clientId === 'string' ? obj.clientId : undefined,
+      clientSecret: typeof obj.clientSecret === 'string' ? obj.clientSecret : undefined,
+    },
+  };
 }
 
 /**

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -3,7 +3,6 @@
  * Created once at startup, provides tools from connected MCP servers.
  */
 
-import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, renameSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { MCPClient, MCPOAuthClientProvider } from '@mastra/mcp';
@@ -104,8 +103,16 @@ function getOAuthStoragePath(projectDir: string, name: string, cfg: McpHttpServe
     clientId: cfg.oauth?.clientId,
     scopes: cfg.oauth?.scopes ?? [],
   });
-  const hash = createHash('sha256').update(key).digest('hex').slice(0, 32);
-  return join(getAppDataDir(), 'mcp-oauth', `${hash}.json`);
+  return join(getAppDataDir(), 'mcp-oauth', `${getStorageKeyFingerprint(key)}.json`);
+}
+
+function getStorageKeyFingerprint(value: string): string {
+  let fingerprint = 0xcbf29ce484222325n;
+  for (let i = 0; i < value.length; i += 1) {
+    fingerprint ^= BigInt(value.charCodeAt(i));
+    fingerprint = BigInt.asUintN(64, fingerprint * 0x100000001b3n);
+  }
+  return fingerprint.toString(16).padStart(16, '0');
 }
 
 /**

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -3,7 +3,7 @@
  * Created once at startup, provides tools from connected MCP servers.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, renameSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { MCPClient, MCPOAuthClientProvider } from '@mastra/mcp';
 import type { MastraMCPServerDefinition, OAuthClientInformation, OAuthStorage } from '@mastra/mcp';
@@ -87,10 +87,8 @@ class FileOAuthStorage implements OAuthStorage {
       mkdirSync(dir, { recursive: true, mode: 0o700 });
     }
     const tmpPath = `${this.filePath}.tmp`;
-    writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
-    chmodSync(tmpPath, 0o600);
+    writeFileSync(tmpPath, JSON.stringify(data, null, 2), { encoding: 'utf-8', mode: 0o600 });
     renameSync(tmpPath, this.filePath);
-    chmodSync(this.filePath, 0o600);
   }
 }
 

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -6,7 +6,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, renameSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { MCPClient, MCPOAuthClientProvider } from '@mastra/mcp';
-import type { MastraMCPServerDefinition, OAuthStorage } from '@mastra/mcp';
+import type { MastraMCPServerDefinition, OAuthClientInformation, OAuthStorage } from '@mastra/mcp';
 import { getAppDataDir } from '../utils/project.js';
 import { loadMcpConfig, getProjectMcpPath, getGlobalMcpPath, getClaudeSettingsPath } from './config.js';
 import type { McpConfig, McpHttpServerConfig, McpServerConfig, McpServerStatus, McpSkippedServer } from './types.js';
@@ -186,7 +186,7 @@ export function createMcpManager(projectDir: string, extraServers?: Record<strin
         ? ({
             client_id: cfg.oauth.clientId,
             ...(cfg.oauth.clientSecret ? { client_secret: cfg.oauth.clientSecret } : {}),
-          } as any)
+          } satisfies OAuthClientInformation)
         : undefined,
       storage: new FileOAuthStorage(getOAuthStoragePath(projectDir, name, cfg)),
     });

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -3,8 +3,12 @@
  * Created once at startup, provides tools from connected MCP servers.
  */
 
-import { MCPClient } from '@mastra/mcp';
-import type { MastraMCPServerDefinition } from '@mastra/mcp';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, renameSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { MCPClient, MCPOAuthClientProvider } from '@mastra/mcp';
+import type { MastraMCPServerDefinition, OAuthStorage } from '@mastra/mcp';
+import { getAppDataDir } from '../utils/project.js';
 import { loadMcpConfig, getProjectMcpPath, getGlobalMcpPath, getClaudeSettingsPath } from './config.js';
 import type { McpConfig, McpHttpServerConfig, McpServerConfig, McpServerStatus, McpSkippedServer } from './types.js';
 
@@ -48,6 +52,60 @@ export interface McpManager {
 
 function getTransport(cfg: McpServerConfig): 'stdio' | 'http' {
   return 'url' in cfg ? 'http' : 'stdio';
+}
+
+class FileOAuthStorage implements OAuthStorage {
+  constructor(private filePath: string) {}
+
+  get(key: string): string | undefined {
+    return this.read()[key];
+  }
+
+  set(key: string, value: string): void {
+    const data = this.read();
+    data[key] = value;
+    this.write(data);
+  }
+
+  delete(key: string): void {
+    const data = this.read();
+    delete data[key];
+    this.write(data);
+  }
+
+  private read(): Record<string, string> {
+    if (!existsSync(this.filePath)) return {};
+    try {
+      return JSON.parse(readFileSync(this.filePath, 'utf-8')) as Record<string, string>;
+    } catch {
+      return {};
+    }
+  }
+
+  private write(data: Record<string, string>): void {
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    const tmpPath = `${this.filePath}.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+    chmodSync(tmpPath, 0o600);
+    renameSync(tmpPath, this.filePath);
+    chmodSync(this.filePath, 0o600);
+  }
+}
+
+function getOAuthStoragePath(projectDir: string, name: string, cfg: McpHttpServerConfig): string {
+  const key = JSON.stringify({
+    projectDir,
+    name,
+    url: cfg.url,
+    redirectUrl: cfg.oauth?.redirectUrl,
+    clientId: cfg.oauth?.clientId,
+    scopes: cfg.oauth?.scopes ?? [],
+  });
+  const hash = createHash('sha256').update(key).digest('hex').slice(0, 32);
+  return join(getAppDataDir(), 'mcp-oauth', `${hash}.json`);
 }
 
 /**
@@ -105,6 +163,28 @@ export function createMcpManager(projectDir: string, extraServers?: Record<strin
     });
   }
 
+  function createOAuthProvider(name: string, cfg: McpHttpServerConfig) {
+    if (!cfg.oauth) return undefined;
+
+    return new MCPOAuthClientProvider({
+      redirectUrl: cfg.oauth.redirectUrl,
+      clientMetadata: {
+        redirect_uris: [cfg.oauth.redirectUrl],
+        client_name: cfg.oauth.clientName ?? `Mastra Code MCP ${name}`,
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        ...(cfg.oauth.scopes?.length ? { scope: cfg.oauth.scopes.join(' ') } : {}),
+      },
+      clientInformation: cfg.oauth.clientId
+        ? ({
+            client_id: cfg.oauth.clientId,
+            ...(cfg.oauth.clientSecret ? { client_secret: cfg.oauth.clientSecret } : {}),
+          } as any)
+        : undefined,
+      storage: new FileOAuthStorage(getOAuthStoragePath(projectDir, name, cfg)),
+    });
+  }
+
   function buildServerDefs(servers: Record<string, McpServerConfig>): Record<string, MastraMCPServerDefinition> {
     const defs: Record<string, MastraMCPServerDefinition> = {};
     for (const [name, cfg] of Object.entries(servers)) {
@@ -113,6 +193,7 @@ export function createMcpManager(projectDir: string, extraServers?: Record<strin
         defs[name] = {
           url: new URL(httpCfg.url),
           requestInit: httpCfg.headers ? { headers: httpCfg.headers } : undefined,
+          authProvider: createOAuthProvider(name, httpCfg),
         };
       } else {
         defs[name] = { command: cfg.command, args: cfg.args, env: cfg.env, stderr: 'pipe' };

--- a/mastracode/src/mcp/types.ts
+++ b/mastracode/src/mcp/types.ts
@@ -25,6 +25,24 @@ export interface McpHttpServerConfig {
   url: string;
   /** Optional HTTP headers (e.g. for authentication) */
   headers?: Record<string, string>;
+  /** Optional OAuth configuration for protected HTTP MCP servers */
+  oauth?: McpHttpOAuthConfig;
+}
+
+/**
+ * OAuth client configuration for an HTTP MCP server.
+ */
+export interface McpHttpOAuthConfig {
+  /** Redirect URL controlled by the user/application for OAuth callbacks */
+  redirectUrl: string;
+  /** Human-readable OAuth client name */
+  clientName?: string;
+  /** Optional scopes requested during OAuth */
+  scopes?: string[];
+  /** Optional pre-registered OAuth client ID */
+  clientId?: string;
+  /** Optional pre-registered OAuth client secret */
+  clientSecret?: string;
 }
 
 /**

--- a/mastracode/src/providers/__tests__/openai-codex-fetch.test.ts
+++ b/mastracode/src/providers/__tests__/openai-codex-fetch.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+const openAIStorage = {
+  reload: vi.fn(),
+  get: vi.fn(),
+  getApiKey: vi.fn(),
+};
+
+describe('OpenAI Codex OAuth fetch', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    openAIStorage.reload.mockReset();
+    openAIStorage.get.mockReset();
+    openAIStorage.getApiKey.mockReset();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('injects Codex OAuth runtime headers', async () => {
+    openAIStorage.get.mockReturnValue({
+      type: 'oauth',
+      access: 'oauth-token',
+      expires: Date.now() + 60_000,
+      accountId: 'acct-123',
+    });
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    const { buildOpenAICodexOAuthFetch } = await import('../openai-codex.js');
+    const fetchWithOAuth = buildOpenAICodexOAuthFetch({ authStorage: openAIStorage as any });
+
+    await fetchWithOAuth('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0].toString()).toBe('https://chatgpt.com/backend-api/codex/responses');
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer oauth-token');
+    expect(headers.get('ChatGPT-Account-ID')).toBe('acct-123');
+    expect(headers.get('originator')).toBe('mastracode');
+    expect(headers.get('User-Agent')).toBe('mastracode');
+  });
+});

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -16,6 +16,8 @@ import { AuthStorage } from '../auth/storage.js';
 
 // Codex API endpoint (not standard OpenAI API)
 const CODEX_API_ENDPOINT = 'https://chatgpt.com/backend-api/codex/responses';
+const CODEX_ORIGINATOR = 'mastracode';
+const CODEX_USER_AGENT = 'mastracode';
 
 // Singleton auth storage instance (shared with claude-max.ts)
 let authStorageInstance: AuthStorage | null = null;
@@ -155,8 +157,14 @@ export function buildOpenAICodexOAuthFetch(
     }
 
     headers.set('Authorization', `Bearer ${accessToken}`);
+    if (!headers.has('originator')) {
+      headers.set('originator', CODEX_ORIGINATOR);
+    }
+    if (!headers.has('User-Agent')) {
+      headers.set('User-Agent', CODEX_USER_AGENT);
+    }
     if (accountId) {
-      headers.set('ChatGPT-Account-Id', accountId);
+      headers.set('ChatGPT-Account-ID', accountId);
     }
 
     // URL rewriting — only when rewriteUrl !== false

--- a/mastracode/src/tui/commands/login.ts
+++ b/mastracode/src/tui/commands/login.ts
@@ -1,5 +1,6 @@
 import { getOAuthProviders, PROVIDER_DEFAULT_MODELS } from '../../auth/storage.js';
 import { LoginDialogComponent } from '../components/login-dialog.js';
+import { promptAuthMode } from '../components/login-mode-selector.js';
 import { LoginSelectorComponent } from '../components/login-selector.js';
 import { showModalOverlay } from '../overlay.js';
 import type { SlashCommandContext } from './types.js';
@@ -10,6 +11,12 @@ async function performLogin(ctx: SlashCommandContext, providerId: string): Promi
 
   if (!ctx.authStorage) {
     ctx.showError('Auth storage not configured');
+    return;
+  }
+
+  const authMode = await promptAuthMode(ctx.state.ui, providerName, provider?.authModes);
+  if (authMode === null) {
+    // User cancelled at the mode-selection step.
     return;
   }
 
@@ -39,6 +46,7 @@ async function performLogin(ctx: SlashCommandContext, providerId: string): Promi
           dialog.showProgress(message);
         },
         signal: dialog.signal,
+        authMode,
       })
       .then(async () => {
         ctx.state.ui.hideOverlay();

--- a/mastracode/src/tui/components/login-mode-selector.ts
+++ b/mastracode/src/tui/components/login-mode-selector.ts
@@ -1,0 +1,113 @@
+/**
+ * Auth-mode selector component used between the provider selector and the login dialog
+ * when an OAuth provider advertises more than one `authModes` entry. Lets the user pick
+ * (for example) "Browser (local callback)" vs "Device code (headless)" without setting
+ * an env var.
+ */
+
+import { Box, Container, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import type { TUI } from '@mariozechner/pi-tui';
+import type { AuthMode } from '../../auth/types.js';
+import { showModalOverlay } from '../overlay.js';
+import { theme } from '../theme.js';
+
+export class LoginModeSelectorComponent extends Box {
+  private listContainer: Container;
+  private modes: ReadonlyArray<AuthMode>;
+  private selectedIndex = 0;
+  private onSelectCallback: (modeId: string) => void;
+  private onCancelCallback: () => void;
+
+  constructor(
+    providerName: string,
+    modes: ReadonlyArray<AuthMode>,
+    onSelect: (modeId: string) => void,
+    onCancel: () => void,
+  ) {
+    super(2, 1, text => theme.bg('overlayBg', text));
+
+    this.modes = modes;
+    this.onSelectCallback = onSelect;
+    this.onCancelCallback = onCancel;
+
+    this.addChild(new Text(theme.fg('text', `How do you want to sign in to ${providerName}?`)));
+    this.addChild(new Spacer(1));
+
+    this.listContainer = new Container();
+    this.addChild(this.listContainer);
+
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(theme.fg('muted', 'Press Enter to select, Escape to cancel')));
+
+    this.updateList();
+  }
+
+  private updateList(): void {
+    this.listContainer.clear();
+
+    for (let i = 0; i < this.modes.length; i++) {
+      const mode = this.modes[i];
+      if (!mode) continue;
+
+      const isSelected = i === this.selectedIndex;
+      const prefix = isSelected ? theme.fg('accent', '→ ') : '  ';
+      const label = isSelected ? theme.fg('accent', mode.name) : mode.name;
+      this.listContainer.addChild(new Text(`${prefix}${label}`));
+
+      if (mode.description) {
+        this.listContainer.addChild(new Text(theme.fg('muted', `    ${mode.description}`)));
+      }
+    }
+  }
+
+  handleInput(keyData: string): void {
+    const kb = getEditorKeybindings();
+
+    if (kb.matches(keyData, 'selectUp')) {
+      this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+      this.updateList();
+    } else if (kb.matches(keyData, 'selectDown')) {
+      this.selectedIndex = Math.min(this.modes.length - 1, this.selectedIndex + 1);
+      this.updateList();
+    } else if (kb.matches(keyData, 'selectConfirm')) {
+      const selected = this.modes[this.selectedIndex];
+      if (selected) {
+        this.onSelectCallback(selected.id);
+      }
+    } else if (kb.matches(keyData, 'selectCancel')) {
+      this.onCancelCallback();
+    }
+  }
+}
+
+/**
+ * Prompt the user to pick an auth mode if the provider advertises more than one.
+ * Returns the chosen mode id, `undefined` when the provider has 0/1 modes (no prompt),
+ * or `null` when the user cancelled.
+ */
+export async function promptAuthMode(
+  tui: TUI,
+  providerName: string,
+  modes: ReadonlyArray<AuthMode> | undefined,
+): Promise<string | undefined | null> {
+  if (!modes || modes.length < 2) {
+    return modes && modes.length === 1 ? modes[0]!.id : undefined;
+  }
+
+  return new Promise(resolve => {
+    const selector = new LoginModeSelectorComponent(
+      providerName,
+      modes,
+      modeId => {
+        tui.hideOverlay();
+        resolve(modeId);
+      },
+      () => {
+        tui.hideOverlay();
+        resolve(null);
+      },
+    );
+
+    showModalOverlay(tui, selector, { widthPercent: 0.8, maxHeight: '60%' });
+  });
+}

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -35,6 +35,7 @@ import { startGoalWithDefaults } from './commands/goal.js';
 
 import type { SlashCommandContext } from './commands/types.js';
 import { LoginDialogComponent } from './components/login-dialog.js';
+import { promptAuthMode } from './components/login-mode-selector.js';
 import { ModelSelectorComponent } from './components/model-selector.js';
 import type { ModelItem } from './components/model-selector.js';
 import { showError, showInfo, showFormattedError, notify } from './display.js';
@@ -912,6 +913,12 @@ export class MastraTUI {
       return;
     }
 
+    const authMode = await promptAuthMode(this.state.ui, providerName, provider?.authModes);
+    if (authMode === null) {
+      // User cancelled at the mode-selection step.
+      return;
+    }
+
     return new Promise(resolve => {
       const dialog = new LoginDialogComponent(this.state.ui, providerId, (success, message) => {
         this.state.ui.hideOverlay();
@@ -938,6 +945,7 @@ export class MastraTUI {
             dialog.showProgress(message);
           },
           signal: dialog.signal,
+          authMode,
         })
         .then(async () => {
           this.state.ui.hideOverlay();


### PR DESCRIPTION
## Description

Improves the existing OpenAI Codex OAuth integration in Mastra Code.

This adds a headless device-code login mode for OpenAI Codex OAuth, selected with `MASTRACODE_OPENAI_CODEX_AUTH_MODE=device`, while keeping the browser callback flow as the default. It also aligns the Codex OAuth/runtime behavior more closely with the official Codex CLI flow by using the Codex device endpoints, Codex connector scopes, `originator: mastracode`, `User-Agent`, and `ChatGPT-Account-ID`.

The OAuth token handling now extracts ChatGPT account ids from id/access token claims, preserves the previous account id during refresh when refreshed tokens omit it, and fails fast when no account id is available. OAuth-backed OpenAI GPT-5 model ids are remapped to Codex model ids before requests are sent.

This also adds HTTP MCP OAuth config support for Mastra Code. HTTP MCP server entries can now pass OAuth client metadata to `@mastra/mcp`, validate redirect URLs, and store OAuth state per project/server/config so tokens are not shared across unrelated projects. The configured MCP redirect URL still needs to be handled by a callback endpoint that completes that MCP server's OAuth flow.

Docs and tests were updated for the new login mode, Codex request behavior, MCP OAuth config, and storage isolation.

## Related issue(s)

Refs #16542

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- Real OpenAI Codex browser OAuth flow completed through the localhost callback with access token, refresh token, and ChatGPT account id present.
- `corepack pnpm --filter ./mastracode test src/auth/providers/openai-codex.test.ts src/providers/__tests__/openai-codex-fetch.test.ts src/mcp/__tests__/config.test.ts src/mcp/__tests__/manager.test.ts src/agents/__tests__/model.test.ts`
- `corepack pnpm --filter ./mastracode lint`
- `git diff --check`

## Notes

This PR does not claim that OpenAI has explicitly approved Mastra Code as a third-party Codex OAuth client. It follows behavior exposed by OpenAI's Codex CLI flow and keeps the implementation behind the existing user-initiated OAuth login path.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a no-browser (device-code) sign-in option for OpenAI Codex and lets HTTP MCP servers be configured for OAuth, storing tokens per project/server so credentials don’t get mixed across projects.

---

## Changes Summary

### OpenAI Codex OAuth Enhancements
- Device-code (headless) login
  - Adds a device-code OAuth flow (loginOpenAICodexDevice) selectable via MASTRACODE_OPENAI_CODEX_AUTH_MODE=device or via the new UI auth-mode selector; browser/local callback remains default.
  - Uses Codex device endpoints, polls for user approval, exchanges codes, and returns normalized OAuth credentials.
- Token & account-id handling
  - Centralized JWT/account-id extraction (base64url decode), preferring id_token claims, falling back to access-token claims, and failing fast if no ChatGPT account ID can be derived.
  - refreshOpenAICodexToken accepts an optional previousAccountId and preserves the prior account ID when refresh responses omit it.
- Codex request alignment & model remapping
  - Adds default Codex headers (originator: mastracode, User-Agent: mastracode) when absent and sends ChatGPT-Account-ID with standardized capitalization.
  - Remaps OpenAI GPT-5 model IDs to Codex model IDs before requests; dynamic model resolution always applies this remapping.
- Exports & testing helpers
  - Exposes openaiCodexOAuthProvider from auth index and expands __testing helpers (JWT/account-id helpers, device-flow helper) for tests.

---

### HTTP MCP Server OAuth Configuration
- Config schema & validation
  - Adds McpHttpOAuthConfig (required redirectUrl; optional clientName, scopes, clientId, clientSecret).
  - Validates redirectUrl (HTTPS required except loopback HTTP, including IPv6/IPv4 loopback cases) and scopes (array of strings). Invalid OAuth entries cause that server to be skipped and a skip reason recorded.
  - Note: a configured redirectUrl still requires a reachable callback endpoint to complete that server’s OAuth flow.
- Per-server, per-project OAuth persistence
  - Adds FileOAuthStorage to persist OAuth state as JSON files with atomic writes and restrictive permissions (0600).
  - Storage filenames are derived from a deterministic fingerprint of project dir, server name, URL, and OAuth settings so tokens are isolated per project/server/config.
  - Manager wires an MCPOAuthClientProvider for HTTP servers with oauth, passing redirect URIs, grant/response types, composed scope, optional client credentials, and the per-server FileOAuthStorage.

---

### UI & Types
- Introduces AuthMode and auth-mode selection UI/component; TUI prompts for auth mode before starting login and passes selected mode into authStorage.login.
- loginOpenAICodex() now accepts mode and signal; refreshOpenAICodexToken(refreshToken, previousAccountId?) added to accept prior account id fallback.

---

### Documentation & Tests
- Docs updated: device-code usage, MCP OAuth examples (.mastracode/mcp.json), redirect URL constraints, and warnings about committing client secrets.
- Tests expanded:
  - OpenAI Codex provider: device flow end-to-end, polling, account-id extraction, refresh behaviors, originator/scope assertions, and auth-mode selection tests.
  - Codex fetch tests: assert correct endpoint and headers (Authorization, ChatGPT-Account-ID, originator, User-Agent).
  - MCP config/manager tests: OAuth parsing, loopback handling, skipped-server reasons, authProvider creation, and per-project token storage isolation.
- Changelog (.changeset) entry added for a mastracode minor release.

---

### Notable implementation notes
- New exported constant OPENAI_CODEX_AUTH_MODES; provider advertises authModes and selects login mode from callbacks.authMode.
- Minimal public API shape changes: added AuthMode type and optional fields on OAuthLoginCallbacks and OAuthProviderInterface; login/refresh signatures updated as noted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16548)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->