### PR TITLE
test(playground): mock branches endpoint in agent observability tab e2e

### DIFF
--- a/packages/playground/e2e/tests/agents/observability-tabs.spec.ts
+++ b/packages/playground/e2e/tests/agents/observability-tabs.spec.ts
@@ -43,6 +43,9 @@ async function mockSystemPackages(page: Page, observabilityEnabled: boolean) {
 test('requests agent traces when runtime observability is available without package metadata', async ({ page }) => {
   await mockSystemPackages(page, true);
 
+  // The Traces tab uses the shared Observability TracesPage, which defaults to
+  // `listMode=branches` (PR #16493) and hits `/observability/branches`. We mock
+  // both endpoints so the assertion still holds if the default flips back.
   let tracesUrl: URL | undefined;
   await page.route('**/api/observability/traces?**', async route => {
     tracesUrl = new URL(route.request().url());
@@ -51,6 +54,17 @@ test('requests agent traces when runtime observability is available without pack
       contentType: 'application/json',
       body: JSON.stringify({
         spans: [],
+        pagination: { page: 0, perPage: 25, total: 0, hasMore: false },
+      }),
+    });
+  });
+  await page.route('**/api/observability/branches?**', async route => {
+    tracesUrl = new URL(route.request().url());
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        branches: [],
         pagination: { page: 0, perPage: 25, total: 0, hasMore: false },
       }),
     });
@@ -83,6 +97,8 @@ test('keeps agent observability tabs disabled when runtime observability is unav
 test('agent traces tab pre-fills the agent filter as URL params on first visit', async ({ page }) => {
   await mockSystemPackages(page, true);
 
+  // Default list mode is `branches` (PR #16493) — mock both endpoints so the
+  // captured URL works regardless of which mode is active.
   let tracesUrl: URL | undefined;
   await page.route('**/api/observability/traces?**', async route => {
     tracesUrl = new URL(route.request().url());
@@ -91,6 +107,17 @@ test('agent traces tab pre-fills the agent filter as URL params on first visit',
       contentType: 'application/json',
       body: JSON.stringify({
         spans: [],
+        pagination: { page: 0, perPage: 25, total: 0, hasMore: false },
+      }),
+    });
+  });
+  await page.route('**/api/observability/branches?**', async route => {
+    tracesUrl = new URL(route.request().url());
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        branches: [],
         pagination: { page: 0, perPage: 25, total: 0, hasMore: false },
       }),
     });
@@ -117,6 +144,16 @@ test('agent traces tab locks the scope filter pills and hides them from the crea
       contentType: 'application/json',
       body: JSON.stringify({
         spans: [],
+        pagination: { page: 0, perPage: 25, total: 0, hasMore: false },
+      }),
+    });
+  });
+  await page.route('**/api/observability/branches?**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        branches: [],
         pagination: { page: 0, perPage: 25, total: 0, hasMore: false },
       }),
     });
@@ -163,6 +200,16 @@ test('saved filters in an agent-scoped traces tab do not leak to other agents or
       }),
     });
   });
+  await page.route('**/api/observability/branches?**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        branches: [],
+        pagination: { page: 0, perPage: 25, total: 0, hasMore: false },
+      }),
+    });
+  });
 
   // Land on a page first so we have an origin to seed localStorage against.
   await page.goto('/observability');
@@ -195,6 +242,16 @@ test('global /observability traces page keeps the filter pills editable', async 
       contentType: 'application/json',
       body: JSON.stringify({
         spans: [],
+        pagination: { page: 0, perPage: 25, total: 0, hasMore: false },
+      }),
+    });
+  });
+  await page.route('**/api/observability/branches?**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        branches: [],
         pagination: { page: 0, perPage: 25, total: 0, hasMore: false },
       }),
     });


### PR DESCRIPTION
## Summary

The agent **Traces** tab now delegates to the shared Observability `TracesPage` (since #16405), and `TracesPage` defaults to `listMode=branches` (since #16493). That default fetches `/api/observability/branches` rather than `/api/observability/traces`, so the e2e tests in `observability-tabs.spec.ts` — which only mocked `/traces` — were sending the real default request into the void on CI.

Two tests were failing on `main`:

- `requests agent traces when runtime observability is available without package metadata` — `No traces found for applied filters` never appeared because the unmocked `/branches` call didn't return the empty payload the empty-state copy depends on.
- `agent traces tab pre-fills the agent filter as URL params on first visit` — `tracesUrl?.searchParams.get('entityType')` was `undefined` because the captured route never fired.

## Fix

Add a `/api/observability/branches?**` route mock alongside the existing `/traces` mock in every test in this file. The branches response uses `{ branches: [], pagination }` to match `ListBranchesResponse` so `'branches' in page` resolves correctly in `use-traces.tsx` and the page renders the "filters applied" empty state. `tracesUrl` is captured from whichever route fires, so the URL assertions stay valid regardless of which list mode is active.

The remaining three tests in the file (lock pills, saved-filter scoping, global observability) were silently passing because they don't assert on the API response, but were relying on the request going unmocked into the dev backend. Mocked them as well to remove that brittleness.

## Test plan

- [ ] Re-run `e2e/tests/agents/observability-tabs.spec.ts` in chromium — five tests should pass.
- [ ] Confirm no regression in the other agent tab e2e specs.

Out of scope: the three `stream.spec.ts` failures (`text stream` / `tool stream` / `workflow stream`) are unrelated to observability — they look like a regression from the signal-stream refactor (#16338 stack) and need separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The agent observability tests were failing because the page recently started fetching from a different API endpoint (branches instead of traces). The tests only mocked the old endpoint, so the new requests had no mock and the tests failed. This fix adds mocks for both endpoints in all the tests, so they work regardless of which one the page actually uses.

---

## Changes

**File: `packages/playground/e2e/tests/agents/observability-tabs.spec.ts`**

Updated all agent and global observability e2e tests to mock both the `/api/observability/traces` and `/api/observability/branches` endpoints. 

### Context

The agent Traces tab now delegates to the shared Observability `TracesPage`, which defaults to `listMode=branches` (PR #16493). This causes the page to fetch `/api/observability/branches` instead of `/api/observability/traces`. Previously, only the traces endpoint was mocked, causing unmocked branches requests to fail CI and break two tests.

### Updates

Each affected test now includes mocks for both endpoints:
- **`/api/observability/traces`** — returns `{ spans: [], pagination: {...} }`
- **`/api/observability/branches`** — returns `{ branches: [], pagination: {...} }`

The `tracesUrl` variable is set by whichever route fires first, preserving URL assertions (`entityType`, `entityId`) regardless of which endpoint is active.

### Tests Updated

Five tests in the file now have dual endpoint mocks:
1. "requests agent traces when runtime observability is available without package metadata"
2. "agent traces tab pre-fills the agent filter as URL params on first visit"
3. "agent traces tab locks the scope filter pills and hides them from the creator dropdown"
4. "saved filters in an agent-scoped traces tab do not leak to other agents or the global view"
5. "global /observability traces page keeps the filter pills editable"

Clarifying comments explain that both endpoints are mocked so assertions remain stable if the list mode default changes in the future.

### Test Plan

- All five updated tests should pass when run in Chromium
- No regression expected in other agent tab e2e specs
- Three stream.spec.ts failures (unrelated) remain out of scope

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16549)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->