### PR TITLE
fix(ci): report test suite for docs-only PRs

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -74,7 +74,7 @@ jobs:
 
   test-suite:
     name: Unit and E2E Tests
-    needs: [changes, prebuild]
+    needs: changes
     if: github.repository == 'mastra-ai/mastra'
     uses: ./.github/workflows/test-suite.yml
     permissions:

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -75,7 +75,7 @@ jobs:
   test-suite:
     name: Unit and E2E Tests
     needs: [changes, prebuild]
-    if: needs.changes.outputs.has_code == 'true' && github.repository == 'mastra-ai/mastra'
+    if: always() && github.repository == 'mastra-ai/mastra'
     uses: ./.github/workflows/test-suite.yml
     permissions:
       actions: read
@@ -83,6 +83,7 @@ jobs:
     with:
       head_sha: ${{ github.event.pull_request.head.sha }}
       base_ref: ${{ github.event.pull_request.base.ref }}
+      has_code: ${{ needs.changes.outputs.has_code }}
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -75,7 +75,7 @@ jobs:
   test-suite:
     name: Unit and E2E Tests
     needs: [changes, prebuild]
-    if: always() && github.repository == 'mastra-ai/mastra'
+    if: github.repository == 'mastra-ai/mastra'
     uses: ./.github/workflows/test-suite.yml
     permissions:
       actions: read

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -9,6 +9,9 @@ on:
       base_ref:
         required: true
         type: string
+      has_code:
+        required: true
+        type: string
     secrets:
       TURBO_TOKEN:
         required: false
@@ -20,6 +23,7 @@ permissions: {}
 jobs:
   unit-test:
     name: UNIT Test (Shard ${{ matrix.shard }})
+    if: inputs.has_code == 'true'
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -78,6 +82,7 @@ jobs:
 
   e2e-test:
     name: E2E Test (${{ matrix.project }})
+    if: inputs.has_code == 'true'
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -150,16 +155,23 @@ jobs:
       contents: read
 
     steps:
+      - name: Skip tests for non-code changes
+        if: inputs.has_code != 'true'
+        run: echo "No code changes detected; skipping unit and E2E tests."
+
       - name: Checkout repo
+        if: inputs.has_code == 'true'
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
           ref: ${{ inputs.head_sha }}
 
       - name: Setup pnpm and Node.js
+        if: inputs.has_code == 'true'
         uses: ./.github/actions/setup-pnpm-node
 
       - name: Download test results
+        if: inputs.has_code == 'true'
         uses: actions/download-artifact@v6
         with:
           pattern: vitest-blob-*
@@ -167,4 +179,5 @@ jobs:
           merge-multiple: true
 
       - name: Merge reports
+        if: inputs.has_code == 'true'
         run: pnpm vitest --merge-reports --reporter=default --reporter=github-actions --passWithNoTests


### PR DESCRIPTION
I noticed docs-only PRs can get stuck waiting for the required `Unit and E2E Tests / Merge Test Reports` check. The prebuild workflow skips the reusable test workflow when `has_code=false`, so that nested required check never gets created.\n\nThis keeps the expensive unit/E2E jobs skipped for docs-only PRs, but always instantiates the reusable test workflow and lets `Merge Test Reports` complete as a no-op when there are no code changes.\n\nValidated with Prettier and YAML parsing for the touched workflow files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

Docs-only pull requests were getting stuck waiting for a test-report check that never started. This change makes GitHub always create the test-suite workflow so the report check completes (doing nothing) when only docs changed, while still skipping expensive tests when there's no code change.

## Summary

This PR fixes a CI issue where docs-only PRs were blocked because the reusable test-suite workflow (and thus the required "Merge Test Reports" check) was never instantiated when no code changes were detected.

### Root Cause
The prebuild workflow previously skipped invoking the reusable test-suite workflow when `needs.changes.outputs.has_code == 'false'`, so the nested required check for merging test reports was never created for docs-only PRs.

### Solution
Always call the reusable test-suite workflow from prebuild (still limited to the official repository), and pass the `has_code` flag to it. The test-suite workflow uses that input to skip expensive jobs and perform a no-op merge step for non-code changes.

### Changes
- .github/workflows/prebuild.yml
  - The `test-suite` job no longer requires `needs.changes.outputs.has_code == 'true'`; it now runs whenever `github.repository == 'mastra-ai/mastra'`.
  - Passes inputs: `head_sha`, `base_ref`, and `has_code: ${{ needs.changes.outputs.has_code }}` to the reusable workflow.
  - Note: the `prebuild` build job remains gated on `has_code` and still only runs for code changes.

- .github/workflows/test-suite.yml
  - Added required workflow_call input: `has_code` (string).
  - Guarded expensive jobs:
    - `unit-test`: runs only when `inputs.has_code == 'true'`.
    - `e2e-test`: runs only when `inputs.has_code == 'true'`.
  - `merge-reports` job:
    - Always runs (if: always()), includes a "Skip tests for non-code changes" step when `inputs.has_code != 'true'`.
    - Checkout/download/merge steps run only when `inputs.has_code == 'true'`, so merge is a no-op for docs-only PRs.

### Result
Docs-only PRs now complete the required Merge Test Reports check as a no-op, preventing them from being blocked, while expensive unit and E2E tests remain skipped when there are no code changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16552)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16552)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->