### PR TITLE
Add region support to BlaxelSandbox

### DIFF
--- a/.changeset/slick-times-call.md
+++ b/.changeset/slick-times-call.md
@@ -1,0 +1,5 @@
+---
+'@mastra/blaxel': minor
+---
+
+Added region support to Blaxel sandboxes.

--- a/.changeset/slick-times-call.md
+++ b/.changeset/slick-times-call.md
@@ -2,4 +2,4 @@
 '@mastra/blaxel': minor
 ---
 
-Added region support to Blaxel sandboxes.
+Added region support to Blaxel sandboxes: `new BlaxelSandbox({ region: 'eu-west-1' })`. When omitted, Mastra falls back to `BL_REGION` and then `auto`.

--- a/docs/src/content/en/reference/workspace/blaxel-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/blaxel-sandbox.mdx
@@ -55,6 +55,7 @@ const workspace = new Workspace({
   sandbox: new BlaxelSandbox({
     image: 'node:20-slim',
     memory: 8192,
+    region: 'auto',
     timeout: '10m',
   }),
 })
@@ -91,6 +92,14 @@ const workspace = new Workspace({
     type: 'string',
     description: "Execution timeout as a duration string (e.g. '5m', '1h'). Maps to the Blaxel sandbox TTL.",
     isOptional: true,
+  },
+  {
+    name: 'region',
+    type: 'string',
+    description:
+      "Blaxel region where the sandbox should be created. Use 'auto' to choose a region automatically, or set a concrete region like 'us-pdx-1'.",
+    isOptional: true,
+    defaultValue: "process.env.BL_REGION || 'auto'",
   },
   {
     name: 'env',

--- a/workspaces/blaxel/README.md
+++ b/workspaces/blaxel/README.md
@@ -19,6 +19,7 @@ const workspace = new Workspace({
   sandbox: new BlaxelSandbox({
     timeout: '5m', // sandbox TTL (default: 5 minutes)
     memory: 4096, // memory in MB (default: 4096)
+    region: 'auto', // region selection (default: BL_REGION or auto)
   }),
 });
 
@@ -37,6 +38,7 @@ const agent = new Agent({
 | `image`    | `string`                              | `'blaxel/ts-app:latest'`     | Docker image to use                                    |
 | `memory`   | `number`                              | `4096`                       | Memory allocation in MB                                |
 | `timeout`  | `string`                              | `'5m'`                       | Sandbox TTL as a duration string (e.g. `'5m'`, `'1h'`) |
+| `region`   | `string`                              | `BL_REGION` or `'auto'`      | Blaxel region where the sandbox should be created      |
 | `env`      | `Record<string, string>`              | —                            | Environment variables to set in the sandbox            |
 | `labels`   | `Record<string, string>`              | —                            | Custom labels for the sandbox                          |
 | `runtimes` | `SandboxRuntime[]`                    | `['node', 'python', 'bash']` | Supported runtimes                                     |

--- a/workspaces/blaxel/src/sandbox/index.test.ts
+++ b/workspaces/blaxel/src/sandbox/index.test.ts
@@ -88,6 +88,15 @@ vi.mock('@blaxel/core', () => ({
   },
 }));
 
+function restoreBlRegion(value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env.BL_REGION;
+    return;
+  }
+
+  process.env.BL_REGION = value;
+}
+
 describe('BlaxelSandbox', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -134,6 +143,26 @@ describe('BlaxelSandbox', () => {
 
       expect((sandbox as any).image).toBe('custom:latest');
       expect((sandbox as any).memory).toBe(8192);
+    });
+
+    it('uses configured region', () => {
+      const sandbox = new BlaxelSandbox({ region: 'eu-lon-1' });
+
+      expect((sandbox as any).region).toBe('eu-lon-1');
+    });
+
+    it('defaults region to BL_REGION, then auto', () => {
+      const originalBlRegion = process.env.BL_REGION;
+
+      try {
+        process.env.BL_REGION = 'us-pdx-1';
+        expect((new BlaxelSandbox() as any).region).toBe('us-pdx-1');
+
+        delete process.env.BL_REGION;
+        expect((new BlaxelSandbox() as any).region).toBe('auto');
+      } finally {
+        restoreBlRegion(originalBlRegion);
+      }
     });
   });
 
@@ -201,6 +230,59 @@ describe('BlaxelSandbox', () => {
           }),
         }),
       );
+    });
+
+    it('passes configured region to sandbox creation', async () => {
+      const { SandboxInstance } = await import('@blaxel/core');
+      const sandbox = new BlaxelSandbox({ id: 'region-id', region: 'eu-lon-1' });
+
+      await sandbox._start();
+
+      expect(SandboxInstance.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          region: 'eu-lon-1',
+        }),
+      );
+    });
+
+    it('passes BL_REGION to sandbox creation when region is not configured', async () => {
+      const { SandboxInstance } = await import('@blaxel/core');
+      const originalBlRegion = process.env.BL_REGION;
+
+      try {
+        process.env.BL_REGION = 'us-was-1';
+        const sandbox = new BlaxelSandbox({ id: 'env-region-id' });
+
+        await sandbox._start();
+
+        expect(SandboxInstance.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            region: 'us-was-1',
+          }),
+        );
+      } finally {
+        restoreBlRegion(originalBlRegion);
+      }
+    });
+
+    it('passes auto to sandbox creation when no region is set', async () => {
+      const { SandboxInstance } = await import('@blaxel/core');
+      const originalBlRegion = process.env.BL_REGION;
+
+      try {
+        delete process.env.BL_REGION;
+        const sandbox = new BlaxelSandbox({ id: 'auto-region-id' });
+
+        await sandbox._start();
+
+        expect(SandboxInstance.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            region: 'auto',
+          }),
+        );
+      } finally {
+        restoreBlRegion(originalBlRegion);
+      }
     });
 
     it('reconnects to existing sandbox by name', async () => {

--- a/workspaces/blaxel/src/sandbox/index.ts
+++ b/workspaces/blaxel/src/sandbox/index.ts
@@ -89,6 +89,12 @@ export interface BlaxelSandboxOptions extends Omit<MastraSandboxOptions, 'proces
    * This maps to the Blaxel sandbox TTL.
    */
   timeout?: string;
+  /**
+   * Blaxel region where the sandbox should be created.
+   *
+   * Defaults to BL_REGION, then 'auto'.
+   */
+  region?: string;
   /** Environment variables to set in the sandbox */
   env?: Record<string, string>;
   /** Custom labels for the sandbox */
@@ -160,6 +166,7 @@ export class BlaxelSandbox extends MastraSandbox {
   private readonly image: string;
   private readonly memory: number;
   private readonly timeout?: string;
+  private readonly region: string;
   private readonly env: Record<string, string>;
   private readonly labels: Record<string, string>;
   private readonly configuredRuntimes: SandboxRuntime[];
@@ -177,6 +184,7 @@ export class BlaxelSandbox extends MastraSandbox {
     this.image = options.image ?? 'blaxel/ts-app:latest';
     this.memory = options.memory ?? 4096;
     this.timeout = options.timeout;
+    this.region = options.region || process.env.BL_REGION || 'auto';
     this.env = options.env ?? {};
     this.labels = options.labels ?? {};
     this.configuredRuntimes = options.runtimes ?? ['node', 'python', 'bash'];
@@ -637,6 +645,7 @@ export class BlaxelSandbox extends MastraSandbox {
         name: sandboxName,
         image: this.image,
         memory: this.memory,
+        region: this.region,
         ...(this.timeout && { ttl: this.timeout }),
         labels: {
           ...this.labels,


### PR DESCRIPTION
## Summary

Closes #17304.

- Add a `region` option to `BlaxelSandbox`.
- Default to `BL_REGION` when set, otherwise `auto`.
- Pass the resolved region to `SandboxInstance.create`.

## Why

Blaxel now warns when sandbox region is missing. This lets Mastra users configure it directly and keeps existing code working without extra setup.

## Validation

- `corepack pnpm --filter @mastra/blaxel test:unit`
- `corepack pnpm --filter @mastra/blaxel build`
- `corepack pnpm --filter @mastra/blaxel lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets you tell Blaxel sandboxes which geographic region to use; it prefers an explicit region, then the BL_REGION environment variable, and otherwise uses "auto". That prevents Blaxel warnings when no region is set.

## Changes

**Implementation** (`workspaces/blaxel/src/sandbox/index.ts`)
- Added optional `region?: string` to `BlaxelSandboxOptions`.
- Resolves region as: explicit `options.region` → `process.env.BL_REGION` → `'auto'`.
- Stores resolved region in a private field and passes `region: this.region` to `SandboxInstance.create`.

**Testing** (`workspaces/blaxel/src/sandbox/index.test.ts`)
- Added `restoreBlRegion()` test helper to manage `process.env.BL_REGION`.
- Added tests for constructor defaulting behavior (explicit option, env fallback, `"auto"` fallback).
- Added tests verifying `region` is forwarded to `SandboxInstance.create`.

**Documentation**
- Updated `docs/src/content/en/reference/workspace/blaxel-sandbox.mdx` to document the `region` parameter, examples, and defaulting behavior.
- Updated `workspaces/blaxel/README.md` usage and configuration docs to include `region`.

**Release**
- Added `.changeset/slick-times-call.md` to mark `@mastra/blaxel` for a minor release describing the new `region` option.

## Summary

Backwards-compatible addition of a `region` option to BlaxelSandbox; defaults from config → BL_REGION → `'auto'`; value is passed to sandbox creation. Tests, docs, and a changeset were updated accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
