### PR TITLE
fix: replay transformed recording hashes

### DIFF
--- a/packages/_llm-recorder/src/llm-recorder.test.ts
+++ b/packages/_llm-recorder/src/llm-recorder.test.ts
@@ -121,6 +121,78 @@ describe('transformRequest', () => {
       recorder.stop();
     }
   });
+
+  it('uses transformed hashes for existing recordings in exact replay mode', async () => {
+    const originalMode = process.env.LLM_TEST_MODE;
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-recorder-transform-'));
+    const name = 'transformed-hash-replay';
+    const filePath = path.join(tempDir, `${name}.json`);
+
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify(
+        {
+          meta: { name, createdAt: '2026-03-26T00:00:00.000Z' },
+          recordings: [
+            {
+              hash: 'stale-before-transform',
+              request: {
+                url: 'https://api.openai.com/v1/responses',
+                method: 'POST',
+                body: { model: 'gpt-4o', input: 'hello', timestamp: 'old' },
+                timestamp: 1,
+              },
+              response: {
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+                body: { id: 'transformed-match', output: [] },
+                isStreaming: false,
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+
+    process.env.LLM_TEST_MODE = 'replay';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const recorder = setupLLMRecording({
+      name,
+      recordingsDir: tempDir,
+      exactMatch: true,
+      transformRequest: ({ url, body }) => {
+        const nextBody = { ...(body as Record<string, unknown>) };
+        delete nextBody.timestamp;
+        return { url, body: nextBody };
+      },
+    });
+    recorder.start();
+
+    try {
+      const response = await fetch('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'gpt-4o', input: 'hello', timestamp: 'new' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ id: 'transformed-match', output: [] });
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('No exact match for hash'));
+    } finally {
+      recorder.stop();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      if (originalMode === undefined) {
+        delete process.env.LLM_TEST_MODE;
+      } else {
+        process.env.LLM_TEST_MODE = originalMode;
+      }
+      vi.restoreAllMocks();
+    }
+  });
 });
 
 /**

--- a/packages/_llm-recorder/src/llm-recorder.ts
+++ b/packages/_llm-recorder/src/llm-recorder.ts
@@ -726,7 +726,12 @@ export function setupLLMRecording(options: LLMRecorderOptions): LLMRecorderInsta
     try {
       const file = loadRecordingFile(recordingPath, options.name);
       existingMeta = file.meta;
-      savedRecordings = file.recordings;
+      savedRecordings = options.transformRequest
+        ? file.recordings.map(recording => {
+            const transformed = options.transformRequest!({ url: recording.request.url, body: recording.request.body });
+            return { ...recording, hash: hashRequest(transformed.url, transformed.body) };
+          })
+        : file.recordings;
     } catch (err) {
       if (!willRecord) {
         throw err;


### PR DESCRIPTION
It fixes exact LLM replay when recordings use request transforms. Loaded recordings now recompute their in-memory hash after applying transformRequest, so exact replay compares transformed live requests with transformed saved requests.

This does not loosen matching or rewrite recording files; if the transformed request still differs, exact replay still fails.

Verified with the llm-recorder test/build, rebuilt test-utils, and the focused memory Thread Cloning integration test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When replaying saved LLM recordings that have been modified (transformed) before use, the system now applies the same modifications to the saved recording before comparing it with the live request. This ensures that the "before" and "after" versions are compared fairly—just like making sure two recipes go through the same cooking process before checking if the results match.

## Changes

The PR updates LLM recording replay behavior to correctly handle request transforms in `exactMatch` mode:

**llm-recorder.ts**: When loading an existing recording file, the code now applies `options.transformRequest` (if provided) to each stored recording's request and recomputes the recording hash based on the transformed values. Previously, loaded recordings were used as-is without per-recording hash re-computation for transforms.

**llm-recorder.test.ts**: Added a new test case verifying that in `exactMatch` replay mode, `setupLLMRecording` uses the transformed request payload when looking up an existing recording hash. The test creates a temporary recordings directory with a stale recording containing a timestamp in the request body, sets `LLM_TEST_MODE` to `replay`, performs a fetch with a different timestamp, and verifies the replayed response matches the stored recording without any "No exact match" warnings.

## Impact

- Enables exact replay matching for recordings that use request transforms
- Preserves dynamic-field normalization stability
- Does not weaken exact matching behavior
- Does not mutate recording files
- If a transformed request still differs between live and saved, exact replay will continue to fail as expected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16556)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->