### PR TITLE
fix: propagate agent signal request context

### DIFF
--- a/.changeset/tiny-points-enter.md
+++ b/.changeset/tiny-points-enter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed agent signal wakeups so idle runs receive request context values while preserving server-owned resource identifiers.

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -446,11 +446,16 @@ export function MastraRuntimeProvider({
   }, [initialLegacyMessages]);
 
   const chatRequestContext = useMemo(() => {
-    if (!agentVersionId) return undefined;
+    if (!agentVersionId && !requestContext) return undefined;
     const ctx = new RequestContext();
-    ctx.set('agentVersionId', agentVersionId);
+    Object.entries(requestContext ?? {}).forEach(([key, value]) => {
+      ctx.set(key, value);
+    });
+    if (agentVersionId) {
+      ctx.set('agentVersionId', agentVersionId);
+    }
     return ctx;
-  }, [agentVersionId]);
+  }, [agentVersionId, requestContext]);
 
   const {
     messages,

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -1204,6 +1204,42 @@ describe('Agent Routes Authorization', () => {
       });
     });
 
+    it('should merge idle stream request context before waking a thread with a signal', async () => {
+      await mockMemory.createThread({
+        threadId: 'signal-thread-with-context',
+        resourceId: 'user-a',
+        title: 'Signal Thread With Context',
+      });
+      const requestContext = createContextWithReservedKeys({ resourceId: 'user-a' });
+      let capturedTarget: any;
+
+      (mockAgent as any).sendSignal = vi.fn((_signal, target) => {
+        capturedTarget = target;
+        return { accepted: true, runId: 'signal-run-id' };
+      });
+
+      const result = await SEND_AGENT_SIGNAL_ROUTE.handler({
+        mastra,
+        agentId: 'test-agent',
+        requestContext,
+        signal: { type: 'user-message', contents: 'hello' },
+        resourceId: 'user-a',
+        threadId: 'signal-thread-with-context',
+        ifIdle: {
+          streamOptions: {
+            requestContext: {
+              fixture: 'text-stream',
+              [MASTRA_RESOURCE_ID_KEY]: 'user-b',
+            },
+          },
+        },
+      } as any);
+
+      expect(result).toEqual({ accepted: true, runId: 'signal-run-id' });
+      expect(capturedTarget.ifIdle.streamOptions.requestContext.get('fixture')).toBe('text-stream');
+      expect(capturedTarget.ifIdle.streamOptions.requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBe('user-a');
+    });
+
     it('should reject sending a signal to a thread owned by a different resource', async () => {
       await mockMemory.createThread({
         threadId: 'signal-thread-owned-by-b',

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -1603,6 +1603,8 @@ export const SEND_AGENT_SIGNAL_ROUTE: ServerRoute<
     ifIdle,
   }) => {
     try {
+      mergeBodyRequestContext(serverRequestContext, ifIdle?.streamOptions?.requestContext);
+
       const agent = await getAgentFromSystem({ mastra, agentId, requestContext: serverRequestContext });
       const effectiveResourceId = getEffectiveResourceId(serverRequestContext, resourceId);
       const effectiveThreadId = getEffectiveThreadId(serverRequestContext, threadId);


### PR DESCRIPTION
This fixes idle agent signal wakeups so request context from stream options is preserved when a thread is woken, while keeping server-owned resource identifiers authoritative.

Before, an idle wakeup could drop body request context before starting the stream. Now the server merges that context before sending the signal, and the playground passes its request context into chat subscriptions.

Verified with the focused server handler test, server build, playground build, and the text stream E2E.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a sleeping background task (idle agent) gets woken up by a signal, the system now remembers and passes along the request details that were sent with the wake-up call. Before, this information would get lost. The fix makes sure that request context is properly carried over when waking idle agents, while the server still controls its own special identifiers.

## Changes

### Playground Request Context Integration
The `MastraRuntimeProvider` now constructs `chatRequestContext` by combining both the provided `requestContext` and `agentVersionId`. This ensures that when the playground initiates chat subscriptions, all relevant request context is passed through to the server.

### Server Signal Handler Enhancement
The `SEND_AGENT_SIGNAL_ROUTE` handler in the agents endpoint now merges request context from `ifIdle.streamOptions.requestContext` into the server's request context before processing the wake signal. This prevents request context from being dropped when idle agents are activated.

### Server Authority Over Resource Identifiers
The merge operation preserves server authority: when the request context contains reserved keys like `MASTRA_RESOURCE_ID_KEY`, the server's own values take precedence over client-provided ones, ensuring resource ownership and access control remain intact.

### Test Coverage
A new test case verifies that the `SEND_AGENT_SIGNAL_ROUTE` handler correctly merges the idle stream options' request context while maintaining server ownership of resource identifiers.

## Files Modified
- `.changeset/tiny-points-enter.md` - Changeset entry for patch version bump
- `packages/playground/src/services/mastra-runtime-provider.tsx` - Enhanced request context construction
- `packages/server/src/server/handlers/agents.ts` - Added request context merging for idle signals
- `packages/server/src/server/handlers/agents.test.ts` - New test for signal request context merging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16557)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->