### PR TITLE
feat(cli): add observability metric commands

### DIFF
--- a/.changeset/tidy-metrics-listen.md
+++ b/.changeset/tidy-metrics-listen.md
@@ -1,0 +1,7 @@
+---
+'mastra': patch
+---
+
+**Added**
+
+Added named `mastra api metric` commands for querying hosted observability metrics, including aggregate, breakdown, timeseries, percentiles, metric name discovery, and metric label discovery.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -1022,6 +1022,62 @@ Lists observability logs. Pass optional JSON input for route-supported filters o
 mastra api log list [input]
 ```
 
+#### `mastra api metric aggregate`
+
+Gets a single aggregate metric value.
+
+```bash
+mastra api metric aggregate '{"name":["latency_ms"],"aggregation":"avg"}'
+```
+
+#### `mastra api metric breakdown`
+
+Gets metric values grouped by a label or field.
+
+```bash
+mastra api metric breakdown '{"name":["latency_ms"],"aggregation":"avg","groupBy":["model"],"limit":10}'
+```
+
+#### `mastra api metric timeseries`
+
+Gets metric values over time.
+
+```bash
+mastra api metric timeseries '{"name":["latency_ms"],"aggregation":"avg","interval":"1h"}'
+```
+
+#### `mastra api metric percentiles`
+
+Gets metric percentile values over time. Percentile values use decimals from `0` to `1`.
+
+```bash
+mastra api metric percentiles '{"name":"latency_ms","percentiles":[0.5,0.95,0.99],"interval":"1h"}'
+```
+
+#### `mastra api metric names`
+
+Lists discovered metric names. Pass optional JSON input for prefix search and limit.
+
+```bash
+mastra api metric names '{"prefix":"lat","limit":10}'
+```
+
+#### `mastra api metric label-keys`
+
+Lists label keys for a metric.
+
+```bash
+mastra api metric label-keys '{"metricName":"latency_ms"}'
+```
+
+#### `mastra api metric label-values`
+
+Lists label values for a metric label key. Pass optional prefix and limit values to narrow the result.
+
+```bash
+mastra api metric label-values '{"metricName":"latency_ms","labelKey":"model","prefix":"g","limit":10}'
+```
+
 #### Observability with `curl`
 
 You can call the hosted observability API directly with your platform access token and project ID:

--- a/packages/cli/src/commands/api/api.test.ts
+++ b/packages/cli/src/commands/api/api.test.ts
@@ -257,6 +257,89 @@ describe('api command executor', () => {
     expect(JSON.parse(stdout)).toEqual({ data: { traceId: 'trace-1', spanId: 'span-2', input: { value: 'hello' } } });
   });
 
+  it('queries metric aggregates and discovery endpoints', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ value: 123 }))
+      .mockResolvedValueOnce(jsonResponse({ series: [{ timestamp: '2026-05-13T00:00:00Z', value: 42 }] }))
+      .mockResolvedValueOnce(jsonResponse({ names: ['latency_ms'] }));
+
+    await executeDescriptor(API_COMMANDS.metricAggregate, [], '{"name":"latency_ms","aggregation":"avg"}', {
+      url: 'https://observability.mastra.ai',
+      header: ['Authorization: Bearer token', 'X-Mastra-Project-Id: project-1'],
+      pretty: false,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://observability.mastra.ai/api/observability/metrics/aggregate',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer token',
+          'X-Mastra-Project-Id': 'project-1',
+          'content-type': 'application/json',
+        },
+        signal: expect.any(AbortSignal),
+        body: JSON.stringify({ name: 'latency_ms', aggregation: 'avg' }),
+      },
+    );
+    expect(JSON.parse(stdout)).toEqual({ data: { value: 123 } });
+
+    stdout = '';
+
+    await executeDescriptor(
+      API_COMMANDS.metricTimeseries,
+      [],
+      '{"name":"latency_ms","aggregation":"avg","interval":"1h"}',
+      {
+        url: 'https://observability.mastra.ai',
+        header: ['Authorization: Bearer token', 'X-Mastra-Project-Id: project-1'],
+        pretty: false,
+      },
+    );
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://observability.mastra.ai/api/observability/metrics/timeseries',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer token',
+          'X-Mastra-Project-Id': 'project-1',
+          'content-type': 'application/json',
+        },
+        signal: expect.any(AbortSignal),
+        body: JSON.stringify({ name: 'latency_ms', aggregation: 'avg', interval: '1h' }),
+      },
+    );
+    expect(JSON.parse(stdout)).toEqual({
+      data: [{ timestamp: '2026-05-13T00:00:00Z', value: 42 }],
+      page: { total: 1, page: 0, perPage: 1, hasMore: false },
+    });
+
+    stdout = '';
+
+    await executeDescriptor(API_COMMANDS.metricNames, [], '{"prefix":"lat","limit":10}', {
+      url: 'https://observability.mastra.ai',
+      header: ['Authorization: Bearer token', 'X-Mastra-Project-Id: project-1'],
+      pretty: false,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      'https://observability.mastra.ai/api/observability/discovery/metric-names?prefix=lat&limit=10',
+      {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token', 'X-Mastra-Project-Id': 'project-1' },
+        signal: expect.any(AbortSignal),
+      },
+    );
+    expect(JSON.parse(stdout)).toEqual({
+      data: ['latency_ms'],
+      page: { total: 1, page: 0, perPage: 1, hasMore: false },
+    });
+  });
+
   it('encodes DELETE JSON input as query params when the route has no body schema', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ result: 'Thread deleted' }));
 

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -247,6 +247,81 @@ export function registerApiCommand(program: CommanderCommand): void {
     ],
   });
 
+  const metric = api.command('metric').description('Query observability metrics');
+  addAction(metric, 'aggregate', 'POST /observability/metrics/aggregate', {
+    description: 'Get an aggregate metric value',
+    input: 'required',
+    examples: [
+      {
+        description: 'Get an average latency metric',
+        command: `mastra api metric aggregate '{"name":"latency_ms","aggregation":"avg"}'`,
+      },
+    ],
+  });
+  addAction(metric, 'breakdown', 'POST /observability/metrics/breakdown', {
+    description: 'Get metric values grouped by a label or field',
+    input: 'required',
+    list: true,
+    examples: [
+      {
+        description: 'Break down latency by model',
+        command: `mastra api metric breakdown '{"name":"latency_ms","aggregation":"avg","groupBy":"model","limit":10}'`,
+      },
+    ],
+  });
+  addAction(metric, 'timeseries', 'POST /observability/metrics/timeseries', {
+    description: 'Get metric values over time',
+    input: 'required',
+    list: true,
+    examples: [
+      {
+        description: 'Get hourly average latency',
+        command: `mastra api metric timeseries '{"name":"latency_ms","aggregation":"avg","interval":"1h"}'`,
+      },
+    ],
+  });
+  addAction(metric, 'percentiles', 'POST /observability/metrics/percentiles', {
+    description: 'Get metric percentile values over time',
+    input: 'required',
+    list: true,
+    examples: [
+      {
+        description: 'Get latency percentiles',
+        command: `mastra api metric percentiles '{"name":"latency_ms","percentiles":[50,95,99],"interval":"1h"}'`,
+      },
+    ],
+  });
+  addAction(metric, 'names', 'GET /observability/discovery/metric-names', {
+    description: 'List discovered metric names',
+    input: 'optional',
+    list: true,
+    examples: [
+      { description: 'Search metric names', command: `mastra api metric names '{"prefix":"lat","limit":10}'` },
+    ],
+  });
+  addAction(metric, 'label-keys', 'GET /observability/discovery/metric-label-keys', {
+    description: 'List label keys for a metric',
+    input: 'required',
+    list: true,
+    examples: [
+      {
+        description: 'List label keys for a metric',
+        command: `mastra api metric label-keys '{"metricName":"latency_ms"}'`,
+      },
+    ],
+  });
+  addAction(metric, 'label-values', 'GET /observability/discovery/metric-label-values', {
+    description: 'List label values for a metric label key',
+    input: 'required',
+    list: true,
+    examples: [
+      {
+        description: 'Search label values for a metric label key',
+        command: `mastra api metric label-values '{"metricName":"latency_ms","labelKey":"model","prefix":"g","limit":10}'`,
+      },
+    ],
+  });
+
   const score = api.command('score').description('Create, list, and inspect scores');
   addAction(score, 'create', 'POST /observability/scores', {
     description: 'Create a score',


### PR DESCRIPTION
## Summary

- add named `mastra api metric` commands for hosted observability metrics
- support aggregate, breakdown, timeseries, percentiles, metric name discovery, and metric label discovery endpoints
- document metric command usage in the CLI reference
- add a patch changeset for the CLI package

## Test plan

- `pnpm --filter mastra exec vitest run src/commands/api/target.test.ts src/commands/api/api.test.ts`
- `pnpm --filter mastra exec tsc --noEmit --incremental`
- `pnpm exec prettier --check docs/src/content/en/reference/cli/mastra.mdx .changeset/tidy-metrics-listen.md packages/cli/src/commands/api/api.test.ts packages/cli/src/commands/api/index.ts`

## Notes

This is stacked on #16563 because the metric commands use the hosted observability target and credential inference added there.
