### PR TITLE
docs: add Mastra Code goals guide

### DIFF
--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -239,6 +239,17 @@ The filename (or directory structure) determines the command name. For example, 
 
 Commands support variables like `$ARGUMENTS` for positional args, `@filename` for file content injection, and `!command` for shell command output.
 
+Add `goal: true` to expose the command as a goal entry point under `/goal/<command-name>`:
+
+```md title=".mastracode/commands/pr-triage.md"
+---
+description: Triage every open PR
+goal: true
+---
+
+Review every open PR and continue until each PR has a concise TL;DR.
+```
+
 ## Skills
 
 Skills are structured instruction files that the agent loads automatically based on trigger conditions. They provide domain-specific guidance without manually pasting instructions.
@@ -253,6 +264,19 @@ Mastra Code scans these directories for skills:
 | Lowest | `~/.claude/skills/` | Global (Claude Code compatible) |
 
 Each skill is a directory containing a `SKILL.md` file with instructions and trigger descriptions. Skills installed via symlinks (e.g., from `npx skills add`) are automatically resolved.
+
+Add `metadata.goal: true` to expose a skill as a goal entry point under `/goal/<skill-name>`:
+
+```md title=".mastracode/skills/release-check/SKILL.md"
+---
+name: release-check
+description: Check whether a release is ready
+metadata:
+  goal: true
+---
+
+Run the release checks and continue until the release is ready or a human decision is required.
+```
 
 ## Agent instructions
 

--- a/docs/src/mastra-code/goals.mdx
+++ b/docs/src/mastra-code/goals.mdx
@@ -1,0 +1,121 @@
+---
+title: 'Goals'
+description: 'Use /goal to keep Mastra Code working on an objective until a judge model marks it complete, asks it to continue, or waits for user input.'
+packages:
+  - 'mastracode'
+---
+
+# Goals
+
+Goals let Mastra Code keep working toward an objective across multiple assistant turns. Use a goal when a task needs repeated work and checks, such as reviewing every open pull request, completing a checklist, or implementing a plan until verification passes.
+
+Start a goal with the `/goal` slash command:
+
+```text
+/goal Review every open PR, categorize each one, and stop only after all PRs have a concise TL;DR.
+```
+
+Mastra Code saves the objective on the current thread, runs the normal assistant turn, then asks a separate judge model what should happen next.
+
+| Decision | Behavior |
+| - | - |
+| `done` | The goal is complete. Mastra Code records the result and exits goal mode. |
+| `continue` | The goal is not complete. Mastra Code adds the judge feedback as a system reminder and starts another turn. |
+| `waiting` | The goal requires user input or a checkpoint. Mastra Code stays in goal mode and waits for you. |
+
+The status line shows goal progress as `goal attempt N/M`. On narrow terminals, it shortens to `attempt N/M`.
+
+## Configure the judge
+
+The first time you run `/goal`, Mastra Code asks which model should judge progress and how many attempts the goal can use. These defaults are saved for future goals.
+
+Use `/judge` to change the defaults later:
+
+```text
+/judge
+```
+
+Changing `/judge` while a goal is active updates that goal's judge model and attempt limit without resetting progress.
+
+## Manage a goal
+
+Use `/goal` subcommands to inspect or control the current goal:
+
+| Command | Description |
+| - | - |
+| `/goal status` | Show the active goal, judge model, and attempt count. |
+| `/goal pause` | Pause the active goal. |
+| `/goal resume` | Resume a paused goal without resetting its attempt count. |
+| `/goal clear` | Remove the current goal from the thread. |
+
+If the judge is evaluating, Mastra Code temporarily blocks new input so a follow-up message cannot race the judge decision. `/goal pause`, `/goal clear`, and `/exit` still work while the judge is running.
+
+Pressing Escape or Ctrl+C does not pause a goal. Use `/goal pause` when you want to pause it explicitly.
+
+## Multiline goals
+
+Goal objectives can span multiple lines:
+
+```text
+/goal Review the release PRs.
+For each PR, explain the change, whether it needs work, and what should happen next.
+Do not stop until every PR has been categorized.
+```
+
+Mastra Code treats the full multiline body as the goal objective.
+
+## Use an approved plan as a goal
+
+When Mastra Code submits a plan, the inline approval UI includes **Use as /goal**. Select it to start a goal from the plan content instead of approving the plan for one implementation pass.
+
+Use this when you want Mastra Code to continue executing and checking the plan until the judge marks it complete.
+
+## Goal-enabled slash commands
+
+Custom slash commands can opt into goal mode with `goal: true` in their YAML frontmatter. Mastra Code exposes those commands as `/goal/<command-name>`.
+
+```md title=".mastracode/commands/pr-triage.md"
+---
+description: Triage every open PR
+goal: true
+---
+
+Inspect every open PR. For each PR, write a concise TL;DR, note whether it needs work, and prioritize PRs where the user is tagged as a reviewer.
+```
+
+Run it as a goal:
+
+```text
+/goal/pr-triage
+```
+
+The command template is expanded first, including `$ARGUMENTS`, file references, and shell substitutions. The expanded prompt becomes the goal objective.
+
+## Goal-enabled skills
+
+Skills can also opt into goal mode by setting `metadata.goal: true` in `SKILL.md` frontmatter:
+
+```md title=".mastracode/skills/release-check/SKILL.md"
+---
+name: release-check
+description: Check whether a release is ready
+metadata:
+  goal: true
+---
+
+Review the release branch, run the required checks, summarize blockers, and continue until the release is ready or a human decision is required.
+```
+
+Run the skill as a goal:
+
+```text
+/goal/release-check
+```
+
+Mastra Code uses the skill instructions as the goal objective and appends any arguments you provide.
+
+## Persistence
+
+Goals are saved in thread metadata. If you switch threads or restart Mastra Code, the current thread restores its goal state, including the objective, judge model, status, attempt count, and attempt limit.
+
+Goal setup messages and final judge results are stored as system reminders in the conversation so resumed threads keep the goal context visible.

--- a/docs/src/mastra-code/index.mdx
+++ b/docs/src/mastra-code/index.mdx
@@ -12,6 +12,7 @@ Mastra Code is a terminal-based AI coding agent that never compacts. Built on Ma
 Mastra Code organizes its capabilities around these areas:
 
 - [**Modes**](/modes): Switch between Build, Plan, and Fast modes to match your workflow.
+- [**Goals**](/goals): Keep Mastra Code working across turns until a judge model marks the objective complete or waits for your input.
 - [**Tools**](/tools): Built-in tools for file viewing, editing, searching, shell commands, and web search.
 - [**Configuration**](/configuration): Project-scoped threads, MCP servers, hooks, custom commands, skills, and database settings.
 - [**Terminal notifications**](/terminal-notifications): Show clickable notifications for Mastra Code running in an inactive terminal pane.
@@ -93,6 +94,8 @@ Mastra Code provides built-in slash commands for managing sessions and settings:
 | `/name` | Rename the current thread |
 | `/models` | Switch model pack |
 | `/mode` | Switch or list modes |
+| `/goal` | Start, inspect, pause, resume, or clear a persistent goal |
+| `/judge` | Configure the judge model and attempt limit for goals |
 | `/permissions` | Configure tool approval permissions |
 | `/settings` | Open the settings panel |
 | `/om` | Configure Observational Memory |
@@ -141,6 +144,7 @@ Mastra Code is built on four layers:
 ## Next steps
 
 - [Modes](/modes)
+- [Goals](/goals)
 - [Tools](/tools)
 - [Configuration](/configuration)
 - [Customization](/customization)

--- a/docs/src/mastra-code/modes.mdx
+++ b/docs/src/mastra-code/modes.mdx
@@ -78,6 +78,7 @@ When the agent finishes analyzing the codebase, it submits a structured plan usi
 After submission, you can:
 
 - **Approve**: Mastra Code switches to Build mode and begins implementation.
+- **Use as /goal**: Start a goal from the approved plan so Mastra Code keeps executing and checking the plan across turns.
 - **Reject**: Stay in Plan mode.
 - **Request changes**: Provide feedback for the agent to revise and resubmit.
 


### PR DESCRIPTION
Adds the Mastra Code goal docs to the monorepo source that feeds the docs site.

The new page explains how to start and manage a goal:

```text
/goal Review every open PR and summarize what needs attention.
```

It also covers judge decisions, `/judge`, `/goal status|pause|resume|clear`, multiline goals, using an approved plan as a goal, and goal-enabled commands and skills.

I also linked Goals from the Mastra Code overview and documented the related command and skill metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds documentation for a new "Goals" feature in Mastra Code that lets an AI assistant work on multi-step tasks across multiple conversation turns. Think of it like giving your AI assistant a big task, it works on it step-by-step, and you can check its progress, pause it, or resume it whenever you want.

## Overview

This documentation-only PR introduces comprehensive guidance on the Mastra Code Goals feature, which enables persistent, multi-turn goal execution with automatic judge-based decision making.

## Files Changed

**docs/src/mastra-code/goals.mdx** (new file)
A complete documentation page covering the Goals feature, including:
- Starting goals via the `/goal` slash command
- Judge decision outcomes (`done`, `continue`, `waiting`)
- Progress tracking via "goal attempt N/M"
- Judge configuration with `/judge` command (model selection, attempt limits)
- Goal management commands (`/goal status`, `/goal pause`, `/goal resume`, `/goal clear`)
- Support for multiline goal objectives
- Using approved plans from Plan mode as goals
- Enabling goal mode for custom commands (`goal: true` in frontmatter)
- Enabling goal mode for skills (`metadata.goal: true` in SKILL.md)
- Persistence behavior and state management

**docs/src/mastra-code/configuration.mdx**
Added documentation for two new configuration options:
- Custom commands: `goal: true` frontmatter field to expose command under `/goal/<command-name>`
- Skills: `metadata.goal: true` in SKILL.md frontmatter to expose skill under `/goal/<skill-name>`

**docs/src/mastra-code/index.mdx**
Updated the Mastra Code overview to:
- Add **Goals** navigation link between **Modes** and **Tools**
- Document two new slash commands: `/goal` (start/manage goals) and `/judge` (configure judge settings)
- Link Goals in the "Next steps" section

**docs/src/mastra-code/modes.mdx**
Enhanced Plan mode documentation with a new post-submission option to use an approved plan as a `/goal`.

## Summary

The PR establishes Goals as a core Mastra Code capability alongside existing Modes and Tools, providing users with complete documentation on how to define multi-turn objectives, monitor execution, control progress, and integrate Goals with custom commands and skills.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16566)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->