### PR TITLE
fix tests

### DIFF
--- a/packages/cli/src/commands/server/env.test.ts
+++ b/packages/cli/src/commands/server/env.test.ts
@@ -46,7 +46,7 @@ afterEach(() => {
 });
 
 describe('resolveAuth', () => {
-  it('prefers MASTRA_ORG_ID over --org', async () => {
+  it('prefers MASTRA_ORG_ID over --org', { timeout: 10_000 }, async () => {
     process.env.MASTRA_ORG_ID = 'env-org';
     const { resolveAuth } = await import('./env.js');
     await expect(resolveAuth('cli-org')).resolves.toEqual({ token: 'tok', orgId: 'env-org' });

--- a/packages/cli/src/commands/studio/deploy.test.ts
+++ b/packages/cli/src/commands/studio/deploy.test.ts
@@ -38,7 +38,7 @@ describe('getMastraVersion', () => {
     return mod.getMastraVersion;
   }
 
-  it('resolves the installed version of mastra from node_modules', async () => {
+  it('resolves the installed version of mastra from node_modules', { timeout: 10000 }, async () => {
     const getMastraVersion = await loadGetMastraVersion();
 
     // Create a fake node_modules/mastra/package.json

--- a/packages/server/src/server/handlers/agent-builder-loading.test.ts
+++ b/packages/server/src/server/handlers/agent-builder-loading.test.ts
@@ -21,7 +21,7 @@ describe('agent builder route loading', () => {
     vi.resetModules();
   });
 
-  it('does not load or register agent builder when importing the server routes', async () => {
+  it('does not load or register agent builder when importing the server routes', { timeout: 10_000 }, async () => {
     const loadAgentBuilder = vi.fn(() => ({
       agentBuilderWorkflows: {},
     }));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Summary
Some tests were running too slowly and timing out. This PR fixes that by explicitly telling three specific tests to wait up to 10 seconds before giving up, giving them enough time to complete.

## Changes

The PR updates three test files to add explicit Vitest timeouts:

- **packages/cli/src/commands/server/env.test.ts**: Added a `10_000` millisecond timeout to the "prefers MASTRA_ORG_ID over --org" test case
- **packages/cli/src/commands/studio/deploy.test.ts**: Added a `10000` millisecond timeout to the `getMastraVersion` test case 
- **packages/server/src/server/handlers/agent-builder-loading.test.ts**: Added a `10_000` millisecond timeout to the first test verifying agent builder routes are not loaded on server import

Each change is a single line modification that configures the test timeout option in the test declaration, with no changes to the actual test logic or assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16568)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->