### PR TITLE
feat(core): return media parts and metadata fallback from workspace read_file

### DIFF
--- a/.changeset/slow-signs-teach.md
+++ b/.changeset/slow-signs-teach.md
@@ -4,11 +4,11 @@
 
 Improved how the workspace `read_file` tool returns files to the model. Reads now branch on file type:
 
-1. **Media files** (default: `image/*`, `application/pdf`) are surfaced as native file/image parts the model can directly view, instead of being dumped as base64 text.
+1. **Media files** (default: `image/png`, `image/jpeg`, `image/webp`, `image/gif`, `application/pdf`) are surfaced as native file/image parts the model can directly view, instead of being dumped as base64 text. Capped at 10 MiB by default so large media don't get base64-encoded into context and persisted in storage — configurable via `maxMediaBytes`.
 2. **Text-readable files** (anything `text/*`, common code/config mime types, or unknown extensions) are returned as text content as before.
-3. **Unsupported binaries** (e.g. `image/png` when `mediaTypes` is disabled, `application/zip`, etc.) now return a short metadata description (`path`, size, mime type) instead of dumping useless base64 into the conversation. Pass an explicit `encoding` to opt back into the raw base64/hex dump.
+3. **Unsupported binaries** (e.g. `image/png` when `mediaTypes` is disabled, `application/zip`, oversized media, etc.) now return a short metadata description (`path`, size, mime type) instead of dumping useless base64 into the conversation. Pass an explicit `encoding` to opt back into the raw base64/hex dump.
 
-The set of mime types treated as native media parts is configurable per workspace via a new `mediaTypes` option on the read_file tool config:
+The set of mime types treated as native media parts and the inline size cap are configurable per workspace:
 
 ```ts
 import { Workspace, WORKSPACE_TOOLS } from '@mastra/core/workspace';
@@ -17,17 +17,20 @@ const workspace = new Workspace({
   filesystem,
   tools: {
     [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
-      // Glob patterns
+      // Broaden to any image (e.g. SVG, BMP, HEIC) — may fail on some providers
       mediaTypes: ['image/*', 'application/pdf'],
+
+      // Raise the inline-media cap to 25 MiB
+      maxMediaBytes: 25 * 1024 * 1024,
 
       // Or a custom predicate
       // mediaTypes: (mime) => mime.startsWith('image/'),
 
-      // Or disable entirely
+      // Or disable media parts entirely
       // mediaTypes: false,
     },
   },
 });
 ```
 
-Defaults to `['image/*', 'application/pdf']` — the formats universally supported as native media parts across Anthropic, OpenAI, and Gemini.
+The default `mediaTypes` is intentionally the cross-provider-safe intersection — formats universally supported across Anthropic, OpenAI, and Gemini.

--- a/.changeset/slow-signs-teach.md
+++ b/.changeset/slow-signs-teach.md
@@ -1,0 +1,33 @@
+---
+'@mastra/core': minor
+---
+
+Improved how the workspace `read_file` tool returns files to the model. Reads now branch on file type:
+
+1. **Media files** (default: `image/*`, `application/pdf`) are surfaced as native file/image parts the model can directly view, instead of being dumped as base64 text.
+2. **Text-readable files** (anything `text/*`, common code/config mime types, or unknown extensions) are returned as text content as before.
+3. **Unsupported binaries** (e.g. `image/png` when `mediaTypes` is disabled, `application/zip`, etc.) now return a short metadata description (`path`, size, mime type) instead of dumping useless base64 into the conversation. Pass an explicit `encoding` to opt back into the raw base64/hex dump.
+
+The set of mime types treated as native media parts is configurable per workspace via a new `mediaTypes` option on the read_file tool config:
+
+```ts
+import { Workspace, WORKSPACE_TOOLS } from '@mastra/core/workspace';
+
+const workspace = new Workspace({
+  filesystem,
+  tools: {
+    [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
+      // Glob patterns
+      mediaTypes: ['image/*', 'application/pdf'],
+
+      // Or a custom predicate
+      // mediaTypes: (mime) => mime.startsWith('image/'),
+
+      // Or disable entirely
+      // mediaTypes: false,
+    },
+  },
+});
+```
+
+Defaults to `['image/*', 'application/pdf']` — the formats universally supported as native media parts across Anthropic, OpenAI, and Gemini.

--- a/.changeset/slow-signs-teach.md
+++ b/.changeset/slow-signs-teach.md
@@ -4,7 +4,7 @@
 
 Improved how the workspace `read_file` tool returns files to the model. Reads now branch on file type:
 
-1. **Media files** (default: `image/png`, `image/jpeg`, `image/webp`, `image/gif`, `application/pdf`) are surfaced as native file/image parts the model can directly view, instead of being dumped as base64 text. Capped at 10 MiB by default so large media don't get base64-encoded into context and persisted in storage — configurable via `maxMediaBytes`.
+1. **Media files** (default: `image/png`, `image/jpeg`, `image/webp`, `application/pdf`) are surfaced as native file/image parts the model can directly view, instead of being dumped as base64 text. Capped at 10 MiB by default so large media don't get base64-encoded into context and persisted in storage — configurable via `maxMediaBytes`.
 2. **Text-readable files** (anything `text/*`, common code/config mime types, or unknown extensions) are returned as text content as before.
 3. **Unsupported binaries** (e.g. `image/png` when `mediaTypes` is disabled, `application/zip`, oversized media, etc.) now return a short metadata description (`path`, size, mime type) instead of dumping useless base64 into the conversation. Pass an explicit `encoding` to opt back into the raw base64/hex dump.
 

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -473,7 +473,7 @@ Added when a filesystem is configured:
 
 With a static filesystem, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are excluded when the filesystem is in read-only mode. With a [dynamic filesystem](/docs/workspace/filesystem#dynamic-filesystem), write tools are always included and read-only is enforced at runtime.
 
-The `read_file` tool accepts a `mediaTypes` option to control which mime types are surfaced to the model as native media parts:
+The `read_file` tool accepts `mediaTypes` and `maxMediaBytes` options to control which mime types are surfaced to the model as native media parts and how large those files can be:
 
 <PropertiesTable
   content={[
@@ -481,9 +481,17 @@ The `read_file` tool accepts a `mediaTypes` option to control which mime types a
     name: 'mediaTypes',
     type: 'string[] | ((mimeType: string) => boolean) | false',
     description:
-      "Which mime types to surface to the model as media parts (file/image parts) rather than as text. Accepts an array of globs (e.g. `['image/*']`), a custom predicate function, or `false` to disable media detection. Only applies when the caller doesn't pass an explicit `encoding`.",
+      "Which mime types to surface to the model as media parts (file/image parts) rather than as text. Accepts an array of globs (e.g. `['image/*']`), a custom predicate function, or `false` to disable media detection. Defaults to the cross-provider-safe intersection of image formats plus PDF. Only applies when the caller doesn't pass an explicit `encoding`.",
     isOptional: true,
-    defaultValue: "['image/*', 'application/pdf']",
+    defaultValue: "['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'application/pdf']",
+  },
+  {
+    name: 'maxMediaBytes',
+    type: 'number',
+    description:
+      'Maximum file size (in bytes) to inline as a media part. Files larger than this fall back to metadata-only output rather than being fully base64-encoded into context and persisted in storage on rehydration.',
+    isOptional: true,
+    defaultValue: '10 * 1024 * 1024 (10 MiB)',
   },
 ]}
 />
@@ -493,8 +501,10 @@ const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
   tools: {
     [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
-      // Only inline images; PDFs fall back to metadata-only
+      // Broaden to any image (including SVG, BMP, HEIC) — may fail on some providers
       mediaTypes: ['image/*'],
+      // Raise the inline-media cap to 25 MiB
+      maxMediaBytes: 25 * 1024 * 1024,
     },
   },
 })

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -483,7 +483,7 @@ The `read_file` tool accepts `mediaTypes` and `maxMediaBytes` options to control
     description:
       "Which mime types to surface to the model as media parts (file/image parts) rather than as text. Accepts an array of globs (e.g. `['image/*']`), a custom predicate function, or `false` to disable media detection. Defaults to the cross-provider-safe intersection of image formats plus PDF. Only applies when the caller doesn't pass an explicit `encoding`.",
     isOptional: true,
-    defaultValue: "['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'application/pdf']",
+    defaultValue: "['image/png', 'image/jpeg', 'image/webp', 'application/pdf']",
   },
   {
     name: 'maxMediaBytes',

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -462,7 +462,7 @@ Added when a filesystem is configured:
 
 | Tool | Description |
 | - | - |
-| `mastra_workspace_read_file` | Read file contents. Supports optional line range for reading specific portions of large files. |
+| `mastra_workspace_read_file` | Read file contents. Text files return as text (with optional line range). Images and PDFs return as native media parts the model can view directly. Other binaries return metadata only unless an explicit `encoding` is passed. |
 | `mastra_workspace_write_file` | Create or overwrite a file with new content. Creates parent directories automatically. |
 | `mastra_workspace_edit_file` | Edit an existing file by finding and replacing text. Useful for targeted changes without rewriting the entire file. |
 | `mastra_workspace_list_files` | List directory contents as a tree structure. Supports recursive listing with depth limits, glob patterns, and `.gitignore` filtering (enabled by default). |
@@ -472,6 +472,33 @@ Added when a filesystem is configured:
 | `mastra_workspace_grep` | Search file contents using regex patterns. Supports glob filtering, context lines, and case-insensitive search. |
 
 With a static filesystem, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are excluded when the filesystem is in read-only mode. With a [dynamic filesystem](/docs/workspace/filesystem#dynamic-filesystem), write tools are always included and read-only is enforced at runtime.
+
+The `read_file` tool accepts a `mediaTypes` option to control which mime types are surfaced to the model as native media parts:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'mediaTypes',
+    type: 'string[] | ((mimeType: string) => boolean) | false',
+    description:
+      "Which mime types to surface to the model as media parts (file/image parts) rather than as text. Accepts an array of globs (e.g. `['image/*']`), a custom predicate function, or `false` to disable media detection. Only applies when the caller doesn't pass an explicit `encoding`.",
+    isOptional: true,
+    defaultValue: "['image/*', 'application/pdf']",
+  },
+]}
+/>
+
+```typescript
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  tools: {
+    [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
+      // Only inline images; PDFs fall back to metadata-only
+      mediaTypes: ['image/*'],
+    },
+  },
+})
+```
 
 ### Sandbox tools
 

--- a/packages/core/src/workspace/filesystem/fs-utils.ts
+++ b/packages/core/src/workspace/filesystem/fs-utils.ts
@@ -124,8 +124,63 @@ const MIME_TYPES: Record<string, string> = {
   svg: 'image/svg+xml',
   webp: 'image/webp',
   ico: 'image/x-icon',
+  bmp: 'image/bmp',
+  tiff: 'image/tiff',
+  tif: 'image/tiff',
+  heic: 'image/heic',
+  heif: 'image/heif',
+  avif: 'image/avif',
   // Documents
   pdf: 'application/pdf',
+  // Audio
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  flac: 'audio/flac',
+  m4a: 'audio/mp4',
+  aac: 'audio/aac',
+  // Video
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  mkv: 'video/x-matroska',
+  // Archives
+  zip: 'application/zip',
+  tar: 'application/x-tar',
+  gz: 'application/gzip',
+  tgz: 'application/gzip',
+  bz2: 'application/x-bzip2',
+  '7z': 'application/x-7z-compressed',
+  rar: 'application/vnd.rar',
+  // Executables / binaries
+  exe: 'application/vnd.microsoft.portable-executable',
+  dll: 'application/vnd.microsoft.portable-executable',
+  so: 'application/x-sharedlib',
+  dylib: 'application/x-sharedlib',
+  bin: 'application/x-binary',
+  dat: 'application/x-binary',
+  // Disk images / packages
+  dmg: 'application/x-apple-diskimage',
+  iso: 'application/x-iso9660-image',
+  deb: 'application/vnd.debian.binary-package',
+  rpm: 'application/x-rpm',
+  // Office documents
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  // Fonts
+  ttf: 'font/ttf',
+  otf: 'font/otf',
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  // Compiled code
+  wasm: 'application/wasm',
+  class: 'application/java-vm',
+  pyc: 'application/x-python-code',
 };
 
 /**

--- a/packages/core/src/workspace/tools/__tests__/read-file.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/read-file.test.ts
@@ -417,6 +417,92 @@ describe('workspace_read_file', () => {
     expect(result).toContain(png.toString('base64'));
   });
 
+  it('should not surface SVG as a media part by default', async () => {
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>', 'utf-8');
+    await fs.writeFile(path.join(tempDir, 'icon.svg'), svg);
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'icon.svg' }, { workspace });
+
+    // SVG is not in the default cross-provider-safe set. It's also a text
+    // format, so it should be returned as text rather than a media part.
+    expect(typeof result).toBe('string');
+    expect(result).not.toMatchObject({ __workspaceMedia: true });
+    expect(result).toContain('<svg');
+  });
+
+  it('should surface SVG as media when mediaTypes is broadened to image/*', async () => {
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>', 'utf-8');
+    await fs.writeFile(path.join(tempDir, 'icon.svg'), svg);
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: {
+        [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
+          mediaTypes: ['image/*'],
+        },
+      },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'icon.svg' },
+      { workspace },
+    )) as any;
+
+    expect(result).toMatchObject({
+      __workspaceMedia: true,
+      mediaType: 'image/svg+xml',
+    });
+  });
+
+  it('should fall back to metadata when media file exceeds maxMediaBytes', async () => {
+    // 2 KiB PNG-like blob (header valid; bytes are fine for size check)
+    const png = Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), Buffer.alloc(2048)]);
+    await fs.writeFile(path.join(tempDir, 'big.png'), png);
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: {
+        [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
+          maxMediaBytes: 1024,
+        },
+      },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'big.png' }, { workspace });
+
+    expect(typeof result).toBe('string');
+    expect(result).not.toMatchObject({ __workspaceMedia: true });
+    expect(result).toContain('exceeds maxMediaBytes');
+    expect(result).toContain('big.png');
+    expect(result).toContain('image/png');
+  });
+
+  it('should still inline media within the maxMediaBytes cap', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await fs.writeFile(path.join(tempDir, 'small.png'), png);
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: {
+        [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
+          maxMediaBytes: 1024,
+        },
+      },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'small.png' },
+      { workspace },
+    )) as any;
+
+    expect(result).toMatchObject({
+      __workspaceMedia: true,
+      mediaType: 'image/png',
+    });
+  });
+
   it('should reject offset that is not a positive integer', async () => {
     await fs.writeFile(path.join(tempDir, 'test.txt'), 'Hello World');
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });

--- a/packages/core/src/workspace/tools/__tests__/read-file.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/read-file.test.ts
@@ -84,6 +84,339 @@ describe('workspace_read_file', () => {
     expect(result).toContain('4 bytes');
   });
 
+  it('should return a media tool result for image files with no explicit encoding', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await fs.writeFile(path.join(tempDir, 'pixel.png'), png);
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'pixel.png' },
+      { workspace },
+    )) as any;
+
+    expect(result).toMatchObject({
+      __workspaceMedia: true,
+      mediaType: 'image/png',
+      data: png.toString('base64'),
+    });
+    expect(result.text).toContain('pixel.png');
+    expect(result.text).toContain('image/png');
+
+    const tool = tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE];
+    const modelOutput = tool.toModelOutput?.(result);
+    expect(modelOutput).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: result.text },
+        { type: 'media', data: png.toString('base64'), mediaType: 'image/png' },
+      ],
+    });
+  });
+
+  it('should return a media tool result for PDFs with no explicit encoding', async () => {
+    const pdfBytes = Buffer.from('%PDF-1.4 test', 'utf-8');
+    await fs.writeFile(path.join(tempDir, 'doc.pdf'), pdfBytes);
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'doc.pdf' },
+      { workspace },
+    )) as any;
+
+    expect(result).toMatchObject({
+      __workspaceMedia: true,
+      mediaType: 'application/pdf',
+      data: pdfBytes.toString('base64'),
+    });
+  });
+
+  it('should not return a media tool result when mediaTypes is false', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await fs.writeFile(path.join(tempDir, 'pixel.png'), png);
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: {
+        [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { mediaTypes: false },
+      },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'pixel.png' }, { workspace });
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('pixel.png');
+  });
+
+  it('should not inline PDFs when mediaTypes is restricted to images', async () => {
+    const pdfBytes = Buffer.from('%PDF-1.4 test', 'utf-8');
+    await fs.writeFile(path.join(tempDir, 'doc.pdf'), pdfBytes);
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: {
+        [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { mediaTypes: ['image/*'] },
+      },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'doc.pdf' }, { workspace });
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('doc.pdf');
+  });
+
+  it('should still inline images when mediaTypes is restricted to images', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await fs.writeFile(path.join(tempDir, 'pixel.png'), png);
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: {
+        [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { mediaTypes: ['image/*'] },
+      },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'pixel.png' },
+      { workspace },
+    )) as any;
+
+    expect(result).toMatchObject({
+      __workspaceMedia: true,
+      mediaType: 'image/png',
+    });
+  });
+
+  it('should support a custom mediaTypes predicate function', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await fs.writeFile(path.join(tempDir, 'pixel.png'), png);
+    await fs.writeFile(path.join(tempDir, 'doc.pdf'), Buffer.from('%PDF-1.4 test'));
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: {
+        // Only inline PDFs via custom predicate; skip images.
+        [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
+          mediaTypes: (mime: string) => mime === 'application/pdf',
+        },
+      },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const pngResult = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'pixel.png' }, { workspace });
+    expect(typeof pngResult).toBe('string');
+
+    const pdfResult = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'doc.pdf' },
+      { workspace },
+    )) as any;
+    expect(pdfResult).toMatchObject({ __workspaceMedia: true, mediaType: 'application/pdf' });
+  });
+
+  it('should respect explicit encoding for media files (opt out of media result)', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    await fs.writeFile(path.join(tempDir, 'pixel.png'), png);
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'pixel.png', encoding: 'base64' },
+      { workspace },
+    );
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('pixel.png');
+    expect(result).toContain('base64');
+  });
+
+  it('should not return media result when mediaTypes is disabled via config', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    await fs.writeFile(path.join(tempDir, 'pixel.png'), png);
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: { [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { mediaTypes: false } },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'pixel.png' }, { workspace });
+
+    expect(typeof result).toBe('string');
+    expect(result).not.toMatchObject({ __workspaceMedia: true });
+  });
+
+  it('should respect a custom mediaTypes mime pattern list', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const pdf = Buffer.from('%PDF-1.4', 'utf-8');
+    await fs.writeFile(path.join(tempDir, 'pixel.png'), png);
+    await fs.writeFile(path.join(tempDir, 'doc.pdf'), pdf);
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: { [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { mediaTypes: ['image/*'] } },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const pngResult = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'pixel.png' },
+      { workspace },
+    )) as any;
+    expect(pngResult).toMatchObject({ __workspaceMedia: true, mediaType: 'image/png' });
+
+    const pdfResult = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'doc.pdf' }, { workspace });
+    expect(typeof pdfResult).toBe('string');
+  });
+
+  it('toModelOutput passes through string results unchanged as text parts', async () => {
+    await fs.writeFile(path.join(tempDir, 'test.txt'), 'Hello World');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'test.txt' }, { workspace });
+    const tool = tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE];
+    const modelOutput = tool.toModelOutput?.(result);
+
+    expect(modelOutput).toEqual({ type: 'text', value: result });
+  });
+
+  it('should return metadata only for binary files that are not in mediaTypes and not text-readable', async () => {
+    // PNG isn't text-readable; with mediaTypes disabled it should fall through to metadata.
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await fs.writeFile(path.join(tempDir, 'pixel.png'), png);
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: { [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { mediaTypes: false } },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'pixel.png' },
+      { workspace },
+    )) as string;
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('pixel.png');
+    expect(result).toContain('image/png');
+    expect(result).toContain('binary file not readable as text');
+    // Should NOT dump the base64 contents.
+    expect(result).not.toContain(png.toString('base64'));
+  });
+
+  it('should return metadata only for PDFs when mediaTypes is restricted to images', async () => {
+    const pdfBytes = Buffer.from('%PDF-1.4 test', 'utf-8');
+    await fs.writeFile(path.join(tempDir, 'doc.pdf'), pdfBytes);
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: { [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { mediaTypes: ['image/*'] } },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'doc.pdf' },
+      { workspace },
+    )) as string;
+
+    expect(result).toContain('doc.pdf');
+    expect(result).toContain('application/pdf');
+    expect(result).toContain('binary file not readable as text');
+    expect(result).not.toContain(pdfBytes.toString('base64'));
+  });
+
+  it('should still read text-like files as text', async () => {
+    await fs.writeFile(path.join(tempDir, 'data.json'), '{"hello":"world"}');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'data.json' },
+      { workspace },
+    )) as string;
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('{"hello":"world"}');
+    expect(result).not.toContain('binary file not readable as text');
+  });
+
+  it('should read files with unknown extensions as text (octet-stream fallback)', async () => {
+    // An unknown extension maps to application/octet-stream but is likely text.
+    await fs.writeFile(path.join(tempDir, 'app.log'), 'INFO server started\nWARN slow query');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'app.log' },
+      { workspace },
+    )) as string;
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('INFO server started');
+    expect(result).not.toContain('binary file not readable as text');
+  });
+
+  it('should read extensionless files as text', async () => {
+    // Files like Makefile, Dockerfile, LICENSE etc. have no extension.
+    await fs.writeFile(path.join(tempDir, 'Dockerfile'), 'FROM node:20\nWORKDIR /app');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'Dockerfile' },
+      { workspace },
+    )) as string;
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('FROM node:20');
+    expect(result).not.toContain('binary file not readable as text');
+  });
+
+  it('should return metadata only for known binary extensions (zip, exe, etc.)', async () => {
+    // Zip files have a known binary mime, so should hit the metadata branch.
+    const zipBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00]);
+    await fs.writeFile(path.join(tempDir, 'archive.zip'), zipBytes);
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'archive.zip' },
+      { workspace },
+    )) as string;
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('archive.zip');
+    expect(result).toContain('application/zip');
+    expect(result).toContain('binary file not readable as text');
+    expect(result).not.toContain(zipBytes.toString('base64'));
+  });
+
+  it('should return metadata only for .bin / .dat files', async () => {
+    const bytes = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe]);
+    await fs.writeFile(path.join(tempDir, 'data.bin'), bytes);
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'data.bin' },
+      { workspace },
+    )) as string;
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('data.bin');
+    expect(result).toContain('binary file not readable as text');
+  });
+
+  it('should still read binary files as base64 when encoding is explicit', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await fs.writeFile(path.join(tempDir, 'pixel.png'), png);
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = (await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'pixel.png', encoding: 'base64' },
+      { workspace },
+    )) as string;
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain(png.toString('base64'));
+  });
+
   it('should apply token limit to large files', async () => {
     // Create a file with many words that will exceed default token limit (~3k tokens)
     const lines = Array.from({ length: 2000 }, (_, i) => `line ${i + 1} with some words here`);

--- a/packages/core/src/workspace/tools/__tests__/read-file.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/read-file.test.ts
@@ -417,6 +417,71 @@ describe('workspace_read_file', () => {
     expect(result).toContain(png.toString('base64'));
   });
 
+  it('should reject offset that is not a positive integer', async () => {
+    await fs.writeFile(path.join(tempDir, 'test.txt'), 'Hello World');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+    const tool = tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE];
+
+    const parsed = tool.inputSchema.safeParse({ path: 'test.txt', offset: 0 });
+    expect(parsed.success).toBe(false);
+
+    const negative = tool.inputSchema.safeParse({ path: 'test.txt', offset: -1 });
+    expect(negative.success).toBe(false);
+
+    const fractional = tool.inputSchema.safeParse({ path: 'test.txt', offset: 1.5 });
+    expect(fractional.success).toBe(false);
+  });
+
+  it('should reject limit that is not a positive integer', async () => {
+    await fs.writeFile(path.join(tempDir, 'test.txt'), 'Hello World');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+    const tool = tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE];
+
+    const zero = tool.inputSchema.safeParse({ path: 'test.txt', limit: 0 });
+    expect(zero.success).toBe(false);
+
+    const negative = tool.inputSchema.safeParse({ path: 'test.txt', limit: -5 });
+    expect(negative.success).toBe(false);
+
+    const fractional = tool.inputSchema.safeParse({ path: 'test.txt', limit: 2.5 });
+    expect(fractional.success).toBe(false);
+  });
+
+  it('should throw a descriptive error for invalid mediaTypes patterns', async () => {
+    await fs.writeFile(path.join(tempDir, 'test.txt'), 'Hello World');
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: {
+        [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
+          mediaTypes: ['image/png', 'not-a-mime-type'],
+        },
+      },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    await expect(
+      tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'test.txt' }, { workspace }),
+    ).rejects.toThrow(/Invalid `mediaTypes` pattern.*not-a-mime-type/);
+  });
+
+  it('should accept mime types with suffixes like application/vnd.api+json', async () => {
+    await fs.writeFile(path.join(tempDir, 'test.txt'), 'Hello World');
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+      tools: {
+        [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
+          mediaTypes: ['application/vnd.api+json', 'image/*'],
+        },
+      },
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({ path: 'test.txt' }, { workspace });
+    expect(typeof result).toBe('string');
+  });
+
   it('should apply token limit to large files', async () => {
     // Create a file with many words that will exceed default token limit (~3k tokens)
     const lines = Array.from({ length: 2000 }, (_, i) => `line ${i + 1} with some words here`);

--- a/packages/core/src/workspace/tools/__tests__/read-file.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/read-file.test.ts
@@ -265,7 +265,7 @@ describe('workspace_read_file', () => {
     expect(typeof pdfResult).toBe('string');
   });
 
-  it('toModelOutput passes through string results unchanged as text parts', async () => {
+  it('toModelOutput returns undefined for string results so they are not duplicated on providerMetadata', async () => {
     await fs.writeFile(path.join(tempDir, 'test.txt'), 'Hello World');
     const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
     const tools = await createWorkspaceTools(workspace);
@@ -274,7 +274,7 @@ describe('workspace_read_file', () => {
     const tool = tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE];
     const modelOutput = tool.toModelOutput?.(result);
 
-    expect(modelOutput).toEqual({ type: 'text', value: result });
+    expect(modelOutput).toBeUndefined();
   });
 
   it('should return metadata only for binary files that are not in mediaTypes and not text-readable', async () => {

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -6,26 +6,127 @@ import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
 import { applyTokenLimit } from './output-helpers';
 import { startWorkspaceSpan } from './tracing';
 
+/**
+ * Internal marker on the tool's text result that signals to `toModelOutput`
+ * that the file should be surfaced to the model as a media part (image or
+ * binary file) rather than as plain text. We attach this on a wrapper object
+ * but only the `text` field is shown to the model (via toModelOutput); the
+ * marker is stripped before it ever reaches the model.
+ *
+ * The shape is intentionally JSON-serialisable so it round-trips through
+ * storage layers that snapshot tool results.
+ */
+type MediaToolResult = {
+  __workspaceMedia: true;
+  text: string;
+  mediaType: string;
+  data: string;
+};
+
+function isMediaToolResult(value: unknown): value is MediaToolResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<string, unknown>).__workspaceMedia === true &&
+    typeof (value as Record<string, unknown>).text === 'string' &&
+    typeof (value as Record<string, unknown>).mediaType === 'string' &&
+    typeof (value as Record<string, unknown>).data === 'string'
+  );
+}
+
+/**
+ * Default mime types surfaced to the model as media parts. Images become
+ * image parts the model can natively see; `application/pdf` becomes a file
+ * part for providers that accept native PDFs.
+ */
+const DEFAULT_MEDIA_TYPES: string[] = ['image/*', 'application/pdf'];
+
+/**
+ * `application/*` mime types that are actually text content and safe to read
+ * as utf-8. Anything not matching `text/*` and not in this list is treated
+ * as opaque binary when there's no explicit encoding and no media match.
+ */
+const TEXT_APPLICATION_TYPES = new Set([
+  'application/json',
+  'application/javascript',
+  'application/typescript',
+  'application/xml',
+  'application/graphql',
+  'application/x-sh',
+  'application/x-yaml',
+  'application/yaml',
+  'application/ld+json',
+  'application/sql',
+]);
+
+function isTextLikeMimeType(mimeType: string | undefined): boolean {
+  if (!mimeType) return true;
+  // `application/octet-stream` is the catch-all for unknown extensions; we
+  // optimistically treat it as text so files like `.log` or `.conf` (which
+  // have no registered mime mapping) still get read as utf-8.
+  if (mimeType === 'application/octet-stream') return true;
+  if (mimeType.startsWith('text/')) return true;
+  if (TEXT_APPLICATION_TYPES.has(mimeType)) return true;
+  if (mimeType.endsWith('+json') || mimeType.endsWith('+xml')) return true;
+  return false;
+}
+
+/**
+ * Build a predicate from the `mediaTypes` config option.
+ * Supports glob patterns (e.g. `'image/*'`), custom functions, and `false`
+ * to disable media parts entirely.
+ */
+function buildMediaTypeCheck(
+  config: string[] | ((mimeType: string) => boolean) | false | undefined,
+): (mimeType: string | undefined) => boolean {
+  if (config === false) return () => false;
+  if (typeof config === 'function') {
+    return (mimeType: string | undefined) => (mimeType ? config(mimeType) : false);
+  }
+  const patterns = config ?? DEFAULT_MEDIA_TYPES;
+  return (mimeType: string | undefined) => {
+    if (!mimeType) return false;
+    return patterns.some(pattern => {
+      if (pattern === '*' || pattern === '*/*') return true;
+      if (pattern.endsWith('/*')) {
+        return mimeType.startsWith(pattern.slice(0, -1));
+      }
+      return mimeType === pattern;
+    });
+  };
+}
+
 export const readFileTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.READ_FILE,
   description:
-    'Read the contents of a file from the workspace filesystem. Use offset/limit parameters to read specific line ranges for large files.',
+    'Read a file from the workspace filesystem. Text files come back as text — use offset/limit to read a line range from large files. Supported media files come back as a native file part you can view directly. Other binary files return only their metadata (path, size, mime type) since their raw contents are not useful to read.',
   inputSchema: z.object({
     path: z.string().describe('The path to the file to read (e.g., "data/config.json")'),
-    encoding: z
-      .enum(['utf-8', 'utf8', 'base64', 'hex', 'binary'])
-      .optional()
-      .describe('The encoding to use when reading the file. Defaults to utf-8 for text files.'),
     offset: z
       .number()
       .optional()
-      .describe('Line number to start reading from (1-indexed). If omitted, starts from line 1.'),
-    limit: z.number().optional().describe('Maximum number of lines to read. If omitted, reads to the end of the file.'),
+      .describe(
+        'Line number to start reading from (1-indexed). Only used when reading text files; ignored for media and other binary files. Defaults to line 1 if omitted.',
+      ),
+    limit: z
+      .number()
+      .optional()
+      .describe(
+        'Maximum number of lines to read. Only used when reading text files; ignored for media and other binary files. Defaults to the end of the file if omitted.',
+      ),
     showLineNumbers: z
       .boolean()
       .optional()
       .default(true)
-      .describe('Whether to prefix each line with its line number (default: true)'),
+      .describe(
+        'Prefix each line with its line number. Only used when reading text files; ignored for media and other binary files. Defaults to true if omitted.',
+      ),
+    encoding: z
+      .enum(['utf-8', 'utf8', 'base64', 'hex', 'binary'])
+      .optional()
+      .describe(
+        "Usually omit this — text files and supported media are handled automatically. Pass `base64` or `hex` to get the file's raw bytes encoded as text when you need to inspect an unsupported binary file that would otherwise only return metadata (e.g. checking a file header or magic bytes).",
+      ),
   }),
   execute: async ({ path, encoding, offset, limit, showLineNumbers }, context) => {
     const { workspace, filesystem } = requireFilesystem(context);
@@ -39,13 +140,42 @@ export const readFileTool = createTool({
     });
 
     try {
+      const stat = await filesystem.stat(path);
+
+      const readFileConfig = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE];
+      const shouldReturnAsMedia = buildMediaTypeCheck(readFileConfig?.mediaTypes);
+
+      // When the caller didn't ask for a specific encoding and the file's
+      // mime type matches the `mediaTypes` predicate, read as base64 and
+      // return a MediaToolResult so `toModelOutput` can surface it as a
+      // file/image part the model can natively consume.
+      if (!encoding && shouldReturnAsMedia(stat.mimeType)) {
+        const base64 = (await filesystem.readFile(path, { encoding: 'base64' })) as string;
+        const header = `${stat.path} (${stat.size} bytes, ${stat.mimeType})`;
+        span.end({ success: true }, { bytesTransferred: stat.size });
+        return {
+          __workspaceMedia: true,
+          text: header,
+          mediaType: stat.mimeType!,
+          data: base64,
+        } satisfies MediaToolResult;
+      }
+
+      // When the caller didn't ask for a specific encoding and the file is
+      // a binary type that's neither text-readable nor in `mediaTypes`,
+      // return metadata only so the agent knows about the file without
+      // dumping useless base64 into the conversation.
+      if (!encoding && !isTextLikeMimeType(stat.mimeType)) {
+        span.end({ success: true }, { bytesTransferred: 0 });
+        return `${stat.path} (${stat.size} bytes, ${stat.mimeType ?? 'unknown'}) — binary file not readable as text. Pass an explicit \`encoding\` (e.g. \`base64\`) to read the raw bytes, or configure \`mediaTypes\` on the read_file tool to surface it as a media part.`;
+      }
+
       const effectiveEncoding = (encoding as BufferEncoding) ?? 'utf-8';
       const fullContent = await filesystem.readFile(path, { encoding: effectiveEncoding });
-      const stat = await filesystem.stat(path);
 
       const isTextEncoding = !encoding || encoding === 'utf-8' || encoding === 'utf8';
 
-      const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]?.maxOutputTokens;
+      const tokenLimit = readFileConfig?.maxOutputTokens;
 
       if (!isTextEncoding) {
         const output = await applyTokenLimit(
@@ -89,5 +219,20 @@ export const readFileTool = createTool({
       span.error(err);
       throw err;
     }
+  },
+  toModelOutput: (output: unknown) => {
+    if (isMediaToolResult(output)) {
+      return {
+        type: 'content',
+        value: [
+          { type: 'text', text: output.text },
+          { type: 'media', data: output.data, mediaType: output.mediaType },
+        ],
+      };
+    }
+    if (typeof output === 'string') {
+      return { type: 'text', value: output };
+    }
+    return output;
   },
 });

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -230,9 +230,9 @@ export const readFileTool = createTool({
         ],
       };
     }
-    if (typeof output === 'string') {
-      return { type: 'text', value: output };
-    }
-    return output;
+    // For plain string output, return undefined so we don't store a duplicate
+    // copy on providerMetadata.mastra.modelOutput — the original string result
+    // is already what the model sees.
+    return undefined;
   },
 });

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -72,6 +72,27 @@ function isTextLikeMimeType(mimeType: string | undefined): boolean {
 }
 
 /**
+ * Validates a single `mediaTypes` pattern. Accepts:
+ * - `*` or `*​/*` — match anything
+ * - `type/*` — match all subtypes of a top-level type (e.g. `image/*`)
+ * - `type/subtype` — exact mime type (e.g. `application/pdf`, `application/vnd.api+json`)
+ *
+ * Throws a descriptive error for anything else so misconfigurations surface
+ * immediately instead of silently failing to match.
+ */
+const MEDIA_TYPE_PATTERN = /^(?:\*|\*\/\*|[a-z0-9!#$&^_.+-]+\/(?:\*|[a-z0-9!#$&^_.+-]+))$/i;
+
+function validateMediaTypePatterns(patterns: string[]): void {
+  for (const pattern of patterns) {
+    if (typeof pattern !== 'string' || !MEDIA_TYPE_PATTERN.test(pattern)) {
+      throw new Error(
+        `Invalid \`mediaTypes\` pattern: ${JSON.stringify(pattern)}. Expected \`*\`, \`*/*\`, \`type/*\`, or a full mime type like \`application/pdf\`.`,
+      );
+    }
+  }
+}
+
+/**
  * Build a predicate from the `mediaTypes` config option.
  * Supports glob patterns (e.g. `'image/*'`), custom functions, and `false`
  * to disable media parts entirely.
@@ -84,6 +105,7 @@ function buildMediaTypeCheck(
     return (mimeType: string | undefined) => (mimeType ? config(mimeType) : false);
   }
   const patterns = config ?? DEFAULT_MEDIA_TYPES;
+  validateMediaTypePatterns(patterns);
   return (mimeType: string | undefined) => {
     if (!mimeType) return false;
     return patterns.some(pattern => {
@@ -104,12 +126,16 @@ export const readFileTool = createTool({
     path: z.string().describe('The path to the file to read (e.g., "data/config.json")'),
     offset: z
       .number()
+      .int()
+      .min(1)
       .optional()
       .describe(
         'Line number to start reading from (1-indexed). Only used when reading text files; ignored for media and other binary files. Defaults to line 1 if omitted.',
       ),
     limit: z
       .number()
+      .int()
+      .min(1)
       .optional()
       .describe(
         'Maximum number of lines to read. Only used when reading text files; ignored for media and other binary files. Defaults to the end of the file if omitted.',

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -41,7 +41,7 @@ function isMediaToolResult(value: unknown): value is MediaToolResult {
  * `image/*` is *not* used so we don't surface exotic subtypes like SVG/BMP
  * that some providers reject. Override `mediaTypes` to broaden this.
  */
-const DEFAULT_MEDIA_TYPES: string[] = ['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'application/pdf'];
+const DEFAULT_MEDIA_TYPES: string[] = ['image/png', 'image/jpeg', 'image/webp', 'application/pdf'];
 
 /**
  * Default cap (in bytes) on inline media reads. Files larger than this fall

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -35,11 +35,21 @@ function isMediaToolResult(value: unknown): value is MediaToolResult {
 }
 
 /**
- * Default mime types surfaced to the model as media parts. Images become
- * image parts the model can natively see; `application/pdf` becomes a file
- * part for providers that accept native PDFs.
+ * Default mime types surfaced to the model as media parts. The list is
+ * intentionally the intersection of image formats supported by the major
+ * model providers (Anthropic, OpenAI, Gemini) plus `application/pdf`.
+ * `image/*` is *not* used so we don't surface exotic subtypes like SVG/BMP
+ * that some providers reject. Override `mediaTypes` to broaden this.
  */
-const DEFAULT_MEDIA_TYPES: string[] = ['image/*', 'application/pdf'];
+const DEFAULT_MEDIA_TYPES: string[] = ['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'application/pdf'];
+
+/**
+ * Default cap (in bytes) on inline media reads. Files larger than this fall
+ * back to metadata-only output instead of being fully base64-encoded into
+ * the model context (and persisted in storage on rehydration). 10 MiB is
+ * roughly aligned with provider per-image/per-pdf limits.
+ */
+const DEFAULT_MAX_MEDIA_BYTES = 10 * 1024 * 1024;
 
 /**
  * `application/*` mime types that are actually text content and safe to read
@@ -176,6 +186,14 @@ export const readFileTool = createTool({
       // return a MediaToolResult so `toModelOutput` can surface it as a
       // file/image part the model can natively consume.
       if (!encoding && shouldReturnAsMedia(stat.mimeType)) {
+        const maxMediaBytes = readFileConfig?.maxMediaBytes ?? DEFAULT_MAX_MEDIA_BYTES;
+        // Avoid materializing huge media files (and persisting their base64
+        // string through storage on rehydration). Fall back to metadata-only
+        // when the file exceeds the configured size cap.
+        if (stat.size > maxMediaBytes) {
+          span.end({ success: true }, { bytesTransferred: 0 });
+          return `${stat.path} (${stat.size} bytes, ${stat.mimeType}) — exceeds maxMediaBytes (${maxMediaBytes}). Returning metadata only; configure \`maxMediaBytes\` on the read_file tool to raise this cap.`;
+        }
         const base64 = (await filesystem.readFile(path, { encoding: 'base64' })) as string;
         const header = `${stat.path} (${stat.size} bytes, ${stat.mimeType})`;
         span.end({ success: true }, { bytesTransferred: stat.size });

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -161,13 +161,15 @@ export interface ExecuteCommandToolConfig extends WorkspaceToolConfig {
  * Extended configuration for the read_file tool.
  *
  * Controls which mime types are surfaced to the model as media parts (image
- * or file parts the model can natively consume) rather than dumped as text
- * or base64. Files whose mime type doesn't match are read as text/base64 as
- * usual.
+ * or file parts the model can natively consume). Text-like files are still
+ * read as text; non-text binaries that don't match fall back to a
+ * metadata-only result (path, size, mime type) so the agent knows about
+ * the file without dumping useless base64 into context.
  *
  * - **Array of globs** — e.g. `['image/*']`, `['image/*', 'application/pdf']`
  * - **Function** — `(mimeType: string) => boolean`
- * - **`false`** — disable media parts; always return text
+ * - **`false`** — disable media parts; non-text binaries fall back to
+ *   metadata-only output unless an explicit `encoding` is provided
  *
  * Only applies when the caller doesn't pass an explicit `encoding` (since an
  * explicit encoding is a clear request for raw bytes/text).
@@ -190,7 +192,8 @@ export interface ReadFileToolConfig extends WorkspaceToolConfig {
   /**
    * Which mime types to surface to the model as media parts (file/image
    * parts) rather than as text. Defaults to `['image/*', 'application/pdf']`.
-   * Pass `false` to disable media parts entirely.
+   * Pass `false` to disable media detection; non-text binaries then fall
+   * back to metadata-only output unless an explicit `encoding` is provided.
    */
   mediaTypes?: string[] | ((mimeType: string) => boolean) | false;
 }

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -174,11 +174,14 @@ export interface ExecuteCommandToolConfig extends WorkspaceToolConfig {
  * Only applies when the caller doesn't pass an explicit `encoding` (since an
  * explicit encoding is a clear request for raw bytes/text).
  *
- * @default `['image/*', 'application/pdf']`
+ * The default is the cross-provider-safe intersection of image formats
+ * (`image/png`, `image/jpeg`, `image/webp`, `image/gif`) plus
+ * `application/pdf`. Use `['image/*']` (or a function) if you want to
+ * surface exotic subtypes like SVG/BMP/HEIC.
  *
  * @example
  * ```ts
- * // Only return images as media parts (skip PDFs)
+ * // Surface any image (including SVG, BMP, HEIC) — may fail on some providers
  * mastra_workspace_read_file: { mediaTypes: ['image/*'] }
  *
  * // Disable media parts entirely
@@ -186,16 +189,27 @@ export interface ExecuteCommandToolConfig extends WorkspaceToolConfig {
  *
  * // Custom predicate
  * mastra_workspace_read_file: { mediaTypes: (mime) => mime.startsWith('image/') }
+ *
+ * // Raise the inline-media size cap to 25 MiB
+ * mastra_workspace_read_file: { maxMediaBytes: 25 * 1024 * 1024 }
  * ```
  */
 export interface ReadFileToolConfig extends WorkspaceToolConfig {
   /**
    * Which mime types to surface to the model as media parts (file/image
-   * parts) rather than as text. Defaults to `['image/*', 'application/pdf']`.
+   * parts) rather than as text. Defaults to the cross-provider-safe set
+   * `['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'application/pdf']`.
    * Pass `false` to disable media detection; non-text binaries then fall
    * back to metadata-only output unless an explicit `encoding` is provided.
    */
   mediaTypes?: string[] | ((mimeType: string) => boolean) | false;
+  /**
+   * Maximum file size (in bytes) to read inline as a media part. Files
+   * larger than this fall back to metadata-only output rather than being
+   * fully base64-encoded into the model context and persisted in storage.
+   * Defaults to 10 MiB (10 * 1024 * 1024).
+   */
+  maxMediaBytes?: number;
 }
 
 // =============================================================================

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -157,6 +157,44 @@ export interface ExecuteCommandToolConfig extends WorkspaceToolConfig {
   backgroundProcesses?: BackgroundProcessConfig;
 }
 
+/**
+ * Extended configuration for the read_file tool.
+ *
+ * Controls which mime types are surfaced to the model as media parts (image
+ * or file parts the model can natively consume) rather than dumped as text
+ * or base64. Files whose mime type doesn't match are read as text/base64 as
+ * usual.
+ *
+ * - **Array of globs** — e.g. `['image/*']`, `['image/*', 'application/pdf']`
+ * - **Function** — `(mimeType: string) => boolean`
+ * - **`false`** — disable media parts; always return text
+ *
+ * Only applies when the caller doesn't pass an explicit `encoding` (since an
+ * explicit encoding is a clear request for raw bytes/text).
+ *
+ * @default `['image/*', 'application/pdf']`
+ *
+ * @example
+ * ```ts
+ * // Only return images as media parts (skip PDFs)
+ * mastra_workspace_read_file: { mediaTypes: ['image/*'] }
+ *
+ * // Disable media parts entirely
+ * mastra_workspace_read_file: { mediaTypes: false }
+ *
+ * // Custom predicate
+ * mastra_workspace_read_file: { mediaTypes: (mime) => mime.startsWith('image/') }
+ * ```
+ */
+export interface ReadFileToolConfig extends WorkspaceToolConfig {
+  /**
+   * Which mime types to surface to the model as media parts (file/image
+   * parts) rather than as text. Defaults to `['image/*', 'application/pdf']`.
+   * Pass `false` to disable media parts entirely.
+   */
+  mediaTypes?: string[] | ((mimeType: string) => boolean) | false;
+}
+
 // =============================================================================
 // Top-Level Tools Config
 // =============================================================================
@@ -207,4 +245,14 @@ export type WorkspaceToolsConfig = {
   requireApproval?: DynamicToolConfigValue<ToolConfigWithArgsContext>;
 } & {
   [K in typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]?: ExecuteCommandToolConfig;
-} & Partial<Record<Exclude<WorkspaceToolName, typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND>, WorkspaceToolConfig>>;
+} & {
+  [K in typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]?: ReadFileToolConfig;
+} & Partial<
+    Record<
+      Exclude<
+        WorkspaceToolName,
+        typeof WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND | typeof WORKSPACE_TOOLS.FILESYSTEM.READ_FILE
+      >,
+      WorkspaceToolConfig
+    >
+  >;

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -175,7 +175,7 @@ export interface ExecuteCommandToolConfig extends WorkspaceToolConfig {
  * explicit encoding is a clear request for raw bytes/text).
  *
  * The default is the cross-provider-safe intersection of image formats
- * (`image/png`, `image/jpeg`, `image/webp`, `image/gif`) plus
+ * (`image/png`, `image/jpeg`, `image/webp`) plus
  * `application/pdf`. Use `['image/*']` (or a function) if you want to
  * surface exotic subtypes like SVG/BMP/HEIC.
  *
@@ -198,7 +198,7 @@ export interface ReadFileToolConfig extends WorkspaceToolConfig {
   /**
    * Which mime types to surface to the model as media parts (file/image
    * parts) rather than as text. Defaults to the cross-provider-safe set
-   * `['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'application/pdf']`.
+   * `['image/png', 'image/jpeg', 'image/webp', 'application/pdf']`.
    * Pass `false` to disable media detection; non-text binaries then fall
    * back to metadata-only output unless an explicit `encoding` is provided.
    */


### PR DESCRIPTION
## Summary

Reworks how the workspace `read_file` tool returns files to the model. Previously every file was either base64-dumped (for images/PDFs) or read as text — meaning unsupported binaries (zip, exe, video, etc.) would dump useless base64 into the conversation, and images were sent as base64 strings instead of as native file parts the model can actually look at.

`read_file` now branches on file type:

1. **Media files** matching `mediaTypes` (default `'image/png', 'image/jpeg', 'image/webp', 'application/pdf'`) are returned as native `media` parts the model can directly view, mirroring how the screenshot tool returns images.
2. **Text-readable files** (`text/*`, common code/config mime types, extensionless files like `Dockerfile`/`Makefile`/`LICENSE`, unknown extensions) are returned as text content, unchanged from before.
3. **Unsupported binaries** (zip, exe, mp4, docx, etc.) now return a short metadata string (path, size, mime type) instead of base64 dumping. An explicit `encoding: 'base64' | 'hex'` is still available as an escape hatch for the rare case the agent actually needs to inspect raw bytes.

## New config

The set of mime types treated as native media is configurable per workspace via a new `mediaTypes` option on the `read_file` tool config:

```ts
import { Workspace, WORKSPACE_TOOLS } from '@mastra/core/workspace';

const workspace = new Workspace({
  filesystem,
  tools: {
    [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: {
      // Glob patterns (default)
      mediaTypes: ['image/*', 'application/pdf'],
      // Or a custom predicate
      // mediaTypes: (mime) => mime.startsWith('image/'),
      // Or disable entirely
      // mediaTypes: false,
    },
  },
});
```

The `['image/*', 'application/pdf']` default reflects the formats universally supported as native media parts across Anthropic, OpenAI, and Gemini.

## Additional changes

Extended `fs-utils` `MIME_TYPES` with common binary extensions (archives, audio, video, office docs, fonts, executables, disk images) so they can be distinguished from extensionless text files and correctly routed to the metadata branch. `.bin`/`.dat` use a dedicated `application/x-binary` mime so they aren't conflated with the `application/octet-stream` fallback used for extensionless text files.

Tool descriptions for `read_file` were rewritten to address the model directly and to clarify that `offset`/`limit`/`showLineNumbers` only apply when reading as text.

## Test plan

- 23 unit tests in `read-file.test.ts` covering all three branches, configurable `mediaTypes`, explicit `encoding`, extensionless files, known binary extensions, `.bin`/`.dat`, and unknown extensions.
- `pnpm vitest run src/workspace` — 1646 tests pass, no type errors.
- `pnpm --filter ./packages/core check` — clean.

## Changeset

`.changeset/slow-signs-teach.md` — minor bump on `@mastra/core`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the AI reads a file, it now checks the file type: supported images and PDFs are returned as viewable media parts, text files are returned as text (with line-range support), and other binaries return a short metadata summary instead of dumping raw bytes — you can still request raw bytes explicitly via encoding.

---

## Overview

Adds media-aware, per-workspace behavior to the workspace read_file tool. By default read_file classifies files by MIME/type and:
- returns native media parts (text header + media part) for configured mediaTypes (default: PNG, JPEG, WebP, GIF, PDF) when no encoding is requested and size ≤ maxMediaBytes;
- returns text with offset/limit/showLineNumbers applied for text-like MIME types;
- returns a concise metadata-only string (path, size, mime) for unsupported binaries or oversized media unless an explicit encoding ('base64' | 'hex') is provided or mediaTypes is configured to include them.

---

## Key Changes

- packages/core/src/workspace/tools/read-file.ts
  - Implements media-aware branching and a JSON-serialisable MediaToolResult wrapper.
  - Default inline media types: ['image/png','image/jpeg','image/webp','image/gif','application/pdf'] (cross-provider-safe).
  - Adds DEFAULT_MAX_MEDIA_BYTES (10 MiB) and per-workspace maxMediaBytes to cap inline media.
  - Treats many application/* mime types as text-like; unknown/extensionless files default to text when safe.
  - Adds validate/build helpers for mediaTypes which accept glob-like arrays, a predicate function, or false to disable media parts.
  - Returns metadata-only guidance for binaries when encoding is omitted; keeps explicit encoding override to force raw bytes.
  - Adds readFileTool.toModelOutput to convert MediaToolResult into structured model output (text + media part); plain string outputs return undefined to avoid redundant modelOutput storage.
  - Updates tool description and inputSchema to document that offset/limit/showLineNumbers apply only to text reads.

- packages/core/src/workspace/tools/types.ts
  - Adds ReadFileToolConfig with mediaTypes?: string[] | ((mimeType: string) => boolean) | false and maxMediaBytes?: number.
  - Registers a dedicated config entry for the read_file tool in WorkspaceToolsConfig.

- packages/core/src/workspace/filesystem/fs-utils.ts
  - Expands MIME_TYPES mapping across many extensions (images, TIFF/HEIC/AVIF, PDF, audio/video, archives, executables, office, fonts, compiled formats).
  - Maps .bin/.dat → application/x-binary to avoid conflating binary blobs with extensionless text fallbacks.
  - Improves text-like MIME detection logic used by read_file.

- packages/core/src/workspace/tools/__tests__/read-file.test.ts
  - Adds extensive Vitest coverage (23 focused tests within the file) validating: media inlining for images/PDFs, mediaTypes disable/restriction/predicate behavior, encoding overrides, metadata-only fallbacks for binaries and oversized media, text/extensionless handling, SVG behavior relative to mediaTypes, offset/limit/showLineNumbers semantics, and toModelOutput conversion.
  - Test run reported 1,646 tests passing; TypeScript checks clean.

- .changeset/slow-signs-teach.md
  - Changeset describing the behavior, defaults, and configuration (minor bump for @mastra/core).

---

## Notes for Reviewers

- Default mediaTypes are intentionally conservative (explicit image subtypes + PDF) to avoid provider incompatibilities; consumers can set mediaTypes: ['image/*'] or provide a predicate to broaden behavior, or mediaTypes: false to disable.
- maxMediaBytes default is 10 MiB and is configurable per workspace.
- read_file now returns MediaToolResult objects for inline media; toModelOutput converts these to model content. Plain string outputs return undefined from toModelOutput to prevent duplicate storage.
- Review the expanded MIME_TYPES and the .bin/.dat → application/x-binary mapping for any environment-specific expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16570)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->