### PR TITLE
Fix prebuild workflow

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -74,7 +74,7 @@ jobs:
 
   test-suite:
     name: Unit and E2E Tests
-    needs: changes
+    needs: [changes, prebuild]
     if: github.repository == 'mastra-ai/mastra'
     uses: ./.github/workflows/test-suite.yml
     permissions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR fixes the order of steps in the test workflow. Before, tests would sometimes start running before the build was done. Now the workflow ensures tests only run after both detecting that code changed AND after the build is complete.

## Summary
The `test-suite` job in the prebuild workflow now depends on both the `changes` and `prebuild` jobs, rather than only the `changes` job. This ensures that unit and E2E tests only execute after code change detection completes AND the prebuild/build step finishes successfully, preventing tests from running against stale or incomplete builds.

**Changes:**
- Line 77: Updated `needs:` from `[changes]` to `[changes, prebuild]`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16571)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->