### PR TITLE
fix(core): bound process handle output retention

### DIFF
--- a/.changeset/two-waves-wink.md
+++ b/.changeset/two-waves-wink.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': minor
+---
+
+Changed background process output retention.
+
+**Before:** Spawned process handles retained all stdout and stderr, which could grow without bound for long-running background processes.
+
+**After:** Spawned process handles now retain the latest 1 MiB of stdout and stderr per stream by default. Pass `maxRetainedBytes` to `processes.spawn()` to customize the limit, use `0` to disable retained polling output, or use `Infinity` to keep the previous retain-all behavior.
+
+```ts
+const handle = await sandbox.processes.spawn('npm run dev', {
+  maxRetainedBytes: 512 * 1024,
+});
+```
+
+Streaming callbacks and reader streams still receive every chunk in full. Handles also expose truncation and dropped-byte counters so callers can detect when `stdout`, `stderr`, or `wait()` results only include retained output.
+
+The built-in `executeCommand()` implementation still retains full output by default; pass `maxRetainedBytes` there only when you want bounded command results.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ test-outputs/
 openapi-ts-error*
 
 .mastra
+.sandbox-profiles/
 *.db*
 *.duckdb
 *.duckdb.wal

--- a/packages/core/src/workspace/sandbox/local-process-manager.ts
+++ b/packages/core/src/workspace/sandbox/local-process-manager.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 
 import type { ResultPromise, Options as ExecaOptions } from 'execa';
 
@@ -52,9 +53,30 @@ class LocalProcessHandle extends ProcessHandle {
         }, options.timeout)
       : undefined;
 
+    const stdoutDecoder = new StringDecoder();
+    const stderrDecoder = new StringDecoder();
+    let stdoutDecoderEnded = false;
+    let stderrDecoderEnded = false;
+
+    const flushStdoutDecoder = () => {
+      if (stdoutDecoderEnded) return;
+      stdoutDecoderEnded = true;
+      const data = stdoutDecoder.end();
+      if (data) this.emitStdout(data);
+    };
+
+    const flushStderrDecoder = () => {
+      if (stderrDecoderEnded) return;
+      stderrDecoderEnded = true;
+      const data = stderrDecoder.end();
+      if (data) this.emitStderr(data);
+    };
+
     this.waitPromise = new Promise<CommandResult>(resolve => {
       subprocess.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
         if (timeoutId) clearTimeout(timeoutId);
+        flushStdoutDecoder();
+        flushStderrDecoder();
         if (timedOut) {
           const timeoutMsg = `\nProcess timed out after ${options!.timeout}ms`;
           this.emitStderr(timeoutMsg);
@@ -75,6 +97,8 @@ class LocalProcessHandle extends ProcessHandle {
 
       subprocess.on('error', (err: Error) => {
         if (timeoutId) clearTimeout(timeoutId);
+        flushStdoutDecoder();
+        flushStderrDecoder();
         this.emitStderr(err.message);
         this.exitCode = 1;
         resolve({
@@ -88,12 +112,16 @@ class LocalProcessHandle extends ProcessHandle {
     });
 
     subprocess.stdout?.on('data', (data: Buffer) => {
-      this.emitStdout(data.toString());
+      const decoded = stdoutDecoder.write(data);
+      if (decoded) this.emitStdout(decoded);
     });
+    subprocess.stdout?.on('end', flushStdoutDecoder);
 
     subprocess.stderr?.on('data', (data: Buffer) => {
-      this.emitStderr(data.toString());
+      const decoded = stderrDecoder.write(data);
+      if (decoded) this.emitStderr(decoded);
     });
+    subprocess.stderr?.on('end', flushStderrDecoder);
   }
 
   async wait(): Promise<CommandResult> {

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -205,6 +205,20 @@ describe('LocalSandbox', () => {
       expect(result.exitCode).not.toBe(0);
     });
 
+    it('should decode UTF-8 characters split across stdout chunks', async () => {
+      if (os.platform() === 'win32') return; // Uses POSIX commands
+      const script = [
+        'const b = Buffer.from([0xf0, 0x9f, 0x99, 0x82]);',
+        'process.stdout.write(b.subarray(0, 2));',
+        'setTimeout(() => process.stdout.write(b.subarray(2)), 10);',
+      ].join('');
+
+      const result = await sandbox.executeCommand('node', ['-e', script]);
+
+      expect(result.success).toBe(true);
+      expect(Buffer.from(result.stdout, 'utf8')).toEqual(Buffer.from([0xf0, 0x9f, 0x99, 0x82]));
+    });
+
     it('should use working directory', async () => {
       if (os.platform() === 'win32') return; // Uses POSIX commands
       // Create a file in tempDir

--- a/packages/core/src/workspace/sandbox/mastra-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/mastra-sandbox.test.ts
@@ -18,6 +18,9 @@ import type { ProviderStatus } from '../lifecycle';
 import { MastraSandbox } from './mastra-sandbox';
 import type { MastraSandboxOptions } from './mastra-sandbox';
 import type { MountManager } from './mount-manager';
+import { ProcessHandle, SandboxProcessManager } from './process-manager';
+import type { SpawnProcessOptions } from './process-manager';
+import type { CommandResult } from './types';
 
 /**
  * Concrete implementation of MastraSandbox WITH mount() method.
@@ -84,6 +87,65 @@ class NonMountableSandbox extends MastraSandbox {
     args?: string[],
   ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
     return { exitCode: 0, stdout: `${command} ${args?.join(' ') || ''}`, stderr: '' };
+  }
+}
+
+class ExecuteCommandProcessHandle extends ProcessHandle {
+  readonly pid = 'execute-command-process';
+  exitCode: number | undefined;
+
+  constructor(
+    options: SpawnProcessOptions | undefined,
+    private readonly output: string,
+  ) {
+    super(options);
+  }
+
+  async wait(): Promise<CommandResult> {
+    this.emitStdout(this.output);
+    this.exitCode = 0;
+    return {
+      success: true,
+      exitCode: 0,
+      stdout: this.stdout,
+      stderr: this.stderr,
+      executionTimeMs: 0,
+    };
+  }
+
+  async kill(): Promise<boolean> {
+    this.exitCode = 137;
+    return true;
+  }
+
+  async sendStdin(): Promise<void> {}
+}
+
+class ExecuteCommandProcessManager extends SandboxProcessManager {
+  lastOptions: SpawnProcessOptions | undefined;
+
+  constructor(private readonly output: string) {
+    super();
+  }
+
+  async spawn(_command: string, options?: SpawnProcessOptions): Promise<ProcessHandle> {
+    this.lastOptions = options;
+    return new ExecuteCommandProcessHandle(options, this.output);
+  }
+
+  async list(): Promise<[]> {
+    return [];
+  }
+}
+
+class ProcessBackedSandbox extends MastraSandbox {
+  readonly id = 'test-process-backed-sandbox';
+  readonly name = 'ProcessBackedSandbox';
+  readonly provider = 'test';
+  status: ProviderStatus = 'pending';
+
+  constructor(processes: SandboxProcessManager) {
+    super({ name: 'ProcessBackedSandbox', processes });
   }
 }
 
@@ -404,6 +466,33 @@ describe('MastraSandbox Base Class', () => {
 
       expect(callCount).toBe(1);
       expect(sandbox.status).toBe('running');
+    });
+  });
+
+  describe('Built-in executeCommand', () => {
+    it('retains full command output by default', async () => {
+      const output = 'x'.repeat(1024 * 1024 + 5);
+      const manager = new ExecuteCommandProcessManager(output);
+      const sandbox = new ProcessBackedSandbox(manager);
+
+      const result = await sandbox.executeCommand!('node', ['script.js']);
+
+      expect(result.stdout).toBe(output);
+      expect(result.stdoutTruncated).toBe(false);
+      expect(result.stdoutDroppedBytes).toBe(0);
+      expect(manager.lastOptions?.maxRetainedBytes).toBe(Infinity);
+    });
+
+    it('passes explicit executeCommand retention limits through to spawn', async () => {
+      const manager = new ExecuteCommandProcessManager('abcdef');
+      const sandbox = new ProcessBackedSandbox(manager);
+
+      const result = await sandbox.executeCommand!('node', ['script.js'], { maxRetainedBytes: 3 });
+
+      expect(result.stdout).toBe('def');
+      expect(result.stdoutTruncated).toBe(true);
+      expect(result.stdoutDroppedBytes).toBe(3);
+      expect(manager.lastOptions?.maxRetainedBytes).toBe(3);
     });
   });
 });

--- a/packages/core/src/workspace/sandbox/mastra-sandbox.ts
+++ b/packages/core/src/workspace/sandbox/mastra-sandbox.ts
@@ -203,7 +203,7 @@ export abstract class MastraSandbox extends MastraBase implements WorkspaceSandb
           const fullCommand = args?.length ? `${command} ${args.map(a => shellQuote(a)).join(' ')}` : command;
           this.logger.debug('Executing command', { sandbox: this.name, command: fullCommand, cwd: opts?.cwd });
 
-          const handle = await pm.spawn(fullCommand, opts ?? {});
+          const handle = await pm.spawn(fullCommand, { ...opts, maxRetainedBytes: opts?.maxRetainedBytes ?? Infinity });
           const result = await handle.wait();
 
           this.logger.debug('Command completed', {

--- a/packages/core/src/workspace/sandbox/process-manager/process-handle.test.ts
+++ b/packages/core/src/workspace/sandbox/process-manager/process-handle.test.ts
@@ -21,7 +21,10 @@ class TestProcessHandle extends ProcessHandle {
     super(options);
   }
 
-  async wait(): Promise<CommandResult> {
+  async wait(_options?: {
+    onStdout?: (data: string) => void;
+    onStderr?: (data: string) => void;
+  }): Promise<CommandResult> {
     return this.waitPromise;
   }
 
@@ -39,6 +42,10 @@ class TestProcessHandle extends ProcessHandle {
       exitCode: 0,
       stdout: this.stdout,
       stderr: this.stderr,
+      stdoutTruncated: this.stdoutTruncated,
+      stderrTruncated: this.stderrTruncated,
+      stdoutDroppedBytes: this.stdoutDroppedBytes,
+      stderrDroppedBytes: this.stderrDroppedBytes,
       executionTimeMs: 0,
     });
   }

--- a/packages/core/src/workspace/sandbox/process-manager/process-handle.test.ts
+++ b/packages/core/src/workspace/sandbox/process-manager/process-handle.test.ts
@@ -1,0 +1,222 @@
+import { once } from 'node:events';
+
+import { describe, expect, it } from 'vitest';
+
+import type { MastraSandbox } from '../mastra-sandbox';
+import type { CommandResult } from '../types';
+import { ProcessHandle } from './process-handle';
+import { SandboxProcessManager } from './process-manager';
+import type { SpawnProcessOptions } from './types';
+
+class TestProcessHandle extends ProcessHandle {
+  readonly pid = 'test-pid';
+  exitCode: number | undefined;
+
+  private resolveWait!: (result: CommandResult) => void;
+  private readonly waitPromise = new Promise<CommandResult>(resolve => {
+    this.resolveWait = resolve;
+  });
+
+  constructor(options?: SpawnProcessOptions) {
+    super(options);
+  }
+
+  async wait(): Promise<CommandResult> {
+    return this.waitPromise;
+  }
+
+  async kill(): Promise<boolean> {
+    this.exitCode = 137;
+    return true;
+  }
+
+  async sendStdin(): Promise<void> {}
+
+  finish(): void {
+    this.exitCode = 0;
+    this.resolveWait({
+      success: true,
+      exitCode: 0,
+      stdout: this.stdout,
+      stderr: this.stderr,
+      executionTimeMs: 0,
+    });
+  }
+}
+
+class TestProcessManager extends SandboxProcessManager {
+  spawnCalls = 0;
+  ensureRunningCalls = 0;
+
+  constructor() {
+    super();
+    this.sandbox = {
+      ensureRunning: async () => {
+        this.ensureRunningCalls += 1;
+      },
+    } as MastraSandbox;
+  }
+
+  async spawn(_command: string, options?: SpawnProcessOptions): Promise<ProcessHandle> {
+    this.spawnCalls += 1;
+    return new TestProcessHandle(options);
+  }
+
+  async list(): Promise<[]> {
+    return [];
+  }
+}
+
+describe('ProcessHandle output retention', () => {
+  it('bounds stdout and stderr to the newest retained bytes by default', () => {
+    const handle = new TestProcessHandle();
+
+    handle.emitStdout('a'.repeat(1024 * 1024));
+    handle.emitStdout('tail');
+    handle.emitStderr('b'.repeat(1024 * 1024));
+    handle.emitStderr('tail');
+
+    expect(Buffer.byteLength(handle.stdout)).toBe(1024 * 1024);
+    expect(handle.stdout).toMatch(/tail$/);
+    expect(Buffer.byteLength(handle.stderr)).toBe(1024 * 1024);
+    expect(handle.stderr).toMatch(/tail$/);
+    expect(handle.stdoutDroppedBytes).toBe(4);
+    expect(handle.stderrDroppedBytes).toBe(4);
+  });
+
+  it('uses maxRetainedBytes for polling output without truncating callbacks', () => {
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+    const handle = new TestProcessHandle({
+      maxRetainedBytes: 5,
+      onStdout: data => stdoutChunks.push(data),
+      onStderr: data => stderrChunks.push(data),
+    });
+
+    handle.emitStdout('hello');
+    handle.emitStdout(' world');
+    handle.emitStderr('error');
+    handle.emitStderr(' text');
+
+    expect(handle.stdout).toBe('world');
+    expect(handle.stderr).toBe(' text');
+    expect(stdoutChunks).toEqual(['hello', ' world']);
+    expect(stderrChunks).toEqual(['error', ' text']);
+  });
+
+  it('rejects invalid retention limits', () => {
+    expect(() => new TestProcessHandle({ maxRetainedBytes: -1 })).toThrow(RangeError);
+    expect(() => new TestProcessHandle({ maxRetainedBytes: Number.NaN })).toThrow(RangeError);
+    expect(() => new TestProcessHandle({ maxRetainedBytes: 1.5 })).toThrow(RangeError);
+  });
+
+  it('validates retention limits before provider spawn is called', async () => {
+    const manager = new TestProcessManager();
+
+    await expect(manager.spawn('sleep 60', { maxRetainedBytes: -1 })).rejects.toThrow(RangeError);
+    expect(manager.ensureRunningCalls).toBe(0);
+    expect(manager.spawnCalls).toBe(0);
+  });
+
+  it('retains everything when maxRetainedBytes is Infinity', () => {
+    const handle = new TestProcessHandle({ maxRetainedBytes: Infinity });
+
+    for (let index = 0; index < 150; index += 1) {
+      handle.emitStdout(`${index},`);
+    }
+
+    expect(handle.stdout).toBe(Array.from({ length: 150 }, (_, index) => `${index},`).join(''));
+    expect(handle.stdoutTruncated).toBe(false);
+    expect(handle.stdoutDroppedBytes).toBe(0);
+  });
+
+  it('handles a single chunk larger than the retention limit', () => {
+    const handle = new TestProcessHandle({ maxRetainedBytes: 6 });
+
+    handle.emitStdout('before-after');
+
+    expect(handle.stdout).toBe('-after');
+    expect(handle.stdoutDroppedBytes).toBe(Buffer.byteLength('before'));
+  });
+
+  it('does not split multibyte characters when trimming to a byte limit', () => {
+    const handle = new TestProcessHandle({ maxRetainedBytes: 5 });
+
+    handle.emitStdout('a🙂b');
+
+    expect(Buffer.byteLength(handle.stdout)).toBe(5);
+    expect(handle.stdout).toBe('🙂b');
+    expect(handle.stdoutTruncated).toBe(true);
+  });
+
+  it('drops a code point that is larger than the retention limit', () => {
+    const handle = new TestProcessHandle({ maxRetainedBytes: 1 });
+
+    handle.emitStdout('🙂');
+    handle.emitStdout('b');
+
+    expect(handle.stdout).toBe('b');
+    expect(handle.stdoutDroppedBytes).toBe(4);
+  });
+
+  it('keeps retained output correct after compacting many chunks', () => {
+    const handle = new TestProcessHandle({ maxRetainedBytes: 10 });
+
+    for (let index = 0; index < 150; index += 1) {
+      handle.emitStdout(String(index % 10));
+    }
+
+    expect(handle.stdout).toBe('0123456789');
+    expect(handle.stdoutDroppedBytes).toBe(140);
+  });
+
+  it('returns retained output from wait after output is truncated', async () => {
+    const handle = new TestProcessHandle({ maxRetainedBytes: 6 });
+
+    handle.emitStdout('before ');
+    handle.emitStdout('after');
+    handle.emitStderr('first ');
+    handle.emitStderr('second');
+    handle.finish();
+
+    await expect(handle.wait()).resolves.toMatchObject({
+      stdout: ' after',
+      stderr: 'second',
+      stdoutTruncated: true,
+      stderrTruncated: true,
+      stdoutDroppedBytes: Buffer.byteLength('before'),
+      stderrDroppedBytes: Buffer.byteLength('first '),
+    });
+    expect(handle.stdoutTruncated).toBe(true);
+    expect(handle.stderrTruncated).toBe(true);
+  });
+
+  it('removes wait listeners after wait resolves', async () => {
+    const handle = new TestProcessHandle();
+    const chunks: string[] = [];
+    const waiting = handle.wait({ onStdout: data => chunks.push(data) });
+
+    handle.emitStdout('during wait');
+    handle.finish();
+    await waiting;
+    handle.emitStdout('after wait');
+
+    expect(chunks).toEqual(['during wait']);
+  });
+
+  it('allows retention to be disabled while keeping reader output intact', async () => {
+    const handle = new TestProcessHandle({ maxRetainedBytes: 0 });
+    const chunks: string[] = [];
+
+    handle.reader.on('data', chunk => chunks.push(chunk.toString()));
+
+    handle.emitStdout('hello');
+    handle.emitStdout(' world');
+    handle.finish();
+
+    await once(handle.reader, 'end');
+
+    expect(handle.stdout).toBe('');
+    expect(chunks.join('')).toBe('hello world');
+  });
+});

--- a/packages/core/src/workspace/sandbox/process-manager/process-handle.ts
+++ b/packages/core/src/workspace/sandbox/process-manager/process-handle.ts
@@ -12,16 +12,139 @@ import { Readable, Writable } from 'node:stream';
 import type { CommandResult } from '../types';
 import type { SpawnProcessOptions } from './types';
 
+export const DEFAULT_MAX_RETAINED_PROCESS_OUTPUT_BYTES = 1024 * 1024;
+const RETAINED_OUTPUT_COMPACT_CHUNK_THRESHOLD = 128;
+
+/** @internal */
+export function validateMaxRetainedProcessOutputBytes(maxRetainedBytes: number): number {
+  if (maxRetainedBytes === Infinity) return maxRetainedBytes;
+  if (!Number.isFinite(maxRetainedBytes) || maxRetainedBytes < 0 || !Number.isInteger(maxRetainedBytes)) {
+    throw new RangeError('maxRetainedBytes must be a non-negative integer or Infinity');
+  }
+  return maxRetainedBytes;
+}
+
+function getPreviousCodePointStart(value: string, end: number): number {
+  let start = end - 1;
+  const codeUnit = value.charCodeAt(start);
+
+  if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff && start > 0) {
+    const previousCodeUnit = value.charCodeAt(start - 1);
+    if (previousCodeUnit >= 0xd800 && previousCodeUnit <= 0xdbff) {
+      start -= 1;
+    }
+  }
+
+  return start;
+}
+
+function trimToMaxBytes(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return '';
+
+  let retainedBytes = 0;
+  let end = value.length;
+  let start = end;
+
+  while (start > 0) {
+    const characterStart = getPreviousCodePointStart(value, start);
+    const characterBytes = Buffer.byteLength(value.slice(characterStart, end));
+    if (retainedBytes + characterBytes > maxBytes) break;
+    retainedBytes += characterBytes;
+    end = characterStart;
+    start = characterStart;
+  }
+
+  const retained = value.slice(start);
+  return retained.length === value.length ? retained : Buffer.from(retained, 'utf8').toString('utf8');
+}
+
+class RetainedOutputBuffer {
+  private chunks: Array<{ data: string; bytes: number }> = [];
+  private bytes = 0;
+  private droppedBytes = 0;
+  private cachedValue: string | undefined;
+
+  constructor(private readonly maxBytes: number) {}
+
+  append(data: string): void {
+    const dataBytes = Buffer.byteLength(data);
+    if (dataBytes === 0) return;
+    if (this.maxBytes === 0) {
+      this.droppedBytes += dataBytes;
+      return;
+    }
+
+    this.chunks.push({ data, bytes: dataBytes });
+    this.bytes += dataBytes;
+    this.cachedValue = undefined;
+
+    this.trim();
+    this.compactIfNeeded();
+  }
+
+  toString(): string {
+    this.cachedValue ??= this.chunks.map(chunk => chunk.data).join('');
+    return this.cachedValue;
+  }
+
+  get truncated(): boolean {
+    return this.droppedBytes > 0;
+  }
+
+  get dropped(): number {
+    return this.droppedBytes;
+  }
+
+  private trim(): void {
+    if (this.maxBytes === Infinity) return;
+
+    while (this.bytes > this.maxBytes && this.chunks.length > 0) {
+      const overflowBytes = this.bytes - this.maxBytes;
+      const firstChunk = this.chunks[0]!;
+
+      if (firstChunk.bytes <= overflowBytes) {
+        this.chunks.shift();
+        this.bytes -= firstChunk.bytes;
+        this.droppedBytes += firstChunk.bytes;
+        continue;
+      }
+
+      const retainedData = trimToMaxBytes(firstChunk.data, firstChunk.bytes - overflowBytes);
+      const retainedBytes = Buffer.byteLength(retainedData);
+      const droppedBytes = firstChunk.bytes - retainedBytes;
+
+      if (retainedBytes === 0) {
+        this.chunks.shift();
+        this.bytes -= droppedBytes;
+        this.droppedBytes += droppedBytes;
+        continue;
+      }
+
+      this.chunks[0] = { data: retainedData, bytes: retainedBytes };
+      this.bytes -= droppedBytes;
+      this.droppedBytes += droppedBytes;
+    }
+  }
+
+  private compactIfNeeded(): void {
+    if (this.chunks.length <= RETAINED_OUTPUT_COMPACT_CHUNK_THRESHOLD) return;
+    const data = this.toString();
+    this.bytes = Buffer.byteLength(data);
+    this.chunks = this.bytes === 0 ? [] : [{ data, bytes: this.bytes }];
+    this.cachedValue = data;
+  }
+}
+
 /**
  * Handle to a spawned process.
  *
  * Subclasses implement the platform-specific primitives (kill, sendStdin,
- * wait). The base class handles stdout/stderr accumulation, callback
+ * wait). The base class handles bounded stdout/stderr accumulation, callback
  * dispatch via `emitStdout`/`emitStderr`, lazy `reader`/`writer` stream
  * getters, and optional streaming callbacks on `wait()`.
  *
  * **For consumers:**
- * - `handle.stdout` — poll accumulated output
+ * - `handle.stdout` — poll retained output
  * - `handle.wait()` — wait for exit, optionally with streaming callbacks
  * - `handle.reader` / `handle.writer` — Node.js stream interop (LSP, JSON-RPC, pipes)
  * - `onStdout`/`onStderr` callbacks in {@link SpawnProcessOptions} — stream at spawn time
@@ -85,14 +208,20 @@ export abstract class ProcessHandle {
     throw new Error(`${this.constructor.name} must implement wait()`);
   }
 
-  private _stdout = '';
-  private _stderr = '';
+  private _stdout: RetainedOutputBuffer;
+  private _stderr: RetainedOutputBuffer;
   private _stdoutListeners = new Set<(data: string) => void>();
   private _stderrListeners = new Set<(data: string) => void>();
   private _reader?: Readable;
   private _writer?: Writable;
 
-  constructor(options?: Pick<SpawnProcessOptions, 'onStdout' | 'onStderr'>) {
+  constructor(options?: Pick<SpawnProcessOptions, 'maxRetainedBytes' | 'onStdout' | 'onStderr'>) {
+    const maxRetainedBytes = validateMaxRetainedProcessOutputBytes(
+      options?.maxRetainedBytes ?? DEFAULT_MAX_RETAINED_PROCESS_OUTPUT_BYTES,
+    );
+    this._stdout = new RetainedOutputBuffer(maxRetainedBytes);
+    this._stderr = new RetainedOutputBuffer(maxRetainedBytes);
+
     // Spawn-time callbacks are permanent listeners
     if (options?.onStdout) this._stdoutListeners.add(options.onStdout);
     if (options?.onStderr) this._stderrListeners.add(options.onStderr);
@@ -105,7 +234,14 @@ export abstract class ProcessHandle {
       if (waitOptions?.onStdout) this._stdoutListeners.add(waitOptions.onStdout);
       if (waitOptions?.onStderr) this._stderrListeners.add(waitOptions.onStderr);
       try {
-        return await implWait();
+        const result = await implWait();
+        return {
+          ...result,
+          stdoutTruncated: this.stdoutTruncated,
+          stderrTruncated: this.stderrTruncated,
+          stdoutDroppedBytes: this.stdoutDroppedBytes,
+          stderrDroppedBytes: this.stderrDroppedBytes,
+        };
       } finally {
         if (waitOptions?.onStdout) this._stdoutListeners.delete(waitOptions.onStdout);
         if (waitOptions?.onStderr) this._stderrListeners.delete(waitOptions.onStderr);
@@ -113,14 +249,34 @@ export abstract class ProcessHandle {
     };
   }
 
-  /** Accumulated stdout so far */
+  /** Retained stdout so far */
   get stdout(): string {
-    return this._stdout;
+    return this._stdout.toString();
   }
 
-  /** Accumulated stderr so far */
+  /** Retained stderr so far */
   get stderr(): string {
-    return this._stderr;
+    return this._stderr.toString();
+  }
+
+  /** Whether stdout has dropped older output due to the retention limit */
+  get stdoutTruncated(): boolean {
+    return this._stdout.truncated;
+  }
+
+  /** Whether stderr has dropped older output due to the retention limit */
+  get stderrTruncated(): boolean {
+    return this._stderr.truncated;
+  }
+
+  /** Number of stdout bytes dropped due to the retention limit */
+  get stdoutDroppedBytes(): number {
+    return this._stdout.dropped;
+  }
+
+  /** Number of stderr bytes dropped due to the retention limit */
+  get stderrDroppedBytes(): number {
+    return this._stderr.dropped;
   }
 
   /**
@@ -128,7 +284,7 @@ export abstract class ProcessHandle {
    * @internal Called by subclasses and process managers to dispatch transport data.
    */
   emitStdout(data: string): void {
-    this._stdout += data;
+    this._stdout.append(data);
     for (const listener of this._stdoutListeners) listener(data);
     this._reader?.push(data);
   }
@@ -138,7 +294,7 @@ export abstract class ProcessHandle {
    * @internal Called by subclasses and process managers to dispatch transport data.
    */
   emitStderr(data: string): void {
-    this._stderr += data;
+    this._stderr.append(data);
     for (const listener of this._stderrListeners) listener(data);
   }
 

--- a/packages/core/src/workspace/sandbox/process-manager/process-manager.ts
+++ b/packages/core/src/workspace/sandbox/process-manager/process-manager.ts
@@ -8,6 +8,7 @@
  */
 
 import type { MastraSandbox } from '../mastra-sandbox';
+import { validateMaxRetainedProcessOutputBytes } from './process-handle';
 import type { ProcessHandle } from './process-handle';
 import type { ProcessInfo, SpawnProcessOptions } from './types';
 
@@ -69,6 +70,10 @@ export abstract class SandboxProcessManager<TSandbox extends MastraSandbox = Mas
     };
 
     this.spawn = async (...args: Parameters<typeof impl.spawn>) => {
+      // Validate before starting a sandbox; ProcessHandle validates again for direct subclass construction.
+      if (args[1]?.maxRetainedBytes !== undefined) {
+        validateMaxRetainedProcessOutputBytes(args[1].maxRetainedBytes);
+      }
       await this.sandbox.ensureRunning();
       const handle = await impl.spawn(...args);
       handle.command = args[0];

--- a/packages/core/src/workspace/sandbox/types.ts
+++ b/packages/core/src/workspace/sandbox/types.ts
@@ -52,6 +52,14 @@ export interface ExecutionResult {
   timedOut?: boolean;
   /** Whether execution was killed */
   killed?: boolean;
+  /** Whether stdout dropped older output due to a retention limit */
+  stdoutTruncated?: boolean;
+  /** Whether stderr dropped older output due to a retention limit */
+  stderrTruncated?: boolean;
+  /** Number of stdout bytes dropped due to a retention limit */
+  stdoutDroppedBytes?: number;
+  /** Number of stderr bytes dropped due to a retention limit */
+  stderrDroppedBytes?: number;
 }
 
 export interface CommandResult extends ExecutionResult {
@@ -82,6 +90,16 @@ export interface CommandOptions {
   onStderr?: (data: string) => void;
   /** Abort signal to cancel the command */
   abortSignal?: AbortSignal;
+  /**
+   * Maximum UTF-8 byte length retained in stdout and stderr per stream.
+   * When exceeded, the oldest output is dropped and the newest output is kept.
+   * Callbacks and reader streams still receive every chunk in full.
+   * Use 0 to disable retention, or Infinity to retain all output. Must be an integer.
+   *
+   * Defaults to 1048576 for spawned processes. The built-in executeCommand
+   * implementation retains all output unless this option is set.
+   */
+  maxRetainedBytes?: number;
 }
 
 /** Options for executeCommand. */

--- a/packages/core/src/workspace/sandbox/types.ts
+++ b/packages/core/src/workspace/sandbox/types.ts
@@ -94,7 +94,8 @@ export interface CommandOptions {
    * Maximum UTF-8 byte length retained in stdout and stderr per stream.
    * When exceeded, the oldest output is dropped and the newest output is kept.
    * Callbacks and reader streams still receive every chunk in full.
-   * Use 0 to disable retention, or Infinity to retain all output. Must be an integer.
+   * Use 0 to disable retention, a positive integer to set a byte limit,
+   * or Infinity to retain all output.
    *
    * Defaults to 1048576 for spawned processes. The built-in executeCommand
    * implementation retains all output unless this option is set.

--- a/packages/core/src/workspace/tools/__tests__/sandbox-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/sandbox-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
 import { WORKSPACE_TOOLS } from '../../constants';
+import type { CommandResult } from '../../sandbox';
 import { Workspace } from '../../workspace';
 import { executeCommandTool, executeCommandWithBackgroundTool } from '../execute-command';
 import { getProcessOutputTool } from '../get-process-output';
@@ -25,16 +26,7 @@ function createMockHandle(opts: {
   stdout?: string;
   stderr?: string;
   exitCode?: number;
-  waitResult?: {
-    exitCode: number;
-    success: boolean;
-    stdout: string;
-    stderr: string;
-    stdoutTruncated?: boolean;
-    stderrTruncated?: boolean;
-    stdoutDroppedBytes?: number;
-    stderrDroppedBytes?: number;
-  };
+  waitResult?: CommandResult;
 }) {
   const handle = {
     pid: opts.pid,

--- a/packages/core/src/workspace/tools/__tests__/sandbox-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/sandbox-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 
+import { WORKSPACE_TOOLS } from '../../constants';
 import { Workspace } from '../../workspace';
 import { executeCommandTool, executeCommandWithBackgroundTool } from '../execute-command';
 import { getProcessOutputTool } from '../get-process-output';
@@ -24,7 +25,16 @@ function createMockHandle(opts: {
   stdout?: string;
   stderr?: string;
   exitCode?: number;
-  waitResult?: { exitCode: number; success: boolean; stdout: string; stderr: string };
+  waitResult?: {
+    exitCode: number;
+    success: boolean;
+    stdout: string;
+    stderr: string;
+    stdoutTruncated?: boolean;
+    stderrTruncated?: boolean;
+    stdoutDroppedBytes?: number;
+    stderrDroppedBytes?: number;
+  };
 }) {
   const handle = {
     pid: opts.pid,
@@ -266,6 +276,48 @@ describe('execute_command tool', () => {
       const result = await executeCommandWithBackgroundTool.execute({ command: 'echo hi' }, ctx);
       expect(result).toBe('foreground result\n');
       expect(sandbox.processes.spawn).not.toHaveBeenCalled();
+    });
+
+    it('passes truncation metadata to background onExit callbacks', async () => {
+      const onExit = vi.fn();
+      const handle = createMockHandle({
+        pid: '42',
+        waitResult: {
+          exitCode: 0,
+          success: true,
+          stdout: 'tail',
+          stderr: '',
+          stdoutTruncated: true,
+          stderrTruncated: false,
+          stdoutDroppedBytes: 1024,
+          stderrDroppedBytes: 0,
+        },
+      });
+      const sandbox = createMockSandbox({
+        processes: {
+          spawn: vi.fn().mockResolvedValue(handle),
+        },
+      });
+      const workspace = new Workspace({
+        sandbox,
+        tools: {
+          [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: {
+            backgroundProcesses: { onExit },
+          },
+        },
+      });
+
+      await executeCommandWithBackgroundTool.execute({ command: 'node server.js', background: true }, { workspace });
+      await vi.waitFor(() => expect(onExit).toHaveBeenCalled());
+
+      expect(onExit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pid: '42',
+          stdout: 'tail',
+          stdoutTruncated: true,
+          stdoutDroppedBytes: 1024,
+        }),
+      );
     });
   });
 });

--- a/packages/core/src/workspace/tools/execute-command.ts
+++ b/packages/core/src/workspace/tools/execute-command.ts
@@ -182,6 +182,10 @@ async function executeCommand(input: Record<string, any>, context: any) {
           exitCode: result.exitCode,
           stdout: result.stdout,
           stderr: result.stderr,
+          stdoutTruncated: result.stdoutTruncated,
+          stderrTruncated: result.stderrTruncated,
+          stdoutDroppedBytes: result.stdoutDroppedBytes,
+          stderrDroppedBytes: result.stderrDroppedBytes,
           toolCallId,
         });
       });

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -121,6 +121,10 @@ export interface BackgroundProcessExitMeta extends BackgroundProcessMeta {
   exitCode: number;
   stdout: string;
   stderr: string;
+  stdoutTruncated?: boolean;
+  stderrTruncated?: boolean;
+  stdoutDroppedBytes?: number;
+  stderrDroppedBytes?: number;
 }
 
 /**


### PR DESCRIPTION
## Description

Adds bounded stdout/stderr retention for spawned process handles so long-lived background processes do not retain output forever.

The default for `processes.spawn()` is now the latest 1 MiB per stream. Callers can customize this with `maxRetainedBytes`, disable retained polling output with `0`, or preserve unlimited retention with `Infinity`.

Streaming callbacks and reader streams still receive every chunk in full. `ProcessHandle`, `wait()` results, and background `onExit` callbacks now expose truncation metadata so callers can tell when retained stdout/stderr dropped older bytes.

The built-in `executeCommand()` path keeps full output by default for compatibility, unless `maxRetainedBytes` is explicitly passed.

Also fixes local process UTF-8 decoding by using `StringDecoder`, so multi-byte characters split across stdout/stderr chunks are preserved.

## Related issue(s)

Fixes #16573

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Verification

- `corepack pnpm --filter ./packages/core test process-manager/process-handle.test.ts`
- `corepack pnpm --filter ./packages/core test workspace/sandbox/local-sandbox.test.ts`
- `corepack pnpm --filter ./packages/core test workspace/sandbox/mastra-sandbox.test.ts`
- `corepack pnpm --filter ./packages/core test workspace/tools/__tests__/sandbox-tools.test.ts`
- `corepack pnpm --filter ./packages/core check`
- targeted `eslint`
- `corepack pnpm build:core`
- `git diff --check`
- local CodeRabbit review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Spawned process handles now retain only the latest 1 MiB per stdout/stderr by default, configurable via a maxRetainedBytes option (0 disables retention, Infinity preserves all).
  - executeCommand retains full output by default unless maxRetainedBytes is set.

- **Bug Fixes**
  - Fixed UTF-8 decoding for multi-byte characters split across output chunks.

- **Diagnostics**
  - Wait results and background-exit callbacks include truncation flags and dropped-byte counts.

- **Tests**
  - Added coverage for retention behavior, truncation metadata, and UTF-8 edge cases.

- **Documentation**
  - Updated docs and ignore patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16574)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->