### PR TITLE
feat(docker): expose sandbox hardening options

### DIFF
--- a/.changeset/cute-clouds-grin.md
+++ b/.changeset/cute-clouds-grin.md
@@ -2,7 +2,7 @@
 "@mastra/docker": minor
 ---
 
-You can now secure and limit Docker sandbox containers with memory, CPU quota/period, PID, capability add/drop, security options, ulimits, read-only root filesystem, and tmpfs options.
+Docker sandbox containers now support resource limits and security hardening through Docker HostConfig options. Configure memory, CPU quota, process IDs, capabilities, security options, read-only root filesystems, and tmpfs mounts.
 
 ```typescript
 const sandbox = new DockerSandbox({

--- a/.changeset/cute-clouds-grin.md
+++ b/.changeset/cute-clouds-grin.md
@@ -1,0 +1,17 @@
+---
+"@mastra/docker": minor
+---
+
+You can now secure and limit Docker sandbox containers with memory, CPU quota/period, PID, capability add/drop, security options, ulimits, read-only root filesystem, and tmpfs options.
+
+```typescript
+const sandbox = new DockerSandbox({
+  memory: 512 * 1024 * 1024,
+  memorySwap: 512 * 1024 * 1024,
+  cpuQuota: 100_000,
+  pidsLimit: 256,
+  readonlyRootfs: true,
+  capDrop: ['ALL'],
+  securityOpt: ['no-new-privileges:true'],
+})
+```

--- a/docs/src/content/en/reference/workspace/docker-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/docker-sandbox.mdx
@@ -96,6 +96,80 @@ const agent = new Agent({
     defaultValue: 'false',
   },
   {
+    name: 'memory',
+    type: 'number',
+    description: 'Memory limit in bytes. Docker treats 0 as unlimited. Maps to Docker HostConfig.Memory.',
+    isOptional: true,
+  },
+  {
+    name: 'memorySwap',
+    type: 'number',
+    description: 'Total memory plus swap in bytes. Maps to Docker HostConfig.MemorySwap.',
+    isOptional: true,
+  },
+  {
+    name: 'cpuShares',
+    type: 'number',
+    description: 'CPU shares relative weight. Maps to Docker HostConfig.CpuShares.',
+    isOptional: true,
+  },
+  {
+    name: 'cpuQuota',
+    type: 'number',
+    description: 'CPU quota in microseconds per period. Maps to Docker HostConfig.CpuQuota.',
+    isOptional: true,
+  },
+  {
+    name: 'cpuPeriod',
+    type: 'number',
+    description: 'CPU period in microseconds. Maps to Docker HostConfig.CpuPeriod.',
+    isOptional: true,
+  },
+  {
+    name: 'pidsLimit',
+    type: 'number',
+    description: 'Maximum number of process IDs in the container. Maps to Docker HostConfig.PidsLimit.',
+    isOptional: true,
+  },
+  {
+    name: 'readonlyRootfs',
+    type: 'boolean',
+    description: 'Mount the container root filesystem as read-only. Maps to Docker HostConfig.ReadonlyRootfs.',
+    isOptional: true,
+  },
+  {
+    name: 'capDrop',
+    type: 'string[]',
+    description:
+      "Linux capabilities to drop. Use ['ALL'] to drop all capabilities before adding specific ones. Maps to Docker HostConfig.CapDrop.",
+    isOptional: true,
+  },
+  {
+    name: 'capAdd',
+    type: 'string[]',
+    description:
+      'Linux capabilities to add back after drops, such as NET_BIND_SERVICE. Maps to Docker HostConfig.CapAdd.',
+    isOptional: true,
+  },
+  {
+    name: 'securityOpt',
+    type: 'string[]',
+    description: "Docker security options, such as ['no-new-privileges:true']. Maps to Docker HostConfig.SecurityOpt.",
+    isOptional: true,
+  },
+  {
+    name: 'ulimits',
+    type: 'Array<{ name: string; soft: number; hard: number }>',
+    description: 'Ulimit entries for the container. Maps to Docker HostConfig.Ulimits.',
+    isOptional: true,
+  },
+  {
+    name: 'tmpfs',
+    type: 'Record<string, string>',
+    description: 'tmpfs mount paths and options. Maps to Docker HostConfig.Tmpfs.',
+    isOptional: true,
+  },
+  {
     name: 'workingDir',
     type: 'string',
     description: 'Working directory inside the container.',
@@ -222,6 +296,42 @@ const sandbox = new DockerSandbox({
 ```
 
 Bind mounts are applied at container creation time. The host paths must exist before the sandbox starts.
+
+## Hardening
+
+Use Docker-specific resource and hardening options to limit a sandbox container. The following example caps memory and process count, limits CPU to a single core with matching `cpuPeriod` and `cpuQuota` values, drops Linux capabilities, makes the root filesystem read-only, and mounts `/tmp` as writable scratch space:
+
+```typescript
+const sandbox = new DockerSandbox({
+  image: 'node:22-slim',
+  memory: 512 * 1024 * 1024,
+  memorySwap: 512 * 1024 * 1024,
+  cpuPeriod: 100_000,
+  cpuQuota: 100_000,
+  pidsLimit: 256,
+  readonlyRootfs: true,
+  capDrop: ['ALL'],
+  capAdd: ['NET_BIND_SERVICE'],
+  securityOpt: ['no-new-privileges:true'],
+  ulimits: [{ name: 'nofile', soft: 1024, hard: 2048 }],
+  tmpfs: {
+    '/tmp': 'rw,noexec,nosuid,size=64m',
+  },
+})
+```
+
+These options map directly to Docker `HostConfig` fields and aren't set unless you pass them.
+
+Review these trade-offs before enabling hardening:
+
+- `readonlyRootfs`: In-container package installs and tools that write outside mounted paths can fail. Add `tmpfs` entries for writable scratch paths such as `/tmp`, and mount tmpfs or volumes for package-manager caches such as `~/.npm` when needed.
+- `capDrop`: Dropping all capabilities disables commands that need Linux capabilities, including `ping`, mount operations, and FUSE-backed tools. Add back only the capabilities your workload needs.
+- `memory`: Docker treats `0` as unlimited. Omit `memory` or pass `0` only when you don't want a memory cap.
+- `memorySwap`: Docker memory and swap behavior depends on the host and Docker daemon configuration. When you set `memory` without `memorySwap`, Docker allows swap up to twice the memory limit by default. Set `memorySwap` equal to `memory` when you want to disable swap for the container; Docker also accepts `-1` for unlimited swap.
+- `pidsLimit`: Very low values can break `docker exec` workloads because each command starts additional processes inside the long-lived container.
+- `privileged`: Privileged containers bypass capability and security-option controls. Don't combine `privileged: true` with capability or security options unless the workload requires it.
+- Reconnection: `DockerSandbox` reuses an existing container when the sandbox ID matches and warns if inspected `HostConfig` hardening values differ. Destroy and recreate the sandbox to apply changed hardening options. Docker can normalize inspected values, and changing `memorySwap` on reconnect can trigger a warning if the original container used Docker's default swap behavior.
+- Docker Desktop: Resource limits apply inside the Docker Desktop virtual machine on macOS and Windows, so the VM's allocated resources can cap what containers receive.
 
 ## Reconnection
 

--- a/workspaces/docker/src/provider.ts
+++ b/workspaces/docker/src/provider.ts
@@ -28,6 +28,30 @@ export interface DockerProviderConfig {
   workingDir?: string;
   /** Run in privileged mode */
   privileged?: boolean;
+  /** Memory limit in bytes */
+  memory?: number;
+  /** Total memory plus swap in bytes */
+  memorySwap?: number;
+  /** CPU shares relative weight */
+  cpuShares?: number;
+  /** CPU quota in microseconds per period */
+  cpuQuota?: number;
+  /** CPU period in microseconds */
+  cpuPeriod?: number;
+  /** Maximum number of PIDs in the container */
+  pidsLimit?: number;
+  /** Mount the container root filesystem as read-only */
+  readonlyRootfs?: boolean;
+  /** Linux capabilities to drop */
+  capDrop?: string[];
+  /** Linux capabilities to add */
+  capAdd?: string[];
+  /** Docker security options */
+  securityOpt?: string[];
+  /** Ulimit entries for Docker HostConfig.Ulimits */
+  ulimits?: DockerSandboxOptions['ulimits'];
+  /** tmpfs mount paths with options */
+  tmpfs?: DockerSandboxOptions['tmpfs'];
 }
 
 export const dockerSandboxProvider: SandboxProvider<DockerProviderConfig> = {
@@ -70,6 +94,68 @@ export const dockerSandboxProvider: SandboxProvider<DockerProviderConfig> = {
         type: 'boolean',
         description: 'Run in privileged mode',
         default: false,
+      },
+      memory: {
+        type: 'number',
+        description: 'Memory limit in bytes',
+      },
+      memorySwap: {
+        type: 'number',
+        description: 'Total memory plus swap in bytes',
+      },
+      cpuShares: {
+        type: 'number',
+        description: 'CPU shares relative weight',
+      },
+      cpuQuota: {
+        type: 'number',
+        description: 'CPU quota in microseconds per period',
+      },
+      cpuPeriod: {
+        type: 'number',
+        description: 'CPU period in microseconds',
+      },
+      pidsLimit: {
+        type: 'number',
+        description: 'Maximum number of PIDs in the container',
+      },
+      readonlyRootfs: {
+        type: 'boolean',
+        description: 'Mount the container root filesystem as read-only',
+      },
+      capDrop: {
+        type: 'array',
+        description: 'Linux capabilities to drop',
+        items: { type: 'string' },
+      },
+      capAdd: {
+        type: 'array',
+        description: 'Linux capabilities to add',
+        items: { type: 'string' },
+      },
+      securityOpt: {
+        type: 'array',
+        description: 'Docker security options',
+        items: { type: 'string' },
+      },
+      ulimits: {
+        type: 'array',
+        description: 'Ulimit entries for Docker HostConfig.Ulimits',
+        items: {
+          type: 'object',
+          required: ['name', 'soft', 'hard'],
+          additionalProperties: false,
+          properties: {
+            name: { type: 'string' },
+            soft: { type: 'number' },
+            hard: { type: 'number' },
+          },
+        },
+      },
+      tmpfs: {
+        type: 'object',
+        description: 'tmpfs mount paths with options',
+        additionalProperties: { type: 'string' },
       },
     },
   },

--- a/workspaces/docker/src/sandbox/index.test.ts
+++ b/workspaces/docker/src/sandbox/index.test.ts
@@ -261,6 +261,92 @@ describe('DockerSandbox', () => {
       expect(createCall.HostConfig.Privileged).toBe(true);
     });
 
+    it('should warn when privileged mode overlaps with capability or security options', async () => {
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+      };
+      const sandbox = new DockerSandbox({
+        privileged: true,
+        readonlyRootfs: true,
+        capDrop: ['ALL'],
+        capAdd: ['NET_BIND_SERVICE'],
+        securityOpt: ['no-new-privileges:true'],
+      });
+      (sandbox as any).__setLogger(logger);
+      await sandbox._start();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('capDrop, capAdd, securityOpt'),
+        expect.objectContaining({
+          fields: expect.arrayContaining(['capDrop', 'capAdd', 'securityOpt']),
+          hostConfigFields: expect.arrayContaining(['CapDrop', 'CapAdd', 'SecurityOpt']),
+        }),
+      );
+      expect(logger.warn.mock.calls.some(call => String(call[0]).includes('ReadonlyRootfs'))).toBe(false);
+    });
+
+    it('should not warn about privileged mode for empty capability or security options', async () => {
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+      };
+      const sandbox = new DockerSandbox({
+        privileged: true,
+        capDrop: [],
+        capAdd: [],
+        securityOpt: [],
+      });
+      (sandbox as any).__setLogger(logger);
+      await sandbox._start();
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('should pass container hardening options to HostConfig', async () => {
+      const sandbox = new DockerSandbox({
+        memory: 512 * 1024 * 1024,
+        memorySwap: 1024 * 1024 * 1024,
+        cpuShares: 512,
+        cpuQuota: 100_000,
+        cpuPeriod: 100_000,
+        pidsLimit: 256,
+        readonlyRootfs: true,
+        capDrop: ['ALL'],
+        capAdd: ['NET_BIND_SERVICE'],
+        securityOpt: ['no-new-privileges:true'],
+        ulimits: [{ name: 'nofile', soft: 1024, hard: 2048 }],
+        tmpfs: { '/tmp': 'rw,noexec,nosuid,size=64m' },
+      });
+      await sandbox._start();
+
+      const createCall = mockDocker.createContainer.mock.calls[0]?.[0];
+      expect(createCall.HostConfig).toEqual(
+        expect.objectContaining({
+          Memory: 512 * 1024 * 1024,
+          MemorySwap: 1024 * 1024 * 1024,
+          CpuShares: 512,
+          CpuQuota: 100_000,
+          CpuPeriod: 100_000,
+          PidsLimit: 256,
+          ReadonlyRootfs: true,
+          CapDrop: ['ALL'],
+          CapAdd: ['NET_BIND_SERVICE'],
+          SecurityOpt: ['no-new-privileges:true'],
+          Ulimits: [{ Name: 'nofile', Soft: 1024, Hard: 2048 }],
+          Tmpfs: { '/tmp': 'rw,noexec,nosuid,size=64m' },
+        }),
+      );
+    });
+
     it('should include labels with mastra metadata', async () => {
       const sandbox = new DockerSandbox({
         id: 'test-sandbox',
@@ -332,6 +418,276 @@ describe('DockerSandbox', () => {
       // Should get the existing container
       expect(mockDocker.getContainer).toHaveBeenCalledWith('existing-container-id');
       expect(sandbox.status).toBe('running');
+    });
+
+    it('should warn when requested hardening options differ on reconnect', async () => {
+      mockDocker.listContainers.mockResolvedValue([{ Id: 'existing-container-id', State: 'running' }]);
+      mockContainer.inspect.mockResolvedValue({
+        Id: 'existing-container-id',
+        State: { Status: 'running', Running: true },
+        HostConfig: {
+          Privileged: false,
+          Memory: 256 * 1024 * 1024,
+        },
+      });
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+      };
+
+      const sandbox = new DockerSandbox({
+        id: 'existing-sandbox',
+        memory: 512 * 1024 * 1024,
+        readonlyRootfs: true,
+        capDrop: ['ALL'],
+      });
+      (sandbox as any).__setLogger(logger);
+      await sandbox._start();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('requested Docker option(s) memory, readonlyRootfs, capDrop differ'),
+        {
+          containerId: 'existing-container-id',
+          fields: ['memory', 'readonlyRootfs', 'capDrop'],
+          hostConfigFields: ['Memory', 'ReadonlyRootfs', 'CapDrop'],
+        },
+      );
+    });
+
+    it('should warn about privileged capability options on reconnect', async () => {
+      mockDocker.listContainers.mockResolvedValue([{ Id: 'existing-container-id', State: 'running' }]);
+      mockContainer.inspect.mockResolvedValue({
+        Id: 'existing-container-id',
+        State: { Status: 'running', Running: true },
+        HostConfig: {
+          Privileged: true,
+          CapDrop: ['ALL'],
+        },
+      });
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+      };
+
+      const sandbox = new DockerSandbox({
+        id: 'existing-sandbox',
+        privileged: true,
+        capDrop: ['ALL'],
+      });
+      (sandbox as any).__setLogger(logger);
+      await sandbox._start();
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Privileged containers can bypass'), {
+        fields: ['capDrop'],
+        hostConfigFields: ['CapDrop'],
+      });
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should warn when privileged is omitted but the reconnected container is privileged', async () => {
+      mockDocker.listContainers.mockResolvedValue([{ Id: 'existing-container-id', State: 'running' }]);
+      mockContainer.inspect.mockResolvedValue({
+        Id: 'existing-container-id',
+        State: { Status: 'running', Running: true },
+        HostConfig: {
+          Privileged: true,
+        },
+      });
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+      };
+
+      const sandbox = new DockerSandbox({ id: 'existing-sandbox' });
+      (sandbox as any).__setLogger(logger);
+      await sandbox._start();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'existing container is privileged, but this DockerSandbox did not request privileged mode',
+        ),
+        {
+          containerId: 'existing-container-id',
+          fields: ['privileged'],
+          hostConfigFields: ['Privileged'],
+        },
+      );
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should warn when privileged is disabled but the reconnected container is privileged', async () => {
+      mockDocker.listContainers.mockResolvedValue([{ Id: 'existing-container-id', State: 'running' }]);
+      mockContainer.inspect.mockResolvedValue({
+        Id: 'existing-container-id',
+        State: { Status: 'running', Running: true },
+        HostConfig: {
+          Privileged: true,
+        },
+      });
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+      };
+
+      const sandbox = new DockerSandbox({
+        id: 'existing-sandbox',
+        privileged: false,
+      });
+      (sandbox as any).__setLogger(logger);
+      await sandbox._start();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('requested Docker option(s) privileged differ'),
+        {
+          containerId: 'existing-container-id',
+          fields: ['privileged'],
+          hostConfigFields: ['Privileged'],
+        },
+      );
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not warn when requested hardening options match on reconnect', async () => {
+      mockDocker.listContainers.mockResolvedValue([{ Id: 'existing-container-id', State: 'running' }]);
+      mockContainer.inspect.mockResolvedValue({
+        Id: 'existing-container-id',
+        State: { Status: 'running', Running: true },
+        HostConfig: {
+          Privileged: false,
+          Memory: 512 * 1024 * 1024,
+          ReadonlyRootfs: true,
+          CapDrop: ['CAP_NET_RAW', 'ALL'],
+          Ulimits: [{ Name: 'nofile', Soft: 1024, Hard: 2048 }],
+          Tmpfs: { '/tmp': 'size=64m,rw' },
+        },
+      });
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+      };
+
+      const sandbox = new DockerSandbox({
+        id: 'existing-sandbox',
+        memory: 512 * 1024 * 1024,
+        readonlyRootfs: true,
+        capDrop: ['ALL', 'NET_RAW'],
+        ulimits: [{ name: 'nofile', soft: 1024, hard: 2048 }],
+        tmpfs: { '/tmp': 'rw,size=64m' },
+      });
+      (sandbox as any).__setLogger(logger);
+      await sandbox._start();
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('should warn when requested ulimits differ on reconnect', async () => {
+      mockDocker.listContainers.mockResolvedValue([{ Id: 'existing-container-id', State: 'running' }]);
+      mockContainer.inspect.mockResolvedValue({
+        Id: 'existing-container-id',
+        State: { Status: 'running', Running: true },
+        HostConfig: {
+          Ulimits: [{ Name: 'nofile', Soft: 1024, Hard: 2048 }],
+        },
+      });
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+      };
+
+      const sandbox = new DockerSandbox({
+        id: 'existing-sandbox',
+        ulimits: [{ name: 'nproc', soft: 1024, hard: 2048 }],
+      });
+      (sandbox as any).__setLogger(logger);
+      await sandbox._start();
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('requested Docker option(s) ulimits differ'), {
+        containerId: 'existing-container-id',
+        fields: ['ulimits'],
+        hostConfigFields: ['Ulimits'],
+      });
+    });
+
+    it('should not warn when empty hardening collections reconnect to unset HostConfig fields', async () => {
+      mockDocker.listContainers.mockResolvedValue([{ Id: 'existing-container-id', State: 'running' }]);
+      mockContainer.inspect.mockResolvedValue({
+        Id: 'existing-container-id',
+        State: { Status: 'running', Running: true },
+        HostConfig: {},
+      });
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+      };
+
+      const sandbox = new DockerSandbox({
+        id: 'existing-sandbox',
+        capDrop: [],
+        capAdd: [],
+        securityOpt: [],
+        ulimits: [],
+        tmpfs: {},
+      });
+      (sandbox as any).__setLogger(logger);
+      await sandbox._start();
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('should not warn when Docker normalizes no-new-privileges separator on reconnect', async () => {
+      mockDocker.listContainers.mockResolvedValue([{ Id: 'existing-container-id', State: 'running' }]);
+      mockContainer.inspect.mockResolvedValue({
+        Id: 'existing-container-id',
+        State: { Status: 'running', Running: true },
+        HostConfig: {
+          SecurityOpt: ['no-new-privileges=true'],
+        },
+      });
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        getTransports: vi.fn(() => new Map()),
+      };
+
+      const sandbox = new DockerSandbox({
+        id: 'existing-sandbox',
+        securityOpt: ['no-new-privileges:true'],
+      });
+      (sandbox as any).__setLogger(logger);
+      await sandbox._start();
+
+      expect(logger.warn).not.toHaveBeenCalled();
     });
 
     it('should start a stopped container on reconnect', async () => {
@@ -645,6 +1001,10 @@ describe('DockerSandbox', () => {
 // =============================================================================
 
 describe('dockerSandboxProvider', () => {
+  beforeEach(() => {
+    resetMockDefaults();
+  });
+
   it('should have correct metadata', async () => {
     const { dockerSandboxProvider } = await import('../provider');
     expect(dockerSandboxProvider.id).toBe('docker');
@@ -660,11 +1020,40 @@ describe('dockerSandboxProvider', () => {
     expect(sandbox).toBeInstanceOf(DockerSandbox);
   });
 
+  it('should create a DockerSandbox instance with hardening config', async () => {
+    const { dockerSandboxProvider } = await import('../provider');
+    const sandbox = dockerSandboxProvider.createSandbox({
+      image: 'node:22-slim',
+      memory: 512 * 1024 * 1024,
+      pidsLimit: 256,
+      readonlyRootfs: true,
+      capDrop: ['ALL'],
+      securityOpt: ['no-new-privileges:true'],
+      tmpfs: { '/tmp': 'rw,noexec,nosuid,size=64m' },
+    });
+    await sandbox._start();
+
+    const createCall = mockDocker.createContainer.mock.calls[0]?.[0];
+    expect(createCall.HostConfig).toEqual(
+      expect.objectContaining({
+        Memory: 512 * 1024 * 1024,
+        PidsLimit: 256,
+        ReadonlyRootfs: true,
+        CapDrop: ['ALL'],
+        SecurityOpt: ['no-new-privileges:true'],
+        Tmpfs: { '/tmp': 'rw,noexec,nosuid,size=64m' },
+      }),
+    );
+  });
+
   it('should have config schema', async () => {
     const { dockerSandboxProvider } = await import('../provider');
     expect(dockerSandboxProvider.configSchema).toBeDefined();
     expect((dockerSandboxProvider.configSchema as any)?.properties?.image).toBeDefined();
     expect((dockerSandboxProvider.configSchema as any)?.properties?.timeout).toBeDefined();
+    expect((dockerSandboxProvider.configSchema as any)?.properties?.memory).toBeDefined();
+    expect((dockerSandboxProvider.configSchema as any)?.properties?.pidsLimit).toBeDefined();
+    expect((dockerSandboxProvider.configSchema as any)?.properties?.capDrop).toBeDefined();
   });
 });
 

--- a/workspaces/docker/src/sandbox/index.test.ts
+++ b/workspaces/docker/src/sandbox/index.test.ts
@@ -637,7 +637,13 @@ describe('DockerSandbox', () => {
       mockContainer.inspect.mockResolvedValue({
         Id: 'existing-container-id',
         State: { Status: 'running', Running: true },
-        HostConfig: {},
+        HostConfig: {
+          CapDrop: null,
+          CapAdd: null,
+          SecurityOpt: null,
+          Ulimits: null,
+          Tmpfs: null,
+        },
       });
       const logger = {
         debug: vi.fn(),

--- a/workspaces/docker/src/sandbox/index.ts
+++ b/workspaces/docker/src/sandbox/index.ts
@@ -9,6 +9,7 @@
  * @see https://docs.docker.com/engine/api/
  */
 
+import { isDeepStrictEqual } from 'node:util';
 import type { RequestContext } from '@mastra/core/di';
 import type { SandboxInfo, ProviderStatus, MastraSandboxOptions } from '@mastra/core/workspace';
 import { MastraSandbox, SandboxError, SandboxNotReadyError } from '@mastra/core/workspace';
@@ -24,6 +25,14 @@ const LOG_PREFIX = '[DockerSandbox]';
  * TODO: Remove once minimum peer dep includes InstructionsOption export.
  */
 type InstructionsOption = string | ((opts: { defaultInstructions: string; requestContext?: RequestContext }) => string);
+
+type DockerSandboxUlimit = {
+  name: string;
+  soft: number;
+  hard: number;
+};
+
+type DockerSandboxTmpfs = Record<string, string>;
 
 // =============================================================================
 // Docker Sandbox Options
@@ -50,6 +59,30 @@ export interface DockerSandboxOptions extends Omit<MastraSandboxOptions, 'proces
    * @default false
    */
   privileged?: boolean;
+  /** Memory limit in bytes (HostConfig.Memory). Docker treats 0 as unlimited. */
+  memory?: number;
+  /** Total memory plus swap in bytes (HostConfig.MemorySwap). */
+  memorySwap?: number;
+  /** CPU shares relative weight (HostConfig.CpuShares). */
+  cpuShares?: number;
+  /** CPU quota in microseconds per period (HostConfig.CpuQuota). */
+  cpuQuota?: number;
+  /** CPU period in microseconds (HostConfig.CpuPeriod). */
+  cpuPeriod?: number;
+  /** Maximum number of PIDs in the container (HostConfig.PidsLimit). */
+  pidsLimit?: number;
+  /** Mount the container root filesystem as read-only (HostConfig.ReadonlyRootfs). */
+  readonlyRootfs?: boolean;
+  /** Linux capabilities to drop (HostConfig.CapDrop), e.g. ['ALL']. */
+  capDrop?: string[];
+  /** Linux capabilities to add (HostConfig.CapAdd). */
+  capAdd?: string[];
+  /** Security options (HostConfig.SecurityOpt), e.g. ['no-new-privileges:true']. */
+  securityOpt?: string[];
+  /** Ulimit entries for Docker HostConfig.Ulimits. */
+  ulimits?: DockerSandboxUlimit[];
+  /** tmpfs mount paths with options (HostConfig.Tmpfs). */
+  tmpfs?: DockerSandboxTmpfs;
   /** Default command timeout in milliseconds
    * @default 300_000 // 5 minutes
    */
@@ -130,6 +163,19 @@ export class DockerSandbox extends MastraSandbox {
   private readonly _volumes: Record<string, string>;
   private readonly _network?: string;
   private readonly _privileged: boolean;
+  private readonly _privilegedWasSet: boolean;
+  private readonly _memory?: number;
+  private readonly _memorySwap?: number;
+  private readonly _cpuShares?: number;
+  private readonly _cpuQuota?: number;
+  private readonly _cpuPeriod?: number;
+  private readonly _pidsLimit?: number;
+  private readonly _readonlyRootfs?: boolean;
+  private readonly _capDrop?: string[];
+  private readonly _capAdd?: string[];
+  private readonly _securityOpt?: string[];
+  private readonly _ulimits?: DockerSandboxUlimit[];
+  private readonly _tmpfs?: DockerSandboxTmpfs;
   private readonly _workingDir: string;
   private readonly _labels: Record<string, string>;
   private readonly _instructionsOverride?: InstructionsOption;
@@ -153,6 +199,19 @@ export class DockerSandbox extends MastraSandbox {
     this._volumes = options.volumes ?? {};
     this._network = options.network;
     this._privileged = options.privileged ?? false;
+    this._privilegedWasSet = options.privileged !== undefined;
+    this._memory = options.memory;
+    this._memorySwap = options.memorySwap;
+    this._cpuShares = options.cpuShares;
+    this._cpuQuota = options.cpuQuota;
+    this._cpuPeriod = options.cpuPeriod;
+    this._pidsLimit = options.pidsLimit;
+    this._readonlyRootfs = options.readonlyRootfs;
+    this._capDrop = options.capDrop;
+    this._capAdd = options.capAdd;
+    this._securityOpt = options.securityOpt;
+    this._ulimits = options.ulimits;
+    this._tmpfs = options.tmpfs;
     this._workingDir = options.workingDir ?? '/workspace';
     this._labels = {
       ...options.labels,
@@ -190,6 +249,9 @@ export class DockerSandbox extends MastraSandbox {
       // Use inspect() to get authoritative container state — listContainers() state
       // can be stale immediately after stop() returns but before container fully exits
       const info = await this._container.inspect();
+      // On reconnect, actual HostConfig controls whether hardening is effective.
+      this._warnOnPrivilegedHardeningConflict(info.HostConfig?.Privileged ?? this._privileged);
+      this._warnOnReconnectedHostConfigMismatch(existing.Id, info.HostConfig);
       const actualState = info.State?.Running ? 'running' : 'stopped';
 
       if (actualState !== 'running') {
@@ -203,6 +265,8 @@ export class DockerSandbox extends MastraSandbox {
       this.logger.debug(`${LOG_PREFIX} Reconnected to container ${existing.Id}`);
       return;
     }
+
+    this._warnOnPrivilegedHardeningConflict(this._privileged);
 
     // Pull image if not available locally
     await this._ensureImage();
@@ -225,6 +289,18 @@ export class DockerSandbox extends MastraSandbox {
         Binds: binds.length > 0 ? binds : undefined,
         NetworkMode: this._network,
         Privileged: this._privileged,
+        Memory: this._memory,
+        MemorySwap: this._memorySwap,
+        CpuShares: this._cpuShares,
+        CpuQuota: this._cpuQuota,
+        CpuPeriod: this._cpuPeriod,
+        PidsLimit: this._pidsLimit,
+        ReadonlyRootfs: this._readonlyRootfs,
+        CapDrop: this._capDrop,
+        CapAdd: this._capAdd,
+        SecurityOpt: this._securityOpt,
+        Ulimits: this._ulimits?.map(toDockerUlimit),
+        Tmpfs: this._tmpfs,
       },
       // Keep stdin open for interactive use
       OpenStdin: true,
@@ -238,6 +314,90 @@ export class DockerSandbox extends MastraSandbox {
     this.processes.setContainer(this._container);
 
     this.logger.debug(`${LOG_PREFIX} Container started: ${this._container.id}`);
+  }
+
+  private _warnOnPrivilegedHardeningConflict(effectivePrivileged: boolean | undefined): void {
+    if (!effectivePrivileged) return;
+
+    // Privileged mode makes capability and security-option controls ineffective.
+    // ReadonlyRootfs, ulimits, tmpfs, memory, CPU, and PID limits still apply.
+    const conflictedHostConfigFields = [
+      this._capDrop && this._capDrop.length > 0 ? 'CapDrop' : undefined,
+      this._capAdd && this._capAdd.length > 0 ? 'CapAdd' : undefined,
+      this._securityOpt && this._securityOpt.length > 0 ? 'SecurityOpt' : undefined,
+    ].filter((field): field is keyof Docker.HostConfig => field !== undefined);
+
+    if (conflictedHostConfigFields.length === 0) return;
+
+    const optionNames = conflictedHostConfigFields.map(toDockerSandboxOptionName);
+
+    this.logger.warn(
+      `${LOG_PREFIX} Privileged containers can bypass some requested hardening controls: ${optionNames.join(', ')}`,
+      { fields: optionNames, hostConfigFields: conflictedHostConfigFields },
+    );
+  }
+
+  private _warnOnReconnectedHostConfigMismatch(containerId: string, hostConfig?: Docker.HostConfig): void {
+    if (!hostConfig) return;
+
+    const mismatchedHostConfigFields = this._requestedHardeningHostConfigEntries(hostConfig)
+      .filter(([field, requestedValue]) => !isHostConfigValueEqual(field, hostConfig[field], requestedValue))
+      .map(([field]) => field);
+
+    if (mismatchedHostConfigFields.length === 0) return;
+
+    if (
+      !this._privilegedWasSet &&
+      hostConfig.Privileged === true &&
+      mismatchedHostConfigFields.includes('Privileged')
+    ) {
+      this.logger.warn(
+        `${LOG_PREFIX} Reconnected to existing container ${containerId}; the existing container is privileged, but this DockerSandbox did not request privileged mode. Destroy and recreate the sandbox to apply the default non-privileged mode.`,
+        { containerId, fields: ['privileged'], hostConfigFields: ['Privileged'] },
+      );
+    }
+
+    const remainingMismatchedHostConfigFields = mismatchedHostConfigFields.filter(
+      field => field !== 'Privileged' || this._privilegedWasSet,
+    );
+
+    if (remainingMismatchedHostConfigFields.length === 0) return;
+
+    const mismatchedOptions = remainingMismatchedHostConfigFields.map(toDockerSandboxOptionName);
+
+    this.logger.warn(
+      `${LOG_PREFIX} Reconnected to existing container ${containerId}; requested Docker option(s) ${mismatchedOptions.join(
+        ', ',
+      )} differ from inspected HostConfig field(s) ${remainingMismatchedHostConfigFields.join(
+        ', ',
+      )} and cannot be applied to the existing container. Destroy and recreate the sandbox to apply them.`,
+      { containerId, fields: mismatchedOptions, hostConfigFields: remainingMismatchedHostConfigFields },
+    );
+  }
+
+  private _requestedHardeningHostConfigEntries(
+    hostConfig?: Docker.HostConfig,
+  ): Array<[keyof Docker.HostConfig, unknown]> {
+    const entries: Array<[keyof Docker.HostConfig, unknown]> = [
+      ['Memory', this._memory],
+      ['MemorySwap', this._memorySwap],
+      ['CpuShares', this._cpuShares],
+      ['CpuQuota', this._cpuQuota],
+      ['CpuPeriod', this._cpuPeriod],
+      ['PidsLimit', this._pidsLimit],
+      ['ReadonlyRootfs', this._readonlyRootfs],
+      ['CapDrop', this._capDrop],
+      ['CapAdd', this._capAdd],
+      ['SecurityOpt', this._securityOpt],
+      ['Ulimits', this._ulimits],
+      ['Tmpfs', this._tmpfs],
+    ];
+
+    if (this._privilegedWasSet || hostConfig?.Privileged === true) {
+      entries.unshift(['Privileged', this._privileged]);
+    }
+
+    return entries.filter((entry): entry is [keyof Docker.HostConfig, unknown] => entry[1] != null);
   }
 
   async stop(): Promise<void> {
@@ -429,4 +589,112 @@ function isImageNotFoundError(error: unknown): boolean {
     return error.message.toLowerCase().includes('no such image');
   }
   return false;
+}
+
+function isHostConfigValueEqual(field: keyof Docker.HostConfig, actual: unknown, expected: unknown): boolean {
+  // Structural equality for the Docker HostConfig shapes exposed by DockerSandboxOptions.
+  return isDeepStrictEqual(normalizeHostConfigValue(field, actual), normalizeHostConfigValue(field, expected));
+}
+
+function normalizeHostConfigValue(field: keyof Docker.HostConfig, value: unknown): unknown {
+  if ((field === 'CapAdd' || field === 'CapDrop') && Array.isArray(value)) {
+    if (value.length === 0) return undefined;
+    return value.map(normalizeCapability).sort();
+  }
+
+  if (field === 'SecurityOpt' && Array.isArray(value)) {
+    if (value.length === 0) return undefined;
+    return value.map(normalizeSecurityOpt).sort();
+  }
+
+  if (field === 'Tmpfs' && value && typeof value === 'object' && !Array.isArray(value)) {
+    if (Object.keys(value).length === 0) return undefined;
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([path, options]) => [path, typeof options === 'string' ? normalizeTmpfsOptions(options) : options]),
+    );
+  }
+
+  if (Array.isArray(value)) {
+    if (field === 'Ulimits' && value.length === 0) return undefined;
+    return value
+      .map(nestedValue => normalizeHostConfigValue(field, nestedValue))
+      .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  }
+
+  if (field === 'Ulimits' && value && typeof value === 'object') {
+    return normalizeUlimit(value);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, nestedValue]) => [key, normalizeHostConfigValue(field, nestedValue)]),
+    );
+  }
+
+  return value;
+}
+
+function normalizeCapability(capability: unknown): unknown {
+  return typeof capability === 'string' ? capability.toUpperCase().replace(/^CAP_/, '') : capability;
+}
+
+function normalizeTmpfsOptions(options: string): string {
+  return options
+    .split(',')
+    .map(option => option.trim())
+    .filter(Boolean)
+    .sort()
+    .join(',');
+}
+
+function normalizeSecurityOpt(option: unknown): unknown {
+  if (typeof option !== 'string') return option;
+
+  const noNewPrivileges = option.match(/^no-new-privileges[:=](.+)$/i);
+  if (noNewPrivileges) {
+    return `no-new-privileges=${noNewPrivileges[1]}`;
+  }
+
+  return option;
+}
+
+function normalizeUlimit(value: object): unknown {
+  const record = value as Record<string, unknown>;
+  return {
+    name: record.name ?? record.Name,
+    soft: record.soft ?? record.Soft,
+    hard: record.hard ?? record.Hard,
+  };
+}
+
+function toDockerUlimit(ulimit: DockerSandboxUlimit): Docker.Ulimit {
+  return {
+    Name: ulimit.name,
+    Soft: ulimit.soft,
+    Hard: ulimit.hard,
+  };
+}
+
+function toDockerSandboxOptionName(field: keyof Docker.HostConfig): string {
+  const optionNames: Partial<Record<keyof Docker.HostConfig, string>> = {
+    Privileged: 'privileged',
+    Memory: 'memory',
+    MemorySwap: 'memorySwap',
+    CpuShares: 'cpuShares',
+    CpuQuota: 'cpuQuota',
+    CpuPeriod: 'cpuPeriod',
+    PidsLimit: 'pidsLimit',
+    ReadonlyRootfs: 'readonlyRootfs',
+    CapDrop: 'capDrop',
+    CapAdd: 'capAdd',
+    SecurityOpt: 'securityOpt',
+    Ulimits: 'ulimits',
+    Tmpfs: 'tmpfs',
+  };
+
+  return optionNames[field] ?? String(field);
 }

--- a/workspaces/docker/src/sandbox/index.ts
+++ b/workspaces/docker/src/sandbox/index.ts
@@ -397,7 +397,7 @@ export class DockerSandbox extends MastraSandbox {
       entries.unshift(['Privileged', this._privileged]);
     }
 
-    return entries.filter((entry): entry is [keyof Docker.HostConfig, unknown] => entry[1] != null);
+    return entries.filter((entry): entry is [keyof Docker.HostConfig, unknown] => isPresentHostConfigValue(entry[1]));
   }
 
   async stop(): Promise<void> {
@@ -597,6 +597,8 @@ function isHostConfigValueEqual(field: keyof Docker.HostConfig, actual: unknown,
 }
 
 function normalizeHostConfigValue(field: keyof Docker.HostConfig, value: unknown): unknown {
+  if (value == null) return undefined;
+
   if ((field === 'CapAdd' || field === 'CapDrop') && Array.isArray(value)) {
     if (value.length === 0) return undefined;
     return value.map(normalizeCapability).sort();
@@ -636,6 +638,13 @@ function normalizeHostConfigValue(field: keyof Docker.HostConfig, value: unknown
   }
 
   return value;
+}
+
+function isPresentHostConfigValue(value: unknown): boolean {
+  if (value == null) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (value && typeof value === 'object') return Object.keys(value).length > 0;
+  return true;
 }
 
 function normalizeCapability(capability: unknown): unknown {


### PR DESCRIPTION
## Description

Adds DockerSandboxOptions for Docker HostConfig hardening and resource controls, including memory, CPU quota/period, PID limits, read-only rootfs, capabilities, securityOpt, ulimits, and tmpfs. The fields are optional, so existing DockerSandbox behavior stays unchanged.

The Docker sandbox provider schema exposes the same fields, and the reference docs include a hardening example with trade-offs. Reconnect now warns when requested hardening options differ from the inspected existing container HostConfig.

## Related issue(s)

Fixes #16572

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Verification

- `corepack pnpm --filter @mastra/docker test:unit`
- `corepack pnpm --filter @mastra/docker test`
- `corepack pnpm --dir workspaces/docker exec tsc --noEmit -p tsconfig.json`
- `corepack pnpm --filter @mastra/docker lint`
- `corepack pnpm --filter @mastra/docker build`
- `corepack pnpm --dir docs exec prettier --check src/content/en/reference/workspace/docker-sandbox.mdx`
- `corepack pnpm --dir docs exec remark --no-stdout --frail --quiet --ext mdx src/content/en/reference/workspace/docker-sandbox.mdx`
- `docs/scripts/vale/bin/vale --minAlertLevel=error --output=line src/content/en/reference/workspace/docker-sandbox.mdx`
- `corepack pnpm exec prettier --check .changeset/cute-clouds-grin.md`
- `git diff --check HEAD~1 HEAD`
- `codex review --uncommitted`
- `claude -p ...`
- `coderabbit review`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets users set Docker resource limits and security hardening options (like memory caps, process limits, read-only rootfs, and dropped capabilities) for Mastra Docker sandboxes through the Mastra API so containers can be constrained and secured without writing raw Docker config.

## Summary

Adds optional Docker HostConfig-based hardening and resource control fields to DockerSandboxOptions and the Docker provider config schema, maps them directly to dockerode/HostConfig, and preserves existing behavior when fields are absent. Reconnect/start flows inspect existing container HostConfig and emit warnings when requested hardening options differ from the inspected container in ways that cannot be applied. Includes docs, tests, and a changeset for @mastra/docker.

### Key Changes

- API & Schema
  - DockerSandboxOptions and DockerProviderConfig gain optional fields: memory, memorySwap, cpuShares, cpuQuota, cpuPeriod, pidsLimit, readonlyRootfs, capDrop, capAdd, securityOpt, ulimits, tmpfs.
  - Provider JSON schema updated to validate these fields (structured ulimits and tmpfs).

- Runtime behavior
  - Provided options are forwarded into docker.createContainer() HostConfig (Memory, MemorySwap, CpuShares/Quota/Period, PidsLimit, ReadonlyRootfs, CapDrop/CapAdd, SecurityOpt, Ulimits, Tmpfs).
  - start()/reconnect inspect container HostConfig and log warnings when requested hardening/resource settings cannot be applied to an existing container (including privileged-mode conflicts).
  - Added normalization and deep-equality helpers for capabilities, security options, ulimits, and tmpfs; treats empty collections/nulls as absent to avoid spurious reconnect warnings.

- Documentation & Tests
  - DockerSandbox reference docs include a new "Hardening" section with examples, trade-offs (readonlyRootfs, capDrop, memorySwap, pidsLimit, privileged, Docker Desktop limits), and mapping to HostConfig.
  - Changeset (.changeset) added for @mastra/docker (minor bump) with a usage snippet.
  - Tests expanded: start/reconnect lifecycle tests cover forwarding HostConfig fields, warnings for privileged/hardening conflicts, reconnect mismatch detection, ulimits/tmpfs behavior, and provider config-schema assertions.

### Scope & Compatibility

- Scoped to @mastra/docker only; no changes to @mastra/core public API.
- Backward compatible: when new fields are not provided, behavior is unchanged.
- Enables common multi-tenant hardening use cases (memory caps, process limits, capability drops, read-only rootfs with tmpfs).

Fixes: #16572

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16577)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->