### PR TITLE
fix(core): share agent signals runtime

### DIFF
--- a/.changeset/shared-signals-runtime.md
+++ b/.changeset/shared-signals-runtime.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent signals so standalone agents coordinate thread streams through a shared runtime.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -357,6 +357,54 @@ describe('Agent signals', () => {
     expect(JSON.stringify(prompts)).not.toContain('discard while running');
   });
 
+  it('supports cross-instance thread subscriptions through the shared runtime without Mastra', async () => {
+    const runner = new Agent({
+      id: 'standalone-shared-agent',
+      name: 'Standalone Shared Runner Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('standalone shared response'),
+    });
+    const observer = new Agent({
+      id: 'standalone-shared-agent',
+      name: 'Standalone Shared Observer Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('standalone observer response'),
+    });
+
+    const subscription = await observer.subscribeToThread({
+      threadId: 'standalone-shared-thread',
+      resourceId: 'standalone-shared-user',
+    });
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+    const firstRunPromise = readNextRun(iterator);
+
+    const stream = await runner.stream('Hello', {
+      memory: { thread: 'standalone-shared-thread', resource: 'standalone-shared-user' },
+    });
+
+    const subscribedRun = await firstRunPromise;
+    expect(subscribedRun.value.runId).toBe(stream.runId);
+    expect(subscribedRun.value.text).toBe('standalone shared response');
+
+    const secondRunPromise = readNextRun(iterator);
+    const signalResult = await runner.sendSignal(
+      { type: 'user-message', contents: 'Hello from standalone shared signal' },
+      {
+        resourceId: 'standalone-shared-user',
+        threadId: 'standalone-shared-thread',
+        ifIdle: {
+          streamOptions: { memory: { resource: 'standalone-shared-user', thread: 'standalone-shared-thread' } },
+        },
+      },
+    );
+    const signalRun = await secondRunPromise;
+    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: signalRun.value.runId }));
+    expect(signalResult.signal.id).toBeDefined();
+    expect(signalRun.value.text).toBe('standalone shared response');
+
+    subscription.unsubscribe();
+  });
+
   it('supports cross-instance thread subscriptions through the Mastra runtime', async () => {
     const runner = new Agent({
       id: 'shared-agent',

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -1,5 +1,5 @@
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
@@ -11,7 +11,7 @@ import {
   signalToDataPartFormat,
   signalToMastraDBMessage,
 } from '../signals';
-import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+import { AgentThreadStreamRuntime, agentThreadStreamRuntime } from '../thread-stream-runtime';
 
 function createTextStreamModel(responseText: string) {
   return new MockLanguageModelV2({
@@ -81,6 +81,10 @@ async function waitForCondition(predicate: () => boolean, timeoutMs = 500) {
 }
 
 describe('Agent signals', () => {
+  beforeEach(() => {
+    agentThreadStreamRuntime.resetForTests();
+  });
+
   it('converts signals between DB, LLM, and data part formats', () => {
     const signal = createSignal({
       id: 'signal-1',

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -102,7 +102,7 @@ import { SaveQueueManager } from './save-queue';
 import { isCreatedAgentSignal } from './signals';
 import { runStreamUntilIdle, runResumeStreamUntilIdle } from './stream-until-idle';
 import type { SubAgent } from './subagent';
-import { AgentThreadStreamRuntime } from './thread-stream-runtime';
+import { agentThreadStreamRuntime } from './thread-stream-runtime';
 import { TripWire } from './trip-wire';
 import type {
   AgentConfig,
@@ -285,14 +285,6 @@ export class Agent<
    * close if they're still the active one.
    */
   #activeStreamUntilIdle = new Map<string, () => void>();
-  /**
-   * Local fallback for standalone Agents that are not registered on a Mastra
-   * instance. Agents registered on the same Mastra instance coordinate through
-   * `mastra.agentThreadStreamRuntime` instead, so cross-agent thread locks and
-   * subscriptions are scoped to that Mastra runtime rather than process-global
-   * Agent state.
-   */
-  #threadStreamRuntime = new AgentThreadStreamRuntime();
   readonly #options?: AgentCreateOptions;
   #legacyHandler?: AgentLegacyHandler;
   #config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext>;
@@ -5967,7 +5959,7 @@ export class Agent<
   }
 
   #getThreadStreamRuntime() {
-    return this.#mastra?.agentThreadStreamRuntime ?? this.#threadStreamRuntime;
+    return agentThreadStreamRuntime;
   }
 
   /**

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -502,3 +502,5 @@ export class AgentThreadStreamRuntime {
     return { accepted: true, runId, signal };
   }
 }
+
+export const agentThreadStreamRuntime = new AgentThreadStreamRuntime();

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -121,6 +121,23 @@ export class AgentThreadStreamRuntime {
     return this.abortRun(activeRunId);
   }
 
+  /** @internal */
+  resetForTests() {
+    this.#preparedRunsById.forEach(preparedRun => {
+      preparedRun.abortController.abort();
+      preparedRun.cleanup();
+    });
+    this.#threadRunsById.clear();
+    this.#threadKeysByRunId.clear();
+    this.#activeThreadRunIds.clear();
+    this.#threadRunSubscribers.clear();
+    this.#pendingSignalsByThread.clear();
+    this.#pendingIdleSignalsByThread.clear();
+    this.#watchedThreadRunIds.clear();
+    this.#preparedRunsById.clear();
+    this.#abortedRunIds.clear();
+  }
+
   #cleanupPreparedRun(runId: string) {
     this.#preparedRunsById.get(runId)?.cleanup();
     this.#preparedRunsById.delete(runId);

--- a/packages/core/src/harness/tracing-propagation.test.ts
+++ b/packages/core/src/harness/tracing-propagation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Agent } from '../agent';
+import { agentThreadStreamRuntime } from '../agent/thread-stream-runtime';
 import type { TracingContext, TracingOptions } from '../observability';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
@@ -39,6 +40,7 @@ describe('Harness tracing propagation', () => {
   let streamSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    agentThreadStreamRuntime.resetForTests();
     agent = createAgent();
     harness = new Harness({
       id: 'test-harness',

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { Agent } from '../agent';
-import { AgentThreadStreamRuntime } from '../agent/thread-stream-runtime';
+import { agentThreadStreamRuntime } from '../agent/thread-stream-runtime';
 import type { DurableAgentLike } from '../agent/types';
 import { isDurableAgentLike } from '../agent/types';
 import { BackgroundTaskManager } from '../background-tasks';
@@ -555,7 +555,6 @@ export class Mastra<
   #bundler?: BundlerConfig;
   #idGenerator?: MastraIdGenerator;
   #pubsub: PubSub;
-  #agentThreadStreamRuntime = new AgentThreadStreamRuntime();
   #backgroundTaskConfig?: BackgroundTaskManagerConfig;
   #backgroundTaskManager?: BackgroundTaskManager;
   #schedulerConfig?: WorkflowSchedulerConfig;
@@ -612,7 +611,7 @@ export class Mastra<
   }
 
   get agentThreadStreamRuntime() {
-    return this.#agentThreadStreamRuntime;
+    return agentThreadStreamRuntime;
   }
 
   get workers(): readonly MastraWorker[] {


### PR DESCRIPTION
This makes the agent signals runtime shared at the module level instead of being scoped to each Agent or Mastra instance. That lets standalone agents coordinate thread subscriptions and signals even when they were not registered on a Mastra instance.

Before, two standalone agent instances could each have their own runtime, so a subscriber on one instance could miss a stream started by another instance with the same thread. Or a signal could start a duplicate stream unintentionally.

After, Agent and Mastra both use the same imported runtime singleton, and there is test coverage for standalone cross-instance subscriptions.

NOTE: this is likely temporary and will be replaced with pubsub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: Agents that used to each run their own "signal engine" now share a single engine so standalone agents can see and react to the same thread streams and signals. This prevents missed or duplicated streams when multiple Agent instances target the same thread.

What changed
- Make the agent thread-stream runtime a module-level singleton:
  - Added export: agentThreadStreamRuntime = new AgentThreadStreamRuntime() (packages/core/src/agent/thread-stream-runtime.ts).
  - Agent now uses the shared runtime import instead of creating a per-agent fallback (packages/core/src/agent/agent.ts).
  - Mastra exposes the same module-level runtime via its getter (packages/core/src/mastra/index.ts).
- Testing / cleanup:
  - Added AgentThreadStreamRuntime.resetForTests() to abort prepared runs and clear internal state for test isolation (packages/core/src/agent/thread-stream-runtime.ts).
  - Tests updated to call resetForTests() in beforeEach and a new integration test verifies cross-instance thread subscriptions between standalone Agent instances (packages/core/src/agent/__tests__/agent-signals.test.ts, packages/core/src/harness/tracing-propagation.test.ts).
- Changeset:
  - .changeset/shared-signals-runtime.md documents a patch fixing agent signals to coordinate through the shared runtime.

Why
- Previously standalone Agent instances could each instantiate their own runtime, causing subscribers on one instance to miss streams started by another or causing duplicate streams. Sharing a single runtime ensures standalone agents coordinate thread subscriptions and signals correctly.

Notes
- The PR adds test coverage for cross-instance subscriptions and marks this shared-runtime approach as likely temporary (may be replaced by a pub/sub implementation later).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16581)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->