### PR TITLE
fix(create-mastra): flush telemetry events

### DIFF
--- a/.changeset/create-mastra-telemetry.md
+++ b/.changeset/create-mastra-telemetry.md
@@ -1,0 +1,5 @@
+---
+'create-mastra': patch
+---
+
+Improve `npm create mastra` telemetry delivery so command completion events are tracked and flushed before the process exits.

--- a/packages/create-mastra/src/index.ts
+++ b/packages/create-mastra/src/index.ts
@@ -1,7 +1,7 @@
 #! /usr/bin/env node
 import { Command } from 'commander';
 
-import { PosthogAnalytics } from 'mastra/dist/analytics/index.js';
+import { PosthogAnalytics, setAnalytics } from 'mastra/dist/analytics/index.js';
 import { create } from 'mastra/dist/commands/create/create.js';
 
 import { getPackageVersion, getCreateVersionTag } from './utils.js';
@@ -14,6 +14,7 @@ const analytics = new PosthogAnalytics({
   host: 'https://us.posthog.com',
   version: version!,
 });
+setAnalytics(analytics);
 
 const program = new Command();
 
@@ -54,42 +55,63 @@ program
   )
   .option('--observe', 'Enable Mastra Observe (writes MASTRA_CLOUD_ACCESS_TOKEN placeholder to .env)')
   .option('--no-observe', 'Do not enable Mastra Observe')
-  .action(async (projectNameArg, args) => {
-    // TODO(major): Remove args.projectName in favor of projectNameArg
-    const projectName = projectNameArg || args.projectName;
-    const timeout = args?.timeout ? (args?.timeout === true ? 60000 : parseInt(args?.timeout, 10)) : undefined;
-
-    if (args.default) {
-      await create({
-        components: ['agents', 'tools', 'workflows', 'scorers'],
-        llmProvider: 'openai',
-        addExample: true,
-        createVersionTag,
-        timeout,
-        projectName,
-        mcpServer: args.mcp,
-        directory: 'src/',
+  .action(async (projectNameArg, args) =>
+    analytics.trackCommandExecution({
+      command: 'create',
+      args: {
+        projectName: projectNameArg || args.projectName,
+        components: args.components,
+        llmProvider: args.llm,
+        addExample: args.example,
+        default: args.default,
         template: args.template,
-        analytics,
-        observe: args.observe,
-      });
-      return;
-    }
+        observability: args.observe,
+      },
+      execution: async () => {
+        // TODO(major): Remove args.projectName in favor of projectNameArg
+        const projectName = projectNameArg || args.projectName;
+        const timeout = args?.timeout ? (args?.timeout === true ? 60000 : parseInt(args?.timeout, 10)) : undefined;
 
-    await create({
-      components: args.components ? args.components.split(',') : [],
-      llmProvider: args.llm,
-      addExample: args.example,
-      llmApiKey: args.llmApiKey,
-      createVersionTag,
-      timeout,
-      projectName,
-      directory: args.dir,
-      mcpServer: args.mcp,
-      template: args.template,
-      analytics,
-      observe: args.observe,
-    });
-  });
+        if (args.default) {
+          await create({
+            components: ['agents', 'tools', 'workflows', 'scorers'],
+            llmProvider: 'openai',
+            addExample: true,
+            createVersionTag,
+            timeout,
+            projectName,
+            mcpServer: args.mcp,
+            directory: 'src/',
+            template: args.template,
+            analytics,
+            observability: args.observe,
+          });
+          return;
+        }
 
-program.parse(process.argv);
+        await create({
+          components: args.components ? args.components.split(',') : [],
+          llmProvider: args.llm,
+          addExample: args.example,
+          llmApiKey: args.llmApiKey,
+          createVersionTag,
+          timeout,
+          projectName,
+          directory: args.dir,
+          mcpServer: args.mcp,
+          template: args.template,
+          analytics,
+          observability: args.observe,
+        });
+      },
+    }),
+  );
+
+try {
+  await program.parseAsync(process.argv);
+} catch (err) {
+  console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+  process.exitCode = 1;
+} finally {
+  await analytics.shutdown(1000);
+}


### PR DESCRIPTION
## Summary

This is the second PR split from the larger CLI telemetry change.

## Scope

- Wire `create-mastra` into the shared analytics singleton with `setAnalytics(analytics)`.
- Track `npm create mastra` command completion through `analytics.trackCommandExecution`.
- Use `program.parseAsync(...)` and await `analytics.shutdown(1000)` so events flush before process exit.
- Add a `create-mastra` patch changeset.

## Intentionally excluded

- Observability selection event tracking for `mastra create` / `mastra init` remains in PR #16524.

## Verification

- `pnpm --filter ./packages/create-mastra build`
- `pnpm typecheck` from `packages/cli`
- `MASTRA_TELEMETRY_DISABLED=1 node packages/create-mastra/dist/index.js --version`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the `create-mastra` tool properly track when someone creates a new project using it and ensures that tracking information is sent before the program closes — similar to making sure you say goodbye before hanging up a phone call instead of just cutting it off mid-word.

## Changes

### Changeset Entry
Adds `.changeset/create-mastra-telemetry.md` documenting a patch release improvement for `npm create mastra` telemetry delivery, ensuring command completion events are tracked and flushed before process exit.

### CLI Entrypoint Updates (`packages/create-mastra/src/index.ts`)
- **Analytics Integration**: Initializes Mastra analytics via `setAnalytics(analytics)` to register the analytics instance globally
- **Command Tracking**: Wraps the `create` action with `analytics.trackCommandExecution()`, passing structured args including the `observability` configuration
- **Async Command Parsing**: Converts command parsing from synchronous `program.parse()` to asynchronous `program.parseAsync()` with explicit error handling (sets `process.exitCode = 1` on failure)
- **Graceful Shutdown**: Adds a `finally` block that calls `analytics.shutdown(1000)` to flush all telemetry events before process exit
- **Parameter Naming**: Updates the `create` call to pass `observability: args.observe` instead of the prior `observe: args.observe`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16582)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->