### PR TITLE
fix(memory): default OM recall scope to thread instead of resource

### DIFF
--- a/.changeset/tame-walls-sniff.md
+++ b/.changeset/tame-walls-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Changed the default recall scope for Observational Memory from resource to thread. This prevents unintended data leakage between users when no explicit scope is configured.

--- a/.changeset/tame-walls-sniff.md
+++ b/.changeset/tame-walls-sniff.md
@@ -3,3 +3,20 @@
 ---
 
 Changed the default recall scope for Observational Memory from resource to thread. This prevents unintended data leakage between users when no explicit scope is configured.
+
+**Before:** omitting `scope` defaulted to resource-scoped recall, exposing all threads under the same resource.
+
+```ts
+// previously leaked history across users
+new Memory({ options: { observationalMemory: { retrieval: true } } });
+```
+
+**After:** omitting `scope` now defaults to thread-scoped recall. To preserve the previous behaviour, set `scope` explicitly.
+
+```ts
+// new default — safe, thread-isolated
+new Memory({ options: { observationalMemory: { retrieval: true } } });
+
+// opt in to resource scope explicitly if needed
+new Memory({ options: { observationalMemory: { retrieval: { scope: 'resource' } } } });
+```

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -2070,8 +2070,7 @@ Notes:
 
     const omConfig = normalizeObservationalMemoryConfig(mergedConfig.observationalMemory);
     if (omConfig?.retrieval) {
-      const retrievalScope =
-        typeof omConfig.retrieval === 'object' ? (omConfig.retrieval.scope ?? 'resource') : 'resource';
+      const retrievalScope = typeof omConfig.retrieval === 'object' ? (omConfig.retrieval.scope ?? 'thread') : 'thread';
       tools.recall = recallTool(mergedConfig, { retrievalScope });
     }
 


### PR DESCRIPTION
## Summary

  Fixes #15426

  When `observationalMemory.retrieval` is set without an explicit `scope`, the `recall`
  tool was defaulting to `resource` scope, which causes conversation history from one
  user's threads to be accessible from another user's thread under the same resource. This
  is a data leakage risk in multi-user setups.

  The safe default should be `thread` scope — users who need cross-thread recall can opt in
   explicitly with `retrieval: { scope: 'resource' }`.

  ## What changed

  `packages/memory/src/index.ts` — one line change: both fallback values in the
  `retrievalScope` computation changed from `'resource'` to `'thread'`.

  ## Behavior

  **Before:**
  ```ts
  new Memory({ options: { observationalMemory: { retrieval: true } } })
  // recall tool → resource scope (leaks across users)

  After:
  new Memory({ options: { observationalMemory: { retrieval: true } } })
  // recall tool → thread scope (safe default)

  // Explicit resource scope still works:
  new Memory({ options: { observationalMemory: { retrieval: { scope: 'resource' } } } })
  // recall tool → resource scope

  Test plan

  - All 1071 existing unit tests pass with no regressions
  - retrieval: true now produces thread-scoped recall tool
  - retrieval: { vector: false } (object without scope) now produces thread-scoped recall
  tool
  - retrieval: { scope: 'resource' } still produces resource-scoped recall tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When memory recall was turned on without extra settings, it used to share notes across everyone using the same resource; this change makes those notes private to each user's conversation thread by default, unless you explicitly opt into sharing.

## Summary

This PR changes the default recall scope for Observational Memory (OM) from `resource` to `thread` when `retrieval` is enabled but no explicit `scope` is provided. This prevents unintended leakage of conversation history across different users sharing the same resource while preserving explicit `resource`-scoped behavior when requested.

### Changes Made

- packages/memory/src/index.ts
  - Defaulted the `retrievalScope` used to configure the `recallTool` to `'thread'` in both fallback cases where `omConfig.retrieval` is an object without `scope`, or where `retrieval` is the boolean `true`. (One-line change: previously defaulted to `'resource'`.)

- .changeset/tame-walls-sniff.md
  - Added a patch changeset documenting the behavioral change and how to opt into resource-scoped recall via `retrieval: { scope: 'resource' }`.

### Impact

- Before: `new Memory({ options: { observationalMemory: { retrieval: true } } })` produced resource-scoped recall (could expose other threads under the same resource).
- After: same configuration now produces thread-scoped recall (isolates per-thread conversation history).
- Explicit `retrieval: { scope: 'resource' }` remains supported.
- All existing unit tests passed per the PR description.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16583)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->