### PR TITLE
feat(playground-ui): add List mode filter, default to traces mode

### DIFF
--- a/.changeset/puny-sites-wave.md
+++ b/.changeset/puny-sites-wave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added a List mode filter to the Observability traces page for switching between Traces and Branches mode, and changed the default to Traces mode. Previously, the page opened in Branches mode; now it opens in Traces mode, and users can switch modes via the new "List mode" property in the Add filter menu.

--- a/.changeset/puny-sites-wave.md
+++ b/.changeset/puny-sites-wave.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': minor
 ---
 
-Added a List mode filter to the Observability traces page for switching between Traces and Branches mode, and changed the default to Traces mode. Previously, the page opened in Branches mode; now it opens in Traces mode, and users can switch modes via the new "List mode" property in the Add filter menu.
+Added a List mode filter to the Observability traces page for switching between Traces and Branches mode, and changed the default to Traces mode. Previously, the page opened in Branches mode; now it opens in Traces mode, and users can switch modes via the new "List mode" property in the Add filter menu. For example: open Observability → Traces (now defaults to Traces) → Add filter → List mode → pick Branches or Traces.

--- a/packages/playground-ui/src/domains/traces/hooks/use-trace-url-state.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-trace-url-state.tsx
@@ -173,7 +173,7 @@ export function useTraceUrlState(
 
   const listMode = useMemo<TraceListMode>(() => {
     const value = searchParams.get(TRACE_LIST_MODE_PARAM);
-    return value && TRACE_LIST_MODE_VALUES.has(value as TraceListMode) ? (value as TraceListMode) : 'branches';
+    return value && TRACE_LIST_MODE_VALUES.has(value as TraceListMode) ? (value as TraceListMode) : 'traces';
   }, [searchParams]);
   const selectedEntityOption = useMemo(
     () => ROOT_ENTITY_TYPE_OPTIONS.find(option => option.entityType === searchParams.get(TRACE_ROOT_ENTITY_TYPE_PARAM)),
@@ -365,7 +365,7 @@ export function useTraceUrlState(
       setSearchParams(
         prev => {
           const next = new URLSearchParams(prev);
-          if (mode === 'branches') {
+          if (mode === 'traces') {
             next.delete(TRACE_LIST_MODE_PARAM);
           } else {
             next.set(TRACE_LIST_MODE_PARAM, mode);

--- a/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
@@ -11,7 +11,7 @@ const fetchTracesFn = async ({
   page,
   perPage,
   filters,
-  listMode = 'branches',
+  listMode = 'traces',
 }: TracesFilters & {
   client: ReturnType<typeof useMastraClient>;
   page: number;
@@ -81,7 +81,7 @@ export function selectUniqueTraces(data: { pages: TracesPageResponse[] }) {
   return { spans, threadTitles };
 }
 
-export const useTraces = ({ filters, listMode = 'branches' }: TracesFilters) => {
+export const useTraces = ({ filters, listMode = 'traces' }: TracesFilters) => {
   const client = useMastraClient();
   const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
 

--- a/packages/playground-ui/src/domains/traces/trace-filters.ts
+++ b/packages/playground-ui/src/domains/traces/trace-filters.ts
@@ -30,7 +30,7 @@ export const TRACE_STATUS_OPTIONS = [
 /** Field ids for "synthetic" filter entries — they live in dedicated URL params
  *  rather than the generic `filter*` set, but appear as rows in the Filter
  *  popover so users can manage all filters from one place. */
-export const TRACE_SYNTHETIC_FILTER_FIELD_IDS = ['rootEntityType', 'status'] as const;
+export const TRACE_SYNTHETIC_FILTER_FIELD_IDS = ['rootEntityType', 'status', 'mode'] as const;
 
 export const TRACE_ROOT_ENTITY_TYPE_PARAM = 'rootEntityType';
 export const TRACE_STATUS_PARAM = 'status';
@@ -40,6 +40,11 @@ export const TRACE_LIST_MODE_PARAM = 'listMode';
 export const TRACE_ANCHOR_SPAN_ID_PARAM = 'anchorSpanId';
 export const TRACE_LIST_MODE_VALUES = new Set(['traces', 'branches'] as const);
 export type TraceListMode = 'traces' | 'branches';
+
+export const TRACE_LIST_MODE_OPTIONS = [
+  { label: 'Traces (default)', value: 'traces' },
+  { label: 'Branches', value: 'branches' },
+] as const satisfies readonly { label: string; value: TraceListMode }[];
 export const TRACE_DATE_PRESET_PARAM = 'datePreset';
 export const TRACE_DATE_FROM_PARAM = 'dateFrom';
 export const TRACE_DATE_TO_PARAM = 'dateTo';
@@ -135,6 +140,7 @@ export function hasAnyTraceFilterParams(params: URLSearchParams): boolean {
   if (params.has(TRACE_DATE_TO_PARAM)) return true;
   if (params.has(TRACE_ROOT_ENTITY_TYPE_PARAM)) return true;
   if (params.has(TRACE_STATUS_PARAM)) return true;
+  if (params.has(TRACE_LIST_MODE_PARAM)) return true;
   for (const fieldId of TRACE_PROPERTY_FILTER_FIELD_IDS) {
     if (params.has(TRACE_PROPERTY_FILTER_PARAM_BY_FIELD[fieldId])) return true;
   }
@@ -168,6 +174,17 @@ export function createTracePropertyFilterFields({
       options: ROOT_ENTITY_TYPE_OPTIONS.map(o => ({ label: o.label, value: o.entityType })),
       placeholder: 'Choose entity type',
       emptyText: 'No entity types.',
+    },
+    {
+      id: 'mode',
+      label: 'List mode',
+      kind: 'pick-multi',
+      searchable: false,
+      options: TRACE_LIST_MODE_OPTIONS.map(o => ({ label: o.label, value: o.value })),
+      placeholder: 'Choose list mode',
+      emptyText: 'No list modes.',
+      omitAnyOption: true,
+      defaultValue: 'traces',
     },
     {
       id: 'entityName',
@@ -227,9 +244,10 @@ export function createTracePropertyFilterFields({
     { id: 'experimentId', label: 'Experiment ID', kind: 'text' },
   ];
   const byLabel = (a: PropertyFilterField, b: PropertyFilterField) => a.label.localeCompare(b.label);
-  const pickMulti = fields.filter(f => f.kind === 'pick-multi').sort(byLabel);
+  const mode = fields.filter(f => f.id === 'mode');
+  const pickMulti = fields.filter(f => f.kind === 'pick-multi' && f.id !== 'mode').sort(byLabel);
   const text = fields.filter(f => f.kind === 'text').sort(byLabel);
-  return [...pickMulti, ...text];
+  return [...mode, ...pickMulti, ...text];
 }
 
 /**
@@ -246,6 +264,7 @@ export function getTracePropertyFilterTokens(searchParams: URLSearchParams): Pro
   const paramToFieldId = new Map<string, string>([
     [TRACE_ROOT_ENTITY_TYPE_PARAM, 'rootEntityType'],
     [TRACE_STATUS_PARAM, 'status'],
+    [TRACE_LIST_MODE_PARAM, 'mode'],
   ]);
   for (const fieldId of TRACE_PROPERTY_FILTER_FIELD_IDS) {
     paramToFieldId.set(TRACE_PROPERTY_FILTER_PARAM_BY_FIELD[fieldId], fieldId);
@@ -285,6 +304,9 @@ export function getPreservedTraceFilterParams(searchParams: URLSearchParams) {
   const status = searchParams.get(TRACE_STATUS_PARAM);
   if (status) next.set(TRACE_STATUS_PARAM, status);
 
+  const listMode = searchParams.get(TRACE_LIST_MODE_PARAM);
+  if (listMode) next.set(TRACE_LIST_MODE_PARAM, listMode);
+
   for (const fieldId of TRACE_PROPERTY_FILTER_FIELD_IDS) {
     const param = TRACE_PROPERTY_FILTER_PARAM_BY_FIELD[fieldId];
     if (fieldId === 'tags') {
@@ -312,6 +334,7 @@ export function getPreservedTraceFilterParams(searchParams: URLSearchParams) {
 export function applyTracePropertyFilterTokens(params: URLSearchParams, tokens: PropertyFilterToken[]) {
   params.delete(TRACE_ROOT_ENTITY_TYPE_PARAM);
   params.delete(TRACE_STATUS_PARAM);
+  params.delete(TRACE_LIST_MODE_PARAM);
   for (const fieldId of TRACE_PROPERTY_FILTER_FIELD_IDS) {
     params.delete(TRACE_PROPERTY_FILTER_PARAM_BY_FIELD[fieldId]);
   }
@@ -323,6 +346,10 @@ export function applyTracePropertyFilterTokens(params: URLSearchParams, tokens: 
     }
     if (token.fieldId === 'status' && typeof token.value === 'string') {
       params.set(TRACE_STATUS_PARAM, token.value);
+      continue;
+    }
+    if (token.fieldId === 'mode' && typeof token.value === 'string') {
+      params.set(TRACE_LIST_MODE_PARAM, token.value);
       continue;
     }
 
@@ -462,6 +489,7 @@ export function neutralizeFilterTokens(
     if (!field) return token;
     if (field.kind === 'text') return { fieldId: token.fieldId, value: '' };
     if (field.kind === 'pick-multi') {
+      if (field.omitAnyOption) return token;
       return field.multi ? { fieldId: token.fieldId, value: [] } : { fieldId: token.fieldId, value: 'Any' };
     }
     return token;

--- a/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
@@ -29,7 +29,10 @@ export function PickMultiPanel({ field, tokens, onChange }: PickMultiPanelProps)
   }, [field.options, query]);
 
   const token = useMemo(() => tokens.find(t => t.fieldId === field.id), [tokens, field.id]);
-  const selectedValue = typeof token?.value === 'string' ? token.value : undefined;
+  // Fall back to `defaultValue` when no token exists — lets view-toggle fields (e.g. List mode)
+  // show their default option pre-selected before the user explicitly picks one.
+  const selectedValue =
+    typeof token?.value === 'string' ? token.value : !field.multi ? field.defaultValue : undefined;
   const selectedValues = useMemo<string[]>(() => {
     if (Array.isArray(token?.value)) return token!.value as string[];
     if (typeof token?.value === 'string') return [token.value];
@@ -109,13 +112,15 @@ export function PickMultiPanel({ field, tokens, onChange }: PickMultiPanelProps)
               <span className="truncate min-w-0 flex-1">{option.label}</span>
             </label>
           ))}
-          <label
-            title="Any"
-            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
-          >
-            <RadioGroupItem data-pick-multi-item="" value="Any" className="shrink-0" />
-            <span className="truncate min-w-0 flex-1">Any</span>
-          </label>
+          {!field.omitAnyOption && (
+            <label
+              title="Any"
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-ui-md text-neutral4 hover:bg-surface4 hover:text-neutral6 cursor-pointer focus-within:bg-surface4 focus-within:text-neutral6 min-w-0"
+            >
+              <RadioGroupItem data-pick-multi-item="" value="Any" className="shrink-0" />
+              <span className="truncate min-w-0 flex-1">Any</span>
+            </label>
+          )}
         </RadioGroup>
       )}
     </>

--- a/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/pick-multi-panel.tsx
@@ -31,8 +31,7 @@ export function PickMultiPanel({ field, tokens, onChange }: PickMultiPanelProps)
   const token = useMemo(() => tokens.find(t => t.fieldId === field.id), [tokens, field.id]);
   // Fall back to `defaultValue` when no token exists — lets view-toggle fields (e.g. List mode)
   // show their default option pre-selected before the user explicitly picks one.
-  const selectedValue =
-    typeof token?.value === 'string' ? token.value : !field.multi ? field.defaultValue : undefined;
+  const selectedValue = typeof token?.value === 'string' ? token.value : !field.multi ? field.defaultValue : undefined;
   const selectedValues = useMemo<string[]>(() => {
     if (Array.isArray(token?.value)) return token!.value as string[];
     if (typeof token?.value === 'string') return [token.value];

--- a/packages/playground-ui/src/ds/components/PropertyFilter/types.ts
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/types.ts
@@ -33,6 +33,13 @@ export type PropertyFilterField =
       searchable?: boolean;
       /** When true, PickMultiPanel renders a "Loading options…" message instead of the list. */
       isLoading?: boolean;
+      /** Single-select only. When true, omit the trailing "Any" radio — used for view-toggle
+       *  fields that are always one of the listed options (no neutral state). */
+      omitAnyOption?: boolean;
+      /** Single-select only. Pre-selects this option in PickMultiPanel when no token exists
+       *  yet — used for view-toggle fields whose "no token" state still corresponds to a
+       *  concrete value (the default). Does NOT create a token implicitly. */
+      defaultValue?: string;
     };
 
 export type PropertyFilterToken = {


### PR DESCRIPTION
## Summary

- Observability traces page now defaults to **Traces** mode (top-level only) instead of **Branches** mode (all branches)
- Adds a **List mode** property to the Add filter menu so users can explicitly switch between Traces and Branches without a dedicated toggle (the old dropdown toggle was removed a few days ago)
- New filter is pinned to the top of the Add filter list; the radio panel pre-selects the current default ("Traces (default)") so the user can see which mode is active before any token exists, and omits the usual "Any" option since the view is always in one of the two modes

## Test plan

- [ ] Open `/traces` — page loads in Traces mode (top-level rows only)
- [ ] Open the Add filter menu — "List mode" appears at the top
- [ ] Click "List mode" — side panel shows "Traces (default)" pre-selected and "Branches"; no "Any" radio
- [ ] Pick "Branches" — a `List mode: Branches` pill appears, URL gets `?listMode=branches`, list switches to branches mode
- [ ] Pick "Traces (default)" from the pill — URL gets `?listMode=traces`, list switches back
- [ ] Remove the pill — URL drops `listMode`, list returns to the default Traces mode
- [ ] Existing bookmarks with `?listMode=branches` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The traces page now shows only top-level traces by default instead of every branch, and you can switch back to seeing branches using a new "List mode" filter in the Add filter menu.

## Changes

### Default Behavior
- The Observability /traces page now defaults to "Traces" mode (top-level rows) instead of "Branches" when no list-mode parameter is present.
- URL state and data-fetching logic treat `traces` as the implicit default; code now clears the `listMode` query param for the default traces case and only sets `?listMode=branches` when branches is explicitly selected.

### New "List mode" Filter
- Added a "List mode" entry pinned to the top of the Add filter menu that offers two choices: "Traces (default)" and "Branches".
- The panel omits an "Any" option and pre-selects "Traces (default)".
- Selecting "Branches" creates a `List mode: Branches` pill, sets `?listMode=branches`, and switches the list to branches mode.
- Selecting "Traces (default)" sets (or rather clears) `?listMode=traces` behaviorally by removing the param; removing the pill clears `listMode` and returns the view to default Traces mode.
- Existing bookmarks/URLs with `?listMode=branches` remain supported.

### Component & Type Updates
- PropertyFilterField (pick-multi) gained:
  - `omitAnyOption?: boolean` — hide the "Any" radio option for single-select fields (used by List mode).
  - `defaultValue?: string` — pre-select an option in the UI when no token exists (so the current mode is visible without creating a token).
- PickMultiPanel now uses `field.defaultValue` as a fallback for single-select fields and conditionally hides the "Any" option when `omitAnyOption` is true.
- Added `TRACE_LIST_MODE_OPTIONS` containing the traces/branches option objects.

### Filter Infrastructure
- Added `mode` as a synthetic trace filter field (so `mode` is rendered first and appears among synthetic fields alongside `rootEntityType` and `status`).
- URL/token handling and preserved-filter logic updated to recognize, preserve, apply, and remove the `listMode` param correctly in the filter pipeline.
- Neutralization logic was adjusted to skip fields that declare `omitAnyOption`, preventing the List mode from being converted to a neutral "Any" value during clears.

### Backward Compatibility
- Bookmarks and URLs that include `?listMode=branches` continue to work unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16587)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16587)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->