### PR TITLE
fix(memory): observe threshold overflow on step zero

### DIFF
--- a/.changeset/dry-trains-hunt.md
+++ b/.changeset/dry-trains-hunt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fix observational memory so step 0 can synchronously observe when a single oversized message already exceeds the configured message token threshold.

--- a/packages/memory/src/processors/observational-memory/__tests__/mid-loop-observation.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/mid-loop-observation.test.ts
@@ -318,28 +318,20 @@ describe('Mid-Loop Observation', () => {
       expect(sealedAtRotate).toEqual([true]);
     });
 
-    it('should NOT trigger observation on step 0', async () => {
+    it('should trigger observation on step 0 when a single large message already exceeds the threshold', async () => {
       const requestContext = createRequestContext(threadId, resourceId);
       const state: Record<string, unknown> = {};
 
-      // Create messageList with messages that exceed threshold
       const messageList = new MessageList({
         threadId,
         resourceId,
       });
 
-      // Add messages that will exceed 500 token threshold
-      for (let i = 0; i < 20; i++) {
-        const msg = createTestMessage(
-          `Step ${i}: `.padEnd(200, 'x'),
-          i % 2 === 0 ? 'user' : 'assistant',
-          `msg-${i}`,
-          new Date(Date.now() - (20 - i) * 1000),
-        );
-        messageList.add(msg, 'memory');
-      }
+      messageList.add(
+        createTestMessage(`Single oversized message: `.padEnd(2500, 'x'), 'user', 'oversized-msg', new Date()),
+        'memory',
+      );
 
-      // Step 0: Should NOT trigger observation (only initializes record)
       await processor.processInputStep({
         messageList,
         messages: messageList.get.all.db(),
@@ -353,10 +345,47 @@ describe('Mid-Loop Observation', () => {
         abort: createAbort(),
       });
 
-      // Check record was created but no observations yet
       const record = await storage.getObservationalMemory(threadId, resourceId);
 
-      // No observations should be saved on step 0
+      expect(record?.activeObservations).toBeTruthy();
+      expect(record?.activeObservations).toContain('*');
+      expect(record?.lastObservedAt).toBeDefined();
+    });
+
+    it('should NOT trigger observation on step 0 when messages stay below the threshold', async () => {
+      const requestContext = createRequestContext(threadId, resourceId);
+      const state: Record<string, unknown> = {};
+
+      const messageList = new MessageList({
+        threadId,
+        resourceId,
+      });
+
+      for (let i = 0; i < 4; i++) {
+        const msg = createTestMessage(
+          `Short step ${i}: `.padEnd(80, 'x'),
+          i % 2 === 0 ? 'user' : 'assistant',
+          `short-msg-${i}`,
+          new Date(Date.now() - (4 - i) * 1000),
+        );
+        messageList.add(msg, 'memory');
+      }
+
+      await processor.processInputStep({
+        messageList,
+        messages: messageList.get.all.db(),
+        requestContext,
+        stepNumber: 0,
+        state,
+        steps: [],
+        systemMessages: [],
+        model: createMockObserverModel() as any,
+        retryCount: 0,
+        abort: createAbort(),
+      });
+
+      const record = await storage.getObservationalMemory(threadId, resourceId);
+
       expect(record?.activeObservations).toBeFalsy();
     });
 

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -184,6 +184,15 @@ export class ObservationStep {
       buffered = true;
     }
 
+    if (this.stepNumber === 0 && statusSnapshot.shouldObserve && !hasIncompleteToolCalls) {
+      const observationResult = await this.handleThresholdObservation(statusSnapshot);
+      observerExchange = observationResult.observerExchange;
+      observed = observationResult.observed;
+      reflected = reflected || observationResult.reflected;
+      didThresholdCleanup = observationResult.didThresholdCleanup;
+      statusSnapshot = observationResult.statusSnapshot;
+    }
+
     // ── Step > 0: Save messages + threshold observation ──────
     if (this.stepNumber > 0) {
       // Save messages from previous step
@@ -199,42 +208,11 @@ export class ObservationStep {
 
       // Threshold observation (step > 0 only, skip if tool calls pending)
       if (statusSnapshot.shouldObserve && !hasIncompleteToolCalls) {
-        const preObsGeneration = this.turn.record.generationCount;
-        const obsResult = await this.runThresholdObservation();
-        observerExchange = obsResult.observerExchange;
-        if (obsResult.succeeded) {
-          observed = true;
-          didThresholdCleanup = true;
-
-          // Cleanup after observation
-          const observedIds = obsResult.activatedMessageIds ?? obsResult.record.observedMessageIds ?? [];
-          const minRemaining = resolveRetentionFloor(
-            om.getObservationConfig().bufferActivation ?? 1,
-            statusSnapshot.threshold,
-          );
-
-          await om.cleanupMessages({
-            threadId,
-            resourceId,
-            messages: messageList,
-            observedMessageIds: observedIds,
-            retentionFloor: minRemaining,
-          });
-
-          if (statusSnapshot.asyncObservationEnabled) {
-            await om.resetBufferingState({
-              threadId,
-              resourceId,
-              recordId: obsResult.record.id,
-              activatedMessageIds: obsResult.activatedMessageIds,
-            });
-          }
-
-          await this.turn.refreshRecord();
-          if (this.turn.record.generationCount > preObsGeneration) {
-            reflected = true;
-          }
-        }
+        const observationResult = await this.handleThresholdObservation(statusSnapshot);
+        observerExchange = observationResult.observerExchange;
+        observed = observationResult.observed;
+        reflected = reflected || observationResult.reflected;
+        didThresholdCleanup = observationResult.didThresholdCleanup;
       }
 
       // Re-fetch status after observation/cleanup for the snapshot
@@ -290,6 +268,67 @@ export class ObservationStep {
     };
     this._prepared = true;
     return this._context;
+  }
+
+  private async handleThresholdObservation(statusSnapshot: any): Promise<{
+    observed: boolean;
+    reflected: boolean;
+    didThresholdCleanup: boolean;
+    observerExchange?: StepContext['observerExchange'];
+    statusSnapshot: typeof statusSnapshot;
+  }> {
+    const { threadId, resourceId, messageList } = this.turn;
+    const om = this.turn.om;
+    const preObsGeneration = this.turn.record.generationCount;
+    const obsResult = await this.runThresholdObservation();
+    let observed = false;
+    let reflected = false;
+    let didThresholdCleanup = false;
+
+    if (obsResult.succeeded) {
+      observed = true;
+      didThresholdCleanup = true;
+
+      const observedIds = obsResult.activatedMessageIds ?? obsResult.record.observedMessageIds ?? [];
+      const minRemaining = resolveRetentionFloor(
+        om.getObservationConfig().bufferActivation ?? 1,
+        statusSnapshot.threshold,
+      );
+
+      await om.cleanupMessages({
+        threadId,
+        resourceId,
+        messages: messageList,
+        observedMessageIds: observedIds,
+        retentionFloor: minRemaining,
+      });
+
+      if (statusSnapshot.asyncObservationEnabled) {
+        await om.resetBufferingState({
+          threadId,
+          resourceId,
+          recordId: obsResult.record.id,
+          activatedMessageIds: obsResult.activatedMessageIds,
+        });
+      }
+
+      await this.turn.refreshRecord();
+      if (this.turn.record.generationCount > preObsGeneration) {
+        reflected = true;
+      }
+    }
+
+    return {
+      observed,
+      reflected,
+      didThresholdCleanup,
+      observerExchange: obsResult.observerExchange,
+      statusSnapshot: await om.getStatus({
+        threadId,
+        resourceId,
+        messages: messageList.get.all.db(),
+      }),
+    };
   }
 
   /**


### PR DESCRIPTION
﻿## Problem

Observational Memory can start a turn already above the `messageTokens` threshold, but `step 0` currently never runs the threshold observation path. That creates a dead zone where a single oversized starting message is neither buffered nor observed until a later step happens.

## Root cause

The threshold observation path lived entirely inside the `stepNumber > 0` branch, while `step 0` only initialized state and skipped the observe/cleanup flow even when `shouldObserve` was already true.

## Fix

- extract the threshold observe/cleanup flow into a small helper
- run that helper on `step 0` too when the threshold is already exceeded and there are no incomplete tool calls
- keep previous-step message persistence inside the `step > 0` branch only
- update the focused regression test to cover a single oversized message on `step 0`
- add a changeset for `@mastra/memory`

## Solution sketch

```mermaid
flowchart TD
    A[processInputStep] --> B{stepNumber == 0?}
    B -- no --> C[save previous-step messages]
    B -- yes --> D[skip previous-step save]
    C --> E{shouldObserve and no incomplete tool calls?}
    D --> E
    E -- no --> F[continue]
    E -- yes --> G[run threshold observation]
    G --> H[cleanup observed messages]
    H --> I[refresh record and status]
```

## Duplicate check

- built for issue `#16523`
- checked adjacent OM work like `#16522`, `#16561`, `#14747`; related context, but not the same step-0 threshold bug
- did not find an open PR specifically fixing the `step 0` dead zone

## Tests

Attempted:

- `pnpm vitest packages/memory/src/processors/observational-memory/__tests__/mid-loop-observation.test.ts`
- `corepack pnpm --filter @mastra/memory exec vitest run src/processors/observational-memory/__tests__/mid-loop-observation.test.ts`
- `corepack pnpm --filter @mastra/memory run test:unit -- src/processors/observational-memory/__tests__/mid-loop-observation.test.ts`

Environment note:

- the local workspace does not have dependencies installed (`node_modules` absent), so `vitest` could not run in this environment

## Risk

Medium. The change intentionally allows observation to happen earlier in a turn, so the main thing to watch is preserving the existing guard around incomplete tool calls and keeping step-0 behavior below the threshold unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you're a note-taker in a meeting. You have a rule: "Once you've taken too many notes, you should save the important bits and throw away the rest to keep room for new notes." This PR fixes a bug where on the very first moment of a meeting, if someone gives you a HUGE note right away, you'd just ignore the rule and keep the massive note around anyway. Now, you'll check and follow the rule even at the very start.

---

## Overview

This PR fixes a bug in Observational Memory where `step 0` fails to observe messages that already exceed the configured `messageTokens` threshold. Previously, the threshold observation logic was completely gated behind `stepNumber > 0`, leaving oversized initial messages unobserved and unbuffered until a subsequent step.

## Changes

### Test Updates (`mid-loop-observation.test.ts`)

- **Removed**: Test asserting that observation does **not** trigger on step 0 when context exceeds threshold
- **Added**: 
  - New test verifying observation **does** trigger on step 0 when a single message exceeds the token threshold (e.g., a ~2500-character message against a 500-token limit)
  - New test verifying observation does **not** trigger on step 0 when messages remain below the threshold
  - Coverage now includes assertions on the observational memory record state after step 0

### Core Logic Refactor (`step.ts`)

- **Extracted helper method**: `handleThresholdObservation()` consolidates the threshold observation/cleanup pipeline (waiting for buffering, re-checking status, attempting activation, running sync observation if needed, sealing/persisting observed messages)
- **Step 0 enhancement**: Now calls `handleThresholdObservation()` when `statusSnapshot.shouldObserve` is true and no incomplete tool calls are pending, enabling synchronous observation for oversized initial messages
- **Step > 0 preservation**: Maintains previous behavior—saves messages from the prior step, then runs threshold observation only if needed
- **Guard condition**: Both step 0 and step > 0 observation check for incomplete tool calls (e.g., provider-executed tools still in `state:'call'`) before attempting observation

### Changeset

- `@mastra/memory` marked for patch release with description: "Fix observational memory so step 0 can synchronously observe when a single oversized message already exceeds the configured message token threshold"

## Risk & Testing Notes

**Risk Level**: Medium — extends observation to an earlier point in the turn lifecycle; important to preserve the incomplete tool call guard and ensure behavior remains unchanged when step 0 is below threshold.

Tests in `mid-loop-observation.test.ts` could not be executed locally due to missing `node_modules`, but the test suite covers both the happy path (observation on oversized step 0 message) and the guard condition (no observation when below threshold).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16588)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->