### PR TITLE
fix(playground-ui): stop leaking relative React type paths into emitted .d.ts

### DIFF
--- a/packages/playground-ui/tsconfig.json
+++ b/packages/playground-ui/tsconfig.json
@@ -16,8 +16,7 @@
     "outDir": "dist",
     "rootDir": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "react": ["./node_modules/@types/react"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"],

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -98,6 +98,7 @@
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/vite": "4.2.2",
     "@testing-library/react": "^16.3.2",
+    "@types/json-schema": "^7.0.15",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",

--- a/packages/playground/src/domains/agents/hooks/use-agent-experiments.ts
+++ b/packages/playground/src/domains/agents/hooks/use-agent-experiments.ts
@@ -55,9 +55,9 @@ export const useAgentExperiments = (agentId: string, attachedScorerIds: string[]
         }),
       );
 
-      return results.flat().toSorted((a, b) => {
-        const dateA = a.startedAt ? new Date(a.startedAt as string).getTime() : 0;
-        const dateB = b.startedAt ? new Date(b.startedAt as string).getTime() : 0;
+      return results.flat().toSorted((a: AgentExperiment, b: AgentExperiment) => {
+        const dateA = a.startedAt ? new Date(a.startedAt).getTime() : 0;
+        const dateB = b.startedAt ? new Date(b.startedAt).getTime() : 0;
         return dateB - dateA;
       }) as AgentExperiment[];
     },

--- a/packages/playground/src/domains/datasets/components/bulk-trace-review-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/bulk-trace-review-dialog.tsx
@@ -163,7 +163,7 @@ export function BulkTraceReviewDialog({
             <Label>Input (JSON) *</Label>
             <CodeEditor
               value={currentItem.input}
-              onChange={v => updateCurrentItem('input', v)}
+              onChange={v => updateCurrentItem('input', v ?? '')}
               showCopyButton={false}
               className="min-h-[120px]"
             />
@@ -173,7 +173,7 @@ export function BulkTraceReviewDialog({
             <Label>Ground Truth (JSON, optional)</Label>
             <CodeEditor
               value={currentItem.groundTruth}
-              onChange={v => updateCurrentItem('groundTruth', v)}
+              onChange={v => updateCurrentItem('groundTruth', v ?? '')}
               showCopyButton={false}
               className="min-h-[80px]"
             />
@@ -183,7 +183,7 @@ export function BulkTraceReviewDialog({
             <Label>Expected Trajectory (JSON, optional)</Label>
             <CodeEditor
               value={currentItem.expectedTrajectory}
-              onChange={v => updateCurrentItem('expectedTrajectory', v)}
+              onChange={v => updateCurrentItem('expectedTrajectory', v ?? '')}
               showCopyButton={false}
               className="min-h-[80px]"
             />

--- a/packages/playground/src/domains/datasets/hooks/use-csv-parser.ts
+++ b/packages/playground/src/domains/datasets/hooks/use-csv-parser.ts
@@ -36,13 +36,13 @@ export function useCSVParser() {
           skipEmptyLines: 'greedy',
           dynamicTyping: false,
           worker: useWorker,
-          complete: results => {
+          complete: (results: Papa.ParseResult<Record<string, string>>) => {
             // Extract headers from first row fields or meta
             const headers = results.meta.fields ?? [];
 
             // Process each row through JSON cell parser
             const allWarnings: string[] = [];
-            const processedData = results.data.map((row, index) => {
+            const processedData = results.data.map((row: Record<string, string>, index: number) => {
               const parsed = parseRow(row);
 
               // Prefix warnings with row number
@@ -60,7 +60,7 @@ export function useCSVParser() {
               warnings: allWarnings,
             });
           },
-          error: err => {
+          error: (err: Error) => {
             reject(new Error(err.message));
           },
         });

--- a/packages/playground/src/domains/mcps/components/MCPToolPanel.tsx
+++ b/packages/playground/src/domains/mcps/components/MCPToolPanel.tsx
@@ -50,7 +50,7 @@ export const MCPToolPanel = ({ toolId, serverId }: MCPToolPanelProps) => {
   });
 
   const handleToolCall = useCallback(
-    async (toolName: string, args: Record<string, unknown>) => {
+    async (_toolName: string, args: Record<string, unknown>) => {
       const response = await executeTool(args);
       return response;
     },

--- a/packages/playground/src/domains/workflows/workflow/zoom-slider.tsx
+++ b/packages/playground/src/domains/workflows/workflow/zoom-slider.tsx
@@ -2,7 +2,7 @@ import { Button, Slider, cn } from '@mastra/playground-ui';
 import type { PanelProps } from '@xyflow/react';
 import { Panel, useViewport, useReactFlow } from '@xyflow/react';
 import { Maximize, Minus, Plus } from 'lucide-react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 
 export const ZoomSlider = forwardRef<HTMLDivElement, Omit<PanelProps, 'children'>>(({ className, ...props }) => {
   const { zoom } = useViewport();

--- a/packages/playground/src/lib/ai-ui/attachments/pdfs-adapter.ts
+++ b/packages/playground/src/lib/ai-ui/attachments/pdfs-adapter.ts
@@ -59,11 +59,4 @@ export class PDFAttachmentAdapter implements AttachmentAdapter {
     });
     return btoa(binary);
   }
-
-  // Optional: Extract text from PDF using a library like pdf.js
-  private async extractTextFromPDF(): Promise<string> {
-    // Implementation would use pdf.js or similar
-    // This is a placeholder
-    return 'Extracted PDF text content';
-  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4333,6 +4333,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14


### PR DESCRIPTION
> **Originating issue:** #15972 (`packages/playground` had no typecheck script; type errors silently landed on `main`)
> **Follow-up tracked in:** #16596 (`AgentExperiment` cast + `toSorted` lib drift)

## TL;DR
One-line config fix in `packages/playground-ui/tsconfig.json` restores correct React types in everything that imports from `@mastra/playground-ui`. Brings the playground typecheck baseline from **135 → 64 errors** with zero behavior change. Part of the cleanup against #15972, which added the `typecheck` script that finally exposed the long-standing baseline.

## Root cause

`packages/playground-ui/tsconfig.json` had:

```json
"paths": {
  "@/*": ["./src/*"],
  "react": ["./node_modules/@types/react"]
}
```

`vite-plugin-dts` respects `paths` and rewrote every `import { ... } from 'react'` in emitted `.d.ts` files to that relative path. Example from `dist/src/ds/components/Button/Button.d.ts:2` **before** the fix:

```ts
import { default as React } from '../../../../node_modules/@types/react';
```

When `packages/playground` imported `Button`, TypeScript resolved that relative path into `playground-ui`'s own `node_modules/@types/react` — **a different React copy** than the one `playground` resolves for itself. The two React type identities don't unify, so:
- `onClick: (e: React.MouseEvent<HTMLButtonElement>) => void` in Button's `.d.ts` was identity-incompatible with the consumer's `MouseEvent`
- Contextual typing for handlers collapsed to `any`
- A lot of `TS7006 implicit any` errors and downstream `TS2322` mismatches were artifacts of this single issue, not real code problems

After the fix:
```ts
import { default as React } from 'react';
```
Bare specifier → consumer resolves its own React → types match.

## Robustness proof

Pasted into `packages/playground/src/` as a sanity check:

```tsx
import { Button } from '@mastra/playground-ui';
<Button onClick={e => {
  e.nonExistentProperty;          // TS2339 caught
  e.preventDefault(123 as never); // TS2554 caught
}}>click</Button>
```

- `e` now inferred as `MouseEvent<HTMLButtonElement, MouseEvent>` (was `any`)
- Both lines fail compilation (were silent before)
- `strict: true` (incl. `strictNullChecks`, `noImplicitAny`) untouched — they were always on, they just have correct types to operate on now.

## What's in this PR

1. **The fix** — drop the `"react"` entry from `packages/playground-ui/tsconfig.json` paths. Single line.
2. **Phase 1 playground cleanups whose value stands on its own** (the upstream fix doesn't help with these):
   - `TS6133`: deleted an unused private placeholder method (`extractTextFromPDF`) that returned the hardcoded string `'Extracted PDF text content'` — code lying about doing PDF extraction. If/when pdf.js is wired up, a real implementation can be written; the stub gave nothing useful as a starting point.
   - `TS7006`: typed `papaparse` callbacks (`Papa.ParseResult<Record<string, string>>`, etc.) and one `AgentExperiment` sort comparator. These are non-React contexts where contextual typing from the upstream fix doesn't apply.
   - Dropped a useless `as string` on `new Date(...)` calls in `use-agent-experiments.ts` (`startedAt: string | Date` already satisfies the `Date` constructor).
   - `TS2307`: added `@types/json-schema@^7.0.15` as a `devDependency` for the existing `import type { JSONSchema7 } from 'json-schema'` imports. All usages are `import type` (no runtime import), and `JSONSchema7` isn't re-exported from `src/exports.ts`, so `devDependencies` is the correct placement.
3. **What was reverted** — every manual `MouseEvent<HTMLButtonElement>`, `boolean` `onOpenChange`, `string | undefined` `CodeEditor onChange` typing I had added earlier in this branch. They're no longer needed: contextual typing now flows correctly through `Button`, `Tree`, `CodeEditor`, etc.

## Deliberately deferred

- Two stray `TS6133` errors (unused `React` namespace imports in `auto-form.tsx` and sibling files) — clearing them surfaces an unrelated `react-refresh/only-export-components` warning; the proper fix is splitting helpers into their own module.
- The `as AgentExperiment[]` cast in `use-agent-experiments.ts` — load-bearing, bridges real API-drift between the hand-rolled local interface and `@mastra/client-js`'s `DatasetExperiment`. Tracked in #16596 with the full plan.

Both fit the "API drift" phase 2 bucket explicitly scoped out of this PR.

## Verification

- `packages/playground-ui`:
  - `pnpm build` ✓ (Vite library mode + vite-plugin-dts)
  - `pnpm test` — same 6 pre-existing failures from a React 19.2.4 vs 19.2.6 mismatch (verified on `main`; orthogonal)
- `packages/playground`:
  - `pnpm typecheck` — **135 → 64 errors** (71 cleared)
  - `pnpm build` ✓ (10.58s)
  - `pnpm lint` — 0 errors, 88 warnings (down from 95 pre-PR)
  - `pnpm vitest run` — 187/187 pass, excluding 5 pre-existing failures in `studio-config-form-api-prefix.test.tsx` (verified pre-existing on `main`)

## History notes

The `react` paths entry has been on `main` since the package was first added (`7a64aff428`, Feb 2025, *feat: shared @mastra/playground ui lib + plug to local dev*). No commit message ever explained it. The only attempt to remove it (`107f0c89ab`, Sep 2025, *feat: sdk react*) lives on an unmerged branch (`origin/sdk/react-replace-tanstack-with-fetch`). Strongest hypothesis is an early-setup workaround for a duplicate-React resolution issue that no longer applies; nothing in the current pnpm hoisting or package layout needs it. Empirically: playground-ui builds, self-tests are unchanged, and consumer typing strictly improves.

## Test plan

- [ ] CI green
- [ ] Manual smoke: `pnpm dev:playground`, navigate to Agents / Datasets / Workflows / Skills / MCPs — confirm no UI regression in the touched flows
- [ ] `pnpm --filter @internal/playground typecheck` locally → expect 64 errors (phase 2 will keep burning these down per #16596 and similar follow-ups)

Closes part of #15972 (CI gap origin; full closure needs phase 2 cleanup of the remaining 64 errors).