### PR TITLE
fix(ci): preserve prebuild gate for docs-only reports

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -75,7 +75,7 @@ jobs:
   test-suite:
     name: Unit and E2E Tests
     needs: [changes, prebuild]
-    if: github.repository == 'mastra-ai/mastra'
+    if: always() && github.repository == 'mastra-ai/mastra' && needs.changes.result == 'success' && (needs.changes.outputs.has_code != 'true' || needs.prebuild.result == 'success')
     uses: ./.github/workflows/test-suite.yml
     permissions:
       actions: read


### PR DESCRIPTION
## Summary
- Keeps `test-suite` dependent on `prebuild` for code PRs, preserving the build gate before the required test report check.
- Allows docs-only PRs to instantiate the reusable test workflow when `prebuild` is skipped.
- Reuses the existing no-op `Merge Test Reports` behavior in `test-suite.yml` for `has_code=false`.

## Background
PR #16552 fixed docs-only PRs getting stuck because the required `Unit and E2E Tests / Merge Test Reports` check was never created. That fix made the reusable `test-suite` workflow run for docs-only PRs, while skipping the expensive unit/E2E jobs through the `has_code` input.

PR #16571 then restored `test-suite` depending on `prebuild`. That makes sense for code PRs because it keeps the required test report check behind a successful top-level build. However, `prebuild` is intentionally skipped when `has_code=false`, so docs-only PRs can again skip the reusable workflow before the required nested report check is created.

## Fix
Keep `needs: [changes, prebuild]`, but make the condition explicit:
- `changes` must succeed.
- If `has_code=true`, `prebuild` must succeed before `test-suite` runs.
- If `has_code=false`, skipped `prebuild` is allowed so the reusable workflow can create the no-op report check.

This preserves the intent of #16571 for code PRs while restoring the docs-only behavior from #16552.

## Validation
- `pnpm prettier --check .github/workflows/prebuild.yml .github/workflows/test-suite.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/prebuild.yml'); YAML.load_file('.github/workflows/test-suite.yml'); puts 'yaml ok'"`
- `actionlint -ignore 'label "starsling-ubuntu-24.04" is unknown' -ignore 'shellcheck reported issue' .github/workflows/prebuild.yml .github/workflows/test-suite.yml`