### PR TITLE
[codex] fix memory semantic recall replay flake

### DIFF
--- a/.changeset/chatty-candles-enter.md
+++ b/.changeset/chatty-candles-enter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed semantic recall to keep remembered messages in stable order when timestamps match, preventing flaky memory replay mismatches.

--- a/packages/_llm-recorder/src/llm-recorder.test.ts
+++ b/packages/_llm-recorder/src/llm-recorder.test.ts
@@ -17,6 +17,7 @@
  * ```
  */
 
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -30,6 +31,31 @@ import {
   getActiveRecorder,
 } from './llm-recorder';
 import type { LLMRecording } from './llm-recorder';
+
+function stableSortKeysForTest(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableSortKeysForTest);
+  }
+
+  if (value !== null && typeof value === 'object' && value.constructor === Object) {
+    return Object.keys(value)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = stableSortKeysForTest((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
+}
+
+function hashRequestForTest(url: string, body: unknown): string {
+  const normalizedBody = stableSortKeysForTest(body);
+  return createHash('md5')
+    .update(`${url}:${typeof normalizedBody === 'string' ? normalizedBody : JSON.stringify(normalizedBody)}`)
+    .digest('hex')
+    .slice(0, 16);
+}
 
 /**
  * Mode detection tests
@@ -119,6 +145,160 @@ describe('transformRequest', () => {
     if (recorder.server) {
       recorder.start();
       recorder.stop();
+    }
+  });
+
+  it('uses transformed hashes for existing recordings in exact replay mode', async () => {
+    const originalMode = process.env.LLM_TEST_MODE;
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-recorder-transform-'));
+    const name = 'transformed-hash-replay';
+    const filePath = path.join(tempDir, `${name}.json`);
+
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify(
+        {
+          meta: { name, createdAt: '2026-03-26T00:00:00.000Z' },
+          recordings: [
+            {
+              hash: 'stale-before-transform',
+              request: {
+                url: 'https://api.openai.com/v1/responses',
+                method: 'POST',
+                body: { model: 'gpt-4o', input: 'hello', timestamp: 'old' },
+                timestamp: 1,
+              },
+              response: {
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+                body: { id: 'transformed-match', output: [] },
+                isStreaming: false,
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+
+    process.env.LLM_TEST_MODE = 'replay';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const recorder = setupLLMRecording({
+      name,
+      recordingsDir: tempDir,
+      exactMatch: true,
+      transformRequest: ({ url, body }) => {
+        const nextBody = { ...(body as Record<string, unknown>) };
+        delete nextBody.timestamp;
+        return { url, body: nextBody };
+      },
+    });
+    recorder.start();
+
+    try {
+      const response = await fetch('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'gpt-4o', input: 'hello', timestamp: 'new' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ id: 'transformed-match', output: [] });
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('No exact match for hash'));
+    } finally {
+      recorder.stop();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      if (originalMode === undefined) {
+        delete process.env.LLM_TEST_MODE;
+      } else {
+        process.env.LLM_TEST_MODE = originalMode;
+      }
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('keeps persisted hashes as exact replay keys when transformRequest is configured', async () => {
+    const originalMode = process.env.LLM_TEST_MODE;
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-recorder-persisted-hash-'));
+    const name = 'persisted-hash-replay';
+    const filePath = path.join(tempDir, `${name}.json`);
+    const url = 'https://api.openai.com/v1/responses';
+    const actualBody = {
+      model: 'gpt-4o',
+      input: [
+        { role: 'system', content: 'You are helpful' },
+        { role: 'user', content: 'actual request' },
+      ],
+    };
+
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify(
+        {
+          meta: { name, createdAt: '2026-03-26T00:00:00.000Z' },
+          recordings: [
+            {
+              hash: hashRequestForTest(url, actualBody),
+              request: {
+                url,
+                method: 'POST',
+                body: {
+                  model: 'gpt-4o',
+                  input: [
+                    { role: 'system', content: 'You are helpful' },
+                    { role: 'user', content: 'persisted body from an older recorder' },
+                  ],
+                },
+                timestamp: 1,
+              },
+              response: {
+                status: 200,
+                statusText: 'OK',
+                headers: { 'content-type': 'application/json' },
+                body: { id: 'persisted-hash-match', output: [] },
+                isStreaming: false,
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+
+    process.env.LLM_TEST_MODE = 'replay';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const recorder = setupLLMRecording({
+      name,
+      recordingsDir: tempDir,
+      exactMatch: true,
+      transformRequest: ({ url, body }) => ({ url, body }),
+    });
+    recorder.start();
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(actualBody),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ id: 'persisted-hash-match', output: [] });
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('No exact match for hash'));
+    } finally {
+      recorder.stop();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      if (originalMode === undefined) {
+        delete process.env.LLM_TEST_MODE;
+      } else {
+        process.env.LLM_TEST_MODE = originalMode;
+      }
+      vi.restoreAllMocks();
     }
   });
 });

--- a/packages/_llm-recorder/src/llm-recorder.ts
+++ b/packages/_llm-recorder/src/llm-recorder.ts
@@ -165,6 +165,11 @@ export interface LLMRecording {
   };
 }
 
+type ReplayRecording = LLMRecording & {
+  /** Additional exact-match hashes derived at replay time for backward compatibility. */
+  lookupHashes?: string[];
+};
+
 /**
  * Metadata stored at the top of each recording file.
  * Makes recording files self-describing — you can open a JSON
@@ -605,14 +610,14 @@ const SIMILARITY_THRESHOLD = 0.6;
  * recording).  Exact hash matches are always exempt.
  */
 function findRecording(
-  recordings: LLMRecording[],
+  recordings: ReplayRecording[],
   hash: string,
   url: string,
   body: unknown,
   usedHashes?: Set<string>,
-): LLMRecording | undefined {
+): ReplayRecording | undefined {
   // 1. Exact hash match (fast path)
-  const exact = recordings.find(r => r.hash === hash);
+  const exact = recordings.find(r => isExactRecordingMatch(r, hash));
   if (exact) {
     return exact;
   }
@@ -701,6 +706,33 @@ function findRecording(
   return undefined;
 }
 
+function isExactRecordingMatch(recording: ReplayRecording, hash: string): boolean {
+  return recording.hash === hash || recording.lookupHashes?.includes(hash) === true;
+}
+
+function prepareReplayRecordings(
+  recordings: LLMRecording[],
+  transformRequest?: LLMRecorderOptions['transformRequest'],
+): ReplayRecording[] {
+  if (!transformRequest) {
+    return recordings;
+  }
+
+  return recordings.map(recording => {
+    const transformed = transformRequest({ url: recording.request.url, body: recording.request.body });
+    const transformedHash = hashRequest(transformed.url, transformed.body);
+
+    if (transformedHash === recording.hash) {
+      return recording;
+    }
+
+    return {
+      ...recording,
+      lookupHashes: [recording.hash, transformedHash],
+    };
+  });
+}
+
 /**
  * Set up LLM response recording/replay
  */
@@ -719,14 +751,14 @@ export function setupLLMRecording(options: LLMRecorderOptions): LLMRecorderInsta
 
   // Load existing recordings / metadata before any mutations (backward compatible)
   // In record/update modes a corrupted file should not block re-recording.
-  let savedRecordings: LLMRecording[] = [];
+  let savedRecordings: ReplayRecording[] = [];
   let existingMeta: RecordingMeta | undefined;
   if (recordingExists) {
     const willRecord = mode === 'record' || mode === 'update';
     try {
       const file = loadRecordingFile(recordingPath, options.name);
       existingMeta = file.meta;
-      savedRecordings = file.recordings;
+      savedRecordings = prepareReplayRecordings(file.recordings, options.transformRequest);
     } catch (err) {
       if (!willRecord) {
         throw err;
@@ -957,11 +989,11 @@ export function setupLLMRecording(options: LLMRecorderOptions): LLMRecorderInsta
         }
 
         if (debug) {
-          const matchType = recording.hash === hash ? 'exact' : 'fuzzy';
+          const matchType = isExactRecordingMatch(recording, hash) ? 'exact' : 'fuzzy';
           console.log(`[llm-recorder]   Matched (${matchType}): ${recording.request.url} [hash: ${recording.hash}]`);
         }
 
-        if (recording.hash !== hash) {
+        if (!isExactRecordingMatch(recording, hash)) {
           // findRecording returned a fuzzy match (rating >= SIMILARITY_THRESHOLD).
           // Accept it with a warning rather than failing the test.
           console.warn(

--- a/packages/core/src/processors/memory/semantic-recall.test.ts
+++ b/packages/core/src/processors/memory/semantic-recall.test.ts
@@ -882,6 +882,74 @@ describe('SemanticRecall', () => {
       expect(msg2Content).toContain(inputMessages[0]!.content.content);
     });
 
+    it('should format same-timestamp cross-thread messages deterministically', async () => {
+      const processor = new SemanticRecall({
+        storage: mockStorage,
+        vector: mockVector,
+        embedder: mockEmbedder,
+        scope: 'resource',
+      });
+
+      const inputMessages: MastraDBMessage[] = [
+        createTestMessage('msg-new', 'user', 'Actually, my favorite color is red.', '2024-01-15T12:00:00.000Z'),
+      ];
+
+      const createdAt = new Date('2024-01-15T10:30:00.000Z');
+      const crossThreadUser: MastraDBMessage = {
+        ...createTestMessage('msg-other-user', 'user', 'My favorite color is blue.', createdAt),
+        threadId: 'other-thread-1',
+      };
+      const crossThreadAssistant: MastraDBMessage = {
+        ...createTestMessage(
+          'msg-other-assistant',
+          'assistant',
+          'Blue is often associated with calmness and serenity.',
+          createdAt,
+        ),
+        threadId: 'other-thread-1',
+      };
+
+      vi.mocked(mockEmbedder.doEmbed).mockResolvedValue({
+        embeddings: [[0.1, 0.2, 0.3]],
+      });
+
+      vi.mocked(mockVector.query).mockResolvedValue([
+        {
+          id: 'msg-other-assistant',
+          score: 0.9,
+          metadata: { message_id: 'msg-other-assistant', thread_id: 'other-thread-1' },
+        },
+        { id: 'msg-other-user', score: 0.85, metadata: { message_id: 'msg-other-user', thread_id: 'other-thread-1' } },
+      ]);
+
+      vi.mocked(mockStorage.listMessages).mockResolvedValue({
+        messages: [crossThreadAssistant, crossThreadUser],
+        total: 2,
+        page: 1,
+        perPage: false,
+        hasMore: false,
+      });
+
+      const messageList = new MessageList();
+      messageList.add(inputMessages, 'input');
+
+      const result = await processor.processInput({
+        messages: inputMessages,
+        messageList,
+        abort: vi.fn() as any,
+        requestContext,
+      });
+
+      const promptMessages = Array.isArray(result) ? result : result.get.all.aiV4.prompt();
+      const content = promptMessages[0]!.content as string;
+      const userIndex = content.indexOf('User: My favorite color is blue.');
+      const assistantIndex = content.indexOf('Assistant: Blue is often associated with calmness and serenity.');
+
+      expect(userIndex).toBeGreaterThan(-1);
+      expect(assistantIndex).toBeGreaterThan(-1);
+      expect(userIndex).toBeLessThan(assistantIndex);
+    });
+
     it('should not add cross-thread messages when scope is thread', async () => {
       const processor = new SemanticRecall({
         storage: mockStorage,

--- a/packages/core/src/processors/memory/semantic-recall.ts
+++ b/packages/core/src/processors/memory/semantic-recall.ts
@@ -244,6 +244,28 @@ export class SemanticRecall implements Processor {
     }
   }
 
+  private sortMessagesForRecall(messages: MastraDBMessage[]): MastraDBMessage[] {
+    const roleOrder: Record<string, number> = {
+      system: 0,
+      user: 1,
+      assistant: 2,
+      tool: 3,
+    };
+
+    return [...messages].sort((a, b) => {
+      const timeDelta = a.createdAt.getTime() - b.createdAt.getTime();
+      if (timeDelta !== 0) return timeDelta;
+
+      const threadDelta = (a.threadId ?? '').localeCompare(b.threadId ?? '');
+      if (threadDelta !== 0) return threadDelta;
+
+      const roleDelta = (roleOrder[a.role] ?? 99) - (roleOrder[b.role] ?? 99);
+      if (roleDelta !== 0) return roleDelta;
+
+      return (a.id ?? '').localeCompare(b.id ?? '');
+    });
+  }
+
   /**
    * Format cross-thread messages as a system message with timestamps and labels
    * Uses the exact formatting logic from main that was tested with longmemeval benchmark
@@ -252,7 +274,7 @@ export class SemanticRecall implements Processor {
     let result = ``;
 
     // Convert to v1 format like main did
-    const v1Messages = new MessageList().add(messages, 'memory').get.all.v1();
+    const v1Messages = new MessageList().add(this.sortMessagesForRecall(messages), 'memory').get.all.v1();
     let lastYmd: string | null = null;
 
     for (const msg of v1Messages) {


### PR DESCRIPTION
## Summary

- Stabilize cross-thread semantic recall formatting so same-timestamp remembered messages are rendered in a deterministic user/assistant order.
- Recompute loaded LLM recording hashes after `transformRequest`, so exact replay compares normalized live requests with normalized saved requests.
- Add focused regressions for both the semantic recall ordering case and transformed recording hash replay.
- Add a patch changeset for `@mastra/core`.

## Root Cause

The `Thread Cloning` memory test was not just an assertion race. The recalled cross-thread context could render the same user/assistant pair in different orders when the messages shared a timestamp. That changes the OpenAI request body and therefore the LLM recorder hash.

Separately, existing recordings were loaded with their stored pre-transform hash. With `exactMatch: true`, a request that normalized to the recorded body could still miss exact replay and fall through to fuzzy matching.

## Impact

The runtime behavior change is intentionally narrow: only the formatted cross-thread semantic recall system message gets deterministic ordering. Same-thread recalled message insertion is left unchanged.

This should unblock the `Memory Tests` failure seen on #16529. It addresses the memory half of #16543. The separate E2E stream flake is not covered here and is being handled separately in #16558.

Related: #16543, #16529, #16556, #16558.

## Validation

- `git diff --check`
- `pnpm exec prettier --write packages/_llm-recorder/src/llm-recorder.ts packages/_llm-recorder/src/llm-recorder.test.ts packages/core/src/processors/memory/semantic-recall.ts packages/core/src/processors/memory/semantic-recall.test.ts .changeset/chatty-candles-enter.md`
- `pnpm --filter ./packages/core exec eslint src/processors/memory/semantic-recall.ts src/processors/memory/semantic-recall.test.ts`
- `pnpm --filter ./packages/_llm-recorder exec eslint src/llm-recorder.ts src/llm-recorder.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/processors/memory/semantic-recall.test.ts --reporter=dot`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/_llm-recorder exec vitest run src/llm-recorder.test.ts --reporter=dot`
- `pnpm --filter ./packages/_llm-recorder build`
- `pnpm --filter ./packages/_test-utils build`
- `LLM_TEST_MODE=replay pnpm vitest run src/agent-memory.test.ts --reporter=dot --bail 1 -t "V5.*should allow continuing conversation on cloned thread independently"` from `packages/memory/integration-tests`
- `LLM_TEST_MODE=replay pnpm vitest run src/agent-memory.test.ts --reporter=dot --bail 1 -t "V6.*should allow continuing conversation on cloned thread independently"` from `packages/memory/integration-tests`

CodeRabbit CLI is installed but local review could not run because it requires `coderabbit auth login` or an API key in this environment.

Additional note: an extra full `_llm-recorder` package run (`pnpm --filter ./packages/_llm-recorder test -- --reporter=dot`) hit an existing `src/vite-plugin.test.ts` relative import path assertion unrelated to the files changed here; the focused recorder test file passes.