### PR TITLE
fix(core): preserve durable object instructions

### DIFF
--- a/.changeset/durable-object-instructions.md
+++ b/.changeset/durable-object-instructions.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed durable agents so object-form system instructions are preserved with provider options.

--- a/.changeset/durable-object-instructions.md
+++ b/.changeset/durable-object-instructions.md
@@ -2,4 +2,4 @@
 "@mastra/core": patch
 ---
 
-Fixed durable agents so object-form system instructions are preserved with provider options.
+Fixed durable agents that could drop object-form system instructions when provider options like `cacheControl` were used. These instructions are now preserved so provider-specific options are respected.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-advanced.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-advanced.test.ts
@@ -125,6 +125,42 @@ describe('DurableAgent instructions handling', () => {
     expect(result.workflowInput.messageListState).toBeDefined();
   });
 
+  it('should preserve object-form instructions with provider options', async () => {
+    const mockModel = createTextModel('Hello');
+
+    const baseAgent = new Agent({
+      id: 'object-instructions-agent',
+      name: 'Object Instructions Agent',
+      instructions: {
+        role: 'system' as const,
+        content: 'You are a strict JSON-only assistant.',
+        providerOptions: {
+          anthropic: {
+            cacheControl: { type: 'ephemeral' },
+          },
+        },
+      },
+      model: mockModel as LanguageModelV2,
+    });
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    const result = await durableAgent.prepare('Hello');
+    const messageList = new MessageList();
+    messageList.deserialize(result.workflowInput.messageListState);
+
+    expect(messageList.getSystemMessages()).toEqual([
+      {
+        role: 'system',
+        content: 'You are a strict JSON-only assistant.',
+        experimental_providerMetadata: {
+          anthropic: {
+            cacheControl: { type: 'ephemeral' },
+          },
+        },
+      },
+    ]);
+  });
+
   it('should handle empty instructions', async () => {
     const mockModel = createTextModel('Hello');
 

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -15,7 +15,7 @@ import type { AgentExecutionOptions } from '../agent.types';
 import { MessageList } from '../message-list';
 import type { MessageListInput } from '../message-list';
 import { SaveQueueManager } from '../save-queue';
-import type { AgentModelManagerConfig, ToolsetsInput, ToolsInput } from '../types';
+import type { AgentInstructions, AgentModelManagerConfig, ToolsetsInput, ToolsInput } from '../types';
 import type { DurableAgenticWorkflowInput, RunRegistryEntry, SerializableStructuredOutput } from './types';
 import { createWorkflowInput } from './utils/serialize-state';
 
@@ -26,7 +26,7 @@ import { createWorkflowInput } from './utils/serialize-state';
 interface DurablePreparationAgent {
   id: string;
   name?: string;
-  getInstructions(opts: { requestContext: RequestContext }): string | string[] | Promise<string | string[]>;
+  getInstructions(opts: { requestContext: RequestContext }): AgentInstructions | Promise<AgentInstructions>;
   getModel(opts: { requestContext: RequestContext }): MastraLanguageModel | Promise<MastraLanguageModel>;
   getModelList(requestContext: RequestContext): Promise<AgentModelManagerConfig[] | null>;
   getMemory(opts: { requestContext: RequestContext }): Promise<MastraMemory | undefined>;
@@ -160,6 +160,8 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
       for (const inst of instructions) {
         messageList.addSystem(inst);
       }
+    } else {
+      messageList.addSystem(instructions);
     }
   }
 


### PR DESCRIPTION
## Summary

- Preserve object-form durable agent instructions, including provider options.
- Tighten the durable preparation instruction type to use AgentInstructions instead of string-only forms.
- Add regression coverage for object-form system instructions and a patch changeset for @mastra/core.

Supersedes #16545.
Fixes #16514.

## Verification

- pnpm build:core
- pnpm test:durable:core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Durable agents were accidentally dropping special system instructions when those instructions were provided as an object with provider-specific options (like Anthropic cacheControl). This PR makes durable agents keep and forward those object-form instructions just like non-durable agents do.

## Overview

Preserve object-form AgentInstructions (including providerOptions) when preparing durable agent executions. Tighten the durable preparation typing so getInstructions returns AgentInstructions (not just string/array), and ensure the preparation code adds object-form system instructions to MessageList via messageList.addSystem(instructions).

## Changes

- prepareForDurableExecution (packages/core/src/agent/durable/preparation.ts)
  - DurablePreparationAgent.getInstructions() now typed to return AgentInstructions | Promise<AgentInstructions>.
  - Preparation logic simplified/normalized: single-object instructions are added directly with messageList.addSystem(instructions), removing reliance on string/array-only branches for object forms.

- Tests (packages/core/src/agent/durable/__tests__/durable-agent-advanced.test.ts)
  - Added a test "should preserve object-form instructions with provider options" that verifies an object-form system instruction containing providerOptions (Anthropic cacheControl) is preserved in the serialized MessageList state and mapped to experimental_providerMetadata.

- Changeset (.changeset/durable-object-instructions.md)
  - Patch-level changeset for @mastra/core noting durable agents now preserve object-form system instructions with provider-specific options.

## Fixes

- Fixes the bug described in Issue #16514: durable.stream()/durable preparation no longer drops single-object CoreSystemMessage/SystemModelMessage instructions (including providerOptions), matching non-durable Agent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16599)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->