### PR TITLE
fix(memory): stabilize semantic recall replay and prompt ordering

### DIFF
--- a/.changeset/itchy-forks-beg.md
+++ b/.changeset/itchy-forks-beg.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+**Fixed** non-deterministic ordering of cross-thread semantic recall messages.
+
+When messages recalled from other threads shared the same timestamp, they were rendered into the system prompt in whatever order the vector query returned them — driven by similarity scores that can vary between equivalent runs. This made any test or evaluation that snapshots prompt output (or hashes the outbound LLM request) flaky.
+
+Recalled cross-thread messages are now sorted by createdAt, then threadId, then role (user → assistant → tool → system), then id before formatting, so the same set of recalled messages always produces the same prompt.

--- a/packages/_llm-recorder/src/llm-recorder.ts
+++ b/packages/_llm-recorder/src/llm-recorder.ts
@@ -165,6 +165,11 @@ export interface LLMRecording {
   };
 }
 
+type ReplayRecording = LLMRecording & {
+  /** Additional exact-match hashes derived at replay time for backward compatibility. */
+  lookupHashes?: string[];
+};
+
 /**
  * Metadata stored at the top of each recording file.
  * Makes recording files self-describing — you can open a JSON
@@ -605,14 +610,14 @@ const SIMILARITY_THRESHOLD = 0.6;
  * recording).  Exact hash matches are always exempt.
  */
 function findRecording(
-  recordings: LLMRecording[],
+  recordings: ReplayRecording[],
   hash: string,
   url: string,
   body: unknown,
   usedHashes?: Set<string>,
-): LLMRecording | undefined {
+): ReplayRecording | undefined {
   // 1. Exact hash match (fast path)
-  const exact = recordings.find(r => r.hash === hash);
+  const exact = recordings.find(r => isExactRecordingMatch(r, hash));
   if (exact) {
     return exact;
   }
@@ -701,6 +706,33 @@ function findRecording(
   return undefined;
 }
 
+function isExactRecordingMatch(recording: ReplayRecording, hash: string): boolean {
+  return recording.hash === hash || recording.lookupHashes?.includes(hash) === true;
+}
+
+function prepareReplayRecordings(
+  recordings: LLMRecording[],
+  transformRequest?: LLMRecorderOptions['transformRequest'],
+): ReplayRecording[] {
+  if (!transformRequest) {
+    return recordings;
+  }
+
+  return recordings.map(recording => {
+    const transformed = transformRequest({ url: recording.request.url, body: recording.request.body });
+    const transformedHash = hashRequest(transformed.url, transformed.body);
+
+    if (transformedHash === recording.hash) {
+      return recording;
+    }
+
+    return {
+      ...recording,
+      lookupHashes: [recording.hash, transformedHash],
+    };
+  });
+}
+
 /**
  * Set up LLM response recording/replay
  */
@@ -719,14 +751,14 @@ export function setupLLMRecording(options: LLMRecorderOptions): LLMRecorderInsta
 
   // Load existing recordings / metadata before any mutations (backward compatible)
   // In record/update modes a corrupted file should not block re-recording.
-  let savedRecordings: LLMRecording[] = [];
+  let savedRecordings: ReplayRecording[] = [];
   let existingMeta: RecordingMeta | undefined;
   if (recordingExists) {
     const willRecord = mode === 'record' || mode === 'update';
     try {
       const file = loadRecordingFile(recordingPath, options.name);
       existingMeta = file.meta;
-      savedRecordings = file.recordings;
+      savedRecordings = prepareReplayRecordings(file.recordings, options.transformRequest);
     } catch (err) {
       if (!willRecord) {
         throw err;
@@ -957,11 +989,11 @@ export function setupLLMRecording(options: LLMRecorderOptions): LLMRecorderInsta
         }
 
         if (debug) {
-          const matchType = recording.hash === hash ? 'exact' : 'fuzzy';
+          const matchType = isExactRecordingMatch(recording, hash) ? 'exact' : 'fuzzy';
           console.log(`[llm-recorder]   Matched (${matchType}): ${recording.request.url} [hash: ${recording.hash}]`);
         }
 
-        if (recording.hash !== hash) {
+        if (!isExactRecordingMatch(recording, hash)) {
           // findRecording returned a fuzzy match (rating >= SIMILARITY_THRESHOLD).
           // Accept it with a warning rather than failing the test.
           console.warn(

--- a/packages/core/src/processors/memory/semantic-recall.ts
+++ b/packages/core/src/processors/memory/semantic-recall.ts
@@ -245,6 +245,38 @@ export class SemanticRecall implements Processor {
   }
 
   /**
+   * Sort recalled messages into a stable order before formatting so that
+   * vector-query result ordering (which depends on similarity scores and can
+   * vary between runs for equivalent results) doesn't change the rendered
+   * prompt. Ordering: createdAt, then threadId, then role (user → assistant →
+   * tool → system), then id. Uses plain string comparison (ASCII identifiers)
+   * to stay locale-independent across CI/dev machines.
+   */
+  private sortMessagesForRecall(messages: MastraDBMessage[]): MastraDBMessage[] {
+    const roleOrder: Record<string, number> = {
+      system: 0,
+      user: 1,
+      assistant: 2,
+      tool: 3,
+    };
+
+    const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+
+    return [...messages].sort((a, b) => {
+      const timeDelta = a.createdAt.getTime() - b.createdAt.getTime();
+      if (timeDelta !== 0) return timeDelta;
+
+      const threadDelta = cmp(a.threadId ?? '', b.threadId ?? '');
+      if (threadDelta !== 0) return threadDelta;
+
+      const roleDelta = (roleOrder[a.role] ?? 99) - (roleOrder[b.role] ?? 99);
+      if (roleDelta !== 0) return roleDelta;
+
+      return cmp(a.id ?? '', b.id ?? '');
+    });
+  }
+
+  /**
    * Format cross-thread messages as a system message with timestamps and labels
    * Uses the exact formatting logic from main that was tested with longmemeval benchmark
    */
@@ -252,7 +284,7 @@ export class SemanticRecall implements Processor {
     let result = ``;
 
     // Convert to v1 format like main did
-    const v1Messages = new MessageList().add(messages, 'memory').get.all.v1();
+    const v1Messages = new MessageList().add(this.sortMessagesForRecall(messages), 'memory').get.all.v1();
     let lastYmd: string | null = null;
 
     for (const msg of v1Messages) {


### PR DESCRIPTION
Cross-thread semantic recall was rendering same-timestamp messages in vector-score order, which can swap equivalent user/assistant pairs between runs and change the rendered system prompt. That broke any downstream that snapshots prompt output or hashes the outbound LLM request — surfaced as a flaky V5 Thread Cloning integration test.

Two fixes:

`semantic-recall.ts` — sort recalled cross-thread messages by `(createdAt, threadId, role, id)` before formatting. Bounded input (semantic recall `topK`), plain string comparison for locale-independence.

`llm-recorder` — when a `transformRequest` is configured, recompute each loaded recording's hash through the current transform on load and keep both the persisted hash and the freshly derived hash as exact-match keys. This makes existing recordings forward-compatible with evolution of `transformRequest` / `hashRequest` without rewriting recording files.

Verified locally: `packages/_llm-recorder` tests 18/18, `semantic-recall.test.ts` 36/36, and all 27 Memory integration `Thread Cloning` tests (V4/V5/V6) pass — previously V5's "should allow continuing conversation on cloned thread independently" was failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16600)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->