### PR TITLE
test(_test-utils): run InMemoryStore tests in CI

### DIFF
--- a/.changeset/humble-clocks-follow.md
+++ b/.changeset/humble-clocks-follow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed listMessages perPage=0 behavior in the in-memory store to match other adapters.

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -134,6 +134,11 @@ export class InMemoryMemory extends MemoryStorage {
     // Calculate offset from page
     const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
 
+    // When perPage is 0 with no includes, there's nothing to return.
+    if (perPage === 0 && (!include || include.length === 0)) {
+      return { messages: [], total: 0, page, perPage: perPageForResponse, hasMore: false };
+    }
+
     // Step 1: Get messages matching threadId(s) and optionally resourceId
     let threadMessages = Array.from(this.db.messages.values()).filter((msg: any) => {
       // Message must be in one of the specified threads
@@ -160,13 +165,13 @@ export class InMemoryMemory extends MemoryStorage {
         : String(bValue).localeCompare(String(aValue));
     });
 
-    // Get total count of thread messages (for pagination metadata)
-    const totalThreadMessages = threadMessages.length;
+    // Get total count of thread messages (for pagination metadata). When
+    // perPage is 0, the count query is skipped so the response total is 0.
+    const totalThreadMessages = perPage === 0 ? 0 : threadMessages.length;
 
-    // Apply pagination to thread messages
-    const start = offset;
-    const end = start + perPage;
-    const paginatedThreadMessages = threadMessages.slice(start, end);
+    // Apply pagination to thread messages. When perPage is 0, skip the main
+    // pagination entirely so only included messages are returned.
+    const paginatedThreadMessages = perPage === 0 ? [] : threadMessages.slice(offset, offset + perPage);
 
     // Convert paginated thread messages to MastraDBMessage
     const messages: MastraDBMessage[] = [];
@@ -278,14 +283,17 @@ export class InMemoryMemory extends MemoryStorage {
 
     // Calculate hasMore
     let hasMore;
-    if (include && include.length > 0) {
+    if (perPage === 0) {
+      // perPage=0 fast path skips pagination entirely
+      hasMore = false;
+    } else if (include && include.length > 0) {
       // When using include, check if we've returned all messages from the thread
       // because include might bring in messages beyond the pagination window
       const returnedThreadMessageIds = new Set(messages.filter(m => m.threadId === threadId).map(m => m.id));
       hasMore = returnedThreadMessageIds.size < totalThreadMessages;
     } else {
       // Standard pagination: check if there are more pages
-      hasMore = end < totalThreadMessages;
+      hasMore = offset + perPage < totalThreadMessages;
     }
 
     return {

--- a/stores/_test-utils/src/domains/memory/threads.ts
+++ b/stores/_test-utils/src/domains/memory/threads.ts
@@ -1134,5 +1134,5 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
 
 function isStorageSupportsSort(storage: MastraStorage): boolean {
   const storageType = storage.constructor.name;
-  return ['LibSQLStore', 'PostgresStore', 'MSSQLStore', 'DynamoDBStore'].includes(storageType);
+  return ['InMemoryStore', 'LibSQLStore', 'PostgresStore', 'MSSQLStore', 'DynamoDBStore'].includes(storageType);
 }

--- a/stores/_test-utils/vitest.config.ts
+++ b/stores/_test-utils/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'e2e:stores/_test-utils',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Description

Wire up the existing `stores/_test-utils/src/index.test.ts` so that the in-memory storage adapter (`InMemoryStore` / `MockStore`) is exercised against the shared storage test suite in CI. The test file already calls `createTestSuite(new MockStore())` plus `createMastraStorageCompositionTests()`, but `stores/_test-utils` had no `vitest.config.ts`, so the root vitest project discovery (which globs `stores/*/vitest.config.ts`) skipped it entirely.

**Changes:**
- Add `stores/_test-utils/vitest.config.ts` so the existing in-memory test gets picked up by the root vitest project discovery (462 tests)
- Add `InMemoryStore` to `isStorageSupportsSort` in `stores/_test-utils/src/domains/memory/threads.ts` so the Thread Sorting suite runs against it (`listThreads` in `InMemoryStore` already honors `orderBy`)
- Fixed a `listMessages` divergence surfaced once the suite started running: when `perPage=0`, `InMemoryStore` now skips the main thread query/count (matching `@mastra/libsql` and `@mastra/pg`) — empty result when no `include`, only the included messages + context windows when `include` is provided, `total=0` and `hasMore=false` in both cases

Result: **462 passed, 0 skipped** in `pnpm --filter @internal/storage-test-utils test`.

## Type of change

- [x] Test update
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

https://claude.ai/code/session_018pEgpDsWg7EtTCMorbpYzY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16602)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->