### PR TITLE
fix(core): support signal attributes on user-messages and multimodal signal contents

### DIFF
--- a/.changeset/signals-normalize-contents.md
+++ b/.changeset/signals-normalize-contents.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Signals now normalize `contents` to `MastraDBMessage[]` once at `createSignal` time (lazy + memoized) via MessageList's input conversion. Both `toLLMMessage` and `toDBMessage` read from this canonical form, fixing two gaps: `user-message` signals now surface their `attributes` to the LLM (inline-wrapped into the first text part), and non-`user-message` signals with multimodal contents (file/image parts) no longer get flattened to text — files survive into both the LLM prompt and DB persistence. The external `signal.contents` shape and `toDataPart` echo are unchanged.

--- a/.changeset/signals-normalize-contents.md
+++ b/.changeset/signals-normalize-contents.md
@@ -3,3 +3,5 @@
 ---
 
 Signals now normalize `contents` to `MastraDBMessage[]` once at `createSignal` time (lazy + memoized) via MessageList's input conversion. Both `toLLMMessage` and `toDBMessage` read from this canonical form, fixing two gaps: `user-message` signals now surface their `attributes` to the LLM (inline-wrapped into the first text part), and non-`user-message` signals with multimodal contents (file/image parts) no longer get flattened to text — files survive into both the LLM prompt and DB persistence. The external `signal.contents` shape and `toDataPart` echo are unchanged.
+
+Forward-compat note: new signal DB rows can now contain real multimodal `content.parts` (text + file/image), where before they were always a single text part. Consumers that walked signal rows assuming a single text part should be updated to handle the full parts array.

--- a/.changeset/signals-normalize-contents.md
+++ b/.changeset/signals-normalize-contents.md
@@ -2,6 +2,11 @@
 '@mastra/core': patch
 ---
 
-Signals now normalize `contents` to `MastraDBMessage[]` once at `createSignal` time (lazy + memoized) via MessageList's input conversion. Both `toLLMMessage` and `toDBMessage` read from this canonical form, fixing two gaps: `user-message` signals now surface their `attributes` to the LLM (inline-wrapped into the first text part), and non-`user-message` signals with multimodal contents (file/image parts) no longer get flattened to text — files survive into both the LLM prompt and DB persistence. The external `signal.contents` shape and `toDataPart` echo are unchanged.
+Two fixes to how signals reach the LLM and DB:
+
+- `user-message` signals now expose their `attributes` to the LLM. Previously `toLLMMessage()` short-circuited and dropped the wrapper for user messages, so attributes were invisible to the model even though they were correctly written to `toDataPart()` and DB metadata.
+- Non-`user-message` signals (`system-reminder`, etc.) with multimodal `contents` now preserve their file/image parts in both the LLM prompt and DB storage. Previously these parts were flattened to text before either projection saw them.
+
+Internally, `createSignal` normalizes `contents` once into the canonical `MastraDBMessage[]` form, and both `toLLMMessage` and `toDBMessage` read from that. The external `signal.contents` value and `toDataPart()` output are unchanged.
 
 Forward-compat note: new signal DB rows can now contain real multimodal `content.parts` (text + file/image), where before they were always a single text part. Consumers that walked signal rows assuming a single text part should be updated to handle the full parts array.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -1,3 +1,4 @@
+import type { CoreMessage } from '@internal/ai-sdk-v4';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -95,7 +96,9 @@ describe('Agent signals', () => {
       metadata: { source: 'test', signal: { userProvided: true } },
     });
 
-    expect(signal.toLLMMessage()).toBe('Signal contents');
+    expect(signal.toLLMMessage()).toEqual([
+      { role: 'user', content: '<user-message priority="high">Signal contents</user-message>' },
+    ]);
     expect(signal.toDataPart()).toEqual({
       type: 'data-user-message',
       data: {
@@ -176,6 +179,183 @@ describe('Agent signals', () => {
     expect(fileSignal.toLLMMessage()).toEqual(fileContents);
     expect(fileSignal.toDataPart().data.contents).toEqual(fileContents);
     expect(mastraDBMessageToSignal(fileSignal.toDBMessage()).contents).toEqual(fileContents);
+  });
+
+  it('renders user-message attributes inline-wrapped for text and multimodal contents', () => {
+    const stringSignal = createSignal({
+      type: 'user-message',
+      contents: 'Hello',
+      attributes: { messageId: 'm-1', userId: 'u-1' },
+    });
+    expect(stringSignal.toLLMMessage()).toEqual([
+      { role: 'user', content: '<user-message messageId="m-1" userId="u-1">Hello</user-message>' },
+    ]);
+
+    const objectTextSignal = createSignal({
+      type: 'user-message',
+      contents: { role: 'user', content: 'Hello again' } as CoreMessage,
+      attributes: { messageId: 'm-1b' },
+    });
+    expect(objectTextSignal.toLLMMessage()).toEqual([
+      { role: 'user', content: '<user-message messageId="m-1b">Hello again</user-message>' },
+    ]);
+
+    const fileContents = {
+      role: 'user' as const,
+      content: [
+        { type: 'text' as const, text: 'Look at this' },
+        {
+          type: 'file' as const,
+          data: 'data:image/png;base64,aGVsbG8=',
+          mediaType: 'image/png',
+        },
+      ],
+    };
+    const multimodalSignal = createSignal({
+      type: 'user-message',
+      contents: fileContents,
+      attributes: { messageId: 'm-2' },
+    });
+    // Multimodal: text part is inline-wrapped, file part is preserved.
+    const multimodalResult = multimodalSignal.toLLMMessage() as MastraDBMessage[];
+    expect(multimodalResult).toHaveLength(1);
+    expect(multimodalResult[0]?.role).toBe('user');
+    expect(multimodalResult[0]?.content.parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'text',
+          text: '<user-message messageId="m-2">Look at this</user-message>',
+        }),
+        expect.objectContaining({
+          type: 'file',
+          data: 'data:image/png;base64,aGVsbG8=',
+        }),
+      ]),
+    );
+
+    // file-only: no text part exists, so the marker is prepended as its own message.
+    const fileOnlyContents = {
+      role: 'user' as const,
+      content: [{ type: 'file' as const, data: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' }],
+    };
+    const fileOnlySignal = createSignal({
+      type: 'user-message',
+      contents: fileOnlyContents,
+      attributes: { messageId: 'm-2d' },
+    });
+    const fileOnlyResult = fileOnlySignal.toLLMMessage() as Array<CoreMessage | MastraDBMessage>;
+    expect(fileOnlyResult[0]).toEqual({ role: 'user', content: '<user-message messageId="m-2d" />' });
+    expect((fileOnlyResult[1] as MastraDBMessage)?.content.parts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'file', data: 'data:image/png;base64,aGVsbG8=' })]),
+    );
+
+    const arraySignal = createSignal({
+      type: 'user-message',
+      contents: ['first', 'second'],
+      attributes: { messageId: 'm-3' },
+    });
+    expect(arraySignal.toLLMMessage()).toEqual([
+      { role: 'user', content: '<user-message messageId="m-3">first\nsecond</user-message>' },
+    ]);
+
+    const noAttributeSignal = createSignal({
+      type: 'user-message',
+      contents: 'Plain message',
+    });
+    expect(noAttributeSignal.toLLMMessage()).toBe('Plain message');
+
+    const onlyNullAttributesSignal = createSignal({
+      type: 'user-message',
+      contents: 'Plain message',
+      attributes: { ignored: null, alsoIgnored: undefined },
+    });
+    expect(onlyNullAttributesSignal.toLLMMessage()).toBe('Plain message');
+  });
+
+  it('renders system-reminder signals with multimodal contents the same way as user-message attributes', () => {
+    // Text-only system-reminder still wraps even without attributes (the wrapper is the signal).
+    const plainReminder = createSignal({
+      type: 'system-reminder',
+      contents: 'Be concise.',
+    });
+    expect(plainReminder.toLLMMessage()).toEqual([
+      { role: 'user', content: '<system-reminder>Be concise.</system-reminder>' },
+    ]);
+
+    // System-reminder with multimodal contents: emit a self-closing marker prefix; original contents survive.
+    const screenshotContents = {
+      role: 'user' as const,
+      content: [
+        { type: 'text' as const, text: 'The user is looking at this screen.' },
+        {
+          type: 'file' as const,
+          data: 'data:image/png;base64,aGVsbG8=',
+          mediaType: 'image/png',
+        },
+      ],
+    };
+    const screenshotReminder = createSignal({
+      type: 'system-reminder',
+      contents: screenshotContents,
+      attributes: { kind: 'screenshot' },
+    });
+    expect(screenshotReminder.toLLMMessage()).toEqual([
+      { role: 'user', content: '<system-reminder kind="screenshot" />' },
+      screenshotContents,
+    ]);
+
+    // System-reminder with only file parts gets the same self-closing prefix.
+    const fileOnlyReminderContents = {
+      role: 'user' as const,
+      content: [{ type: 'file' as const, data: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' }],
+    };
+    const fileOnlyReminder = createSignal({
+      type: 'system-reminder',
+      contents: fileOnlyReminderContents,
+      attributes: { kind: 'reference-image' },
+    });
+    expect(fileOnlyReminder.toLLMMessage()).toEqual([
+      { role: 'user', content: '<system-reminder kind="reference-image" />' },
+      fileOnlyReminderContents,
+    ]);
+  });
+
+  it('persists multimodal signal contents as faithful DB parts so UIs can render them', () => {
+    const fileContents = {
+      role: 'user' as const,
+      content: [
+        { type: 'text' as const, text: 'Look at this' },
+        { type: 'file' as const, data: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' },
+      ],
+    };
+
+    const userMessage = createSignal({
+      type: 'user-message',
+      contents: fileContents,
+      attributes: { messageId: 'm-1' },
+    });
+    const userDb = userMessage.toDBMessage();
+    expect(userDb.content.parts).toEqual([
+      expect.objectContaining({ type: 'text', text: 'Look at this' }),
+      expect.objectContaining({ type: 'file', data: 'data:image/png;base64,aGVsbG8=' }),
+    ]);
+    // Original raw contents are still preserved in metadata as the source of truth.
+    expect((userDb.content.metadata as { signal: { contents: unknown } }).signal.contents).toEqual(fileContents);
+
+    const reminder = createSignal({
+      type: 'system-reminder',
+      contents: fileContents,
+      attributes: { kind: 'screenshot' },
+    });
+    const reminderDb = reminder.toDBMessage();
+    expect(reminderDb.content.parts).toEqual([
+      expect.objectContaining({ type: 'text', text: 'Look at this' }),
+      expect.objectContaining({ type: 'file', data: 'data:image/png;base64,aGVsbG8=' }),
+    ]);
+
+    // Empty contents still produce a single empty text part so consumers that assume non-empty parts stay happy.
+    const emptyReminder = createSignal({ type: 'system-reminder', contents: '' });
+    expect(emptyReminder.toDBMessage().content.parts).toEqual([{ type: 'text', text: '' }]);
   });
 
   it('rejects invalid XML names for contextual signal markup', () => {

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
 import { Agent } from '../agent';
+import type { MastraDBMessage } from '../message-list/state/types';
 import {
   createSignal,
   dataPartToSignal,
@@ -331,6 +332,43 @@ describe('Agent signals', () => {
     expect(fileOnlyResult[0]).toEqual({ role: 'user', content: '<system-reminder kind="reference-image" />' });
     expect((fileOnlyResult[1] as MastraDBMessage)?.content.parts).toEqual(
       expect.arrayContaining([expect.objectContaining({ type: 'file', data: 'data:image/png;base64,aGVsbG8=' })]),
+    );
+
+    // System-reminder with array-valued contents (multiple CoreMessages, mixed text + file)
+    // gets the marker inlined into the very first text part — no nested arrays, no
+    // dropped messages.
+    const arrayReminderContents = [
+      { role: 'user' as const, content: 'Step one of the screen.' },
+      {
+        role: 'user' as const,
+        content: [
+          { type: 'text' as const, text: 'Step two has this attachment.' },
+          { type: 'file' as const, data: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' },
+        ],
+      },
+    ];
+    const arrayReminder = createSignal({
+      type: 'system-reminder',
+      contents: arrayReminderContents,
+      attributes: { kind: 'walkthrough' },
+    });
+    const arrayResult = arrayReminder.toLLMMessage() as MastraDBMessage[];
+    expect(arrayResult).toHaveLength(2);
+    // Only the first text part across all messages gets wrapped.
+    expect(arrayResult[0]?.content.parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'text',
+          text: '<system-reminder kind="walkthrough">Step one of the screen.</system-reminder>',
+        }),
+      ]),
+    );
+    // Subsequent text parts pass through untouched.
+    expect(arrayResult[1]?.content.parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'text', text: 'Step two has this attachment.' }),
+        expect.objectContaining({ type: 'file', data: 'data:image/png;base64,aGVsbG8=' }),
+      ]),
     );
   });
 

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -282,7 +282,8 @@ describe('Agent signals', () => {
       { role: 'user', content: '<system-reminder>Be concise.</system-reminder>' },
     ]);
 
-    // System-reminder with multimodal contents: emit a self-closing marker prefix; original contents survive.
+    // System-reminder with multimodal contents: text part is inline-wrapped with the marker,
+    // file part is preserved alongside it on the same logical turn.
     const screenshotContents = {
       role: 'user' as const,
       content: [
@@ -299,12 +300,24 @@ describe('Agent signals', () => {
       contents: screenshotContents,
       attributes: { kind: 'screenshot' },
     });
-    expect(screenshotReminder.toLLMMessage()).toEqual([
-      { role: 'user', content: '<system-reminder kind="screenshot" />' },
-      screenshotContents,
-    ]);
+    const screenshotResult = screenshotReminder.toLLMMessage() as MastraDBMessage[];
+    expect(screenshotResult).toHaveLength(1);
+    expect(screenshotResult[0]?.role).toBe('user');
+    expect(screenshotResult[0]?.content.parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'text',
+          text: '<system-reminder kind="screenshot">The user is looking at this screen.</system-reminder>',
+        }),
+        expect.objectContaining({
+          type: 'file',
+          data: 'data:image/png;base64,aGVsbG8=',
+        }),
+      ]),
+    );
 
-    // System-reminder with only file parts gets the same self-closing prefix.
+    // System-reminder with only file parts has no text to inline-wrap, so the marker is
+    // prepended as its own self-closing message.
     const fileOnlyReminderContents = {
       role: 'user' as const,
       content: [{ type: 'file' as const, data: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' }],
@@ -314,10 +327,11 @@ describe('Agent signals', () => {
       contents: fileOnlyReminderContents,
       attributes: { kind: 'reference-image' },
     });
-    expect(fileOnlyReminder.toLLMMessage()).toEqual([
-      { role: 'user', content: '<system-reminder kind="reference-image" />' },
-      fileOnlyReminderContents,
-    ]);
+    const fileOnlyResult = fileOnlyReminder.toLLMMessage() as Array<CoreMessage | MastraDBMessage>;
+    expect(fileOnlyResult[0]).toEqual({ role: 'user', content: '<system-reminder kind="reference-image" />' });
+    expect((fileOnlyResult[1] as MastraDBMessage)?.content.parts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'file', data: 'data:image/png;base64,aGVsbG8=' })]),
+    );
   });
 
   it('persists multimodal signal contents as faithful DB parts so UIs can render them', () => {

--- a/packages/core/src/agent/signals.ts
+++ b/packages/core/src/agent/signals.ts
@@ -174,8 +174,8 @@ function isTextOnlyDb(dbMessages: MastraDBMessage[]): boolean {
 }
 
 // Inline-wrap the first text part of the normalized DB messages with the signal's XML tag,
-// or prefix a self-closing marker message when no text part exists. Used by user-message
-// signals so the wrapper stays adjacent to the message it labels when possible.
+// or prefix a self-closing marker message when no text part exists. Keeps the wrapper
+// adjacent to its payload so the model sees the marker and its text/file parts as one turn.
 function injectMarkerInline(
   signal: Pick<AgentSignalInput, 'type' | 'contents' | 'attributes'>,
   dbMessages: MastraDBMessage[],
@@ -232,20 +232,11 @@ function signalToLLMMessage(
     return [{ role: 'user', content } satisfies CoreMessage];
   }
 
-  // Multimodal user-message: inline-inject the marker into the first text part so attributes
-  // like messageId stay tied to the message they describe.
-  if (isUserMessage) {
-    return injectMarkerInline(signal, normalized);
-  }
-
-  // Multimodal non-user-message: prefix a self-closing marker and pass the original contents
-  // through untouched. Framework context (system-reminder, screenshot, etc.) should remain
-  // distinct from its reference material, not have the marker hidden inside it.
-  const prefixMessage = {
-    role: 'user',
-    content: signalToXmlMarkup({ type: signal.type, attributes: signal.attributes }),
-  } satisfies CoreMessage;
-  return [prefixMessage, signal.contents] as BaseMessageListInput;
+  // Multimodal: inline-inject the marker into the first text part so the wrapper stays
+  // adjacent to its payload. Works for both user-message (attributes like messageId tie to
+  // the user's text) and framework signals (the reminder text becomes the wrapper's body
+  // alongside the file/image part).
+  return injectMarkerInline(signal, normalized);
 }
 
 function signalToDataPart(signal: ReturnType<typeof normalizeSignal>): AgentSignalDataPart {

--- a/packages/core/src/agent/signals.ts
+++ b/packages/core/src/agent/signals.ts
@@ -1,7 +1,8 @@
 import type { CoreMessage } from '@internal/ai-sdk-v4';
 
+import { MessageList } from './message-list';
 import type { BaseMessageListInput } from './message-list';
-import type { MastraDBMessage } from './message-list/state/types';
+import type { MastraDBMessage, MastraMessagePart } from './message-list/state/types';
 
 /**
  * @experimental Agent signals are experimental and may change in a future release.
@@ -33,7 +34,7 @@ export type UserMessageAgentSignalInput = AgentSignalInputBase & {
  */
 export type ContextAgentSignalInput = AgentSignalInputBase & {
   type: Exclude<AgentSignalType, 'user-message'>;
-  contents: string;
+  contents: AgentSignalContents;
 };
 
 /**
@@ -113,43 +114,138 @@ function signalAttributesToXml(attributes?: AgentSignalInput['attributes']): str
   return serialized ? ` ${serialized}` : '';
 }
 
-export function signalToXmlMarkup(signal: Pick<AgentSignalInput, 'type' | 'contents' | 'attributes'>): string {
+// Render a text-only signal as a single XML element string. For multimodal contents
+// (file/image parts) use signalToLLMMessage which preserves attachments. This helper exists
+// for callers that already have a flat string and want the canonical XML wrapping.
+export function signalToXmlMarkup(signal: {
+  type: AgentSignalInput['type'];
+  contents?: string;
+  attributes?: AgentSignalInput['attributes'];
+}): string {
   assertXmlName(signal.type, 'tag name');
-  return `<${signal.type}${signalAttributesToXml(signal.attributes)}>${escapeXml(signalContentsToText(signal.contents))}</${signal.type}>`;
+  const attributesXml = signalAttributesToXml(signal.attributes);
+  // Self-close when there is no inner text — conventional XML shape for empty elements.
+  if (!signal.contents) return `<${signal.type}${attributesXml} />`;
+  return `<${signal.type}${attributesXml}>${escapeXml(signal.contents)}</${signal.type}>`;
 }
 
-function signalContentsToText(contents: AgentSignalContents): string {
-  if (typeof contents === 'string') return contents;
-  if (Array.isArray(contents)) {
-    return contents.map(content => signalContentsToText(content as AgentSignalContents)).join('\n');
-  }
-  if (contents && typeof contents === 'object') {
-    const content = (contents as { content?: unknown }).content;
-    if (typeof content === 'string') return content;
-    if (Array.isArray(content)) {
-      return content
-        .map(part =>
-          part && typeof part === 'object' && 'text' in part ? String((part as { text: unknown }).text) : '',
-        )
-        .filter(Boolean)
-        .join('\n');
+// Normalize the loose BaseMessageListInput surface (string / CoreMessage / arrays / etc.) into
+// a single canonical MastraDBMessage[] shape using MessageList's own input pipeline. Once we
+// have this, the LLM and DB projections both read from the same walked representation instead
+// of each re-walking the raw input with its own duck-typing logic.
+function normalizeContents(contents: AgentSignalContents): MastraDBMessage[] {
+  const list = new MessageList();
+  list.add(contents, 'input');
+  return list.get.all.db();
+}
+
+// Flatten the canonical normalized form back into the text-only parts a UI would render.
+// Used by mastraDBMessageToSignal / dataPartToSignal to recover a string for non-user-message
+// signals whose original contents weren't preserved in metadata.
+function dbMessagesToText(dbMessages: MastraDBMessage[]): string {
+  return dbMessages
+    .flatMap(msg => msg.content?.parts ?? [])
+    .filter((part): part is { type: 'text'; text: string } => part.type === 'text' && typeof part.text === 'string')
+    .map(part => part.text)
+    .filter(Boolean)
+    .join('\n');
+}
+
+// Project the canonical normalized form into the MastraMessagePart[] shape stored on
+// signal DB rows. Falls back to a single empty text part so consumers that assume non-empty
+// parts arrays stay happy.
+function dbMessagesToParts(dbMessages: MastraDBMessage[]): MastraMessagePart[] {
+  const parts = dbMessages.flatMap(msg => msg.content?.parts ?? []);
+  return parts.length > 0 ? parts : [{ type: 'text', text: '' }];
+}
+
+function hasMeaningfulAttributes(attributes?: AgentSignalInput['attributes']): boolean {
+  if (!attributes) return false;
+  return Object.keys(attributes).some(key => {
+    const value = attributes[key];
+    return value !== null && value !== undefined;
+  });
+}
+
+// True when every part in the normalized form is a text part. Drives the choice between the
+// "wrap as single CoreMessage" fast path and the multimodal handling below.
+function isTextOnlyDb(dbMessages: MastraDBMessage[]): boolean {
+  return dbMessages.every(msg => (msg.content?.parts ?? []).every(part => part.type === 'text'));
+}
+
+// Inline-wrap the first text part of the normalized DB messages with the signal's XML tag,
+// or prefix a self-closing marker message when no text part exists. Used by user-message
+// signals so the wrapper stays adjacent to the message it labels when possible.
+function injectMarkerInline(
+  signal: Pick<AgentSignalInput, 'type' | 'contents' | 'attributes'>,
+  dbMessages: MastraDBMessage[],
+): BaseMessageListInput {
+  let wrapped = false;
+  const next = dbMessages.map(dbMsg => {
+    if (wrapped || !dbMsg.content?.parts) return { ...dbMsg, role: 'user' as const };
+    const parts: MastraMessagePart[] = [];
+    for (const part of dbMsg.content.parts) {
+      if (!wrapped && part.type === 'text') {
+        wrapped = true;
+        parts.push({ ...part, text: signalToXmlMarkup({ ...signal, contents: part.text }) });
+      } else {
+        parts.push(part);
+      }
     }
-  }
-  return '';
+    return { ...dbMsg, role: 'user' as const, content: { ...dbMsg.content, parts } };
+  });
+
+  if (wrapped) return next;
+
+  // No text part anywhere — prepend a self-closing marker message so attributes still surface.
+  const prefixMessage = {
+    role: 'user',
+    content: signalToXmlMarkup({ type: signal.type, attributes: signal.attributes }),
+  } satisfies CoreMessage;
+  return [prefixMessage, ...next];
 }
 
-function signalToLLMMessage(signal: Pick<AgentSignalInput, 'type' | 'contents' | 'attributes'>): BaseMessageListInput {
-  if (signal.type === 'user-message') {
+// Build the LLM-facing projection from the pre-normalized canonical form. Three shapes:
+//   1. user-message with no attributes → pass original contents through unchanged
+//   2. text-only → single wrapped CoreMessage
+//   3. multimodal → user-message inlines the marker into the first text part; other signal
+//      types prefix a self-closing marker so framework context stays distinct from the
+//      preserved original contents
+function signalToLLMMessage(
+  signal: Pick<AgentSignalInput, 'type' | 'contents' | 'attributes'>,
+  normalized: MastraDBMessage[],
+): BaseMessageListInput {
+  const isUserMessage = signal.type === 'user-message';
+  const hasAttrs = hasMeaningfulAttributes(signal.attributes);
+
+  // user-message is the model's natural input language; pass through untouched unless attributes
+  // need surfacing. Non-user-message signals always wrap — the XML wrapper is what tells the
+  // model "this is framework context, not a user/assistant turn".
+  if (isUserMessage && !hasAttrs) {
     return signal.contents;
   }
 
-  return [
-    {
-      // user role for system messages because "system" role can not in any provider go contextually within conversation history, which is what signals need to do. Not assistant role because then the assistant will think it was the one who said that. User role is the only appropriate role. We wrap in xml tags to make it clearer to the LLM that this is system added context.
-      role: 'user',
-      content: signalToXmlMarkup({ ...signal, contents: signalContentsToText(signal.contents) }),
-    } as CoreMessage,
-  ];
+  // Text-only fast path: emit a single wrapped user message. user role because providers reject
+  // system role mid-conversation, and assistant role would confuse the model about who spoke.
+  if (isTextOnlyDb(normalized)) {
+    const content = signalToXmlMarkup({ ...signal, contents: dbMessagesToText(normalized) });
+    return [{ role: 'user', content } satisfies CoreMessage];
+  }
+
+  // Multimodal user-message: inline-inject the marker into the first text part so attributes
+  // like messageId stay tied to the message they describe.
+  if (isUserMessage) {
+    return injectMarkerInline(signal, normalized);
+  }
+
+  // Multimodal non-user-message: prefix a self-closing marker and pass the original contents
+  // through untouched. Framework context (system-reminder, screenshot, etc.) should remain
+  // distinct from its reference material, not have the marker hidden inside it.
+  const prefixMessage = {
+    role: 'user',
+    content: signalToXmlMarkup({ type: signal.type, attributes: signal.attributes }),
+  } satisfies CoreMessage;
+  return [prefixMessage, signal.contents] as BaseMessageListInput;
 }
 
 function signalToDataPart(signal: ReturnType<typeof normalizeSignal>): AgentSignalDataPart {
@@ -168,6 +264,7 @@ function signalToDataPart(signal: ReturnType<typeof normalizeSignal>): AgentSign
 
 function signalToDBMessage(
   signal: ReturnType<typeof normalizeSignal>,
+  normalized: MastraDBMessage[],
   options?: { threadId?: string; resourceId?: string },
 ): MastraDBMessage {
   return {
@@ -179,7 +276,7 @@ function signalToDBMessage(
     type: signal.type,
     content: {
       format: 2,
-      parts: [{ type: 'text', text: signalContentsToText(signal.contents) }],
+      parts: dbMessagesToParts(normalized),
       metadata: {
         signal: {
           id: signal.id,
@@ -203,12 +300,16 @@ export function isCreatedAgentSignal(input: unknown): input is CreatedAgentSigna
 
 export function createSignal(input: AgentSignalInput): CreatedAgentSignal {
   const signal = normalizeSignal(input);
+  // Walk contents once via MessageList; both toDBMessage and toLLMMessage read from the
+  // memoized canonical form instead of duck-typing the raw input shape themselves.
+  let normalizedCache: MastraDBMessage[] | undefined;
+  const normalized = () => (normalizedCache ??= normalizeContents(signal.contents));
 
   return {
     ...signal,
     __isCreatedSignal: true as const,
-    toDBMessage: options => signalToDBMessage(signal, options),
-    toLLMMessage: () => signalToLLMMessage(signal),
+    toDBMessage: options => signalToDBMessage(signal, normalized(), options),
+    toLLMMessage: () => signalToLLMMessage(signal, normalized()),
     toDataPart: () => signalToDataPart(signal),
   };
 }
@@ -258,7 +359,9 @@ export function mastraDBMessageToSignal(message: MastraDBMessage): CreatedAgentS
   };
 
   return createSignal(
-    type === 'user-message' ? { ...base, type, contents } : { ...base, type, contents: signalContentsToText(contents) },
+    type === 'user-message'
+      ? { ...base, type, contents }
+      : { ...base, type, contents: dbMessagesToText(normalizeContents(contents)) },
   );
 }
 
@@ -266,6 +369,6 @@ export function dataPartToSignal(part: AgentSignalDataPart): CreatedAgentSignal 
   return createSignal(
     part.data.type === 'user-message'
       ? { ...part.data, type: 'user-message' }
-      : { ...part.data, contents: signalContentsToText(part.data.contents) },
+      : { ...part.data, contents: dbMessagesToText(normalizeContents(part.data.contents)) },
   );
 }

--- a/packages/core/src/agent/signals.ts
+++ b/packages/core/src/agent/signals.ts
@@ -208,9 +208,8 @@ function injectMarkerInline(
 // Build the LLM-facing projection from the pre-normalized canonical form. Three shapes:
 //   1. user-message with no attributes → pass original contents through unchanged
 //   2. text-only → single wrapped CoreMessage
-//   3. multimodal → user-message inlines the marker into the first text part; other signal
-//      types prefix a self-closing marker so framework context stays distinct from the
-//      preserved original contents
+//   3. multimodal → inline the marker into the first text part so the wrapper stays
+//      adjacent to its payload (file/image parts ride along on the same turn)
 function signalToLLMMessage(
   signal: Pick<AgentSignalInput, 'type' | 'contents' | 'attributes'>,
   normalized: MastraDBMessage[],


### PR DESCRIPTION
## Overview

Signals carry user input and framework context (system reminders, screenshots, etc.) into the agent loop. Each signal has a loose `contents: BaseMessageListInput` field — string, `CoreMessage`, array of messages, `MastraDBMessage`, anything `MessageList` accepts as input.

Previously, every projection of a signal — to the LLM prompt, to a DB row, to a data part — had to re-walk that loose shape with its own duck-typed helpers (`signalContentsToText`, etc.). That meant two gaps in behavior:

1. **`user-message` signals never surfaced their `attributes` to the LLM.** `signalToLLMMessage` short-circuited for user messages and returned `signal.contents` verbatim, so `attributes` like `messageId` were invisible to the model — even though they were correctly written to the data part and DB metadata.
2. **Non-`user-message` signals with multimodal contents lost their file/image parts.** `signalContentsToText` flattened everything to a string before either the LLM prompt or the DB row saw it, so a `system-reminder` carrying a screenshot would never reach the model.

This PR normalizes `signal.contents` once at `createSignal` time (lazy + memoized) via `MessageList`'s input conversion. `signalToLLMMessage` and `signalToDBMessage` both read from the canonical `MastraDBMessage[]` form instead of re-walking the raw input. The external `signal.contents` value is unchanged — `toDataPart`, the metadata stash, and round-tripping via `mastraDBMessageToSignal` all still echo the original input.

## Before / After

### `user-message` signals + attributes

**Before:** `signalToLLMMessage` returned `signal.contents` verbatim, attributes dropped.
```
user: hello
```

**After:** the marker is inline-wrapped into the first text part so the attributes stay adjacent to the message they describe.
```
user: <user-message messageId="m-1">hello</user-message>
```

For multimodal user messages, the wrapper is injected into the first text part and file parts are preserved on the same logical turn:
```
user: <user-message messageId="m-2">Look at this</user-message> [image]
```

If there is no text part to wrap into (file-only), the marker is prefixed as its own self-closing message:
```
user: <user-message messageId="m-2d" />
user: [image]
```

### `system-reminder` (and other non-`user-message`) signals + multimodal contents

**Before:** `signalContentsToText` flattened multimodal contents to a string, dropping every file/image part before the model saw it.
```
user: <system-reminder kind="screenshot">The user is looking at this screen.</system-reminder>
# (no image — silently dropped)
```

**After:** the marker is inline-wrapped into the first text part, and the file part rides along on the same turn.
```
user: <system-reminder kind="screenshot">The user is looking at this screen.</system-reminder> [image]
```

### DB persistence

**Before:** `signalToDBMessage` called `signalContentsToText`, so the DB row only ever stored a single text part, dropping every file/image part for downstream UIs.

**After:** `signalToDBMessage` reads the canonical normalized parts (text + file + image) and stores them faithfully.

### External contract

Unchanged. `signal.contents` is still the original input the caller passed in. `toDataPart().data.contents`, `metadata.signal.contents`, and `mastraDBMessageToSignal(toDBMessage()).contents` all preserve the original shape.

## Implementation notes

- `createSignal` runs `new MessageList().add(contents, 'input').get.all.db()` lazily on first use. Control signals that never invoke `toLLMMessage`/`toDBMessage` pay nothing.
- `signalToLLMMessage` now has three branches: (1) `user-message` with no attributes → pass through unchanged, (2) text-only → single wrapped `CoreMessage`, (3) multimodal → `injectMarkerInline` wraps the first text part (or prefixes a self-closing marker if there is no text part).
- `signalToDBMessage` builds `content.parts` from `dbMessagesToParts(normalized)` instead of the old single-text-part shape, so file/image parts survive into storage.
- `mastraDBMessageToSignal` and `dataPartToSignal` route the round-trip through `normalizeContents` + `dbMessagesToText` so non-`user-message` round-trips still get a stable text form.

## Test plan

- 26/26 tests in `packages/core/src/agent/__tests__/agent-signals.test.ts` pass, including 7 new scenarios covering:
  - `user-message` + attributes inline-wrap with single `CoreMessage` contents
  - `user-message` + attributes inline-wrap with multimodal (text + file) contents
  - `user-message` + attributes with file-only contents (self-closing marker prefix)
  - `user-message` + attributes with array-of-strings contents
  - `user-message` with `null`/`undefined`-only attributes (treated as no attributes)
  - `system-reminder` + multimodal contents (text part inline-wrapped, file part preserved)
  - `system-reminder` + file-only contents (self-closing marker prefix)
  - DB persistence preserves file/image parts faithfully
- 2693/2693 tests pass across the full `@mastra/core` suite (agent + channels + processors + message-list).
- Typecheck clean.

## Stack

PR #16517 (channel signals migration) is now stacked on top of this PR. The channels work depends on `user-message` attributes reaching the LLM, which this PR fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The PR makes the system convert a signal's contents into a single, standard internal format once when the signal is created, and then reuses that normalized form for both sending to the LLM and saving to the database—so attributes and multimodal parts are handled consistently and not lost.

## Changes

### Release Notes
- Signals now normalize `contents` to `MastraDBMessage[]` once at `createSignal` time (lazy + memoized) using `MessageList().add(contents, 'input').get.all.db()`. Both `toLLMMessage` and `toDBMessage` read from that normalized representation.
- Behavioral fixes:
  - `user-message` signals now surface `attributes` (e.g., `messageId`) to the LLM by inlining an attribute marker into the first text part; if a user message contains only files, a self-closing marker message is emitted and file parts are preserved.
  - Non-`user-message` signals with multimodal contents no longer drop file/image parts; the attribute marker is inline-wrapped into the first text part and file/image parts are preserved to both LLM and DB.
  - DB persistence stores all normalized parts (text + file + image) instead of a single flattened text part.
- Forward-compat note: DB rows may now contain full `content.parts` arrays (multimodal parts) rather than always a single text part—consumers that assumed a single text part should be updated.

### Tests
- Added/updated tests (26 agent-signal tests; 2693@mastra/core tests still pass). New scenarios cover:
  - `user-message` attribute wrapping (text, multimodal, file-only, array contents).
  - Equivalent multimodal and file-only behaviors for non-user messages (e.g., `system-reminder`).
  - DB persistence fidelity for multimodal contents and edge cases (empty contents).
- All new and existing tests pass; typecheck clean.

### Implementation
- `ContextAgentSignalInput.contents` broadened: `string` → `AgentSignalContents`.
- `createSignal` memoizes normalized `MastraDBMessage[]`.
- New helpers: normalize contents via `MessageList`, dbMessages→text helper, and dbMessages→parts helper (with empty-text fallback).
- `signalToLLMMessage` branches:
  1. user-message + no attributes → pass-through
  2. text-only → single wrapped CoreMessage
  3. multimodal → inject marker inline into first text part, or prefix self-closing marker if no text part
- `signalToDBMessage` builds `content.parts` from normalized DB messages (preserving file/image parts).
- `mastraDBMessageToSignal` and `dataPartToSignal` round-trip via normalization + dbMessagesToText for stable text reconstruction.
- `signalToXmlMarkup` updated to accept optional `contents` and render escaped/validated tag/attribute names, using self-closing form for empty content.

### Comments / Notes
- Removed an earlier branch that prefixed markers based on original `signal.contents`; all multimodal messages now use the same inline-marker approach (no nested arrays).
- Stale doc comment and tests updated (commit notes referenced).
- Developer will add a forward-compat changeset/release-note advising consumers that DB rows may include full parts arrays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16604)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->