### PR TITLE
fix(playground): align IME composition e2e assertions with @assistant-ui/react 0.14

### DIFF
--- a/packages/playground/e2e/tests/agents/$agentId/ime-composition.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/ime-composition.spec.ts
@@ -16,8 +16,11 @@ import { resetStorage } from '../../__utils__/reset-storage';
  * candidate was incorrectly submitting the chat. Issue #16464 — the original
  * fix tracked composition state in a ref that got stuck `true` when users
  * switched input methods mid-composition (Caps Lock / Cmd+Space), permanently
- * killing Enter. Current fix reads the browser-owned `event.isComposing` flag
- * directly (plus legacy `keyCode === 229`) so there is no state to get stuck.
+ * killing Enter. The current implementation delegates IME handling to
+ * `@assistant-ui/react`'s ComposerPrimitive.Input, which reads the
+ * browser-owned `event.isComposing` flag directly on each keydown and only
+ * tracks composition state via the live `compositionstart` / `compositionend`
+ * events — so there is no ref state that can get stuck.
  */
 
 let page: Page;
@@ -54,8 +57,10 @@ test('Enter during IME composition does not submit, Enter after composition does
 
   // Press Enter while composing. We use dispatchEvent with isComposing: true
   // to mirror what browsers send during IME (Playwright's keyboard.press does
-  // not flag isComposing on its own).
-  const submitsDuringComposition = await page.evaluate(() => {
+  // not flag isComposing on its own). The composer's IME guard short-circuits
+  // before any submit logic runs, so it does NOT call preventDefault — it just
+  // returns early. That's the behavior we care about: no submission.
+  const defaultPreventedDuringComposition = await page.evaluate(() => {
     const el = document.activeElement as HTMLTextAreaElement | null;
     if (!el) throw new Error('No active textarea');
     const event = new KeyboardEvent('keydown', {
@@ -69,11 +74,11 @@ test('Enter during IME composition does not submit, Enter after composition does
     return event.defaultPrevented;
   });
 
-  // The fix calls preventDefault() during composition — assert that.
-  expect(submitsDuringComposition).toBe(true);
+  // Guard returns early during composition without calling preventDefault.
+  expect(defaultPreventedDuringComposition).toBe(false);
 
-  // The URL should still be /chat/new because no submit happened, and the
-  // textarea should still hold the in-progress text.
+  // The real user-facing check: the URL should still be /chat/new because no
+  // submit happened, and the textarea should still hold the in-progress text.
   await expect(page).toHaveURL(/\/chat\/new$/);
   await expect(chatInput).toHaveValue('hello');
 
@@ -119,7 +124,8 @@ test('Enter after IME switch (no compositionend) still submits — #16464 regres
   // …and deliberately DO NOT fire compositionend, mimicking the IME-switch case.
 
   // A subsequent Enter with isComposing=false (the IME is no longer active) should
-  // submit, because the guard now reads from the live event, not a stale ref.
+  // submit, because the guard reads from the live event, not a stale ref. The
+  // composer calls preventDefault() before requesting the form submit.
   const defaultPrevented = await page.evaluate(() => {
     const el = document.activeElement as HTMLTextAreaElement | null;
     if (!el) throw new Error('No active textarea');
@@ -134,8 +140,9 @@ test('Enter after IME switch (no compositionend) still submits — #16464 regres
     return event.defaultPrevented;
   });
 
-  // Guard should NOT have preventDefaulted this Enter — the IME is no longer composing.
-  expect(defaultPrevented).toBe(false);
+  // Guard let this Enter through to the submit path — preventDefault was
+  // called as part of requesting the form submit (not as a way to block it).
+  expect(defaultPrevented).toBe(true);
 
   // And the submit should go through end-to-end.
   await chatInput.focus();


### PR DESCRIPTION
The two ime-composition e2e tests have been failing on main since the @assistant-ui/react 0.14 upgrade in #16527. The library now delegates IME handling internally, with different preventDefault semantics than the manual guard it replaced. The end-to-end product assertions in those tests (URL, message visibility, textarea value) are still correct — only the two `defaultPrevented` checks were inverted.

The new library behavior:

```ts
// Inside ComposerPrimitive.Input keydown handler:
if (e.nativeEvent.isComposing) return; // early return, no preventDefault
// ...later, when Enter should submit:
e.preventDefault();
requestSubmit();
```

So during composition `defaultPrevented` is `false`, and outside composition (Enter submits) `defaultPrevented` is `true` — the opposite of what the tests asserted. Flipped both, with comments explaining why. Verified locally by running ime-composition + stream specs against the kitchen-sink fixture; all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

When people type in other languages using Input Method Editors (IMEs) like Chinese pinyin, pressing Enter should confirm the typing tool's candidate—not send the message. This PR updates tests to match how the updated chat library now handles this: it checks a live signal from the browser (not a memory note) to know if you're actively typing with an IME, so it stops Enter from submitting while you're composing, but allows it to submit once you're done.

---

## Overview

This PR fixes two end-to-end Playwright tests in the playground's IME composition test suite that were failing due to a behavioral change in `@assistant-ui/react` 0.14. The library now delegates IME composition handling to read the native browser `event.isComposing` flag directly rather than tracking it in application state.

## What Changed

**File:** `packages/playground/e2e/tests/agents/$agentId/ime-composition.spec.ts`

The test assertions were flipped to align with the updated library behavior:

1. **First test** ("Enter during IME composition does not submit..."): 
   - Changed assertion from `expect(defaultPreventedDuringComposition).toBe(true)` to `.toBe(false)`
   - The input handler now returns early without calling `preventDefault()` when `event.isComposing` is true
   - Updated accompanying comments to clarify that the guard "short-circuits before any submit logic runs"
   - User-facing assertions remain unchanged: URL stays `/chat/new`, textarea preserves text

2. **Second test** ("Enter after IME switch..."—#16464 regression):
   - Changed assertion from `expect(defaultPrevented).toBe(false)` to `.toBe(true)`
   - When `isComposing` is false (after IME switch), the input handler calls `preventDefault()` as part of the normal submit flow
   - Updated comments to explain that the guard now reads from the "live event, not a stale ref"
   - User-facing assertions remain unchanged: URL navigates away, message appears in thread

## Why This Matters

The previous fix tracked composition state in a ref that could get "stuck" true when users switched input methods without a proper `compositionend` event. The new implementation delegates to `@assistant-ui/react`'s `ComposerPrimitive.Input`, which reads the browser-owned `event.isComposing` flag directly on each keydown. This eliminates the risk of stale state and improves IME handling reliability.

The change is purely about aligning test expectations with the new underlying behavior—the user-facing functionality (preventing accidental message submission during composition, allowing submission after) remains intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16607)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->