### PR TITLE
chore(changeset): bump auth-workos and core to minor for ee foundation

### DIFF
--- a/.changeset/clean-garlics-show.md
+++ b/.changeset/clean-garlics-show.md
@@ -1,8 +1,8 @@
 ---
-'@mastra/auth-workos': patch
+'@mastra/auth-workos': minor
 ---
 
-Implemented the optional `getAvailableRoles` and `getPermissionsForRole` methods on the WorkOS RBAC provider, so consumers using `@mastra/core/auth/ee` capabilities can list configured roles and inspect their permissions through WorkOS.
+Added optional `getAvailableRoles` and `getPermissionsForRole` methods to the WorkOS RBAC provider, so consumers can list configured roles and inspect their permissions through `@mastra/auth-workos`.
 
 ```typescript
 import { MastraRBACWorkos } from '@mastra/auth-workos';

--- a/.changeset/seven-readers-bet.md
+++ b/.changeset/seven-readers-bet.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/core': patch
+'@mastra/core': minor
 ---
 
 Added an opt-in foundation for building agent-builder admin policies and role-aware capabilities, available under two new entry points.


### PR DESCRIPTION
PR #16578 shipped the `@mastra/core/auth/ee` and `@mastra/core/agent-builder/ee` entry points and added `getAvailableRoles`/`getPermissionsForRole` to `MastraRBACWorkos`. Both are backward-compatible feature additions, so the changesets that landed with them should have been `minor`, not `patch`.

This PR:

- Bumps `.changeset/seven-readers-bet.md` (`@mastra/core`) from `patch` to `minor`.
- Bumps `.changeset/clean-garlics-show.md` (`@mastra/auth-workos`) from `patch` to `minor`.
- Re-scopes the auth-workos changeset body so it only references `@mastra/auth-workos` (CodeRabbit pointed out the original body mentioned `@mastra/core/auth/ee`, which doesn't match the frontmatter).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes the version labels for two packages. Previously, updates that added new optional features were incorrectly marked as "patch" (tiny fixes), but they should have been marked as "minor" (new features). This PR corrects those labels.

## Summary

Updates two changesets to bump packages from `patch` to `minor` release level:

**@mastra/auth-workos:**
- Changes release type from `patch` to `minor`
- Adds two optional methods to the WorkOS RBAC provider:
  - `getAvailableRoles`: Lists configured roles
  - `getPermissionsForRole(roleId)`: Retrieves permissions for a specific role
- Rescopes changeset body to only reference `@mastra/auth-workos` (removed references to `@mastra/core/auth/ee`)

**@mastra/core:**
- Changes release type from `patch` to `minor`

**Rationale:**

PR #16578 introduced backward-compatible feature additions (`getAvailableRoles` and `getPermissionsForRole` methods) to `MastraRBACWorkos`. These new optional features should be released as a `minor` version bump (new functionality added) rather than a `patch` bump (bug fixes/patches only).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16615)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->