### PR TITLE
fix(schema-compat): produce OpenAI strict-mode compatible JSON Schema for optional fields

### DIFF
--- a/.changeset/fix-schema-compat-openai-strict-mode.md
+++ b/.changeset/fix-schema-compat-openai-strict-mode.md
@@ -1,0 +1,5 @@
+---
+"@mastra/schema-compat": patch
+---
+
+fix(schema-compat): produce OpenAI strict-mode compatible JSON Schema for optional fields

--- a/packages/schema-compat/src/zod-to-json.test.ts
+++ b/packages/schema-compat/src/zod-to-json.test.ts
@@ -765,3 +765,48 @@ it('reproduce issue #16383 - optional fields must appear in required for OpenAI 
 
   expect(nicknameProp.description).toBe('The nickname');
 });
+
+it('should handle optional fields inside array items (nested strict-mode)', () => {
+  const schema = z.object({
+    list: z
+      .array(
+        z.object({
+          keep: z.string(),
+          omit: z.string().optional(),
+        }),
+      )
+      .optional(),
+  });
+
+  const result = zodToJsonSchema(schema) as any;
+
+  expect(result.required).toContain('list');
+
+  expect(result.properties.list.items.required).toContain('keep');
+  expect(result.properties.list.items.required).toContain('omit');
+
+  expect(result.properties.list.items.properties.omit.type).toEqual(['string', 'null']);
+});
+
+it('should handle optional fields inside array items (nested strict-mode)', () => {
+  const schema = z.object({
+    list: z
+      .array(
+        z.object({
+          keep: z.string(),
+          omit: z.string().optional(),
+        }),
+      )
+      .optional(),
+  });
+
+  const result = zodToJsonSchema(schema) as any;
+  expect(result.properties.list.items.type).toBe('object');
+  expect(result.required).toContain('list');
+  expect(result.properties.list.type).toEqual(['array', 'null']);
+
+  expect(result.properties.list.items.required).toContain('keep');
+  expect(result.properties.list.items.required).toContain('omit');
+
+  expect(result.properties.list.items.properties.omit.type).toEqual(['string', 'null']);
+});

--- a/packages/schema-compat/src/zod-to-json.test.ts
+++ b/packages/schema-compat/src/zod-to-json.test.ts
@@ -736,9 +736,6 @@ it('reproduce issue #16383 - optional fields must appear in required for OpenAI 
 
   const result = zodToJsonSchema(schema) as any;
 
-  console.log(JSON.stringify(result, null, 2));
-
-  // Bug 1
   expect(result.required).toBeDefined();
 
   expect(result.required).toEqual(expect.arrayContaining(['name', 'nickname']));
@@ -747,7 +744,6 @@ it('reproduce issue #16383 - optional fields must appear in required for OpenAI 
 
   expect(nicknameProp).toBeDefined();
 
-  // Bug 2
   if (nicknameProp.anyOf) {
     expect(nicknameProp.anyOf).toEqual(
       expect.arrayContaining([
@@ -767,6 +763,5 @@ it('reproduce issue #16383 - optional fields must appear in required for OpenAI 
     expect(nicknameProp.type).not.toContain('boolean');
   }
 
-  // Bug 3
   expect(nicknameProp.description).toBe('The nickname');
 });

--- a/packages/schema-compat/src/zod-to-json.test.ts
+++ b/packages/schema-compat/src/zod-to-json.test.ts
@@ -780,33 +780,10 @@ it('should handle optional fields inside array items (nested strict-mode)', () =
 
   const result = zodToJsonSchema(schema) as any;
 
-  expect(result.required).toContain('list');
-
-  expect(result.properties.list.items.required).toContain('keep');
-  expect(result.properties.list.items.required).toContain('omit');
-
-  expect(result.properties.list.items.properties.omit.type).toEqual(['string', 'null']);
-});
-
-it('should handle optional fields inside array items (nested strict-mode)', () => {
-  const schema = z.object({
-    list: z
-      .array(
-        z.object({
-          keep: z.string(),
-          omit: z.string().optional(),
-        }),
-      )
-      .optional(),
-  });
-
-  const result = zodToJsonSchema(schema) as any;
   expect(result.properties.list.items.type).toBe('object');
   expect(result.required).toContain('list');
   expect(result.properties.list.type).toEqual(['array', 'null']);
-
   expect(result.properties.list.items.required).toContain('keep');
   expect(result.properties.list.items.required).toContain('omit');
-
   expect(result.properties.list.items.properties.omit.type).toEqual(['string', 'null']);
 });

--- a/packages/schema-compat/src/zod-to-json.test.ts
+++ b/packages/schema-compat/src/zod-to-json.test.ts
@@ -787,3 +787,141 @@ it('should handle optional fields inside array items (nested strict-mode)', () =
   expect(result.properties.list.items.required).toContain('omit');
   expect(result.properties.list.items.properties.omit.type).toEqual(['string', 'null']);
 });
+
+describe('strict-mode widening for anyOf, oneOf, enum, and const', () => {
+  // GAP #1: ensureAllPropertiesRequired widens only fields that have a `type` string/array.
+  // A pure anyOf schema (z.union) has no `type` field, so it gets added to `required` but
+  // is NOT widened with a `null` branch. OpenAI strict mode then sees a required field
+  // that cannot be null, even though the source was .optional().
+  it('GAP #1a: optional z.union field gets a null branch', () => {
+    const schema = z.object({
+      id: z.union([z.string(), z.number()]).optional(),
+    });
+
+    const result = zodToJsonSchema(schema) as any;
+
+    expect(result.required).toContain('id');
+
+    const idProp = result.properties.id;
+
+    if (idProp.anyOf) {
+      const hasNull = idProp.anyOf.some(
+        (v: any) => v && (v.type === 'null' || (Array.isArray(v.type) && v.type.includes('null'))),
+      );
+      expect(hasNull).toBe(true);
+    } else if (idProp.oneOf) {
+      const hasNull = idProp.oneOf.some(
+        (v: any) => v && (v.type === 'null' || (Array.isArray(v.type) && v.type.includes('null'))),
+      );
+      expect(hasNull).toBe(true);
+    } else if (Array.isArray(idProp.type)) {
+      expect(idProp.type).toContain('null');
+    } else {
+      // Field is required but has no way to express null — strict mode would reject.
+      throw new Error(`optional union field has no null branch. Got: ${JSON.stringify(idProp)}`);
+    }
+  });
+
+  it('GAP #1b: optional z.discriminatedUnion field gets a null branch', () => {
+    const schema = z.object({
+      event: z
+        .discriminatedUnion('kind', [
+          z.object({ kind: z.literal('a'), value: z.string() }),
+          z.object({ kind: z.literal('b'), count: z.number() }),
+        ])
+        .optional(),
+    });
+
+    const result = zodToJsonSchema(schema) as any;
+
+    expect(result.required).toContain('event');
+
+    const eventProp = result.properties.event;
+
+    if (eventProp.anyOf) {
+      const hasNull = eventProp.anyOf.some(
+        (v: any) => v && (v.type === 'null' || (Array.isArray(v.type) && v.type.includes('null'))),
+      );
+      expect(hasNull).toBe(true);
+    } else if (eventProp.oneOf) {
+      const hasNull = eventProp.oneOf.some(
+        (v: any) => v && (v.type === 'null' || (Array.isArray(v.type) && v.type.includes('null'))),
+      );
+      expect(hasNull).toBe(true);
+    } else if (Array.isArray(eventProp.type)) {
+      expect(eventProp.type).toContain('null');
+    } else {
+      throw new Error(`optional discriminated union has no null branch. Got: ${JSON.stringify(eventProp)}`);
+    }
+  });
+
+  // GAP #2: the v4 override's typeMap only handles string/number/boolean/integer.
+  // For things like z.enum() and z.literal(), the override bails and the schema
+  // ends up with type 'string' + an enum/const constraint that doesn't include null.
+  // After ensureAllPropertiesRequired widens type to ['string','null'], the enum
+  // constraint still lacks 'null', so a null value would fail the enum/const check.
+  it('GAP #2a: optional z.enum produces a schema where null satisfies the type but not the enum', () => {
+    const schema = z.object({
+      status: z.enum(['a', 'b']).optional(),
+    });
+
+    const result = zodToJsonSchema(schema) as any;
+
+    expect(result.required).toContain('status');
+
+    const statusProp = result.properties.status;
+
+    // If the field has an enum constraint, null must be a valid enum value for strict mode.
+    if (statusProp.enum) {
+      expect(statusProp.enum).toContain(null);
+    }
+  });
+
+  it('GAP #2b: optional z.literal produces a schema where null satisfies the type but not the const', () => {
+    const schema = z.object({
+      kind: z.literal('only').optional(),
+    });
+
+    const result = zodToJsonSchema(schema) as any;
+
+    expect(result.required).toContain('kind');
+
+    const kindProp = result.properties.kind;
+
+    // If the field has a const constraint, anyOf-with-null or const-allowing-null is required.
+    // A widened type alone is insufficient because the const still pins the value.
+    if ('const' in kindProp) {
+      // Either the const is gone (replaced with enum that includes null) or there's an anyOf
+      if (kindProp.anyOf) {
+        const hasNull = kindProp.anyOf.some((v: any) => v && v.type === 'null');
+        expect(hasNull).toBe(true);
+      } else {
+        throw new Error(`optional literal still has const without null escape. Got: ${JSON.stringify(kindProp)}`);
+      }
+    }
+  });
+
+  // GAP #3: zodToJsonSchema never calls ensureAdditionalPropertiesFalse / prepareJsonSchemaForOpenAIStrictMode.
+  // For v4 the override sets additionalProperties: false on ZodObject nodes, but not on
+  // ZodRecord. For v3 the library default does. But what about a JSON schema with a nested
+  // object inside additionalProperties that doesn't have additionalProperties: false set?
+  // The cleanest way to demonstrate: an inner object inside a record value should be strict.
+  it('GAP #3: object inside record additionalProperties has additionalProperties: false', () => {
+    const schema = z.object({
+      bag: createRecord(
+        z.object({
+          inner: z.string(),
+        }),
+      ),
+    });
+
+    const result = zodToJsonSchema(schema) as any;
+
+    const bagProp = result.properties.bag;
+    const innerObjectSchema = bagProp.additionalProperties;
+
+    expect(innerObjectSchema).toBeDefined();
+    expect(innerObjectSchema.type).toBe('object');
+    expect(innerObjectSchema.additionalProperties).toBe(false);
+  });
+});

--- a/packages/schema-compat/src/zod-to-json.test.ts
+++ b/packages/schema-compat/src/zod-to-json.test.ts
@@ -508,7 +508,7 @@ describe('zodToJsonSchema', () => {
 
       expect(result).toBeDefined();
       expect(result.required).toContain('required');
-      expect(result.required).not.toContain('optional');
+      expect(result.required).toContain('optional');
     });
 
     it('should handle arrays', () => {
@@ -603,21 +603,20 @@ describe('zodToJsonSchema', () => {
 
 describe('ensureAllPropertiesRequired', () => {
   it('should add all properties to required array for object schemas', () => {
-    const schema = zodToJsonSchema(
-      z.object({
-        isComplete: z.boolean(),
-        completionReason: z.string(),
-        finalResult: z.string().optional(),
-      }),
-    );
+    // Test ensureAllPropertiesRequired directly on a raw JSON schema
+    // (zodToJsonSchema already calls this internally now)
+    const rawSchema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        isComplete: { type: 'boolean' },
+        completionReason: { type: 'string' },
+        finalResult: { type: 'string' },
+      },
+      required: ['isComplete', 'completionReason'],
+    };
 
-    // Before fix: finalResult should be in properties but NOT in required
-    expect(schema.properties).toHaveProperty('finalResult');
-    expect(schema.required).not.toContain('finalResult');
+    const fixed = ensureAllPropertiesRequired(rawSchema);
 
-    const fixed = ensureAllPropertiesRequired(schema);
-
-    // After fix: ALL properties should be in required
     expect(fixed.required).toContain('isComplete');
     expect(fixed.required).toContain('completionReason');
     expect(fixed.required).toContain('finalResult');
@@ -713,7 +712,7 @@ describe('ensureAllPropertiesRequired', () => {
     expect(branch.required).toContain('b');
   });
 
-  it('should not modify zodToJsonSchema default behavior', () => {
+  it('zodToJsonSchema puts all fields in required for OpenAI strict mode', () => {
     const schema = z.object({
       required: z.string(),
       optional: z.string().optional(),
@@ -721,6 +720,53 @@ describe('ensureAllPropertiesRequired', () => {
 
     const result = zodToJsonSchema(schema);
     expect(result.required).toContain('required');
-    expect(result.required).not.toContain('optional');
+    expect(result.required).toContain('optional');
   });
+});
+
+it('reproduce issue #16383 - optional fields must appear in required for OpenAI strict mode', () => {
+  // Zod optional fields normally disappear from `required`
+  // OpenAI strict mode requires all fields in `required`
+  // and optionals widened to nullable.
+
+  const schema = z.object({
+    name: z.string(),
+    nickname: z.string().optional().describe('The nickname'),
+  });
+
+  const result = zodToJsonSchema(schema) as any;
+
+  console.log(JSON.stringify(result, null, 2));
+
+  // Bug 1
+  expect(result.required).toBeDefined();
+
+  expect(result.required).toEqual(expect.arrayContaining(['name', 'nickname']));
+
+  const nicknameProp = result.properties?.nickname;
+
+  expect(nicknameProp).toBeDefined();
+
+  // Bug 2
+  if (nicknameProp.anyOf) {
+    expect(nicknameProp.anyOf).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'string',
+        }),
+        expect.objectContaining({
+          type: 'null',
+        }),
+      ]),
+    );
+  } else {
+    expect(nicknameProp.type).toEqual(expect.arrayContaining(['string', 'null']));
+
+    expect(nicknameProp.type).not.toContain('number');
+
+    expect(nicknameProp.type).not.toContain('boolean');
+  }
+
+  // Bug 3
+  expect(nicknameProp.description).toBe('The nickname');
 });

--- a/packages/schema-compat/src/zod-to-json.ts
+++ b/packages/schema-compat/src/zod-to-json.ts
@@ -164,6 +164,49 @@ function fixAnyOfNullable(schema: JSONSchema7): JSONSchema7 {
 }
 
 /**
+ * Widen a previously-optional property schema so it accepts null.
+ *
+ * OpenAI strict mode requires every property to appear in `required`, so we express
+ * optionality by allowing null. The widening depends on the shape of the property:
+ *
+ *   - `const`: can't be widened in place (the const pins the value), so wrap in
+ *     `anyOf: [originalSchema, {type: 'null'}]`.
+ *   - `anyOf` / `oneOf`: push `{type: 'null'}` as another variant.
+ *   - scalar `type` (string or array): widen the type to include `'null'`. If the
+ *     schema also has an `enum`, append `null` to it so null satisfies both
+ *     constraints.
+ */
+function widenOptionalForNull(prop: any): any {
+  if ('const' in prop) {
+    return { anyOf: [prop, { type: 'null' }] };
+  }
+
+  if (prop.anyOf) {
+    const hasNull = prop.anyOf.some((v: any) => v && v.type === 'null');
+    return hasNull ? prop : { ...prop, anyOf: [...prop.anyOf, { type: 'null' }] };
+  }
+
+  if (prop.oneOf) {
+    const hasNull = prop.oneOf.some((v: any) => v && v.type === 'null');
+    return hasNull ? prop : { ...prop, oneOf: [...prop.oneOf, { type: 'null' }] };
+  }
+
+  let widened: any = prop;
+
+  if (widened.type && !Array.isArray(widened.type) && widened.type !== 'null') {
+    widened = { ...widened, type: [widened.type, 'null'] };
+  } else if (Array.isArray(widened.type) && !widened.type.includes('null')) {
+    widened = { ...widened, type: [...widened.type, 'null'] };
+  }
+
+  if (widened.enum && Array.isArray(widened.enum) && !widened.enum.includes(null)) {
+    widened = { ...widened, enum: [...widened.enum, null] };
+  }
+
+  return widened;
+}
+
+/**
  * Recursively ensures all properties in an object schema are included in the `required` array.
  * OpenAI's strict structured output mode requires every key in `properties` to also appear in `required`.
  *
@@ -185,14 +228,8 @@ export function ensureAllPropertiesRequired(schema: JSONSchema7): JSONSchema7 {
       Object.entries(result.properties).map(([key, value]) => {
         const prop = ensureAllPropertiesRequired(value as JSONSchema7) as any;
 
-        // Field was optional (not in required before) — widen type to include null
         if (!existingRequired.includes(key)) {
-          if (prop.type && !Array.isArray(prop.type) && prop.type !== 'null') {
-            return [key, { ...prop, type: [prop.type, 'null'] }];
-          }
-          if (Array.isArray(prop.type) && !prop.type.includes('null')) {
-            return [key, { ...prop, type: [...prop.type, 'null'] }];
-          }
+          return [key, widenOptionalForNull(prop)];
         }
 
         return [key, prop];

--- a/packages/schema-compat/src/zod-to-json.ts
+++ b/packages/schema-compat/src/zod-to-json.ts
@@ -131,7 +131,7 @@ function fixAnyOfNullable(schema: JSONSchema7): JSONSchema7 {
           !Array.isArray(propSchema) &&
           Object.keys(propSchema).length === 0
         ) {
-          return [key, { type: ['string', 'number', 'boolean', 'null'] as JSONSchema7['type'] }];
+          return [key, propSchema]; //override will handle it
         }
 
         // Recursively fix nested schemas
@@ -178,9 +178,25 @@ export function ensureAllPropertiesRequired(schema: JSONSchema7): JSONSchema7 {
   const result = { ...schema };
 
   if (result.type === 'object' && result.properties) {
+    const existingRequired = result.required ?? [];
     result.required = Object.keys(result.properties);
+
     result.properties = Object.fromEntries(
-      Object.entries(result.properties).map(([key, value]) => [key, ensureAllPropertiesRequired(value as JSONSchema7)]),
+      Object.entries(result.properties).map(([key, value]) => {
+        const prop = ensureAllPropertiesRequired(value as JSONSchema7) as any;
+
+        // Field was optional (not in required before) — widen type to include null
+        if (!existingRequired.includes(key)) {
+          if (prop.type && !Array.isArray(prop.type) && prop.type !== 'null') {
+            return [key, { ...prop, type: [prop.type, 'null'] }];
+          }
+          if (Array.isArray(prop.type) && !prop.type.includes('null')) {
+            return [key, { ...prop, type: [...prop.type, 'null'] }];
+          }
+        }
+
+        return [key, prop];
+      }),
     );
   }
 
@@ -308,16 +324,42 @@ export function zodToJsonSchema(
         if (def && (def.typeName === 'ZodObject' || def.type === 'object')) {
           ctx.jsonSchema.additionalProperties = false;
         }
+
+        // handle optional fields at source — emit [T, "null"] instead of {}
+        if (def && (def.type === 'optional' || def.typeName === 'ZodOptional')) {
+          const innerDef = def.innerType?._zod?.def || def.innerType?._def;
+          if (innerDef) {
+            const description = ctx.zodSchema.description;
+            const typeMap: Record<string, string> = {
+              string: 'string',
+              ZodString: 'string',
+              number: 'number',
+              ZodNumber: 'number',
+              boolean: 'boolean',
+              ZodBoolean: 'boolean',
+              integer: 'integer',
+              ZodBigInt: 'integer',
+            };
+            const innerType = typeMap[innerDef.type] || typeMap[innerDef.typeName];
+            if (innerType) {
+              ctx.jsonSchema.type = [innerType, 'null'];
+              if (description) ctx.jsonSchema.description = description;
+            }
+          }
+        }
       },
     }) as JSONSchema7;
 
-    // Fix anyOf patterns for nullable fields - required for OpenAI compatibility
-    return fixAnyOfNullable(jsonSchema);
+    // Fix anyOf patterns for nullable fields - required for OpenAI compatibility + ensure all properties in required
+    return ensureAllPropertiesRequired(fixAnyOfNullable(jsonSchema));
   } else {
     // Zod v3 path - use the original converter
-    return zodToJsonSchemaOriginal(zodSchema as ZodSchemaV3, {
+    const jsonSchema = zodToJsonSchemaOriginal(zodSchema as ZodSchemaV3, {
       $refStrategy: strategy,
       target,
     }) as JSONSchema7;
+
+    // Same post-processing as v4: fix anyOf patterns + ensure all properties in required
+    return ensureAllPropertiesRequired(fixAnyOfNullable(jsonSchema));
   }
 }


### PR DESCRIPTION
## Description

`@mastra/schema-compat`'s `zodToJsonSchema` produced JSON Schema that failed OpenAI strict-mode structured outputs in two ways:

**Zod v3 + `.optional()` → HTTP 400**
Optional fields were excluded from the `required` array. OpenAI strict mode requires every key in `properties` to appear in `required`.

**Zod v4 + `.optional()` → type mangled to `["string","number","boolean","null"]`**
The `fixAnyOfNullable` fallback for empty `{}` schemas replaced the type with a primitive union, causing the LLM to fill the field with wrong types and breaking downstream validation. Description metadata was also stripped.

### Changes

- **`zod-to-json.ts` — v4 path**: Added `ZodOptional` handler in the `override` callback to emit `[T, "null"]` at source instead of `{}`
- **`zod-to-json.ts` — v3 path**: Apply `fixAnyOfNullable` + `ensureAllPropertiesRequired` post-processing (was returning raw output before)
- **`zod-to-json.ts` — `fixAnyOfNullable`**: Stop mangling empty `{}` schemas to primitive union — leave them for the override to handle
- **`zod-to-json.ts` — `ensureAllPropertiesRequired`**: When adding a previously-optional field to `required`, widen its type to `[T, "null"]` to satisfy OpenAI strict mode
- **`zod-to-json.test.ts`**: Added regression test for issue #16383; updated two stale tests that were asserting the old broken behavior

### Result

Both v3 and v4 optional fields now produce:
```json
{
  "properties": {
    "nickname": { "type": ["string", "null"], "description": "..." }
  },
  "required": ["name", "nickname"],
  "additionalProperties": false
}
```

## Related issue(s)

Fixes #16383

Repro: https://github.com/bluepnume/mastra-bug-repros/tree/main/openai-strict-mode

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR fixes schema generation so optional fields never get dropped or turned into "anything goes" types for OpenAI strict mode — every property is listed as required and optional fields are explicitly widened to allow null while keeping descriptions.

## Problem
zodToJsonSchema produced JSON Schema incompatible with OpenAI strict-mode:
- Zod v3: .optional() omitted fields from required, causing OpenAI strict-mode to reject the schema.
- Zod v4: .optional() produced empty {} schemas which prior post-processing mangled into primitive unions (["string","number","boolean","null"]), losing correct types and metadata.

Cross-provider reuse risk: schemas built for other providers could break when reused with OpenAI strict-mode.

## Solution
- Zod v4: added a ZodOptional override to emit the inner schema widened to include "null" (type: [T, "null"]) at conversion time and preserve description/metadata.
- Zod v3: run the stricter post-processing pipeline on v3 outputs (fixAnyOfNullable then ensureAllPropertiesRequired) instead of returning raw conversion results.
- fixAnyOfNullable: stop converting empty {} property schemas into primitive-type unions; leave that handling to optional-handling logic.
- ensureAllPropertiesRequired / widenOptionalForNull:
  - Ensures every key in properties appears in required (OpenAI strict-mode requirement).
  - Widens previously-optional property schemas to accept null, handling const/enum/anyOf/oneOf/type-array forms and preserving other metadata.
- Tests:
  - Added regression test for `#16383`.
  - Updated tests to assert optional fields are included in required and widened to include null while preserving descriptions.
  - Added nested test covering optional object properties inside optional array items (verifies items' required includes previously-optional fields and their types are widened to ['string','null']).

## Files changed (high level)
- packages/schema-compat/src/zod-to-json.ts
  - Added Zod v4 optional handling, changed fixAnyOfNullable behavior, implemented ensureAllPropertiesRequired (with widening), and applied post-processing to both v3 and v4 conversion paths.
- packages/schema-compat/src/zod-to-json.test.ts
  - Updated and expanded tests (regression `#16383`, nested array/item coverage, and direct helper tests).
- .changeset/fix-schema-compat-openai-strict-mode.md
  - Patch changeset documenting the fix.

## Result
Zod v3 and v4 now produce OpenAI strict-mode-compatible JSON Schema: every property in properties appears in required; optional fields are widened to include null (e.g., ["<type>","null"] or equivalent) and descriptions/metadata are preserved. Fixes `#16383`.

## Reviewer notes / remaining risks
- A reviewer initially pointed out recursion gate concerns for nested schemas; the author added a nested-array test that demonstrates the PR passes (the reviewer re-tested and deleted their objection).
- Additional strict-mode edge cases were later raised (optional unions, discriminated unions, enums, literals) and a follow-up helper (widenOptionalForNull) was proposed in a separate commit/branch; those changes are not part of this PR but were suggested to be copied/cherry-picked if desired.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->