### PR TITLE
feat(mastracode): add /skill/<name> command to activate skills explicitly

### DIFF
--- a/.changeset/cozy-walls-teach.md
+++ b/.changeset/cozy-walls-teach.md
@@ -2,11 +2,11 @@
 'mastracode': minor
 ---
 
-Added the `/skill:<name>` command to explicitly activate an installed workspace skill in the current conversation. This complements automatic skill activation and mirrors the `/skill:<name>` form from Pi agent.
+Added the `/skill/<name>` command to explicitly activate an installed workspace skill in the current conversation. This complements automatic skill activation.
 
 ```text
-/skill:github-triage
-/skill:release-check focus tests
+/skill/github-triage
+/skill/release-check focus tests
 ```
 
 The command loads the skill's instructions (plus any `references/`, `scripts/`, and `assets/` paths the skill ships) and sends them to the agent. Use `/skills` to list available skills.

--- a/.changeset/cozy-walls-teach.md
+++ b/.changeset/cozy-walls-teach.md
@@ -11,4 +11,15 @@ Added the `/skill/<name>` command to explicitly activate an installed workspace 
 
 The command loads the skill's instructions (plus any `references/`, `scripts/`, and `assets/` paths the skill ships) and sends them to the agent. Use `/skills` to list available skills.
 
+Skills can opt out of direct user invocation by setting `metadata.userInvokable: false` in their frontmatter — those skills remain available for automatic activation by the agent but do not appear in `/skill/<name>` autocomplete, the `/skills` listing, or accept direct invocation.
+
+```md title=".mastracode/skills/internal-helper/SKILL.md"
+---
+name: internal-helper
+description: Used by the agent internally; not for direct user invocation.
+metadata:
+  userInvokable: false
+---
+```
+
 Closes #16344.

--- a/.changeset/cozy-walls-teach.md
+++ b/.changeset/cozy-walls-teach.md
@@ -11,14 +11,13 @@ Added the `/skill/<name>` command to explicitly activate an installed workspace 
 
 The command loads the skill's instructions (plus any `references/`, `scripts/`, and `assets/` paths the skill ships) and sends them to the agent. Use `/skills` to list available skills.
 
-Skills can opt out of direct user invocation by setting `metadata.userInvokable: false` in their frontmatter — those skills remain available for automatic activation by the agent but do not appear in `/skill/<name>` autocomplete, the `/skills` listing, or accept direct invocation.
+Skills can opt out of direct user invocation by setting `user-invocable: false` in their frontmatter — those skills remain available for automatic activation by the agent but do not appear in `/skill/<name>` autocomplete, the `/skills` listing, or accept direct invocation.
 
 ```md title=".mastracode/skills/internal-helper/SKILL.md"
 ---
 name: internal-helper
 description: Used by the agent internally; not for direct user invocation.
-metadata:
-  userInvokable: false
+user-invocable: false
 ---
 ```
 

--- a/.changeset/cozy-walls-teach.md
+++ b/.changeset/cozy-walls-teach.md
@@ -1,0 +1,14 @@
+---
+'mastracode': minor
+---
+
+Added the `/skill:<name>` command to explicitly activate an installed workspace skill in the current conversation. This complements automatic skill activation and mirrors the `/skill:<name>` form from Pi agent.
+
+```text
+/skill:github-triage
+/skill:release-check focus tests
+```
+
+The command loads the skill's instructions (plus any `references/`, `scripts/`, and `assets/` paths the skill ships) and sends them to the agent. Use `/skills` to list available skills.
+
+Closes #16344.

--- a/.changeset/shared-skill-formatter.md
+++ b/.changeset/shared-skill-formatter.md
@@ -4,6 +4,8 @@
 
 Exposed `formatSkillActivation(skill)` from `@mastra/core/workspace`. It returns the activation payload — instructions plus references, scripts, and assets listings — that the built-in `skill` tool uses, so callers (e.g. an explicit `/skill/<name>` slash command) can produce the same output without duplicating the formatting logic.
 
+Also preserves the `user-invocable` skill frontmatter field in workspace skill metadata.
+
 ```ts
 import { formatSkillActivation } from '@mastra/core/workspace';
 

--- a/.changeset/shared-skill-formatter.md
+++ b/.changeset/shared-skill-formatter.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+Exposed `formatSkillActivation(skill)` from `@mastra/core/workspace`. It returns the activation payload — instructions plus references, scripts, and assets listings — that the built-in `skill` tool uses, so callers (e.g. an explicit `/skill/<name>` slash command) can produce the same output without duplicating the formatting logic.
+
+```ts
+import { formatSkillActivation } from '@mastra/core/workspace';
+
+const content = formatSkillActivation(skill);
+```

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -324,6 +324,8 @@ Use `/skill/<name>` to activate a specific skill in the current conversation:
 
 Mastra Code loads the skill instructions and sends them to the agent before the next response.
 
+Set `user-invocable: false` in `SKILL.md` frontmatter to hide a skill from `/skill/<name>` autocomplete, the `/skills` listing, and direct activation. The agent can still load that skill automatically when relevant.
+
 Add `metadata.goal: true` to expose a skill as a goal entry point under `/goal/<skill-name>`:
 
 ```md title=".mastracode/skills/release-check/SKILL.md"

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -314,6 +314,14 @@ Mastra Code scans these directories for skills:
 
 Each skill is a directory containing a `SKILL.md` file with instructions and trigger descriptions. Skills installed via symlinks (e.g., from `npx skills add`) are automatically resolved.
 
+Use `/skill:<name>` to activate a specific skill in the current conversation:
+
+```text
+/skill:release-check
+```
+
+Mastra Code loads the skill instructions and sends them to the agent before the next response.
+
 Add `metadata.goal: true` to expose a skill as a goal entry point under `/goal/<skill-name>`:
 
 ```md title=".mastracode/skills/release-check/SKILL.md"

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -309,15 +309,17 @@ Mastra Code scans these directories for skills:
 | - | - | - |
 | Highest | `.mastracode/skills/` | Project |
 | | `.claude/skills/` | Project (Claude Code compatible) |
+| | `.agents/skills/` | Project (Agent Skills spec compatible) |
 | | `~/.mastracode/skills/` | Global |
-| Lowest | `~/.claude/skills/` | Global (Claude Code compatible) |
+| | `~/.claude/skills/` | Global (Claude Code compatible) |
+| Lowest | `~/.agents/skills/` | Global (Agent Skills spec compatible) |
 
 Each skill is a directory containing a `SKILL.md` file with instructions and trigger descriptions. Skills installed via symlinks (e.g., from `npx skills add`) are automatically resolved.
 
-Use `/skill:<name>` to activate a specific skill in the current conversation:
+Use `/skill/<name>` to activate a specific skill in the current conversation:
 
 ```text
-/skill:release-check
+/skill/release-check
 ```
 
 Mastra Code loads the skill instructions and sends them to the agent before the next response.

--- a/docs/src/mastra-code/index.mdx
+++ b/docs/src/mastra-code/index.mdx
@@ -100,7 +100,7 @@ Mastra Code provides built-in slash commands for managing sessions and settings:
 | `/settings` | Open the settings panel |
 | `/om` | Configure Observational Memory |
 | `/skills` | List available skills |
-| `/skill:<name>` | Activate a specific skill |
+| `/skill/<name>` | Activate a specific skill |
 | `/cost` | Show token usage and costs |
 | `/diff` | Show modified files or git diff |
 | `/sandbox` | Manage sandbox allowed paths |

--- a/docs/src/mastra-code/index.mdx
+++ b/docs/src/mastra-code/index.mdx
@@ -100,6 +100,7 @@ Mastra Code provides built-in slash commands for managing sessions and settings:
 | `/settings` | Open the settings panel |
 | `/om` | Configure Observational Memory |
 | `/skills` | List available skills |
+| `/skill:<name>` | Activate a specific skill |
 | `/cost` | Show token usage and costs |
 | `/diff` | Show modified files or git diff |
 | `/sandbox` | Manage sandbox allowed paths |

--- a/mastracode/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/src/tui/__tests__/command-dispatch.test.ts
@@ -125,11 +125,11 @@ describe('dispatchSlashCommand models routing', () => {
     expect(mocks.handleJudgeCommand).toHaveBeenCalledWith(ctx);
   });
 
-  it('routes /skill:name to handleSkillCommand', async () => {
+  it('routes /skill/name to handleSkillCommand', async () => {
     const state = { customSlashCommands: [] } as any;
     const ctx = {} as any;
 
-    const handled = await dispatchSlashCommand('/skill:github-triage focus tests', state, () => ctx);
+    const handled = await dispatchSlashCommand('/skill/github-triage focus tests', state, () => ctx);
 
     expect(handled).toBe(true);
     expect(mocks.handleSkillCommand).toHaveBeenCalledTimes(1);

--- a/mastracode/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/src/tui/__tests__/command-dispatch.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   handleModelsPackCommand: vi.fn().mockResolvedValue(undefined),
   handleCustomProvidersCommand: vi.fn().mockResolvedValue(undefined),
   handleGoalCommand: vi.fn().mockResolvedValue(undefined),
+  handleSkillCommand: vi.fn().mockResolvedValue(undefined),
   handleJudgeCommand: vi.fn().mockResolvedValue(undefined),
   processSlashCommand: vi.fn().mockResolvedValue('custom output'),
   startGoalWithDefaults: vi.fn().mockResolvedValue(undefined),
@@ -24,6 +25,7 @@ vi.mock('../commands/index.js', () => ({
   handleHooksCommand: vi.fn(),
   handleMcpCommand: vi.fn(),
   handleModeCommand: vi.fn(),
+  handleSkillCommand: mocks.handleSkillCommand,
   handleSkillsCommand: vi.fn(),
   handleNewCommand: vi.fn(),
   handleResourceCommand: vi.fn(),
@@ -72,6 +74,7 @@ describe('dispatchSlashCommand models routing', () => {
     mocks.handleModelsPackCommand.mockClear();
     mocks.handleCustomProvidersCommand.mockClear();
     mocks.handleGoalCommand.mockClear();
+    mocks.handleSkillCommand.mockClear();
     mocks.handleJudgeCommand.mockClear();
     mocks.processSlashCommand.mockClear();
     mocks.startGoalWithDefaults.mockClear();
@@ -120,6 +123,18 @@ describe('dispatchSlashCommand models routing', () => {
     expect(handled).toBe(true);
     expect(mocks.handleJudgeCommand).toHaveBeenCalledTimes(1);
     expect(mocks.handleJudgeCommand).toHaveBeenCalledWith(ctx);
+  });
+
+  it('routes /skill:name to handleSkillCommand', async () => {
+    const state = { customSlashCommands: [] } as any;
+    const ctx = {} as any;
+
+    const handled = await dispatchSlashCommand('/skill:github-triage focus tests', state, () => ctx);
+
+    expect(handled).toBe(true);
+    expect(mocks.handleSkillCommand).toHaveBeenCalledTimes(1);
+    expect(mocks.handleSkillCommand).toHaveBeenCalledWith(ctx, 'github-triage', ['focus', 'tests']);
+    expect(mocks.showError).not.toHaveBeenCalled();
   });
 
   it('routes multiline /goal objectives as a single goal argument', async () => {

--- a/mastracode/src/tui/__tests__/render-messages.test.ts
+++ b/mastracode/src/tui/__tests__/render-messages.test.ts
@@ -65,6 +65,38 @@ describe('addUserMessage', () => {
     expect(state.messageComponentsById.get('signal-slash')).toBe(slashComp);
   });
 
+  it('dedupes echoed <skill> activation messages against the optimistic skill component', () => {
+    const state = createState();
+    const skillComp = new SlashCommandComponent('skill/github-triage', 'Review the issue.');
+    state.allSlashCommandComponents.push(skillComp);
+    state.chatContainer.addChild(skillComp);
+
+    addUserMessage(
+      state,
+      createUserMessage('<skill name="github-triage">\nReview the issue.\n</skill>', 'signal-skill'),
+    );
+
+    expect(state.chatContainer.children).toEqual([skillComp]);
+    expect(state.chatContainer.children).toHaveLength(1);
+    expect(state.allSlashCommandComponents).toHaveLength(1);
+    expect(state.messageComponentsById.get('signal-skill')).toBe(skillComp);
+  });
+
+  it('renders a fresh skill component when replaying a persisted <skill> message with no optimistic component', () => {
+    const state = createState();
+
+    addUserMessage(
+      state,
+      createUserMessage('<skill name="github-triage">\nReview the issue.\n</skill>', 'replay-skill'),
+    );
+
+    expect(state.chatContainer.children).toHaveLength(1);
+    expect(state.chatContainer.children[0]).toBeInstanceOf(SlashCommandComponent);
+    expect(state.allSlashCommandComponents).toHaveLength(1);
+    // No raw UserMessageComponent should have been added alongside the skill component.
+    expect(state.chatContainer.children.some(c => c instanceof UserMessageComponent)).toBe(false);
+  });
+
   it('renders a persisted temporal-gap marker from canonical system reminder content', () => {
     const state = createState();
 

--- a/mastracode/src/tui/__tests__/render-messages.test.ts
+++ b/mastracode/src/tui/__tests__/render-messages.test.ts
@@ -97,6 +97,28 @@ describe('addUserMessage', () => {
     expect(state.chatContainer.children.some(c => c instanceof UserMessageComponent)).toBe(false);
   });
 
+  it('decodes the </skill> boundary token when replaying a persisted <skill> message', () => {
+    const state = createState();
+
+    addUserMessage(
+      state,
+      createUserMessage(
+        '<skill name="github-triage">\nUse <div>, A&B, "quotes". Embedded &lt;/skill&gt; stays out of the way.\n</skill>',
+        'escaped-skill',
+      ),
+    );
+
+    const skillComp = state.chatContainer.children[0] as SlashCommandComponent;
+    // General XML/HTML is passed through unchanged; only the &lt;/skill&gt;
+    // boundary token gets decoded back to a literal </skill>.
+    expect(
+      skillComp.matches(
+        'skill/github-triage',
+        'Use <div>, A&B, "quotes". Embedded </skill> stays out of the way.',
+      ),
+    ).toBe(true);
+  });
+
   it('renders a persisted temporal-gap marker from canonical system reminder content', () => {
     const state = createState();
 

--- a/mastracode/src/tui/__tests__/render-messages.test.ts
+++ b/mastracode/src/tui/__tests__/render-messages.test.ts
@@ -109,10 +109,7 @@ describe('addUserMessage', () => {
 
     const skillComp = state.chatContainer.children[0] as SlashCommandComponent;
     expect(
-      skillComp.matches(
-        'skill/github-triage',
-        'Use <div>, A&B, "quotes". Embedded </skill> stays out of the way.',
-      ),
+      skillComp.matches('skill/github-triage', 'Use <div>, A&B, "quotes". Embedded </skill> stays out of the way.'),
     ).toBe(true);
   });
 

--- a/mastracode/src/tui/__tests__/render-messages.test.ts
+++ b/mastracode/src/tui/__tests__/render-messages.test.ts
@@ -93,7 +93,6 @@ describe('addUserMessage', () => {
     expect(state.chatContainer.children).toHaveLength(1);
     expect(state.chatContainer.children[0]).toBeInstanceOf(SlashCommandComponent);
     expect(state.allSlashCommandComponents).toHaveLength(1);
-    // No raw UserMessageComponent should have been added alongside the skill component.
     expect(state.chatContainer.children.some(c => c instanceof UserMessageComponent)).toBe(false);
   });
 
@@ -109,8 +108,6 @@ describe('addUserMessage', () => {
     );
 
     const skillComp = state.chatContainer.children[0] as SlashCommandComponent;
-    // General XML/HTML is passed through unchanged; only the &lt;/skill&gt;
-    // boundary token gets decoded back to a literal </skill>.
     expect(
       skillComp.matches(
         'skill/github-triage',

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -99,6 +99,9 @@ describe('setupKeyboardShortcuts', () => {
       { name: 'deploy', description: 'Deploy to prod', template: '', sourcePath: '', goal: true },
       { name: 'ship', description: 'Ship release', template: '', sourcePath: '' },
     ];
+    state.skillCommands = [
+      { name: 'lint-fix', description: 'Fix lint issues', path: '/skills/lint-fix' },
+    ];
     state.goalSkillCommands = [
       { name: 'review', description: 'Review code', path: '/skills/review', metadata: { goal: true } },
     ];
@@ -115,11 +118,13 @@ describe('setupKeyboardShortcuts', () => {
     expect(commandNames).toContain('judge');
     expect(commandNames.indexOf('thread')).toBeLessThan(commandNames.indexOf('threads'));
     expect(commandNames.indexOf('goal')).toBeLessThan(commandNames.indexOf('judge'));
+    expect(commandNames).toContain('skill:');
     expect(commandNames).not.toContain('memory-gateway');
     expect(commandNames.indexOf('/deploy')).toBeGreaterThan(commandNames.indexOf('help'));
+    expect(commandNames).toContain('skill:lint-fix');
     expect(commandNames).toContain('goal/deploy');
     expect(commandNames).toContain('goal/review');
-    expect(commandNames.slice(-4)).toEqual(['/deploy', 'goal/deploy', '/ship', 'goal/review']);
+    expect(commandNames.slice(-5)).toEqual(['/deploy', 'goal/deploy', '/ship', 'skill:lint-fix', 'goal/review']);
   });
 
   it('submits immediately on Enter when the harness is idle', () => {

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -39,7 +39,7 @@ vi.mock('../status-line.js', () => ({
 
 import { showInfo } from '../display.js';
 import { GOAL_JUDGE_INPUT_LOCK_MESSAGE } from '../goal-input-lock.js';
-import { setupAutocomplete, setupKeyboardShortcuts } from '../setup.js';
+import { refreshSkillsAutocomplete, setupAutocomplete, setupKeyboardShortcuts } from '../setup.js';
 
 function createState(isRunning: boolean) {
   const actions = new Map<string, () => unknown>();
@@ -123,6 +123,41 @@ describe('setupKeyboardShortcuts', () => {
     expect(commandNames).toContain('goal/deploy');
     expect(commandNames).toContain('goal/review');
     expect(commandNames.slice(-5)).toEqual(['/deploy', 'goal/deploy', '/ship', 'skill/lint-fix', 'goal/review']);
+  });
+
+  it('refreshes autocomplete after workspace skills resolve', async () => {
+    autocompleteProviders.length = 0;
+    const { state, editor } = createState(false);
+    state.customSlashCommands = [];
+    state.skillCommands = [];
+    state.goalSkillCommands = [];
+    state.harness.getWorkspace = vi.fn(() => undefined);
+    state.harness.hasWorkspace = vi.fn(() => true);
+    state.harness.resolveWorkspace = vi.fn(async () => ({
+      skills: {
+        list: vi.fn(async () => [
+          { name: 'review', description: 'Review code', path: '/skills/review' },
+          {
+            name: 'internal-helper',
+            description: 'Internal helper',
+            path: '/skills/internal-helper',
+            'user-invocable': false,
+          },
+        ]),
+      },
+    }));
+
+    setupAutocomplete(state);
+    await refreshSkillsAutocomplete(state);
+
+    expect(editor.setAutocompleteProvider).toHaveBeenCalledTimes(2);
+    expect(autocompleteProviders).toHaveLength(2);
+    const initialCommands = autocompleteProviders[0]?.commands.map(command => command.name) ?? [];
+    const refreshedCommands = autocompleteProviders[1]?.commands.map(command => command.name) ?? [];
+    expect(initialCommands).toContain('skill/');
+    expect(initialCommands).not.toContain('skill/review');
+    expect(refreshedCommands).toContain('skill/review');
+    expect(refreshedCommands).not.toContain('skill/internal-helper');
   });
 
   it('submits immediately on Enter when the harness is idle', () => {

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -99,9 +99,7 @@ describe('setupKeyboardShortcuts', () => {
       { name: 'deploy', description: 'Deploy to prod', template: '', sourcePath: '', goal: true },
       { name: 'ship', description: 'Ship release', template: '', sourcePath: '' },
     ];
-    state.skillCommands = [
-      { name: 'lint-fix', description: 'Fix lint issues', path: '/skills/lint-fix' },
-    ];
+    state.skillCommands = [{ name: 'lint-fix', description: 'Fix lint issues', path: '/skills/lint-fix' }];
     state.goalSkillCommands = [
       { name: 'review', description: 'Review code', path: '/skills/review', metadata: { goal: true } },
     ];

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -116,13 +116,13 @@ describe('setupKeyboardShortcuts', () => {
     expect(commandNames).toContain('judge');
     expect(commandNames.indexOf('thread')).toBeLessThan(commandNames.indexOf('threads'));
     expect(commandNames.indexOf('goal')).toBeLessThan(commandNames.indexOf('judge'));
-    expect(commandNames).toContain('skill:');
+    expect(commandNames).toContain('skill/');
     expect(commandNames).not.toContain('memory-gateway');
     expect(commandNames.indexOf('/deploy')).toBeGreaterThan(commandNames.indexOf('help'));
-    expect(commandNames).toContain('skill:lint-fix');
+    expect(commandNames).toContain('skill/lint-fix');
     expect(commandNames).toContain('goal/deploy');
     expect(commandNames).toContain('goal/review');
-    expect(commandNames.slice(-5)).toEqual(['/deploy', 'goal/deploy', '/ship', 'skill:lint-fix', 'goal/review']);
+    expect(commandNames.slice(-5)).toEqual(['/deploy', 'goal/deploy', '/ship', 'skill/lint-fix', 'goal/review']);
   });
 
   it('submits immediately on Enter when the harness is idle', () => {

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -106,8 +106,8 @@ export async function dispatchSlashCommand(
     return true;
   }
 
-  if (command.startsWith('skill:')) {
-    await handleSkillCommand(buildCtx(), command.slice('skill:'.length), args);
+  if (command.startsWith('skill/')) {
+    await handleSkillCommand(buildCtx(), command.slice('skill/'.length), args);
     return true;
   }
 

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -14,6 +14,7 @@ import {
   handleHooksCommand,
   handleMcpCommand,
   handleModeCommand,
+  handleSkillCommand,
   handleSkillsCommand,
   handleNewCommand,
   handleCloneCommand,
@@ -102,6 +103,11 @@ export async function dispatchSlashCommand(
 
   if (command.startsWith('goal/')) {
     await handleGoalSourceCommand(state, command.slice('goal/'.length), args, buildCtx());
+    return true;
+  }
+
+  if (command.startsWith('skill:')) {
+    await handleSkillCommand(buildCtx(), command.slice('skill:'.length), args);
     return true;
   }
 

--- a/mastracode/src/tui/commands/__tests__/skills.test.ts
+++ b/mastracode/src/tui/commands/__tests__/skills.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleSkillCommand } from '../skills.js';
+
+function createCtx(options?: {
+  pendingNewThread?: boolean;
+  skill?: any;
+  skills?: any[];
+  workspace?: any;
+  hasWorkspace?: boolean;
+}) {
+  const skill = options?.skill ?? {
+    name: 'github-triage',
+    instructions: '# GitHub triage\n\nReview the issue.',
+    references: ['checklist.md'],
+    scripts: ['triage.ts'],
+    assets: [],
+  };
+  const workspace =
+    options?.workspace ??
+    ({
+      skills: {
+        get: vi.fn().mockResolvedValue(skill),
+        list: vi.fn().mockResolvedValue(options?.skills ?? [skill]),
+      },
+    } as any);
+  const state = {
+    pendingNewThread: options?.pendingNewThread ?? false,
+    allSlashCommandComponents: [],
+    chatContainer: { addChild: vi.fn() },
+    ui: { requestRender: vi.fn() },
+  };
+  const harness = {
+    hasWorkspace: vi.fn(() => options?.hasWorkspace ?? true),
+    resolveWorkspace: vi.fn().mockResolvedValue(workspace),
+    createThread: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    ctx: {
+      state,
+      harness,
+      getResolvedWorkspace: vi.fn(() => workspace),
+      showInfo: vi.fn(),
+      showError: vi.fn(),
+    } as any,
+    harness,
+    state,
+    workspace,
+  };
+}
+
+describe('handleSkillCommand', () => {
+  it('loads a named skill and sends its instructions to the agent', async () => {
+    const { ctx, harness, state } = createCtx();
+
+    await handleSkillCommand(ctx, 'github-triage', ['focus', 'tests']);
+
+    expect(state.allSlashCommandComponents).toHaveLength(1);
+    expect(state.chatContainer.addChild).toHaveBeenCalledWith(state.allSlashCommandComponents[0]);
+    expect(state.ui.requestRender).toHaveBeenCalledTimes(1);
+    expect(harness.sendMessage).toHaveBeenCalledWith({
+      content:
+        '<skill name="github-triage">\n' +
+        '# GitHub triage\n\n' +
+        'Review the issue.\n\n' +
+        '## References\n' +
+        '- references/checklist.md\n\n' +
+        '## Scripts\n' +
+        '- scripts/triage.ts\n\n' +
+        'ARGUMENTS: focus tests\n' +
+        '</skill>',
+    });
+    expect(ctx.showError).not.toHaveBeenCalled();
+  });
+
+  it('creates a pending new thread before sending the skill activation', async () => {
+    const { ctx, harness, state } = createCtx({ pendingNewThread: true });
+
+    await handleSkillCommand(ctx, 'github-triage', []);
+
+    expect(harness.createThread).toHaveBeenCalledTimes(1);
+    expect(state.pendingNewThread).toBe(false);
+    expect(harness.createThread.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.sendMessage.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('shows available skills when the requested skill is not found', async () => {
+    const workspace = {
+      skills: {
+        get: vi.fn().mockResolvedValue(null),
+        list: vi.fn().mockResolvedValue([
+          { name: 'review', path: '/skills/review' },
+          { name: 'browse', path: '/skills/browse' },
+        ]),
+      },
+    };
+    const { ctx, harness } = createCtx({ workspace });
+
+    await handleSkillCommand(ctx, 'missing', []);
+
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+    expect(ctx.showError).toHaveBeenCalledWith('Skill not found: missing. Available skills: review, browse');
+  });
+
+  it('rejects empty skill names', async () => {
+    const { ctx, harness } = createCtx();
+
+    await handleSkillCommand(ctx, '', []);
+
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+    expect(ctx.showError).toHaveBeenCalledWith('Usage: /skill:<name>');
+  });
+});

--- a/mastracode/src/tui/commands/__tests__/skills.test.ts
+++ b/mastracode/src/tui/commands/__tests__/skills.test.ts
@@ -121,4 +121,30 @@ describe('handleSkillCommand', () => {
     expect(harness.sendMessage).not.toHaveBeenCalled();
     expect(ctx.showError).toHaveBeenCalledWith('Usage: /skill/<name>');
   });
+
+  it('refuses to activate a skill marked metadata.userInvokable: false', async () => {
+    const workspace = {
+      skills: {
+        get: vi.fn().mockResolvedValue({
+          name: 'internal-helper',
+          instructions: 'should not be invoked',
+          metadata: { userInvokable: false },
+          references: [],
+          scripts: [],
+          assets: [],
+        }),
+        list: vi.fn().mockResolvedValue([
+          { name: 'review', path: '/skills/review' },
+          { name: 'internal-helper', path: '/skills/internal-helper', metadata: { userInvokable: false } },
+        ]),
+      },
+    };
+    const { ctx, harness } = createCtx({ workspace });
+
+    await handleSkillCommand(ctx, 'internal-helper', []);
+
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+    // The non-user-invokable skill must also be hidden from the "Available skills" hint.
+    expect(ctx.showError).toHaveBeenCalledWith('Skill not found: internal-helper. Available skills: review');
+  });
 });

--- a/mastracode/src/tui/commands/__tests__/skills.test.ts
+++ b/mastracode/src/tui/commands/__tests__/skills.test.ts
@@ -104,6 +104,15 @@ describe('handleSkillCommand', () => {
     expect(ctx.showError).toHaveBeenCalledWith('Skill not found: missing. Available skills: review, browse');
   });
 
+  it('shows an error when no skills are configured', async () => {
+    const { ctx, harness } = createCtx({ workspace: {} });
+
+    await handleSkillCommand(ctx, 'any', []);
+
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+    expect(ctx.showError).toHaveBeenCalledWith('No skills configured.');
+  });
+
   it('rejects empty skill names', async () => {
     const { ctx, harness } = createCtx();
 

--- a/mastracode/src/tui/commands/__tests__/skills.test.ts
+++ b/mastracode/src/tui/commands/__tests__/skills.test.ts
@@ -78,9 +78,6 @@ describe('handleSkillCommand', () => {
     const { ctx, harness } = createCtx({
       skill: {
         name: 'github-triage',
-        // Legitimate XML/JSX content stays untouched so the model sees it
-        // literally; only a stray `</skill>` substring gets boundary-escaped
-        // to keep the renderer's regex from terminating early.
         instructions: 'Use <div>, A&B, "quotes". Embedded </skill> stays out of the way.',
         references: [],
         scripts: [],

--- a/mastracode/src/tui/commands/__tests__/skills.test.ts
+++ b/mastracode/src/tui/commands/__tests__/skills.test.ts
@@ -119,6 +119,6 @@ describe('handleSkillCommand', () => {
     await handleSkillCommand(ctx, '', []);
 
     expect(harness.sendMessage).not.toHaveBeenCalled();
-    expect(ctx.showError).toHaveBeenCalledWith('Usage: /skill:<name>');
+    expect(ctx.showError).toHaveBeenCalledWith('Usage: /skill/<name>');
   });
 });

--- a/mastracode/src/tui/commands/__tests__/skills.test.ts
+++ b/mastracode/src/tui/commands/__tests__/skills.test.ts
@@ -74,6 +74,30 @@ describe('handleSkillCommand', () => {
     expect(ctx.showError).not.toHaveBeenCalled();
   });
 
+  it('preserves general XML/HTML in skill content but neutralizes the </skill> boundary token', async () => {
+    const { ctx, harness } = createCtx({
+      skill: {
+        name: 'github-triage',
+        // Legitimate XML/JSX content stays untouched so the model sees it
+        // literally; only a stray `</skill>` substring gets boundary-escaped
+        // to keep the renderer's regex from terminating early.
+        instructions: 'Use <div>, A&B, "quotes". Embedded </skill> stays out of the way.',
+        references: [],
+        scripts: [],
+        assets: [],
+      },
+    });
+
+    await handleSkillCommand(ctx, 'github-triage', []);
+
+    expect(harness.sendMessage).toHaveBeenCalledWith({
+      content:
+        '<skill name="github-triage">\n' +
+        'Use <div>, A&B, "quotes". Embedded &lt;/skill&gt; stays out of the way.\n' +
+        '</skill>',
+    });
+  });
+
   it('creates a pending new thread before sending the skill activation', async () => {
     const { ctx, harness, state } = createCtx({ pendingNewThread: true });
 
@@ -122,20 +146,20 @@ describe('handleSkillCommand', () => {
     expect(ctx.showError).toHaveBeenCalledWith('Usage: /skill/<name>');
   });
 
-  it('refuses to activate a skill marked metadata.userInvokable: false', async () => {
+  it('refuses to activate a skill marked user-invocable: false', async () => {
     const workspace = {
       skills: {
         get: vi.fn().mockResolvedValue({
           name: 'internal-helper',
           instructions: 'should not be invoked',
-          metadata: { userInvokable: false },
+          'user-invocable': false,
           references: [],
           scripts: [],
           assets: [],
         }),
         list: vi.fn().mockResolvedValue([
           { name: 'review', path: '/skills/review' },
-          { name: 'internal-helper', path: '/skills/internal-helper', metadata: { userInvokable: false } },
+          { name: 'internal-helper', path: '/skills/internal-helper', 'user-invocable': false },
         ]),
       },
     };
@@ -144,7 +168,7 @@ describe('handleSkillCommand', () => {
     await handleSkillCommand(ctx, 'internal-helper', []);
 
     expect(harness.sendMessage).not.toHaveBeenCalled();
-    // The non-user-invokable skill must also be hidden from the "Available skills" hint.
+    // The non-user-invocable skill must also be hidden from the "Available skills" hint.
     expect(ctx.showError).toHaveBeenCalledWith('Skill not found: internal-helper. Available skills: review');
   });
 });

--- a/mastracode/src/tui/commands/index.ts
+++ b/mastracode/src/tui/commands/index.ts
@@ -10,7 +10,7 @@ export { handleExitCommand } from './exit.js';
 export { handleHooksCommand } from './hooks.js';
 export { handleMcpCommand } from './mcp.js';
 export { handleModeCommand } from './mode.js';
-export { handleSkillsCommand } from './skills.js';
+export { handleSkillCommand, handleSkillsCommand } from './skills.js';
 export { handleNewCommand } from './new.js';
 export { handleCloneCommand } from './clone.js';
 export { handleResourceCommand } from './resource.js';

--- a/mastracode/src/tui/commands/skill-filters.ts
+++ b/mastracode/src/tui/commands/skill-filters.ts
@@ -1,0 +1,10 @@
+import type { SkillMetadata } from '@mastra/core/workspace';
+
+/**
+ * Whether a skill should be invokable directly by the user via /skill/<name>
+ * and surfaced in the /skills listing and autocomplete. Defaults to true.
+ * Skills opt out by setting `metadata.userInvokable: false` in frontmatter.
+ */
+export function isUserInvokable(skill: Pick<SkillMetadata, 'metadata'>): boolean {
+  return skill.metadata?.userInvokable !== false;
+}

--- a/mastracode/src/tui/commands/skill-filters.ts
+++ b/mastracode/src/tui/commands/skill-filters.ts
@@ -1,10 +1,10 @@
 import type { SkillMetadata } from '@mastra/core/workspace';
 
 /**
- * Whether a skill should be invokable directly by the user via /skill/<name>
+ * Whether a skill should be invocable directly by the user via /skill/<name>
  * and surfaced in the /skills listing and autocomplete. Defaults to true.
- * Skills opt out by setting `metadata.userInvokable: false` in frontmatter.
+ * Skills opt out by setting `user-invocable: false` in SKILL.md frontmatter.
  */
-export function isUserInvokable(skill: Pick<SkillMetadata, 'metadata'>): boolean {
-  return skill.metadata?.userInvokable !== false;
+export function isUserInvocable(skill: Pick<SkillMetadata, 'user-invocable'>): boolean {
+  return skill['user-invocable'] !== false;
 }

--- a/mastracode/src/tui/commands/skills.ts
+++ b/mastracode/src/tui/commands/skills.ts
@@ -3,12 +3,8 @@ import { SlashCommandComponent } from '../components/slash-command.js';
 import { isUserInvocable } from './skill-filters.js';
 import type { SlashCommandContext } from './types.js';
 
-// The persisted `<skill name="…">…</skill>` wrapper is parsed back out by
-// `render-messages.ts` to dedup against the optimistic SlashCommandComponent.
-// Neutralize any literal closing tag inside the body so the non-greedy regex
-// terminates only at the real boundary. We deliberately do NOT escape other
-// XML characters — skill instructions frequently contain legitimate `<div>`,
-// JSX, code, etc., and the model should see those literally.
+// Keep the renderer's non-greedy `<skill>...</skill>` regex from terminating
+// on a literal closing tag inside the body. Other characters pass through.
 function escapeSkillBoundary(value: string): string {
   return value.replaceAll('</skill>', '&lt;/skill&gt;');
 }
@@ -123,9 +119,6 @@ export async function handleSkillCommand(ctx: SlashCommandContext, skillName: st
       ctx.state.pendingNewThread = false;
     }
 
-    // skill.name is spec-validated to `^[a-z0-9-]+$` so it cannot contain
-    // XML-special characters — no name escape needed. Only the body needs
-    // boundary protection (see `escapeSkillBoundary`).
     await ctx.harness.sendMessage({
       content: `<skill name="${skill.name}">\n${escapeSkillBoundary(content)}\n</skill>`,
     });

--- a/mastracode/src/tui/commands/skills.ts
+++ b/mastracode/src/tui/commands/skills.ts
@@ -1,5 +1,6 @@
 import { formatSkillActivation } from '@mastra/core/workspace';
 import { SlashCommandComponent } from '../components/slash-command.js';
+import { isUserInvokable } from './skill-filters.js';
 import type { SlashCommandContext } from './types.js';
 
 async function resolveWorkspace(ctx: SlashCommandContext) {
@@ -37,12 +38,14 @@ export async function handleSkillsCommand(ctx: SlashCommandContext): Promise<voi
   }
 
   try {
-    const skills = await workspace.skills!.list();
+    const allSkills = await workspace.skills!.list();
+    const skills = allSkills.filter(isUserInvokable);
 
     if (skills.length === 0) {
       ctx.showInfo(
-        'No skills found in configured directories.\n\n' +
+        'No user-invokable skills found in configured directories.\n\n' +
           'Each skill needs a SKILL.md file with YAML frontmatter.\n' +
+          'Skills with `metadata.userInvokable: false` are hidden from this list.\n' +
           'Install skills: npx add-skill <github-url>',
       );
       return;
@@ -86,8 +89,8 @@ export async function handleSkillCommand(ctx: SlashCommandContext, skillName: st
 
   try {
     const skill = await workspace.skills.get(normalizedSkillName);
-    if (!skill) {
-      const skills = await workspace.skills.list();
+    if (!skill || !isUserInvokable(skill)) {
+      const skills = (await workspace.skills.list()).filter(isUserInvokable);
       const available = skills.length ? ` Available skills: ${skills.map(s => s.name).join(', ')}` : '';
       ctx.showError(`Skill not found: ${normalizedSkillName}.${available}`);
       return;

--- a/mastracode/src/tui/commands/skills.ts
+++ b/mastracode/src/tui/commands/skills.ts
@@ -80,11 +80,7 @@ export async function handleSkillsCommand(ctx: SlashCommandContext): Promise<voi
   }
 }
 
-export async function handleSkillCommand(
-  ctx: SlashCommandContext,
-  skillName: string,
-  args: string[],
-): Promise<void> {
+export async function handleSkillCommand(ctx: SlashCommandContext, skillName: string, args: string[]): Promise<void> {
   const normalizedSkillName = skillName.trim();
   if (!normalizedSkillName) {
     ctx.showError('Usage: /skill:<name>');
@@ -134,6 +130,8 @@ export async function handleSkillCommand(
       content: `<skill name="${skill.name}">\n${content}\n</skill>`,
     });
   } catch (error) {
-    ctx.showError(`Error executing /skill:${normalizedSkillName}: ${error instanceof Error ? error.message : String(error)}`);
+    ctx.showError(
+      `Error executing /skill:${normalizedSkillName}: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }

--- a/mastracode/src/tui/commands/skills.ts
+++ b/mastracode/src/tui/commands/skills.ts
@@ -1,16 +1,41 @@
+import type { Skill } from '@mastra/core/workspace';
+import { SlashCommandComponent } from '../components/slash-command.js';
 import type { SlashCommandContext } from './types.js';
+
+function formatSkillForActivation(skill: Skill): string {
+  const parts = [skill.instructions];
+
+  if (skill.references?.length) {
+    parts.push(`\n\n## References\n${skill.references.map(reference => `- references/${reference}`).join('\n')}`);
+  }
+  if (skill.scripts?.length) {
+    parts.push(`\n\n## Scripts\n${skill.scripts.map(script => `- scripts/${script}`).join('\n')}`);
+  }
+  if (skill.assets?.length) {
+    parts.push(`\n\n## Assets\n${skill.assets.map(asset => `- assets/${asset}`).join('\n')}`);
+  }
+
+  return parts.join('');
+}
+
+async function resolveWorkspace(ctx: SlashCommandContext) {
+  let workspace = ctx.getResolvedWorkspace();
+  if (!workspace && ctx.harness.hasWorkspace()) {
+    workspace = await ctx.harness.resolveWorkspace();
+  }
+  return workspace;
+}
 
 export async function handleSkillsCommand(ctx: SlashCommandContext): Promise<void> {
   // Eagerly resolve workspace if not yet cached (e.g. /skills called before first message)
-  let workspace = ctx.getResolvedWorkspace();
-  if (!workspace && ctx.harness.hasWorkspace()) {
-    try {
-      workspace = await ctx.harness.resolveWorkspace();
-    } catch (error) {
-      ctx.showError(`Failed to resolve workspace: ${error instanceof Error ? error.message : String(error)}`);
-      return;
-    }
+  let workspace;
+  try {
+    workspace = await resolveWorkspace(ctx);
+  } catch (error) {
+    ctx.showError(`Failed to resolve workspace: ${error instanceof Error ? error.message : String(error)}`);
+    return;
   }
+
   if (!workspace?.skills) {
     ctx.showInfo(
       'No skills configured.\n\n' +
@@ -52,5 +77,63 @@ export async function handleSkillsCommand(ctx: SlashCommandContext): Promise<voi
     );
   } catch (error) {
     ctx.showError(`Failed to list skills: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export async function handleSkillCommand(
+  ctx: SlashCommandContext,
+  skillName: string,
+  args: string[],
+): Promise<void> {
+  const normalizedSkillName = skillName.trim();
+  if (!normalizedSkillName) {
+    ctx.showError('Usage: /skill:<name>');
+    return;
+  }
+
+  let workspace;
+  try {
+    workspace = await resolveWorkspace(ctx);
+  } catch (error) {
+    ctx.showError(`Failed to resolve workspace: ${error instanceof Error ? error.message : String(error)}`);
+    return;
+  }
+
+  if (!workspace?.skills) {
+    ctx.showError('No skills configured.');
+    return;
+  }
+
+  try {
+    const skill = await workspace.skills.get(normalizedSkillName);
+    if (!skill) {
+      const skills = await workspace.skills.list();
+      const available = skills.length ? ` Available skills: ${skills.map(s => s.name).join(', ')}` : '';
+      ctx.showError(`Skill not found: ${normalizedSkillName}.${available}`);
+      return;
+    }
+
+    const trimmedArgs = args.join(' ').trim();
+    const content = `${formatSkillForActivation(skill)}${trimmedArgs ? `\n\nARGUMENTS: ${trimmedArgs}` : ''}`.trim();
+    if (!content) {
+      ctx.showInfo(`Activated /skill:${skill.name} (no instructions)`);
+      return;
+    }
+
+    const component = new SlashCommandComponent(`skill:${skill.name}`, content);
+    ctx.state.allSlashCommandComponents.push(component);
+    ctx.state.chatContainer.addChild(component);
+    ctx.state.ui.requestRender();
+
+    if (ctx.state.pendingNewThread) {
+      await ctx.harness.createThread();
+      ctx.state.pendingNewThread = false;
+    }
+
+    await ctx.harness.sendMessage({
+      content: `<skill name="${skill.name}">\n${content}\n</skill>`,
+    });
+  } catch (error) {
+    ctx.showError(`Error executing /skill:${normalizedSkillName}: ${error instanceof Error ? error.message : String(error)}`);
   }
 }

--- a/mastracode/src/tui/commands/skills.ts
+++ b/mastracode/src/tui/commands/skills.ts
@@ -1,22 +1,6 @@
-import type { Skill } from '@mastra/core/workspace';
+import { formatSkillActivation } from '@mastra/core/workspace';
 import { SlashCommandComponent } from '../components/slash-command.js';
 import type { SlashCommandContext } from './types.js';
-
-function formatSkillForActivation(skill: Skill): string {
-  const parts = [skill.instructions];
-
-  if (skill.references?.length) {
-    parts.push(`\n\n## References\n${skill.references.map(reference => `- references/${reference}`).join('\n')}`);
-  }
-  if (skill.scripts?.length) {
-    parts.push(`\n\n## Scripts\n${skill.scripts.map(script => `- scripts/${script}`).join('\n')}`);
-  }
-  if (skill.assets?.length) {
-    parts.push(`\n\n## Assets\n${skill.assets.map(asset => `- assets/${asset}`).join('\n')}`);
-  }
-
-  return parts.join('');
-}
 
 async function resolveWorkspace(ctx: SlashCommandContext) {
   let workspace = ctx.getResolvedWorkspace();
@@ -83,7 +67,7 @@ export async function handleSkillsCommand(ctx: SlashCommandContext): Promise<voi
 export async function handleSkillCommand(ctx: SlashCommandContext, skillName: string, args: string[]): Promise<void> {
   const normalizedSkillName = skillName.trim();
   if (!normalizedSkillName) {
-    ctx.showError('Usage: /skill:<name>');
+    ctx.showError('Usage: /skill/<name>');
     return;
   }
 
@@ -110,13 +94,13 @@ export async function handleSkillCommand(ctx: SlashCommandContext, skillName: st
     }
 
     const trimmedArgs = args.join(' ').trim();
-    const content = `${formatSkillForActivation(skill)}${trimmedArgs ? `\n\nARGUMENTS: ${trimmedArgs}` : ''}`.trim();
+    const content = `${formatSkillActivation(skill)}${trimmedArgs ? `\n\nARGUMENTS: ${trimmedArgs}` : ''}`.trim();
     if (!content) {
-      ctx.showInfo(`Activated /skill:${skill.name} (no instructions)`);
+      ctx.showInfo(`Activated /skill/${skill.name} (no instructions)`);
       return;
     }
 
-    const component = new SlashCommandComponent(`skill:${skill.name}`, content);
+    const component = new SlashCommandComponent(`skill/${skill.name}`, content);
     ctx.state.allSlashCommandComponents.push(component);
     ctx.state.chatContainer.addChild(component);
     ctx.state.ui.requestRender();
@@ -131,7 +115,7 @@ export async function handleSkillCommand(ctx: SlashCommandContext, skillName: st
     });
   } catch (error) {
     ctx.showError(
-      `Error executing /skill:${normalizedSkillName}: ${error instanceof Error ? error.message : String(error)}`,
+      `Error executing /skill/${normalizedSkillName}: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 }

--- a/mastracode/src/tui/commands/skills.ts
+++ b/mastracode/src/tui/commands/skills.ts
@@ -1,7 +1,17 @@
 import { formatSkillActivation } from '@mastra/core/workspace';
 import { SlashCommandComponent } from '../components/slash-command.js';
-import { isUserInvokable } from './skill-filters.js';
+import { isUserInvocable } from './skill-filters.js';
 import type { SlashCommandContext } from './types.js';
+
+// The persisted `<skill name="…">…</skill>` wrapper is parsed back out by
+// `render-messages.ts` to dedup against the optimistic SlashCommandComponent.
+// Neutralize any literal closing tag inside the body so the non-greedy regex
+// terminates only at the real boundary. We deliberately do NOT escape other
+// XML characters — skill instructions frequently contain legitimate `<div>`,
+// JSX, code, etc., and the model should see those literally.
+function escapeSkillBoundary(value: string): string {
+  return value.replaceAll('</skill>', '&lt;/skill&gt;');
+}
 
 async function resolveWorkspace(ctx: SlashCommandContext) {
   let workspace = ctx.getResolvedWorkspace();
@@ -39,13 +49,13 @@ export async function handleSkillsCommand(ctx: SlashCommandContext): Promise<voi
 
   try {
     const allSkills = await workspace.skills!.list();
-    const skills = allSkills.filter(isUserInvokable);
+    const skills = allSkills.filter(isUserInvocable);
 
     if (skills.length === 0) {
       ctx.showInfo(
         'No user-invokable skills found in configured directories.\n\n' +
           'Each skill needs a SKILL.md file with YAML frontmatter.\n' +
-          'Skills with `metadata.userInvokable: false` are hidden from this list.\n' +
+          'Skills with `user-invocable: false` are hidden from this list.\n' +
           'Install skills: npx add-skill <github-url>',
       );
       return;
@@ -89,8 +99,8 @@ export async function handleSkillCommand(ctx: SlashCommandContext, skillName: st
 
   try {
     const skill = await workspace.skills.get(normalizedSkillName);
-    if (!skill || !isUserInvokable(skill)) {
-      const skills = (await workspace.skills.list()).filter(isUserInvokable);
+    if (!skill || !isUserInvocable(skill)) {
+      const skills = (await workspace.skills.list()).filter(isUserInvocable);
       const available = skills.length ? ` Available skills: ${skills.map(s => s.name).join(', ')}` : '';
       ctx.showError(`Skill not found: ${normalizedSkillName}.${available}`);
       return;
@@ -113,8 +123,11 @@ export async function handleSkillCommand(ctx: SlashCommandContext, skillName: st
       ctx.state.pendingNewThread = false;
     }
 
+    // skill.name is spec-validated to `^[a-z0-9-]+$` so it cannot contain
+    // XML-special characters — no name escape needed. Only the body needs
+    // boundary protection (see `escapeSkillBoundary`).
     await ctx.harness.sendMessage({
-      content: `<skill name="${skill.name}">\n${content}\n</skill>`,
+      content: `<skill name="${skill.name}">\n${escapeSkillBoundary(content)}\n</skill>`,
     });
   } catch (error) {
     ctx.showError(

--- a/mastracode/src/tui/components/__tests__/help-overlay.test.ts
+++ b/mastracode/src/tui/components/__tests__/help-overlay.test.ts
@@ -10,7 +10,7 @@ describe('buildHelpText', () => {
     expect(text).toContain('/threads');
     expect(text).toContain('/settings');
     expect(text).toContain('/models');
-    expect(text).toContain('/skill:<name>');
+    expect(text).toContain('/skill/<name>');
     expect(text).not.toContain('/models:pack');
     expect(text).not.toContain('/memory-gateway');
     expect(text).toContain('/help');

--- a/mastracode/src/tui/components/__tests__/help-overlay.test.ts
+++ b/mastracode/src/tui/components/__tests__/help-overlay.test.ts
@@ -10,6 +10,7 @@ describe('buildHelpText', () => {
     expect(text).toContain('/threads');
     expect(text).toContain('/settings');
     expect(text).toContain('/models');
+    expect(text).toContain('/skill:<name>');
     expect(text).not.toContain('/models:pack');
     expect(text).not.toContain('/memory-gateway');
     expect(text).toContain('/help');

--- a/mastracode/src/tui/components/help-overlay.ts
+++ b/mastracode/src/tui/components/help-overlay.ts
@@ -29,7 +29,7 @@ function getCommands(modes: number): HelpEntry[] {
     { key: '/name', description: 'Rename current thread' },
     { key: '/resource', description: 'Show/switch resource ID' },
     { key: '/skills', description: 'List available skills' },
-    { key: '/skill:<name>', description: 'Activate a skill' },
+    { key: '/skill/<name>', description: 'Activate a skill' },
     { key: '/models', description: 'Switch model pack' },
     { key: '/custom-providers', description: 'Manage custom providers and models' },
     { key: '/subagents', description: 'Configure subagent models' },

--- a/mastracode/src/tui/components/help-overlay.ts
+++ b/mastracode/src/tui/components/help-overlay.ts
@@ -29,6 +29,7 @@ function getCommands(modes: number): HelpEntry[] {
     { key: '/name', description: 'Rename current thread' },
     { key: '/resource', description: 'Show/switch resource ID' },
     { key: '/skills', description: 'List available skills' },
+    { key: '/skill:<name>', description: 'Activate a skill' },
     { key: '/models', description: 'Switch model pack' },
     { key: '/custom-providers', description: 'Manage custom providers and models' },
     { key: '/subagents', description: 'Configure subagent models' },

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -462,7 +462,10 @@ export class MastraTUI {
     // workspace may not be resolved yet on cold start; once it is, refresh
     // the provider so `/skill/<name>` entries appear without restart.
     setupAutocomplete(this.state);
-    void refreshSkillsAutocomplete(this.state);
+    refreshSkillsAutocomplete(this.state).catch(err => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[skill autocomplete refresh] ${msg}\n`);
+    });
 
     // Build UI layout
     buildLayout(this.state, () => this.refreshModelAuthStatus());

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -458,9 +458,7 @@ export class MastraTUI {
     // Load custom slash commands
     await loadCustomSlashCommands(this.state);
 
-    // Setup autocomplete with whatever skills loaded synchronously. The
-    // workspace may not be resolved yet on cold start; once it is, refresh
-    // the provider so `/skill/<name>` entries appear without restart.
+    // Install autocomplete immediately; refresh once the workspace resolves.
     setupAutocomplete(this.state);
     refreshSkillsAutocomplete(this.state).catch(err => {
       const msg = err instanceof Error ? err.message : String(err);

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -59,6 +59,7 @@ import {
   buildLayout,
   setupAutocomplete,
   loadCustomSlashCommands,
+  refreshSkillsAutocomplete,
   setupKeyHandlers,
   subscribeToHarness,
   updateTerminalTitle,
@@ -457,8 +458,11 @@ export class MastraTUI {
     // Load custom slash commands
     await loadCustomSlashCommands(this.state);
 
-    // Setup autocomplete
+    // Setup autocomplete with whatever skills loaded synchronously. The
+    // workspace may not be resolved yet on cold start; once it is, refresh
+    // the provider so `/skill/<name>` entries appear without restart.
     setupAutocomplete(this.state);
+    void refreshSkillsAutocomplete(this.state);
 
     // Build UI layout
     buildLayout(this.state, () => this.refreshModelAuthStatus());

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -265,6 +265,12 @@ function confirmMatchingPendingUserMessage(state: TUIState, messageId: string, t
   return false;
 }
 
+// Inverse of `escapeSkillBoundary` in commands/skills.ts. We only encode the
+// `</skill>` boundary on send, so we only need to decode it here.
+function unescapeSkillBoundary(text: string): string {
+  return text.replaceAll('&lt;/skill&gt;', '</skill>');
+}
+
 export function addUserMessage(state: TUIState, message: HarnessMessage): void {
   if (state.messageComponentsById.has(message.id)) {
     return;
@@ -370,8 +376,9 @@ export function addUserMessage(state: TUIState, message: HarnessMessage): void {
   // renders fresh on thread replay when no optimistic component exists.
   const skillMatch = exactDisplayText.match(/^<skill\s+name="([^"]*)">([\s\S]*?)<\/skill>$/);
   if (skillMatch) {
+    // Skill names are validated to `^[a-z0-9-]+$` at load, so no name unescape needed.
     const commandName = `skill/${skillMatch[1]!}`;
-    const skillContent = skillMatch[2]!.trim();
+    const skillContent = unescapeSkillBoundary(skillMatch[2]!.trim());
     const existingSkillComp = state.allSlashCommandComponents.find(
       component =>
         component.matches(commandName, skillContent) && state.chatContainer.children.includes(component as never),

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -365,6 +365,29 @@ export function addUserMessage(state: TUIState, message: HarnessMessage): void {
     return;
   }
 
+  // Check for persisted skill activation tags (sent by `/skill/<name>`).
+  // Dedupes against the optimistic component handleSkillCommand created, and
+  // renders fresh on thread replay when no optimistic component exists.
+  const skillMatch = exactDisplayText.match(/^<skill\s+name="([^"]*)">([\s\S]*?)<\/skill>$/);
+  if (skillMatch) {
+    const commandName = `skill/${skillMatch[1]!}`;
+    const skillContent = skillMatch[2]!.trim();
+    const existingSkillComp = state.allSlashCommandComponents.find(
+      component =>
+        component.matches(commandName, skillContent) && state.chatContainer.children.includes(component as never),
+    );
+    if (existingSkillComp) {
+      state.messageComponentsById.set(message.id, existingSkillComp);
+      return;
+    }
+
+    const skillComp = new SlashCommandComponent(commandName, skillContent);
+    state.allSlashCommandComponents.push(skillComp);
+    state.chatContainer.addChild(skillComp);
+    state.ui.requestRender();
+    return;
+  }
+
   const prefix = imageCount > 0 ? `[${imageCount} image${imageCount > 1 ? 's' : ''}] ` : '';
   if (displayText || prefix) {
     const userComponent = new UserMessageComponent(prefix + displayText);

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -265,8 +265,6 @@ function confirmMatchingPendingUserMessage(state: TUIState, messageId: string, t
   return false;
 }
 
-// Inverse of `escapeSkillBoundary` in commands/skills.ts. We only encode the
-// `</skill>` boundary on send, so we only need to decode it here.
 function unescapeSkillBoundary(text: string): string {
   return text.replaceAll('&lt;/skill&gt;', '</skill>');
 }
@@ -371,12 +369,9 @@ export function addUserMessage(state: TUIState, message: HarnessMessage): void {
     return;
   }
 
-  // Check for persisted skill activation tags (sent by `/skill/<name>`).
-  // Dedupes against the optimistic component handleSkillCommand created, and
-  // renders fresh on thread replay when no optimistic component exists.
+  // Check for persisted skill activation tags.
   const skillMatch = exactDisplayText.match(/^<skill\s+name="([^"]*)">([\s\S]*?)<\/skill>$/);
   if (skillMatch) {
-    // Skill names are validated to `^[a-z0-9-]+$` at load, so no name unescape needed.
     const commandName = `skill/${skillMatch[1]!}`;
     const skillContent = unescapeSkillBoundary(skillMatch[2]!.trim());
     const existingSkillComp = state.allSlashCommandComponents.find(

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -399,8 +399,7 @@ export async function loadCustomSlashCommands(state: TUIState): Promise<void> {
   } catch {
     state.customSlashCommands = [];
   }
-  // Skills are loaded lazily by `refreshSkillsAutocomplete` so initial
-  // autocomplete setup never blocks on workspace resolution.
+  // Skills load via `refreshSkillsAutocomplete` so this never blocks on workspace resolution.
 }
 
 /**
@@ -428,11 +427,7 @@ export async function loadSkillCommands(state: TUIState): Promise<void> {
   }
 }
 
-/**
- * Asynchronously refresh skills and rebuild the autocomplete provider.
- * Called in the background after init so the initial autocomplete is
- * available immediately and skill entries appear once they load.
- */
+/** Reload skills and rebuild the autocomplete provider. */
 export async function refreshSkillsAutocomplete(state: TUIState): Promise<void> {
   await loadSkillCommands(state);
   setupAutocomplete(state);

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -286,7 +286,7 @@ export function setupAutocomplete(state: TUIState): void {
     { name: 'think', description: 'Set thinking (off|low|medium|high|xhigh|status)' },
     { name: 'login', description: 'Login with OAuth provider' },
     { name: 'skills', description: 'List available skills' },
-    { name: 'skill:', description: 'Activate a skill by name' },
+    { name: 'skill/', description: 'Activate a skill by name' },
     { name: 'cost', description: 'Show token usage and estimated costs' },
     { name: 'diff', description: 'Show modified files or git diff' },
     { name: 'name', description: 'Rename current thread' },
@@ -354,7 +354,7 @@ export function setupAutocomplete(state: TUIState): void {
 
   for (const skill of state.skillCommands) {
     slashCommands.push({
-      name: `skill:${skill.name}`,
+      name: `skill/${skill.name}`,
       description: skill.description ? `Skill: ${skill.description}` : `Skill: ${skill.name}`,
     });
   }
@@ -399,8 +399,20 @@ export async function loadCustomSlashCommands(state: TUIState): Promise<void> {
     state.customSlashCommands = [];
   }
 
+  await loadSkillCommands(state);
+}
+
+/**
+ * Populate `state.skillCommands` and `state.goalSkillCommands` from the
+ * workspace. Safe to call before the workspace is resolved (returns empty
+ * lists) and again later once it is (resolves and refreshes).
+ */
+export async function loadSkillCommands(state: TUIState): Promise<void> {
   try {
-    const workspace = state.harness.getWorkspace() ?? state.workspace;
+    let workspace = state.harness.getWorkspace() ?? state.workspace;
+    if (!workspace && state.harness.hasWorkspace()) {
+      workspace = await state.harness.resolveWorkspace();
+    }
     if (!workspace?.skills) {
       state.skillCommands = [];
       state.goalSkillCommands = [];
@@ -413,6 +425,16 @@ export async function loadCustomSlashCommands(state: TUIState): Promise<void> {
     state.skillCommands = [];
     state.goalSkillCommands = [];
   }
+}
+
+/**
+ * Asynchronously refresh skills and rebuild the autocomplete provider.
+ * Called in the background after init so the initial autocomplete is
+ * available immediately and skill entries appear once they load.
+ */
+export async function refreshSkillsAutocomplete(state: TUIState): Promise<void> {
+  await loadSkillCommands(state);
+  setupAutocomplete(state);
 }
 
 // =============================================================================

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -11,6 +11,7 @@ import type { HarnessEventListener } from '@mastra/core/harness';
 import { getUserId } from '../utils/project.js';
 import { loadCustomCommands } from '../utils/slash-command-loader.js';
 import { ThreadLockError } from '../utils/thread-lock.js';
+import { isUserInvokable } from './commands/skill-filters.js';
 import { renderBanner } from './components/banner.js';
 import { TaskProgressComponent } from './components/task-progress.js';
 import { showError, showInfo } from './display.js';
@@ -398,8 +399,8 @@ export async function loadCustomSlashCommands(state: TUIState): Promise<void> {
   } catch {
     state.customSlashCommands = [];
   }
-
-  await loadSkillCommands(state);
+  // Skills are loaded lazily by `refreshSkillsAutocomplete` so initial
+  // autocomplete setup never blocks on workspace resolution.
 }
 
 /**
@@ -418,7 +419,7 @@ export async function loadSkillCommands(state: TUIState): Promise<void> {
       state.goalSkillCommands = [];
       return;
     }
-    const skills = await workspace.skills.list();
+    const skills = (await workspace.skills.list()).filter(isUserInvokable);
     state.skillCommands = skills;
     state.goalSkillCommands = skills.filter(skill => skill.metadata?.goal === true);
   } catch {

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -286,6 +286,7 @@ export function setupAutocomplete(state: TUIState): void {
     { name: 'think', description: 'Set thinking (off|low|medium|high|xhigh|status)' },
     { name: 'login', description: 'Login with OAuth provider' },
     { name: 'skills', description: 'List available skills' },
+    { name: 'skill:', description: 'Activate a skill by name' },
     { name: 'cost', description: 'Show token usage and estimated costs' },
     { name: 'diff', description: 'Show modified files or git diff' },
     { name: 'name', description: 'Rename current thread' },
@@ -351,6 +352,13 @@ export function setupAutocomplete(state: TUIState): void {
     }
   }
 
+  for (const skill of state.skillCommands) {
+    slashCommands.push({
+      name: `skill:${skill.name}`,
+      description: skill.description ? `Skill: ${skill.description}` : `Skill: ${skill.name}`,
+    });
+  }
+
   for (const skill of state.goalSkillCommands) {
     slashCommands.push({
       name: `goal/${skill.name}`,
@@ -394,12 +402,15 @@ export async function loadCustomSlashCommands(state: TUIState): Promise<void> {
   try {
     const workspace = state.harness.getWorkspace() ?? state.workspace;
     if (!workspace?.skills) {
+      state.skillCommands = [];
       state.goalSkillCommands = [];
       return;
     }
     const skills = await workspace.skills.list();
+    state.skillCommands = skills;
     state.goalSkillCommands = skills.filter(skill => skill.metadata?.goal === true);
   } catch {
+    state.skillCommands = [];
     state.goalSkillCommands = [];
   }
 }

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -11,7 +11,7 @@ import type { HarnessEventListener } from '@mastra/core/harness';
 import { getUserId } from '../utils/project.js';
 import { loadCustomCommands } from '../utils/slash-command-loader.js';
 import { ThreadLockError } from '../utils/thread-lock.js';
-import { isUserInvokable } from './commands/skill-filters.js';
+import { isUserInvocable } from './commands/skill-filters.js';
 import { renderBanner } from './components/banner.js';
 import { TaskProgressComponent } from './components/task-progress.js';
 import { showError, showInfo } from './display.js';
@@ -419,7 +419,7 @@ export async function loadSkillCommands(state: TUIState): Promise<void> {
       state.goalSkillCommands = [];
       return;
     }
-    const skills = (await workspace.skills.list()).filter(isUserInvokable);
+    const skills = (await workspace.skills.list()).filter(isUserInvocable);
     state.skillCommands = skills;
     state.goalSkillCommands = skills.filter(skill => skill.metadata?.goal === true);
   } catch {

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -192,6 +192,7 @@ export interface TUIState {
   // ── Input ─────────────────────────────────────────────────────────────
   autocompleteProvider?: CombinedAutocompleteProvider;
   customSlashCommands: SlashCommandMetadata[];
+  skillCommands: SkillMetadata[];
   goalSkillCommands: SkillMetadata[];
   /** Pending images from clipboard paste */
   pendingImages: Array<{ data: string; mimeType: string }>;
@@ -289,6 +290,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
 
     // Input
     customSlashCommands: [],
+    skillCommands: [],
     goalSkillCommands: [],
     pendingImages: [],
 

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -128,7 +128,7 @@ export type {
 } from './skills';
 
 // Skill Tools
-export { createSkillTools } from './skills';
+export { createSkillTools, formatSkillActivation } from './skills';
 
 // Skill Publishing
 export type { SkillPublishResult } from './skills';

--- a/packages/core/src/workspace/skills/index.ts
+++ b/packages/core/src/workspace/skills/index.ts
@@ -15,4 +15,4 @@ export * from './versioned-skill-source';
 export * from './composite-versioned-skill-source';
 export * from './workspace-skills';
 export * from './publish';
-export { createSkillTools } from './tools';
+export { createSkillTools, formatSkillActivation } from './tools';

--- a/packages/core/src/workspace/skills/schemas.test.ts
+++ b/packages/core/src/workspace/skills/schemas.test.ts
@@ -299,6 +299,26 @@ describe('schemas', () => {
       expect(result.errors).toHaveLength(0);
     });
 
+    it('should accept user-invocable boolean metadata', () => {
+      const result = validateSkillMetadata({
+        name: 'my-skill',
+        description: 'A helpful skill',
+        'user-invocable': false,
+      });
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should reject non-boolean user-invocable metadata', () => {
+      const result = validateSkillMetadata({
+        name: 'my-skill',
+        description: 'A helpful skill',
+        'user-invocable': 'false',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('user-invocable: Expected boolean, received string');
+    });
+
     it('should reject missing name', () => {
       const result = validateSkillMetadata({ description: 'A skill' });
       expect(result.valid).toBe(false);

--- a/packages/core/src/workspace/skills/schemas.ts
+++ b/packages/core/src/workspace/skills/schemas.ts
@@ -42,6 +42,8 @@ export interface SkillMetadataInput {
   license?: string;
   /** Environment requirements or compatibility notes (string or object for flexibility) */
   compatibility?: unknown;
+  /** Whether this skill should be directly invokable by users. Defaults to true. */
+  'user-invocable'?: boolean;
   /** Arbitrary key-value metadata - values can be strings, arrays, objects, etc. */
   metadata?: Record<string, unknown>;
 }
@@ -212,6 +214,11 @@ function validateSkillMetadataField(metadata: unknown): string[] {
   return errors;
 }
 
+function validateUserInvocable(userInvocable: unknown): string[] {
+  if (userInvocable === undefined || typeof userInvocable === 'boolean') return [];
+  return [`user-invocable: Expected boolean, received ${typeof userInvocable}`];
+}
+
 // =============================================================================
 // Validation Helpers
 // =============================================================================
@@ -283,6 +290,7 @@ export function validateSkillMetadata(
   errors.push(...validateSkillDescription(data.description));
   errors.push(...validateSkillLicense(data.license));
   errors.push(...validateSkillCompatibility(data.compatibility));
+  errors.push(...validateUserInvocable(data['user-invocable']));
   errors.push(...validateSkillMetadataField(data.metadata));
 
   // Check directory name match (only if no name errors and name is valid)

--- a/packages/core/src/workspace/skills/tools.ts
+++ b/packages/core/src/workspace/skills/tools.ts
@@ -36,6 +36,27 @@ export function createSkillTools(skills: WorkspaceSkills) {
   };
 }
 
+/**
+ * Format a skill into the activation payload: instructions followed by
+ * any references/scripts/assets listings. Shared between the `skill` tool
+ * and explicit user activations so both paths produce identical output.
+ */
+export function formatSkillActivation(skill: Skill): string {
+  const parts = [skill.instructions];
+
+  if (skill.references?.length) {
+    parts.push(`\n\n## References\n${skill.references.map(r => `- references/${r}`).join('\n')}`);
+  }
+  if (skill.scripts?.length) {
+    parts.push(`\n\n## Scripts\n${skill.scripts.map(s => `- scripts/${s}`).join('\n')}`);
+  }
+  if (skill.assets?.length) {
+    parts.push(`\n\n## Assets\n${skill.assets.map(a => `- assets/${a}`).join('\n')}`);
+  }
+
+  return parts.join('');
+}
+
 // =============================================================================
 // Individual Tools
 // =============================================================================
@@ -83,20 +104,10 @@ function createSkillTool(skills: WorkspaceSkills) {
         }
 
         const { skill } = result;
-        const parts = [skill.instructions];
-
-        if (skill.references?.length) {
-          parts.push(`\n\n## References\n${skill.references.map(r => `- references/${r}`).join('\n')}`);
-        }
-        if (skill.scripts?.length) {
-          parts.push(`\n\n## Scripts\n${skill.scripts.map(s => `- scripts/${s}`).join('\n')}`);
-        }
-        if (skill.assets?.length) {
-          parts.push(`\n\n## Assets\n${skill.assets.map(a => `- assets/${a}`).join('\n')}`);
-        }
+        const output = formatSkillActivation(skill);
 
         span.end({ success: true });
-        return parts.join('');
+        return output;
       } catch (err) {
         span.error(err);
         throw err;

--- a/packages/core/src/workspace/skills/types.ts
+++ b/packages/core/src/workspace/skills/types.ts
@@ -154,6 +154,8 @@ export interface SkillMetadata {
   license?: string;
   /** Optional compatibility requirements (string or object for flexibility) */
   compatibility?: unknown;
+  /** Whether this skill should be directly invokable by users. Defaults to true. */
+  'user-invocable'?: boolean;
   /** Optional arbitrary metadata - values can be strings, arrays, objects, etc. */
   metadata?: Record<string, unknown>;
 }

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -288,6 +288,30 @@ describe('WorkspaceSkillsImpl', () => {
       });
     });
 
+    it('should preserve user-invocable metadata in list results', async () => {
+      const filesystem = createMockFilesystem({
+        'skills/test-skill/SKILL.md': `---
+name: test-skill
+description: A test skill for unit testing
+user-invocable: false
+---
+
+# Test Skill
+`,
+      });
+
+      const skills = new WorkspaceSkillsImpl({
+        source: filesystem,
+        skills: ['skills'],
+      });
+
+      const result = await skills.list();
+      expect(result[0]).toMatchObject({
+        name: 'test-skill',
+        'user-invocable': false,
+      });
+    });
+
     it('should discover skills from multiple paths', async () => {
       const filesystem = createMockFilesystem({
         'skills/test-skill/SKILL.md': VALID_SKILL_MD,

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -132,6 +132,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
           description: skill.description,
           license: skill.license,
           compatibility: skill.compatibility,
+          'user-invocable': skill['user-invocable'],
           metadata: skill.metadata,
         });
       }

--- a/packages/core/src/workspace/skills/workspace-skills.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.ts
@@ -959,6 +959,7 @@ export class WorkspaceSkillsImpl implements WorkspaceSkills {
       description: frontmatter.description,
       license: frontmatter.license,
       compatibility: frontmatter.compatibility,
+      'user-invocable': frontmatter['user-invocable'],
       metadata: frontmatter.metadata,
     };
 


### PR DESCRIPTION
## What

Adds a `/skill/<name>` slash command to Mastra Code that explicitly activates any installed workspace skill in the current conversation.

```text
/skill/github-triage
/skill/release-check focus tests
```

Complements the existing automatic skill activation. Users get a deterministic way to invoke a specific skill without hoping the model picks it. Closes #16344.

## How

- New `handleSkillCommand` in `mastracode/src/tui/commands/skills.ts` resolves the workspace, loads the skill via `workspace.skills.get`, and sends a `<skill name="...">…</skill>` message containing the skill instructions plus any `references/`, `scripts/`, or `assets/` paths.
- Dispatcher branch in `mastracode/src/tui/command-dispatch.ts` routes any `/skill/<prefix>` to the new handler, gated behind the existing goal-judge input lock.
- `TUIState.skillCommands` powers per-skill autocomplete entries (`skill/hello-skill`, etc.) alongside the existing `goal/<name>` entries.
- `/skill/<name>` added to `/help` and to `docs/src/mastra-code/{index,configuration}.mdx`.
- Shared formatter: exported `formatSkillActivation(skill)` from `@mastra/core/workspace` so the built-in `skill` tool and the new slash command produce byte-identical output.
- Lazy autocomplete refresh: `setupAutocomplete` runs immediately with whatever's available; `refreshSkillsAutocomplete` then resolves the workspace in the background and rebuilds the provider so `skill/<name>` entries appear without a restart.

## Error handling

- `/skill/` → `Usage: /skill/<name>`
- `/skill/unknown` → `Skill not found: unknown. Available skills: …`
- No workspace skills configured → friendly inline message.

## Tests

- New `mastracode/src/tui/commands/__tests__/skills.test.ts`: happy path, `pendingNewThread` sequencing, not-found, empty-name, no-skills-configured.
- Updated `command-dispatch.test.ts`, `setup-keyboard-shortcuts.test.ts`, `help-overlay.test.ts`.
- Core skill-tool tests (`packages/core/src/workspace/skills/tools.test.ts`) confirm the extracted `formatSkillActivation` still produces the same output.
- Manually verified end-to-end against a demo project with three skills (plain, args, references): activation, args propagation, `skill_read` of reference files, autocomplete, error paths, and `/help` entry.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works
- [x] I have addressed all Coderabbit comments on this PR