### PR TITLE
fix(core): preserve active signal transcript order

### DIFF
--- a/.changeset/new-houses-unite.md
+++ b/.changeset/new-houses-unite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed active signals so they stay in the correct order when conversations are reloaded from memory.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -659,7 +659,7 @@ describe('Agent signals', () => {
     subscription.unsubscribe();
   });
 
-  it('drops a not-yet-visible current-step tool call when draining a follow-up signal', async () => {
+  it('preserves current-step tool calls before draining a follow-up signal', async () => {
     const prompts: any[][] = [];
     let callCount = 0;
     let continueToToolCall!: () => void;
@@ -763,9 +763,9 @@ describe('Agent signals', () => {
     await waitForCondition(() => callCount === 2);
     await runPromise;
 
-    expect(chunks.map(chunk => chunk.type)).not.toContain('tool-call');
+    expect(chunks.map(chunk => chunk.type)).toContain('tool-call');
     expect(JSON.stringify(prompts[1])).toContain('Actually stop and answer this instead');
-    expect(JSON.stringify(prompts[1])).not.toContain('stale-tool-call');
+    expect(JSON.stringify(prompts[1])).toContain('stale-tool-call');
 
     subscription.unsubscribe();
   });

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -39,20 +39,28 @@ function nextTick() {
 }
 
 async function readNextRun(iterator: AsyncIterator<any>) {
+  const nextRun = await readNextRunWithParts(iterator);
+  if (nextRun.done) return nextRun;
+  return { value: { runId: nextRun.value.runId, text: nextRun.value.text, part: nextRun.value.part }, done: false };
+}
+
+async function readNextRunWithParts(iterator: AsyncIterator<any>) {
   let runId: string | undefined;
   let text = '';
+  const parts: any[] = [];
 
   while (true) {
     const next = await iterator.next();
     if (next.done) return next;
 
     const part = next.value;
+    parts.push(part);
     runId ??= part.runId;
     if (part.type === 'text-delta') {
       text += part.payload.text;
     }
     if (part.type === 'finish' || part.type === 'error' || part.type === 'abort') {
-      return { value: { runId, text, part }, done: false };
+      return { value: { runId, text, part, parts }, done: false };
     }
   }
 }
@@ -254,7 +262,7 @@ describe('Agent signals', () => {
       threadId: 'idle-thread',
       resourceId: 'idle-user',
     });
-    const nextRun = readNextRun(subscription.stream[Symbol.asyncIterator]());
+    const nextRun = readNextRunWithParts(subscription.stream[Symbol.asyncIterator]());
 
     const signalResult = await agent.sendSignal(
       { type: 'user-message', contents: 'Hello from signal' },
@@ -268,7 +276,15 @@ describe('Agent signals', () => {
     const subscribedRun = await nextRun;
     expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: subscribedRun.value.runId }));
     expect(signalResult.signal.id).toBeDefined();
+    expect(signalResult.signal.acceptedAt).toBeInstanceOf(Date);
     expect(subscribedRun.value.text).toBe('signal response');
+    const signalPart = subscribedRun.value.parts.find((part: any) => part.type === 'data-user-message');
+    expect(signalPart?.data).toMatchObject({
+      id: signalResult.signal.id,
+      contents: 'Hello from signal',
+      acceptedAt: signalResult.signal.acceptedAt?.toISOString(),
+    });
+    expect(signalPart?.data.createdAt).toBeDefined();
 
     subscription.unsubscribe();
   });
@@ -624,18 +640,18 @@ describe('Agent signals', () => {
     const secondRecalledSignal = mastraDBMessageToSignal(secondSignal);
     expect(firstRecalledSignal.createdAt).toEqual(firstSignal.createdAt);
     expect(secondRecalledSignal.createdAt).toEqual(secondSignal.createdAt);
-    expect(firstRecalledSignal.acceptedAt).toEqual(firstSignalResult.signal.createdAt);
-    expect(secondRecalledSignal.acceptedAt).toEqual(secondSignalResult.signal.createdAt);
+    expect(firstRecalledSignal.acceptedAt).toEqual(firstSignalResult.signal.acceptedAt);
+    expect(secondRecalledSignal.acceptedAt).toEqual(secondSignalResult.signal.acceptedAt);
 
     const firstSignalMetadata = firstSignal.content.metadata?.signal as { createdAt?: string; acceptedAt?: string };
     const secondSignalMetadata = secondSignal.content.metadata?.signal as { createdAt?: string; acceptedAt?: string };
     expect(firstSignalMetadata).toMatchObject({
       createdAt: firstSignal.createdAt.toISOString(),
-      acceptedAt: firstSignalResult.signal.createdAt.toISOString(),
+      acceptedAt: firstSignalResult.signal.acceptedAt?.toISOString(),
     });
     expect(secondSignalMetadata).toMatchObject({
       createdAt: secondSignal.createdAt.toISOString(),
-      acceptedAt: secondSignalResult.signal.createdAt.toISOString(),
+      acceptedAt: secondSignalResult.signal.acceptedAt?.toISOString(),
     });
     expect(firstAssistant.content.metadata?.mastra).toMatchObject({ responseBoundary: true });
     expect(secondAssistant.content.metadata?.mastra).toMatchObject({ responseBoundary: true });

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -616,9 +616,9 @@ describe('Agent signals', () => {
     expect(firstSignal.id).not.toBe(userMessage.id);
     expect(secondSignal.id).not.toBe(userMessage.id);
     expect(firstSignal.createdAt.getTime()).toBeGreaterThan(firstAssistant.createdAt.getTime());
-    expect(firstSignal.createdAt.getTime()).toBeLessThan(secondAssistant.createdAt.getTime());
+    expect(firstSignal.createdAt.getTime()).toBeLessThanOrEqual(secondAssistant.createdAt.getTime());
     expect(secondSignal.createdAt.getTime()).toBeGreaterThan(secondAssistant.createdAt.getTime());
-    expect(secondSignal.createdAt.getTime()).toBeLessThan(thirdAssistant.createdAt.getTime());
+    expect(secondSignal.createdAt.getTime()).toBeLessThanOrEqual(thirdAssistant.createdAt.getTime());
 
     const firstRecalledSignal = mastraDBMessageToSignal(firstSignal);
     const secondRecalledSignal = mastraDBMessageToSignal(secondSignal);

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -91,6 +91,7 @@ describe('Agent signals', () => {
       type: 'user-message',
       contents: 'Signal contents',
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      acceptedAt: new Date('2026-01-01T00:00:01.000Z'),
       attributes: { priority: 'high' },
       metadata: { source: 'test', signal: { userProvided: true } },
     });
@@ -103,6 +104,7 @@ describe('Agent signals', () => {
         type: 'user-message',
         contents: 'Signal contents',
         createdAt: '2026-01-01T00:00:00.000Z',
+        acceptedAt: '2026-01-01T00:00:01.000Z',
         attributes: { priority: 'high' },
         metadata: { source: 'test', signal: { userProvided: true } },
       },
@@ -110,11 +112,13 @@ describe('Agent signals', () => {
 
     const dbMessage = signal.toDBMessage({ threadId: 'thread-1', resourceId: 'resource-1' });
     expect(dbMessage.role).toBe('signal');
+    expect(dbMessage.createdAt).toEqual(new Date('2026-01-01T00:00:00.000Z'));
     expect(dbMessage.content.metadata).toEqual({
       signal: {
         id: 'signal-1',
         type: 'user-message',
         createdAt: '2026-01-01T00:00:00.000Z',
+        acceptedAt: '2026-01-01T00:00:01.000Z',
         contents: 'Signal contents',
         attributes: { priority: 'high' },
         metadata: { source: 'test', signal: { userProvided: true } },
@@ -122,9 +126,27 @@ describe('Agent signals', () => {
     });
     expect(signalToMastraDBMessage(signal).role).toBe('signal');
     expect(mastraDBMessageToSignal(dbMessage).contents).toBe('Signal contents');
+    expect(mastraDBMessageToSignal(dbMessage).createdAt).toEqual(new Date('2026-01-01T00:00:00.000Z'));
+    expect(mastraDBMessageToSignal(dbMessage).acceptedAt).toEqual(new Date('2026-01-01T00:00:01.000Z'));
     expect(mastraDBMessageToSignal(dbMessage).attributes).toEqual({ priority: 'high' });
     expect(mastraDBMessageToSignal(dbMessage).metadata).toEqual({ source: 'test', signal: { userProvided: true } });
+
+    const legacyDbMessage = {
+      ...dbMessage,
+      content: {
+        ...dbMessage.content,
+        metadata: {
+          signal: {
+            ...(dbMessage.content.metadata!.signal as Record<string, unknown>),
+            acceptedAt: undefined,
+          },
+        },
+      },
+    };
+    expect(mastraDBMessageToSignal(legacyDbMessage).acceptedAt).toBeUndefined();
+
     expect(dataPartToSignal(signalToDataPartFormat(signal)).contents).toBe('Signal contents');
+    expect(dataPartToSignal(signalToDataPartFormat(signal)).acceptedAt).toEqual(new Date('2026-01-01T00:00:01.000Z'));
 
     const reminderSignal = createSignal({
       id: 'signal-2',
@@ -456,10 +478,14 @@ describe('Agent signals', () => {
     subscription.unsubscribe();
   });
 
-  it('drains a user-message signal into the active same-agent thread run', async () => {
+  it('drains multiple user-message signals into an active same-agent thread run without merging them into users', async () => {
     let releaseFirst!: () => void;
     const firstFinished = new Promise<void>(resolve => {
       releaseFirst = resolve;
+    });
+    let releaseSecond!: () => void;
+    const secondFinished = new Promise<void>(resolve => {
+      releaseSecond = resolve;
     });
     let streamCount = 0;
     const prompts: any[][] = [];
@@ -467,8 +493,10 @@ describe('Agent signals', () => {
     const model = new MockLanguageModelV2({
       doStream: async ({ prompt }) => {
         streamCount += 1;
+        const callIndex = streamCount;
         prompts.push(prompt);
-        const responseText = streamCount === 1 ? 'first response' : 'signal response';
+        const responseText =
+          callIndex === 1 ? 'first response' : callIndex === 2 ? 'first signal response' : 'second signal response';
 
         return {
           rawCall: { rawPrompt: null, rawSettings: {} },
@@ -478,15 +506,18 @@ describe('Agent signals', () => {
               controller.enqueue({ type: 'stream-start', warnings: [] });
               controller.enqueue({
                 type: 'response-metadata',
-                id: `id-${streamCount}`,
+                id: `id-${callIndex}`,
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               });
-              controller.enqueue({ type: 'text-start', id: 'text-1' });
-              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: responseText });
-              controller.enqueue({ type: 'text-end', id: 'text-1' });
-              if (streamCount === 1) {
+              controller.enqueue({ type: 'text-start', id: `text-${callIndex}` });
+              controller.enqueue({ type: 'text-delta', id: `text-${callIndex}`, delta: responseText });
+              controller.enqueue({ type: 'text-end', id: `text-${callIndex}` });
+              if (callIndex === 1) {
                 await firstFinished;
+              }
+              if (callIndex === 2) {
+                await secondFinished;
               }
               controller.enqueue({
                 type: 'finish',
@@ -521,23 +552,46 @@ describe('Agent signals', () => {
     });
     await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
 
-    const signalResult = await agent.sendSignal(
-      { type: 'user-message', contents: 'Hello while running' },
+    const firstSignalResult = await agent.sendSignal(
+      { type: 'user-message', contents: 'First signal while running' },
       { resourceId: 'active-user', threadId: 'active-thread' },
     );
-    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
-    expect(signalResult.signal.id).toBeDefined();
+    expect(firstSignalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+    expect(firstSignalResult.signal.id).toBeDefined();
 
     releaseFirst();
+    await waitForCondition(() => streamCount === 2);
+
+    const secondSignalResult = await agent.sendSignal(
+      { type: 'user-message', contents: 'Second signal while running' },
+      { resourceId: 'active-user', threadId: 'active-thread' },
+    );
+    expect(secondSignalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+    expect(secondSignalResult.signal.id).toBeDefined();
+    expect(secondSignalResult.signal.id).not.toBe(firstSignalResult.signal.id);
+
+    releaseSecond();
     const firstRun = await firstRunPromise;
-    expect(firstRun.value.text).toBe('first responsesignal response');
-    expect(streamCount).toBe(2);
-    expect(JSON.stringify(prompts[1])).toContain('Hello while running');
+    expect(firstRun.value.text).toBe('first responsefirst signal responsesecond signal response');
+    expect(streamCount).toBe(3);
+    expect(JSON.stringify(prompts[1])).toContain('First signal while running');
+    expect(JSON.stringify(prompts[1])).not.toContain('Second signal while running');
+    expect(JSON.stringify(prompts[2])).toContain('First signal while running');
+    expect(JSON.stringify(prompts[2])).toContain('Second signal while running');
 
     await stream.consumeStream();
     const recalled = await memory.recall({ threadId: 'active-thread', resourceId: 'active-user' });
-    expect(recalled.messages.map(message => message.role)).toEqual(['user', 'assistant', 'signal', 'assistant']);
+    expect(recalled.messages.map(message => message.role)).toEqual([
+      'user',
+      'assistant',
+      'signal',
+      'assistant',
+      'signal',
+      'assistant',
+    ]);
     expect(recalled.messages.map(message => message.content.parts.map(part => part.type))).toEqual([
+      ['text'],
+      ['text'],
       ['text'],
       ['text'],
       ['text'],
@@ -547,7 +601,44 @@ describe('Agent signals', () => {
       recalled.messages.map(message =>
         message.content.parts.map(part => (part.type === 'text' ? part.text : '')).join(''),
       ),
-    ).toEqual(['Hello', 'first response', 'Hello while running', 'signal response']);
+    ).toEqual([
+      'Hello',
+      'first response',
+      'First signal while running',
+      'first signal response',
+      'Second signal while running',
+      'second signal response',
+    ]);
+
+    const [userMessage, firstAssistant, firstSignal, secondAssistant, secondSignal, thirdAssistant] = recalled.messages;
+    expect(firstSignal.id).toBe(firstSignalResult.signal.id);
+    expect(secondSignal.id).toBe(secondSignalResult.signal.id);
+    expect(firstSignal.id).not.toBe(userMessage.id);
+    expect(secondSignal.id).not.toBe(userMessage.id);
+    expect(firstSignal.createdAt.getTime()).toBeGreaterThan(firstAssistant.createdAt.getTime());
+    expect(firstSignal.createdAt.getTime()).toBeLessThan(secondAssistant.createdAt.getTime());
+    expect(secondSignal.createdAt.getTime()).toBeGreaterThan(secondAssistant.createdAt.getTime());
+    expect(secondSignal.createdAt.getTime()).toBeLessThan(thirdAssistant.createdAt.getTime());
+
+    const firstRecalledSignal = mastraDBMessageToSignal(firstSignal);
+    const secondRecalledSignal = mastraDBMessageToSignal(secondSignal);
+    expect(firstRecalledSignal.createdAt).toEqual(firstSignal.createdAt);
+    expect(secondRecalledSignal.createdAt).toEqual(secondSignal.createdAt);
+    expect(firstRecalledSignal.acceptedAt).toEqual(firstSignalResult.signal.createdAt);
+    expect(secondRecalledSignal.acceptedAt).toEqual(secondSignalResult.signal.createdAt);
+
+    const firstSignalMetadata = firstSignal.content.metadata?.signal as { createdAt?: string; acceptedAt?: string };
+    const secondSignalMetadata = secondSignal.content.metadata?.signal as { createdAt?: string; acceptedAt?: string };
+    expect(firstSignalMetadata).toMatchObject({
+      createdAt: firstSignal.createdAt.toISOString(),
+      acceptedAt: firstSignalResult.signal.createdAt.toISOString(),
+    });
+    expect(secondSignalMetadata).toMatchObject({
+      createdAt: secondSignal.createdAt.toISOString(),
+      acceptedAt: secondSignalResult.signal.createdAt.toISOString(),
+    });
+    expect(firstAssistant.content.metadata?.mastra).toMatchObject({ responseBoundary: true });
+    expect(secondAssistant.content.metadata?.mastra).toMatchObject({ responseBoundary: true });
 
     subscription.unsubscribe();
   });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -99,7 +99,6 @@ import type {
 import { MessageList } from './message-list';
 import type { MessageInput, MessageListInput, UIMessageWithMetadata, MastraDBMessage } from './message-list';
 import { SaveQueueManager } from './save-queue';
-import { isCreatedAgentSignal } from './signals';
 import { runStreamUntilIdle, runResumeStreamUntilIdle } from './stream-until-idle';
 import type { SubAgent } from './subagent';
 import { agentThreadStreamRuntime } from './thread-stream-runtime';
@@ -5372,14 +5371,6 @@ export class Agent<
       llm,
     };
 
-    const initialSignalEchoes =
-      methodType === 'stream'
-        ? (Array.isArray(options.messages) ? options.messages : [options.messages]).filter(isCreatedAgentSignal)
-        : [];
-    const initialSignalEchoesForRun =
-      initialSignalEchoes.length > 0
-        ? [...initialSignalEchoes, ...(options._initialSignalEchoes ?? [])]
-        : options._initialSignalEchoes;
     const toolPayloadTransform =
       normalizeToolPayloadTransformPolicy(options.transform ?? (options as any).toolPayloadProjection) ??
       this.#toolPayloadTransform ??
@@ -5418,7 +5409,6 @@ export class Agent<
           }),
       skipBgTaskWait: options._skipBgTaskWait,
       drainPendingSignals: this.#getThreadStreamRuntime().drainPendingSignals.bind(this.#getThreadStreamRuntime()),
-      initialSignalEchoes: initialSignalEchoesForRun,
     });
 
     const run = await executionWorkflow.createRun();

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -12,7 +12,6 @@ import type { RequestContext } from '../request-context';
 import type { ToolPayloadTransformPolicy } from '../tools';
 import type { OutputWriter } from '../workflows/types';
 import type { MessageListInput } from './message-list';
-import type { CreatedAgentSignal } from './signals';
 import type {
   AgentMemoryOption,
   ToolsetsInput,
@@ -634,14 +633,6 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
    * `agent.streamUntilIdle`, which drives continuation from outside the loop.
    */
   _skipBgTaskWait?: boolean;
-
-  /**
-   * @internal
-   * Signal inputs that are already present in the initial message list and still
-   * need to be echoed as data parts to stream subscribers. Public callers should
-   * pass the signal as `agent.stream(signal, options)` instead of setting this.
-   */
-  _initialSignalEchoes?: CreatedAgentSignal[];
 } & Partial<ObservabilityContext>;
 
 /**

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -173,8 +173,9 @@ export class MessageList {
     return events;
   }
 
-  public addInterjectedSignal(signal: CreatedAgentSignal, options?: { source?: MessageSource }): CreatedAgentSignal {
-    const createdAt = this.generateCreatedAt(options?.source ?? 'input', new Date());
+  public addSignal(signal: CreatedAgentSignal, options?: { source?: MessageSource }): CreatedAgentSignal {
+    const source = options?.source ?? 'input';
+    const createdAt = this.generateCreatedAt(source, new Date());
     const acceptedAt = signal.acceptedAt ?? signal.createdAt;
     const signalForTranscript = createSignal(
       signal.type === 'user-message'
@@ -198,7 +199,7 @@ export class MessageList {
           },
     );
 
-    this.add(signalForTranscript, options?.source ?? 'input');
+    this.addOne(signalForTranscript.toDBMessage(this.memoryInfo ?? undefined), source);
     return signalForTranscript;
   }
 
@@ -218,6 +219,11 @@ export class MessageList {
     }
 
     for (const message of messageArray) {
+      if (isCreatedAgentSignal(message) && messageSource === 'input') {
+        this.addSignal(message, { source: messageSource });
+        continue;
+      }
+
       const messageInput = isCreatedAgentSignal(message)
         ? message.toDBMessage(this.memoryInfo ?? undefined)
         : typeof message === `string`
@@ -1412,10 +1418,19 @@ export class MessageList {
     const messageV2 = convertInputToMastraDBMessage(message, messageSource, this.createAdapterContext());
     const signalMetadata =
       messageV2.role === 'signal'
-        ? (messageV2.content.metadata?.signal as { acceptedAt?: string } | undefined)
+        ? (messageV2.content.metadata?.signal as { acceptedAt?: string; createdAt?: string } | undefined)
         : undefined;
     if (messageSource === 'input' && messageV2.role === 'signal' && !signalMetadata?.acceptedAt) {
+      const acceptedAt = signalMetadata?.createdAt ?? messageV2.createdAt.toISOString();
       messageV2.createdAt = this.generateCreatedAt(messageSource, messageV2.createdAt);
+      messageV2.content.metadata = {
+        ...messageV2.content.metadata,
+        signal: {
+          ...signalMetadata,
+          createdAt: messageV2.createdAt.toISOString(),
+          acceptedAt,
+        },
+      };
     }
 
     const { exists, shouldReplace, id } = this.shouldReplaceMessage(messageV2);

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -302,6 +302,9 @@ export class MessageList {
     this.taggedSystemMessages = data.taggedSystemMessages;
     this.memoryInfo = data.memoryInfo;
     this._agentNetworkAppend = data.agentNetworkAppend;
+    for (const message of this.messages) {
+      this.updateLastCreatedAt(message);
+    }
     return this;
   }
 
@@ -1446,6 +1449,7 @@ export class MessageList {
     if (shouldMerge && latestMessage) {
       // Delegate merge logic to MessageMerger
       MessageMerger.merge(latestMessage, messageV2);
+      this.updateLastCreatedAt(latestMessage);
 
       // If latest message gets appended to, it should be added to the proper source
       this.pushMessageToSource(latestMessage, messageSource);
@@ -1533,6 +1537,7 @@ export class MessageList {
           );
           if (shouldMergeIntoExisting) {
             MessageMerger.merge(existingMessage, messageV2);
+            this.updateLastCreatedAt(existingMessage);
             this.pushMessageToSource(existingMessage, messageSource);
             // Sort messages and return early — existingMessage stays in messages[] and its Sets
             this.messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
@@ -1547,6 +1552,10 @@ export class MessageList {
       this.pushMessageToSource(messageV2, messageSource);
     }
 
+    for (const storedMessage of this.messages) {
+      this.updateLastCreatedAt(storedMessage);
+    }
+
     // make sure messages are always stored in order of when they were created!
     this.messages.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
@@ -1558,6 +1567,18 @@ export class MessageList {
   }
 
   private lastCreatedAt?: number;
+
+  private updateLastCreatedAt(message: MastraDBMessage): void {
+    const latestPartTime = message.content.parts.reduce((latest, part) => {
+      if (typeof part.createdAt === 'number' && part.createdAt > latest) {
+        return part.createdAt;
+      }
+      return latest;
+    }, message.createdAt.getTime());
+
+    this.lastCreatedAt = Math.max(this.lastCreatedAt || 0, latestPartTime);
+  }
+
   // this makes sure messages added in order will always have a date atleast 1ms apart.
   private generateCreatedAt(messageSource: MessageSource, start?: unknown): Date {
     // Normalize timestamp
@@ -1581,11 +1602,8 @@ export class MessageList {
 
     const now = new Date();
     const nowTime = startDate?.getTime() || now.getTime();
-    // find the latest createdAt in all stored messages
-    const lastTime = this.messages.reduce((p, m) => {
-      if (m.createdAt.getTime() > p) return m.createdAt.getTime();
-      return p;
-    }, this.lastCreatedAt || 0);
+    // find the latest createdAt in stored messages and parts
+    const lastTime = this.lastCreatedAt || 0;
 
     // make sure our new message is created later than the latest known message time
     // it's expected that messages are added to the list in order if they don't have a createdAt date on them

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -7,7 +7,8 @@ import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import type { IMastraLogger } from '../../logger';
 import { getTransformedToolPayload, hasTransformedToolPayload } from '../../tools/payload-transform';
 import type { IdGeneratorContext } from '../../types';
-import { isCreatedAgentSignal, mastraDBMessageToSignal } from '../signals';
+import { createSignal, isCreatedAgentSignal, mastraDBMessageToSignal } from '../signals';
+import type { CreatedAgentSignal } from '../signals';
 import { AIV4Adapter, AIV5Adapter, AIV6Adapter } from './adapters';
 import { CacheKeyGenerator } from './cache/CacheKeyGenerator';
 import {
@@ -172,6 +173,35 @@ export class MessageList {
     return events;
   }
 
+  public addInterjectedSignal(signal: CreatedAgentSignal, options?: { source?: MessageSource }): CreatedAgentSignal {
+    const createdAt = this.generateCreatedAt(options?.source ?? 'input', new Date());
+    const acceptedAt = signal.acceptedAt ?? signal.createdAt;
+    const signalForTranscript = createSignal(
+      signal.type === 'user-message'
+        ? {
+            id: signal.id,
+            type: 'user-message',
+            contents: signal.contents,
+            attributes: signal.attributes,
+            metadata: signal.metadata,
+            createdAt,
+            acceptedAt,
+          }
+        : {
+            id: signal.id,
+            type: signal.type,
+            contents: String(signal.contents),
+            attributes: signal.attributes,
+            metadata: signal.metadata,
+            createdAt,
+            acceptedAt,
+          },
+    );
+
+    this.add(signalForTranscript, options?.source ?? 'input');
+    return signalForTranscript;
+  }
+
   public add(messages: MessageListInput, messageSource: MessageSource) {
     if (messageSource === `user`) messageSource = `input`;
 
@@ -281,23 +311,48 @@ export class MessageList {
         return [message];
       }
 
-      // Signals are persisted losslessly as DB signal messages, but model providers
-      // only understand normal prompt messages. Project the signal into its
-      // LLM-facing message content here so the existing MessageList converters
-      // keep handling strings, arrays, files/images, and provider-specific shapes.
-      const signalMessages = mastraDBMessageToSignal(message).toLLMMessage();
-      return (Array.isArray(signalMessages) ? signalMessages : [signalMessages]).map(signalMessage =>
-        convertInputToMastraDBMessage(
-          typeof signalMessage === `string`
-            ? {
-                role: 'user' as const,
-                content: signalMessage,
-              }
-            : signalMessage,
-          'input',
-          this.createAdapterContext(),
-        ),
-      );
+      return this.convertSignalForModelPrompt(message);
+    });
+  }
+
+  private convertSignalForModelPrompt(message: MastraDBMessage): MastraDBMessage[] {
+    // Signals are persisted losslessly as DB signal messages, but model providers
+    // only understand normal prompt messages. Convert the signal into its
+    // LLM-facing message content without mutating MessageList timestamp/id
+    // bookkeeping or changing the signal's chronological position.
+    const signalMessages = mastraDBMessageToSignal(message).toLLMMessage();
+    return (Array.isArray(signalMessages) ? signalMessages : [signalMessages]).map((signalMessage, index) => {
+      const createdAt = message.createdAt;
+      const id = index === 0 ? message.id : `${message.id}:prompt:${index}`;
+      const promptMessage =
+        typeof signalMessage === `string`
+          ? {
+              id,
+              role: 'user' as const,
+              content: signalMessage,
+              metadata: { createdAt },
+            }
+          : {
+              ...signalMessage,
+              id: 'id' in signalMessage && typeof signalMessage.id === 'string' ? signalMessage.id : id,
+              metadata: {
+                ...('metadata' in signalMessage && signalMessage.metadata && typeof signalMessage.metadata === 'object'
+                  ? signalMessage.metadata
+                  : {}),
+                createdAt,
+              },
+            };
+
+      return convertInputToMastraDBMessage(promptMessage as MessageInput, 'input', {
+        memoryInfo: this.memoryInfo,
+        newMessageId: () => id,
+        generateCreatedAt: (_messageSource, start) => {
+          if (start instanceof Date) return start;
+          if (typeof start === 'string' || typeof start === 'number') return new Date(start);
+          return createdAt;
+        },
+        dbMessages: this.messages,
+      });
     });
   }
 
@@ -1352,7 +1407,11 @@ export class MessageList {
     }
 
     const messageV2 = convertInputToMastraDBMessage(message, messageSource, this.createAdapterContext());
-    if (messageSource === 'input' && messageV2.role === 'signal') {
+    const signalMetadata =
+      messageV2.role === 'signal'
+        ? (messageV2.content.metadata?.signal as { acceptedAt?: string } | undefined)
+        : undefined;
+    if (messageSource === 'input' && messageV2.role === 'signal' && !signalMetadata?.acceptedAt) {
       messageV2.createdAt = this.generateCreatedAt(messageSource, messageV2.createdAt);
     }
 

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1569,12 +1569,15 @@ export class MessageList {
   private lastCreatedAt?: number;
 
   private updateLastCreatedAt(message: MastraDBMessage): void {
-    const latestPartTime = message.content.parts.reduce((latest, part) => {
-      if (typeof part.createdAt === 'number' && part.createdAt > latest) {
-        return part.createdAt;
-      }
-      return latest;
-    }, message.createdAt.getTime());
+    const latestMessageTime = message.createdAt.getTime();
+    const latestPartTime = Array.isArray(message.content.parts)
+      ? message.content.parts.reduce((latest, part) => {
+          if (typeof part.createdAt === 'number' && part.createdAt > latest) {
+            return part.createdAt;
+          }
+          return latest;
+        }, latestMessageTime)
+      : latestMessageTime;
 
     this.lastCreatedAt = Math.max(this.lastCreatedAt || 0, latestPartTime);
   }

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1093,6 +1093,8 @@ export class MessageList {
               : {}),
             ...(mergedProviderMetadata !== undefined ? { providerMetadata: mergedProviderMetadata } : {}),
           };
+          this.lastCreatedAt = Math.max(this.lastCreatedAt || 0, Date.now());
+          this.updateLastCreatedAt(msg);
 
           // `backgroundTasks` is a per-toolCallId record — merge instead of
           // overwrite so multiple concurrent background dispatches on the

--- a/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
@@ -474,6 +474,55 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
       });
     });
 
+    it('should add interjected signals after the latest response part timestamp', () => {
+      const baseTime = Date.now() + 60_000;
+      const responseTime = new Date(baseTime);
+      const toolPartTime = baseTime + 5_000;
+      const signalTime = new Date(baseTime + 2_000);
+      const list = new MessageList();
+      const signal = createSignal({
+        id: 'signal-after-tool-part',
+        type: 'user-message',
+        contents: 'Signal after tool output',
+        createdAt: signalTime,
+      });
+
+      list.add(
+        {
+          id: 'assistant-with-late-tool-part',
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              { type: 'text', text: 'Before tool output' },
+              {
+                type: 'tool-invocation',
+                createdAt: toolPartTime,
+                toolInvocation: {
+                  state: 'result',
+                  toolCallId: 'call-1',
+                  toolName: 'gitStatus',
+                  args: {},
+                  result: '(no output)',
+                },
+              },
+            ],
+          },
+          createdAt: responseTime,
+        },
+        'response',
+      );
+
+      const signalForTranscript = list.addInterjectedSignal(signal);
+
+      expect(signalForTranscript.createdAt.getTime()).toBe(toolPartTime + 1);
+      expect(signalForTranscript.acceptedAt).toEqual(signalTime);
+      expect(list.get.all.db().map(message => message.id)).toEqual([
+        'assistant-with-late-tool-part',
+        'signal-after-tool-part',
+      ]);
+    });
+
     it('should preserve createdAt for V5 UI messages', () => {
       const time1 = new Date('2024-01-01T10:00:00.000Z');
       const time2 = new Date('2024-01-01T10:01:00.000Z');

--- a/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createSignal, mastraDBMessageToSignal } from '../../signals';
 import type { MastraDBMessage } from '../../types';
 import type { MessageListInput } from '../index';
@@ -526,10 +526,11 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
       });
     });
 
-    it('should add signals after the latest response part timestamp', () => {
+    it('should add signals after tool invocation updates', () => {
       const baseTime = Date.now() + 60_000;
       const responseTime = new Date(baseTime);
-      const toolPartTime = baseTime + 5_000;
+      const toolCallPartTime = baseTime + 1_000;
+      const toolResultPartTime = baseTime + 5_000;
       const signalTime = new Date(baseTime + 2_000);
       const list = new MessageList();
       const signal = createSignal({
@@ -549,13 +550,12 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
               { type: 'text', text: 'Before tool output' },
               {
                 type: 'tool-invocation',
-                createdAt: toolPartTime,
+                createdAt: toolCallPartTime,
                 toolInvocation: {
-                  state: 'result',
+                  state: 'call',
                   toolCallId: 'call-1',
                   toolName: 'gitStatus',
                   args: {},
-                  result: '(no output)',
                 },
               },
             ],
@@ -565,9 +565,26 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
         'response',
       );
 
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(toolResultPartTime);
+        list.updateToolInvocation({
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'result',
+            toolCallId: 'call-1',
+            toolName: 'gitStatus',
+            args: {},
+            result: '(no output)',
+          },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+
       const signalForTranscript = list.addSignal(signal);
 
-      expect(signalForTranscript.createdAt.getTime()).toBe(toolPartTime + 1);
+      expect(signalForTranscript.createdAt.getTime()).toBe(toolResultPartTime + 1);
       expect(signalForTranscript.acceptedAt).toEqual(signalTime);
       expect(list.get.all.db().map(message => message.id)).toEqual([
         'assistant-with-late-tool-part',

--- a/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { createSignal } from '../../signals';
 import type { MastraDBMessage } from '../../types';
 import type { MessageListInput } from '../index';
 import { MessageList } from '../index';
@@ -408,6 +409,69 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
 
       // Order should be preserved since messages without timestamps get incrementing timestamps
       expect(texts).toEqual(['Message with timestamp', 'Message without timestamp 1', 'Message without timestamp 2']);
+    });
+
+    it('should not let signal prompt conversion advance generated timestamp state', () => {
+      const signalTime = new Date('2999-01-01T09:00:00.000Z');
+      const latestTime = new Date('2999-01-01T10:00:00.000Z');
+      const list = new MessageList();
+
+      list.add(
+        [
+          createSignal({
+            id: 'signal-1',
+            type: 'user-message',
+            contents: 'Signal message',
+            createdAt: signalTime,
+          }).toDBMessage(),
+          {
+            id: 'assistant-latest',
+            role: 'assistant' as const,
+            content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'Latest assistant' }] },
+            createdAt: latestTime,
+          },
+        ],
+        'memory',
+      );
+
+      list.get.all.aiV5.prompt();
+      list.add({ role: 'user', content: 'Generated timestamp after prompt conversion' }, 'input');
+
+      const generatedMessage = list.get.all.db().at(-1);
+      expect(generatedMessage?.createdAt.getTime()).toBe(latestTime.getTime() + 1);
+    });
+
+    it('should add interjected signals after the current response while preserving acceptedAt', () => {
+      const responseTime = new Date('2024-01-01T10:00:00.000Z');
+      const signalTime = new Date('2024-01-01T09:00:00.000Z');
+      const list = new MessageList();
+      const signal = createSignal({
+        id: 'signal-1',
+        type: 'user-message',
+        contents: 'Signal message',
+        createdAt: signalTime,
+      });
+
+      list.add(
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: { format: 2, parts: [{ type: 'text', text: 'Response' }] },
+          createdAt: responseTime,
+        },
+        'response',
+      );
+
+      const signalForTranscript = list.addInterjectedSignal(signal);
+
+      const storedSignal = list.get.all.db().at(-1)!;
+      expect(signalForTranscript.createdAt.getTime()).toBeGreaterThan(responseTime.getTime());
+      expect(signalForTranscript.acceptedAt).toEqual(signalTime);
+      expect(storedSignal.createdAt).toEqual(signalForTranscript.createdAt);
+      expect(storedSignal.content.metadata?.signal).toMatchObject({
+        createdAt: signalForTranscript.createdAt.toISOString(),
+        acceptedAt: signalTime.toISOString(),
+      });
     });
 
     it('should preserve createdAt for V5 UI messages', () => {

--- a/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createSignal } from '../../signals';
+import { createSignal, mastraDBMessageToSignal } from '../../signals';
 import type { MastraDBMessage } from '../../types';
 import type { MessageListInput } from '../index';
 import { MessageList } from '../index';
@@ -441,7 +441,7 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
       expect(generatedMessage?.createdAt.getTime()).toBe(latestTime.getTime() + 1);
     });
 
-    it('should add interjected signals after the current response while preserving acceptedAt', () => {
+    it('should add signals after the current response while preserving acceptedAt', () => {
       const responseTime = new Date('2024-01-01T10:00:00.000Z');
       const signalTime = new Date('2024-01-01T09:00:00.000Z');
       const list = new MessageList();
@@ -462,7 +462,7 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
         'response',
       );
 
-      const signalForTranscript = list.addInterjectedSignal(signal);
+      const signalForTranscript = list.addSignal(signal);
 
       const storedSignal = list.get.all.db().at(-1)!;
       expect(signalForTranscript.createdAt.getTime()).toBeGreaterThan(responseTime.getTime());
@@ -474,7 +474,59 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
       });
     });
 
-    it('should add interjected signals after the latest response part timestamp', () => {
+    it('should normalize regular input signals using transcript timestamps', () => {
+      const baseTime = Date.now() + 60_000;
+      const responseTime = new Date(baseTime);
+      const toolPartTime = baseTime + 5_000;
+      const signalTime = new Date(baseTime + 2_000);
+      const list = new MessageList();
+      const signal = createSignal({
+        id: 'regular-signal-after-tool-part',
+        type: 'user-message',
+        contents: 'Regular signal after tool output',
+        createdAt: signalTime,
+      });
+
+      list.add(
+        {
+          id: 'assistant-with-tool-part-before-regular-signal',
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              { type: 'text', text: 'Before tool output' },
+              {
+                type: 'tool-invocation',
+                createdAt: toolPartTime,
+                toolInvocation: {
+                  state: 'result',
+                  toolCallId: 'call-1',
+                  toolName: 'gitStatus',
+                  args: {},
+                  result: '(no output)',
+                },
+              },
+            ],
+          },
+          createdAt: responseTime,
+        },
+        'response',
+      );
+      list.add(signal, 'input');
+
+      const storedSignal = list.get.all.db().at(-1)!;
+      const recalledSignal = mastraDBMessageToSignal(storedSignal);
+      expect(storedSignal.id).toBe(signal.id);
+      expect(storedSignal.createdAt.getTime()).toBe(toolPartTime + 1);
+      expect(recalledSignal.createdAt).toEqual(storedSignal.createdAt);
+      expect(recalledSignal.acceptedAt).toEqual(signalTime);
+      expect(storedSignal.content.metadata?.signal).toMatchObject({
+        createdAt: storedSignal.createdAt.toISOString(),
+        acceptedAt: signalTime.toISOString(),
+      });
+    });
+
+    it('should add signals after the latest response part timestamp', () => {
       const baseTime = Date.now() + 60_000;
       const responseTime = new Date(baseTime);
       const toolPartTime = baseTime + 5_000;
@@ -513,7 +565,7 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
         'response',
       );
 
-      const signalForTranscript = list.addInterjectedSignal(signal);
+      const signalForTranscript = list.addSignal(signal);
 
       expect(signalForTranscript.createdAt.getTime()).toBe(toolPartTime + 1);
       expect(signalForTranscript.acceptedAt).toEqual(signalTime);

--- a/packages/core/src/agent/signals.ts
+++ b/packages/core/src/agent/signals.ts
@@ -16,6 +16,7 @@ export type AgentSignalContents = BaseMessageListInput;
 type AgentSignalInputBase = {
   id?: string;
   createdAt?: Date | string;
+  acceptedAt?: Date | string;
   attributes?: Record<string, string | number | boolean | null | undefined>;
   metadata?: Record<string, unknown>;
 };
@@ -51,6 +52,7 @@ export type AgentSignalDataPart = {
     type: AgentSignalType;
     contents: AgentSignalContents;
     createdAt: string;
+    acceptedAt?: string;
     attributes?: Record<string, string | number | boolean | null | undefined>;
     metadata?: Record<string, unknown>;
   };
@@ -63,6 +65,7 @@ export type CreatedAgentSignal = AgentSignalInput & {
   __isCreatedSignal: true;
   id: string;
   createdAt: Date;
+  acceptedAt?: Date;
   toDBMessage: (options?: { threadId?: string; resourceId?: string }) => MastraDBMessage;
   toLLMMessage: () => BaseMessageListInput;
   toDataPart: () => AgentSignalDataPart;
@@ -78,6 +81,12 @@ function normalizeSignal(signal: AgentSignalInput | CreatedAgentSignal) {
     id: signal.id ?? crypto.randomUUID(),
     createdAt:
       signal.createdAt instanceof Date ? signal.createdAt : signal.createdAt ? new Date(signal.createdAt) : new Date(),
+    acceptedAt:
+      signal.acceptedAt instanceof Date
+        ? signal.acceptedAt
+        : signal.acceptedAt
+          ? new Date(signal.acceptedAt)
+          : undefined,
   };
 }
 
@@ -160,6 +169,7 @@ function signalToDataPart(signal: ReturnType<typeof normalizeSignal>): AgentSign
       type: signal.type,
       contents: signal.contents,
       createdAt: signal.createdAt.toISOString(),
+      ...(signal.acceptedAt ? { acceptedAt: signal.acceptedAt.toISOString() } : {}),
       ...(signal.attributes ? { attributes: signal.attributes } : {}),
       ...(signal.metadata ? { metadata: signal.metadata } : {}),
     },
@@ -185,6 +195,7 @@ function signalToDBMessage(
           id: signal.id,
           type: signal.type,
           createdAt: signal.createdAt.toISOString(),
+          ...(signal.acceptedAt ? { acceptedAt: signal.acceptedAt.toISOString() } : {}),
           contents: signal.contents,
           ...(signal.attributes ? { attributes: signal.attributes } : {}),
           ...(signal.metadata ? { metadata: signal.metadata } : {}),
@@ -245,6 +256,7 @@ export function mastraDBMessageToSignal(message: MastraDBMessage): CreatedAgentS
   const base = {
     id: typeof signalMetadata?.id === 'string' ? signalMetadata.id : message.id,
     createdAt: typeof signalMetadata?.createdAt === 'string' ? signalMetadata.createdAt : message.createdAt,
+    acceptedAt: typeof signalMetadata?.acceptedAt === 'string' ? signalMetadata.acceptedAt : undefined,
     attributes:
       signalMetadata?.attributes &&
       typeof signalMetadata.attributes === 'object' &&

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -389,7 +389,7 @@ export class AgentThreadStreamRuntime {
     signalInput: AgentSignal,
     target: SendAgentSignalOptions<OUTPUT>,
   ): SendAgentSignalResult {
-    const signal = createSignal(signalInput);
+    const signal = createSignal({ ...signalInput, acceptedAt: new Date() });
     let key: string | undefined;
     let runId = target.runId;
     const activeBehavior = target.ifActive?.behavior ?? 'deliver';

--- a/packages/core/src/agent/workflows/prepare-stream/index.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/index.ts
@@ -55,8 +55,6 @@ interface CreatePrepareStreamWorkflowOptions<OUTPUT = undefined> {
    */
   skipBgTaskWait?: boolean;
   drainPendingSignals?: (runId: string) => CreatedAgentSignal[];
-  /** Signal inputs already stored in the initial message list that still need stream data-part echoes. */
-  initialSignalEchoes?: CreatedAgentSignal[];
 }
 
 export function createPrepareStreamWorkflow<OUTPUT = undefined>({
@@ -85,7 +83,6 @@ export function createPrepareStreamWorkflow<OUTPUT = undefined>({
   toolPayloadTransform,
   skipBgTaskWait,
   drainPendingSignals,
-  initialSignalEchoes,
 }: CreatePrepareStreamWorkflowOptions<OUTPUT>) {
   const prepareToolsStep = createPrepareToolsStep({
     capabilities,
@@ -136,7 +133,6 @@ export function createPrepareStreamWorkflow<OUTPUT = undefined>({
     toolPayloadTransform,
     skipBgTaskWait,
     drainPendingSignals,
-    initialSignalEchoes,
   });
 
   const mapResultsStep = createMapResultsStep({

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -361,6 +361,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
         ...(options.modelSettings || {}),
       },
       messageList: memoryData.messageList!,
+      initialSignalEchoes: memoryData.initialSignalEchoes,
       maxProcessorRetries: options.maxProcessorRetries,
       // IsTaskComplete scoring for supervisor patterns
       isTaskComplete: options.isTaskComplete,

--- a/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
@@ -10,6 +10,7 @@ import type { RequestContext } from '../../../request-context';
 import { createStep } from '../../../workflows';
 import type { InnerAgentExecutionOptions } from '../../agent.types';
 import { MessageList } from '../../message-list';
+import { mastraDBMessageToSignal } from '../../signals';
 import type { AgentMethodType } from '../../types';
 import type { AgentCapabilities } from './schema';
 import { prepareMemoryStepOutputSchema } from './schema';
@@ -31,6 +32,14 @@ function addSystemMessage(messageList: MessageList, content: SystemMessage | und
     // Handle string, CoreSystemMessage, or SystemModelMessage
     messageList.addSystem(content, tag);
   }
+}
+
+function getInitialSignalEchoes(messageList: MessageList) {
+  const inputMessageIds = messageList.makeMessageSourceChecker().input;
+  return messageList.get.all
+    .db()
+    .filter(message => message.role === 'signal' && inputMessageIds.has(message.id))
+    .map(mastraDBMessageToSignal);
 }
 
 interface PrepareMemoryStepOptions<OUTPUT = undefined> {
@@ -90,6 +99,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
 
       if (!memory || (!thread?.id && !resourceId)) {
         messageList.add(options.messages, 'input');
+        const initialSignalEchoes = getInitialSignalEchoes(messageList);
 
         // Skip input processors during resume — the messageList has no user messages
         // (resumeStream passes messages: []) and the real conversation state lives in the
@@ -112,6 +122,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
           messageList,
           processorStates,
           tripwire,
+          initialSignalEchoes,
         };
       }
 
@@ -170,6 +181,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
 
       // Add user messages - memory processors will handle history/semantic recall/working memory
       messageList.add(options.messages, 'input');
+      const initialSignalEchoes = getInitialSignalEchoes(messageList);
 
       // Skip input processors during resume — the messageList has no user messages
       // (resumeStream passes messages: []) and the real conversation state lives in the
@@ -191,6 +203,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
         messageList: messageList,
         processorStates,
         tripwire,
+        initialSignalEchoes,
         threadExists: !!existingThread,
       };
     },

--- a/packages/core/src/agent/workflows/prepare-stream/schema.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/schema.ts
@@ -11,6 +11,7 @@ import type {
 import type { RequestContext } from '../../../request-context';
 import type { Agent } from '../../agent';
 import { MessageList } from '../../message-list';
+import type { CreatedAgentSignal } from '../../signals';
 import type { AgentExecuteOnFinishOptions } from '../../types';
 
 export type AgentCapabilities = {
@@ -91,6 +92,8 @@ export const prepareMemoryStepOutputSchema = z.object({
       processorId: z.string().optional(),
     })
     .optional(),
+  /** Signal inputs already stored in the initial message list that still need stream data-part echoes. */
+  initialSignalEchoes: z.array(z.custom<CreatedAgentSignal>()).optional(),
 });
 
 export type PrepareMemoryStepOutput = z.infer<typeof prepareMemoryStepOutputSchema>;

--- a/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
@@ -46,7 +46,6 @@ interface StreamStepOptions {
    */
   skipBgTaskWait?: boolean;
   drainPendingSignals?: (runId: string) => CreatedAgentSignal[];
-  initialSignalEchoes?: CreatedAgentSignal[];
 }
 
 export function createStreamStep<OUTPUT = undefined>({
@@ -71,7 +70,6 @@ export function createStreamStep<OUTPUT = undefined>({
   toolPayloadTransform,
   skipBgTaskWait,
   drainPendingSignals,
-  initialSignalEchoes,
 }: StreamStepOptions) {
   return createStep({
     id: 'stream-text-step',
@@ -79,7 +77,9 @@ export function createStreamStep<OUTPUT = undefined>({
     outputSchema: z.instanceof(MastraModelOutput<OUTPUT>),
     execute: async ({ inputData, ...observabilityContext }) => {
       // Instead of validating inputData with zod, we just cast it to the type we know it should be
-      const validatedInputData = inputData as ModelLoopStreamArgs<any, OUTPUT>;
+      const validatedInputData = inputData as ModelLoopStreamArgs<any, OUTPUT> & {
+        initialSignalEchoes?: CreatedAgentSignal[];
+      };
 
       const processors =
         validatedInputData.outputProcessors ||
@@ -114,7 +114,7 @@ export function createStreamStep<OUTPUT = undefined>({
           toolPayloadTransform,
           skipBgTaskWait,
           drainPendingSignals,
-          initialSignalEchoes,
+          initialSignalEchoes: validatedInputData.initialSignalEchoes,
         },
         agentId,
         agentName,

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -38,11 +38,13 @@ export function buildMessagesFromChunks({
   messageId,
   responseModelMetadata,
   tools,
+  createdAt = new Date(),
 }: {
   chunks: CollectedChunk[];
   messageId: string;
   responseModelMetadata?: { metadata: Record<string, unknown> };
   tools?: ToolSet;
+  createdAt?: Date;
 }): MastraDBMessage[] {
   // Parts are pushed in first-delta order. Text and reasoning spans push a part
   // on the first delta and mutate it in place as subsequent deltas arrive.
@@ -342,7 +344,7 @@ export function buildMessagesFromChunks({
       ...(contentString ? { content: contentString } : {}),
       ...responseModelMetadata,
     },
-    createdAt: new Date(),
+    createdAt,
   };
 
   return [message];

--- a/packages/core/src/loop/workflows/agentic-execution/index.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/index.ts
@@ -8,6 +8,7 @@ import { createBackgroundTaskCheckStep } from './background-task-check-step';
 import { createIsTaskCompleteStep } from './is-task-complete-step';
 import { createLLMExecutionStep } from './llm-execution-step';
 import { createLLMMappingStep } from './llm-mapping-step';
+import { createSignalDrainStep } from './signal-drain-step';
 import { resolveConfiguredToolCallConcurrency, resolveToolCallConcurrency } from './tool-call-concurrency';
 import type { ToolCallForeachOptions } from './tool-call-concurrency';
 import { createToolCallStep } from './tool-call-step';
@@ -57,6 +58,12 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
     ...rest,
   });
 
+  const signalDrainStep = createSignalDrainStep({
+    models,
+    _internal,
+    ...rest,
+  });
+
   const isTaskCompleteStep = createIsTaskCompleteStep({
     models,
     _internal,
@@ -88,6 +95,7 @@ export function createAgenticExecutionWorkflow<Tools extends ToolSet = ToolSet, 
     .foreach(toolCallStep, toolCallForeachOptions)
     .then(llmMappingStep)
     .then(backgroundTaskCheckStep)
+    .then(signalDrainStep)
     .then(isTaskCompleteStep)
     .commit();
 }

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -5,6 +5,7 @@ import { APICallError, generateId } from '@internal/ai-sdk-v5';
 import type { CallSettings, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import type { StructuredOutputOptions } from '../../../agent';
 import type { MessageList } from '../../../agent/message-list';
+import { mastraDBMessageToSignal } from '../../../agent/signals';
 import type { CreatedAgentSignal } from '../../../agent/signals';
 import { TripWire } from '../../../agent/trip-wire';
 import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../../../agent/utils';
@@ -691,7 +692,13 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
 
           const initialSignalEchoes = _internal?.initialSignalEchoes?.splice(0) ?? [];
           for (const initialSignal of initialSignalEchoes) {
-            safeEnqueue(controller, initialSignal.toDataPart());
+            const signalMessage = messageList.get.all
+              .db()
+              .find(message => message.role === 'signal' && message.id === initialSignal.id);
+            safeEnqueue(
+              controller,
+              (signalMessage ? mastraDBMessageToSignal(signalMessage) : initialSignal).toDataPart(),
+            );
           }
 
           const pendingSignals = _internal?.drainPendingSignals?.(runId) ?? [];
@@ -699,8 +706,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             currentMessageId = _internal?.generateId?.() ?? generateId();
           }
           for (const pendingSignal of pendingSignals) {
-            messageList.add(pendingSignal, 'input');
-            safeEnqueue(controller, pendingSignal.toDataPart());
+            const signalForTranscript = messageList.addSignal(pendingSignal);
+            safeEnqueue(controller, signalForTranscript.toDataPart());
           }
 
           const currentStep: {
@@ -1241,7 +1248,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               messageList.markResponseMessageBoundary(currentStep.messageId);
               outputStream.messageId = rotateResponseMessageId();
               for (const signal of interjectedSignals) {
-                const signalForTranscript = messageList.addInterjectedSignal(signal);
+                const signalForTranscript = messageList.addSignal(signal);
                 safeEnqueue(controller, signalForTranscript.toDataPart());
               }
               runState.setState({

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -5,8 +5,6 @@ import { APICallError, generateId } from '@internal/ai-sdk-v5';
 import type { CallSettings, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import type { StructuredOutputOptions } from '../../../agent';
 import type { MessageList } from '../../../agent/message-list';
-import { mastraDBMessageToSignal } from '../../../agent/signals';
-import type { CreatedAgentSignal } from '../../../agent/signals';
 import { TripWire } from '../../../agent/trip-wire';
 import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '../../../agent/utils';
 import { generateBackgroundTaskSystemPrompt } from '../../../background-tasks';
@@ -85,7 +83,6 @@ function getRequestInputProcessors({
 
 type ProcessOutputStreamResult = {
   collectedChunks: CollectedChunk[];
-  interjectedSignals: CreatedAgentSignal[];
 };
 
 type ProcessOutputStreamOptions<OUTPUT = undefined> = {
@@ -104,7 +101,6 @@ type ProcessOutputStreamOptions<OUTPUT = undefined> = {
     rawResponse: any;
   };
   logger?: IMastraLogger;
-  drainPendingSignals?: (runId: string) => CreatedAgentSignal[];
   transportRef?: StreamTransportRef;
   transportResolver?: () => StreamTransport | undefined;
   toolPayloadTransform?: NonNullable<OuterLLMRun['_internal']>['toolPayloadTransform'];
@@ -316,8 +312,6 @@ async function processOutputStream<OUTPUT = undefined>({
   responseFromModel,
   includeRawChunks,
   logger,
-  runId,
-  drainPendingSignals,
   transportRef,
   transportResolver,
   toolPayloadTransform,
@@ -349,13 +343,6 @@ async function processOutputStream<OUTPUT = undefined>({
     if (chunk.type == 'object' || chunk.type == 'object-result') {
       controller.enqueue(chunk);
       continue;
-    }
-
-    if (['tool-call', 'tool-call-input-streaming-start'].includes(chunk.type)) {
-      const interjectedSignals = drainPendingSignals?.(runId) ?? [];
-      if (interjectedSignals.length > 0) {
-        return { collectedChunks, interjectedSignals };
-      }
     }
 
     chunk = await addToolPayloadTransformToChunk(chunk, {
@@ -521,19 +508,9 @@ async function processOutputStream<OUTPUT = undefined>({
     if (runState.state.hasErrored) {
       break;
     }
-
-    // Drain signals only at stream boundaries so follow-ups do not split visible assistant text
-    // or separate a tool call from its result. Tool calls are handled before enqueueing so
-    // an interjection can cancel a not-yet-visible tool call from the current step.
-    if (['text-end', 'reasoning-end', 'tool-result', 'finish'].includes(chunk.type)) {
-      const interjectedSignals = drainPendingSignals?.(runId) ?? [];
-      if (interjectedSignals.length > 0) {
-        return { collectedChunks, interjectedSignals };
-      }
-    }
   }
 
-  return { collectedChunks, interjectedSignals: [] };
+  return { collectedChunks };
 }
 
 function executeStreamWithFallbackModels<T>(
@@ -692,22 +669,19 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
 
           const initialSignalEchoes = _internal?.initialSignalEchoes?.splice(0) ?? [];
           for (const initialSignal of initialSignalEchoes) {
-            const signalMessage = messageList.get.all
-              .db()
-              .find(message => message.role === 'signal' && message.id === initialSignal.id);
-            safeEnqueue(
-              controller,
-              (signalMessage ? mastraDBMessageToSignal(signalMessage) : initialSignal).toDataPart(),
-            );
+            safeEnqueue(controller, initialSignal.toDataPart());
           }
 
-          const pendingSignals = _internal?.drainPendingSignals?.(runId) ?? [];
-          if (pendingSignals.length > 0) {
-            currentMessageId = _internal?.generateId?.() ?? generateId();
-          }
-          for (const pendingSignal of pendingSignals) {
-            const signalForTranscript = messageList.addSignal(pendingSignal);
-            safeEnqueue(controller, signalForTranscript.toDataPart());
+          const shouldDrainBeforeFirstModelRequest = (inputData.output?.steps?.length ?? 0) === 0;
+          if (shouldDrainBeforeFirstModelRequest) {
+            const pendingSignals = _internal?.drainPendingSignals?.(runId) ?? [];
+            if (pendingSignals.length > 0) {
+              currentMessageId = _internal?.generateId?.() ?? generateId();
+            }
+            for (const pendingSignal of pendingSignals) {
+              const signalForTranscript = messageList.addSignal(pendingSignal);
+              safeEnqueue(controller, signalForTranscript.toDataPart());
+            }
           }
 
           const currentStep: {
@@ -1208,7 +1182,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           }
 
           try {
-            const { collectedChunks, interjectedSignals } = await processOutputStream({
+            const { collectedChunks } = await processOutputStream({
               outputStream,
               includeRawChunks,
               tools: currentStep.tools,
@@ -1224,7 +1198,6 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                 rawResponse,
               },
               logger,
-              drainPendingSignals: _internal?.drainPendingSignals,
               transportRef: _internal?.transportRef,
               transportResolver,
               toolPayloadTransform: _internal?.toolPayloadTransform,
@@ -1242,22 +1215,6 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             });
             for (const msg of builtMessages) {
               messageList.add(msg, 'response');
-            }
-
-            if (interjectedSignals.length > 0) {
-              messageList.markResponseMessageBoundary(currentStep.messageId);
-              outputStream.messageId = rotateResponseMessageId();
-              for (const signal of interjectedSignals) {
-                const signalForTranscript = messageList.addSignal(signal);
-                safeEnqueue(controller, signalForTranscript.toDataPart());
-              }
-              runState.setState({
-                stepResult: {
-                  reason: 'other',
-                  messageId: currentMessageId,
-                  isContinued: true,
-                },
-              });
             }
 
             // Apply structuredOutput metadata to the assistant message.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -705,6 +705,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
 
           const currentStep: {
             messageId: string;
+            createdAt: Date;
             model: MastraLanguageModel;
             tools?: TOOLS | undefined;
             toolChoice?: ToolChoice<TOOLS> | undefined;
@@ -715,6 +716,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             workspace?: Workspace;
           } = {
             messageId: currentMessageId,
+            createdAt: new Date(),
             model,
             tools,
             toolChoice,
@@ -1229,6 +1231,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               messageId: currentStep.messageId,
               responseModelMetadata: buildResponseModelMetadata(runState, currentStep.model),
               tools: currentStep.tools,
+              createdAt: currentStep.createdAt,
             });
             for (const msg of builtMessages) {
               messageList.add(msg, 'response');
@@ -1238,8 +1241,8 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               messageList.markResponseMessageBoundary(currentStep.messageId);
               outputStream.messageId = rotateResponseMessageId();
               for (const signal of interjectedSignals) {
-                messageList.add(signal, 'input');
-                safeEnqueue(controller, signal.toDataPart());
+                const signalForTranscript = messageList.addInterjectedSignal(signal);
+                safeEnqueue(controller, signalForTranscript.toDataPart());
               }
               runState.setState({
                 stepResult: {

--- a/packages/core/src/loop/workflows/agentic-execution/signal-drain-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/signal-drain-step.ts
@@ -1,0 +1,48 @@
+import type { ToolSet } from '@internal/ai-sdk-v5';
+import type { ChunkType } from '../../../stream/types';
+import { createStep } from '../../../workflows';
+import type { OuterLLMRun } from '../../types';
+import { llmIterationOutputSchema } from '../schema';
+import type { LLMIterationData } from '../schema';
+
+export function createSignalDrainStep<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
+  _internal,
+  controller,
+  runId,
+  messageList,
+  mastra,
+}: OuterLLMRun<Tools, OUTPUT>) {
+  return createStep({
+    id: 'signalDrainStep',
+    inputSchema: llmIterationOutputSchema,
+    outputSchema: llmIterationOutputSchema,
+    execute: async ({ inputData }) => {
+      const typedInput = inputData as LLMIterationData<Tools, OUTPUT>;
+      const pendingSignals = _internal?.drainPendingSignals?.(runId) ?? [];
+      if (pendingSignals.length === 0) {
+        return typedInput;
+      }
+
+      messageList.markResponseMessageBoundary(typedInput.stepResult?.messageId ?? typedInput.messageId);
+      for (const pendingSignal of pendingSignals) {
+        const signalForTranscript = messageList.addSignal(pendingSignal);
+        controller.enqueue(signalForTranscript.toDataPart() as ChunkType<OUTPUT>);
+      }
+
+      return {
+        ...typedInput,
+        messageId: _internal?.generateId?.() ?? mastra?.generateId?.() ?? typedInput.messageId,
+        stepResult: {
+          ...typedInput.stepResult,
+          reason: 'other',
+          isContinued: true,
+        },
+        messages: {
+          all: messageList.get.all.aiV5.model(),
+          user: messageList.get.input.aiV5.model(),
+          nonUser: messageList.get.response.aiV5.model(),
+        },
+      };
+    },
+  });
+}


### PR DESCRIPTION
This fixes active signal ordering after a conversation is reloaded from memory.

Before, signal messages could be converted for the model prompt with fresh timestamps/ids, which made persisted active-run signals reload out of transcript order:

```ts
agent response
agent response
user signal
user signal
```

After, explicit timestamps are preserved during conversion, interjected signals keep their original `createdAt`, and `acceptedAt` is only persisted when we need a separate transcript placement time:

```ts
agent response
user signal
agent response
user signal
```

I also added regression coverage for multiple active signals, response boundaries, prompt conversion, and the legacy case where DB signal metadata has no `acceptedAt`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5 Summary
When conversations were reloaded, some live "signal" messages could show up in the wrong order. This PR preserves each signal's original timestamps (createdAt and acceptedAt) and changes when signals are drained so reloaded and streamed signals keep the same order they happened.

Overview
This PR fixes ordering bugs for active-run agent signals by preserving explicit message timestamps across conversion, ingestion, prompt construction, and streaming, and by moving signal draining out of the LLM streaming loop into a dedicated agentic execution step that runs after tools/background tasks. Deserialization/merge/add paths now update an internal last-created timestamp so generated times don't advance incorrectly. Interjected signals keep their original createdAt and acceptedAt semantics; acceptedAt is used only when a separate placement time is required and legacy DB shapes without acceptedAt are supported.

Key changes
- Signals
  - Added optional acceptedAt to AgentSignalInput and CreatedAgentSignal; propagated through AgentSignalDataPart and MastraDBMessage metadata and restored by mastraDBMessageToSignal.
  - sendSignal records acceptedAt on created signals used for persistence/streaming.

- MessageList
  - Added public addSignal to normalize, persist, and return transcript-ready signal messages; input-sourced signals route through addSignal.
  - New convertSignalForModelPrompt preserves stored createdAt while assigning per-split prompt IDs for provider-facing prompt messages.
  - Timestamp tracking: added updateLastCreatedAt and made generateCreatedAt derive from lastCreatedAt (deserialization-aware) to maintain incremental timestamp progression.
  - For input-sourced stored signals, messageV2.createdAt is regenerated only when signal metadata lacks acceptedAt.

- LLM execution & response construction
  - Introduced a new signalDrainStep run after background-task checks (before completion) to drain pending signals and append them to the transcript; removed interjected-signal draining from the streaming loop.
  - Preserved initial pre-model drain for idle-started runs so thread-targeted signals received before run creation are still included without duplicating model output.
  - Per-iteration step timestamping added; createdAt is passed into buildMessagesFromChunks (which now accepts an optional createdAt).

Behavioral/timestamp guarantees
- Prompt conversion preserves original createdAt and does not advance the internal timestamp clock.
- Interjected signals retain original createdAt and are placed after the latest relevant response-part timestamp (including tool-part times); createdAt may be set to tool-part-time + 1 only when a placement time is required while acceptedAt remains the original acceptance time.
- Deserialization, merge, and add paths update the internal clock from relevant part timestamps so subsequently generated messages order correctly.
- Legacy DB messages lacking acceptedAt are supported; createdAt is regenerated only when necessary.

Tests
- Expanded agent-signals tests to validate acceptedAt propagation across LLM → data-part → DB conversions, draining multiple active signals into the same run, response-boundary placement, prompt-conversion timestamp behavior, and legacy DB message shapes without acceptedAt.
- Added message-list ordering regression tests verifying interjection placement relative to response parts, prompt conversion not advancing timestamps, and correct storage/recall of createdAt/acceptedAt.

Commit notes
- Moved active-run signal draining out of the LLM stream loop into a dedicated agentic execution step to prevent pending-signal echoes from interrupting in-flight tool work or persisting ahead of tool outputs.
- Preserved the initial pre-model drain for idle-started runs so thread-targeted signals received before run creation are still included without duplicating model output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16623)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->