### PR TITLE
fix: make brightdata tools bun compatible

### DIFF
--- a/.changeset/brightdata-bun-compatible.md
+++ b/.changeset/brightdata-bun-compatible.md
@@ -1,0 +1,5 @@
+---
+"@mastra/brightdata": patch
+---
+
+Fix Bright Data tools under Bun by replacing the SDK runtime client with fetch-based REST calls.

--- a/integrations/brightdata/package.json
+++ b/integrations/brightdata/package.json
@@ -49,9 +49,6 @@
   "engines": {
     "node": ">=22.13.0"
   },
-  "dependencies": {
-    "@brightdata/sdk": "^1.1.0"
-  },
   "peerDependencies": {
     "@mastra/core": ">=1.0.0-0 <2.0.0-0",
     "zod": ">=3.0.0"

--- a/integrations/brightdata/src/__tests__/client.test.ts
+++ b/integrations/brightdata/src/__tests__/client.test.ts
@@ -1,30 +1,47 @@
-import { bdclient } from '@brightdata/sdk';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
 import { closeClient, getBrightDataClient } from '../client.js';
 
-vi.mock('@brightdata/sdk', () => ({
-  bdclient: vi.fn(function () {
-    return {
-      search: { google: vi.fn(), bing: vi.fn(), yandex: vi.fn() },
-      scrapeUrl: vi.fn(),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-  }),
-}));
+const fetchMock = vi.fn();
 
 describe('getBrightDataClient', () => {
-  const originalEnv = process.env.BRIGHTDATA_API_TOKEN;
+  const originalApiToken = process.env.BRIGHTDATA_API_TOKEN;
+  const originalSerpZone = process.env.BRIGHTDATA_SERP_ZONE;
+  const originalWebUnlockerZone = process.env.BRIGHTDATA_WEB_UNLOCKER_ZONE;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
     delete process.env.BRIGHTDATA_API_TOKEN;
+    delete process.env.BRIGHTDATA_SERP_ZONE;
+    delete process.env.BRIGHTDATA_WEB_UNLOCKER_ZONE;
+    fetchMock.mockImplementation(async (_url, init: RequestInit) => {
+      const body =
+        typeof init.body === 'string' ? (JSON.parse(init.body) as { format?: string }) : {};
+
+      return body.format === 'json' ? Response.json({}) : new Response('ok');
+    });
   });
 
   afterEach(() => {
-    if (originalEnv !== undefined) {
-      process.env.BRIGHTDATA_API_TOKEN = originalEnv;
+    vi.unstubAllGlobals();
+
+    if (originalApiToken !== undefined) {
+      process.env.BRIGHTDATA_API_TOKEN = originalApiToken;
     } else {
       delete process.env.BRIGHTDATA_API_TOKEN;
+    }
+
+    if (originalSerpZone !== undefined) {
+      process.env.BRIGHTDATA_SERP_ZONE = originalSerpZone;
+    } else {
+      delete process.env.BRIGHTDATA_SERP_ZONE;
+    }
+
+    if (originalWebUnlockerZone !== undefined) {
+      process.env.BRIGHTDATA_WEB_UNLOCKER_ZONE = originalWebUnlockerZone;
+    } else {
+      delete process.env.BRIGHTDATA_WEB_UNLOCKER_ZONE;
     }
   });
 
@@ -32,37 +49,101 @@ describe('getBrightDataClient', () => {
     expect(() => getBrightDataClient()).toThrow('Bright Data API token is required');
   });
 
-  it('should use the API key from config', () => {
-    getBrightDataClient({ apiKey: 'test-key-123' });
-    expect(bdclient).toHaveBeenCalledWith({ apiKey: 'test-key-123' });
+  it('should use the API key from config', async () => {
+    const client = getBrightDataClient({ apiKey: 'test-key-123' });
+
+    await client.scrapeUrl('https://example.com');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.brightdata.com/request',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-key-123',
+        }),
+      }),
+    );
   });
 
-  it('should fall back to BRIGHTDATA_API_TOKEN env var', () => {
+  it('should fall back to BRIGHTDATA_API_TOKEN env var', async () => {
     process.env.BRIGHTDATA_API_TOKEN = 'env-key-456';
-    getBrightDataClient();
-    expect(bdclient).toHaveBeenCalledWith({ apiKey: 'env-key-456' });
+    const client = getBrightDataClient();
+
+    await client.scrapeUrl('https://example.com');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.brightdata.com/request',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer env-key-456',
+        }),
+      }),
+    );
   });
 
-  it('should prefer config.apiKey over env var', () => {
+  it('should prefer config.apiKey over env var', async () => {
     process.env.BRIGHTDATA_API_TOKEN = 'env-key-456';
-    getBrightDataClient({ apiKey: 'config-key-789' });
-    expect(bdclient).toHaveBeenCalledWith({ apiKey: 'config-key-789' });
+    const client = getBrightDataClient({ apiKey: 'config-key-789' });
+
+    await client.scrapeUrl('https://example.com');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.brightdata.com/request',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer config-key-789',
+        }),
+      }),
+    );
   });
 
-  it('should pass through additional options', () => {
-    getBrightDataClient({ apiKey: 'test-key', timeout: 60000, webUnlockerZone: 'my_zone' });
-    expect(bdclient).toHaveBeenCalledWith({
+  it('should use custom zones from config', async () => {
+    const client = getBrightDataClient({
       apiKey: 'test-key',
-      timeout: 60000,
-      webUnlockerZone: 'my_zone',
+      serpZone: 'my_serp',
+      webUnlockerZone: 'my_unlocker',
+    });
+
+    await client.search.google('pizza');
+    await client.scrapeUrl('https://example.com');
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      zone: 'my_serp',
+    });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
+      zone: 'my_unlocker',
+    });
+  });
+
+  it('should use custom zones from env vars', async () => {
+    process.env.BRIGHTDATA_SERP_ZONE = 'env_serp';
+    process.env.BRIGHTDATA_WEB_UNLOCKER_ZONE = 'env_unlocker';
+    const client = getBrightDataClient({ apiKey: 'test-key' });
+
+    await client.search.google('pizza');
+    await client.scrapeUrl('https://example.com');
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      zone: 'env_serp',
+    });
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toMatchObject({
+      zone: 'env_unlocker',
     });
   });
 
   it('should return a client object', () => {
     const client = getBrightDataClient({ apiKey: 'test-key' });
     expect(client).toBeDefined();
-    expect(client.search).toBeDefined();
+    expect(client.search.google).toBeDefined();
     expect(client.scrapeUrl).toBeDefined();
+  });
+
+  it('should map auth errors to the SDK-compatible message', async () => {
+    fetchMock.mockResolvedValue(new Response('nope', { status: 401 }));
+    const client = getBrightDataClient({ apiKey: 'test-key' });
+
+    await expect(client.scrapeUrl('https://example.com')).rejects.toThrow(
+      'invalid API key or insufficient permissions',
+    );
   });
 });
 
@@ -72,25 +153,25 @@ describe('closeClient', () => {
   });
 
   it('should call close() on the client', async () => {
-    const client = getBrightDataClient({ apiKey: 'a' }) as unknown as {
-      close: ReturnType<typeof vi.fn>;
+    const client = {
+      close: vi.fn().mockResolvedValue(undefined),
+      scrapeUrl: vi.fn(),
+      search: { google: vi.fn() },
     };
 
-    await closeClient(client as any);
+    await closeClient(client);
 
     expect(client.close).toHaveBeenCalledTimes(1);
   });
 
-  it('should be a no-op when the client has no close method', async () => {
-    const client = { search: {}, scrapeUrl: vi.fn() };
-
-    await expect(closeClient(client as any)).resolves.toBeUndefined();
-  });
-
   it('should swallow errors thrown by close() so they cannot mask the primary error', async () => {
-    const client = { close: vi.fn().mockRejectedValue(new Error('close failed')) };
+    const client = {
+      close: vi.fn().mockRejectedValue(new Error('close failed')),
+      scrapeUrl: vi.fn(),
+      search: { google: vi.fn() },
+    };
 
-    await expect(closeClient(client as any)).resolves.toBeUndefined();
+    await expect(closeClient(client)).resolves.toBeUndefined();
     expect(client.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/integrations/brightdata/src/__tests__/client.test.ts
+++ b/integrations/brightdata/src/__tests__/client.test.ts
@@ -130,6 +130,15 @@ describe('getBrightDataClient', () => {
     });
   });
 
+  it('should allow callers to override the Google results language', async () => {
+    const client = getBrightDataClient({ apiKey: 'test-key' });
+
+    await client.search.google('pizza', { language: 'es' });
+
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(requestBody.url).toContain('hl=es');
+  });
+
   it('should return a client object', () => {
     const client = getBrightDataClient({ apiKey: 'test-key' });
     expect(client).toBeDefined();

--- a/integrations/brightdata/src/__tests__/fetch.test.ts
+++ b/integrations/brightdata/src/__tests__/fetch.test.ts
@@ -1,16 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockScrapeUrl = vi.fn();
-const mockClose = vi.fn().mockResolvedValue(undefined);
+const fetchMock = vi.fn();
 
-vi.mock('@brightdata/sdk', () => ({
-  bdclient: vi.fn(function () {
-    return {
-      search: { google: vi.fn(), bing: vi.fn(), yandex: vi.fn() },
-      scrapeUrl: mockScrapeUrl,
-      close: mockClose,
-    };
-  }),
+vi.mock('@mastra/core/tools', () => ({
+  createTool: vi.fn(config => config),
 }));
 
 import { createBrightDataFetchTool } from '../fetch.js';
@@ -18,7 +11,8 @@ import { createBrightDataFetchTool } from '../fetch.js';
 describe('createBrightDataFetchTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockScrapeUrl.mockResolvedValue('# Example Page\n\nHello world.');
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockResolvedValue(new Response('# Example Page\n\nHello world.'));
   });
 
   it('should create a tool with id brightdata-fetch', () => {
@@ -39,8 +33,14 @@ describe('createBrightDataFetchTool', () => {
 
     const result = await tool.execute!({ url: 'https://example.com' }, {} as any);
 
-    expect(mockScrapeUrl).toHaveBeenCalledWith('https://example.com', {
-      dataFormat: 'markdown',
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+    expect(requestBody).toEqual({
+      data_format: 'markdown',
+      format: 'raw',
+      method: 'GET',
+      url: 'https://example.com',
+      zone: 'sdk_unlocker',
     });
 
     expect(result).toEqual({
@@ -50,7 +50,7 @@ describe('createBrightDataFetchTool', () => {
   });
 
   it('should let errors propagate', async () => {
-    mockScrapeUrl.mockRejectedValue(new Error('Network unreachable'));
+    fetchMock.mockRejectedValue(new Error('Network unreachable'));
 
     const tool = createBrightDataFetchTool({ apiKey: 'test-key' });
 
@@ -59,20 +59,18 @@ describe('createBrightDataFetchTool', () => {
     );
   });
 
-  it('should close the client after a successful execute', async () => {
+  it('should make one Bright Data request after a successful execute', async () => {
     const tool = createBrightDataFetchTool({ apiKey: 'test-key' });
 
     await tool.execute!({ url: 'https://example.com' }, {} as any);
 
-    expect(mockClose).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should close the client even when execute throws', async () => {
-    mockScrapeUrl.mockRejectedValue(new Error('boom'));
+  it('should preserve the primary error when execute throws', async () => {
+    fetchMock.mockRejectedValue(new Error('boom'));
     const tool = createBrightDataFetchTool({ apiKey: 'test-key' });
 
     await expect(tool.execute!({ url: 'https://example.com' }, {} as any)).rejects.toThrow('boom');
-
-    expect(mockClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/integrations/brightdata/src/__tests__/fetch.test.ts
+++ b/integrations/brightdata/src/__tests__/fetch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const fetchMock = vi.fn();
 
@@ -13,6 +13,10 @@ describe('createBrightDataFetchTool', () => {
     vi.clearAllMocks();
     vi.stubGlobal('fetch', fetchMock);
     fetchMock.mockResolvedValue(new Response('# Example Page\n\nHello world.'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('should create a tool with id brightdata-fetch', () => {

--- a/integrations/brightdata/src/__tests__/search.test.ts
+++ b/integrations/brightdata/src/__tests__/search.test.ts
@@ -52,7 +52,7 @@ describe('createBrightDataSearchTool', () => {
     const tool = createBrightDataSearchTool({ apiKey: 'test-key' });
 
     const result = await tool.execute!(
-      { query: 'pizza restaurants', country: 'us', start: 10 },
+      { query: 'pizza restaurants', country: 'us', language: 'es', start: 10 },
       {} as any,
     );
 
@@ -66,6 +66,7 @@ describe('createBrightDataSearchTool', () => {
     expect(requestBody.url).toContain('https://www.google.com/search');
     expect(requestBody.url).toContain('q=pizza+restaurants');
     expect(requestBody.url).toContain('gl=us');
+    expect(requestBody.url).toContain('hl=es');
     expect(requestBody.url).toContain('start=10');
 
     expect(result).toEqual({
@@ -86,6 +87,7 @@ describe('createBrightDataSearchTool', () => {
     const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
 
     expect(requestBody.url).toContain('q=simple+search');
+    expect(requestBody.url).toContain('hl=en');
     expect(requestBody.url).not.toContain('gl=');
     expect(requestBody.url).not.toContain('start=');
   });

--- a/integrations/brightdata/src/__tests__/search.test.ts
+++ b/integrations/brightdata/src/__tests__/search.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const fetchMock = vi.fn();
 
@@ -29,6 +29,10 @@ describe('createBrightDataSearchTool', () => {
         current_page: 2,
       }),
     );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('should create a tool with id brightdata-search', () => {

--- a/integrations/brightdata/src/__tests__/search.test.ts
+++ b/integrations/brightdata/src/__tests__/search.test.ts
@@ -1,16 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockGoogle = vi.fn();
-const mockClose = vi.fn().mockResolvedValue(undefined);
+const fetchMock = vi.fn();
 
-vi.mock('@brightdata/sdk', () => ({
-  bdclient: vi.fn(function () {
-    return {
-      search: { google: mockGoogle, bing: vi.fn(), yandex: vi.fn() },
-      scrapeUrl: vi.fn(),
-      close: mockClose,
-    };
-  }),
+vi.mock('@mastra/core/tools', () => ({
+  createTool: vi.fn(config => config),
 }));
 
 import { createBrightDataSearchTool } from '../search.js';
@@ -18,21 +11,24 @@ import { createBrightDataSearchTool } from '../search.js';
 describe('createBrightDataSearchTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGoogle.mockResolvedValue({
-      organic: [
-        {
-          link: 'https://example.com/a',
-          title: 'Example A',
-          description: 'A description',
-        },
-        {
-          link: 'https://example.com/b',
-          title: 'Example B',
-          description: 'B description',
-        },
-      ],
-      current_page: 2,
-    });
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockResolvedValue(
+      Response.json({
+        organic: [
+          {
+            link: 'https://example.com/a',
+            title: 'Example A',
+            description: 'A description',
+          },
+          {
+            link: 'https://example.com/b',
+            title: 'Example B',
+            description: 'B description',
+          },
+        ],
+        current_page: 2,
+      }),
+    );
   });
 
   it('should create a tool with id brightdata-search', () => {
@@ -56,10 +52,17 @@ describe('createBrightDataSearchTool', () => {
       {} as any,
     );
 
-    expect(mockGoogle).toHaveBeenCalledWith('pizza restaurants', {
-      country: 'us',
-      start: 10,
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+    expect(requestBody).toMatchObject({
+      format: 'json',
+      method: 'GET',
+      zone: 'sdk_serp',
     });
+    expect(requestBody.url).toContain('https://www.google.com/search');
+    expect(requestBody.url).toContain('q=pizza+restaurants');
+    expect(requestBody.url).toContain('gl=us');
+    expect(requestBody.url).toContain('start=10');
 
     expect(result).toEqual({
       query: 'pizza restaurants',
@@ -76,14 +79,15 @@ describe('createBrightDataSearchTool', () => {
 
     await tool.execute!({ query: 'simple search' }, {} as any);
 
-    expect(mockGoogle).toHaveBeenCalledWith('simple search', {
-      country: undefined,
-      start: undefined,
-    });
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+    expect(requestBody.url).toContain('q=simple+search');
+    expect(requestBody.url).not.toContain('gl=');
+    expect(requestBody.url).not.toContain('start=');
   });
 
   it('should default to empty results when organic is missing', async () => {
-    mockGoogle.mockResolvedValue({});
+    fetchMock.mockResolvedValue(Response.json({}));
 
     const tool = createBrightDataSearchTool({ apiKey: 'test-key' });
     const result = (await tool.execute!({ query: 'test' }, {} as any)) as any;
@@ -93,7 +97,7 @@ describe('createBrightDataSearchTool', () => {
   });
 
   it('should default currentPage to 1 when current_page is missing or non-positive', async () => {
-    mockGoogle.mockResolvedValue({ organic: [], current_page: 0 });
+    fetchMock.mockResolvedValue(Response.json({ organic: [], current_page: 0 }));
 
     const tool = createBrightDataSearchTool({ apiKey: 'test-key' });
     const result = (await tool.execute!({ query: 'test' }, {} as any)) as any;
@@ -102,15 +106,17 @@ describe('createBrightDataSearchTool', () => {
   });
 
   it('should filter out organic entries missing link or title', async () => {
-    mockGoogle.mockResolvedValue({
-      organic: [
-        { link: 'https://ok.example', title: 'Has both', description: 'ok' },
-        { link: '', title: 'Missing link', description: 'x' },
-        { link: 'https://nope.example', title: '', description: 'x' },
-        null,
-      ],
-      current_page: 1,
-    });
+    fetchMock.mockResolvedValue(
+      Response.json({
+        organic: [
+          { link: 'https://ok.example', title: 'Has both', description: 'ok' },
+          { link: '', title: 'Missing link', description: 'x' },
+          { link: 'https://nope.example', title: '', description: 'x' },
+          null,
+        ],
+        current_page: 1,
+      }),
+    );
 
     const tool = createBrightDataSearchTool({ apiKey: 'test-key' });
     const result = (await tool.execute!({ query: 'test' }, {} as any)) as any;
@@ -121,7 +127,7 @@ describe('createBrightDataSearchTool', () => {
   });
 
   it('should let errors propagate', async () => {
-    mockGoogle.mockRejectedValue(new Error('API rate limit exceeded'));
+    fetchMock.mockRejectedValue(new Error('API rate limit exceeded'));
 
     const tool = createBrightDataSearchTool({ apiKey: 'test-key' });
 
@@ -131,8 +137,8 @@ describe('createBrightDataSearchTool', () => {
   });
 
   it('should parse string responses (SDK returns JSON-encoded text)', async () => {
-    mockGoogle.mockResolvedValue(
-      JSON.stringify({
+    fetchMock.mockResolvedValue(
+      Response.json({
         organic: [
           { link: 'https://from.string', title: 'Stringified', description: 'ok' },
         ],
@@ -149,20 +155,18 @@ describe('createBrightDataSearchTool', () => {
     expect(result.currentPage).toBe(3);
   });
 
-  it('should close the client after a successful execute', async () => {
+  it('should make one Bright Data request after a successful execute', async () => {
     const tool = createBrightDataSearchTool({ apiKey: 'test-key' });
 
     await tool.execute!({ query: 'test' }, {} as any);
 
-    expect(mockClose).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should close the client even when execute throws', async () => {
-    mockGoogle.mockRejectedValue(new Error('boom'));
+  it('should preserve the primary error when execute throws', async () => {
+    fetchMock.mockRejectedValue(new Error('boom'));
     const tool = createBrightDataSearchTool({ apiKey: 'test-key' });
 
     await expect(tool.execute!({ query: 'test' }, {} as any)).rejects.toThrow('boom');
-
-    expect(mockClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/integrations/brightdata/src/__tests__/tools.test.ts
+++ b/integrations/brightdata/src/__tests__/tools.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
-vi.mock('@brightdata/sdk', () => ({
-  bdclient: vi.fn(function () {
-    return {
-      search: { google: vi.fn(), bing: vi.fn(), yandex: vi.fn() },
-      scrapeUrl: vi.fn(),
-    };
-  }),
+vi.mock('@mastra/core/tools', () => ({
+  createTool: vi.fn(config => config),
 }));
 
 import { createBrightDataTools } from '../tools.js';

--- a/integrations/brightdata/src/client.ts
+++ b/integrations/brightdata/src/client.ts
@@ -1,7 +1,132 @@
-import { bdclient } from '@brightdata/sdk';
+const REQUEST_ENDPOINT = 'https://api.brightdata.com/request';
+const DEFAULT_SERP_ZONE = 'sdk_serp';
+const DEFAULT_WEB_UNLOCKER_ZONE = 'sdk_unlocker';
+const DEFAULT_TIMEOUT = 120_000;
 
-export type BrightDataClientOptions = ConstructorParameters<typeof bdclient>[0];
-export type BrightDataClient = bdclient;
+type RequestFormat = 'raw' | 'json';
+type DataFormat = 'html' | 'markdown' | 'screenshot';
+
+export interface BrightDataClientOptions {
+  [key: string]: unknown;
+  apiKey?: string;
+  timeout?: number;
+  webUnlockerZone?: string;
+  serpZone?: string;
+}
+
+interface RequestOptions {
+  country?: string;
+  dataFormat?: DataFormat;
+  format?: RequestFormat;
+  method?: string;
+  timeout?: number;
+  zone?: string;
+}
+
+interface SearchOptions extends RequestOptions {
+  start?: number;
+}
+
+interface BrightDataRequestBody {
+  country?: string;
+  data_format?: Exclude<DataFormat, 'html'>;
+  format: RequestFormat;
+  method: string;
+  url: string;
+  zone: string;
+}
+
+export interface BrightDataClient {
+  search: {
+    google: (query: string, options?: SearchOptions) => Promise<unknown>;
+  };
+  scrapeUrl: (url: string, options?: RequestOptions) => Promise<string>;
+  close: () => Promise<void>;
+}
+
+async function requestBrightData(
+  apiKey: string,
+  body: BrightDataRequestBody,
+  timeout = DEFAULT_TIMEOUT,
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(REQUEST_ENDPOINT, {
+      body: JSON.stringify(body),
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      signal: controller.signal,
+    });
+
+    const responseText = await response.text();
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        throw new Error('invalid API key or insufficient permissions');
+      }
+
+      if (response.status === 400) {
+        throw new Error(`bad request: ${responseText}`);
+      }
+
+      throw new Error(`request failed with status ${response.status}: ${responseText}`);
+    }
+
+    if (body.format === 'json') {
+      return responseText ? JSON.parse(responseText) : {};
+    }
+
+    return responseText;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Request timed out after ${timeout}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function buildGoogleSearchUrl(query: string, options: SearchOptions = {}) {
+  const url = new URL('https://www.google.com/search');
+  url.searchParams.set('q', query.trim());
+  url.searchParams.set('brd_json', '1');
+  url.searchParams.set('hl', 'en');
+
+  if (options.country) {
+    url.searchParams.set('gl', options.country);
+  }
+
+  if (options.start !== undefined) {
+    url.searchParams.set('start', String(options.start));
+  }
+
+  return url.toString();
+}
+
+function toRequestBody(url: string, zone: string, options: RequestOptions = {}): BrightDataRequestBody {
+  const body: BrightDataRequestBody = {
+    format: options.format ?? 'raw',
+    method: options.method ?? 'GET',
+    url,
+    zone,
+  };
+
+  if (options.country) {
+    body.country = options.country;
+  }
+
+  if (options.dataFormat && options.dataFormat !== 'html') {
+    body.data_format = options.dataFormat;
+  }
+
+  return body;
+}
 
 export function getBrightDataClient(config?: BrightDataClientOptions): BrightDataClient {
   const apiKey = config?.apiKey ?? process.env.BRIGHTDATA_API_TOKEN;
@@ -10,16 +135,45 @@ export function getBrightDataClient(config?: BrightDataClientOptions): BrightDat
       'Bright Data API token is required. Pass { apiKey } or set BRIGHTDATA_API_TOKEN env var.',
     );
   }
-  return new bdclient({ ...config, apiKey });
+
+  const timeout = config?.timeout;
+  const serpZone = config?.serpZone ?? process.env.BRIGHTDATA_SERP_ZONE ?? DEFAULT_SERP_ZONE;
+  const webUnlockerZone =
+    config?.webUnlockerZone ?? process.env.BRIGHTDATA_WEB_UNLOCKER_ZONE ?? DEFAULT_WEB_UNLOCKER_ZONE;
+
+  return {
+    search: {
+      google: async (query: string, options: SearchOptions = {}) => {
+        const url = buildGoogleSearchUrl(query, options);
+        return requestBrightData(
+          apiKey,
+          toRequestBody(url, options.zone ?? serpZone, {
+            ...options,
+            format: options.format ?? 'json',
+            method: 'GET',
+          }),
+          options.timeout ?? timeout,
+        );
+      },
+    },
+    scrapeUrl: async (url: string, options: RequestOptions = {}) => {
+      const response = await requestBrightData(
+        apiKey,
+        toRequestBody(url, options.zone ?? webUnlockerZone, options),
+        options.timeout ?? timeout,
+      );
+
+      return typeof response === 'string' ? response : JSON.stringify(response);
+    },
+    close: async () => {},
+  };
 }
 
 export async function closeClient(client: BrightDataClient): Promise<void> {
-  const close = (client as { close?: () => Promise<void> | void }).close;
-  if (typeof close === 'function') {
-    try {
-      await close.call(client);
-    } catch {
-      // best-effort cleanup; never mask the primary tool error from the finally block
-    }
+  const close = client.close;
+  try {
+    await close.call(client);
+  } catch {
+    // best-effort cleanup; never mask the primary tool error from the finally block
   }
 }

--- a/integrations/brightdata/src/client.ts
+++ b/integrations/brightdata/src/client.ts
@@ -49,8 +49,9 @@ async function requestBrightData(
   body: BrightDataRequestBody,
   timeout = DEFAULT_TIMEOUT,
 ): Promise<unknown> {
+  const effectiveTimeout = Number.isFinite(timeout) && timeout > 0 ? timeout : DEFAULT_TIMEOUT;
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
 
   try {
     const response = await fetch(REQUEST_ENDPOINT, {
@@ -84,7 +85,7 @@ async function requestBrightData(
     return responseText;
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error(`Request timed out after ${timeout}ms`);
+      throw new Error(`Request timed out after ${effectiveTimeout}ms`);
     }
     throw error;
   } finally {

--- a/integrations/brightdata/src/client.ts
+++ b/integrations/brightdata/src/client.ts
@@ -24,6 +24,7 @@ interface RequestOptions {
 }
 
 interface SearchOptions extends RequestOptions {
+  language?: string;
   start?: number;
 }
 
@@ -97,7 +98,7 @@ function buildGoogleSearchUrl(query: string, options: SearchOptions = {}) {
   const url = new URL('https://www.google.com/search');
   url.searchParams.set('q', query.trim());
   url.searchParams.set('brd_json', '1');
-  url.searchParams.set('hl', 'en');
+  url.searchParams.set('hl', options.language ?? 'en');
 
   if (options.country) {
     url.searchParams.set('gl', options.country);

--- a/integrations/brightdata/src/search.ts
+++ b/integrations/brightdata/src/search.ts
@@ -13,6 +13,7 @@ const inputSchema = z.object({
     .describe('2-letter country code for geo-targeted results (e.g., "us", "gb")'),
   language: z
     .string()
+    .length(2)
     .optional()
     .describe('Language code for localized Google results (e.g., "en", "es", "fr")'),
   start: z
@@ -39,7 +40,7 @@ export function createBrightDataSearchTool(config?: BrightDataClientOptions) {
   return createTool({
     id: 'brightdata-search',
     description:
-      "Search Google and get back parsed organic results (link, title, description). Uses Bright Data's SERP API which bypasses bot detection. Supports country targeting and pagination via result offset.",
+      "Search Google and get back parsed organic results (link, title, description). Uses Bright Data's SERP API which bypasses bot detection. Supports country and language targeting, plus pagination via result offset.",
     inputSchema,
     outputSchema,
     execute: async input => {

--- a/integrations/brightdata/src/search.ts
+++ b/integrations/brightdata/src/search.ts
@@ -11,6 +11,10 @@ const inputSchema = z.object({
     .length(2)
     .optional()
     .describe('2-letter country code for geo-targeted results (e.g., "us", "gb")'),
+  language: z
+    .string()
+    .optional()
+    .describe('Language code for localized Google results (e.g., "en", "es", "fr")'),
   start: z
     .number()
     .int()
@@ -43,6 +47,7 @@ export function createBrightDataSearchTool(config?: BrightDataClientOptions) {
       try {
         const rawResponse = await client.search.google(input.query, {
           country: input.country,
+          language: input.language,
           start: input.start,
         });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1508,10 +1508,6 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
 
   integrations/brightdata:
-    dependencies:
-      '@brightdata/sdk':
-        specifier: ^1.1.0
-        version: 1.1.0
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -9777,10 +9773,6 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
-  '@brightdata/sdk@1.1.0':
-    resolution: {integrity: sha512-KTMxst7OAp/gUpUsl2ixWGSKLn8lTZx8W9UqmMeC04/36v9l5A9hJF+41iqvvTcvYJsiGzc1XfQFCtJAZeb0fQ==}
-    engines: {node: '>=20.0.0'}
-
   '@browserbasehq/sdk@2.10.0':
     resolution: {integrity: sha512-pOL4yW8P8AI2+N5y6zEP6XXKqIXtYyKunr1JXppqQDOyKLxxvZEDqQCHJXWUzqgx3R1tGWpn7m9AjXN7MeYInA==}
 
@@ -17131,10 +17123,6 @@ packages:
   '@supabase/supabase-js@2.105.4':
     resolution: {integrity: sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==}
     engines: {node: '>=20.0.0'}
-
-  '@supercharge/promise-pool@3.3.0':
-    resolution: {integrity: sha512-qGzCltMN05ohRRQAXB8TPWt+0Coz9Va266gr9nYN1qc/f/EIaup3VRg7b59mtRaeKTRcxreF20l/udCM/gOqNg==}
-    engines: {node: '>=8'}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -32083,12 +32071,6 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
-  '@brightdata/sdk@1.1.0':
-    dependencies:
-      '@supercharge/promise-pool': 3.3.0
-      undici: 7.25.0
-      zod: 4.4.3
-
   '@browserbasehq/sdk@2.10.0(encoding@0.1.13)':
     dependencies:
       '@types/node': 22.19.15
@@ -41637,8 +41619,6 @@ snapshots:
       '@supabase/postgrest-js': 2.105.4
       '@supabase/realtime-js': 2.105.4
       '@supabase/storage-js': 2.105.4
-
-  '@supercharge/promise-pool@3.3.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:


### PR DESCRIPTION
## Summary
- replace the Bright Data SDK runtime client with a fetch-based REST client for search and fetch tools
- remove the SDK dependency that triggers Bun's missing `undici.interceptors.dns()` path
- expose the Google search language option while preserving the default `hl=en`
- validate the search language input as a two-letter code
- update existing brightdata unit tests for the REST-backed client
- add a patch changeset for `@mastra/brightdata`

Fixes #16627

## Tests
- `./node_modules/.bin/vitest run` from `integrations/brightdata`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Bright Data tools broke on Bun because the Bright Data SDK used a network hook Bun doesn't support. This PR removes that SDK and reimplements the client with simple fetch-based HTTP calls so the tools run under Bun while keeping the same features.

## Overview

Fixes issue `#16627` by replacing the runtime Bright Data SDK client with a lightweight fetch-based REST client for the search and fetch tools in integrations/brightdata. Removes the `@brightdata/sdk` dependency (and its transitive undici usage), updates tests to stub global fetch, exposes and validates an optional two-letter Google search language parameter (default hl=en), and adds a patch changeset for `@mastra/brightdata`.

## Key changes

- Package
  - Removed dependency: `@brightdata/sdk` from integrations/brightdata/package.json.
  - Added .changeset/brightdata-bun-compatible.md to bump the package with a patch release.

- Fetch-based client (integrations/brightdata/src/client.ts)
  - Replaces SDK usage with requestBrightData(...) that POSTs to Bright Data endpoints using fetch with an AbortController timeout and optional JSON parsing.
  - Maps HTTP errors to friendly messages:
    - 401/403 → "invalid API key or insufficient permissions"
    - 400 → "bad request: <body>"
    - other non-OK → "request failed with status <status>: <body>"
  - Adds helpers buildGoogleSearchUrl(...) and toRequestBody(...).
  - getBrightDataClient(config?) now:
    - reads apiKey from config.apiKey or BRIGHTDATA_API_TOKEN (throws if missing),
    - honors serpZone and webUnlockerZone from config or env,
    - exposes search.google(query, options?) — requests the SERP endpoint with format:'json' and accepts optional language (validated as a two-letter code, default hl=en),
    - exposes scrapeUrl(url, options?) — requests the web unlocker endpoint and returns a string,
    - exposes close() as an async no-op.
  - closeClient(client) calls client.close() in a best-effort try/catch (swallows errors).

- Types / exported signatures
  - BrightDataClientOptions and BrightDataClient are now local explicit interfaces (apiKey?, timeout?, webUnlockerZone?, serpZone?; search.google, scrapeUrl, close).
  - getBrightDataClient and closeClient signatures updated accordingly.

- Tool input contract
  - createBrightDataSearchTool inputSchema now accepts optional language: string (2-letter code) for Google localization; default behavior preserves hl=en.

- Tests (integrations/brightdata/src/__tests__)
  - All relevant tests refactored to stub global fetch (vi.stubGlobal('fetch', ...)) instead of mocking `@brightdata/sdk`.
  - client.test.ts: asserts API key precedence (config > env), zone selection (config/env), request payloads include zone values, and auth error mapping remains SDK-compatible.
  - fetch.test.ts: validates the JSON request body (data_format/format/method/url/zone), success/error behavior, single-request assertion, and error preservation.
  - search.test.ts: validates request payload mapping (q/gl/start/language), response shaping (organic filtering, currentPage fallback), single-request behavior, and error propagation.
  - tools.test.ts: verifies returned tool objects' ids, descriptions, and schemas (mocks createTool).
  - Tests run command for maintainers: ./node_modules/.bin/vitest run (was used locally to confirm 32 tests passed).

## Impact

- Bun compatibility: prevents synchronous failure from undici.interceptors.dns() by removing `@brightdata/sdk` and using fetch.
- Reduced dependency surface and simpler runtime behavior.
- Functional compatibility preserved for tools; client types are now explicit local interfaces.
- Tests updated to exercise the REST-backed client.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->