### PR TITLE
style(playground-ui): unify chevron icon in property filter dropdown

### DIFF
--- a/.changeset/quiet-icons-shift.md
+++ b/.changeset/quiet-icons-shift.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Polished the property filter dropdown so the chevron icon next to each option keeps the same shape when its side panel opens 

--- a/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-creator.tsx
+++ b/packages/playground-ui/src/ds/components/PropertyFilter/property-filter-creator.tsx
@@ -1,11 +1,4 @@
-import {
-  ArrowLeftIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  FilterIcon,
-  ListFilterPlusIcon,
-  PlusIcon,
-} from 'lucide-react';
+import { ArrowLeftIcon, ChevronRightIcon, FilterIcon, ListFilterPlusIcon, PlusIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PickMultiPanel } from './pick-multi-panel';
 import type { PropertyFilterField, PropertyFilterToken } from './types';
@@ -387,7 +380,7 @@ function PickMultiMenuItem({ field, tokens, onChange, open, onToggle, onClose }:
             });
           }}
         >
-          {open && <ChevronLeftIcon className="h-4 w-4 text-neutral3 shrink-0" />}
+          {open && <ChevronRightIcon className="h-4 w-4 text-neutral3 shrink-0" />}
           <span className="truncate">{field.label}</span>
           {!open && <ChevronRightIcon className="h-4 w-4 ml-auto text-neutral3 shrink-0" />}
         </button>


### PR DESCRIPTION
## Summary

- Use the same \`ChevronRightIcon\` for both open and closed states of pick-multi menu items in the property filter dropdown.
- Only the position changes: left of the label when the side panel is open, right edge (\`ml-auto\`) when closed — instead of swapping the icon to \`ChevronLeftIcon\` on open.
- Removes the now-unused \`ChevronLeftIcon\` import.

## Test plan

- [ ] Open Observability → Traces → **Add Filter**.
- [ ] Hover/click a property with a side panel (e.g. **Environment**, **Status**, **List mode**).
- [ ] Confirm the chevron stays as \`›\` in both states — at the right edge when the option is closed, flush left next to the label when its side panel is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

The property filter dropdown had a little arrow that would flip its direction when you opened a side panel. This PR makes it simpler: the arrow always points the same way (›), but just moves from the right edge to the left side when the panel opens—kind of like sliding your hand instead of turning it around!

## Overview

This PR unifies the chevron icon display in the property filter dropdown component used in the Observability traces feature. Instead of swapping between different arrow icons (`ChevronRightIcon` ↔ `ChevronLeftIcon`) based on the side panel state, the component now consistently uses `ChevronRightIcon` in both states, with only its position changing.

## Changes

### `property-filter-creator.tsx`
- **Removed import**: Deleted the unused `ChevronLeftIcon` import; now only `ChevronRightIcon` is imported from `lucide-react`
- **Unified icon behavior in `PickMultiMenuItem`**:
  - When side panel is **open**: Renders `ChevronRightIcon` positioned left of the field label (without `ml-auto`)
  - When side panel is **closed**: Renders `ChevronRightIcon` positioned at the right edge with `ml-auto` class
  - Both states maintain the same visual icon (›), changing only position instead of type

### `.changeset/quiet-icons-shift.md`
- Added changeset entry documenting the `patch`-level UI polish for `@mastra/playground-ui`

## Testing

Verify the changes by:
1. Navigate to Observability → Traces → Add Filter
2. Interact with properties that have expandable side panels (Environment, Status, List mode, etc.)
3. Confirm the chevron icon (›) maintains consistent appearance in both open and closed states
4. Verify it slides from right edge (closed) to left of label (open), rather than flipping direction

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16635)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->