### PR TITLE
feat(playground-ui): add Level column and Show subtraces toggle to traces list

### DIFF
--- a/.changeset/neat-traces-step.md
+++ b/.changeset/neat-traces-step.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved the Observability traces list. Replaced the ID column with a Level column whose icon shows whether each row is a top-level Trace or a nested Subtrace; the header tooltip shows a legend. Replaced the "List mode" option in the Add Filter menu with a standalone "Show subtraces" toggle — off shows only top-level traces, on includes subtraces. The toggle hides automatically when the active storage provider doesn't support subtraces.

--- a/.changeset/neat-traces-step.md
+++ b/.changeset/neat-traces-step.md
@@ -2,4 +2,11 @@
 '@mastra/playground-ui': patch
 ---
 
-Improved the Observability traces list. Replaced the ID column with a Level column whose icon shows whether each row is a top-level Trace or a nested Subtrace; the header tooltip shows a legend. Replaced the "List mode" option in the Add Filter menu with a standalone "Show subtraces" toggle — off shows only top-level traces, on includes subtraces. The toggle hides automatically when the active storage provider doesn't support subtraces.
+Improved the Observability traces list to make the with-subtraces view more discoverable.
+
+- **Added:** A **Level** column whose icon distinguishes top-level **Trace** rows from nested **Subtrace** rows.
+- **Added:** A tooltip legend on the **Level** header showing both icons side by side.
+- **Added:** A standalone **Show subtraces** toggle next to **Add Filter** — off keeps the default top-level view, on includes subtraces.
+- **Removed:** The **List mode** entry from the **Add Filter** menu (now driven by the toggle).
+
+**Usage:** Open Observability → Traces → switch **Show subtraces** on. The **Level** column updates: top-level rows keep the Trace icon, nested rows show the Subtrace (↳) icon. The toggle is hidden automatically when the active storage provider doesn't support subtraces.

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -1,4 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { CornerDownRightIcon, ListTreeIcon } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { getInputPreview } from '../utils/span-utils';
 import { DataListSkeleton, TracesDataList } from '@/ds/components/DataList';
@@ -17,6 +18,8 @@ export type TracesListViewTrace = {
   traceId: string;
   /** Required for branch rows; absent on plain trace rows (which are root-rooted). */
   spanId?: string | null;
+  /** `null`/missing → root span. Drives the Kind column's icon (top-level trace vs nested branch). */
+  parentSpanId?: string | null;
   name: string;
   entityType?: string | null;
   entityId?: string | null;
@@ -28,7 +31,7 @@ export type TracesListViewTrace = {
 };
 
 // Fixed widths on non-flex columns prevent track shifts as the virtualizer swaps rows in/out.
-const COLUMNS = '7rem 6rem 9rem 14rem minmax(8rem,1fr) 14rem 6rem';
+const COLUMNS = '4rem 6rem 9rem 14rem minmax(8rem,1fr) 14rem 6rem';
 
 const ROW_HEIGHT = 36;
 const OVERSCAN = 8;
@@ -106,7 +109,22 @@ export function TracesListView({
   return (
     <TracesDataList columns={COLUMNS} scrollRef={scrollRef} className="min-w-0">
       <TracesDataList.Top>
-        <TracesDataList.TopCell>ID</TracesDataList.TopCell>
+        <TracesDataList.TopCellWithTooltip
+          tooltip={
+            <div className="grid gap-1">
+              <span className="flex items-center gap-1.5">
+                <ListTreeIcon className="size-4 shrink-0" aria-hidden />
+                Trace
+              </span>
+              <span className="flex items-center gap-1.5">
+                <CornerDownRightIcon className="size-4 shrink-0" aria-hidden />
+                Subtrace
+              </span>
+            </div>
+          }
+        >
+          Level
+        </TracesDataList.TopCellWithTooltip>
         <TracesDataList.TopCell>Date</TracesDataList.TopCell>
         <TracesDataList.TopCell>Time</TracesDataList.TopCell>
         <TracesDataList.TopCell>Name</TracesDataList.TopCell>
@@ -140,7 +158,7 @@ export function TracesListView({
                 onClick={() => onTraceClick(trace)}
                 className={cn(isFeatured && 'bg-surface4')}
               >
-                <TracesDataList.IdCell traceId={trace.traceId} />
+                <TracesDataList.KindCell parentSpanId={trace.parentSpanId} />
                 <TracesDataList.DateCell timestamp={displayDate} />
                 <TracesDataList.TimeCell timestamp={displayDate} />
                 <TracesDataList.NameCell name={trace.name} />

--- a/packages/playground-ui/src/domains/traces/trace-filters.ts
+++ b/packages/playground-ui/src/domains/traces/trace-filters.ts
@@ -30,7 +30,7 @@ export const TRACE_STATUS_OPTIONS = [
 /** Field ids for "synthetic" filter entries — they live in dedicated URL params
  *  rather than the generic `filter*` set, but appear as rows in the Filter
  *  popover so users can manage all filters from one place. */
-export const TRACE_SYNTHETIC_FILTER_FIELD_IDS = ['rootEntityType', 'status', 'mode'] as const;
+export const TRACE_SYNTHETIC_FILTER_FIELD_IDS = ['rootEntityType', 'status'] as const;
 
 export const TRACE_ROOT_ENTITY_TYPE_PARAM = 'rootEntityType';
 export const TRACE_STATUS_PARAM = 'status';
@@ -153,7 +153,6 @@ export function createTracePropertyFilterFields({
   availableServiceNames,
   availableEnvironments,
   loading,
-  branchesSupported = true,
 }: {
   availableTags: string[];
   availableRootEntityNames: string[];
@@ -165,13 +164,7 @@ export function createTracePropertyFilterFields({
     serviceNames?: boolean;
     environments?: boolean;
   };
-  /** When false, the Branches option is hidden from the List mode pick-multi panel —
-   *  used when the active storage provider doesn't implement `listBranches`. */
-  branchesSupported?: boolean;
 }): PropertyFilterField[] {
-  const listModeOptions = branchesSupported
-    ? TRACE_LIST_MODE_OPTIONS
-    : TRACE_LIST_MODE_OPTIONS.filter(o => o.value !== 'branches');
   const fields: PropertyFilterField[] = [
     {
       id: 'rootEntityType',
@@ -181,17 +174,6 @@ export function createTracePropertyFilterFields({
       options: ROOT_ENTITY_TYPE_OPTIONS.map(o => ({ label: o.label, value: o.entityType })),
       placeholder: 'Choose entity type',
       emptyText: 'No entity types.',
-    },
-    {
-      id: 'mode',
-      label: 'List mode',
-      kind: 'pick-multi',
-      searchable: false,
-      options: listModeOptions.map(o => ({ label: o.label, value: o.value })),
-      placeholder: 'Choose list mode',
-      emptyText: 'No list modes.',
-      omitAnyOption: true,
-      defaultValue: 'traces',
     },
     {
       id: 'entityName',
@@ -251,10 +233,9 @@ export function createTracePropertyFilterFields({
     { id: 'experimentId', label: 'Experiment ID', kind: 'text' },
   ];
   const byLabel = (a: PropertyFilterField, b: PropertyFilterField) => a.label.localeCompare(b.label);
-  const mode = fields.filter(f => f.id === 'mode');
-  const pickMulti = fields.filter(f => f.kind === 'pick-multi' && f.id !== 'mode').sort(byLabel);
+  const pickMulti = fields.filter(f => f.kind === 'pick-multi').sort(byLabel);
   const text = fields.filter(f => f.kind === 'text').sort(byLabel);
-  return [...mode, ...pickMulti, ...text];
+  return [...pickMulti, ...text];
 }
 
 /**
@@ -271,7 +252,6 @@ export function getTracePropertyFilterTokens(searchParams: URLSearchParams): Pro
   const paramToFieldId = new Map<string, string>([
     [TRACE_ROOT_ENTITY_TYPE_PARAM, 'rootEntityType'],
     [TRACE_STATUS_PARAM, 'status'],
-    [TRACE_LIST_MODE_PARAM, 'mode'],
   ]);
   for (const fieldId of TRACE_PROPERTY_FILTER_FIELD_IDS) {
     paramToFieldId.set(TRACE_PROPERTY_FILTER_PARAM_BY_FIELD[fieldId], fieldId);
@@ -341,7 +321,6 @@ export function getPreservedTraceFilterParams(searchParams: URLSearchParams) {
 export function applyTracePropertyFilterTokens(params: URLSearchParams, tokens: PropertyFilterToken[]) {
   params.delete(TRACE_ROOT_ENTITY_TYPE_PARAM);
   params.delete(TRACE_STATUS_PARAM);
-  params.delete(TRACE_LIST_MODE_PARAM);
   for (const fieldId of TRACE_PROPERTY_FILTER_FIELD_IDS) {
     params.delete(TRACE_PROPERTY_FILTER_PARAM_BY_FIELD[fieldId]);
   }
@@ -353,10 +332,6 @@ export function applyTracePropertyFilterTokens(params: URLSearchParams, tokens: 
     }
     if (token.fieldId === 'status' && typeof token.value === 'string') {
       params.set(TRACE_STATUS_PARAM, token.value);
-      continue;
-    }
-    if (token.fieldId === 'mode' && typeof token.value === 'string') {
-      params.set(TRACE_LIST_MODE_PARAM, token.value);
       continue;
     }
 

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
@@ -41,14 +41,14 @@ export function TracesDataListIdCell({ traceId }: TracesDataListIdCellProps) {
 // ---------------------------------------------------------------------------
 
 export interface TracesDataListKindCellProps {
-  /** `null`/missing → root span (top-level trace). Set → nested branch row. */
+  /** `null`/missing → root span (Trace). Set → nested span (Subtrace). */
   parentSpanId?: string | null;
 }
 
 export function TracesDataListKindCell({ parentSpanId }: TracesDataListKindCellProps) {
   const isRoot = parentSpanId == null;
   const Icon = isRoot ? ListTreeIcon : CornerDownRightIcon;
-  const label = isRoot ? 'Top-level trace' : 'Nested branch';
+  const label = isRoot ? 'Trace' : 'Subtrace';
   return (
     <DataListCell height="compact" className="flex items-center justify-center">
       <span title={label} aria-label={label} className="inline-flex">

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
@@ -1,4 +1,5 @@
 import { format, isToday } from 'date-fns';
+import { CornerDownRightIcon, ListTreeIcon } from 'lucide-react';
 import { DataListCell } from '../data-list-cells';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { WorkflowIcon } from '@/ds/icons/WorkflowIcon';
@@ -31,6 +32,28 @@ export function TracesDataListIdCell({ traceId }: TracesDataListIdCellProps) {
   return (
     <DataListCell height="compact" className="text-ui-smd font-mono text-neutral3">
       {getShortId(traceId)}
+    </DataListCell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// KindCell
+// ---------------------------------------------------------------------------
+
+export interface TracesDataListKindCellProps {
+  /** `null`/missing → root span (top-level trace). Set → nested branch row. */
+  parentSpanId?: string | null;
+}
+
+export function TracesDataListKindCell({ parentSpanId }: TracesDataListKindCellProps) {
+  const isRoot = parentSpanId == null;
+  const Icon = isRoot ? ListTreeIcon : CornerDownRightIcon;
+  const label = isRoot ? 'Top-level trace' : 'Nested branch';
+  return (
+    <DataListCell height="compact" className="flex items-center justify-center">
+      <span title={label} aria-label={label} className="inline-flex">
+        <Icon className={cn('shrink-0', isRoot ? 'size-4 text-neutral3' : 'size-3 text-neutral3')} aria-hidden />
+      </span>
     </DataListCell>
   );
 }

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
@@ -7,9 +7,10 @@ import { DataListSpacer } from '../data-list-spacer';
 import { DataListSubheader } from '../data-list-subheader';
 import { DataListSubHeading } from '../data-list-subheading';
 import { DataListTop } from '../data-list-top';
-import { DataListTopCell } from '../data-list-top-cell';
+import { DataListTopCell, DataListTopCellWithTooltip } from '../data-list-top-cell';
 import {
   TracesDataListIdCell,
+  TracesDataListKindCell,
   TracesDataListDateCell,
   TracesDataListTimeCell,
   TracesDataListNameCell,
@@ -25,12 +26,14 @@ function TracesDataListRoot(props: ComponentProps<typeof DataListRoot>) {
 export const TracesDataList = Object.assign(TracesDataListRoot, {
   Top: DataListTop,
   TopCell: DataListTopCell,
+  TopCellWithTooltip: DataListTopCellWithTooltip,
   RowButton: DataListRowButton,
   NoMatch: DataListNoMatch,
   Subheader: DataListSubheader,
   SubHeading: DataListSubHeading,
   Spacer: DataListSpacer,
   IdCell: TracesDataListIdCell,
+  KindCell: TracesDataListKindCell,
   DateCell: TracesDataListDateCell,
   TimeCell: TracesDataListTimeCell,
   NameCell: TracesDataListNameCell,

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
@@ -24,7 +24,7 @@ export const DataListTopCell = forwardRef<HTMLSpanElement, DataListTopCellProps>
 
 export type DataListTopCellWithTooltipProps = {
   children: ReactNode;
-  tooltip: string;
+  tooltip: ReactNode;
   className?: string;
 };
 

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -1,11 +1,13 @@
 import { EntityType } from '@mastra/core/observability';
 import {
   DateTimeRangePicker,
+  Label,
   NoTracesInfo,
   Notice,
   PageLayout,
   PropertyFilterCreator,
   SpanDataPanelView,
+  Switch,
   TraceDataPanelView,
   TracesErrorContent,
   TracesLayout,
@@ -151,7 +153,6 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
           serviceNames: isServiceNamesLoading,
           environments: isEnvironmentsLoading,
         },
-        branchesSupported: !branchesUnsupported,
       }),
     [
       availableTags,
@@ -162,7 +163,6 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
       isEntityNamesLoading,
       isServiceNamesLoading,
       isEnvironmentsLoading,
-      branchesUnsupported,
     ],
   );
 
@@ -270,6 +270,17 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
         onStartTextFilter={setAutoFocusFilterFieldId}
         hiddenFieldIds={hiddenCreatorFieldIds}
       />
+      {!branchesUnsupported && (
+        <div className="flex h-form-default items-center gap-2 ml-auto">
+          <Switch
+            id="show-subtraces"
+            checked={url.listMode === 'branches'}
+            onCheckedChange={checked => url.handleListModeChange(checked ? 'branches' : 'traces')}
+            disabled={isTracesLoading}
+          />
+          <Label htmlFor="show-subtraces">Show subtraces</Label>
+        </div>
+      )}
     </>
   );
 
@@ -293,7 +304,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
   const pageTopArea = (
     <PageLayout.TopArea>
       <PageLayout.Row>
-        <PageLayout.Column className="flex flex-wrap items-start justify-start gap-2">
+        <PageLayout.Column className="flex flex-wrap items-start justify-start gap-2 w-full">
           {toolbarControls}
         </PageLayout.Column>
       </PageLayout.Row>


### PR DESCRIPTION
## Summary

- New **Level** column on the Observability traces list. Replaces the ID column with an icon that distinguishes top-level **Trace** rows (full-tree icon) from nested **Subtrace** rows (↳ icon). The header tooltip shows a legend with both icons.
- New **Show subtraces** toggle next to the **Add Filter** button. Replaces the "List mode" entry that used to live inside the Add Filter dropdown:
  - Off → default list mode (top-level traces only).
  - On → list mode that also includes subtraces.
- Hides the toggle when the active storage provider doesn't support subtraces, parallel to the existing branches-not-supported fallback that flips back to the default mode and shows the dismissible notice.

## Test plan

- [ ] Open Observability → Traces. Confirm a **Level** column replaces ID; all rows show the top-level Trace icon (default mode).
- [ ] Hover the **Level** header → tooltip shows a legend with both icons (Trace + Subtrace).
- [ ] Toggle **Show subtraces** on → list re-fetches; root rows still show the Trace icon, nested rows now show the Subtrace (↳) icon.
- [ ] Toggle off → list reverts to top-level only.
- [ ] Open **Add Filter** → confirm there's no longer a "List mode" entry in the property list.
- [ ] On a storage provider that doesn't implement subtraces: switch on the toggle, confirm the page flips back to default mode, shows the dismissible notice, and hides the toggle for the rest of the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the trace list easier to read and control: it adds a visual "Level" column that shows whether a row is a top-level trace or a nested subtrace, and it moves the "show subtraces" control out of the filter menu into a clear on/off toggle next to "Add Filter."

## Changes

### Observability UI - Traces List Column and Controls

**New Level Column with Visual Indicators**
- Replaces the ID column with a "Level" column that shows:
  - Full-tree icon for top-level traces (root)
  - Corner-down/right (↳) icon for nested subtraces
- Level header tooltip shows a legend containing both icons
- `TracesListViewTrace` now includes optional `parentSpanId?: string | null` to determine level

**Show Subtraces Toggle**
- Adds a standalone "Show subtraces" Switch next to the "Add Filter" button, replacing the previous "List mode" entry in the Add Filter dropdown
- Behavior:
  - Off (default): show top-level traces only
  - On: include subtraces; list re-fetches and shows nested rows with the subtrace icon
- Toggle is hidden when the active storage provider does not support subtraces; in that case the UI falls back to default mode and displays a dismissible notice (matching existing branches-not-supported behavior)
- URL/listMode preservation remains compatible with existing params where applicable

**Filter Configuration Updates**
- Removed synthetic `mode` ("List mode") from `TRACE_SYNTHETIC_FILTER_FIELD_IDS`, `createTracePropertyFilterFields`, and token/URL mapping logic
- Simplified filter field generation and removed special-case handling for `mode`; URL preservation still may retain `listMode` param

**Design System & Components**
- Added `TracesDataListKindCell` component to render the Level icons per row (new exported props include optional `parentSpanId`)
- `DataListTopCellWithTooltip.tooltip` now accepts `ReactNode` (supports icon legend), and `TracesDataList` exposes `TopCellWithTooltip` for column headers

### Changeset
- Added a patch changeset (.changeset/neat-traces-step.md) documenting the new Level column, tooltip legend, standalone Show subtraces toggle, and storage-provider fallback

### Types / Public API
- Added optional `parentSpanId?: string | null` to `TracesListViewTrace` (used to determine trace vs subtrace)
- Added `TracesDataListKindCell` export and `TopCellWithTooltip` static on `TracesDataList`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16643)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->