### PR TITLE
fix(create-mastra): avoid late org prompt during observability setup

### DIFF
--- a/.changeset/tame-paws-nail.md
+++ b/.changeset/tame-paws-nail.md
@@ -1,0 +1,6 @@
+---
+'mastra': patch
+'create-mastra': patch
+---
+
+Fixed create-mastra observability setup so fresh projects use your saved organization instead of showing an extra organization picker at the end of project creation.

--- a/packages/cli/src/commands/init/observability-provision.test.ts
+++ b/packages/cli/src/commands/init/observability-provision.test.ts
@@ -328,6 +328,7 @@ describe('provisionObservabilityProject', () => {
     expect(result.projectId).toBe('p1');
     expect(result.projectName).toBe('my-app');
     expect(result.token).toBe('sk_my_app');
+    expect(resolveCurrentOrgMock).toHaveBeenCalledWith('test-token');
 
     // No picker, no name re-prompt, no list call.
     expect(selectMock).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/init/observability-provision.ts
+++ b/packages/cli/src/commands/init/observability-provision.ts
@@ -69,7 +69,8 @@ export async function provisionObservabilityProject({
   token?: string;
 } = {}): Promise<ObservabilityProvisionResult> {
   const token = providedToken ?? (await getToken());
-  const { orgId, orgName } = await resolveCurrentOrg(token, { forcePrompt: true });
+  const { orgId, orgName } =
+    mode === 'create' ? await resolveCurrentOrg(token) : await resolveCurrentOrg(token, { forcePrompt: true });
 
   let project: ObservabilityProject;
   if (observabilityProject) {


### PR DESCRIPTION
This narrows the fix to the create-mastra observability path that PR #16582 exposed.

PR #16582 changed create-mastra to pass `observability: args.observe`, so `--observe` now reaches the observability provisioning flow. In fresh-project create mode, that flow was still forcing an organization picker at the very end of project creation, even when the user already had a saved current organization.

That late prompt is where the reported output stops:

```text
Mastra agent skills installed (in Universal)
Git repository initialized
Select an organization
Ehindero's Organization (current)
Warning: Detected unsettled top-level await at .../create-mastra/dist/index.js
  await program.parseAsync(process.argv);
```

This change keeps `mastra init` behavior unchanged: it still forces the org picker for existing projects. For `create-mastra` fresh-project observability setup, it now uses the saved current org through the normal `resolveCurrentOrg(token)` path. If no current org exists, the normal org picker behavior is still available.

Validated by confirming the pre-change create path could reach the late org picker, then rebuilding and confirming create-mastra with `--observe` completes using the saved org without showing that final picker. Also ran targeted org/provision tests, CLI typecheck, focused lint, mastra build, and create-mastra build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16644)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->