### PR TITLE
fix(core): honor activeTools in durable streams

### DIFF
--- a/.changeset/curly-birds-move.md
+++ b/.changeset/curly-birds-move.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed durable agents to honor activeTools when streaming.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-stream.test.ts
@@ -7,7 +7,7 @@
 
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { z } from 'zod';
 import { EventEmitterPubSub } from '../../../events/event-emitter';
 import { createTool } from '../../../tools';
@@ -148,6 +148,221 @@ describe('DurableAgent streaming execution', () => {
   });
 
   describe('basic streaming', () => {
+    it('should pass activeTools through to the LLM request', async () => {
+      const doStream = vi.fn(async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Done' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      }));
+
+      const mockModel = new MockLanguageModelV2({ doStream });
+      const allowedTool = createTool({
+        id: 'allowedTool',
+        description: 'Allowed tool',
+        inputSchema: z.object({}),
+        execute: async () => 'allowed',
+      });
+      const hiddenTool = createTool({
+        id: 'hiddenTool',
+        description: 'Hidden tool',
+        inputSchema: z.object({}),
+        execute: async () => 'hidden',
+      });
+
+      const baseAgent = new Agent({
+        id: 'active-tools-agent',
+        name: 'Active Tools Agent',
+        instructions: 'Use only enabled tools',
+        model: mockModel as LanguageModelV2,
+        tools: { allowedTool, hiddenTool },
+      });
+      const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+      const { output, cleanup } = await durableAgent.stream('Use the allowed tool', {
+        activeTools: ['allowedTool'],
+      });
+
+      await output.consumeStream();
+
+      expect(doStream).toHaveBeenCalledTimes(1);
+      expect(doStream.mock.calls[0]?.[0].tools.map((tool: { name: string }) => tool.name)).toEqual(['allowedTool']);
+
+      cleanup();
+    });
+
+    it('should allow input processors to clear activeTools for LLM request and tool execution', async () => {
+      let callCount = 0;
+      const doStream = vi.fn(async () => {
+        callCount++;
+        return {
+          stream: convertArrayToReadableStream(
+            callCount === 1
+              ? [
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolName: 'hiddenTool',
+                    input: JSON.stringify({}),
+                    providerExecuted: false,
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'tool-calls',
+                    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                  },
+                ]
+              : [
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+                  { type: 'text-start', id: 'text-1' },
+                  { type: 'text-delta', id: 'text-1', delta: 'Done' },
+                  { type: 'text-end', id: 'text-1' },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                  },
+                ],
+          ),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        };
+      });
+
+      const mockModel = new MockLanguageModelV2({ doStream });
+      const hiddenExecute = vi.fn(async () => 'hidden');
+      const allowedTool = createTool({
+        id: 'allowedTool',
+        description: 'Allowed tool',
+        inputSchema: z.object({}),
+        execute: async () => 'allowed',
+      });
+      const hiddenTool = createTool({
+        id: 'hiddenTool',
+        description: 'Hidden tool',
+        inputSchema: z.object({}),
+        execute: hiddenExecute,
+      });
+
+      const baseAgent = new Agent({
+        id: 'active-tools-clear-agent',
+        name: 'Active Tools Clear Agent',
+        instructions: 'Use available tools',
+        model: mockModel as LanguageModelV2,
+        tools: { allowedTool, hiddenTool },
+        inputProcessors: [
+          {
+            id: 'clear-active-tools',
+            name: 'Clear Active Tools',
+            processInputStep: async () => ({ activeTools: undefined }),
+          },
+        ],
+      });
+      const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+      const { output, cleanup } = await durableAgent.stream('Use tools', {
+        activeTools: ['allowedTool'],
+      });
+
+      await output.consumeStream();
+
+      expect(doStream).toHaveBeenCalledTimes(2);
+      expect(doStream.mock.calls[0]?.[0].tools.map((tool: { name: string }) => tool.name)).toEqual([
+        'allowedTool',
+        'hiddenTool',
+      ]);
+      expect(hiddenExecute).toHaveBeenCalledOnce();
+
+      cleanup();
+    });
+
+    it('should not execute tool calls outside activeTools', async () => {
+      const hiddenExecute = vi.fn(async () => 'hidden');
+      let callCount = 0;
+      const doStream = vi.fn(async () => {
+        callCount++;
+        return {
+          stream: convertArrayToReadableStream(
+            callCount === 1
+              ? [
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolName: 'hiddenTool',
+                    input: JSON.stringify({}),
+                    providerExecuted: false,
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'tool-calls',
+                    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                  },
+                ]
+              : [
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+                  { type: 'text-start', id: 'text-1' },
+                  { type: 'text-delta', id: 'text-1', delta: 'Done' },
+                  { type: 'text-end', id: 'text-1' },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                  },
+                ],
+          ),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        };
+      });
+
+      const mockModel = new MockLanguageModelV2({ doStream });
+      const allowedTool = createTool({
+        id: 'allowedTool',
+        description: 'Allowed tool',
+        inputSchema: z.object({}),
+        execute: async () => 'allowed',
+      });
+      const hiddenTool = createTool({
+        id: 'hiddenTool',
+        description: 'Hidden tool',
+        inputSchema: z.object({}),
+        execute: hiddenExecute,
+      });
+
+      const baseAgent = new Agent({
+        id: 'active-tools-enforcement-agent',
+        name: 'Active Tools Enforcement Agent',
+        instructions: 'Use only enabled tools',
+        model: mockModel as LanguageModelV2,
+        tools: { allowedTool, hiddenTool },
+      });
+      const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+      const { output, cleanup } = await durableAgent.stream('Try a hidden tool', {
+        activeTools: ['allowedTool'],
+      });
+
+      await output.consumeStream();
+
+      expect(hiddenExecute).not.toHaveBeenCalled();
+      expect(doStream).toHaveBeenCalledTimes(2);
+
+      cleanup();
+    });
+
     it('should stream text response and invoke onChunk callback', async () => {
       const mockModel = createTextStreamModel('Hello, world!');
       const chunks: any[] = [];

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -46,6 +46,8 @@ export interface DurableAgentStreamOptions<OUTPUT = undefined> {
   clientTools?: AgentExecutionOptions<OUTPUT>['clientTools'];
   /** Tool selection strategy */
   toolChoice?: AgentExecutionOptions<OUTPUT>['toolChoice'];
+  /** Tool names enabled for this execution */
+  activeTools?: AgentExecutionOptions<OUTPUT>['activeTools'];
   /** Model-specific settings like temperature */
   modelSettings?: AgentExecutionOptions<OUTPUT>['modelSettings'];
   /** Require approval for all tool calls */

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -325,6 +325,7 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
     options: {
       maxSteps: execOptions?.maxSteps,
       toolChoice: execOptions?.toolChoice as any,
+      activeTools: execOptions?.activeTools,
       temperature: execOptions?.modelSettings?.temperature,
       requireToolApproval: execOptions?.requireToolApproval,
       toolCallConcurrency: execOptions?.toolCallConcurrency,

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -138,6 +138,8 @@ export interface SerializableDurableOptions {
   maxSteps?: number;
   /** Tool selection strategy */
   toolChoice?: 'auto' | 'none' | 'required' | { type: 'tool'; toolName: string };
+  /** Tool names enabled for this execution */
+  activeTools?: string[];
   /** Temperature for LLM sampling */
   temperature?: number;
   /** Whether to require tool approval globally */
@@ -255,6 +257,8 @@ export interface DurableToolCallInput {
   providerExecuted?: boolean;
   /** Output if provider-executed */
   output?: unknown;
+  /** Tool names enabled for the step that produced this call, or null if a processor cleared the restriction */
+  activeTools?: string[] | null;
 }
 
 /**

--- a/packages/core/src/agent/durable/utils/serialize-state.ts
+++ b/packages/core/src/agent/durable/utils/serialize-state.ts
@@ -160,6 +160,7 @@ export function serializeDurableState(params: {
 export function serializeDurableOptions(options: {
   maxSteps?: number;
   toolChoice?: any;
+  activeTools?: string[];
   temperature?: number;
   requireToolApproval?: boolean;
   toolCallConcurrency?: number;
@@ -189,6 +190,7 @@ export function serializeDurableOptions(options: {
   return {
     maxSteps: options.maxSteps,
     toolChoice: serializedToolChoice,
+    activeTools: options.activeTools,
     temperature: options.temperature,
     requireToolApproval: options.requireToolApproval,
     toolCallConcurrency: options.toolCallConcurrency,

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -269,7 +269,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               currentModel = (processInputStepResult.model ?? currentModel) as typeof currentModel;
               currentTools = (processInputStepResult.tools ?? currentTools) as ToolSet;
               currentToolChoice = processInputStepResult.toolChoice as ToolChoice<ToolSet> | undefined;
-              currentActiveTools = processInputStepResult.activeTools ?? currentActiveTools;
+              currentActiveTools = processInputStepResult.activeTools;
               currentModelSettings = {
                 ...currentModelSettings,
                 ...(processInputStepResult.modelSettings ?? {}),

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -74,6 +74,7 @@ const durableLLMOutputSchema = z.object({
       toolName: z.string(),
       args: z.record(z.string(), z.any()),
       providerMetadata: z.record(z.string(), z.any()).optional(),
+      activeTools: z.array(z.string()).nullable().optional(),
     }),
   ),
   stepResult: z.object({
@@ -191,6 +192,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             let currentModel = model;
             let currentTools = tools as unknown as ToolSet;
             let currentToolChoice = execOptions.toolChoice as ToolChoice<ToolSet> | undefined;
+            let currentActiveTools = execOptions.activeTools;
             let currentModelSettings = { temperature: execOptions.temperature };
 
             // 6. Rebuild MODEL_GENERATION span from passed data
@@ -256,6 +258,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 },
                 tools: currentTools,
                 toolChoice: currentToolChoice,
+                activeTools: currentActiveTools,
                 modelSettings: currentModelSettings,
                 structuredOutput: structuredOutput as any,
                 retryCount: (inputData as any).processorRetryCount ?? 0,
@@ -266,6 +269,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               currentModel = (processInputStepResult.model ?? currentModel) as typeof currentModel;
               currentTools = (processInputStepResult.tools ?? currentTools) as ToolSet;
               currentToolChoice = processInputStepResult.toolChoice as ToolChoice<ToolSet> | undefined;
+              currentActiveTools = processInputStepResult.activeTools;
               currentModelSettings = {
                 ...currentModelSettings,
                 ...(processInputStepResult.modelSettings ?? {}),
@@ -301,7 +305,10 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             // structuring step instead of asking the model for json_schema.
             modelSpanTracker?.setInferenceContext?.({
               parameters: currentModelSettings as Record<string, unknown> | undefined,
-              availableTools: getStepAvailableToolNames(currentTools as Record<string, unknown> | undefined),
+              availableTools: getStepAvailableToolNames(
+                currentTools as Record<string, unknown> | undefined,
+                currentActiveTools,
+              ),
               toolChoice: currentToolChoice,
               responseFormat: structuredOutput ? 'json_schema' : undefined,
             });
@@ -314,6 +321,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               inputMessages,
               tools: currentTools,
               toolChoice: currentToolChoice,
+              activeTools: currentActiveTools,
               options: { abortSignal: executionAbortSignal },
               modelSettings: {
                 ...currentModelSettings,
@@ -408,6 +416,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                       providerMetadata: payload.providerMetadata as Record<string, unknown> | undefined,
                       providerExecuted: payload.providerExecuted,
                       output: payload.output,
+                      activeTools: currentActiveTools ?? null,
                     });
                     break;
                   }

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -269,7 +269,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               currentModel = (processInputStepResult.model ?? currentModel) as typeof currentModel;
               currentTools = (processInputStepResult.tools ?? currentTools) as ToolSet;
               currentToolChoice = processInputStepResult.toolChoice as ToolChoice<ToolSet> | undefined;
-              currentActiveTools = processInputStepResult.activeTools;
+              currentActiveTools = processInputStepResult.activeTools ?? currentActiveTools;
               currentModelSettings = {
                 ...currentModelSettings,
                 ...(processInputStepResult.modelSettings ?? {}),

--- a/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
@@ -124,10 +124,12 @@ export function createDurableLLMMappingStep() {
       }
 
       // 3. Determine if we should continue
-      // Preserve the LLM step's isContinued (which respects finishReason),
-      // but force-stop if all tools errored (no point re-calling LLM)
+      // Preserve the LLM step's isContinued (which respects finishReason).
+      // Keep ToolNotFoundError recoverable so the model can see the error and
+      // retry with one of the currently available tool names.
       const allToolsErrored = toolResults.length > 0 && toolResults.every(r => r.error !== undefined);
-      const isContinued = llmOutput.stepResult.isContinued && !allToolsErrored;
+      const allToolsNotFound = allToolsErrored && toolResults.every(r => r.error?.name === 'ToolNotFoundError');
+      const isContinued = llmOutput.stepResult.isContinued && (!allToolsErrored || allToolsNotFound);
 
       // 4. Build the output
       const output: DurableAgenticExecutionOutput = {

--- a/packages/core/src/agent/durable/workflows/steps/tool-call-bg.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call-bg.test.ts
@@ -107,7 +107,9 @@ function executeStep(pubsub: any, initData: any, input?: any) {
 }
 
 afterEach(() => {
-  globalRunRegistry.delete(RUN_ID);
+  if (globalRunRegistry.has(RUN_ID)) {
+    globalRunRegistry.delete(RUN_ID);
+  }
   vi.clearAllMocks();
 });
 
@@ -435,5 +437,37 @@ describe('durable tool-call background task dispatch', () => {
     const callArgs = vi.mocked(createBackgroundTask).mock.calls[0]![1]!;
     expect(callArgs.threadId).toBe('thread-1');
     expect(callArgs.resourceId).toBe('user-1');
+  });
+});
+
+describe('durable tool-call activeTools enforcement', () => {
+  it('rejects Mastra-resolved tools outside activeTools when the run registry is unavailable', async () => {
+    const pubsub = mockPubsub();
+    const hiddenExecute = vi.fn().mockResolvedValue('hidden');
+    vi.mocked(_resolveTool).mockReturnValue({
+      execute: hiddenExecute,
+    } as any);
+
+    const result = await executeStep(
+      pubsub,
+      makeInitData({
+        options: {
+          requireToolApproval: false,
+          activeTools: ['allowedTool'],
+        },
+      }),
+      {
+        ...baseInput(),
+        toolName: 'hiddenTool',
+      },
+    );
+
+    expect(result.error).toEqual(
+      expect.objectContaining({
+        name: 'ToolNotFoundError',
+        message: expect.stringContaining('Available tools: allowedTool'),
+      }),
+    );
+    expect(hiddenExecute).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -30,6 +30,7 @@ const durableToolCallInputSchema = z.object({
   providerMetadata: z.record(z.string(), z.any()).optional(),
   providerExecuted: z.boolean().optional(),
   output: z.any().optional(),
+  activeTools: z.array(z.string()).nullable().optional(),
 });
 
 /**
@@ -123,7 +124,7 @@ export function createDurableToolCallStep() {
       const pubsub = (params as any)[PUBSUB_SYMBOL] as PubSub | undefined;
 
       const typedInput = inputData as DurableToolCallInput;
-      const { toolCallId, toolName, args, providerExecuted, output } = typedInput;
+      const { toolCallId, toolName, args, providerExecuted, output, activeTools } = typedInput;
 
       // Get context from init data (the parent workflow input)
       const initData = getInitData<{
@@ -157,10 +158,20 @@ export function createDurableToolCallStep() {
         tool = resolveTool(toolName, mastra as Mastra);
       }
 
-      if (!tool) {
+      const toolKey = registryEntry?.tools?.[toolName]
+        ? toolName
+        : Object.entries(registryEntry?.tools ?? {}).find(([, registeredTool]) => registeredTool === tool)?.[0];
+      const effectiveActiveTools = activeTools === null ? undefined : (activeTools ?? agentOptions.activeTools);
+      const activeToolKey = toolKey ?? toolName;
+      const isHiddenByActiveTools = effectiveActiveTools !== undefined && !effectiveActiveTools.includes(activeToolKey);
+
+      if (!tool || isHiddenByActiveTools) {
+        const availableToolNames = effectiveActiveTools ?? Object.keys(registryEntry?.tools ?? {});
+        const availableToolsStr =
+          availableToolNames.length > 0 ? ` Available tools: ${availableToolNames.join(', ')}` : '';
         const error = {
           name: 'ToolNotFoundError',
-          message: `Tool ${toolName} not found`,
+          message: `Tool "${toolName}" not found.${availableToolsStr}. Call tools by their exact name only — never add prefixes, namespaces, or colons.`,
         };
         if (pubsub) {
           await emitChunkEvent(pubsub, runId, {


### PR DESCRIPTION
## Description

Fixes durable agent streaming so `activeTools` is preserved from `DurableAgent.stream` options through workflow input, per-step LLM execution, processor updates, observability metadata, and the final model execute call.

It also rejects durable tool calls outside the active set before execution while keeping `ToolNotFoundError` recoverable, so the model can retry with an allowed tool instead of ending the durable loop early.

Regression tests cover LLM tool filtering, processor-cleared `activeTools`, replay-resolved tools, and hidden tool-call rejection.

## Related issue(s)

Fixes #16619.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Validation run locally:

- `pnpm prettier:changed`
- `pnpm --filter ./packages/core test src/agent/durable/__tests__/durable-agent-stream.test.ts`
- `pnpm --filter ./packages/core test src/agent/durable/workflows/steps/tool-call-bg.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `git diff --check`

Two independent local `codex review --base main` runs found no actionable issues. Local `coderabbit review --plain` was attempted, but the CLI stayed in setup and produced no findings.