### PR TITLE
feat(agent-builder): render atomic per-field client tools as dedicated ToolCards

### DIFF
--- a/packages/editor/src/ee/agent-builder-agent.ts
+++ b/packages/editor/src/ee/agent-builder-agent.ts
@@ -135,7 +135,17 @@ Example:
 - Bad: “No matching skill found, calling createSkillTool.”
 - Good: “I added a new capability so your agent can handle this specific need properly.”
 
-Phase 6 — Prepare the final agent instructions
+Phase 6 — Select the agent's model
+Choose the provider and the exact model the new agent will run on. This phase only decides the model — instructions are written in Phase 7.
+
+Rules:
+- Pick the most capable model that fits the user's use case. For coding, reasoning-heavy, or planning tasks, prefer top-tier models (e.g. \`openai/gpt-5.5\` or \`anthropic/claude-opus-4-7\` when available). For short, simple, or high-volume tasks, prefer a smaller variant from the same provider (e.g. a \`mini\` or \`nano\`) to keep latency and cost low.
+- Always pin a concrete, versioned model id. Never use floating aliases such as \`latest\`, \`stable\`, or a bare provider name.
+- When several versions of the same family are available, prefer the newest numbered variant (highest version / date) from the chosen provider, including newer \`mini\`, \`nano\`, or numbered releases. Do not pin an older version unless the user explicitly asks for one.
+- Only choose models that are actually available in the current environment. If the ideal model is not available, fall back to the newest available model from the same provider, then to the newest available model overall.
+- Output the choice as \`provider/model-id\` (e.g. \`openai/gpt-5.5-mini\`, \`anthropic/claude-opus-4-7\`).
+
+Phase 7 — Prepare the final agent instructions
 Create an outcome-focused system prompt for the new agent.
 
 The agent's system prompt must:
@@ -185,6 +195,7 @@ Behavior rules:
 - Always summarize what the created agent can do after creation.
 - Always call \`agentBuilderTool\` whenever agent identity, instructions, or capabilities are decided.
 - Use \`createSkillTool\` when the user's goal requires a capability that does not already exist.
+- If you need to use a CLI somehow, you must be connected to a workspace. If no workspace is connected, refuse the CLI action and tell the user they need to connect a workspace first, in simple non-technical wording.
 
 Your final answer to the user should be concise, friendly, and focused on the agent's real-world abilities.`,
   model: 'openai/gpt-5-mini',

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/messages.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/messages.test.tsx
@@ -6,12 +6,45 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import type { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { AGENT_BUILDER_TOOL_NAME } from '../../agent-builder-edit/hooks/use-agent-builder-tool';
 import { CONNECT_CHANNEL_TOOL_NAME } from '../../agent-builder-edit/hooks/use-connect-channel-tool';
 import { MessageRow } from '../messages';
+import {
+  SET_AGENT_BROWSER_ENABLED_TOOL_NAME,
+  SET_AGENT_DESCRIPTION_TOOL_NAME,
+  SET_AGENT_INSTRUCTIONS_TOOL_NAME,
+  SET_AGENT_MODEL_TOOL_NAME,
+  SET_AGENT_NAME_TOOL_NAME,
+  SET_AGENT_SKILLS_TOOL_NAME,
+  SET_AGENT_TOOLS_TOOL_NAME,
+  SET_AGENT_WORKSPACE_ID_TOOL_NAME,
+} from '@/domains/agent-builder/hooks/use-agent-builder-tools';
+import type { AgentBuilderEditFormValues } from '@/domains/agent-builder/schemas';
 import { server } from '@/test/msw-server';
+
+type ToolPart = MastraUIMessage['parts'][number];
+
+const FormWrapper = ({
+  children,
+  defaultValues,
+}: {
+  children: ReactNode;
+  defaultValues?: Partial<AgentBuilderEditFormValues>;
+}) => {
+  const methods = useForm<AgentBuilderEditFormValues>({
+    defaultValues: { name: '', description: '', instructions: '', ...defaultValues },
+  });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+const renderRow = (parts: ToolPart[], defaultValues?: Partial<AgentBuilderEditFormValues>) =>
+  render(
+    <FormWrapper defaultValues={defaultValues}>
+      <MessageRow message={buildMessage(parts)} />
+    </FormWrapper>,
+  );
 
 const ChannelsWrapper = ({ children }: { children: ReactNode }) => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -35,33 +68,6 @@ describe('MessageRow dynamic-tool rendering', () => {
     cleanup();
   });
 
-  it('renders tool display names for agent-builder tool calls', () => {
-    const { container } = render(
-      <MessageRow
-        message={buildMessage([
-          {
-            type: 'dynamic-tool',
-            toolCallId: 'call-1',
-            toolName: AGENT_BUILDER_TOOL_NAME,
-            state: 'output-available',
-            input: {
-              tools: [
-                { id: 'web-search', name: 'Web Search' },
-                { id: 'weather-lookup', name: 'Weather Lookup' },
-              ],
-            },
-            output: { success: true },
-          } as MastraUIMessage['parts'][number],
-        ])}
-      />,
-    );
-
-    expect(container.textContent).toContain('Web Search');
-    expect(container.textContent).toContain('Weather Lookup');
-    expect(container.textContent).not.toContain('web-search');
-    expect(container.textContent).not.toContain('weather-lookup');
-  });
-
   it('renders the generic shimmer for non-builder dynamic tools', () => {
     const { container } = render(
       <MessageRow
@@ -78,8 +84,9 @@ describe('MessageRow dynamic-tool rendering', () => {
       />,
     );
 
-    // Generic shimmer ends with "..." — don't pin the exact word since it's random.
-    expect(container.textContent?.endsWith('...')).toBe(true);
+    // Unknown dynamic tools render as a GenericTool ToolCard showing "Executing <toolName>".
+    expect(container.textContent).toContain('Executing');
+    expect(container.textContent).toContain('some-other-tool');
     expect(container.textContent).not.toContain('Web Search');
   });
 
@@ -117,28 +124,289 @@ describe('MessageRow dynamic-tool rendering', () => {
     });
   });
 
-  it('renders tool display names for persisted agent-builder tool parts (post-reload shape)', () => {
-    const { container } = render(
-      <MessageRow
-        message={buildMessage([
-          {
-            type: `tool-${AGENT_BUILDER_TOOL_NAME}`,
-            toolCallId: 'call-3',
-            state: 'output-available',
-            input: {
-              tools: [
-                { id: 'web-search', name: 'Web Search' },
-                { id: 'weather-lookup', name: 'Weather Lookup' },
-              ],
-            },
-            output: { success: true },
-          } as MastraUIMessage['parts'][number],
-        ])}
-      />,
+  it('renders MessageSetAgentName for streaming dynamic-tool', () => {
+    renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-name',
+          toolName: SET_AGENT_NAME_TOOL_NAME,
+          state: 'output-available',
+          input: { name: 'Acme Bot' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { name: 'Acme Bot' },
     );
+    const input = screen.getByTestId('agent-builder-chat-set-agent-name-input') as HTMLInputElement;
+    expect(input.value).toBe('Acme Bot');
+  });
 
+  it('renders MessageSetAgentName for persisted tool part', () => {
+    renderRow(
+      [
+        {
+          type: `tool-${SET_AGENT_NAME_TOOL_NAME}`,
+          toolCallId: 'call-name-r',
+          state: 'output-available',
+          input: { name: 'Acme Bot' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { name: 'Acme Bot' },
+    );
+    const input = screen.getByTestId('agent-builder-chat-set-agent-name-input') as HTMLInputElement;
+    expect(input.value).toBe('Acme Bot');
+  });
+
+  it('renders MessageSetAgentDescription for streaming dynamic-tool', () => {
+    renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-desc',
+          toolName: SET_AGENT_DESCRIPTION_TOOL_NAME,
+          state: 'output-available',
+          input: { description: 'A helpful research assistant.' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { description: 'A helpful research assistant.' },
+    );
+    const input = screen.getByTestId('agent-builder-chat-set-agent-description-input') as HTMLInputElement;
+    expect(input.value).toBe('A helpful research assistant.');
+  });
+
+  it('renders MessageSetAgentDescription for persisted tool part', () => {
+    renderRow(
+      [
+        {
+          type: `tool-${SET_AGENT_DESCRIPTION_TOOL_NAME}`,
+          toolCallId: 'call-desc-r',
+          state: 'output-available',
+          input: { description: 'A helpful research assistant.' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { description: 'A helpful research assistant.' },
+    );
+    const input = screen.getByTestId('agent-builder-chat-set-agent-description-input') as HTMLInputElement;
+    expect(input.value).toBe('A helpful research assistant.');
+  });
+
+  it('renders MessageSetAgentInstructions collapsible for streaming dynamic-tool', () => {
+    renderRow([
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'call-instr',
+        toolName: SET_AGENT_INSTRUCTIONS_TOOL_NAME,
+        state: 'output-available',
+        input: { instructions: 'Always answer in French.' },
+        output: { success: true },
+      } as ToolPart,
+    ]);
+    expect(screen.getByTestId('agent-builder-chat-set-agent-instructions-trigger')).toBeTruthy();
+    expect(screen.getByText('Agent instructions')).toBeTruthy();
+  });
+
+  it('renders MessageSetAgentInstructions collapsible for persisted tool part', () => {
+    renderRow([
+      {
+        type: `tool-${SET_AGENT_INSTRUCTIONS_TOOL_NAME}`,
+        toolCallId: 'call-instr-r',
+        state: 'output-available',
+        input: { instructions: 'Always answer in French.' },
+        output: { success: true },
+      } as ToolPart,
+    ]);
+    expect(screen.getByTestId('agent-builder-chat-set-agent-instructions-trigger')).toBeTruthy();
+    expect(screen.getByText('Agent instructions')).toBeTruthy();
+  });
+
+  it('renders MessageSetAgentTools for streaming dynamic-tool', () => {
+    const { container } = renderRow([
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'call-tools',
+        toolName: SET_AGENT_TOOLS_TOOL_NAME,
+        state: 'output-available',
+        input: {
+          tools: [
+            { id: 'web-search', name: 'Web Search' },
+            { id: 'weather-lookup', name: 'Weather Lookup' },
+          ],
+        },
+        output: { success: true },
+      } as ToolPart,
+    ]);
     expect(container.textContent).toContain('Web Search');
     expect(container.textContent).toContain('Weather Lookup');
+  });
+
+  it('renders MessageSetAgentTools for persisted tool part', () => {
+    const { container } = renderRow([
+      {
+        type: `tool-${SET_AGENT_TOOLS_TOOL_NAME}`,
+        toolCallId: 'call-tools-r',
+        state: 'output-available',
+        input: {
+          tools: [
+            { id: 'web-search', name: 'Web Search' },
+            { id: 'weather-lookup', name: 'Weather Lookup' },
+          ],
+        },
+        output: { success: true },
+      } as ToolPart,
+    ]);
+    expect(container.textContent).toContain('Web Search');
+    expect(container.textContent).toContain('Weather Lookup');
+  });
+
+  it('renders MessageSetAgentSkills for streaming dynamic-tool', () => {
+    const { container } = renderRow([
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'call-skills',
+        toolName: SET_AGENT_SKILLS_TOOL_NAME,
+        state: 'output-available',
+        input: {
+          skills: [
+            { id: 'sk-1', name: 'Summarize' },
+            { id: 'sk-2', name: 'Translate' },
+          ],
+        },
+        output: { success: true },
+      } as ToolPart,
+    ]);
+    expect(container.textContent).toContain('Summarize');
+    expect(container.textContent).toContain('Translate');
+  });
+
+  it('renders MessageSetAgentSkills for persisted tool part', () => {
+    const { container } = renderRow([
+      {
+        type: `tool-${SET_AGENT_SKILLS_TOOL_NAME}`,
+        toolCallId: 'call-skills-r',
+        state: 'output-available',
+        input: {
+          skills: [
+            { id: 'sk-1', name: 'Summarize' },
+            { id: 'sk-2', name: 'Translate' },
+          ],
+        },
+        output: { success: true },
+      } as ToolPart,
+    ]);
+    expect(container.textContent).toContain('Summarize');
+    expect(container.textContent).toContain('Translate');
+  });
+
+  it('renders MessageSetAgentModel as a ToolCard with provider/model dropdowns for streaming dynamic-tool', () => {
+    server.use(
+      http.get('*/api/agents/providers', () => HttpResponse.json({ providers: [] })),
+      http.get('*/api/editor/builder/settings', () => HttpResponse.json({ enabled: false })),
+    );
+    render(
+      <ChannelsWrapper>
+        <FormWrapper defaultValues={{ model: { provider: 'openai', name: 'gpt-4o' } }}>
+          <MessageRow
+            message={buildMessage([
+              {
+                type: 'dynamic-tool',
+                toolCallId: 'call-model',
+                toolName: SET_AGENT_MODEL_TOOL_NAME,
+                state: 'output-available',
+                input: { model: { provider: 'openai', name: 'gpt-4o' } },
+                output: { success: true },
+              } as ToolPart,
+            ])}
+          />
+        </FormWrapper>
+      </ChannelsWrapper>,
+    );
+    expect(screen.getByTestId('agent-builder-chat-set-agent-model')).toBeTruthy();
+    // The header still surfaces the selected provider/model as help text.
+    expect(screen.getByText('openai/gpt-4o')).toBeTruthy();
+  });
+
+  it('renders MessageSetAgentModel as a ToolCard with provider/model dropdowns for persisted tool part', () => {
+    server.use(
+      http.get('*/api/agents/providers', () => HttpResponse.json({ providers: [] })),
+      http.get('*/api/editor/builder/settings', () => HttpResponse.json({ enabled: false })),
+    );
+    render(
+      <ChannelsWrapper>
+        <FormWrapper defaultValues={{ model: { provider: 'openai', name: 'gpt-4o' } }}>
+          <MessageRow
+            message={buildMessage([
+              {
+                type: `tool-${SET_AGENT_MODEL_TOOL_NAME}`,
+                toolCallId: 'call-model-r',
+                state: 'output-available',
+                input: { model: { provider: 'openai', name: 'gpt-4o' } },
+                output: { success: true },
+              } as ToolPart,
+            ])}
+          />
+        </FormWrapper>
+      </ChannelsWrapper>,
+    );
+    expect(screen.getByTestId('agent-builder-chat-set-agent-model')).toBeTruthy();
+    expect(screen.getByText('openai/gpt-4o')).toBeTruthy();
+  });
+
+  it('renders MessageSetAgentBrowserEnabled (enabled) for streaming dynamic-tool', () => {
+    const { container } = renderRow([
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'call-browser',
+        toolName: SET_AGENT_BROWSER_ENABLED_TOOL_NAME,
+        state: 'output-available',
+        input: { browserEnabled: true },
+        output: { success: true },
+      } as ToolPart,
+    ]);
+    expect(container.textContent).toContain('Your agent will now be able to interact with web pages');
+  });
+
+  it('renders MessageSetAgentBrowserEnabled (disabled) for persisted tool part', () => {
+    const { container } = renderRow([
+      {
+        type: `tool-${SET_AGENT_BROWSER_ENABLED_TOOL_NAME}`,
+        toolCallId: 'call-browser-r',
+        state: 'output-available',
+        input: { browserEnabled: false },
+        output: { success: true },
+      } as ToolPart,
+    ]);
+    expect(container.textContent).toContain('Your agent will no longer interact with web pages');
+  });
+
+  it('renders MessageSetAgentWorkspaceId for streaming dynamic-tool', () => {
+    const { container } = renderRow([
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'call-ws',
+        toolName: SET_AGENT_WORKSPACE_ID_TOOL_NAME,
+        state: 'output-available',
+        input: { workspaceId: 'ws-123' },
+        output: { success: true },
+      } as ToolPart,
+    ]);
+    expect(container.textContent).toContain('ws-123');
+  });
+
+  it('renders MessageSetAgentWorkspaceId for persisted tool part', () => {
+    const { container } = renderRow([
+      {
+        type: `tool-${SET_AGENT_WORKSPACE_ID_TOOL_NAME}`,
+        toolCallId: 'call-ws-r',
+        state: 'output-available',
+        input: { workspaceId: 'ws-123' },
+        output: { success: true },
+      } as ToolPart,
+    ]);
+    expect(container.textContent).toContain('ws-123');
   });
 
   it('renders the inline Slack connect widget for persisted connectChannel tool parts (post-reload shape)', async () => {

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -1,14 +1,44 @@
-import { Skeleton, Txt } from '@mastra/playground-ui';
+import {
+  Card,
+  CodeEditor,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  MarkdownRenderer,
+  Skeleton,
+  TextFieldBlock,
+  Txt,
+} from '@mastra/playground-ui';
 import type { MastraUIMessage } from '@mastra/react';
-import { Check, Loader2 } from 'lucide-react';
+import { AlignLeft, Check, ChevronRight, FileText, Globe, Loader2, Sparkles, Type, Wrench } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
-import Markdown from 'react-markdown';
+import { Controller, useFormContext } from 'react-hook-form';
 import { ConnectChannelMessage } from '../agent-builder-edit/connect-channel-message';
-import { AGENT_BUILDER_TOOL_NAME } from '../agent-builder-edit/hooks/use-agent-builder-tool';
 import { CONNECT_CHANNEL_TOOL_NAME } from '../agent-builder-edit/hooks/use-connect-channel-tool';
 import { Shimmer } from './shimmer';
+import {
+  SET_AGENT_BROWSER_ENABLED_TOOL_NAME,
+  SET_AGENT_DESCRIPTION_TOOL_NAME,
+  SET_AGENT_INSTRUCTIONS_TOOL_NAME,
+  SET_AGENT_MODEL_TOOL_NAME,
+  SET_AGENT_NAME_TOOL_NAME,
+  SET_AGENT_SKILLS_TOOL_NAME,
+  SET_AGENT_TOOLS_TOOL_NAME,
+  SET_AGENT_WORKSPACE_ID_TOOL_NAME,
+} from '@/domains/agent-builder/hooks/use-agent-builder-tools';
+import type { AgentBuilderEditFormValues } from '@/domains/agent-builder/schemas';
+import { LLMModels, LLMProviders, cleanProviderId } from '@/domains/llm';
 
-export const MessageRow = ({ message, agentId }: { message: MastraUIMessage; agentId?: string }) => {
+export const MessageRow = ({
+  message,
+  agentId,
+  isStreaming = false,
+}: {
+  message: MastraUIMessage;
+  agentId?: string;
+  isStreaming?: boolean;
+}) => {
   return (
     <>
       {message.parts.map((part, index) => {
@@ -25,33 +55,103 @@ export const MessageRow = ({ message, agentId }: { message: MastraUIMessage; age
             );
 
           case 'dynamic-tool': {
-            if (part.toolName === AGENT_BUILDER_TOOL_NAME) {
-              const toolsAdded = (part.input as { tools: { id: string; name: string }[] })?.tools ?? [];
-              return <BuilderAgentToolMessage toolsAdded={toolsAdded} key={key} />;
+            switch (part.toolName) {
+              case CONNECT_CHANNEL_TOOL_NAME: {
+                const platform = (part.input as { platform?: string } | undefined)?.platform ?? 'slack';
+                return (
+                  <ToolCard key={key}>
+                    <ConnectChannelMessage platformId={platform} agentId={agentId} />
+                  </ToolCard>
+                );
+              }
+              case SET_AGENT_NAME_TOOL_NAME:
+                return <MessageSetAgentName key={key} disabled={isStreaming} />;
+              case SET_AGENT_DESCRIPTION_TOOL_NAME:
+                return <MessageSetAgentDescription key={key} disabled={isStreaming} />;
+              case SET_AGENT_INSTRUCTIONS_TOOL_NAME:
+                return <MessageSetAgentInstructions key={key} disabled={isStreaming} />;
+              case SET_AGENT_TOOLS_TOOL_NAME: {
+                const input = (part.input as { tools?: { id: string; name: string }[] } | undefined) ?? {};
+                return <MessageSetAgentTools key={key} tools={input.tools ?? []} />;
+              }
+              case SET_AGENT_SKILLS_TOOL_NAME: {
+                const input = (part.input as { skills?: { id: string; name: string }[] } | undefined) ?? {};
+                return <MessageSetAgentSkills key={key} skills={input.skills ?? []} />;
+              }
+              case SET_AGENT_MODEL_TOOL_NAME: {
+                const input = (part.input as { model?: { provider: string; name: string } } | undefined) ?? {};
+                return (
+                  <MessageSetAgentModel
+                    key={key}
+                    model={input.model ?? { provider: '', name: '' }}
+                    disabled={isStreaming}
+                  />
+                );
+              }
+              case SET_AGENT_BROWSER_ENABLED_TOOL_NAME: {
+                const input = (part.input as { browserEnabled?: boolean } | undefined) ?? {};
+                return <MessageSetAgentBrowserEnabled key={key} browserEnabled={input.browserEnabled ?? false} />;
+              }
+              case SET_AGENT_WORKSPACE_ID_TOOL_NAME: {
+                const input = (part.input as { workspaceId?: string } | undefined) ?? {};
+                return <MessageSetAgentWorkspaceId key={key} workspaceId={input.workspaceId ?? ''} />;
+              }
+              default: {
+                const extra = part as { input?: unknown; output?: unknown };
+                return <GenericTool key={key} toolName={part.toolName} input={extra.input} output={extra.output} />;
+              }
             }
-
-            if (part.toolName === CONNECT_CHANNEL_TOOL_NAME) {
-              const platform = (part.input as { platform?: string } | undefined)?.platform ?? 'slack';
-              return <ConnectChannelMessage key={key} platformId={platform} agentId={agentId} />;
-            }
-
-            return <ToolExecutionMessage key={key} />;
-          }
-
-          case `tool-${AGENT_BUILDER_TOOL_NAME}`: {
-            const toolsAdded = (part.input as { tools?: { id: string; name: string }[] } | undefined)?.tools ?? [];
-            return <BuilderAgentToolMessage toolsAdded={toolsAdded} key={key} />;
           }
 
           case `tool-${CONNECT_CHANNEL_TOOL_NAME}`: {
             const platform = (part.input as { platform?: string } | undefined)?.platform ?? 'slack';
-            return <ConnectChannelMessage key={key} platformId={platform} agentId={agentId} />;
+            return (
+              <ToolCard key={key}>
+                <ConnectChannelMessage platformId={platform} agentId={agentId} />
+              </ToolCard>
+            );
+          }
+
+          case `tool-${SET_AGENT_NAME_TOOL_NAME}`:
+            return <MessageSetAgentName key={key} disabled={isStreaming} />;
+          case `tool-${SET_AGENT_DESCRIPTION_TOOL_NAME}`:
+            return <MessageSetAgentDescription key={key} disabled={isStreaming} />;
+          case `tool-${SET_AGENT_INSTRUCTIONS_TOOL_NAME}`:
+            return <MessageSetAgentInstructions key={key} disabled={isStreaming} />;
+          case `tool-${SET_AGENT_TOOLS_TOOL_NAME}`: {
+            const input = (part.input as { tools?: { id: string; name: string }[] } | undefined) ?? {};
+            return <MessageSetAgentTools key={key} tools={input.tools ?? []} />;
+          }
+          case `tool-${SET_AGENT_SKILLS_TOOL_NAME}`: {
+            const input = (part.input as { skills?: { id: string; name: string }[] } | undefined) ?? {};
+            return <MessageSetAgentSkills key={key} skills={input.skills ?? []} />;
+          }
+          case `tool-${SET_AGENT_MODEL_TOOL_NAME}`: {
+            const input = (part.input as { model?: { provider: string; name: string } } | undefined) ?? {};
+            return (
+              <MessageSetAgentModel
+                key={key}
+                model={input.model ?? { provider: '', name: '' }}
+                disabled={isStreaming}
+              />
+            );
+          }
+          case `tool-${SET_AGENT_BROWSER_ENABLED_TOOL_NAME}`: {
+            const input = (part.input as { browserEnabled?: boolean } | undefined) ?? {};
+            return <MessageSetAgentBrowserEnabled key={key} browserEnabled={input.browserEnabled ?? false} />;
+          }
+          case `tool-${SET_AGENT_WORKSPACE_ID_TOOL_NAME}`: {
+            const input = (part.input as { workspaceId?: string } | undefined) ?? {};
+            return <MessageSetAgentWorkspaceId key={key} workspaceId={input.workspaceId ?? ''} />;
           }
 
           default: {
             if (typeof part.type === 'string' && part.type.startsWith('tool-')) {
-              return <ToolExecutionMessage key={key} />;
+              const toolName = part.type.slice('tool-'.length);
+              const extra = part as { input?: unknown; output?: unknown };
+              return <GenericTool key={key} toolName={toolName} input={extra.input} output={extra.output} />;
             }
+
             return null;
           }
         }
@@ -66,10 +166,10 @@ export const Txtmessage = ({ txt, role }: { txt: string; role: MastraUIMessage['
       <div className="flex justify-end">
         <Txt
           variant="ui-md"
-          className="whitespace-pre-wrap bg-white text-black rounded-2xl px-4 py-2.5 max-w-[80%]"
+          className="bg-white text-black rounded-2xl px-4 py-2.5 max-w-[80%] [&_ul]:!space-y-1 [&_ol]:!space-y-1 [&_li]:!my-0 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_li]:!leading-normal"
           as="div"
         >
-          <Markdown>{txt}</Markdown>
+          <MarkdownRenderer className="space-y-2">{txt}</MarkdownRenderer>
         </Txt>
       </div>
     );
@@ -77,8 +177,12 @@ export const Txtmessage = ({ txt, role }: { txt: string; role: MastraUIMessage['
 
   if (role === 'assistant' || role === 'system') {
     return (
-      <Txt variant="ui-md" className="whitespace-pre-wrap leading-relaxed text-neutral4 max-w-[80%]" as="div">
-        <Markdown>{txt}</Markdown>
+      <Txt
+        variant="ui-md"
+        className="text-neutral4 max-w-[80%] [&_ul]:!space-y-1 [&_ol]:!space-y-1 [&_li]:!my-0 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_li]:!leading-normal"
+        as="div"
+      >
+        <MarkdownRenderer className="space-y-2">{txt}</MarkdownRenderer>
       </Txt>
     );
   }
@@ -202,24 +306,334 @@ export const ToolExecutionMessage = () => {
   );
 };
 
-const BuilderAgentToolMessage = ({ toolsAdded, key }: { toolsAdded: { id: string; name: string }[]; key: string }) => {
-  if (toolsAdded.length === 0) {
-    return null;
+const safeStringify = (value: unknown): string => {
+  if (value === undefined) return '';
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
   }
+};
+
+export const GenericTool = ({ toolName, input, output }: { toolName: string; input?: unknown; output?: unknown }) => {
+  const inputJson = safeStringify(input);
+  const outputJson = safeStringify(output);
+  const hasOutput = outputJson.length > 0;
 
   return (
-    <div className="border border-1 p-3 rounded-xl">
-      <Txt variant="ui-sm" className="whitespace-pre-wrap leading-relaxed text-neutral3 pb-2" as="div">
-        Agent capabilities unlocked:
-      </Txt>
-
-      <ul key={key} className="space-y-1">
-        {toolsAdded.map((tool: { id: string; name: string }) => (
-          <li key={`${key}-${tool.id}`} className="flex items-center gap-2">
-            <Check className="w-4 h-4 text-neutral3" /> <Txtmessage key={key} txt={tool.name} role="assistant" />
-          </li>
-        ))}
-      </ul>
-    </div>
+    <ToolCard testId="agent-builder-chat-generic-tool">
+      <Collapsible>
+        <CollapsibleTrigger
+          className="flex w-full items-center gap-2 text-left group"
+          data-testid="agent-builder-chat-generic-tool-trigger"
+        >
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-border1/60 bg-surface1 px-2 py-0.5">
+            <Wrench className="size-3.5 shrink-0 text-neutral4" aria-hidden />
+            <Txt variant="ui-sm" className="text-neutral5" as="span">
+              Executing <span className="font-mono text-neutral6">{toolName}</span>
+            </Txt>
+          </span>
+          <ChevronRight
+            className="size-4 shrink-0 text-neutral4 transition-transform group-data-[state=open]:rotate-90"
+            aria-hidden
+          />
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="mt-3 flex flex-col gap-2" data-testid="agent-builder-chat-generic-tool-content">
+            <div className="rounded-md border border-border1/60 bg-surface1 overflow-hidden">
+              <div className="px-2 py-1 border-b border-border1/60">
+                <Txt variant="ui-sm" className="text-neutral3" as="div">
+                  Input
+                </Txt>
+              </div>
+              <pre className="m-0 max-h-[320px] overflow-auto p-3 text-xs leading-relaxed text-neutral5 whitespace-pre-wrap break-words">
+                {inputJson || '{}'}
+              </pre>
+            </div>
+            {hasOutput ? (
+              <div className="rounded-md border border-border1/60 bg-surface1 overflow-hidden">
+                <div className="px-2 py-1 border-b border-border1/60">
+                  <Txt variant="ui-sm" className="text-neutral3" as="div">
+                    Output
+                  </Txt>
+                </div>
+                <pre className="m-0 max-h-[320px] overflow-auto p-3 text-xs leading-relaxed text-neutral5 whitespace-pre-wrap break-words">
+                  {outputJson}
+                </pre>
+              </div>
+            ) : null}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </ToolCard>
   );
 };
+
+export const ToolCard = ({ children, testId }: { children: ReactNode; testId?: string }) => (
+  <Card
+    data-testid={testId}
+    className="max-w-[80%] p-3 bg-surface2/60 border-border1/60 animate-in fade-in slide-in-from-left-2 duration-300"
+  >
+    {children}
+  </Card>
+);
+
+const ToolMessageLine = ({ children }: { children: ReactNode }) => (
+  <Txt variant="ui-md" className="whitespace-pre-wrap leading-relaxed text-neutral4" as="div">
+    {children}
+  </Txt>
+);
+
+const ToolCardField = ({
+  icon,
+  label,
+  helpText,
+  children,
+}: {
+  icon: ReactNode;
+  label: string;
+  helpText: string;
+  children: ReactNode;
+}) => (
+  <ToolCard>
+    <div className="flex items-start gap-3">
+      <div className="mt-1 text-neutral4">{icon}</div>
+      <div className="flex flex-col gap-2 flex-1 min-w-0">
+        <div className="flex flex-col gap-0.5">
+          <Txt variant="ui-md" className="text-neutral6" as="div">
+            {label}
+          </Txt>
+          <Txt variant="ui-sm" className="text-neutral3" as="div">
+            {helpText}
+          </Txt>
+        </div>
+        {children}
+      </div>
+    </div>
+  </ToolCard>
+);
+
+export const MessageSetAgentName = ({ disabled = false }: { disabled?: boolean }) => {
+  const { control } = useFormContext<AgentBuilderEditFormValues>();
+  return (
+    <ToolCardField
+      icon={<Type className="size-5 shrink-0" aria-hidden />}
+      label="Agent name"
+      helpText="The display name shown to users."
+    >
+      <Controller
+        control={control}
+        name="name"
+        render={({ field }) => (
+          <TextFieldBlock
+            name={field.name}
+            label="Agent name"
+            labelIsHidden
+            size="md"
+            placeholder="Untitled agent"
+            value={field.value ?? ''}
+            onChange={field.onChange}
+            onBlur={field.onBlur}
+            disabled={disabled}
+            testId="agent-builder-chat-set-agent-name-input"
+          />
+        )}
+      />
+    </ToolCardField>
+  );
+};
+
+export const MessageSetAgentDescription = ({ disabled = false }: { disabled?: boolean }) => {
+  const { control } = useFormContext<AgentBuilderEditFormValues>();
+  return (
+    <ToolCardField
+      icon={<AlignLeft className="size-5 shrink-0" aria-hidden />}
+      label="Agent description"
+      helpText="A short summary shown when browsing agents."
+    >
+      <Controller
+        control={control}
+        name="description"
+        render={({ field }) => (
+          <TextFieldBlock
+            name={field.name}
+            label="Agent description"
+            labelIsHidden
+            size="md"
+            placeholder="What is this agent for?"
+            value={field.value ?? ''}
+            onChange={field.onChange}
+            onBlur={field.onBlur}
+            disabled={disabled}
+            testId="agent-builder-chat-set-agent-description-input"
+          />
+        )}
+      />
+    </ToolCardField>
+  );
+};
+
+export const MessageSetAgentInstructions = ({ disabled = false }: { disabled?: boolean }) => {
+  const { control } = useFormContext<AgentBuilderEditFormValues>();
+  return (
+    <ToolCard>
+      <Collapsible>
+        <CollapsibleTrigger
+          className="flex w-full items-start gap-3 text-left"
+          data-testid="agent-builder-chat-set-agent-instructions-trigger"
+        >
+          <div className="flex items-start gap-3 flex-1 min-w-0">
+            <FileText className="size-5 shrink-0 text-neutral4 mt-0.5" aria-hidden />
+            <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+              <Txt variant="ui-md" className="text-neutral6" as="div">
+                Agent instructions
+              </Txt>
+              <Txt variant="ui-sm" className="text-neutral3" as="div">
+                The system prompt that guides the agent. Click to view or edit.
+              </Txt>
+            </div>
+          </div>
+          <ChevronRight className="size-4 shrink-0 text-neutral4 mt-1" aria-hidden />
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div
+            className="mt-3 rounded-md border border-border1/60 bg-surface1 overflow-hidden"
+            data-testid="agent-builder-chat-set-agent-instructions-editor"
+          >
+            <Controller
+              control={control}
+              name="instructions"
+              render={({ field }) => (
+                <CodeEditor
+                  value={field.value ?? ''}
+                  onChange={field.onChange}
+                  language="markdown"
+                  editable={!disabled}
+                  placeholder="You are a helpful assistant that…"
+                  showCopyButton={false}
+                  className="min-h-[160px] max-h-[320px] overflow-auto border-0 bg-transparent p-3 rounded-none"
+                />
+              )}
+            />
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </ToolCard>
+  );
+};
+
+export const MessageSetAgentTools = ({ tools }: { tools: { id: string; name: string }[] }) => (
+  <ToolCard>
+    <div className="flex items-start gap-3">
+      <Wrench className="size-5 shrink-0 text-neutral4" aria-hidden />
+      <div className="flex flex-col gap-2 flex-1 min-w-0">
+        <div className="flex flex-col gap-0.5">
+          <Txt variant="ui-md" className="text-neutral6" as="div">
+            {tools.length === 0 ? 'No tools enabled' : `${tools.length} tool${tools.length === 1 ? '' : 's'} enabled`}
+          </Txt>
+          <Txt variant="ui-sm" className="text-neutral3" as="div">
+            Your agent will use these tools to complete tasks.
+          </Txt>
+        </div>
+        {tools.length > 0 && (
+          <ul className="flex flex-wrap gap-1.5">
+            {tools.map(t => (
+              <li key={t.id} className="rounded-md border border-border1 bg-surface3 px-2 py-1">
+                <Txt variant="ui-sm" className="text-neutral6 truncate" as="span">
+                  {t.name}
+                </Txt>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  </ToolCard>
+);
+
+export const MessageSetAgentSkills = ({ skills }: { skills: { id: string; name: string }[] }) => (
+  <ToolCard>
+    <ToolMessageLine>Enabling skills: {skills.map(s => s.name).join(', ')}</ToolMessageLine>
+  </ToolCard>
+);
+
+export const MessageSetAgentModel = ({
+  model,
+  disabled = false,
+}: {
+  model: { provider: string; name: string };
+  disabled?: boolean;
+}) => {
+  const { control, setValue } = useFormContext<AgentBuilderEditFormValues>();
+  const fallbackLabel =
+    model.provider && model.name ? `${model.provider}/${model.name}` : 'Pick the AI model that powers your agent.';
+  return (
+    <ToolCardField
+      icon={<Sparkles className="size-5 shrink-0" aria-hidden />}
+      label="Agent model"
+      helpText={fallbackLabel}
+    >
+      <Controller
+        control={control}
+        name="model"
+        render={({ field }) => {
+          const provider = field.value?.provider ?? '';
+          const modelId = field.value?.name ?? '';
+          return (
+            <div
+              className="flex flex-col gap-2 min-w-0 sm:flex-row sm:items-center"
+              data-testid="agent-builder-chat-set-agent-model"
+            >
+              <div className="flex-1 basis-0 min-w-0">
+                <LLMProviders
+                  value={provider}
+                  onValueChange={next => {
+                    const cleaned = cleanProviderId(next);
+                    setValue('model', { provider: cleaned, name: '' }, { shouldDirty: true });
+                  }}
+                  disabled={disabled}
+                  className="w-full !min-w-0"
+                />
+              </div>
+              <div className="flex-1 basis-0 min-w-0">
+                <LLMModels
+                  llmId={provider}
+                  value={modelId}
+                  onValueChange={next => {
+                    setValue('model', { provider: cleanProviderId(provider), name: next }, { shouldDirty: true });
+                  }}
+                  disabled={disabled}
+                  className="w-full !min-w-0"
+                />
+              </div>
+            </div>
+          );
+        }}
+      />
+    </ToolCardField>
+  );
+};
+
+export const MessageSetAgentBrowserEnabled = ({ browserEnabled }: { browserEnabled: boolean }) => (
+  <ToolCard>
+    <div className="flex items-start gap-3">
+      <Globe className="size-5 shrink-0 text-neutral4" aria-hidden />
+      <div className="flex flex-col gap-0.5">
+        <Txt variant="ui-md" className="text-neutral6" as="div">
+          {browserEnabled ? 'Browser access enabled' : 'Browser access disabled'}
+        </Txt>
+        <Txt variant="ui-sm" className="text-neutral3" as="div">
+          {browserEnabled
+            ? 'Your agent will now be able to interact with web pages'
+            : 'Your agent will no longer interact with web pages'}
+        </Txt>
+      </div>
+    </div>
+  </ToolCard>
+);
+
+export const MessageSetAgentWorkspaceId = ({ workspaceId }: { workspaceId: string }) => (
+  <ToolCard>
+    <ToolMessageLine>Setting workspace to: {workspaceId}</ToolMessageLine>
+  </ToolCard>
+);

--- a/packages/playground/src/domains/agent-builder/hooks/use-agent-builder-tools.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-agent-builder-tools.ts
@@ -1,0 +1,15 @@
+/**
+ * Tool-name constants for the atomic per-field agent-builder client tools.
+ *
+ * Each constant is the wire name the server emits in `dynamic-tool` /
+ * `tool-<name>` parts, and is used by the chat message renderer to dispatch
+ * the right ToolCard component.
+ */
+export const SET_AGENT_NAME_TOOL_NAME = 'set-agent-name';
+export const SET_AGENT_DESCRIPTION_TOOL_NAME = 'set-agent-description';
+export const SET_AGENT_INSTRUCTIONS_TOOL_NAME = 'set-agent-instructions';
+export const SET_AGENT_MODEL_TOOL_NAME = 'set-agent-model';
+export const SET_AGENT_TOOLS_TOOL_NAME = 'set-agent-tools';
+export const SET_AGENT_SKILLS_TOOL_NAME = 'set-agent-skills';
+export const SET_AGENT_WORKSPACE_ID_TOOL_NAME = 'set-agent-workspace-id';
+export const SET_AGENT_BROWSER_ENABLED_TOOL_NAME = 'set-agent-browser-enabled';


### PR DESCRIPTION
## Summary

Refactors the agent-builder chat to render each per-field client tool as its own purpose-built ToolCard instead of a single bundled tool message, and tightens the agent-builder system prompt around model selection and CLI usage.

On the playground side, every atomic builder tool now has a dedicated card in the chat: the model setter is a live provider/model picker (mirroring the configure panel), and any unknown tool falls back to a collapsible GenericTool card that surfaces JSON input/output for debugging.

The system prompt was also tightened: phase 6 is now a precise model-selection step (no floating aliases like `latest`, pinned `provider/model-id`, capability-vs-size heuristic, deterministic fallback), and a workspace rule blocks the agent from running CLI actions until the user connects a workspace.

## What changed

**`packages/playground`**
- New `use-agent-builder-tools.ts` exposing atomic tool-name constants (`set-agent-name`, `set-agent-description`, `set-agent-instructions`, `set-agent-model`, `set-agent-tools`, `set-agent-skills`, `set-agent-workspace-id`, `set-agent-browser-enabled`).
- `messages.tsx` rewritten to render a dedicated ToolCard per atomic tool; model picker uses `LLMProviders` / `LLMModels` and is disabled while streaming.
- Unknown dynamic tools render as a collapsible `GenericTool` ToolCard ("Executing <toolName>") that reveals JSON input/output on expand.
- Tests updated to cover the new picker and fallback behavior.

**`packages/editor`**
- Agent-builder system prompt phase 6 rewritten as a precise model-selection step.
- New behavior rule: if a CLI is needed, refuse until the agent is connected to a workspace.

## Test plan

- `pnpm --filter @internal/playground vitest run src/domains/agent-builder/components/chat-primitives/__tests__/messages.test.tsx` → 19/19 passing.