### PR TITLE
Add FGA route policy coverage controls

### DIFF
--- a/.changeset/clean-seals-press.md
+++ b/.changeset/clean-seals-press.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed stored resource updates to preserve existing metadata keys.

--- a/.changeset/cyan-humans-wear.md
+++ b/.changeset/cyan-humans-wear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added FGA context metadata, per-tool execution authorization, and stored resource scope configuration types.

--- a/.changeset/cyan-humans-wear.md
+++ b/.changeset/cyan-humans-wear.md
@@ -2,4 +2,4 @@
 '@mastra/core': minor
 ---
 
-Added FGA context metadata, per-tool execution authorization, and stored resource scope configuration types.
+Added consistent FGA execution context across agents, tools, memory, and internal workflow execution. When FGA is configured, userless protected execution now fails closed.

--- a/.changeset/cyan-humans-wear.md
+++ b/.changeset/cyan-humans-wear.md
@@ -2,4 +2,13 @@
 '@mastra/core': minor
 ---
 
-Added consistent FGA execution context across agents, tools, memory, and internal workflow execution. When FGA is configured, userless protected execution now fails closed.
+Added consistent FGA execution checks across agents, tools, memory, and workflows to prevent unauthenticated executions when FGA is configured. Pass an authenticated user through `requestContext` when invoking protected APIs directly:
+
+```ts
+const requestContext = new RequestContext();
+requestContext.set('user', user);
+
+await agent.generate('Summarize this thread', {
+  requestContext,
+});
+```

--- a/.changeset/moody-dingos-end.md
+++ b/.changeset/moody-dingos-end.md
@@ -2,4 +2,13 @@
 '@mastra/server': minor
 ---
 
-Added built-in FGA metadata for stored resource routes, route-manifest coverage, and optional request scope isolation for stored resource APIs.
+Added automatic FGA metadata for stored resource routes plus optional request scope isolation for stored resource APIs. Enable protected-route coverage with provider options:
+
+```ts
+const fga = new MastraFGAWorkos({
+  resourceMapping,
+  permissionMapping,
+  requireForProtectedRoutes: true,
+  auditProtectedRoutes: 'warn',
+});
+```

--- a/.changeset/moody-dingos-end.md
+++ b/.changeset/moody-dingos-end.md
@@ -2,4 +2,4 @@
 '@mastra/server': minor
 ---
 
-Added built-in FGA metadata and optional request scope isolation for stored resource routes.
+Added built-in FGA metadata for stored resource routes, route-manifest coverage, and optional request scope isolation for stored resource APIs.

--- a/.changeset/moody-dingos-end.md
+++ b/.changeset/moody-dingos-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': minor
+---
+
+Added built-in FGA metadata and optional request scope isolation for stored resource routes.

--- a/docs/src/content/en/docs/server/auth/fga.mdx
+++ b/docs/src/content/en/docs/server/auth/fga.mdx
@@ -59,6 +59,8 @@ When using `MastraFGAWorkos`, set `fetchMemberships: true` on `MastraAuthWorkos`
 
 Use `thread` as the resource-mapping key for memory authorization. `MastraFGAWorkos` still accepts the legacy alias `memory`, but new configs should prefer `thread`.
 
+When `server.fga` is configured, Mastra enforces FGA on protected actions. If a protected action has no authenticated user, Mastra denies it. If `server.fga` is not configured, these FGA checks are skipped and Mastra keeps the previous behavior.
+
 ### Resource mapping
 
 The `resourceMapping` tells Mastra how to resolve FGA resource types and IDs from request context. Keys are Mastra resource types, values define the FGA resource type and how to derive the ID:
@@ -206,17 +208,20 @@ const fga = new MastraFGAWorkos({
 
 When an FGA provider is configured, Mastra automatically checks authorization at these lifecycle points:
 
-| Lifecycle point | Permission checked | Resource |
-| - | - | - |
-| Agent execution (`generate`, `stream`) | `agents:execute` | `{ type: 'agent', id: agentId }` |
-| Workflow execution | `workflows:execute` | `{ type: 'workflow', id: workflowId }` |
-| Tool execution | `tools:execute` | `{ type: 'tool', id: toolName }` or the derived MCP or agent tool ID |
-| Thread/memory access | `memory:read`, `memory:write`, `memory:delete` | `{ type: 'thread', id: threadId }` |
-| MCP tool execution | `tools:execute` | `{ type: 'tool', id: [serverName, toolName] }` |
-| Stored resource routes | Stored resource permission for the route action | Stored resource type and route ID |
-| HTTP resource routes | Configured per route | Configured per route |
+| Lifecycle point | Permission checked | Resource type | Resource ID |
+| - | - | - | - |
+| Agent execution (`generate`, `stream`) | `agents:execute` | `agent` | `agentId` |
+| Built-in workflow HTTP execution routes and `Workflow.execute()` | `workflows:execute` | `workflow` | `workflowId` |
+| Standalone tool execution | `tools:execute` | `tool` | `toolName` |
+| Agent tool execution | `tools:execute` | `tool` | `${agentId}:${toolName}` |
+| MCP tool execution | `tools:execute` | `tool` | `JSON.stringify([serverName, toolName])` |
+| Thread and memory access | `memory:read`, `memory:write`, `memory:delete` | `thread` | `threadId` |
+| Stored resource routes | Stored resource permission for the route action | Stored resource type | Route record ID, or the stored-resource scope for collection routes |
+| HTTP resource routes | Configured per route | Configured per route | Configured per route |
 
-All checks are **no-ops when FGA is not configured**, maintaining backward compatibility.
+Direct SDK calls to `createRun().start()`, `resume()`, or `restart()` are not independently checked by core FGA in this release. Make those calls from a protected route or guard them in application code. Pass a `requestContext` with an authenticated user when invoking protected entry points directly.
+
+Core agent, internal workflow, tool, and memory checks also pass `requestContext` and action metadata to the FGA provider. Route checks pass `requestContext`. Thread checks pass the owning `resourceId` when available.
 
 ## Custom FGA provider
 

--- a/docs/src/content/en/docs/server/auth/fga.mdx
+++ b/docs/src/content/en/docs/server/auth/fga.mdx
@@ -33,6 +33,7 @@ const mastra = new Mastra({
     auth: new MastraAuthWorkos({
       /* ... */
       fetchMemberships: true,
+      mapUserToResourceId: user => user.teamId,
     }),
     fga: new MastraFGAWorkos({
       resourceMapping: {
@@ -47,6 +48,9 @@ const mastra = new Mastra({
         [MastraFGAPermissions.MEMORY_WRITE]: 'update',
       },
     }),
+    storedResources: {
+      scope: true,
+    },
   },
 });
 ```
@@ -75,6 +79,7 @@ resourceMapping: {
 - `user` — the authenticated user
 - `resourceId` — the owning Mastra resource ID when available (for example, a thread's `resourceId`)
 - `requestContext` — the current request context for advanced tenant resolution
+- `metadata` — provider-specific metadata for the attempted action
 
 Return `undefined` from `deriveId()` to fall back to the original Mastra resource ID.
 
@@ -97,9 +102,43 @@ If no mapping exists for a permission, the original string is passed through.
 
 Use `validatePermissions()` to validate the full set of permissions Mastra may emit at startup. Use this when a provider requires every Mastra permission to have an explicit provider permission slug.
 
+### Stored resource scoping
+
+FGA authorizes access to a resource. It does not automatically filter stored records that live in shared storage. Enable stored resource scoping when the built-in stored resource APIs are used in a multi-tenant app.
+
+```typescript prettier: false
+const mastra = new Mastra({
+  server: {
+    auth: new MastraAuthWorkos({
+      /* ... */
+      mapUserToResourceId: user => user.teamId,
+    }),
+    storedResources: {
+      scope: true,
+    },
+  },
+});
+```
+
+With `scope: true`, Mastra reads `MASTRA_RESOURCE_ID_KEY` from the request context. `mapUserToResourceId()` sets this value after authentication. Stored resource handlers persist the scope in record metadata and filter list, read, update, publish, and delete operations by that scope.
+
+Use an object when the scope needs custom request logic:
+
+```typescript prettier: false
+storedResources: {
+  scope: {
+    metadataKey: 'teamId',
+    resolve: ({ user }) => user.teamId,
+    requireScope: true,
+  },
+},
+```
+
+If `requireScope` is `true` or omitted, scoped stored resource routes fail when no scope can be resolved.
+
 ### Route policy coverage
 
-Mastra includes route-level FGA metadata for built-in resource routes, including agents, workflows, tools, MCP tools, memory threads, responses, and conversations. A route is checked when it has route-level `fga` metadata, when Mastra can derive built-in metadata for that route, or when the provider supplies metadata with `resolveRouteFGA()`.
+Mastra includes route-level FGA metadata for built-in resource routes, including agents, workflows, tools, MCP tools, memory threads, responses, conversations, and stored resources. Stored resource route coverage includes `/stored/agents`, `/stored/mcp-clients`, `/stored/prompt-blocks`, `/stored/scorers`, `/stored/skills`, and `/stored/workspaces`. A route is checked when it has route-level `fga` metadata, when Mastra can derive built-in metadata for that route, or when the provider supplies metadata with `resolveRouteFGA()`.
 
 To deny protected routes that do not resolve FGA metadata, configure route policy coverage on the FGA provider:
 
@@ -171,9 +210,10 @@ When an FGA provider is configured, Mastra automatically checks authorization at
 | - | - | - |
 | Agent execution (`generate`, `stream`) | `agents:execute` | `{ type: 'agent', id: agentId }` |
 | Workflow execution | `workflows:execute` | `{ type: 'workflow', id: workflowId }` |
-| Tool execution | `tools:execute` | `{ type: 'tool', id: toolName }` |
+| Tool execution | `tools:execute` | `{ type: 'tool', id: toolName }` or the derived MCP or agent tool ID |
 | Thread/memory access | `memory:read`, `memory:write`, `memory:delete` | `{ type: 'thread', id: threadId }` |
-| MCP tool execution | `tools:execute` | `{ type: 'tool', id: toolName }` |
+| MCP tool execution | `tools:execute` | `{ type: 'tool', id: [serverName, toolName] }` |
+| Stored resource routes | Stored resource permission for the route action | Stored resource type and route ID |
 | HTTP resource routes | Configured per route | Configured per route |
 
 All checks are **no-ops when FGA is not configured**, maintaining backward compatibility.

--- a/packages/core/src/agent/__tests__/agent-fga.test.ts
+++ b/packages/core/src/agent/__tests__/agent-fga.test.ts
@@ -72,7 +72,17 @@ describe('Agent FGA checks', () => {
 
       expect(fgaProvider.require).toHaveBeenCalledWith(
         { id: 'user-1', organizationMembershipId: 'om-1' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+        {
+          resource: { type: 'agent', id: 'test-agent' },
+          permission: 'agents:execute',
+          context: expect.objectContaining({
+            requestContext,
+            metadata: expect.objectContaining({
+              agentId: 'test-agent',
+              agentName: 'test-agent',
+            }),
+          }),
+        },
       );
     });
 
@@ -87,6 +97,19 @@ describe('Agent FGA checks', () => {
       requestContext.set('user', { id: 'user-1' });
 
       await expect(agent.generate('test', { requestContext: requestContext as any })).rejects.toThrow(FGADeniedError);
+    });
+
+    it('should fail closed when FGA is configured and no user is available', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.generate('test', { requestContext: new RequestContext() as any })).rejects.toThrow(
+        FGADeniedError,
+      );
+      expect(fgaProvider.require).not.toHaveBeenCalled();
     });
 
     it('should not call FGA check when no FGA provider configured', async () => {
@@ -124,7 +147,17 @@ describe('Agent FGA checks', () => {
 
       expect(fgaProvider.require).toHaveBeenCalledWith(
         { id: 'user-1', organizationMembershipId: 'om-1' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+        {
+          resource: { type: 'agent', id: 'test-agent' },
+          permission: 'agents:execute',
+          context: expect.objectContaining({
+            requestContext,
+            metadata: expect.objectContaining({
+              agentId: 'test-agent',
+              agentName: 'test-agent',
+            }),
+          }),
+        },
       );
     });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -150,6 +150,11 @@ type ProcessorLoadedToolsProvider = {
   }) => Record<string, ToolToConvert> | Promise<Record<string, ToolToConvert>>;
 };
 
+type AgentSnapshotMemoryInfo = {
+  threadId?: string;
+  resourceId?: string;
+};
+
 type ProcessorWorkflowChildrenContainer = {
   steps?: Record<string, unknown> | unknown[];
   children?: Record<string, unknown> | unknown[];
@@ -5333,22 +5338,74 @@ export class Agent<
     return existingSnapshot;
   }
 
+  #getSnapshotMemoryInfo(existingSnapshot: any): AgentSnapshotMemoryInfo | undefined {
+    for (const key in existingSnapshot?.context) {
+      const step = existingSnapshot?.context[key];
+      if (step && step.status === 'suspended' && step.suspendPayload?.__streamState) {
+        return step.suspendPayload?.__streamState?.messageList?.memoryInfo;
+      }
+    }
+
+    return undefined;
+  }
+
+  #getAgentExecutionResourceId({
+    requestContext,
+    memory,
+    snapshotMemoryInfo,
+  }: {
+    requestContext?: RequestContext;
+    memory?: AgentExecutionOptionsBase<any>['memory'];
+    snapshotMemoryInfo?: AgentSnapshotMemoryInfo;
+  }): string | undefined {
+    const resourceIdFromContext = requestContext?.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+    return resourceIdFromContext || memory?.resource || snapshotMemoryInfo?.resourceId;
+  }
+
+  async #requireAgentExecutionFGA({
+    requestContext,
+    memory,
+    runId,
+    snapshotMemoryInfo,
+  }: {
+    requestContext?: RequestContext;
+    memory?: AgentExecutionOptionsBase<any>['memory'];
+    runId?: string;
+    snapshotMemoryInfo?: AgentSnapshotMemoryInfo;
+  }): Promise<void> {
+    const fgaProvider = this.#mastra?.getServer()?.fga;
+    if (!fgaProvider) {
+      return;
+    }
+
+    const user = requestContext?.get('user');
+    const executionResourceId = this.#getAgentExecutionResourceId({ requestContext, memory, snapshotMemoryInfo });
+    const { getAgentFGAResourceId, requireFGA } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
+    await requireFGA({
+      fgaProvider,
+      user,
+      resource: { type: 'agent', id: getAgentFGAResourceId(this.id) },
+      permission: MastraFGAPermissions.AGENTS_EXECUTE,
+      requestContext,
+      context: {
+        resourceId: executionResourceId,
+      },
+      metadata: {
+        agentId: this.id,
+        agentName: this.name,
+        runId,
+        executionResourceId,
+      },
+    });
+  }
+
   /**
    * Executes the agent call, handling tools, memory, and streaming.
    * @internal
    */
   async #execute<OUTPUT>({ methodType, resumeContext, ...options }: InnerAgentExecutionOptions<OUTPUT>) {
     const existingSnapshot = resumeContext?.snapshot;
-    let snapshotMemoryInfo;
-    if (existingSnapshot) {
-      for (const key in existingSnapshot?.context) {
-        const step = existingSnapshot?.context[key];
-        if (step && step.status === 'suspended' && step.suspendPayload?.__streamState) {
-          snapshotMemoryInfo = step.suspendPayload?.__streamState?.messageList?.memoryInfo;
-          break;
-        }
-      }
-    }
+    const snapshotMemoryInfo = this.#getSnapshotMemoryInfo(existingSnapshot);
     const requestContext = options.requestContext || new RequestContext();
 
     // Build version overrides by merging: Mastra defaults < requestContext < call-site
@@ -5405,7 +5462,6 @@ export class Agent<
     // Reserved keys from requestContext take precedence for security.
     // This allows middleware to securely set resourceId/threadId based on authenticated user,
     // preventing attackers from hijacking another user's memory by passing different values in the body.
-    const resourceIdFromContext = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
     const threadIdFromContext = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
 
     const threadFromArgs = resolveThreadIdFromArgs({
@@ -5416,7 +5472,11 @@ export class Agent<
       overrideId: threadIdFromContext,
     });
 
-    const resourceId = resourceIdFromContext || options.memory?.resource || snapshotMemoryInfo?.resourceId;
+    const resourceId = this.#getAgentExecutionResourceId({
+      requestContext,
+      memory: options.memory,
+      snapshotMemoryInfo,
+    });
     const memoryConfig = options.memory?.options;
 
     const llm = (await this.getLLM({
@@ -6051,30 +6111,6 @@ export class Agent<
     // Validate request context if schema is provided
     await this.#validateRequestContext(options?.requestContext);
 
-    // FGA authorization check
-    const fgaProvider = this.#mastra?.getServer()?.fga;
-    if (fgaProvider) {
-      const user = options?.requestContext?.get('user');
-      const executionResourceId =
-        options?.memory?.resource ?? (options?.requestContext?.get(MASTRA_RESOURCE_ID_KEY) as string | undefined);
-      const { getAgentFGAResourceId, requireFGA } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
-      await requireFGA({
-        fgaProvider,
-        user,
-        resource: { type: 'agent', id: getAgentFGAResourceId(this.id) },
-        permission: MastraFGAPermissions.AGENTS_EXECUTE,
-        requestContext: options?.requestContext,
-        context: {
-          resourceId: executionResourceId,
-        },
-        metadata: {
-          agentId: this.id,
-          agentName: this.name,
-          runId: options?.runId,
-        },
-      });
-    }
-
     const defaultOptions = await this.getDefaultOptions({
       requestContext: options?.requestContext,
     });
@@ -6082,6 +6118,8 @@ export class Agent<
       defaultOptions as Record<string, unknown>,
       (options ?? {}) as Record<string, unknown>,
     ) as AgentExecutionOptions<any> & { model?: DynamicArgument<MastraModelConfig> };
+
+    await this.#requireAgentExecutionFGA(mergedOptions);
 
     const llm = await this.getLLM({
       requestContext: mergedOptions.requestContext,
@@ -6220,31 +6258,6 @@ export class Agent<
     // Validate request context if schema is provided
     await this.#validateRequestContext(streamOptions?.requestContext);
 
-    // FGA authorization check
-    const streamFgaProvider = this.#mastra?.getServer()?.fga;
-    if (streamFgaProvider) {
-      const user = streamOptions?.requestContext?.get('user');
-      const executionResourceId =
-        streamOptions?.memory?.resource ??
-        (streamOptions?.requestContext?.get(MASTRA_RESOURCE_ID_KEY) as string | undefined);
-      const { getAgentFGAResourceId, requireFGA } = await import('../auth/ee/fga-check');
-      await requireFGA({
-        fgaProvider: streamFgaProvider,
-        user,
-        resource: { type: 'agent', id: getAgentFGAResourceId(this.id) },
-        permission: MastraFGAPermissions.AGENTS_EXECUTE,
-        requestContext: streamOptions?.requestContext,
-        context: {
-          resourceId: executionResourceId,
-        },
-        metadata: {
-          agentId: this.id,
-          agentName: this.name,
-          runId: streamOptions?.runId,
-        },
-      });
-    }
-
     const defaultOptions = await this.getDefaultOptions({
       requestContext: streamOptions?.requestContext,
     });
@@ -6252,6 +6265,8 @@ export class Agent<
       defaultOptions as Record<string, unknown>,
       (streamOptions ?? {}) as Record<string, unknown>,
     ) as AgentExecutionOptions<OUTPUT> & { model?: DynamicArgument<MastraModelConfig> };
+
+    await this.#requireAgentExecutionFGA(mergedOptions);
 
     const llm = await this.getLLM({
       requestContext: mergedOptions.requestContext,
@@ -6529,10 +6544,20 @@ export class Agent<
       requestContext: streamOptions?.requestContext,
     });
 
-    let mergedStreamOptions = deepMerge(
+    const mergedStreamOptions = deepMerge(
       defaultOptions as Record<string, unknown>,
       (streamOptions ?? {}) as Record<string, unknown>,
     ) as typeof defaultOptions & { model?: DynamicArgument<MastraModelConfig> };
+
+    const runId = streamOptions?.runId ?? '';
+    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
+    const snapshotMemoryInfo = this.#getSnapshotMemoryInfo(existingSnapshot);
+    await this.#requireAgentExecutionFGA({
+      requestContext: mergedStreamOptions.requestContext,
+      memory: mergedStreamOptions.memory,
+      runId: mergedStreamOptions.runId,
+      snapshotMemoryInfo,
+    });
 
     const llm = await this.getLLM({
       requestContext: mergedStreamOptions.requestContext,
@@ -6558,8 +6583,6 @@ export class Agent<
       });
     }
 
-    const runId = streamOptions?.runId ?? '';
-    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
     await this.#getThreadStreamRuntime().waitForCrossAgentThreadRun(
       this as Agent<any, any, any, any>,
       mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
@@ -6668,6 +6691,15 @@ export class Agent<
       (options ?? {}) as Record<string, unknown>,
     ) as typeof defaultOptions & { model?: DynamicArgument<MastraModelConfig> };
 
+    const runId = options?.runId ?? '';
+    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeGenerate' });
+    await this.#requireAgentExecutionFGA({
+      requestContext: mergedOptions.requestContext,
+      memory: mergedOptions.memory,
+      runId: mergedOptions.runId,
+      snapshotMemoryInfo: this.#getSnapshotMemoryInfo(existingSnapshot),
+    });
+
     const llm = await this.getLLM({
       requestContext: mergedOptions.requestContext,
       model: mergedOptions.model as DynamicArgument<MastraModelConfig, TRequestContext> | undefined,
@@ -6695,9 +6727,6 @@ export class Agent<
         },
       });
     }
-
-    const runId = options?.runId ?? '';
-    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeGenerate' });
 
     const result = await this.#execute({
       ...mergedOptions,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6055,15 +6055,24 @@ export class Agent<
     const fgaProvider = this.#mastra?.getServer()?.fga;
     if (fgaProvider) {
       const user = options?.requestContext?.get('user');
-      if (user) {
-        const { checkFGA } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
-        await checkFGA({
-          fgaProvider,
-          user,
-          resource: { type: 'agent', id: this.id },
-          permission: MastraFGAPermissions.AGENTS_EXECUTE,
-        });
-      }
+      const executionResourceId =
+        options?.memory?.resource ?? (options?.requestContext?.get(MASTRA_RESOURCE_ID_KEY) as string | undefined);
+      const { getAgentFGAResourceId, requireFGA } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
+      await requireFGA({
+        fgaProvider,
+        user,
+        resource: { type: 'agent', id: getAgentFGAResourceId(this.id) },
+        permission: MastraFGAPermissions.AGENTS_EXECUTE,
+        requestContext: options?.requestContext,
+        context: {
+          resourceId: executionResourceId,
+        },
+        metadata: {
+          agentId: this.id,
+          agentName: this.name,
+          runId: options?.runId,
+        },
+      });
     }
 
     const defaultOptions = await this.getDefaultOptions({
@@ -6215,15 +6224,25 @@ export class Agent<
     const streamFgaProvider = this.#mastra?.getServer()?.fga;
     if (streamFgaProvider) {
       const user = streamOptions?.requestContext?.get('user');
-      if (user) {
-        const { checkFGA } = await import('../auth/ee/fga-check');
-        await checkFGA({
-          fgaProvider: streamFgaProvider,
-          user,
-          resource: { type: 'agent', id: this.id },
-          permission: MastraFGAPermissions.AGENTS_EXECUTE,
-        });
-      }
+      const executionResourceId =
+        streamOptions?.memory?.resource ??
+        (streamOptions?.requestContext?.get(MASTRA_RESOURCE_ID_KEY) as string | undefined);
+      const { getAgentFGAResourceId, requireFGA } = await import('../auth/ee/fga-check');
+      await requireFGA({
+        fgaProvider: streamFgaProvider,
+        user,
+        resource: { type: 'agent', id: getAgentFGAResourceId(this.id) },
+        permission: MastraFGAPermissions.AGENTS_EXECUTE,
+        requestContext: streamOptions?.requestContext,
+        context: {
+          resourceId: executionResourceId,
+        },
+        metadata: {
+          agentId: this.id,
+          agentName: this.name,
+          runId: streamOptions?.runId,
+        },
+      });
     }
 
     const defaultOptions = await this.getDefaultOptions({

--- a/packages/core/src/auth/ee/__tests__/fga-check.test.ts
+++ b/packages/core/src/auth/ee/__tests__/fga-check.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 
-import { checkFGA, FGADeniedError } from '../fga-check';
+import { checkFGA, FGADeniedError, requireFGA } from '../fga-check';
 import type { IFGAProvider } from '../interfaces/fga';
 import { MastraFGAPermissions } from '../interfaces/permissions.generated';
 
@@ -59,6 +59,21 @@ describe('checkFGA', () => {
         permission: MastraFGAPermissions.AGENTS_EXECUTE,
       }),
     ).rejects.toThrow(FGADeniedError);
+  });
+
+  it('should fail closed when FGA is configured and no user is available', async () => {
+    const provider = createMockFGAProvider(true);
+
+    await expect(
+      requireFGA({
+        fgaProvider: provider,
+        user: undefined,
+        resource: { type: 'agent', id: 'agent-1' },
+        permission: MastraFGAPermissions.AGENTS_EXECUTE,
+      }),
+    ).rejects.toThrow('authenticated user is required');
+
+    expect(provider.require).not.toHaveBeenCalled();
   });
 
   it('should pass user and permission to provider', async () => {

--- a/packages/core/src/auth/ee/fga-check.ts
+++ b/packages/core/src/auth/ee/fga-check.ts
@@ -92,7 +92,10 @@ export async function requireFGA(options: RequireFGAOptions): Promise<void> {
     throw new FGADeniedError(user, resource, permission, 'authenticated user is required');
   }
 
-  await fgaProvider.require(user, fgaContext ? { resource, permission, context: fgaContext } : { resource, permission });
+  await fgaProvider.require(
+    user,
+    fgaContext ? { resource, permission, context: fgaContext } : { resource, permission },
+  );
 }
 
 /**

--- a/packages/core/src/auth/ee/fga-check.ts
+++ b/packages/core/src/auth/ee/fga-check.ts
@@ -15,6 +15,54 @@ export interface CheckFGAOptions {
   context?: FGACheckContext;
 }
 
+export interface RequireFGAOptions extends CheckFGAOptions {
+  requestContext?: FGACheckContext['requestContext'];
+  metadata?: Record<string, unknown>;
+}
+
+function mergeFGAContext({
+  context,
+  requestContext,
+  metadata,
+}: Pick<RequireFGAOptions, 'context' | 'requestContext' | 'metadata'>): FGACheckContext | undefined {
+  const mergedContext: FGACheckContext = {
+    ...context,
+  };
+
+  if (requestContext) {
+    mergedContext.requestContext = requestContext;
+  }
+
+  if (metadata || context?.metadata) {
+    mergedContext.metadata = {
+      ...(context?.metadata ?? {}),
+      ...(metadata ?? {}),
+    };
+  }
+
+  return Object.keys(mergedContext).length > 0 ? mergedContext : undefined;
+}
+
+export function getAgentFGAResourceId(agentId: string): string {
+  return agentId;
+}
+
+export function getWorkflowFGAResourceId(workflowId: string): string {
+  return workflowId;
+}
+
+export function getStandaloneToolFGAResourceId(toolName: string): string {
+  return toolName;
+}
+
+export function getAgentToolFGAResourceId(agentId: string, toolName: string): string {
+  return `${agentId}:${toolName}`;
+}
+
+export function getMCPToolFGAResourceId(serverName: string, toolName: string): string {
+  return JSON.stringify([serverName, toolName]);
+}
+
 /**
  * Check fine-grained authorization for a resource.
  *
@@ -22,13 +70,29 @@ export interface CheckFGAOptions {
  * Delegates to fgaProvider.require() which throws FGADeniedError if denied.
  */
 export async function checkFGA(options: CheckFGAOptions): Promise<void> {
-  const { fgaProvider, user, resource, permission, context } = options;
+  await requireFGA(options);
+}
+
+/**
+ * Require fine-grained authorization for a resource.
+ *
+ * No-op if no FGA provider is configured. When FGA is configured, a missing
+ * user fails closed.
+ */
+export async function requireFGA(options: RequireFGAOptions): Promise<void> {
+  const { fgaProvider, user, resource, permission, context, requestContext, metadata } = options;
 
   if (!fgaProvider) {
     return;
   }
 
-  await fgaProvider.require(user, { resource, permission, context });
+  const fgaContext = mergeFGAContext({ context, requestContext, metadata });
+
+  if (!user) {
+    throw new FGADeniedError(user, resource, permission, 'authenticated user is required');
+  }
+
+  await fgaProvider.require(user, fgaContext ? { resource, permission, context: fgaContext } : { resource, permission });
 }
 
 /**
@@ -40,9 +104,18 @@ export class FGADeniedError extends Error {
   public readonly permission: MastraFGAPermissionInput;
   public readonly status: number;
 
-  constructor(user: any, resource: { type: string; id: string }, permission: MastraFGAPermissionInput) {
+  constructor(
+    user: any,
+    resource: { type: string; id: string },
+    permission: MastraFGAPermissionInput,
+    reason?: string,
+  ) {
     const userId = user?.id || user?.workosId || 'unknown';
-    super(`FGA authorization denied: user ${userId} cannot ${permission} on ${resource.type}:${resource.id}`);
+    super(
+      reason
+        ? `FGA authorization denied: ${reason}`
+        : `FGA authorization denied: user ${userId} cannot ${permission} on ${resource.type}:${resource.id}`,
+    );
     this.name = 'FGADeniedError';
     this.user = user;
     this.resource = resource;

--- a/packages/core/src/auth/ee/index.ts
+++ b/packages/core/src/auth/ee/index.ts
@@ -26,7 +26,13 @@ export {
 } from './license';
 
 // FGA check utility
-export { checkFGA, FGADeniedError, type CheckFGAOptions } from './fga-check';
+export {
+  checkFGA,
+  requireFGA,
+  FGADeniedError,
+  type CheckFGAOptions,
+  type RequireFGAOptions,
+} from './fga-check';
 
 // Default implementations
 export * from './defaults';

--- a/packages/core/src/auth/ee/index.ts
+++ b/packages/core/src/auth/ee/index.ts
@@ -26,13 +26,7 @@ export {
 } from './license';
 
 // FGA check utility
-export {
-  checkFGA,
-  requireFGA,
-  FGADeniedError,
-  type CheckFGAOptions,
-  type RequireFGAOptions,
-} from './fga-check';
+export { checkFGA, requireFGA, FGADeniedError, type CheckFGAOptions, type RequireFGAOptions } from './fga-check';
 
 // Default implementations
 export * from './defaults';

--- a/packages/core/src/auth/ee/interfaces/fga.ts
+++ b/packages/core/src/auth/ee/interfaces/fga.ts
@@ -30,6 +30,10 @@ export interface FGACheckContext {
    * data to derive the authorization resource identifier.
    */
   requestContext?: RequestContext;
+  /**
+   * Optional provider-specific metadata about the attempted action.
+   */
+  metadata?: Record<string, unknown>;
 }
 
 /**

--- a/packages/core/src/auth/ee/interfaces/fga.ts
+++ b/packages/core/src/auth/ee/interfaces/fga.ts
@@ -29,7 +29,7 @@ export interface FGACheckContext {
    * Optional request context for providers that need additional request-scoped
    * data to derive the authorization resource identifier.
    */
-  requestContext?: RequestContext;
+  requestContext?: RequestContext<any>;
   /**
    * Optional provider-specific metadata about the attempted action.
    */
@@ -59,7 +59,7 @@ export interface FGARouteConfig {
   /** Static or dynamic resource ID resolver. */
   resourceId?:
     | string
-    | ((params: Record<string, unknown>, context: { requestContext?: RequestContext }) => string | undefined);
+    | ((params: Record<string, unknown>, context: { requestContext?: RequestContext<any> }) => string | undefined);
   /** Permission to check for this route. Falls back to the route permission when omitted. */
   permission?: MastraFGAPermissionInput;
 }
@@ -81,7 +81,7 @@ export interface FGARouteInfo {
 export interface FGARouteResolverContext {
   route: FGARouteInfo;
   params: Record<string, unknown>;
-  requestContext?: RequestContext;
+  requestContext?: RequestContext<any>;
 }
 
 /**
@@ -238,9 +238,9 @@ export interface FGAListResourcesOptions {
  *
  * const fga = new MastraFGAWorkos({
  *   resourceMapping: {
- *     agents: { fgaResourceType: 'team', deriveId: (ctx) => ctx.user.teamId },
- *     workflows: { fgaResourceType: 'team', deriveId: (ctx) => ctx.user.teamId },
- *     memory: { fgaResourceType: 'user', deriveId: (ctx) => ctx.user.userId },
+ *     agent: { fgaResourceType: 'team', deriveId: (ctx) => ctx.user.teamId },
+ *     workflow: { fgaResourceType: 'team', deriveId: (ctx) => ctx.user.teamId },
+ *     thread: { fgaResourceType: 'user', deriveId: (ctx) => ctx.resourceId ?? ctx.user.userId },
  *   },
  *   permissionMapping: {
  *     [MastraFGAPermissions.AGENTS_READ]: 'read',

--- a/packages/core/src/auth/ee/interfaces/permissions.generated.ts
+++ b/packages/core/src/auth/ee/interfaces/permissions.generated.ts
@@ -13,15 +13,12 @@
  */
 export const RESOURCES = [
   'a2a',
-  'agent-builder',
   'agents',
-  'auth',
   'background-tasks',
   'channels',
   'datasets',
   'embedders',
   'experiments',
-  'infrastructure',
   'logs',
   'mcp',
   'memory',
@@ -83,18 +80,14 @@ export const PERMISSION_PATTERNS = {
   '*:publish': '*:publish',
   /** View all resources */
   '*:read': '*:read',
-  /** Change visibility/audience (e.g. private↔public) all resources */
+  /** Change visibility/audience all resources */
   '*:share': '*:share',
   /** Create and modify all resources */
   '*:write': '*:write',
   /** Full access to agent-to-agent communication */
   'a2a:*': 'a2a:*',
-  /** Full access to agent builder */
-  'agent-builder:*': 'agent-builder:*',
   /** Full access to agents */
   'agents:*': 'agents:*',
-  /** Full access to auth */
-  'auth:*': 'auth:*',
   /** Full access to background tasks */
   'background-tasks:*': 'background-tasks:*',
   /** Full access to channels */
@@ -105,8 +98,6 @@ export const PERMISSION_PATTERNS = {
   'embedders:*': 'embedders:*',
   /** Full access to experiments */
   'experiments:*': 'experiments:*',
-  /** Full access to infrastructure */
-  'infrastructure:*': 'infrastructure:*',
   /** Full access to logs */
   'logs:*': 'logs:*',
   /** Full access to MCP servers */
@@ -153,12 +144,6 @@ export const PERMISSION_PATTERNS = {
   'a2a:read': 'a2a:read',
   /** Create and modify agent-to-agent communication */
   'a2a:write': 'a2a:write',
-  /** Execute agent builder */
-  'agent-builder:execute': 'agent-builder:execute',
-  /** View agent builder */
-  'agent-builder:read': 'agent-builder:read',
-  /** Create and modify agent builder */
-  'agent-builder:write': 'agent-builder:write',
   /** Create agents */
   'agents:create': 'agents:create',
   /** Delete agents */
@@ -169,8 +154,6 @@ export const PERMISSION_PATTERNS = {
   'agents:read': 'agents:read',
   /** Create and modify agents */
   'agents:write': 'agents:write',
-  /** View auth */
-  'auth:read': 'auth:read',
   /** View background tasks */
   'background-tasks:read': 'background-tasks:read',
   /** View channels */
@@ -189,8 +172,6 @@ export const PERMISSION_PATTERNS = {
   'embedders:read': 'embedders:read',
   /** View experiments */
   'experiments:read': 'experiments:read',
-  /** View infrastructure */
-  'infrastructure:read': 'infrastructure:read',
   /** View logs */
   'logs:read': 'logs:read',
   /** Execute MCP servers */
@@ -233,8 +214,6 @@ export const PERMISSION_PATTERNS = {
   'stored-agents:publish': 'stored-agents:publish',
   /** View stored agents */
   'stored-agents:read': 'stored-agents:read',
-  /** Change visibility/audience (e.g. private↔public) stored agents */
-  'stored-agents:share': 'stored-agents:share',
   /** Create and modify stored agents */
   'stored-agents:write': 'stored-agents:write',
   /** Delete stored MCP clients */
@@ -267,8 +246,6 @@ export const PERMISSION_PATTERNS = {
   'stored-skills:publish': 'stored-skills:publish',
   /** View stored skills */
   'stored-skills:read': 'stored-skills:read',
-  /** Change visibility/audience (e.g. private↔public) stored skills */
-  'stored-skills:share': 'stored-skills:share',
   /** Create and modify stored skills */
   'stored-skills:write': 'stored-skills:write',
   /** Delete stored workspaces */
@@ -309,14 +286,18 @@ export const PERMISSION_PATTERNS = {
   'workspaces:read': 'workspaces:read',
   /** Create and modify workspaces */
   'workspaces:write': 'workspaces:write',
-  /** Full access to all stored-* resources (stored-agents, stored-skills, stored-prompt-blocks, stored-mcp-clients, stored-scorers, stored-workspaces) */
+  /** Full access to all stored resource families */
   'stored:*': 'stored:*',
-  /** View any stored-* resource */
+  /** View all stored resource families */
   'stored:read': 'stored:read',
-  /** Create and modify any stored-* resource */
+  /** Create and modify all stored resource families */
   'stored:write': 'stored:write',
-  /** Delete any stored-* resource */
+  /** Delete all stored resource families */
   'stored:delete': 'stored:delete',
+  /** Change visibility/audience stored agents */
+  'stored-agents:share': 'stored-agents:share',
+  /** Change visibility/audience stored skills */
+  'stored-skills:share': 'stored-skills:share',
 } as const;
 
 /**
@@ -335,15 +316,11 @@ export type PermissionPattern = keyof typeof PERMISSION_PATTERNS;
 export const PERMISSIONS = [
   'a2a:read',
   'a2a:write',
-  'agent-builder:execute',
-  'agent-builder:read',
-  'agent-builder:write',
   'agents:create',
   'agents:delete',
   'agents:execute',
   'agents:read',
   'agents:write',
-  'auth:read',
   'background-tasks:read',
   'channels:read',
   'channels:write',
@@ -353,7 +330,6 @@ export const PERMISSIONS = [
   'datasets:write',
   'embedders:read',
   'experiments:read',
-  'infrastructure:read',
   'logs:read',
   'mcp:execute',
   'mcp:read',
@@ -375,7 +351,6 @@ export const PERMISSIONS = [
   'stored-agents:delete',
   'stored-agents:publish',
   'stored-agents:read',
-  'stored-agents:share',
   'stored-agents:write',
   'stored-mcp-clients:delete',
   'stored-mcp-clients:publish',
@@ -392,7 +367,6 @@ export const PERMISSIONS = [
   'stored-skills:delete',
   'stored-skills:publish',
   'stored-skills:read',
-  'stored-skills:share',
   'stored-skills:write',
   'stored-workspaces:delete',
   'stored-workspaces:read',
@@ -431,12 +405,6 @@ export const MastraFGAPermissions = {
   A2A_READ: 'a2a:read',
   /** Create and modify agent-to-agent communication */
   A2A_WRITE: 'a2a:write',
-  /** Execute agent builder */
-  AGENT_BUILDER_EXECUTE: 'agent-builder:execute',
-  /** View agent builder */
-  AGENT_BUILDER_READ: 'agent-builder:read',
-  /** Create and modify agent builder */
-  AGENT_BUILDER_WRITE: 'agent-builder:write',
   /** Create agents */
   AGENTS_CREATE: 'agents:create',
   /** Delete agents */
@@ -447,8 +415,6 @@ export const MastraFGAPermissions = {
   AGENTS_READ: 'agents:read',
   /** Create and modify agents */
   AGENTS_WRITE: 'agents:write',
-  /** View auth */
-  AUTH_READ: 'auth:read',
   /** View background tasks */
   BACKGROUND_TASKS_READ: 'background-tasks:read',
   /** View channels */
@@ -467,8 +433,6 @@ export const MastraFGAPermissions = {
   EMBEDDERS_READ: 'embedders:read',
   /** View experiments */
   EXPERIMENTS_READ: 'experiments:read',
-  /** View infrastructure */
-  INFRASTRUCTURE_READ: 'infrastructure:read',
   /** View logs */
   LOGS_READ: 'logs:read',
   /** Execute MCP servers */
@@ -511,8 +475,6 @@ export const MastraFGAPermissions = {
   STORED_AGENTS_PUBLISH: 'stored-agents:publish',
   /** View stored agents */
   STORED_AGENTS_READ: 'stored-agents:read',
-  /** Change visibility/audience (e.g. private↔public) stored agents */
-  STORED_AGENTS_SHARE: 'stored-agents:share',
   /** Create and modify stored agents */
   STORED_AGENTS_WRITE: 'stored-agents:write',
   /** Delete stored MCP clients */
@@ -545,8 +507,6 @@ export const MastraFGAPermissions = {
   STORED_SKILLS_PUBLISH: 'stored-skills:publish',
   /** View stored skills */
   STORED_SKILLS_READ: 'stored-skills:read',
-  /** Change visibility/audience (e.g. private↔public) stored skills */
-  STORED_SKILLS_SHARE: 'stored-skills:share',
   /** Create and modify stored skills */
   STORED_SKILLS_WRITE: 'stored-skills:write',
   /** Delete stored workspaces */

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -588,19 +588,23 @@ https://mastra.ai/en/docs/memory/overview`,
     const fgaProvider = mastra?.getServer()?.fga;
     if (!fgaProvider) return;
 
-    const { checkFGA } = await import('../auth/ee/fga-check');
-    await checkFGA({
+    const { requireFGA } = await import('../auth/ee/fga-check');
+    await requireFGA({
       fgaProvider,
       user,
       resource: { type: 'thread', id: threadId },
       permission,
+      requestContext,
       context:
         resourceId || requestContext
           ? {
               resourceId,
-              requestContext,
             }
           : undefined,
+      metadata: {
+        threadId,
+        resourceId,
+      },
     });
   }
 

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -172,6 +172,39 @@ export type ValidationErrorHook = (
   context: ValidationErrorContext,
 ) => ValidationErrorResponse | undefined | void;
 
+export type StoredResourceScopeConfig =
+  | boolean
+  | {
+      /**
+       * Metadata key used to persist the resolved stored-resource scope.
+       *
+       * @default 'mastra.resourceId'
+       */
+      metadataKey?: string;
+      /**
+       * Resolve the stored-resource scope for the current request. When omitted,
+       * Mastra uses MASTRA_RESOURCE_ID_KEY from the request context.
+       */
+      resolve?: (context: {
+        requestContext?: RequestContext;
+        user?: unknown;
+      }) => string | undefined | null | Promise<string | undefined | null>;
+      /**
+       * When true, scoped stored-resource routes fail if no scope can be resolved.
+       *
+       * @default true
+       */
+      requireScope?: boolean;
+    };
+
+export type StoredResourcesConfig = {
+  /**
+   * Opt-in tenant/resource scoping for stored resources. When enabled, stored
+   * resource handlers persist and filter a scope value in record metadata.
+   */
+  scope?: StoredResourceScopeConfig;
+};
+
 export type ServerConfig = {
   /**
    * Port for the server
@@ -356,6 +389,11 @@ export type ServerConfig = {
    * on THIS specific resource).
    */
   fga?: IFGAProvider<any>;
+
+  /**
+   * Stored-resource route and handler behavior.
+   */
+  storedResources?: StoredResourcesConfig;
 
   /**
    * If you want to run `mastra dev` with HTTPS, you can run it with the `--https` flag and provide the key and cert files here.

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -95,7 +95,7 @@ describe('CoreToolBuilder FGA', () => {
       resource: { type: 'tool', id: 'agent-1:search' },
       permission: 'tools:execute',
       context: expect.objectContaining({
-        resourceId: 'agent-1:search',
+        resourceId: 'tenant-1',
         requestContext,
         metadata: expect.objectContaining({
           toolName: 'search',
@@ -146,7 +146,6 @@ describe('CoreToolBuilder FGA', () => {
     expect(fgaProvider.require).not.toHaveBeenCalled();
     expect(execute).not.toHaveBeenCalled();
   });
-
 });
 
 describe('MCP Tool Tracing', () => {

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -109,6 +109,44 @@ describe('CoreToolBuilder FGA', () => {
     });
     expect(execute).toHaveBeenCalled();
   });
+
+  it('fails closed when FGA is configured and a tool executes without a user', async () => {
+    const execute = vi.fn().mockResolvedValue({ result: 'ok' });
+    const testTool = createTool({
+      id: 'search',
+      description: 'Search',
+      inputSchema: z.object({ query: z.string() }),
+      execute,
+    });
+    const fgaProvider = {
+      require: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'search',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        requestContext: new RequestContext(),
+        mastra: {
+          getServer: () => ({ fga: fgaProvider }),
+        } as any,
+      },
+    });
+
+    const builtTool = builder.build();
+    await expect(builtTool.execute!({ query: 'docs' }, { toolCallId: 'call-1', messages: [] })).rejects.toThrow(
+      'authenticated user is required',
+    );
+    expect(fgaProvider.require).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
 });
 
 describe('MCP Tool Tracing', () => {

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -9,6 +9,108 @@ import { createTool } from '../../tools';
 import { isProviderDefinedTool, isVercelTool } from '../toolchecks';
 import { CoreToolBuilder } from './builder';
 
+describe('CoreToolBuilder FGA', () => {
+  it('executes tools without FGA when only auth/server config is present', async () => {
+    const execute = vi.fn().mockResolvedValue({ result: 'ok' });
+    const testTool = createTool({
+      id: 'search',
+      description: 'Search',
+      inputSchema: z.object({ query: z.string() }),
+      execute,
+    });
+    const requestContext = new RequestContext();
+    requestContext.set('user', { id: 'user-1' });
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'search',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        requestContext,
+        mastra: {
+          getServer: () => ({ auth: {} }),
+        } as any,
+      },
+    });
+
+    const builtTool = builder.build();
+    await expect(builtTool.execute!({ query: 'docs' }, { toolCallId: 'call-1', messages: [] })).resolves.toEqual({
+      result: 'ok',
+    });
+    expect(execute).toHaveBeenCalledWith(
+      { query: 'docs' },
+      expect.objectContaining({
+        mastra: expect.any(Object),
+        requestContext,
+      }),
+    );
+  });
+
+  it('checks tool execution FGA before executing a tool', async () => {
+    const execute = vi.fn().mockResolvedValue({ result: 'ok' });
+    const testTool = createTool({
+      id: 'search',
+      description: 'Search',
+      inputSchema: z.object({ query: z.string() }),
+      execute,
+    });
+    const user = { id: 'user-1' };
+    const requestContext = new RequestContext();
+    requestContext.set('user', user);
+    const fgaProvider = {
+      require: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'search',
+        agentId: 'agent-1',
+        agentName: 'Agent 1',
+        runId: 'run-1',
+        threadId: 'thread-1',
+        resourceId: 'tenant-1',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        requestContext,
+        mastra: {
+          getServer: () => ({ fga: fgaProvider }),
+        } as any,
+      },
+    });
+
+    const builtTool = builder.build();
+    await builtTool.execute!({ query: 'docs' }, { toolCallId: 'call-1', messages: [] });
+
+    expect(fgaProvider.require).toHaveBeenCalledWith(user, {
+      resource: { type: 'tool', id: 'agent-1:search' },
+      permission: 'tools:execute',
+      context: expect.objectContaining({
+        resourceId: 'agent-1:search',
+        requestContext,
+        metadata: expect.objectContaining({
+          toolName: 'search',
+          agentId: 'agent-1',
+          agentName: 'Agent 1',
+          runId: 'run-1',
+          threadId: 'thread-1',
+          executionResourceId: 'tenant-1',
+        }),
+      }),
+    });
+    expect(execute).toHaveBeenCalled();
+  });
+});
+
 describe('MCP Tool Tracing', () => {
   it('should use MCP_TOOL_CALL span type when tool has mcpMetadata', async () => {
     const testTool = createTool({

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -574,43 +574,39 @@ export class CoreToolBuilder extends MastraBase {
         mastra: options.mastra && 'observability' in options.mastra ? (options.mastra as Mastra) : undefined,
       });
 
+      const fgaProvider = (options.mastra as any)?.getServer?.()?.fga;
+      const user = toolRequestContext?.get('user');
+      if (fgaProvider) {
+        const { getAgentToolFGAResourceId, getMCPToolFGAResourceId, getStandaloneToolFGAResourceId, requireFGA } =
+          await import('../../auth/ee/fga-check');
+        const toolResourceId = mcpMeta?.serverName
+          ? getMCPToolFGAResourceId(mcpMeta.serverName, options.name)
+          : options.agentId
+            ? getAgentToolFGAResourceId(options.agentId, options.name)
+            : getStandaloneToolFGAResourceId(options.name);
+        await requireFGA({
+          fgaProvider,
+          user,
+          resource: { type: 'tool', id: toolResourceId },
+          permission: MastraFGAPermissions.TOOLS_EXECUTE,
+          requestContext: toolRequestContext,
+          context: {
+            resourceId: options.resourceId,
+          },
+          metadata: {
+            toolName: options.name,
+            agentId: options.agentId,
+            agentName: options.agentName,
+            runId: options.runId,
+            threadId: options.threadId,
+            executionResourceId: options.resourceId,
+            mcpMetadata: mcpMeta,
+          },
+        });
+      }
+
       try {
         logger.debug(start, { ...logData, ...rest, model: logModelObject, args });
-
-        const fgaProvider = (options.mastra as any)?.getServer?.()?.fga;
-        const user = toolRequestContext?.get('user');
-        if (fgaProvider) {
-          const {
-            getAgentToolFGAResourceId,
-            getMCPToolFGAResourceId,
-            getStandaloneToolFGAResourceId,
-            requireFGA,
-          } = await import('../../auth/ee/fga-check');
-          const toolResourceId = mcpMeta?.serverName
-            ? getMCPToolFGAResourceId(mcpMeta.serverName, options.name)
-            : options.agentId
-              ? getAgentToolFGAResourceId(options.agentId, options.name)
-              : getStandaloneToolFGAResourceId(options.name);
-          await requireFGA({
-            fgaProvider,
-            user,
-            resource: { type: 'tool', id: toolResourceId },
-            permission: MastraFGAPermissions.TOOLS_EXECUTE,
-            requestContext: toolRequestContext,
-            context: {
-              resourceId: toolResourceId,
-            },
-            metadata: {
-              toolName: options.name,
-              agentId: options.agentId,
-              agentName: options.agentName,
-              runId: options.runId,
-              threadId: options.threadId,
-              executionResourceId: options.resourceId,
-              mcpMetadata: mcpMeta,
-            },
-          });
-        }
 
         // Validate input parameters if schema exists
         // Use the processed schema for validation if available, otherwise fall back to original

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -579,30 +579,35 @@ export class CoreToolBuilder extends MastraBase {
 
         const fgaProvider = (options.mastra as any)?.getServer?.()?.fga;
         const user = toolRequestContext?.get('user');
-        if (fgaProvider && user) {
+        if (fgaProvider) {
+          const {
+            getAgentToolFGAResourceId,
+            getMCPToolFGAResourceId,
+            getStandaloneToolFGAResourceId,
+            requireFGA,
+          } = await import('../../auth/ee/fga-check');
           const toolResourceId = mcpMeta?.serverName
-            ? JSON.stringify([mcpMeta.serverName, options.name])
+            ? getMCPToolFGAResourceId(mcpMeta.serverName, options.name)
             : options.agentId
-              ? `${options.agentId}:${options.name}`
-              : options.name;
-          const { checkFGA } = await import('../../auth/ee/fga-check');
-          await checkFGA({
+              ? getAgentToolFGAResourceId(options.agentId, options.name)
+              : getStandaloneToolFGAResourceId(options.name);
+          await requireFGA({
             fgaProvider,
             user,
             resource: { type: 'tool', id: toolResourceId },
             permission: MastraFGAPermissions.TOOLS_EXECUTE,
+            requestContext: toolRequestContext,
             context: {
               resourceId: toolResourceId,
-              requestContext: toolRequestContext,
-              metadata: {
-                toolName: options.name,
-                agentId: options.agentId,
-                agentName: options.agentName,
-                runId: options.runId,
-                threadId: options.threadId,
-                executionResourceId: options.resourceId,
-                mcpMetadata: mcpMeta,
-              },
+            },
+            metadata: {
+              toolName: options.name,
+              agentId: options.agentId,
+              agentName: options.agentName,
+              runId: options.runId,
+              threadId: options.threadId,
+              executionResourceId: options.resourceId,
+              mcpMetadata: mcpMeta,
             },
           });
         }

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -12,6 +12,7 @@ import {
   jsonSchema,
 } from '@mastra/schema-compat';
 import { z } from 'zod/v4';
+import { MastraFGAPermissions } from '../../auth/ee';
 import { backgroundOverrideJsonSchema, backgroundOverrideZodSchema } from '../../background-tasks';
 import { MastraBase } from '../../base';
 import { ErrorCategory, MastraError, ErrorDomain } from '../../error';
@@ -575,6 +576,36 @@ export class CoreToolBuilder extends MastraBase {
 
       try {
         logger.debug(start, { ...logData, ...rest, model: logModelObject, args });
+
+        const fgaProvider = (options.mastra as any)?.getServer?.()?.fga;
+        const user = toolRequestContext?.get('user');
+        if (fgaProvider && user) {
+          const toolResourceId = mcpMeta?.serverName
+            ? JSON.stringify([mcpMeta.serverName, options.name])
+            : options.agentId
+              ? `${options.agentId}:${options.name}`
+              : options.name;
+          const { checkFGA } = await import('../../auth/ee/fga-check');
+          await checkFGA({
+            fgaProvider,
+            user,
+            resource: { type: 'tool', id: toolResourceId },
+            permission: MastraFGAPermissions.TOOLS_EXECUTE,
+            context: {
+              resourceId: toolResourceId,
+              requestContext: toolRequestContext,
+              metadata: {
+                toolName: options.name,
+                agentId: options.agentId,
+                agentName: options.agentName,
+                runId: options.runId,
+                threadId: options.threadId,
+                executionResourceId: options.resourceId,
+                mcpMetadata: mcpMeta,
+              },
+            },
+          });
+        }
 
         // Validate input parameters if schema exists
         // Use the processed schema for validation if available, otherwise fall back to original

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -13,6 +13,7 @@ import { Agent } from '../agent';
 import { EventEmitterPubSub } from '../events/event-emitter';
 import { MastraLanguageModelV2Mock as MockLanguageModelV2 } from '../loop/test-utils/MastraLanguageModelV2Mock';
 import { Mastra } from '../mastra';
+import { RequestContext } from '../request-context';
 import { MockStore } from '../storage/mock';
 import { createTool } from '../tools/tool';
 import { PUBSUB_SYMBOL } from './constants';
@@ -677,6 +678,109 @@ describe('Workflow (Default Engine Specifics)', () => {
       expect(childRuns?.runs.length).toBe(1);
       // Regression guard for #15246: child workflow snapshots must inherit the parent's resourceId.
       expect(childRuns?.runs[0]?.resourceId).toBe('workspace-1');
+    });
+  });
+
+  describe('FGA checks', () => {
+    function createFGAWorkflow() {
+      const step = createStep({
+        id: 'fga-step',
+        inputSchema: z.object({ value: z.string() }),
+        outputSchema: z.object({ value: z.string() }),
+        execute: async ({ inputData }) => inputData,
+      });
+
+      return createWorkflow({
+        id: 'fga-workflow',
+        inputSchema: z.object({ value: z.string() }),
+        outputSchema: z.object({ value: z.string() }),
+        steps: [step],
+      })
+        .then(step)
+        .commit();
+    }
+
+    it('checks internal workflow execution FGA with request context metadata', async () => {
+      const fgaProvider = {
+        require: vi.fn().mockResolvedValue(undefined),
+        check: vi.fn(),
+        filterAccessible: vi.fn(),
+      };
+      const workflow = createFGAWorkflow();
+      const mastra = new Mastra({
+        logger: false,
+        server: { fga: fgaProvider },
+      });
+      workflow.__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+
+      const result = await (workflow as any).execute({
+        runId: 'run-1',
+        resourceId: 'tenant-1',
+        inputData: { value: 'ok' },
+        state: {},
+        setState: vi.fn(),
+        suspend: vi.fn(),
+        [PUBSUB_SYMBOL]: new EventEmitterPubSub(),
+        mastra,
+        requestContext,
+        abort: vi.fn(),
+        abortSignal: new AbortController().signal,
+        engine: 'default',
+        bail: vi.fn(),
+      });
+
+      expect(result).toEqual({ value: 'ok' });
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'user-1' },
+        {
+          resource: { type: 'workflow', id: 'fga-workflow' },
+          permission: 'workflows:execute',
+          context: expect.objectContaining({
+            resourceId: 'tenant-1',
+            requestContext,
+            metadata: expect.objectContaining({
+              workflowId: 'fga-workflow',
+              runId: 'run-1',
+              resourceId: 'tenant-1',
+            }),
+          }),
+        },
+      );
+    });
+
+    it('fails closed when internal workflow FGA is configured and no user is available', async () => {
+      const fgaProvider = {
+        require: vi.fn().mockResolvedValue(undefined),
+        check: vi.fn(),
+        filterAccessible: vi.fn(),
+      };
+      const workflow = createFGAWorkflow();
+      const mastra = new Mastra({
+        logger: false,
+        server: { fga: fgaProvider },
+      });
+      workflow.__registerMastra(mastra);
+
+      await expect(
+        (workflow as any).execute({
+          runId: 'run-2',
+          inputData: { value: 'ok' },
+          state: {},
+          setState: vi.fn(),
+          suspend: vi.fn(),
+          [PUBSUB_SYMBOL]: new EventEmitterPubSub(),
+          mastra,
+          requestContext: new RequestContext(),
+          abort: vi.fn(),
+          abortSignal: new AbortController().signal,
+          engine: 'default',
+          bail: vi.fn(),
+        }),
+      ).rejects.toThrow('authenticated user is required');
+      expect(fgaProvider.require).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2551,15 +2551,22 @@ export class Workflow<
     const fgaProvider = mastra?.getServer()?.fga;
     if (fgaProvider) {
       const user = requestContext?.get('user' as any);
-      if (user) {
-        const { checkFGA } = await import('../auth/ee/fga-check');
-        await checkFGA({
-          fgaProvider,
-          user,
-          resource: { type: 'workflow', id: this.id },
-          permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
-        });
-      }
+      const { getWorkflowFGAResourceId, requireFGA } = await import('../auth/ee/fga-check');
+      await requireFGA({
+        fgaProvider,
+        user,
+        resource: { type: 'workflow', id: getWorkflowFGAResourceId(this.id) },
+        permission: MastraFGAPermissions.WORKFLOWS_EXECUTE,
+        requestContext,
+        context: {
+          resourceId,
+        },
+        metadata: {
+          workflowId: this.id,
+          runId,
+          resourceId,
+        },
+      });
     }
 
     const effectiveValidateInputs = validateInputs ?? this.#options.validateInputs ?? true;

--- a/packages/server/scripts/permission-generator.ts
+++ b/packages/server/scripts/permission-generator.ts
@@ -24,9 +24,17 @@ const ACTION_DESCRIPTIONS: Record<string, string> = {
   create: 'Create',
   delete: 'Delete',
   execute: 'Execute',
+  publish: 'Publish, activate, or restore',
   read: 'View',
+  share: 'Change visibility/audience',
   write: 'Create and modify',
 };
+
+/**
+ * Permission actions that are valid for role definitions even when no current
+ * server route derives them directly.
+ */
+const ADDITIONAL_ACTIONS = ['share'];
 
 /** Descriptions for resources (used for TSDoc comments in autocomplete) */
 const RESOURCE_DESCRIPTIONS: Record<string, string> = {
@@ -40,13 +48,31 @@ const RESOURCE_DESCRIPTIONS: Record<string, string> = {
   observability: 'traces and spans',
   processors: 'processors',
   scores: 'evaluation scores',
+  stored: 'all stored resource families',
   'stored-agents': 'stored agents',
+  'stored-mcp-clients': 'stored MCP clients',
+  'stored-prompt-blocks': 'stored prompt blocks',
+  'stored-scorers': 'stored scorers',
+  'stored-skills': 'stored skills',
+  'stored-workspaces': 'stored workspaces',
   system: 'system info',
   tools: 'tools',
   vector: 'vector stores',
   workflows: 'workflows',
   workspaces: 'workspaces',
 };
+
+/**
+ * Compound permission patterns supported by the RBAC matcher.
+ */
+const ADDITIONAL_PERMISSION_PATTERNS = [
+  'stored:*',
+  'stored:read',
+  'stored:write',
+  'stored:delete',
+  'stored-agents:share',
+  'stored-skills:share',
+];
 
 /**
  * Generates a human-readable description for a permission pattern.
@@ -106,7 +132,7 @@ export function derivePermissionData(): PermissionData {
   }
 
   const resources = [...resourceSet].sort();
-  const actions = [...actionSet].sort();
+  const actions = [...new Set([...actionSet, ...ADDITIONAL_ACTIONS])].sort();
   const permissions = [...permissionSet].sort();
 
   return { resources, actions, permissions };
@@ -124,6 +150,7 @@ export function generatePermissionFileContent(data: PermissionData): string {
     ...actions.map(a => `*:${a}`), // Action wildcards
     ...resources.map(r => `${r}:*`), // Resource wildcards
     ...permissions, // Specific permissions
+    ...ADDITIONAL_PERMISSION_PATTERNS, // Compound aliases
   ];
 
   // Generate the PERMISSION_PATTERNS object entries with TSDoc comments

--- a/packages/server/src/server/handlers/agent-versions.ts
+++ b/packages/server/src/server/handlers/agent-versions.ts
@@ -17,6 +17,7 @@ import {
 } from '../schemas/agent-versions';
 import type { ServerRoute, RouteSchemas, InferParams } from '../server-adapter/routes';
 import { createRoute } from '../server-adapter/routes/route-builder';
+import { assertStoredResourceScope, getStoredResourceScope } from '../utils';
 
 import { handleError } from './error';
 import {
@@ -68,7 +69,7 @@ export const LIST_AGENT_VERSIONS_ROUTE = createRoute({
   summary: 'List agent versions',
   description: 'Returns a paginated list of all versions for a stored agent',
   tags: ['Agent Versions'],
-  handler: async ({ mastra, agentId, page, perPage, orderBy }) => {
+  handler: async ({ mastra, agentId, page, perPage, orderBy, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -94,6 +95,7 @@ export const LIST_AGENT_VERSIONS_ROUTE = createRoute({
       if (!storedAgent && !codeAgentExists) {
         throw new HTTPException(404, { message: `Agent with id ${agentId} not found` });
       }
+      assertStoredResourceScope(storedAgent, await getStoredResourceScope(mastra, requestContext));
 
       const result = await agentsStore.listVersions({
         agentId,
@@ -123,7 +125,7 @@ export const CREATE_AGENT_VERSION_ROUTE = createRoute({
   summary: 'Create agent version',
   description: 'Creates a new version snapshot of the current agent configuration',
   tags: ['Agent Versions'],
-  handler: async ({ mastra, agentId, changeMessage }) => {
+  handler: async ({ mastra, agentId, changeMessage, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -141,6 +143,7 @@ export const CREATE_AGENT_VERSION_ROUTE = createRoute({
       if (!agent) {
         throw new HTTPException(404, { message: `Agent with id ${agentId} not found` });
       }
+      assertStoredResourceScope(agent, await getStoredResourceScope(mastra, requestContext));
 
       // Get the current active version to snapshot its config
       let currentConfig: Record<string, unknown> = {};
@@ -215,7 +218,7 @@ export const GET_AGENT_VERSION_ROUTE = createRoute({
   summary: 'Get agent version',
   description: 'Returns a specific version of an agent by its version ID',
   tags: ['Agent Versions'],
-  handler: async ({ mastra, agentId, versionId }) => {
+  handler: async ({ mastra, agentId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -238,6 +241,8 @@ export const GET_AGENT_VERSION_ROUTE = createRoute({
       if (version.agentId !== agentId) {
         throw new HTTPException(404, { message: `Version with id ${versionId} not found for agent ${agentId}` });
       }
+      const agent = await agentsStore.getById(agentId);
+      assertStoredResourceScope(agent, await getStoredResourceScope(mastra, requestContext));
 
       return version;
     } catch (error) {
@@ -259,7 +264,7 @@ export const ACTIVATE_AGENT_VERSION_ROUTE = createRoute({
   summary: 'Activate agent version',
   description: 'Sets a specific version as the active version for the agent',
   tags: ['Agent Versions'],
-  handler: async ({ mastra, agentId, versionId }) => {
+  handler: async ({ mastra, agentId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -277,6 +282,7 @@ export const ACTIVATE_AGENT_VERSION_ROUTE = createRoute({
       if (!agent) {
         throw new HTTPException(404, { message: `Agent with id ${agentId} not found` });
       }
+      assertStoredResourceScope(agent, await getStoredResourceScope(mastra, requestContext));
 
       // Verify version exists and belongs to this agent
       const version = await agentsStore.getVersion(versionId);
@@ -321,7 +327,7 @@ export const RESTORE_AGENT_VERSION_ROUTE = createRoute({
   summary: 'Restore agent version',
   description: 'Restores the agent configuration from a version, creating a new version',
   tags: ['Agent Versions'],
-  handler: async ({ mastra, agentId, versionId }) => {
+  handler: async ({ mastra, agentId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -339,6 +345,7 @@ export const RESTORE_AGENT_VERSION_ROUTE = createRoute({
       if (!agent) {
         throw new HTTPException(404, { message: `Agent with id ${agentId} not found` });
       }
+      assertStoredResourceScope(agent, await getStoredResourceScope(mastra, requestContext));
 
       // Get the version to restore
       const versionToRestore = await agentsStore.getVersion(versionId);
@@ -422,7 +429,7 @@ export const DELETE_AGENT_VERSION_ROUTE = createRoute({
   summary: 'Delete agent version',
   description: 'Deletes a specific version (cannot delete the active version)',
   tags: ['Agent Versions'],
-  handler: async ({ mastra, agentId, versionId }) => {
+  handler: async ({ mastra, agentId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -440,6 +447,7 @@ export const DELETE_AGENT_VERSION_ROUTE = createRoute({
       if (!agent) {
         throw new HTTPException(404, { message: `Agent with id ${agentId} not found` });
       }
+      assertStoredResourceScope(agent, await getStoredResourceScope(mastra, requestContext));
 
       // Verify version exists and belongs to this agent
       const version = await agentsStore.getVersion(versionId);
@@ -498,7 +506,7 @@ export const COMPARE_AGENT_VERSIONS_ROUTE: ServerRoute<
   summary: 'Compare agent versions',
   description: 'Compares two versions and returns the differences between them',
   tags: ['Agent Versions'],
-  handler: async ({ mastra, agentId, from, to }) => {
+  handler: async ({ mastra, agentId, from, to, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -510,6 +518,8 @@ export const COMPARE_AGENT_VERSIONS_ROUTE: ServerRoute<
       if (!agentsStore) {
         throw new HTTPException(500, { message: 'Agents storage domain is not available' });
       }
+      const agent = await agentsStore.getById(agentId);
+      assertStoredResourceScope(agent, await getStoredResourceScope(mastra, requestContext));
 
       // Get both versions
       const fromVersion = await agentsStore.getVersion(from);

--- a/packages/server/src/server/handlers/mcp-client-versions.ts
+++ b/packages/server/src/server/handlers/mcp-client-versions.ts
@@ -14,6 +14,7 @@ import {
   compareMCPClientVersionsResponseSchema,
 } from '../schemas/mcp-client-versions';
 import { createRoute } from '../server-adapter/routes/route-builder';
+import { assertStoredResourceScope, getStoredResourceScope } from '../utils';
 
 import { handleError } from './error';
 import {
@@ -40,7 +41,7 @@ export const LIST_MCP_CLIENT_VERSIONS_ROUTE = createRoute({
   summary: 'List MCP client versions',
   description: 'Returns a paginated list of all versions for a stored MCP client',
   tags: ['MCP Client Versions'],
-  handler: async ({ mastra, mcpClientId, page, perPage, orderBy }) => {
+  handler: async ({ mastra, mcpClientId, page, perPage, orderBy, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -57,6 +58,7 @@ export const LIST_MCP_CLIENT_VERSIONS_ROUTE = createRoute({
       if (!mcpClient) {
         throw new HTTPException(404, { message: `MCP client with id ${mcpClientId} not found` });
       }
+      assertStoredResourceScope(mcpClient, await getStoredResourceScope(mastra, requestContext));
 
       const result = await mcpClientStore.listVersions({
         mcpClientId,
@@ -86,7 +88,7 @@ export const CREATE_MCP_CLIENT_VERSION_ROUTE = createRoute({
   summary: 'Create MCP client version',
   description: 'Creates a new version snapshot of the current MCP client configuration',
   tags: ['MCP Client Versions'],
-  handler: async ({ mastra, mcpClientId, changeMessage }) => {
+  handler: async ({ mastra, mcpClientId, changeMessage, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -103,6 +105,7 @@ export const CREATE_MCP_CLIENT_VERSION_ROUTE = createRoute({
       if (!mcpClient) {
         throw new HTTPException(404, { message: `MCP client with id ${mcpClientId} not found` });
       }
+      assertStoredResourceScope(mcpClient, await getStoredResourceScope(mastra, requestContext));
 
       let currentConfig: Record<string, unknown> = {};
       if (mcpClient.activeVersionId) {
@@ -174,7 +177,7 @@ export const GET_MCP_CLIENT_VERSION_ROUTE = createRoute({
   summary: 'Get MCP client version',
   description: 'Returns a specific version of an MCP client by its version ID',
   tags: ['MCP Client Versions'],
-  handler: async ({ mastra, mcpClientId, versionId }) => {
+  handler: async ({ mastra, mcpClientId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -198,6 +201,8 @@ export const GET_MCP_CLIENT_VERSION_ROUTE = createRoute({
           message: `Version with id ${versionId} not found for MCP client ${mcpClientId}`,
         });
       }
+      const mcpClient = await mcpClientStore.getById(mcpClientId);
+      assertStoredResourceScope(mcpClient, await getStoredResourceScope(mastra, requestContext));
 
       return version;
     } catch (error) {
@@ -219,7 +224,7 @@ export const ACTIVATE_MCP_CLIENT_VERSION_ROUTE = createRoute({
   summary: 'Activate MCP client version',
   description: 'Sets a specific version as the active version for the MCP client',
   tags: ['MCP Client Versions'],
-  handler: async ({ mastra, mcpClientId, versionId }) => {
+  handler: async ({ mastra, mcpClientId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -236,6 +241,7 @@ export const ACTIVATE_MCP_CLIENT_VERSION_ROUTE = createRoute({
       if (!mcpClient) {
         throw new HTTPException(404, { message: `MCP client with id ${mcpClientId} not found` });
       }
+      assertStoredResourceScope(mcpClient, await getStoredResourceScope(mastra, requestContext));
 
       const version = await mcpClientStore.getVersion(versionId);
       if (!version) {
@@ -280,7 +286,7 @@ export const RESTORE_MCP_CLIENT_VERSION_ROUTE = createRoute({
   summary: 'Restore MCP client version',
   description: 'Restores the MCP client configuration from a version, creating a new version',
   tags: ['MCP Client Versions'],
-  handler: async ({ mastra, mcpClientId, versionId }) => {
+  handler: async ({ mastra, mcpClientId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -297,6 +303,7 @@ export const RESTORE_MCP_CLIENT_VERSION_ROUTE = createRoute({
       if (!mcpClient) {
         throw new HTTPException(404, { message: `MCP client with id ${mcpClientId} not found` });
       }
+      assertStoredResourceScope(mcpClient, await getStoredResourceScope(mastra, requestContext));
 
       const versionToRestore = await mcpClientStore.getVersion(versionId);
       if (!versionToRestore) {
@@ -374,7 +381,7 @@ export const DELETE_MCP_CLIENT_VERSION_ROUTE = createRoute({
   summary: 'Delete MCP client version',
   description: 'Deletes a specific version (cannot delete the active version)',
   tags: ['MCP Client Versions'],
-  handler: async ({ mastra, mcpClientId, versionId }) => {
+  handler: async ({ mastra, mcpClientId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -391,6 +398,7 @@ export const DELETE_MCP_CLIENT_VERSION_ROUTE = createRoute({
       if (!mcpClient) {
         throw new HTTPException(404, { message: `MCP client with id ${mcpClientId} not found` });
       }
+      assertStoredResourceScope(mcpClient, await getStoredResourceScope(mastra, requestContext));
 
       const version = await mcpClientStore.getVersion(versionId);
       if (!version) {
@@ -437,7 +445,7 @@ export const COMPARE_MCP_CLIENT_VERSIONS_ROUTE = createRoute({
   summary: 'Compare MCP client versions',
   description: 'Compares two versions and returns the differences between them',
   tags: ['MCP Client Versions'],
-  handler: async ({ mastra, mcpClientId, from, to }) => {
+  handler: async ({ mastra, mcpClientId, from, to, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -449,6 +457,8 @@ export const COMPARE_MCP_CLIENT_VERSIONS_ROUTE = createRoute({
       if (!mcpClientStore) {
         throw new HTTPException(500, { message: 'MCP clients storage domain is not available' });
       }
+      const mcpClient = await mcpClientStore.getById(mcpClientId);
+      assertStoredResourceScope(mcpClient, await getStoredResourceScope(mastra, requestContext));
 
       const fromVersion = await mcpClientStore.getVersion(from);
       if (!fromVersion) {

--- a/packages/server/src/server/handlers/prompt-block-versions.ts
+++ b/packages/server/src/server/handlers/prompt-block-versions.ts
@@ -14,6 +14,7 @@ import {
   comparePromptBlockVersionsResponseSchema,
 } from '../schemas/prompt-block-versions';
 import { createRoute } from '../server-adapter/routes/route-builder';
+import { assertStoredResourceScope, getStoredResourceScope } from '../utils';
 
 import { handleError } from './error';
 import {
@@ -41,7 +42,7 @@ export const LIST_PROMPT_BLOCK_VERSIONS_ROUTE = createRoute({
   summary: 'List prompt block versions',
   description: 'Returns a paginated list of all versions for a stored prompt block',
   tags: ['Prompt Block Versions'],
-  handler: async ({ mastra, promptBlockId, page, perPage, orderBy }) => {
+  handler: async ({ mastra, promptBlockId, page, perPage, orderBy, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -58,6 +59,7 @@ export const LIST_PROMPT_BLOCK_VERSIONS_ROUTE = createRoute({
       if (!promptBlock) {
         throw new HTTPException(404, { message: `Prompt block with id ${promptBlockId} not found` });
       }
+      assertStoredResourceScope(promptBlock, await getStoredResourceScope(mastra, requestContext));
 
       const result = await promptBlockStore.listVersions({
         blockId: promptBlockId,
@@ -87,7 +89,7 @@ export const CREATE_PROMPT_BLOCK_VERSION_ROUTE = createRoute({
   summary: 'Create prompt block version',
   description: 'Creates a new version snapshot of the current prompt block configuration',
   tags: ['Prompt Block Versions'],
-  handler: async ({ mastra, promptBlockId, changeMessage }) => {
+  handler: async ({ mastra, promptBlockId, changeMessage, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -104,6 +106,7 @@ export const CREATE_PROMPT_BLOCK_VERSION_ROUTE = createRoute({
       if (!promptBlock) {
         throw new HTTPException(404, { message: `Prompt block with id ${promptBlockId} not found` });
       }
+      assertStoredResourceScope(promptBlock, await getStoredResourceScope(mastra, requestContext));
 
       let currentConfig: Record<string, unknown> = {};
       if (promptBlock.activeVersionId) {
@@ -172,7 +175,7 @@ export const GET_PROMPT_BLOCK_VERSION_ROUTE = createRoute({
   summary: 'Get prompt block version',
   description: 'Returns a specific version of a prompt block by its version ID',
   tags: ['Prompt Block Versions'],
-  handler: async ({ mastra, promptBlockId, versionId }) => {
+  handler: async ({ mastra, promptBlockId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -196,6 +199,8 @@ export const GET_PROMPT_BLOCK_VERSION_ROUTE = createRoute({
           message: `Version with id ${versionId} not found for prompt block ${promptBlockId}`,
         });
       }
+      const promptBlock = await promptBlockStore.getById(promptBlockId);
+      assertStoredResourceScope(promptBlock, await getStoredResourceScope(mastra, requestContext));
 
       return version;
     } catch (error) {
@@ -217,7 +222,7 @@ export const ACTIVATE_PROMPT_BLOCK_VERSION_ROUTE = createRoute({
   summary: 'Activate prompt block version',
   description: 'Sets a specific version as the active version for the prompt block',
   tags: ['Prompt Block Versions'],
-  handler: async ({ mastra, promptBlockId, versionId }) => {
+  handler: async ({ mastra, promptBlockId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -234,6 +239,7 @@ export const ACTIVATE_PROMPT_BLOCK_VERSION_ROUTE = createRoute({
       if (!promptBlock) {
         throw new HTTPException(404, { message: `Prompt block with id ${promptBlockId} not found` });
       }
+      assertStoredResourceScope(promptBlock, await getStoredResourceScope(mastra, requestContext));
 
       const version = await promptBlockStore.getVersion(versionId);
       if (!version) {
@@ -278,7 +284,7 @@ export const RESTORE_PROMPT_BLOCK_VERSION_ROUTE = createRoute({
   summary: 'Restore prompt block version',
   description: 'Restores the prompt block configuration from a version, creating a new version',
   tags: ['Prompt Block Versions'],
-  handler: async ({ mastra, promptBlockId, versionId }) => {
+  handler: async ({ mastra, promptBlockId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -295,6 +301,7 @@ export const RESTORE_PROMPT_BLOCK_VERSION_ROUTE = createRoute({
       if (!promptBlock) {
         throw new HTTPException(404, { message: `Prompt block with id ${promptBlockId} not found` });
       }
+      assertStoredResourceScope(promptBlock, await getStoredResourceScope(mastra, requestContext));
 
       const versionToRestore = await promptBlockStore.getVersion(versionId);
       if (!versionToRestore) {
@@ -369,7 +376,7 @@ export const DELETE_PROMPT_BLOCK_VERSION_ROUTE = createRoute({
   summary: 'Delete prompt block version',
   description: 'Deletes a specific version (cannot delete the active version)',
   tags: ['Prompt Block Versions'],
-  handler: async ({ mastra, promptBlockId, versionId }) => {
+  handler: async ({ mastra, promptBlockId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -386,6 +393,7 @@ export const DELETE_PROMPT_BLOCK_VERSION_ROUTE = createRoute({
       if (!promptBlock) {
         throw new HTTPException(404, { message: `Prompt block with id ${promptBlockId} not found` });
       }
+      assertStoredResourceScope(promptBlock, await getStoredResourceScope(mastra, requestContext));
 
       const version = await promptBlockStore.getVersion(versionId);
       if (!version) {
@@ -432,7 +440,7 @@ export const COMPARE_PROMPT_BLOCK_VERSIONS_ROUTE = createRoute({
   summary: 'Compare prompt block versions',
   description: 'Compares two versions and returns the differences between them',
   tags: ['Prompt Block Versions'],
-  handler: async ({ mastra, promptBlockId, from, to }) => {
+  handler: async ({ mastra, promptBlockId, from, to, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -444,6 +452,8 @@ export const COMPARE_PROMPT_BLOCK_VERSIONS_ROUTE = createRoute({
       if (!promptBlockStore) {
         throw new HTTPException(500, { message: 'Prompt blocks storage domain is not available' });
       }
+      const promptBlock = await promptBlockStore.getById(promptBlockId);
+      assertStoredResourceScope(promptBlock, await getStoredResourceScope(mastra, requestContext));
 
       const fromVersion = await promptBlockStore.getVersion(from);
       if (!fromVersion) {

--- a/packages/server/src/server/handlers/scorer-versions.ts
+++ b/packages/server/src/server/handlers/scorer-versions.ts
@@ -14,6 +14,7 @@ import {
   compareScorerVersionsResponseSchema,
 } from '../schemas/scorer-versions';
 import { createRoute } from '../server-adapter/routes/route-builder';
+import { assertStoredResourceScope, getStoredResourceScope } from '../utils';
 
 import { handleError } from './error';
 import {
@@ -50,7 +51,7 @@ export const LIST_SCORER_VERSIONS_ROUTE = createRoute({
   summary: 'List scorer versions',
   description: 'Returns a paginated list of all versions for a stored scorer',
   tags: ['Scorer Versions'],
-  handler: async ({ mastra, scorerId, page, perPage, orderBy }) => {
+  handler: async ({ mastra, scorerId, page, perPage, orderBy, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -67,6 +68,7 @@ export const LIST_SCORER_VERSIONS_ROUTE = createRoute({
       if (!scorer) {
         throw new HTTPException(404, { message: `Scorer with id ${scorerId} not found` });
       }
+      assertStoredResourceScope(scorer, await getStoredResourceScope(mastra, requestContext));
 
       const result = await scorerStore.listVersions({
         scorerDefinitionId: scorerId,
@@ -96,7 +98,7 @@ export const CREATE_SCORER_VERSION_ROUTE = createRoute({
   summary: 'Create scorer version',
   description: 'Creates a new version snapshot of the current scorer configuration',
   tags: ['Scorer Versions'],
-  handler: async ({ mastra, scorerId, changeMessage }) => {
+  handler: async ({ mastra, scorerId, changeMessage, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -113,6 +115,7 @@ export const CREATE_SCORER_VERSION_ROUTE = createRoute({
       if (!scorer) {
         throw new HTTPException(404, { message: `Scorer with id ${scorerId} not found` });
       }
+      assertStoredResourceScope(scorer, await getStoredResourceScope(mastra, requestContext));
 
       let currentConfig: Record<string, unknown> = {};
       if (scorer.activeVersionId) {
@@ -181,7 +184,7 @@ export const GET_SCORER_VERSION_ROUTE = createRoute({
   summary: 'Get scorer version',
   description: 'Returns a specific version of a scorer by its version ID',
   tags: ['Scorer Versions'],
-  handler: async ({ mastra, scorerId, versionId }) => {
+  handler: async ({ mastra, scorerId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -205,6 +208,8 @@ export const GET_SCORER_VERSION_ROUTE = createRoute({
           message: `Version with id ${versionId} not found for scorer ${scorerId}`,
         });
       }
+      const scorer = await scorerStore.getById(scorerId);
+      assertStoredResourceScope(scorer, await getStoredResourceScope(mastra, requestContext));
 
       return version;
     } catch (error) {
@@ -226,7 +231,7 @@ export const ACTIVATE_SCORER_VERSION_ROUTE = createRoute({
   summary: 'Activate scorer version',
   description: 'Sets a specific version as the active version for the scorer',
   tags: ['Scorer Versions'],
-  handler: async ({ mastra, scorerId, versionId }) => {
+  handler: async ({ mastra, scorerId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -243,6 +248,7 @@ export const ACTIVATE_SCORER_VERSION_ROUTE = createRoute({
       if (!scorer) {
         throw new HTTPException(404, { message: `Scorer with id ${scorerId} not found` });
       }
+      assertStoredResourceScope(scorer, await getStoredResourceScope(mastra, requestContext));
 
       const version = await scorerStore.getVersion(versionId);
       if (!version) {
@@ -287,7 +293,7 @@ export const RESTORE_SCORER_VERSION_ROUTE = createRoute({
   summary: 'Restore scorer version',
   description: 'Restores the scorer configuration from a version, creating a new version',
   tags: ['Scorer Versions'],
-  handler: async ({ mastra, scorerId, versionId }) => {
+  handler: async ({ mastra, scorerId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -304,6 +310,7 @@ export const RESTORE_SCORER_VERSION_ROUTE = createRoute({
       if (!scorer) {
         throw new HTTPException(404, { message: `Scorer with id ${scorerId} not found` });
       }
+      assertStoredResourceScope(scorer, await getStoredResourceScope(mastra, requestContext));
 
       const versionToRestore = await scorerStore.getVersion(versionId);
       if (!versionToRestore) {
@@ -378,7 +385,7 @@ export const DELETE_SCORER_VERSION_ROUTE = createRoute({
   summary: 'Delete scorer version',
   description: 'Deletes a specific version (cannot delete the active version)',
   tags: ['Scorer Versions'],
-  handler: async ({ mastra, scorerId, versionId }) => {
+  handler: async ({ mastra, scorerId, versionId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -395,6 +402,7 @@ export const DELETE_SCORER_VERSION_ROUTE = createRoute({
       if (!scorer) {
         throw new HTTPException(404, { message: `Scorer with id ${scorerId} not found` });
       }
+      assertStoredResourceScope(scorer, await getStoredResourceScope(mastra, requestContext));
 
       const version = await scorerStore.getVersion(versionId);
       if (!version) {
@@ -441,7 +449,7 @@ export const COMPARE_SCORER_VERSIONS_ROUTE = createRoute({
   summary: 'Compare scorer versions',
   description: 'Compares two versions and returns the differences between them',
   tags: ['Scorer Versions'],
-  handler: async ({ mastra, scorerId, from, to }) => {
+  handler: async ({ mastra, scorerId, from, to, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -453,6 +461,8 @@ export const COMPARE_SCORER_VERSIONS_ROUTE = createRoute({
       if (!scorerStore) {
         throw new HTTPException(500, { message: 'Scorer definitions storage domain is not available' });
       }
+      const scorer = await scorerStore.getById(scorerId);
+      assertStoredResourceScope(scorer, await getStoredResourceScope(mastra, requestContext));
 
       const fromVersion = await scorerStore.getVersion(from);
       if (!fromVersion) {

--- a/packages/server/src/server/handlers/stored-agents.test.ts
+++ b/packages/server/src/server/handlers/stored-agents.test.ts
@@ -233,12 +233,14 @@ function createMockEditor(): MockEditor {
 interface MockMastra {
   getStorage: ReturnType<typeof vi.fn>;
   getEditor: ReturnType<typeof vi.fn>;
+  getServer: ReturnType<typeof vi.fn>;
 }
 
-function createMockMastra(options: { storage?: MockStorage; editor?: MockEditor } = {}): MockMastra {
+function createMockMastra(options: { storage?: MockStorage; editor?: MockEditor; server?: Record<string, unknown> } = {}): MockMastra {
   return {
     getStorage: vi.fn().mockReturnValue(options.storage),
     getEditor: vi.fn().mockReturnValue(options.editor),
+    getServer: vi.fn().mockReturnValue(options.server ?? {}),
   };
 }
 
@@ -316,6 +318,68 @@ describe('Stored Agents Handlers', () => {
         name: 'Test Agent 1',
         description: 'First test agent',
       });
+    });
+
+    it('should scope stored agent lists by request resource metadata when configured', async () => {
+      mockMastra = createMockMastra({
+        storage: mockStorage,
+        editor: mockEditor,
+        server: { storedResources: { scope: true } },
+      });
+      mockAgentsData.set('agent1', {
+        id: 'agent1',
+        name: 'Team Agent',
+        model: { name: 'gpt-4', provider: 'openai' },
+        metadata: { 'mastra.resourceId': 'team-a' },
+      });
+      mockAgentsData.set('agent2', {
+        id: 'agent2',
+        name: 'Other Team Agent',
+        model: { name: 'gpt-4', provider: 'openai' },
+        metadata: { 'mastra.resourceId': 'team-b' },
+      });
+      const context = createTestContext(mockMastra);
+      context.requestContext.set('mastra__resourceId', 'team-a');
+
+      const result = await LIST_STORED_AGENTS_ROUTE.handler({
+        ...context,
+        page: 1,
+      });
+
+      expect(result.agents.map(agent => agent.id)).toEqual(['agent1']);
+      expect(mockAgentsStore.listResolved).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata: { 'mastra.resourceId': 'team-a' } }),
+      );
+    });
+
+    it('should not scope stored agent lists when auth is configured without stored resource scope', async () => {
+      mockMastra = createMockMastra({
+        storage: mockStorage,
+        editor: mockEditor,
+        server: { auth: {} },
+      });
+      mockAgentsData.set('agent1', {
+        id: 'agent1',
+        name: 'Team Agent',
+        model: { name: 'gpt-4', provider: 'openai' },
+        metadata: { 'mastra.resourceId': 'team-a' },
+      });
+      mockAgentsData.set('agent2', {
+        id: 'agent2',
+        name: 'Other Team Agent',
+        model: { name: 'gpt-4', provider: 'openai' },
+        metadata: { 'mastra.resourceId': 'team-b' },
+      });
+      const context = createTestContext(mockMastra);
+      context.requestContext.set('mastra__resourceId', 'team-a');
+
+      const result = await LIST_STORED_AGENTS_ROUTE.handler({
+        ...context,
+        page: 1,
+      });
+
+      expect(result.agents.map(agent => agent.id)).toEqual(['agent1', 'agent2']);
+      expect(mockAgentsStore.listResolved).toHaveBeenCalledWith(expect.objectContaining({ metadata: undefined }));
     });
 
     it('should support pagination', async () => {

--- a/packages/server/src/server/handlers/stored-agents.test.ts
+++ b/packages/server/src/server/handlers/stored-agents.test.ts
@@ -236,7 +236,9 @@ interface MockMastra {
   getServer: ReturnType<typeof vi.fn>;
 }
 
-function createMockMastra(options: { storage?: MockStorage; editor?: MockEditor; server?: Record<string, unknown> } = {}): MockMastra {
+function createMockMastra(
+  options: { storage?: MockStorage; editor?: MockEditor; server?: Record<string, unknown> } = {},
+): MockMastra {
   return {
     getStorage: vi.fn().mockReturnValue(options.storage),
     getEditor: vi.fn().mockReturnValue(options.editor),

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -18,7 +18,7 @@ import {
 } from '../schemas/stored-agents';
 import type { ServerRoute, RouteSchemas, InferParams } from '../server-adapter/routes';
 import { createRoute } from '../server-adapter/routes/route-builder';
-import { toSlug } from '../utils';
+import { assertStoredResourceScope, getStoredResourceScope, scopeStoredResourceMetadata, toSlug } from '../utils';
 
 import { handleError } from './error';
 import { handleAutoVersioning } from './version-helpers';
@@ -61,7 +61,7 @@ export const LIST_STORED_AGENTS_ROUTE = createRoute({
   description: 'Returns a paginated list of all agents stored in the database',
   tags: ['Stored Agents'],
   requiresAuth: true,
-  handler: async ({ mastra, page, perPage, orderBy, status, authorId, metadata }) => {
+  handler: async ({ mastra, page, perPage, orderBy, status, authorId, metadata, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -74,13 +74,14 @@ export const LIST_STORED_AGENTS_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Agents storage domain is not available' });
       }
 
+      const scope = await getStoredResourceScope(mastra, requestContext);
       const result = await agentsStore.listResolved({
         page,
         perPage,
         orderBy,
         status,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
       });
 
       return result;
@@ -105,7 +106,7 @@ export const GET_STORED_AGENT_ROUTE = createRoute({
     'Returns a specific agent from storage by its unique identifier. Use ?status=draft to resolve with the latest (draft) version, or ?status=published (default) for the active published version.',
   tags: ['Stored Agents'],
   requiresAuth: true,
-  handler: async ({ mastra, storedAgentId, status }) => {
+  handler: async ({ mastra, storedAgentId, status, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -123,6 +124,7 @@ export const GET_STORED_AGENT_ROUTE = createRoute({
       if (!agent) {
         throw new HTTPException(404, { message: `Stored agent with id ${storedAgentId} not found` });
       }
+      assertStoredResourceScope(agent, await getStoredResourceScope(mastra, requestContext));
 
       return agent;
     } catch (error) {
@@ -156,6 +158,7 @@ export const CREATE_STORED_AGENT_ROUTE: ServerRoute<
     id: providedId,
     authorId,
     metadata,
+    requestContext,
     name,
     description,
     instructions,
@@ -207,7 +210,7 @@ export const CREATE_STORED_AGENT_ROUTE: ServerRoute<
         agent: {
           id,
           authorId,
-          metadata,
+          metadata: scopeStoredResourceMetadata(metadata, await getStoredResourceScope(mastra, requestContext)),
           name,
           description,
           instructions,
@@ -274,6 +277,7 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
     // Metadata-level fields
     authorId,
     metadata,
+    requestContext,
     // Config fields (snapshot-level)
     name,
     description,
@@ -312,6 +316,8 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
       if (!existing) {
         throw new HTTPException(404, { message: `Stored agent with id ${storedAgentId} not found` });
       }
+      const scope = await getStoredResourceScope(mastra, requestContext);
+      assertStoredResourceScope(existing, scope);
 
       // Update the agent with both metadata-level and config-level fields
       // The storage layer handles separating these into agent-record updates vs new-version creation
@@ -319,7 +325,7 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
       const updatedAgent = await agentsStore.update({
         id: storedAgentId,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
         name,
         description,
         instructions,
@@ -413,7 +419,7 @@ export const DELETE_STORED_AGENT_ROUTE = createRoute({
   description: 'Deletes an agent from storage by its unique identifier',
   tags: ['Stored Agents'],
   requiresAuth: true,
-  handler: async ({ mastra, storedAgentId }) => {
+  handler: async ({ mastra, storedAgentId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -431,6 +437,7 @@ export const DELETE_STORED_AGENT_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored agent with id ${storedAgentId} not found` });
       }
+      assertStoredResourceScope(existing, await getStoredResourceScope(mastra, requestContext));
 
       await agentsStore.delete(storedAgentId);
 

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -318,6 +318,10 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
       }
       const scope = await getStoredResourceScope(mastra, requestContext);
       assertStoredResourceScope(existing, scope);
+      const scopedMetadata =
+        metadata !== undefined
+          ? scopeStoredResourceMetadata({ ...(existing.metadata ?? {}), ...metadata }, scope)
+          : undefined;
 
       // Update the agent with both metadata-level and config-level fields
       // The storage layer handles separating these into agent-record updates vs new-version creation
@@ -325,7 +329,7 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
       const updatedAgent = await agentsStore.update({
         id: storedAgentId,
         authorId,
-        metadata: scopeStoredResourceMetadata(metadata, scope),
+        ...(scopedMetadata !== undefined ? { metadata: scopedMetadata } : {}),
         name,
         description,
         instructions,

--- a/packages/server/src/server/handlers/stored-mcp-clients.ts
+++ b/packages/server/src/server/handlers/stored-mcp-clients.ts
@@ -12,7 +12,7 @@ import {
   deleteStoredMCPClientResponseSchema,
 } from '../schemas/stored-mcp-clients';
 import { createRoute } from '../server-adapter/routes/route-builder';
-import { toSlug } from '../utils';
+import { assertStoredResourceScope, getStoredResourceScope, scopeStoredResourceMetadata, toSlug } from '../utils';
 
 import { handleError } from './error';
 import { handleAutoVersioning, MCP_CLIENT_SNAPSHOT_CONFIG_FIELDS } from './version-helpers';
@@ -35,7 +35,7 @@ export const LIST_STORED_MCP_CLIENTS_ROUTE = createRoute({
   description: 'Returns a paginated list of all MCP client configurations stored in the database',
   tags: ['Stored MCP Clients'],
   requiresAuth: true,
-  handler: async ({ mastra, page, perPage, orderBy, status, authorId, metadata }) => {
+  handler: async ({ mastra, page, perPage, orderBy, status, authorId, metadata, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -48,13 +48,14 @@ export const LIST_STORED_MCP_CLIENTS_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'MCP clients storage domain is not available' });
       }
 
+      const scope = await getStoredResourceScope(mastra, requestContext);
       const result = await mcpClientStore.listResolved({
         page,
         perPage,
         orderBy,
         status,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
       });
 
       return result;
@@ -79,7 +80,7 @@ export const GET_STORED_MCP_CLIENT_ROUTE = createRoute({
     'Returns a specific MCP client from storage by its unique identifier. Use ?status=draft to resolve with the latest (draft) version, or ?status=published (default) for the active published version.',
   tags: ['Stored MCP Clients'],
   requiresAuth: true,
-  handler: async ({ mastra, storedMCPClientId, status }) => {
+  handler: async ({ mastra, storedMCPClientId, status, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -97,6 +98,7 @@ export const GET_STORED_MCP_CLIENT_ROUTE = createRoute({
       if (!mcpClient) {
         throw new HTTPException(404, { message: `Stored MCP client with id ${storedMCPClientId} not found` });
       }
+      assertStoredResourceScope(mcpClient, await getStoredResourceScope(mastra, requestContext));
 
       return mcpClient;
     } catch (error) {
@@ -118,7 +120,7 @@ export const CREATE_STORED_MCP_CLIENT_ROUTE = createRoute({
   description: 'Creates a new MCP client configuration in storage with the provided servers',
   tags: ['Stored MCP Clients'],
   requiresAuth: true,
-  handler: async ({ mastra, id: providedId, authorId, metadata, name, description, servers }) => {
+  handler: async ({ mastra, id: providedId, authorId, metadata, name, description, servers, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -150,7 +152,7 @@ export const CREATE_STORED_MCP_CLIENT_ROUTE = createRoute({
         mcpClient: {
           id,
           authorId,
-          metadata,
+          metadata: scopeStoredResourceMetadata(metadata, await getStoredResourceScope(mastra, requestContext)),
           name,
           description,
           servers,
@@ -191,6 +193,7 @@ export const UPDATE_STORED_MCP_CLIENT_ROUTE = createRoute({
     // Metadata-level fields
     authorId,
     metadata,
+    requestContext,
     // Config fields (snapshot-level)
     name,
     description,
@@ -213,12 +216,14 @@ export const UPDATE_STORED_MCP_CLIENT_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored MCP client with id ${storedMCPClientId} not found` });
       }
+      const scope = await getStoredResourceScope(mastra, requestContext);
+      assertStoredResourceScope(existing, scope);
 
       // Update the MCP client with both metadata-level and config-level fields
       const updatedMCPClient = await mcpClientStore.update({
         id: storedMCPClientId,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
         name,
         description,
         servers,
@@ -269,7 +274,7 @@ export const DELETE_STORED_MCP_CLIENT_ROUTE = createRoute({
   description: 'Deletes an MCP client from storage by its unique identifier',
   tags: ['Stored MCP Clients'],
   requiresAuth: true,
-  handler: async ({ mastra, storedMCPClientId }) => {
+  handler: async ({ mastra, storedMCPClientId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -287,6 +292,7 @@ export const DELETE_STORED_MCP_CLIENT_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored MCP client with id ${storedMCPClientId} not found` });
       }
+      assertStoredResourceScope(existing, await getStoredResourceScope(mastra, requestContext));
 
       await mcpClientStore.delete(storedMCPClientId);
 

--- a/packages/server/src/server/handlers/stored-mcp-clients.ts
+++ b/packages/server/src/server/handlers/stored-mcp-clients.ts
@@ -218,12 +218,16 @@ export const UPDATE_STORED_MCP_CLIENT_ROUTE = createRoute({
       }
       const scope = await getStoredResourceScope(mastra, requestContext);
       assertStoredResourceScope(existing, scope);
+      const scopedMetadata =
+        metadata !== undefined
+          ? scopeStoredResourceMetadata({ ...(existing.metadata ?? {}), ...metadata }, scope)
+          : undefined;
 
       // Update the MCP client with both metadata-level and config-level fields
       const updatedMCPClient = await mcpClientStore.update({
         id: storedMCPClientId,
         authorId,
-        metadata: scopeStoredResourceMetadata(metadata, scope),
+        ...(scopedMetadata !== undefined ? { metadata: scopedMetadata } : {}),
         name,
         description,
         servers,

--- a/packages/server/src/server/handlers/stored-prompt-blocks.ts
+++ b/packages/server/src/server/handlers/stored-prompt-blocks.ts
@@ -12,7 +12,7 @@ import {
   deleteStoredPromptBlockResponseSchema,
 } from '../schemas/stored-prompt-blocks';
 import { createRoute } from '../server-adapter/routes/route-builder';
-import { toSlug } from '../utils';
+import { assertStoredResourceScope, getStoredResourceScope, scopeStoredResourceMetadata, toSlug } from '../utils';
 
 import { handleError } from './error';
 import { handleAutoVersioning } from './version-helpers';
@@ -51,7 +51,7 @@ export const LIST_STORED_PROMPT_BLOCKS_ROUTE = createRoute({
   description: 'Returns a paginated list of all prompt blocks stored in the database',
   tags: ['Stored Prompt Blocks'],
   requiresAuth: true,
-  handler: async ({ mastra, page, perPage, orderBy, status, authorId, metadata }) => {
+  handler: async ({ mastra, page, perPage, orderBy, status, authorId, metadata, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -64,13 +64,14 @@ export const LIST_STORED_PROMPT_BLOCKS_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Prompt blocks storage domain is not available' });
       }
 
+      const scope = await getStoredResourceScope(mastra, requestContext);
       const result = await promptBlockStore.listResolved({
         page,
         perPage,
         orderBy,
         status,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
       });
 
       // For each block, fetch the latest version to compute hasDraft.
@@ -105,7 +106,7 @@ export const GET_STORED_PROMPT_BLOCK_ROUTE = createRoute({
     'Returns a specific prompt block from storage by its unique identifier. Use ?status=draft to resolve with the latest (draft) version, or ?status=published (default) for the active published version.',
   tags: ['Stored Prompt Blocks'],
   requiresAuth: true,
-  handler: async ({ mastra, storedPromptBlockId, status }) => {
+  handler: async ({ mastra, storedPromptBlockId, status, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -123,6 +124,7 @@ export const GET_STORED_PROMPT_BLOCK_ROUTE = createRoute({
       if (!promptBlock) {
         throw new HTTPException(404, { message: `Stored prompt block with id ${storedPromptBlockId} not found` });
       }
+      assertStoredResourceScope(promptBlock, await getStoredResourceScope(mastra, requestContext));
 
       const latestVersion = await promptBlockStore.getLatestVersion(storedPromptBlockId);
 
@@ -156,6 +158,7 @@ export const CREATE_STORED_PROMPT_BLOCK_ROUTE = createRoute({
     content,
     rules,
     requestContextSchema,
+    requestContext,
   }) => {
     try {
       const storage = mastra.getStorage();
@@ -188,7 +191,7 @@ export const CREATE_STORED_PROMPT_BLOCK_ROUTE = createRoute({
         promptBlock: {
           id,
           authorId,
-          metadata,
+          metadata: scopeStoredResourceMetadata(metadata, await getStoredResourceScope(mastra, requestContext)),
           name,
           description,
           content,
@@ -243,6 +246,7 @@ export const UPDATE_STORED_PROMPT_BLOCK_ROUTE = createRoute({
     content,
     rules,
     requestContextSchema,
+    requestContext,
   }) => {
     try {
       const storage = mastra.getStorage();
@@ -261,12 +265,14 @@ export const UPDATE_STORED_PROMPT_BLOCK_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored prompt block with id ${storedPromptBlockId} not found` });
       }
+      const scope = await getStoredResourceScope(mastra, requestContext);
+      assertStoredResourceScope(existing, scope);
 
       // Update the prompt block with both metadata-level and config-level fields
       const updatedPromptBlock = await promptBlockStore.update({
         id: storedPromptBlockId,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
         name,
         description,
         content,
@@ -325,7 +331,7 @@ export const DELETE_STORED_PROMPT_BLOCK_ROUTE = createRoute({
   description: 'Deletes a prompt block from storage by its unique identifier',
   tags: ['Stored Prompt Blocks'],
   requiresAuth: true,
-  handler: async ({ mastra, storedPromptBlockId }) => {
+  handler: async ({ mastra, storedPromptBlockId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -343,6 +349,7 @@ export const DELETE_STORED_PROMPT_BLOCK_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored prompt block with id ${storedPromptBlockId} not found` });
       }
+      assertStoredResourceScope(existing, await getStoredResourceScope(mastra, requestContext));
 
       await promptBlockStore.delete(storedPromptBlockId);
 

--- a/packages/server/src/server/handlers/stored-prompt-blocks.ts
+++ b/packages/server/src/server/handlers/stored-prompt-blocks.ts
@@ -267,12 +267,16 @@ export const UPDATE_STORED_PROMPT_BLOCK_ROUTE = createRoute({
       }
       const scope = await getStoredResourceScope(mastra, requestContext);
       assertStoredResourceScope(existing, scope);
+      const scopedMetadata =
+        metadata !== undefined
+          ? scopeStoredResourceMetadata({ ...(existing.metadata ?? {}), ...metadata }, scope)
+          : undefined;
 
       // Update the prompt block with both metadata-level and config-level fields
       const updatedPromptBlock = await promptBlockStore.update({
         id: storedPromptBlockId,
         authorId,
-        metadata: scopeStoredResourceMetadata(metadata, scope),
+        ...(scopedMetadata !== undefined ? { metadata: scopedMetadata } : {}),
         name,
         description,
         content,

--- a/packages/server/src/server/handlers/stored-scorers.ts
+++ b/packages/server/src/server/handlers/stored-scorers.ts
@@ -253,12 +253,16 @@ export const UPDATE_STORED_SCORER_ROUTE = createRoute({
       }
       const scope = await getStoredResourceScope(mastra, requestContext);
       assertStoredResourceScope(existing, scope);
+      const scopedMetadata =
+        metadata !== undefined
+          ? scopeStoredResourceMetadata({ ...(existing.metadata ?? {}), ...metadata }, scope)
+          : undefined;
 
       // Update the scorer definition with both metadata-level and config-level fields
       const updatedScorer = await scorerStore.update({
         id: storedScorerId,
         authorId,
-        metadata: scopeStoredResourceMetadata(metadata, scope),
+        ...(scopedMetadata !== undefined ? { metadata: scopedMetadata } : {}),
         name,
         description,
         type,

--- a/packages/server/src/server/handlers/stored-scorers.ts
+++ b/packages/server/src/server/handlers/stored-scorers.ts
@@ -12,7 +12,7 @@ import {
   deleteStoredScorerResponseSchema,
 } from '../schemas/stored-scorers';
 import { createRoute } from '../server-adapter/routes/route-builder';
-import { toSlug } from '../utils';
+import { assertStoredResourceScope, getStoredResourceScope, scopeStoredResourceMetadata, toSlug } from '../utils';
 
 import { handleError } from './error';
 import { handleAutoVersioning } from './version-helpers';
@@ -46,7 +46,7 @@ export const LIST_STORED_SCORERS_ROUTE = createRoute({
   description: 'Returns a paginated list of all scorer definitions stored in the database',
   tags: ['Stored Scorers'],
   requiresAuth: true,
-  handler: async ({ mastra, page, perPage, orderBy, status, authorId, metadata }) => {
+  handler: async ({ mastra, page, perPage, orderBy, status, authorId, metadata, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -59,13 +59,14 @@ export const LIST_STORED_SCORERS_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Scorer definitions storage domain is not available' });
       }
 
+      const scope = await getStoredResourceScope(mastra, requestContext);
       const result = await scorerStore.listResolved({
         page,
         perPage,
         orderBy,
         status,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
       });
 
       return result;
@@ -90,7 +91,7 @@ export const GET_STORED_SCORER_ROUTE = createRoute({
     'Returns a specific scorer definition from storage by its unique identifier. Use ?status=draft to resolve with the latest (draft) version, or ?status=published (default) for the active published version.',
   tags: ['Stored Scorers'],
   requiresAuth: true,
-  handler: async ({ mastra, storedScorerId, status }) => {
+  handler: async ({ mastra, storedScorerId, status, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -108,6 +109,7 @@ export const GET_STORED_SCORER_ROUTE = createRoute({
       if (!scorer) {
         throw new HTTPException(404, { message: `Stored scorer definition with id ${storedScorerId} not found` });
       }
+      assertStoredResourceScope(scorer, await getStoredResourceScope(mastra, requestContext));
 
       return scorer;
     } catch (error) {
@@ -142,6 +144,7 @@ export const CREATE_STORED_SCORER_ROUTE = createRoute({
     scoreRange,
     presetConfig,
     defaultSampling,
+    requestContext,
   }) => {
     try {
       const storage = mastra.getStorage();
@@ -174,7 +177,7 @@ export const CREATE_STORED_SCORER_ROUTE = createRoute({
         scorerDefinition: {
           id,
           authorId,
-          metadata,
+          metadata: scopeStoredResourceMetadata(metadata, await getStoredResourceScope(mastra, requestContext)),
           name,
           description,
           type,
@@ -229,6 +232,7 @@ export const UPDATE_STORED_SCORER_ROUTE = createRoute({
     scoreRange,
     presetConfig,
     defaultSampling,
+    requestContext,
   }) => {
     try {
       const storage = mastra.getStorage();
@@ -247,12 +251,14 @@ export const UPDATE_STORED_SCORER_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored scorer definition with id ${storedScorerId} not found` });
       }
+      const scope = await getStoredResourceScope(mastra, requestContext);
+      assertStoredResourceScope(existing, scope);
 
       // Update the scorer definition with both metadata-level and config-level fields
       const updatedScorer = await scorerStore.update({
         id: storedScorerId,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
         name,
         description,
         type,
@@ -323,7 +329,7 @@ export const DELETE_STORED_SCORER_ROUTE = createRoute({
   description: 'Deletes a scorer definition from storage by its unique identifier',
   tags: ['Stored Scorers'],
   requiresAuth: true,
-  handler: async ({ mastra, storedScorerId }) => {
+  handler: async ({ mastra, storedScorerId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -341,6 +347,7 @@ export const DELETE_STORED_SCORER_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored scorer definition with id ${storedScorerId} not found` });
       }
+      assertStoredResourceScope(existing, await getStoredResourceScope(mastra, requestContext));
 
       await scorerStore.delete(storedScorerId);
 

--- a/packages/server/src/server/handlers/stored-skills.test.ts
+++ b/packages/server/src/server/handlers/stored-skills.test.ts
@@ -1,0 +1,130 @@
+import type { Mastra } from '@mastra/core';
+import { RequestContext } from '@mastra/core/request-context';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { ServerContext } from '../server-adapter';
+
+import { DELETE_STORED_SKILL_ROUTE, UPDATE_STORED_SKILL_ROUTE } from './stored-skills';
+
+interface MockStoredSkill {
+  id: string;
+  name: string;
+  description: string;
+  instructions: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface MockSkillsStore {
+  getById: ReturnType<typeof vi.fn>;
+  getByIdResolved: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+}
+
+interface MockStorage {
+  getStore: ReturnType<typeof vi.fn>;
+}
+
+interface MockMastra {
+  getStorage: ReturnType<typeof vi.fn>;
+  getServer: ReturnType<typeof vi.fn>;
+}
+
+function createMockSkillsStore(skills: Map<string, MockStoredSkill>): MockSkillsStore {
+  return {
+    getById: vi.fn(async (id: string) => skills.get(id) ?? null),
+    getByIdResolved: vi.fn(async (id: string) => skills.get(id) ?? null),
+    update: vi.fn(async (updates: Partial<MockStoredSkill> & { id: string }) => {
+      const existing = skills.get(updates.id);
+      if (!existing) return null;
+
+      const updated = { ...existing };
+      for (const [key, value] of Object.entries(updates)) {
+        if (key !== 'id' && value !== undefined) {
+          (updated as Record<string, unknown>)[key] = value;
+        }
+      }
+      skills.set(updates.id, updated);
+      return updated;
+    }),
+    delete: vi.fn(async (id: string) => {
+      skills.delete(id);
+    }),
+  };
+}
+
+function createMockMastra(skillsStore: MockSkillsStore): MockMastra {
+  const storage: MockStorage = {
+    getStore: vi.fn(async (storeName: string) => (storeName === 'skills' ? skillsStore : null)),
+  };
+
+  return {
+    getStorage: vi.fn(() => storage),
+    getServer: vi.fn(() => ({ storedResources: { scope: true } })),
+  };
+}
+
+function createTestContext(mastra: MockMastra): ServerContext {
+  const requestContext = new RequestContext();
+  requestContext.set('mastra__resourceId', 'team-a');
+
+  return {
+    mastra: mastra as unknown as Mastra,
+    requestContext,
+    abortSignal: new AbortController().signal,
+  };
+}
+
+describe('Stored Skills Handlers', () => {
+  let skills: Map<string, MockStoredSkill>;
+  let skillsStore: MockSkillsStore;
+  let mastra: MockMastra;
+
+  beforeEach(() => {
+    skills = new Map([
+      [
+        'skill-1',
+        {
+          id: 'skill-1',
+          name: 'skill-one',
+          description: 'Skill one',
+          instructions: 'Use skill one.',
+          metadata: { 'mastra.resourceId': 'team-a', existing: true },
+        },
+      ],
+    ]);
+    skillsStore = createMockSkillsStore(skills);
+    mastra = createMockMastra(skillsStore);
+  });
+
+  it('merges existing metadata with incoming metadata during scoped updates', async () => {
+    await UPDATE_STORED_SKILL_ROUTE.handler({
+      ...createTestContext(mastra),
+      storedSkillId: 'skill-1',
+      metadata: { incoming: 'value', 'mastra.resourceId': 'team-b' },
+    });
+
+    expect(skillsStore.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'skill-1',
+        metadata: {
+          'mastra.resourceId': 'team-a',
+          existing: true,
+          incoming: 'value',
+        },
+      }),
+    );
+    expect(skillsStore.getById).not.toHaveBeenCalled();
+  });
+
+  it('uses the resolved skill for delete scope checks', async () => {
+    await DELETE_STORED_SKILL_ROUTE.handler({
+      ...createTestContext(mastra),
+      storedSkillId: 'skill-1',
+    });
+
+    expect(skillsStore.getById).not.toHaveBeenCalled();
+    expect(skillsStore.getByIdResolved).toHaveBeenCalledTimes(1);
+    expect(skillsStore.delete).toHaveBeenCalledWith('skill-1');
+  });
+});

--- a/packages/server/src/server/handlers/stored-skills.ts
+++ b/packages/server/src/server/handlers/stored-skills.ts
@@ -242,6 +242,10 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
       }
       const scope = await getStoredResourceScope(mastra, requestContext);
       assertStoredResourceScope(existing, scope);
+      const scopedMetadata =
+        metadata !== undefined
+          ? scopeStoredResourceMetadata({ ...(existing.metadata ?? {}), ...metadata }, scope)
+          : undefined;
 
       // Update the skill with both entity-level and config-level fields
       // The storage layer handles separating these into record updates vs new-version creation
@@ -257,7 +261,7 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
         references,
         scripts,
         assets,
-        metadata: scopeStoredResourceMetadata(metadata, scope),
+        ...(scopedMetadata !== undefined ? { metadata: scopedMetadata } : {}),
       });
 
       // Return the resolved skill with the updated config

--- a/packages/server/src/server/handlers/stored-skills.ts
+++ b/packages/server/src/server/handlers/stored-skills.ts
@@ -15,7 +15,7 @@ import {
   publishStoredSkillResponseSchema,
 } from '../schemas/stored-skills';
 import { createRoute } from '../server-adapter/routes/route-builder';
-import { toSlug } from '../utils';
+import { assertStoredResourceScope, getStoredResourceScope, scopeStoredResourceMetadata, toSlug } from '../utils';
 
 import { handleError } from './error';
 
@@ -36,7 +36,7 @@ export const LIST_STORED_SKILLS_ROUTE = createRoute({
   description: 'Returns a paginated list of all skill configurations stored in the database',
   tags: ['Stored Skills'],
   requiresAuth: true,
-  handler: async ({ mastra, page, perPage, orderBy, authorId, metadata }) => {
+  handler: async ({ mastra, page, perPage, orderBy, authorId, metadata, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -49,12 +49,13 @@ export const LIST_STORED_SKILLS_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Skills storage domain is not available' });
       }
 
+      const scope = await getStoredResourceScope(mastra, requestContext);
       const result = await skillStore.listResolved({
         page,
         perPage,
         orderBy,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
       });
 
       return result;
@@ -77,7 +78,7 @@ export const GET_STORED_SKILL_ROUTE = createRoute({
   description: 'Returns a specific skill from storage by its unique identifier (resolved with active version config)',
   tags: ['Stored Skills'],
   requiresAuth: true,
-  handler: async ({ mastra, storedSkillId }) => {
+  handler: async ({ mastra, storedSkillId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -95,6 +96,7 @@ export const GET_STORED_SKILL_ROUTE = createRoute({
       if (!skill) {
         throw new HTTPException(404, { message: `Stored skill with id ${storedSkillId} not found` });
       }
+      assertStoredResourceScope(skill, await getStoredResourceScope(mastra, requestContext));
 
       return skill;
     } catch (error) {
@@ -130,6 +132,7 @@ export const CREATE_STORED_SKILL_ROUTE = createRoute({
     scripts,
     assets,
     metadata,
+    requestContext,
   }) => {
     try {
       const storage = mastra.getStorage();
@@ -171,7 +174,7 @@ export const CREATE_STORED_SKILL_ROUTE = createRoute({
           references,
           scripts,
           assets,
-          metadata,
+          metadata: scopeStoredResourceMetadata(metadata, await getStoredResourceScope(mastra, requestContext)),
         },
       });
 
@@ -218,6 +221,7 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
     scripts,
     assets,
     metadata,
+    requestContext,
   }) => {
     try {
       const storage = mastra.getStorage();
@@ -236,6 +240,8 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored skill with id ${storedSkillId} not found` });
       }
+      const scope = await getStoredResourceScope(mastra, requestContext);
+      assertStoredResourceScope(await skillStore.getByIdResolved(storedSkillId), scope);
 
       // Update the skill with both entity-level and config-level fields
       // The storage layer handles separating these into record updates vs new-version creation
@@ -251,7 +257,7 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
         references,
         scripts,
         assets,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
       });
 
       // Return the resolved skill with the updated config
@@ -280,7 +286,7 @@ export const DELETE_STORED_SKILL_ROUTE = createRoute({
   description: 'Deletes a skill from storage by its unique identifier',
   tags: ['Stored Skills'],
   requiresAuth: true,
-  handler: async ({ mastra, storedSkillId }) => {
+  handler: async ({ mastra, storedSkillId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -298,6 +304,10 @@ export const DELETE_STORED_SKILL_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored skill with id ${storedSkillId} not found` });
       }
+      assertStoredResourceScope(
+        await skillStore.getByIdResolved(storedSkillId),
+        await getStoredResourceScope(mastra, requestContext),
+      );
 
       await skillStore.delete(storedSkillId);
 
@@ -328,7 +338,7 @@ export const PUBLISH_STORED_SKILL_ROUTE = createRoute({
     'Snapshots the skill directory from the filesystem into content-addressable blob storage, creates a new version with a tree manifest, and marks the skill as published',
   tags: ['Stored Skills'],
   requiresAuth: true,
-  handler: async ({ mastra, storedSkillId, skillPath }) => {
+  handler: async ({ mastra, storedSkillId, skillPath, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -351,6 +361,10 @@ export const PUBLISH_STORED_SKILL_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored skill with id ${storedSkillId} not found` });
       }
+      assertStoredResourceScope(
+        await skillStore.getByIdResolved(storedSkillId),
+        await getStoredResourceScope(mastra, requestContext),
+      );
 
       // Validate skillPath to prevent path traversal
       const path = await import('node:path');

--- a/packages/server/src/server/handlers/stored-skills.ts
+++ b/packages/server/src/server/handlers/stored-skills.ts
@@ -235,13 +235,13 @@ export const UPDATE_STORED_SKILL_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Skills storage domain is not available' });
       }
 
-      // Check if skill exists
-      const existing = await skillStore.getById(storedSkillId);
+      // Check if skill exists. Skill metadata lives on the resolved snapshot.
+      const existing = await skillStore.getByIdResolved(storedSkillId);
       if (!existing) {
         throw new HTTPException(404, { message: `Stored skill with id ${storedSkillId} not found` });
       }
       const scope = await getStoredResourceScope(mastra, requestContext);
-      assertStoredResourceScope(await skillStore.getByIdResolved(storedSkillId), scope);
+      assertStoredResourceScope(existing, scope);
 
       // Update the skill with both entity-level and config-level fields
       // The storage layer handles separating these into record updates vs new-version creation
@@ -299,15 +299,12 @@ export const DELETE_STORED_SKILL_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Skills storage domain is not available' });
       }
 
-      // Check if skill exists
-      const existing = await skillStore.getById(storedSkillId);
+      // Check if skill exists. Skill metadata lives on the resolved snapshot.
+      const existing = await skillStore.getByIdResolved(storedSkillId);
       if (!existing) {
         throw new HTTPException(404, { message: `Stored skill with id ${storedSkillId} not found` });
       }
-      assertStoredResourceScope(
-        await skillStore.getByIdResolved(storedSkillId),
-        await getStoredResourceScope(mastra, requestContext),
-      );
+      assertStoredResourceScope(existing, await getStoredResourceScope(mastra, requestContext));
 
       await skillStore.delete(storedSkillId);
 
@@ -356,15 +353,12 @@ export const PUBLISH_STORED_SKILL_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Blob storage domain is not available' });
       }
 
-      // Verify skill exists
-      const existing = await skillStore.getById(storedSkillId);
+      // Verify skill exists. Skill metadata lives on the resolved snapshot.
+      const existing = await skillStore.getByIdResolved(storedSkillId);
       if (!existing) {
         throw new HTTPException(404, { message: `Stored skill with id ${storedSkillId} not found` });
       }
-      assertStoredResourceScope(
-        await skillStore.getByIdResolved(storedSkillId),
-        await getStoredResourceScope(mastra, requestContext),
-      );
+      assertStoredResourceScope(existing, await getStoredResourceScope(mastra, requestContext));
 
       // Validate skillPath to prevent path traversal
       const path = await import('node:path');

--- a/packages/server/src/server/handlers/stored-workspaces.ts
+++ b/packages/server/src/server/handlers/stored-workspaces.ts
@@ -11,7 +11,7 @@ import {
   deleteStoredWorkspaceResponseSchema,
 } from '../schemas/stored-workspaces';
 import { createRoute } from '../server-adapter/routes/route-builder';
-import { toSlug } from '../utils';
+import { assertStoredResourceScope, getStoredResourceScope, scopeStoredResourceMetadata, toSlug } from '../utils';
 
 import { handleError } from './error';
 
@@ -32,7 +32,7 @@ export const LIST_STORED_WORKSPACES_ROUTE = createRoute({
   description: 'Returns a paginated list of all workspace configurations stored in the database',
   tags: ['Stored Workspaces'],
   requiresAuth: true,
-  handler: async ({ mastra, page, perPage, orderBy, authorId, metadata }) => {
+  handler: async ({ mastra, page, perPage, orderBy, authorId, metadata, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -45,12 +45,13 @@ export const LIST_STORED_WORKSPACES_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Workspaces storage domain is not available' });
       }
 
+      const scope = await getStoredResourceScope(mastra, requestContext);
       const result = await workspaceStore.listResolved({
         page,
         perPage,
         orderBy,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
       });
 
       return result;
@@ -74,7 +75,7 @@ export const GET_STORED_WORKSPACE_ROUTE = createRoute({
     'Returns a specific workspace from storage by its unique identifier (resolved with active version config)',
   tags: ['Stored Workspaces'],
   requiresAuth: true,
-  handler: async ({ mastra, storedWorkspaceId }) => {
+  handler: async ({ mastra, storedWorkspaceId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -92,6 +93,7 @@ export const GET_STORED_WORKSPACE_ROUTE = createRoute({
       if (!workspace) {
         throw new HTTPException(404, { message: `Stored workspace with id ${storedWorkspaceId} not found` });
       }
+      assertStoredResourceScope(workspace, await getStoredResourceScope(mastra, requestContext));
 
       return workspace;
     } catch (error) {
@@ -128,6 +130,7 @@ export const CREATE_STORED_WORKSPACE_ROUTE = createRoute({
     tools,
     autoSync,
     operationTimeout,
+    requestContext,
   }) => {
     try {
       const storage = mastra.getStorage();
@@ -160,7 +163,7 @@ export const CREATE_STORED_WORKSPACE_ROUTE = createRoute({
         workspace: {
           id,
           authorId,
-          metadata,
+          metadata: scopeStoredResourceMetadata(metadata, await getStoredResourceScope(mastra, requestContext)),
           name,
           description,
           filesystem,
@@ -218,6 +221,7 @@ export const UPDATE_STORED_WORKSPACE_ROUTE = createRoute({
     tools,
     autoSync,
     operationTimeout,
+    requestContext,
   }) => {
     try {
       const storage = mastra.getStorage();
@@ -236,13 +240,15 @@ export const UPDATE_STORED_WORKSPACE_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored workspace with id ${storedWorkspaceId} not found` });
       }
+      const scope = await getStoredResourceScope(mastra, requestContext);
+      assertStoredResourceScope(existing, scope);
 
       // Update the workspace with both metadata-level and config-level fields
       // The storage layer handles separating these into record updates vs new-version creation
       await workspaceStore.update({
         id: storedWorkspaceId,
         authorId,
-        metadata,
+        metadata: scopeStoredResourceMetadata(metadata, scope),
         name,
         description,
         filesystem,
@@ -281,7 +287,7 @@ export const DELETE_STORED_WORKSPACE_ROUTE = createRoute({
   description: 'Deletes a workspace from storage by its unique identifier',
   tags: ['Stored Workspaces'],
   requiresAuth: true,
-  handler: async ({ mastra, storedWorkspaceId }) => {
+  handler: async ({ mastra, storedWorkspaceId, requestContext }) => {
     try {
       const storage = mastra.getStorage();
 
@@ -299,6 +305,7 @@ export const DELETE_STORED_WORKSPACE_ROUTE = createRoute({
       if (!existing) {
         throw new HTTPException(404, { message: `Stored workspace with id ${storedWorkspaceId} not found` });
       }
+      assertStoredResourceScope(existing, await getStoredResourceScope(mastra, requestContext));
 
       await workspaceStore.delete(storedWorkspaceId);
 

--- a/packages/server/src/server/handlers/stored-workspaces.ts
+++ b/packages/server/src/server/handlers/stored-workspaces.ts
@@ -242,13 +242,17 @@ export const UPDATE_STORED_WORKSPACE_ROUTE = createRoute({
       }
       const scope = await getStoredResourceScope(mastra, requestContext);
       assertStoredResourceScope(existing, scope);
+      const scopedMetadata =
+        metadata !== undefined
+          ? scopeStoredResourceMetadata({ ...(existing.metadata ?? {}), ...metadata }, scope)
+          : undefined;
 
       // Update the workspace with both metadata-level and config-level fields
       // The storage layer handles separating these into record updates vs new-version creation
       await workspaceStore.update({
         id: storedWorkspaceId,
         authorId,
-        metadata: scopeStoredResourceMetadata(metadata, scope),
+        ...(scopedMetadata !== undefined ? { metadata: scopedMetadata } : {}),
         name,
         description,
         filesystem,

--- a/packages/server/src/server/handlers/utils.ts
+++ b/packages/server/src/server/handlers/utils.ts
@@ -106,7 +106,7 @@ export async function validateThreadOwnership(
 
 /**
  * Validates both coarse resource ownership and fine-grained thread access.
- * FGA enforcement is a no-op when either auth user or FGA provider is absent.
+ * FGA enforcement is a no-op when no FGA provider is configured.
  */
 export async function enforceThreadAccess({
   mastra,

--- a/packages/server/src/server/server-adapter/index.test.ts
+++ b/packages/server/src/server/server-adapter/index.test.ts
@@ -256,6 +256,79 @@ describe('FGA Middleware - checkRouteFGA', () => {
     );
   });
 
+  it('should derive built-in FGA metadata for stored resource item and collection routes', async () => {
+    const fgaProvider = createMockFGAProvider(true);
+    const mastra = { getServer: () => ({ fga: fgaProvider }) };
+    const requestContext = new Map<string, unknown>();
+    requestContext.set('user', { id: 'user-1' });
+    requestContext.set('mastra__resourceId', 'team-1');
+
+    await expect(
+      checkRouteFGA(
+        mastra,
+        {
+          method: 'GET',
+          path: '/stored/agents/:storedAgentId',
+          requiresAuth: true,
+        } as any,
+        requestContext as any,
+        { storedAgentId: 'agent-1' },
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      checkRouteFGA(
+        mastra,
+        {
+          method: 'POST',
+          path: '/stored/skills/:storedSkillId/publish',
+          requiresAuth: true,
+        } as any,
+        requestContext as any,
+        { storedSkillId: 'skill-1' },
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      checkRouteFGA(
+        mastra,
+        {
+          method: 'GET',
+          path: '/stored/workspaces',
+          requiresAuth: true,
+        } as any,
+        requestContext as any,
+        {},
+      ),
+    ).resolves.toBeNull();
+
+    expect(fgaProvider.check).toHaveBeenNthCalledWith(
+      1,
+      { id: 'user-1' },
+      {
+        resource: { type: 'stored-agents', id: 'agent-1' },
+        permission: 'stored-agents:read',
+        context: { resourceId: 'agent-1', requestContext },
+      },
+    );
+    expect(fgaProvider.check).toHaveBeenNthCalledWith(
+      2,
+      { id: 'user-1' },
+      {
+        resource: { type: 'stored-skills', id: 'skill-1' },
+        permission: 'stored-skills:publish',
+        context: { resourceId: 'skill-1', requestContext },
+      },
+    );
+    expect(fgaProvider.check).toHaveBeenNthCalledWith(
+      3,
+      { id: 'user-1' },
+      {
+        resource: { type: 'stored-workspaces', id: 'team-1' },
+        permission: 'stored-workspaces:read',
+        context: { resourceId: 'team-1', requestContext },
+      },
+    );
+  });
+
   it('should return null when FGA check passes', async () => {
     const fgaProvider = createMockFGAProvider(true);
     const mastra = { getServer: () => ({ fga: fgaProvider }) };

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -13,6 +13,7 @@ import { coreAuthMiddleware } from '../auth/helpers';
 import {
   MASTRA_CLIENT_TYPE_HEADER,
   MASTRA_IS_STUDIO_KEY,
+  MASTRA_RESOURCE_ID_KEY,
   isReservedRequestContextKey,
   isStudioClientTypeHeader,
 } from '../constants';
@@ -131,6 +132,43 @@ function getToolRoutePermission(path: string): MastraFGAPermissionInput {
   return path.includes('/execute') ? 'tools:execute' : 'tools:read';
 }
 
+const STORED_ROUTE_FGA: Record<string, { resourceType: string; idParams: string[] }> = {
+  agents: { resourceType: 'stored-agents', idParams: ['storedAgentId', 'agentId'] },
+  'mcp-clients': { resourceType: 'stored-mcp-clients', idParams: ['storedMCPClientId', 'mcpClientId'] },
+  'prompt-blocks': { resourceType: 'stored-prompt-blocks', idParams: ['storedPromptBlockId', 'promptBlockId'] },
+  scorers: { resourceType: 'stored-scorers', idParams: ['storedScorerId', 'scorerId'] },
+  skills: { resourceType: 'stored-skills', idParams: ['storedSkillId'] },
+  workspaces: { resourceType: 'stored-workspaces', idParams: ['storedWorkspaceId'] },
+};
+
+function getStoredResourceRouteFGAConfig(path: string, permission: MastraFGAPermissionInput): FGARouteConfig | null {
+  const match = path.match(/^\/stored\/([^/]+)/);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  const config = STORED_ROUTE_FGA[match[1]];
+  if (!config) {
+    return null;
+  }
+
+  return {
+    resourceType: config.resourceType,
+    resourceId: (params, { requestContext }) => {
+      for (const idParam of config.idParams) {
+        const id = params[idParam];
+        if (typeof id === 'string' && id) {
+          return id;
+        }
+      }
+
+      const scopedResourceId = requestContext?.get(MASTRA_RESOURCE_ID_KEY);
+      return typeof scopedResourceId === 'string' && scopedResourceId ? scopedResourceId : config.resourceType;
+    },
+    permission,
+  };
+}
+
 function getBuiltInRouteFGAConfig(route: ServerRoute): FGARouteConfig | null {
   if (!isProtectedFGARoute(route) || !route.path || !route.method) {
     return null;
@@ -142,6 +180,11 @@ function getBuiltInRouteFGAConfig(route: ServerRoute): FGARouteConfig | null {
   }
 
   const path = route.path;
+  const storedRouteConfig = getStoredResourceRouteFGAConfig(path, permission);
+  if (storedRouteConfig) {
+    return storedRouteConfig;
+  }
+
   if (path.startsWith('/agents/:agentId/tools/:toolId')) {
     return {
       resourceType: 'tool',

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -13,7 +13,6 @@ import { coreAuthMiddleware } from '../auth/helpers';
 import {
   MASTRA_CLIENT_TYPE_HEADER,
   MASTRA_IS_STUDIO_KEY,
-  MASTRA_RESOURCE_ID_KEY,
   isReservedRequestContextKey,
   isStudioClientTypeHeader,
 } from '../constants';
@@ -21,6 +20,7 @@ import { formatZodError } from '../handlers/error';
 import { normalizeRoutePath } from '../utils';
 import { generateOpenAPIDocument, convertCustomRoutesToOpenAPIPaths } from './openapi-utils';
 import { SERVER_ROUTES, getEffectivePermission } from './routes';
+import { getBuiltInRouteFGAConfig } from './routes/fga-manifest';
 import type { ServerRoute } from './routes';
 
 export * from './routes';
@@ -126,143 +126,6 @@ function getRoutePermissions(route: ServerRoute): MastraFGAPermissionInput[] {
   return [getEffectivePermission(route), route.fga?.permission].filter(
     (permission): permission is MastraFGAPermissionInput => Boolean(permission),
   );
-}
-
-function getToolRoutePermission(path: string): MastraFGAPermissionInput {
-  return path.includes('/execute') ? 'tools:execute' : 'tools:read';
-}
-
-const STORED_ROUTE_FGA: Record<string, { resourceType: string; idParams: string[] }> = {
-  agents: { resourceType: 'stored-agents', idParams: ['storedAgentId', 'agentId'] },
-  'mcp-clients': { resourceType: 'stored-mcp-clients', idParams: ['storedMCPClientId', 'mcpClientId'] },
-  'prompt-blocks': { resourceType: 'stored-prompt-blocks', idParams: ['storedPromptBlockId', 'promptBlockId'] },
-  scorers: { resourceType: 'stored-scorers', idParams: ['storedScorerId', 'scorerId'] },
-  skills: { resourceType: 'stored-skills', idParams: ['storedSkillId'] },
-  workspaces: { resourceType: 'stored-workspaces', idParams: ['storedWorkspaceId'] },
-};
-
-function getStoredResourceRouteFGAConfig(path: string, permission: MastraFGAPermissionInput): FGARouteConfig | null {
-  const match = path.match(/^\/stored\/([^/]+)/);
-  if (!match?.[1]) {
-    return null;
-  }
-
-  const config = STORED_ROUTE_FGA[match[1]];
-  if (!config) {
-    return null;
-  }
-
-  return {
-    resourceType: config.resourceType,
-    resourceId: (params, { requestContext }) => {
-      for (const idParam of config.idParams) {
-        const id = params[idParam];
-        if (typeof id === 'string' && id) {
-          return id;
-        }
-      }
-
-      const scopedResourceId = requestContext?.get(MASTRA_RESOURCE_ID_KEY);
-      return typeof scopedResourceId === 'string' && scopedResourceId ? scopedResourceId : config.resourceType;
-    },
-    permission,
-  };
-}
-
-function getBuiltInRouteFGAConfig(route: ServerRoute): FGARouteConfig | null {
-  if (!isProtectedFGARoute(route) || !route.path || !route.method) {
-    return null;
-  }
-
-  const permission = getEffectivePermission(route) as MastraFGAPermissionInput | null;
-  if (!permission) {
-    return null;
-  }
-
-  const path = route.path;
-  const storedRouteConfig = getStoredResourceRouteFGAConfig(path, permission);
-  if (storedRouteConfig) {
-    return storedRouteConfig;
-  }
-
-  if (path.startsWith('/agents/:agentId/tools/:toolId')) {
-    return {
-      resourceType: 'tool',
-      resourceId: ({ agentId, toolId }) => `${String(agentId)}:${String(toolId)}`,
-      permission: getToolRoutePermission(path),
-    };
-  }
-
-  if (path.startsWith('/agents/:agentId')) {
-    return { resourceType: 'agent', resourceIdParam: 'agentId', permission };
-  }
-
-  if (path.startsWith('/workflows/:workflowId')) {
-    return { resourceType: 'workflow', resourceIdParam: 'workflowId', permission };
-  }
-
-  if (path.startsWith('/tools/:toolId')) {
-    return { resourceType: 'tool', resourceIdParam: 'toolId', permission };
-  }
-
-  if (path.startsWith('/mcp/:serverId/tools/:toolId')) {
-    return {
-      resourceType: 'tool',
-      resourceId: ({ serverId, toolId }) => JSON.stringify([String(serverId), String(toolId)]),
-      permission: getToolRoutePermission(path),
-    };
-  }
-
-  if (path.startsWith('/mcp/:serverId')) {
-    return { resourceType: 'mcp', resourceIdParam: 'serverId', permission };
-  }
-
-  if (path.startsWith('/memory/threads/:threadId') || path.startsWith('/memory/network/threads/:threadId')) {
-    return { resourceType: 'thread', resourceIdParam: 'threadId', permission };
-  }
-
-  if (path === '/memory/threads' || path === '/memory/network/threads') {
-    return {
-      resourceType: 'thread',
-      resourceId: ({ threadId, resourceId }) => {
-        if (typeof threadId === 'string') return threadId;
-        return typeof resourceId === 'string' ? resourceId : undefined;
-      },
-      permission,
-    };
-  }
-
-  if (path === '/memory/save-messages' || path === '/memory/network/save-messages') {
-    return {
-      resourceType: 'thread',
-      resourceId: ({ messages }) => {
-        if (!Array.isArray(messages)) return undefined;
-        const threadId = messages.find(
-          message => message && typeof message === 'object' && 'threadId' in message,
-        )?.threadId;
-        return typeof threadId === 'string' ? threadId : undefined;
-      },
-      permission,
-    };
-  }
-
-  if (path === '/v1/responses') {
-    return { resourceType: 'agent', resourceIdParam: 'agent_id', permission };
-  }
-
-  if (path.startsWith('/v1/responses/:responseId')) {
-    return { resourceType: 'response', resourceIdParam: 'responseId', permission };
-  }
-
-  if (path === '/v1/conversations') {
-    return { resourceType: 'agent', resourceIdParam: 'agent_id', permission };
-  }
-
-  if (path.startsWith('/v1/conversations/:conversationId')) {
-    return { resourceType: 'conversation', resourceIdParam: 'conversationId', permission };
-  }
-
-  return null;
 }
 
 async function resolveRouteFGAConfig(

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -19,9 +19,9 @@ import {
 import { formatZodError } from '../handlers/error';
 import { normalizeRoutePath } from '../utils';
 import { generateOpenAPIDocument, convertCustomRoutesToOpenAPIPaths } from './openapi-utils';
+import type { ServerRoute } from './routes';
 import { SERVER_ROUTES, getEffectivePermission } from './routes';
 import { getBuiltInRouteFGAConfig } from './routes/fga-manifest';
-import type { ServerRoute } from './routes';
 
 export * from './routes';
 export { redactStreamChunk } from './redact';

--- a/packages/server/src/server/server-adapter/routes/fga-manifest.ts
+++ b/packages/server/src/server/server-adapter/routes/fga-manifest.ts
@@ -1,0 +1,154 @@
+import type { FGARouteConfig, MastraFGAPermissionInput } from '@mastra/core/auth/ee';
+
+import { MASTRA_RESOURCE_ID_KEY } from '../../constants';
+import type { ServerRoute } from './index';
+import { getEffectivePermission } from './permissions';
+
+function isProtectedFGARoute(route: Pick<ServerRoute, 'requiresAuth'>): boolean {
+  return route.requiresAuth !== false;
+}
+
+function getToolRoutePermission(path: string): MastraFGAPermissionInput {
+  return path.includes('/execute') ? 'tools:execute' : 'tools:read';
+}
+
+function getAgentToolResourceId(agentId: string, toolId: string): string {
+  return `${agentId}:${toolId}`;
+}
+
+function getMCPToolResourceId(serverId: string, toolId: string): string {
+  return JSON.stringify([serverId, toolId]);
+}
+
+const STORED_ROUTE_FGA: Record<string, { resourceType: string; idParams: string[] }> = {
+  agents: { resourceType: 'stored-agents', idParams: ['storedAgentId', 'agentId'] },
+  'mcp-clients': { resourceType: 'stored-mcp-clients', idParams: ['storedMCPClientId', 'mcpClientId'] },
+  'prompt-blocks': { resourceType: 'stored-prompt-blocks', idParams: ['storedPromptBlockId', 'promptBlockId'] },
+  scorers: { resourceType: 'stored-scorers', idParams: ['storedScorerId', 'scorerId'] },
+  skills: { resourceType: 'stored-skills', idParams: ['storedSkillId'] },
+  workspaces: { resourceType: 'stored-workspaces', idParams: ['storedWorkspaceId'] },
+};
+
+function getStoredResourceRouteFGAConfig(path: string, permission: MastraFGAPermissionInput): FGARouteConfig | null {
+  const match = path.match(/^\/stored\/([^/]+)/);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  const config = STORED_ROUTE_FGA[match[1]];
+  if (!config) {
+    return null;
+  }
+
+  return {
+    resourceType: config.resourceType,
+    resourceId: (params, { requestContext }) => {
+      for (const idParam of config.idParams) {
+        const id = params[idParam];
+        if (typeof id === 'string' && id) {
+          return id;
+        }
+      }
+
+      const scopedResourceId = requestContext?.get(MASTRA_RESOURCE_ID_KEY);
+      return typeof scopedResourceId === 'string' && scopedResourceId ? scopedResourceId : config.resourceType;
+    },
+    permission,
+  };
+}
+
+export function getBuiltInRouteFGAConfig(route: ServerRoute): FGARouteConfig | null {
+  if (!isProtectedFGARoute(route) || !route.path || !route.method) {
+    return null;
+  }
+
+  const permission = getEffectivePermission(route) as MastraFGAPermissionInput | null;
+  if (!permission) {
+    return null;
+  }
+
+  const path = route.path;
+  const storedRouteConfig = getStoredResourceRouteFGAConfig(path, permission);
+  if (storedRouteConfig) {
+    return storedRouteConfig;
+  }
+
+  if (path.startsWith('/agents/:agentId/tools/:toolId')) {
+    return {
+      resourceType: 'tool',
+      resourceId: ({ agentId, toolId }) => getAgentToolResourceId(String(agentId), String(toolId)),
+      permission: getToolRoutePermission(path),
+    };
+  }
+
+  if (path.startsWith('/agents/:agentId')) {
+    return { resourceType: 'agent', resourceIdParam: 'agentId', permission };
+  }
+
+  if (path.startsWith('/workflows/:workflowId')) {
+    return { resourceType: 'workflow', resourceIdParam: 'workflowId', permission };
+  }
+
+  if (path.startsWith('/tools/:toolId')) {
+    return { resourceType: 'tool', resourceIdParam: 'toolId', permission };
+  }
+
+  if (path.startsWith('/mcp/:serverId/tools/:toolId')) {
+    return {
+      resourceType: 'tool',
+      resourceId: ({ serverId, toolId }) => getMCPToolResourceId(String(serverId), String(toolId)),
+      permission: getToolRoutePermission(path),
+    };
+  }
+
+  if (path.startsWith('/mcp/:serverId')) {
+    return { resourceType: 'mcp', resourceIdParam: 'serverId', permission };
+  }
+
+  if (path.startsWith('/memory/threads/:threadId') || path.startsWith('/memory/network/threads/:threadId')) {
+    return { resourceType: 'thread', resourceIdParam: 'threadId', permission };
+  }
+
+  if (path === '/memory/threads' || path === '/memory/network/threads') {
+    return {
+      resourceType: 'thread',
+      resourceId: ({ threadId, resourceId }) => {
+        if (typeof threadId === 'string') return threadId;
+        return typeof resourceId === 'string' ? resourceId : undefined;
+      },
+      permission,
+    };
+  }
+
+  if (path === '/memory/save-messages' || path === '/memory/network/save-messages') {
+    return {
+      resourceType: 'thread',
+      resourceId: ({ messages }) => {
+        if (!Array.isArray(messages)) return undefined;
+        const threadId = messages.find(
+          message => message && typeof message === 'object' && 'threadId' in message,
+        )?.threadId;
+        return typeof threadId === 'string' ? threadId : undefined;
+      },
+      permission,
+    };
+  }
+
+  if (path === '/v1/responses') {
+    return { resourceType: 'agent', resourceIdParam: 'agent_id', permission };
+  }
+
+  if (path.startsWith('/v1/responses/:responseId')) {
+    return { resourceType: 'response', resourceIdParam: 'responseId', permission };
+  }
+
+  if (path === '/v1/conversations') {
+    return { resourceType: 'agent', resourceIdParam: 'agent_id', permission };
+  }
+
+  if (path.startsWith('/v1/conversations/:conversationId')) {
+    return { resourceType: 'conversation', resourceIdParam: 'conversationId', permission };
+  }
+
+  return null;
+}

--- a/packages/server/src/server/server-adapter/routes/fga-manifest.ts
+++ b/packages/server/src/server/server-adapter/routes/fga-manifest.ts
@@ -1,8 +1,8 @@
 import type { FGARouteConfig, MastraFGAPermissionInput } from '@mastra/core/auth/ee';
 
 import { MASTRA_RESOURCE_ID_KEY } from '../../constants';
-import type { ServerRoute } from './index';
 import { getEffectivePermission } from './permissions';
+import type { ServerRoute } from './index';
 
 function isProtectedFGARoute(route: Pick<ServerRoute, 'requiresAuth'>): boolean {
   return route.requiresAuth !== false;

--- a/packages/server/src/server/server-adapter/routes/permissions.test.ts
+++ b/packages/server/src/server/server-adapter/routes/permissions.test.ts
@@ -327,9 +327,9 @@ describe('derivePermission', () => {
       expect(derivePermission({ path: '/stored/skills/:storedSkillId/publish', method: 'POST' })).toBe(
         'stored-skills:publish',
       );
-      expect(
-        derivePermission({ path: '/stored/agents/:agentId/versions/:versionId/activate', method: 'POST' }),
-      ).toBe('stored-agents:publish');
+      expect(derivePermission({ path: '/stored/agents/:agentId/versions/:versionId/activate', method: 'POST' })).toBe(
+        'stored-agents:publish',
+      );
       expect(derivePermission({ path: '/stored/scorers/:scorerId/versions/:versionId/restore', method: 'POST' })).toBe(
         'stored-scorers:publish',
       );

--- a/packages/server/src/server/server-adapter/routes/permissions.test.ts
+++ b/packages/server/src/server/server-adapter/routes/permissions.test.ts
@@ -105,6 +105,14 @@ describe('extractResource', () => {
       expect(extractResource('/stored/agents/:agentId')).toBe('stored-agents');
     });
 
+    it('should extract specific stored resource families', () => {
+      expect(extractResource('/stored/mcp-clients/:mcpClientId')).toBe('stored-mcp-clients');
+      expect(extractResource('/stored/prompt-blocks/:promptBlockId')).toBe('stored-prompt-blocks');
+      expect(extractResource('/stored/scorers/:scorerId')).toBe('stored-scorers');
+      expect(extractResource('/stored/skills/:skillId')).toBe('stored-skills');
+      expect(extractResource('/stored/workspaces/:workspaceId')).toBe('stored-workspaces');
+    });
+
     it('should extract a2a from /.well-known paths', () => {
       expect(extractResource('/.well-known/:agentId/agent-card.json')).toBe('a2a');
     });
@@ -313,6 +321,18 @@ describe('derivePermission', () => {
 
     it('should derive stored-agents:write for POST /stored/agents', () => {
       expect(derivePermission({ path: '/stored/agents', method: 'POST' })).toBe('stored-agents:write');
+    });
+
+    it('should derive publish for stored publish, activate, and restore operations', () => {
+      expect(derivePermission({ path: '/stored/skills/:storedSkillId/publish', method: 'POST' })).toBe(
+        'stored-skills:publish',
+      );
+      expect(
+        derivePermission({ path: '/stored/agents/:agentId/versions/:versionId/activate', method: 'POST' }),
+      ).toBe('stored-agents:publish');
+      expect(derivePermission({ path: '/stored/scorers/:scorerId/versions/:versionId/restore', method: 'POST' })).toBe(
+        'stored-scorers:publish',
+      );
     });
 
     it('should derive a2a:read for GET /.well-known/:agentId/agent-card.json', () => {

--- a/packages/server/src/server/server-adapter/routes/permissions.ts
+++ b/packages/server/src/server/server-adapter/routes/permissions.ts
@@ -47,6 +47,17 @@ const EXECUTE_PATTERNS = [
   '/clone',
 ];
 
+const PUBLISH_PATTERNS = ['/publish', '/activate', '/restore'];
+
+const STORED_RESOURCE_SEGMENTS: Record<string, string> = {
+  agents: 'stored-agents',
+  'mcp-clients': 'stored-mcp-clients',
+  'prompt-blocks': 'stored-prompt-blocks',
+  scorers: 'stored-scorers',
+  skills: 'stored-skills',
+  workspaces: 'stored-workspaces',
+};
+
 /**
  * Extracts the primary resource name from a route path.
  *
@@ -74,9 +85,9 @@ export function extractResource(path: string): string | null {
 
   const firstSegment = segments[0];
 
-  // Handle special case: /stored/agents → 'stored-agents'
-  if (firstSegment === 'stored' && segments[1] === 'agents') {
-    return 'stored-agents';
+  // Handle special case: /stored/<family> → 'stored-<family>'
+  if (firstSegment === 'stored' && segments[1]) {
+    return STORED_RESOURCE_SEGMENTS[segments[1]] ?? null;
   }
 
   // Handle .well-known paths (A2A protocol)
@@ -99,6 +110,11 @@ export function deriveAction(method: string, path: string): string {
 
   // For POST requests, check if it's an execute operation
   if (upperMethod === 'POST') {
+    const isPublishOperation = PUBLISH_PATTERNS.some(pattern => path.includes(pattern));
+    if (isPublishOperation) {
+      return 'publish';
+    }
+
     const isExecuteOperation = EXECUTE_PATTERNS.some(pattern => path.includes(pattern));
     return isExecuteOperation ? 'execute' : 'write';
   }

--- a/packages/server/src/server/utils.ts
+++ b/packages/server/src/server/utils.ts
@@ -63,7 +63,7 @@ export type StoredResourceLike = {
 };
 
 export async function getStoredResourceScope(
-  mastra: any,
+  mastra: Pick<Mastra, 'getServer'>,
   requestContext: RequestContext | undefined,
 ): Promise<StoredResourceScope | undefined> {
   const scopeConfig = mastra?.getServer?.()?.storedResources?.scope;

--- a/packages/server/src/server/utils.ts
+++ b/packages/server/src/server/utils.ts
@@ -1,10 +1,13 @@
 import type { Mastra } from '@mastra/core';
+import type { RequestContext } from '@mastra/core/di';
 import type { SystemMessage } from '@mastra/core/llm';
 import type { StepWithComponent, Workflow, WorkflowInfo } from '@mastra/core/workflows';
 import { toStandardSchema, standardSchemaToJSONSchema } from '@mastra/schema-compat/schema';
 import type { PublicSchema } from '@mastra/schema-compat/schema';
 
 import { stringify } from 'superjson';
+import { MASTRA_RESOURCE_ID_KEY } from './constants';
+import { HTTPException } from './http-exception';
 
 /**
  * Convert any PublicSchema to a JSON Schema.
@@ -46,6 +49,70 @@ export function normalizeRoutePath(path: string): string {
     normalized = `/${normalized}`;
   }
   return normalized;
+}
+
+const DEFAULT_STORED_RESOURCE_SCOPE_METADATA_KEY = 'mastra.resourceId';
+
+export type StoredResourceScope = {
+  metadataKey: string;
+  value: string;
+};
+
+export type StoredResourceLike = {
+  metadata?: Record<string, unknown> | null;
+};
+
+export async function getStoredResourceScope(
+  mastra: any,
+  requestContext: RequestContext | undefined,
+): Promise<StoredResourceScope | undefined> {
+  const scopeConfig = mastra?.getServer?.()?.storedResources?.scope;
+  if (!scopeConfig) {
+    return undefined;
+  }
+
+  const options = scopeConfig === true ? {} : scopeConfig;
+  const metadataKey = options.metadataKey ?? DEFAULT_STORED_RESOURCE_SCOPE_METADATA_KEY;
+  const user = requestContext?.get('user');
+  const resolved = options.resolve
+    ? await options.resolve({ requestContext, user })
+    : (requestContext?.get(MASTRA_RESOURCE_ID_KEY) as string | undefined);
+
+  if (!resolved) {
+    if (options.requireScope === false) {
+      return undefined;
+    }
+    throw new HTTPException(403, { message: 'Stored resource scope is required' });
+  }
+
+  return { metadataKey, value: resolved };
+}
+
+export function scopeStoredResourceMetadata(
+  metadata: Record<string, unknown> | undefined,
+  scope: StoredResourceScope | undefined,
+): Record<string, unknown> | undefined {
+  if (!scope) {
+    return metadata;
+  }
+
+  return {
+    ...(metadata ?? {}),
+    [scope.metadataKey]: scope.value,
+  };
+}
+
+export function assertStoredResourceScope(
+  resource: StoredResourceLike | null | undefined,
+  scope: StoredResourceScope | undefined,
+): void {
+  if (!resource || !scope) {
+    return;
+  }
+
+  if (resource.metadata?.[scope.metadataKey] !== scope.value) {
+    throw new HTTPException(404, { message: 'Stored resource not found' });
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

This PR makes Mastra's FGA path safer and easier to extend for hosted server routes. ELI5: if auth says "this route is protected," FGA should either know what resource/permission to check or clearly fail/warn instead of silently letting the request through.

Before this change, configuring `server.fga` did not guarantee protected resource routes were FGA-protected because `checkRouteFGA` only ran when each route had explicit `route.fga` metadata. This adds provider-level policy coverage controls (`requireForProtectedRoutes`, `auditProtectedRoutes`, `resolveRouteFGA`, and `validatePermissions`), built-in FGA metadata resolution for Mastra resource routes, and startup validation for emitted permissions.

Example: a protected `POST /workflows/:workflowId/start` route can now derive `{ resource: { type: 'workflow', id: workflowId }, permission: 'workflows:execute' }` without each adapter route manually mutating metadata. Built-in coverage also applies to agents, workflows, tools, MCP tools, memory threads, responses, and conversations, while custom providers can still override route mapping globally with `resolveRouteFGA`.

The built-in resolver is now the source of truth for those resource routes, so redundant per-route `fga` blocks were removed from the server handlers while keeping special tool resource IDs for agent-scoped and MCP tools.

Follow-up review fixes also align direct execution FGA checks with the same resource scope used at runtime, guard agent resume paths (`resumeStream` / `resumeGenerate`), and preserve stored resource metadata on partial updates when `metadata` is omitted.

This also hardens the WorkOS provider boundary: when WorkOS reports an FGA resource is missing (`entity_not_found`/404), `check()` now returns denial and `require()` throws `FGADeniedError` instead of leaking a provider-specific error that can become a 500. The docs and focused tests were updated to cover the new route policy behavior and WorkOS denial semantics.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: This PR makes the server automatically check fine‑grained permissions for common protected routes so actions are blocked unless explicitly allowed, treats missing users or missing FGA resources as denials (not server errors), and exposes provider-level switches so operators can require/audit/resolve route FGA behavior.

Summary:
- Provider-level FGA controls
  - Added server provider options: requireForProtectedRoutes, auditProtectedRoutes, resolveRouteFGA, validatePermissions.
- Built-in route-to-FGA resolution
  - New resolver getBuiltInRouteFGAConfig maps common routes (agents, workflows, tools, MCP tools, stored resources, memory threads, responses/conversations) to resource+permission pairs so protected routes can be checked without per-route fga blocks.
  - server-adapter now uses the built-in resolver at request time and for startup coverage validation; redundant per-route fga blocks removed while preserving agent-scoped and MCP tool resource IDs.
- FGA enforcement refactor & fail-closed semantics
  - Introduced requireFGA(options) (packages/core/src/auth/ee/fga-check.ts); checkFGA delegates to it. requireFGA accepts requestContext + metadata and fail-closes (throws FGADeniedError) when an FGA provider exists but no authenticated user.
  - FGADeniedError gains an optional reason for standardized messages.
- Provider boundary hardening
  - WorkOS provider: when WorkOS reports missing FGA resources (entity_not_found / 404), checks produce denials (check() returns denial; require() throws FGADeniedError) instead of provider-specific 500s.
- Integrations updated to use richer context/metadata
  - Agents, workflows, CoreToolBuilder/tools, memory threads updated to call requireFGA with merged context/metadata (agentId, workflowId, runId, threadId, executionResourceId, resourceId, etc.), aligning direct execution and resume paths with runtime resource scopes.
- Stored-resource scoping
  - Added StoredResourceScopeConfig and StoredResourcesConfig to ServerConfig (packages/core/src/server/types.ts).
  - New utilities: getStoredResourceScope, scopeStoredResourceMetadata, assertStoredResourceScope (packages/server/src/server/utils.ts).
  - Many stored-* route handlers and version endpoints (agents, mcp-clients, prompt-blocks, scorers, skills, workspaces, etc.) now thread requestContext, derive scope, scope persisted metadata, and assert scope on reads/updates/deletes.
  - Tests updated to cover stored-route FGA/metadata resolution and scoping behavior; server-adapter tests added for built-in stored route derivation.
- Permissions generation and generated permissions
  - Permission generator recognizes publish, includes share in ACTIONS, and expands stored:* families and compound permission patterns (packages/server/scripts/permission-generator.ts).
  - Generated permissions updated: removed agent-builder, auth, and infrastructure families; reorganized stored-...:share patterns and adjusted PERMISSIONS/Permission unions (packages/core/src/auth/ee/interfaces/permissions.generated.ts).
- Tests, docs, and release notes
  - Added/updated tests for built-in route FGA derivation, fail-closed semantics (agents, tools, workflows, memory), permission derivation, and stored-resource scoping.
  - Documentation expanded for FGA setup, stored-resource scoping, enforcement points, and examples (docs/src/content/en/docs/server/auth/fga.mdx).
- Misc
  - Preserved stored resource metadata on partial updates (merge-incoming-with-existing), avoided duplicate fetches by reusing resolved stored objects for checks, updated changesets, and minor export/comment refactors.

Labels: bug fix, new feature, documentation update, test update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16651)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->