### PR TITLE
fix(core): transform <system-reminder> tags for Azure OpenAI to avoid content moderation

### DIFF
--- a/.changeset/some-regions-yawn.md
+++ b/.changeset/some-regions-yawn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Azure OpenAI content moderation false-positives caused by `<system-reminder>` tags in Observational Memory and temporal gap markers. When using Azure OpenAI, these tags are now renamed to `<memory-context>` on the outbound request only — persisted history and other providers are unaffected.

--- a/packages/core/src/processors/provider-history-compat.test.ts
+++ b/packages/core/src/processors/provider-history-compat.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, it } from 'vitest';
 import { MessageList } from '../agent/message-list';
 import {
   anthropicStripForeignReasoningContent,
+  azureSystemReminderTransform,
   cerebrasStripReasoningContent,
   isMaybeAnthropic,
+  isMaybeAzure,
   isMaybeCerebras,
   ProviderHistoryCompat,
 } from './provider-history-compat';
@@ -630,5 +632,184 @@ describe('ProcessorRunner.runProcessLLMRequest', () => {
 
     const assistant = result.prompt.find(m => m.role === 'assistant')!;
     expect((assistant.content as any[]).map(p => p.type)).toEqual(['reasoning', 'text']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isMaybeAzure
+// ---------------------------------------------------------------------------
+
+describe('isMaybeAzure', () => {
+  it('matches gateway-prefixed azure model id strings', () => {
+    expect(isMaybeAzure('azure/gpt-4o')).toBe(true);
+    expect(isMaybeAzure('azure:gpt-4o')).toBe(true);
+  });
+
+  it('matches resolved language model objects with azure provider', () => {
+    expect(isMaybeAzure({ provider: 'azure.chat', modelId: 'gpt-4o' })).toBe(true);
+    expect(isMaybeAzure({ provider: 'azure', modelId: 'gpt-4o' })).toBe(true);
+    expect(isMaybeAzure({ provider: 'azure.openai', modelId: 'gpt-4o' })).toBe(true);
+  });
+
+  it('matches object-shaped models with generic providers and azure-prefixed model IDs', () => {
+    expect(isMaybeAzure({ provider: 'openai-compatible.chat', modelId: 'azure/gpt-4o' })).toBe(true);
+  });
+
+  it('does not match non-azure providers', () => {
+    expect(isMaybeAzure('openai/gpt-4o')).toBe(false);
+    expect(isMaybeAzure({ provider: 'openai.chat', modelId: 'gpt-4o' })).toBe(false);
+    expect(isMaybeAzure('azure-foo')).toBe(false);
+  });
+
+  it('returns false for unknown shapes', () => {
+    expect(isMaybeAzure(undefined)).toBe(false);
+    expect(isMaybeAzure(null)).toBe(false);
+    expect(isMaybeAzure(() => 'azure/gpt-4o')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// azureSystemReminderTransform rule
+// ---------------------------------------------------------------------------
+
+const OM_CONTINUATION = '<system-reminder>You are in the middle of an observation, please continue.</system-reminder>';
+const TEMPORAL_GAP = '<system-reminder type="temporal-gap" precedesMessageId="msg-1">2 hours passed.</system-reminder>';
+
+function promptWithSystemReminder(text: string): LanguageModelV2Prompt {
+  return [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+    { role: 'user', content: [{ type: 'text', text: text }] },
+  ];
+}
+
+describe('azureSystemReminderTransform', () => {
+  it('renames <system-reminder> tags to <memory-context> in user message text parts', () => {
+    const result = azureSystemReminderTransform.applyToPrompt!({
+      prompt: promptWithSystemReminder(OM_CONTINUATION),
+      model: { provider: 'azure.chat', modelId: 'gpt-4o' },
+    });
+
+    expect(result).toBeDefined();
+    const lastUser = result!.filter(m => m.role === 'user').at(-1)!;
+    const text = (lastUser.content as any[])[0].text as string;
+    expect(text).toContain('<memory-context>');
+    expect(text).toContain('</memory-context>');
+    expect(text).not.toContain('<system-reminder>');
+    expect(text).not.toContain('</system-reminder>');
+  });
+
+  it('preserves attributes on the opening tag (temporal gap markers)', () => {
+    const result = azureSystemReminderTransform.applyToPrompt!({
+      prompt: promptWithSystemReminder(TEMPORAL_GAP),
+      model: { provider: 'azure.chat', modelId: 'gpt-4o' },
+    });
+
+    expect(result).toBeDefined();
+    const lastUser = result!.filter(m => m.role === 'user').at(-1)!;
+    const text = (lastUser.content as any[])[0].text as string;
+    expect(text).toContain('<memory-context type="temporal-gap" precedesMessageId="msg-1">');
+    expect(text).toContain('</memory-context>');
+    expect(text).not.toContain('system-reminder');
+  });
+
+  it('handles a message with both OM hint and temporal gap in separate user messages', () => {
+    const prompt: LanguageModelV2Prompt = [
+      { role: 'user', content: [{ type: 'text', text: TEMPORAL_GAP }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'user', content: [{ type: 'text', text: OM_CONTINUATION }] },
+    ];
+
+    const result = azureSystemReminderTransform.applyToPrompt!({
+      prompt,
+      model: { provider: 'azure.chat', modelId: 'gpt-4o' },
+    });
+
+    expect(result).toBeDefined();
+    const userMessages = result!.filter(m => m.role === 'user');
+    for (const msg of userMessages) {
+      const text = (msg.content as any[])[0].text as string;
+      expect(text).not.toContain('system-reminder');
+      expect(text).toContain('memory-context');
+    }
+  });
+
+  it('does not touch non-user messages (system and assistant)', () => {
+    const systemContent = 'You are a helpful assistant.';
+    const prompt: LanguageModelV2Prompt = [
+      { role: 'system', content: systemContent },
+      { role: 'user', content: [{ type: 'text', text: OM_CONTINUATION }] },
+      { role: 'assistant', content: [{ type: 'text', text: OM_CONTINUATION }] },
+    ];
+
+    const result = azureSystemReminderTransform.applyToPrompt!({
+      prompt,
+      model: { provider: 'azure.chat', modelId: 'gpt-4o' },
+    });
+
+    expect(result).toBeDefined();
+    const sys = result![0]!;
+    expect(sys.content).toBe(systemContent);
+    const asst = result!.find(m => m.role === 'assistant')!;
+    expect((asst.content as any[])[0].text).toBe(OM_CONTINUATION);
+  });
+
+  it('returns undefined when no system-reminder tags are present', () => {
+    const result = azureSystemReminderTransform.applyToPrompt!({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'just a normal message' }] }],
+      model: { provider: 'azure.chat', modelId: 'gpt-4o' },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when model is not Azure', () => {
+    const result = azureSystemReminderTransform.applyToPrompt!({
+      prompt: promptWithSystemReminder(OM_CONTINUATION),
+      model: { provider: 'openai.chat', modelId: 'gpt-4o' },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('does not mutate the original prompt', () => {
+    const original = promptWithSystemReminder(OM_CONTINUATION);
+    const originalJson = JSON.stringify(original);
+
+    azureSystemReminderTransform.applyToPrompt!({
+      prompt: original,
+      model: { provider: 'azure.chat', modelId: 'gpt-4o' },
+    });
+
+    expect(JSON.stringify(original)).toBe(originalJson);
+  });
+});
+
+describe('ProviderHistoryCompat.processLLMRequest (Azure)', () => {
+  it('transforms system-reminder tags on azure models', () => {
+    const handler = new ProviderHistoryCompat();
+    const args = makeRequestArgs(promptWithSystemReminder(OM_CONTINUATION), {
+      provider: 'azure.chat',
+      modelId: 'gpt-4o',
+    });
+
+    const result = handler.processLLMRequest(args);
+
+    expect(result).toBeDefined();
+    const lastUser = (result as { prompt: LanguageModelV2Prompt }).prompt.filter(m => m.role === 'user').at(-1)!;
+    const text = (lastUser.content as any[])[0].text as string;
+    expect(text).toContain('<memory-context>');
+    expect(text).not.toContain('<system-reminder>');
+  });
+
+  it('returns undefined for non-azure models with system-reminder tags', () => {
+    const handler = new ProviderHistoryCompat();
+    const args = makeRequestArgs(promptWithSystemReminder(OM_CONTINUATION), {
+      provider: 'openai.chat',
+      modelId: 'gpt-4o',
+    });
+
+    expect(handler.processLLMRequest(args)).toBeUndefined();
   });
 });

--- a/packages/core/src/processors/provider-history-compat.ts
+++ b/packages/core/src/processors/provider-history-compat.ts
@@ -221,6 +221,17 @@ export function isMaybeAnthropic(
   return matchesProviderPrefix(model, 'anthropic');
 }
 
+export function isMaybeAzure(
+  model:
+    | string
+    | { provider?: string; modelId?: string }
+    | ((...args: any[]) => any)
+    | { model: any; enabled?: boolean }[]
+    | unknown,
+): boolean {
+  return matchesProviderPrefix(model, 'azure');
+}
+
 /**
  * Returns a copy of the prompt with selected `reasoning` parts stripped from
  * assistant messages. Returns `undefined` if no changes were necessary.
@@ -306,6 +317,64 @@ export const anthropicStripForeignReasoningContent: CompatRule = {
 };
 
 // ---------------------------------------------------------------------------
+// Built-in rule: Azure OpenAI <system-reminder> tag transform
+// ---------------------------------------------------------------------------
+
+/**
+ * Renames `<system-reminder>` opening and closing tags to `<memory-context>`
+ * in a text string, preserving any attributes on the opening tag.
+ */
+function renameSystemReminderTags(text: string): string {
+  return text
+    .replaceAll('<system-reminder>', '<memory-context>')
+    .replaceAll(/<system-reminder(\s[^>]+)>/g, '<memory-context$1>')
+    .replaceAll('</system-reminder>', '</memory-context>');
+}
+
+function transformSystemReminderInPrompt(prompt: LanguageModelV2Prompt): LanguageModelV2Prompt | undefined {
+  let mutated = false;
+  const next: LanguageModelV2Prompt = prompt.map(message => {
+    if (message.role !== 'user') return message;
+
+    let partsMutated = false;
+    const newContent = message.content.map(part => {
+      if (part.type !== 'text') return part;
+      const transformed = renameSystemReminderTags(part.text);
+      if (transformed !== part.text) {
+        partsMutated = true;
+        return { ...part, text: transformed };
+      }
+      return part;
+    });
+
+    if (partsMutated) {
+      mutated = true;
+      return { ...message, content: newContent };
+    }
+    return message;
+  });
+  return mutated ? next : undefined;
+}
+
+/**
+ * Azure OpenAI's content-moderation layer treats `<system-reminder>` as a
+ * prompt-injection signal and responds with a canned refusal.
+ *
+ * Mastra injects `<system-reminder>` into user messages for Observational
+ * Memory continuation hints and temporal gap markers. This rule renames
+ * the tag to `<memory-context>` in the outbound prompt for Azure models.
+ * The rename is wire-only — persisted history and other providers retain
+ * the original tag so Anthropic and distilled models see what they expect.
+ */
+export const azureSystemReminderTransform: CompatRule = {
+  name: 'azure-system-reminder-transform',
+  applyToPrompt({ prompt, model }) {
+    if (!isMaybeAzure(model)) return undefined;
+    return transformSystemReminderInPrompt(prompt);
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Default rule set
 // ---------------------------------------------------------------------------
 
@@ -317,6 +386,7 @@ export const DEFAULT_COMPAT_RULES: CompatRule[] = [
   anthropicToolIdFormat,
   cerebrasStripReasoningContent,
   anthropicStripForeignReasoningContent,
+  azureSystemReminderTransform,
 ];
 
 // ---------------------------------------------------------------------------
@@ -343,6 +413,10 @@ export const DEFAULT_COMPAT_RULES: CompatRule[] = [
  * - **anthropic-strip-foreign-reasoning-content** — strips non-Anthropic
  *   `reasoning` parts from assistant messages in the outbound prompt when the
  *   resolved model is Anthropic. Anthropic-native reasoning parts are kept.
+ * - **azure-system-reminder-transform** — renames `<system-reminder>` tags to
+ *   `<memory-context>` in user message text parts when the resolved model is
+ *   Azure, to avoid content-moderation false-positives. Wire-only; persisted
+ *   history is unchanged.
  *
  * To add custom rules, pass them to the constructor:
  * ```ts


### PR DESCRIPTION
Fixes #16531

Azure's content moderation flags `<system-reminder>` as a prompt-injection signal and returns a canned refusal instead of the model's output. This happens for both Observational Memory continuation hints and temporal gap markers, which both inject `<system-reminder>` tags into user messages.

Added a new `azureSystemReminderTransform` CompatRule in `ProviderHistoryCompat` that renames the tag to `<memory-context>` in the outbound prompt when the resolved model is Azure. The rename is wire-only — persisted history and other providers (Anthropic, distilled models) are unaffected and keep seeing `<system-reminder>` as intended.

Before (sent to Azure):
```
<system-reminder>You are in the middle of an observation...</system-reminder>
```

After (sent to Azure):
```
<memory-context>You are in the middle of an observation...</memory-context>
```

Also exports `isMaybeAzure` for consistency with the existing `isMaybeCerebras` and `isMaybeAnthropic` helpers.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a problem where Azure OpenAI incorrectly rejects messages from an AI library because it thinks a special internal tag (`<system-reminder>`) is a hacking attempt. The fix renames these tags to `<memory-context>` only when sending requests to Azure, so Azure doesn't reject them. The change only affects what gets sent to Azure; everything stored in history and sent to other AI providers stays the same.

---

## Overview

This change fixes Azure OpenAI's false-positive content moderation flagging on Observational Memory continuation hints and temporal gap markers. When the library sends requests containing `<system-reminder>` tags to Azure OpenAI, Azure's content moderation layer treats them as potential prompt injection, causing the model to return canned refusals instead of intended outputs.

The fix implements a wire-only transformation: `<system-reminder>` tags are rewritten to `<memory-context>` only for outbound Azure OpenAI requests, while persisted history and all other providers (Anthropic, distilled models, etc.) continue using the original `<system-reminder>` tags.

## Changes Made

**Core Implementation (`provider-history-compat.ts`):**
- Added `isMaybeAzure()` helper function to detect Azure OpenAI models by string patterns (`azure/<...>` or `azure:<...>`), provider objects, and other model configurations
- Implemented `azureSystemReminderTransform` CompatRule that:
  - Targets user message text parts containing `<system-reminder>` tags
  - Rewrites opening tags to `<memory-context>` while preserving all attributes (e.g., temporal-gap markers)
  - Leaves non-user messages and non-Azure requests unchanged
  - Returns `undefined` when no transformation is needed (avoiding unnecessary mutations)
- Registered the new rule in `DEFAULT_COMPAT_RULES` for automatic application

**Test Coverage (`provider-history-compat.test.ts`):**
- Added `isMaybeAzure` test suite covering model ID patterns, provider-shaped objects, and non-Azure cases
- Added `azureSystemReminderTransform` test suite verifying:
  - Tag rewriting with attribute preservation
  - Correct handling of tags across multiple user messages
  - Non-mutation of original prompt
  - Proper behavior when tags are absent or model is non-Azure
- Added integration tests for `ProviderHistoryCompat.processLLMRequest` with Azure models

**Release Documentation (`.changeset`):**
- Added patch release entry documenting the Azure OpenAI content moderation fix

## Impact

- Resolves issue #16531: Observational memory can now continue on Azure OpenAI without triggering content moderation refusals
- No breaking changes; persisted history format remains unchanged
- Other providers and stored data unaffected
- Exports `isMaybeAzure` and `azureSystemReminderTransform` for potential reuse in other compatibility rules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16653)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->