### PR TITLE
fix: improve goal mode judge UX

### DIFF
--- a/.changeset/goal-judge-ux.md
+++ b/.changeset/goal-judge-ux.md
@@ -1,0 +1,5 @@
+---
+"mastracode": patch
+---
+
+Improve goal mode UX with `/goal` actions, built-in subcommand autocomplete, goal-aware planning guidance, full-response judge evaluation, readonly judge workspace verification, live judge activity, Ctrl+C judge aborts, duration-based goal status, and clearer plan approval rendering.

--- a/.changeset/goal-judge-ux.md
+++ b/.changeset/goal-judge-ux.md
@@ -2,4 +2,4 @@
 "mastracode": patch
 ---
 
-Improve goal mode UX with `/goal` actions, built-in subcommand autocomplete, goal-aware planning guidance, full-response judge evaluation, readonly judge workspace verification, live judge activity, Ctrl+C judge aborts, duration-based goal status, and clearer plan approval rendering with streamed plan previews.
+Improve goal mode UX with `/goal` actions, built-in subcommand autocomplete, goal-aware planning guidance, full-response judge evaluation, readonly judge workspace verification, live muted judge activity, Ctrl+C judge aborts, duration-based goal status, and clearer plan approval rendering with streamed plan previews.

--- a/.changeset/goal-judge-ux.md
+++ b/.changeset/goal-judge-ux.md
@@ -2,4 +2,4 @@
 "mastracode": patch
 ---
 
-Improve goal mode UX with `/goal` actions, built-in subcommand autocomplete, goal-aware planning guidance, full-response judge evaluation, readonly judge workspace verification, live judge activity, Ctrl+C judge aborts, duration-based goal status, and clearer plan approval rendering.
+Improve goal mode UX with `/goal` actions, built-in subcommand autocomplete, goal-aware planning guidance, full-response judge evaluation, readonly judge workspace verification, live judge activity, Ctrl+C judge aborts, duration-based goal status, and clearer plan approval rendering with streamed plan previews.

--- a/.changeset/goal-judge-ux.md
+++ b/.changeset/goal-judge-ux.md
@@ -2,4 +2,10 @@
 "mastracode": patch
 ---
 
-Improve goal mode UX with `/goal` actions, built-in subcommand autocomplete, goal-aware planning guidance, full-response judge evaluation, readonly judge workspace verification, live muted judge activity, Ctrl+C judge aborts, duration-based goal status, and clearer plan approval rendering with streamed plan previews.
+Improve goal mode UX:
+
+- Add `/goal` actions and built-in subcommand autocomplete.
+- Add goal-aware planning guidance so submitted plans can be used as executable goals.
+- Let the judge evaluate full assistant responses and verify work with readonly workspace tools.
+- Stream muted judge activity into the goal box and support Ctrl+C judge aborts.
+- Show duration-based goal status and clearer plan approval rendering with streamed plan previews.

--- a/mastracode/src/agents/__tests__/prompts.test.ts
+++ b/mastracode/src/agents/__tests__/prompts.test.ts
@@ -91,6 +91,53 @@ describe('buildFullPrompt', () => {
     expect(prompt).not.toContain('<coding_behavior>');
   });
 
+  it('describes goal mode and goal-ready plan expectations in the base prompt', () => {
+    const prompt = buildFullPrompt({
+      projectPath: '/tmp/project',
+      projectName: 'test-project',
+      gitBranch: 'main',
+      platform: 'darwin',
+      date: '2026-03-23',
+      mode: 'build',
+      activePlan: null,
+      modeId: 'build',
+      currentDate: '2026-03-23',
+      workingDir: '/tmp/project',
+      state: {
+        permissionRules: { tools: {} },
+      },
+    });
+
+    expect(prompt).toContain('## Goal Mode Awareness');
+    expect(prompt).toContain('A goal is a persistent objective');
+    expect(prompt).toContain('submit_plan tool may also be started as a goal');
+    expect(prompt).toContain('make them goal-ready');
+    expect(prompt).toContain('concrete, outcome-focused, verifiable, and bounded');
+  });
+
+  it('includes goal mode as a submit_plan approval option in plan mode', () => {
+    const prompt = buildFullPrompt({
+      projectPath: '/tmp/project',
+      projectName: 'test-project',
+      gitBranch: 'main',
+      platform: 'darwin',
+      date: '2026-03-23',
+      mode: 'plan',
+      activePlan: null,
+      modeId: 'plan',
+      currentDate: '2026-03-23',
+      workingDir: '/tmp/project',
+      state: {
+        permissionRules: { tools: {} },
+      },
+    });
+
+    expect(prompt).toContain('## Goal-Ready Plans');
+    expect(prompt).toContain('The submit_plan approval UI can let the user approve the plan normally or start it as a persistent goal');
+    expect(prompt).toContain('**Start as goal**');
+    expect(prompt).toContain('goal judge can tell when the work is done');
+  });
+
   it('includes common binary availability in environment details', () => {
     const prompt = buildFullPrompt({
       projectPath: '/tmp/project',

--- a/mastracode/src/agents/__tests__/prompts.test.ts
+++ b/mastracode/src/agents/__tests__/prompts.test.ts
@@ -133,7 +133,9 @@ describe('buildFullPrompt', () => {
     });
 
     expect(prompt).toContain('## Goal-Ready Plans');
-    expect(prompt).toContain('The submit_plan approval UI can let the user approve the plan normally or start it as a persistent goal');
+    expect(prompt).toContain(
+      'The submit_plan approval UI can let the user approve the plan normally or start it as a persistent goal',
+    );
     expect(prompt).toContain('**Start as goal**');
     expect(prompt).toContain('goal judge can tell when the work is done');
   });

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -44,6 +44,13 @@ ${ctx.toolGuidance}
 - For unfamiliar codebases, check git log to understand recent changes and patterns.
 - Identify existing conventions (naming, structure, error handling) and follow them.
 
+## Goal Mode Awareness
+- Mastra Code has a goal mode for longer-running work. A goal is a persistent objective that the agent continues pursuing across turns until a judge decides the goal is complete, should continue, should pause, or should wait for user input.
+- Users can start goal mode directly with /goal <objective>. In plan mode, plans submitted with the submit_plan tool may also be started as a goal if the user selects that option in the approval UI.
+- Help users create good goals by making objectives concrete, outcome-focused, verifiable, and bounded. Prefer goals that state the desired end state, relevant constraints, and what proof or verification should be produced.
+- When writing implementation plans, make them goal-ready: structure steps so they can be carried out autonomously after approval, include clear verification criteria, call out risks/blockers, and avoid vague instructions that would leave the goal judge unable to determine completion.
+- If a proposed goal is too broad or ambiguous to pursue safely, ask a focused clarification or suggest a tighter objective.
+
 # Coding Philosophy
 
 - **Avoid over-engineering.** Only make changes that are directly requested or clearly necessary.

--- a/mastracode/src/agents/prompts/plan.ts
+++ b/mastracode/src/agents/prompts/plan.ts
@@ -26,6 +26,14 @@ Before writing any plan, build a mental model of the codebase:
 4. Trace data flow: where does input come from, how is it transformed, where does it go?
 5. Identify existing patterns the codebase uses (naming, structure, error handling, testing).
 
+## Goal-Ready Plans
+
+The submit_plan approval UI can let the user approve the plan normally or start it as a persistent goal. Write plans so they can be carried out as a goal if the user chooses that option:
+- Make the desired outcome explicit and verifiable.
+- Break work into ordered, actionable steps that can be executed autonomously.
+- Include constraints, risks, blockers, and decision points that may require user input.
+- Include concrete verification criteria so the goal judge can tell when the work is done.
+
 ## Your Plan Output
 
 Produce a clear, step-by-step plan with this structure:
@@ -65,6 +73,7 @@ submit_plan({
 
 The user will see the plan rendered inline and can:
 - **Approve** — automatically switches to Build mode for implementation
+- **Start as goal** — approves the plan and enters goal mode so the agent keeps working toward the plan until judged complete, paused, or waiting for user input
 - **Reject** — stays in Plan mode
 - **Request changes** — provides feedback for you to revise and resubmit
 

--- a/mastracode/src/tui/__tests__/goal-manager.test.ts
+++ b/mastracode/src/tui/__tests__/goal-manager.test.ts
@@ -168,7 +168,8 @@ describe('GoalManager', () => {
     const result = await manager.evaluateAfterTurn(state);
 
     const expectedThreadId = `parent-thread-${goal.id}`;
-    expect(mocks.stream).toHaveBeenCalledWith(expect.stringContaining('Latest assistant message'),
+    expect(mocks.stream).toHaveBeenCalledWith(
+      expect.stringContaining('Latest assistant message'),
       expect.objectContaining({
         memory: { thread: expectedThreadId, resource: 'resource-1' },
         structuredOutput: { schema: expect.any(Object) },
@@ -285,9 +286,7 @@ describe('GoalManager', () => {
     expect(onActivity).toHaveBeenCalledWith('read src/file.ts');
     expect(onActivity).toHaveBeenCalledWith('search "TODO"');
     expect(onActivity).toHaveBeenCalledWith('find files **/*.ts');
-    expect(mocks.stream.mock.calls[0]?.[1]).toEqual(
-      expect.objectContaining({ abortSignal: abortController.signal }),
-    );
+    expect(mocks.stream.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ abortSignal: abortController.signal }));
   });
 
   it('includes guidance to wait after answering a user question', async () => {

--- a/mastracode/src/tui/__tests__/goal-manager.test.ts
+++ b/mastracode/src/tui/__tests__/goal-manager.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   stream: vi.fn(),
   agentConstructor: vi.fn(),
+  createWorkspaceTools: vi.fn(),
 }));
 
 vi.mock('@mastra/core/agent', () => ({
@@ -18,6 +19,34 @@ vi.mock('@mastra/core/processors', () => ({
   },
   StreamErrorRetryProcessor: class {
     readonly id = 'stream-error-retry-processor';
+  },
+}));
+
+vi.mock('@mastra/core/workspace', () => ({
+  createWorkspaceTools: mocks.createWorkspaceTools,
+  WORKSPACE_TOOLS: {
+    FILESYSTEM: {
+      READ_FILE: 'filesystem.read_file',
+      WRITE_FILE: 'filesystem.write_file',
+      EDIT_FILE: 'filesystem.edit_file',
+      DELETE_FILE: 'filesystem.delete_file',
+      LIST_FILES: 'filesystem.list_files',
+      CREATE_DIRECTORY: 'filesystem.create_directory',
+      GET_FILE_INFO: 'filesystem.get_file_info',
+      SEARCH_FILES: 'filesystem.search_files',
+      AST_EDIT: 'filesystem.ast_edit',
+    },
+    SANDBOX: {
+      EXECUTE_COMMAND: 'sandbox.execute_command',
+      GET_PROCESS_OUTPUT: 'sandbox.get_process_output',
+      KILL_PROCESS: 'sandbox.kill_process',
+    },
+    LSP: { INSPECT: 'lsp.inspect' },
+    SKILLS: {
+      ACTIVATE: 'skills.activate',
+      SEARCH: 'skills.search',
+      READ: 'skills.read',
+    },
   },
 }));
 
@@ -53,6 +82,7 @@ describe('GoalManager', () => {
   beforeEach(() => {
     mocks.stream.mockReset();
     mocks.agentConstructor.mockReset();
+    mocks.createWorkspaceTools.mockReset();
   });
 
   it('preserves turn count when resuming a paused goal', () => {
@@ -138,10 +168,12 @@ describe('GoalManager', () => {
     const result = await manager.evaluateAfterTurn(state);
 
     const expectedThreadId = `parent-thread-${goal.id}`;
-    expect(mocks.stream).toHaveBeenCalledWith(expect.stringContaining('Latest assistant message'), {
-      memory: { thread: expectedThreadId, resource: 'resource-1' },
-      structuredOutput: { schema: expect.any(Object) },
-    });
+    expect(mocks.stream).toHaveBeenCalledWith(expect.stringContaining('Latest assistant message'),
+      expect.objectContaining({
+        memory: { thread: expectedThreadId, resource: 'resource-1' },
+        structuredOutput: { schema: expect.any(Object) },
+      }),
+    );
     expect(mocks.stream).toHaveBeenCalledWith(expect.stringContaining('Latest user message'), expect.any(Object));
     expect(mocks.stream).toHaveBeenCalledWith(
       expect.stringContaining('Can you explain what kind of feedback you need?'),
@@ -167,6 +199,115 @@ describe('GoalManager', () => {
     expect(manager.getGoal()?.turnsUsed).toBe(1);
     expect(result.continuation).toContain('[Goal attempt 1/50]');
     expect(result.continuation).toContain('Need one more step.');
+  });
+
+  it('passes full assistant content to the judge without truncating', async () => {
+    mocks.stream.mockResolvedValue({
+      consumeStream: vi.fn().mockResolvedValue(undefined),
+      getFullOutput: vi.fn().mockResolvedValue({ object: { decision: 'done', reason: 'Complete.' } }),
+    });
+    mocks.agentConstructor.mockImplementation(function () {
+      return { stream: mocks.stream };
+    });
+    const longAssistant = 'x'.repeat(4500);
+    const state = createState({
+      listMessages: vi.fn().mockResolvedValue([
+        { role: 'user', content: [{ type: 'text', text: 'Finish this.' }] },
+        { role: 'assistant', content: [{ type: 'text', text: longAssistant }] },
+      ]),
+    } as Partial<TUIState['harness']>);
+    const manager = new GoalManager();
+    manager.setGoal('finish the task', 'openai/gpt-5.4-mini');
+
+    await manager.evaluateAfterTurn(state);
+
+    expect(mocks.stream).toHaveBeenCalledWith(expect.stringContaining(longAssistant), expect.any(Object));
+    expect(mocks.stream.mock.calls[0]?.[0]).not.toContain('[truncated]');
+  });
+
+  it('configures the judge with only readonly workspace tools and disables approvals', async () => {
+    mocks.stream.mockResolvedValue({
+      consumeStream: vi.fn().mockResolvedValue(undefined),
+      getFullOutput: vi.fn().mockResolvedValue({ object: { decision: 'done', reason: 'Complete.' } }),
+    });
+    mocks.agentConstructor.mockImplementation(function () {
+      return { stream: mocks.stream };
+    });
+    mocks.createWorkspaceTools.mockResolvedValue({
+      view: { id: 'view', requireApproval: true, needsApprovalFn: vi.fn() },
+      search_content: { id: 'search_content', requireApproval: true },
+      find_files: { id: 'find_files', requireApproval: false },
+      file_stat: { id: 'file_stat', requireApproval: true },
+      lsp_inspect: { id: 'lsp_inspect', requireApproval: true },
+      write_file: { id: 'write_file', requireApproval: false },
+      execute_command: { id: 'execute_command', requireApproval: false },
+    });
+    const workspace = { id: 'workspace' };
+    const state = createState({ getWorkspace: vi.fn(() => workspace) } as Partial<TUIState['harness']>);
+    const manager = new GoalManager();
+    manager.setGoal('finish the task', 'openai/gpt-5.4-mini');
+
+    await manager.evaluateAfterTurn(state);
+
+    expect(mocks.createWorkspaceTools).toHaveBeenCalledWith(workspace, { requestContext: {}, workspace });
+    const agentConfig = mocks.agentConstructor.mock.calls[0]?.[0] as { tools?: Record<string, any> } | undefined;
+    expect(Object.keys(agentConfig?.tools ?? {}).sort()).toEqual([
+      'file_stat',
+      'find_files',
+      'lsp_inspect',
+      'search_content',
+      'view',
+    ]);
+    expect(agentConfig?.tools?.view.requireApproval).toBe(false);
+    expect(agentConfig?.tools?.view.needsApprovalFn).toBeUndefined();
+  });
+
+  it('reports judge activity for readonly tool calls and passes abort signal', async () => {
+    const fullStream = (async function* () {
+      yield { type: 'tool-call', payload: { toolName: 'view', args: { path: 'src/file.ts' } } };
+      yield { type: 'tool-call', payload: { toolName: 'search_content', args: { pattern: 'TODO' } } };
+      yield { type: 'tool-call', toolName: 'find_files', input: { pattern: '**/*.ts' } };
+    })();
+    mocks.stream.mockResolvedValue({
+      fullStream,
+      getFullOutput: vi.fn().mockResolvedValue({ object: { decision: 'done', reason: 'Complete.' } }),
+    });
+    mocks.agentConstructor.mockImplementation(function () {
+      return { stream: mocks.stream };
+    });
+    const abortController = new AbortController();
+    const onActivity = vi.fn();
+    const manager = new GoalManager();
+    manager.setGoal('finish the task', 'openai/gpt-5.4-mini');
+
+    await manager.evaluateAfterTurn(createState(), { abortSignal: abortController.signal, onActivity });
+
+    expect(onActivity).toHaveBeenCalledWith('read src/file.ts');
+    expect(onActivity).toHaveBeenCalledWith('search "TODO"');
+    expect(onActivity).toHaveBeenCalledWith('find files **/*.ts');
+    expect(mocks.stream.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    );
+  });
+
+  it('includes guidance to wait after answering a user question', async () => {
+    mocks.stream.mockResolvedValue({
+      consumeStream: vi.fn().mockResolvedValue(undefined),
+      getFullOutput: vi.fn().mockResolvedValue({ object: { decision: 'waiting', reason: 'Answered user question.' } }),
+    });
+    mocks.agentConstructor.mockImplementation(function () {
+      return { stream: mocks.stream };
+    });
+    const manager = new GoalManager();
+    manager.setGoal('finish the task', 'openai/gpt-5.4-mini');
+
+    await manager.evaluateAfterTurn(createState());
+
+    expect(mocks.agentConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instructions: expect.stringContaining('latest user message asks a question or requests clarification'),
+      }),
+    );
   });
 
   it('configures provider compatibility and retry processors on the judge agent', async () => {

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -8,11 +8,13 @@ vi.mock('node:fs', () => ({
   default: {},
 }));
 
-const autocompleteProviders: Array<{ commands: Array<{ name: string; description: string }> }> = [];
+const autocompleteProviders: Array<{
+  commands: Array<{ name: string; description: string; getArgumentCompletions?: (prefix: string) => Array<{ value: string }> }>;
+}> = [];
 
 vi.mock('@mariozechner/pi-tui', () => ({
   CombinedAutocompleteProvider: class {
-    constructor(commands: Array<{ name: string; description: string }>) {
+    constructor(commands: Array<{ name: string; description: string; getArgumentCompletions?: (prefix: string) => Array<{ value: string }> }>) {
       autocompleteProviders.push({ commands });
     }
   },
@@ -113,6 +115,16 @@ describe('setupKeyboardShortcuts', () => {
     expect(commandNames[0]).toBe('new');
     expect(commandNames).toContain('thread');
     expect(commandNames).toContain('judge');
+    const goalCommand = autocompleteProviders[0]?.commands.find(command => command.name === 'goal') as
+      | { getArgumentCompletions?: (prefix: string) => Array<{ value: string }> }
+      | undefined;
+    expect(goalCommand?.getArgumentCompletions?.('').map(command => command.value)).toEqual([
+      'status',
+      'pause',
+      'resume',
+      'clear',
+    ]);
+    expect(goalCommand?.getArgumentCompletions?.('pa').map(command => command.value)).toEqual(['pause']);
     expect(commandNames.indexOf('thread')).toBeLessThan(commandNames.indexOf('threads'));
     expect(commandNames.indexOf('goal')).toBeLessThan(commandNames.indexOf('judge'));
     expect(commandNames).not.toContain('memory-gateway');
@@ -222,6 +234,29 @@ describe('setupKeyboardShortcuts', () => {
     expect(editor.setText).not.toHaveBeenCalled();
     expect(queueFollowUpMessage).not.toHaveBeenCalled();
     expect(showInfo).toHaveBeenCalledWith(state, GOAL_JUDGE_INPUT_LOCK_MESSAGE);
+    expect(state.ui.requestRender).toHaveBeenCalled();
+  });
+
+  it('aborts an active goal judge even when the harness is idle', () => {
+    const { state, editor, actions } = createState(false);
+    const abortController = new AbortController();
+    const component = { setInterrupted: vi.fn() };
+    state.activeGoalJudge = { modelId: 'openai/gpt-5.5', abortController, component };
+    editor.getText.mockReturnValue('');
+
+    setupKeyboardShortcuts(state, {
+      stop: vi.fn(),
+      doubleCtrlCMs: 500,
+      queueFollowUpMessage: vi.fn(),
+    });
+
+    actions.get('clear')?.();
+
+    expect(abortController.signal.aborted).toBe(true);
+    expect(component.setInterrupted).toHaveBeenCalledTimes(1);
+    expect(state.userInitiatedAbort).toBe(true);
+    expect(state.harness.abort).not.toHaveBeenCalled();
+    expect(editor.setText).not.toHaveBeenCalled();
     expect(state.ui.requestRender).toHaveBeenCalled();
   });
 

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -9,12 +9,22 @@ vi.mock('node:fs', () => ({
 }));
 
 const autocompleteProviders: Array<{
-  commands: Array<{ name: string; description: string; getArgumentCompletions?: (prefix: string) => Array<{ value: string }> }>;
+  commands: Array<{
+    name: string;
+    description: string;
+    getArgumentCompletions?: (prefix: string) => Array<{ value: string }>;
+  }>;
 }> = [];
 
 vi.mock('@mariozechner/pi-tui', () => ({
   CombinedAutocompleteProvider: class {
-    constructor(commands: Array<{ name: string; description: string; getArgumentCompletions?: (prefix: string) => Array<{ value: string }> }>) {
+    constructor(
+      commands: Array<{
+        name: string;
+        description: string;
+        getArgumentCompletions?: (prefix: string) => Array<{ value: string }>;
+      }>,
+    ) {
       autocompleteProviders.push({ commands });
     }
   },

--- a/mastracode/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/src/tui/__tests__/status-line.test.ts
@@ -90,6 +90,7 @@ function createState() {
       gitBranch: 'feat/mc-queueing-ux',
     },
     pendingQueuedActions: [],
+    goalManager: { getGoal: vi.fn(() => null) },
     ui: { requestRender: vi.fn() },
   } as any;
 }
@@ -104,6 +105,7 @@ describe('updateStatusLine', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     process.stdout.columns = originalColumns;
   });
 
@@ -208,31 +210,38 @@ describe('updateStatusLine', () => {
     expect(chalkRgbMock).toHaveBeenCalledWith(53, 117, 221);
   });
 
-  it('shows active goal attempts as 1-indexed', () => {
+  it('shows active goal duration instead of attempt count', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-05-15T12:00:00.000Z');
+    vi.setSystemTime(now);
     const state = createState();
     state.goalManager = {
-      getGoal: vi.fn(() => ({ status: 'active', turnsUsed: 0, maxTurns: 20 })),
+      getGoal: vi.fn(() => ({ status: 'active', turnsUsed: 0, maxTurns: 20, startedAt: '2026-05-15T10:50:00.000Z' })),
     };
 
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('goal attempt 1/20');
-    expect(rendered).not.toContain('goal attempt 0/20');
-    expect(rendered).not.toContain('judge 1/20');
+    expect(rendered).toContain('pursuing goal (1hr10m)');
+    expect(rendered).not.toContain('goal attempt');
+    expect(rendered).not.toContain('1/20');
+    vi.useRealTimers();
   });
 
-  it('uses a compact active goal attempt label on narrow screens', () => {
+  it('uses a compact active goal duration label on narrow screens', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T12:00:00.000Z'));
     const state = createState();
     state.goalManager = {
-      getGoal: vi.fn(() => ({ status: 'active', turnsUsed: 0, maxTurns: 20 })),
+      getGoal: vi.fn(() => ({ status: 'active', turnsUsed: 0, maxTurns: 20, startedAt: '2026-05-13T09:00:00.000Z' })),
     };
     process.stdout.columns = 35;
 
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('attempt 1/20');
-    expect(rendered).not.toContain('goal attempt 1/20');
+    expect(rendered).toContain('goal (2days3hr)');
+    expect(rendered).not.toContain('pursuing goal');
+    vi.useRealTimers();
   });
 });

--- a/mastracode/src/tui/commands/__tests__/goal.test.ts
+++ b/mastracode/src/tui/commands/__tests__/goal.test.ts
@@ -15,7 +15,87 @@ const promptMocks = vi.hoisted(() => ({
   cyclesSubmitHandler: undefined as ((value: number) => void) | undefined,
 }));
 
+const overlayMocks = vi.hoisted(() => ({
+  showModalOverlay: vi.fn(),
+}));
+
 vi.mock('../../../onboarding/settings.js', () => settingsMock);
+
+vi.mock('@mariozechner/pi-tui', () => ({
+  Box: class {
+    children: unknown[] = [];
+    constructor() {}
+    addChild(child: unknown) {
+      this.children.push(child);
+    }
+  },
+  SelectList: class {
+    onSelect?: (item: { value: string; label: string }) => void;
+    onCancel?: () => void;
+    constructor(
+      public items: Array<{ value: string; label: string }>,
+      public visibleItems: number,
+      public theme: unknown,
+    ) {}
+    handleInput() {}
+  },
+  Spacer: class {
+    constructor(public size: number) {}
+  },
+  Text: class {
+    constructor(
+      public text: string,
+      public x?: number,
+      public y?: number,
+    ) {}
+  },
+}));
+
+vi.mock('../../overlay.js', () => ({
+  showModalOverlay: overlayMocks.showModalOverlay,
+}));
+
+vi.mock('@mastra/core/agent', () => ({
+  Agent: vi.fn(),
+}));
+
+vi.mock('@mastra/core/processors', () => ({
+  PrefillErrorHandler: class {},
+  ProviderHistoryCompat: class {},
+  StreamErrorRetryProcessor: class {},
+}));
+
+vi.mock('../../../agents/model.js', () => ({
+  getModel: vi.fn(() => ({ modelId: 'mock-model' })),
+}));
+
+vi.mock('@mastra/core/workspace', () => ({
+  createWorkspaceTools: vi.fn(),
+  WORKSPACE_TOOLS: {
+    FILESYSTEM: {
+      READ_FILE: 'filesystem.read_file',
+      WRITE_FILE: 'filesystem.write_file',
+      EDIT_FILE: 'filesystem.edit_file',
+      DELETE_FILE: 'filesystem.delete_file',
+      LIST_FILES: 'filesystem.list_files',
+      CREATE_DIRECTORY: 'filesystem.create_directory',
+      GET_FILE_INFO: 'filesystem.get_file_info',
+      SEARCH_FILES: 'filesystem.search_files',
+      AST_EDIT: 'filesystem.ast_edit',
+    },
+    SANDBOX: {
+      EXECUTE_COMMAND: 'sandbox.execute_command',
+      GET_PROCESS_OUTPUT: 'sandbox.get_process_output',
+      KILL_PROCESS: 'sandbox.kill_process',
+    },
+    LSP: { INSPECT: 'lsp.inspect' },
+    SKILLS: {
+      ACTIVATE: 'skills.activate',
+      SEARCH: 'skills.search',
+      READ: 'skills.read',
+    },
+  },
+}));
 
 vi.mock('../../components/model-selector.js', () => ({
   ModelSelectorComponent: class {
@@ -66,6 +146,25 @@ describe('createGoalReminderMessage', () => {
 });
 
 describe('handleGoalCommand', () => {
+  it('opens an action modal for /goal with no arguments', async () => {
+    overlayMocks.showModalOverlay.mockClear();
+    const ctx = {
+      state: {
+        goalManager: { getGoal: vi.fn(() => null) },
+        ui: { hideOverlay: vi.fn() },
+      },
+      showInfo: vi.fn(),
+    } as any;
+
+    const result = handleGoalCommand(ctx, []);
+
+    expect(overlayMocks.showModalOverlay).toHaveBeenCalledTimes(1);
+    expect(ctx.showInfo).not.toHaveBeenCalledWith('No goal set. Use /goal <text> to set one.');
+    const modal = overlayMocks.showModalOverlay.mock.calls[0]?.[1] as { handleInput?: (data: string) => void };
+    expect(modal.handleInput).toEqual(expect.any(Function));
+    void result;
+  });
+
   it('resumes a paused goal without resetting the turn counter', async () => {
     const goal = {
       id: 'goal-1',

--- a/mastracode/src/tui/commands/goal.ts
+++ b/mastracode/src/tui/commands/goal.ts
@@ -3,13 +3,15 @@
  *
  * Usage:
  *   /goal <text>      Set a standing goal (asks for judge defaults only if unset)
- *   /goal             Show current goal status
+ *   /goal             Open goal actions
  *   /goal status      Show current goal status
  *   /goal pause       Pause the continuation loop
  *   /goal resume      Resume (resets turn counter)
  *   /goal clear       Drop the goal
  *   /judge            Set global judge model and max-attempt defaults
  */
+import { Box, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
+import type { SelectItem } from '@mariozechner/pi-tui';
 import type { HarnessMessage } from '@mastra/core/harness';
 import { loadSettings, saveSettings } from '../../onboarding/settings.js';
 import { GoalCyclesDialogComponent } from '../components/goal-cycles-dialog.js';
@@ -17,7 +19,9 @@ import { ModelSelectorComponent } from '../components/model-selector.js';
 import type { ModelItem } from '../components/model-selector.js';
 import { DEFAULT_MAX_TURNS } from '../goal-manager.js';
 import type { GoalState } from '../goal-manager.js';
+import { showModalOverlay } from '../overlay.js';
 import { promptForApiKeyIfNeeded } from '../prompt-api-key.js';
+import { getSelectListTheme, theme } from '../theme.js';
 
 import type { SlashCommandContext } from './types.js';
 
@@ -30,15 +34,14 @@ export async function handleGoalCommand(ctx: SlashCommandContext, args: string[]
   const goalManager = state.goalManager;
   const subCommand = args[0]?.toLowerCase();
 
-  // /goal (no args) or /goal status — show current state
-  if (!subCommand || subCommand === 'status') {
-    const goal = goalManager.getGoal();
-    if (!goal) {
-      ctx.showInfo('No goal set. Use /goal <text> to set one.');
-      return;
-    }
-    const statusLine = `Goal (${goal.status}): "${goal.objective}" — ${goal.turnsUsed}/${goal.maxTurns} turns used [judge: ${goal.judgeModelId}]`;
-    ctx.showInfo(statusLine);
+  if (!subCommand) {
+    await showGoalActionModal(ctx);
+    return;
+  }
+
+  // /goal status — show current state
+  if (subCommand === 'status') {
+    showGoalStatus(ctx);
     return;
   }
 
@@ -101,6 +104,78 @@ export async function handleGoalCommand(ctx: SlashCommandContext, args: string[]
   // /goal <text> — set a new goal using saved judge defaults, asking only once if needed.
   const objective = args.join(' ');
   await startGoalWithDefaults(ctx, objective);
+}
+
+function formatGoalStatus(goal: GoalState): string {
+  return `Goal (${goal.status}): "${goal.objective}" — ${goal.turnsUsed}/${goal.maxTurns} turns used [judge: ${goal.judgeModelId}]`;
+}
+
+function showGoalStatus(ctx: SlashCommandContext): void {
+  const goal = ctx.state.goalManager.getGoal();
+  if (!goal) {
+    ctx.showInfo('No goal set. Use /goal <text> to set one.');
+    return;
+  }
+  ctx.showInfo(formatGoalStatus(goal));
+}
+
+async function showGoalActionModal(ctx: SlashCommandContext): Promise<void> {
+  const goal = ctx.state.goalManager.getGoal();
+  const items: SelectItem[] = [
+    {
+      value: 'status',
+      label: `  Status  ${theme.fg('dim', goal ? formatGoalStatus(goal) : 'No goal set')}`,
+    },
+  ];
+
+  if (goal?.status === 'active') {
+    items.push({ value: 'pause', label: `  Pause  ${theme.fg('dim', 'Pause the continuation loop')}` });
+  } else if (goal?.status === 'paused') {
+    items.push({ value: 'resume', label: `  Resume  ${theme.fg('dim', 'Resume and send a continuation')}` });
+  }
+
+  if (goal) {
+    items.push({ value: 'clear', label: `  Clear  ${theme.fg('dim', 'Drop the current goal')}` });
+  }
+
+  items.push(
+    { value: 'judge', label: `  Judge settings  ${theme.fg('dim', 'Set judge model and max attempts')}` },
+    { value: 'new-hint', label: `  New goal  ${theme.fg('dim', 'Type /goal <objective> to start')}` },
+  );
+
+  return new Promise<void>(resolve => {
+    const container = new Box(4, 2, (text: string) => theme.bg('overlayBg', text));
+    container.addChild(new Text(theme.bold(theme.fg('accent', 'Goal Actions')), 0, 0));
+    container.addChild(new Spacer(1));
+
+    const selectList = new SelectList(items, items.length, getSelectListTheme());
+    selectList.onSelect = async (item: SelectItem) => {
+      ctx.state.ui.hideOverlay();
+      try {
+        if (item.value === 'status') showGoalStatus(ctx);
+        else if (item.value === 'pause') await handleGoalCommand(ctx, ['pause']);
+        else if (item.value === 'resume') await handleGoalCommand(ctx, ['resume']);
+        else if (item.value === 'clear') await handleGoalCommand(ctx, ['clear']);
+        else if (item.value === 'judge') await handleJudgeCommand(ctx);
+        else if (item.value === 'new-hint') ctx.showInfo('Type /goal <objective> to start a new goal.');
+      } finally {
+        resolve();
+      }
+    };
+
+    selectList.onCancel = () => {
+      ctx.state.ui.hideOverlay();
+      resolve();
+    };
+
+    container.addChild(selectList);
+    container.addChild(new Spacer(1));
+    container.addChild(new Text(theme.fg('dim', '↑↓ navigate · Enter select · Esc cancel'), 0, 0));
+
+    const modal = container as Box & { handleInput: (data: string) => void };
+    modal.handleInput = (data: string) => selectList.handleInput(data);
+    showModalOverlay(ctx.state.ui, modal, { maxHeight: '60%' });
+  });
 }
 
 export async function handleJudgeCommand(ctx: SlashCommandContext): Promise<void> {

--- a/mastracode/src/tui/commands/goal.ts
+++ b/mastracode/src/tui/commands/goal.ts
@@ -110,6 +110,10 @@ function formatGoalStatus(goal: GoalState): string {
   return `Goal (${goal.status}): "${goal.objective}" — ${goal.turnsUsed}/${goal.maxTurns} turns used [judge: ${goal.judgeModelId}]`;
 }
 
+function formatGoalStatusRow(goal: GoalState): string {
+  return formatGoalStatus(goal).replace(/\s+/g, ' ');
+}
+
 function showGoalStatus(ctx: SlashCommandContext): void {
   const goal = ctx.state.goalManager.getGoal();
   if (!goal) {
@@ -124,7 +128,7 @@ async function showGoalActionModal(ctx: SlashCommandContext): Promise<void> {
   const items: SelectItem[] = [
     {
       value: 'status',
-      label: `  Status  ${theme.fg('dim', goal ? formatGoalStatus(goal) : 'No goal set')}`,
+      label: `  Status  ${theme.fg('dim', goal ? formatGoalStatusRow(goal) : 'No goal set')}`,
     },
   ];
 

--- a/mastracode/src/tui/components/__tests__/judge-display.test.ts
+++ b/mastracode/src/tui/components/__tests__/judge-display.test.ts
@@ -81,4 +81,19 @@ describe('JudgeDisplayComponent', () => {
     expect(rendered).not.toContain('continue');
     expect(rendered).toContain('(1/20)');
   });
+
+  it('separates judge activity from the final reason', () => {
+    const component = new JudgeDisplayComponent(null, 1, 20);
+    component.addActivity('read src/file.ts');
+    component.setResult({ decision: 'continue', reason: 'Keep going.' }, 1, 20);
+
+    const lines = renderPlain(component);
+    const activityIndex = lines.findIndex(line => line.includes('• read src/file.ts'));
+    const reasonIndex = lines.findIndex(line => line.includes('Keep going.'));
+    const separator = lines[activityIndex + 1];
+
+    expect(activityIndex).toBeGreaterThan(-1);
+    expect(reasonIndex).toBe(activityIndex + 2);
+    expect(separator).toMatch(/^\s*│\s+│\s*$/);
+  });
 });

--- a/mastracode/src/tui/components/__tests__/plan-approval-inline.test.ts
+++ b/mastracode/src/tui/components/__tests__/plan-approval-inline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { PlanApprovalInlineComponent } from '../plan-approval-inline.js';
+import { PlanApprovalInlineComponent, PlanResultComponent } from '../plan-approval-inline.js';
 
 describe('PlanApprovalInlineComponent', () => {
   it('includes a goal option and calls onGoal when selected', () => {
@@ -27,5 +27,67 @@ describe('PlanApprovalInlineComponent', () => {
     (component as any).handleSelection('goal');
 
     expect(onGoal).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the plan inside a border', () => {
+    const component = new PlanApprovalInlineComponent(
+      {
+        planId: 'plan-1',
+        title: 'Ship it',
+        plan: 'Build the feature',
+        onApprove: vi.fn(),
+        onGoal: vi.fn(),
+        onReject: vi.fn(),
+      },
+      {} as any,
+    );
+
+    const rendered = component.render(80).join('\n');
+
+    expect(rendered).toContain('╭');
+    expect(rendered).toContain('Build the feature');
+    expect(rendered).toContain('╰');
+  });
+
+  it('renders requested changes below the plan after feedback is submitted', () => {
+    const onReject = vi.fn();
+    const component = new PlanApprovalInlineComponent(
+      {
+        planId: 'plan-1',
+        title: 'Ship it',
+        plan: 'Build the feature',
+        onApprove: vi.fn(),
+        onGoal: vi.fn(),
+        onReject,
+      },
+      {} as any,
+    );
+
+    (component as any).handleReject('Add verification steps');
+    const lines = component.render(80);
+    const planLineIndex = lines.findIndex(line => line.includes('Build the feature'));
+    const feedbackLineIndex = lines.findIndex(line => line.includes('Requested changes: Add verification steps'));
+
+    expect(onReject).toHaveBeenCalledWith('Add verification steps');
+    expect(planLineIndex).toBeGreaterThan(-1);
+    expect(feedbackLineIndex).toBeGreaterThan(planLineIndex);
+  });
+
+  it('renders persisted requested changes below the plan', () => {
+    const component = new PlanResultComponent({
+      title: 'Ship it',
+      plan: 'Build the feature',
+      isApproved: false,
+      feedback: 'Add verification steps',
+    });
+
+    const lines = component.render(80);
+    const headerIndex = lines.findIndex(line => line.includes('Changes requested'));
+    const planLineIndex = lines.findIndex(line => line.includes('Build the feature'));
+    const feedbackLineIndex = lines.findIndex(line => line.includes('Requested changes: Add verification steps'));
+
+    expect(headerIndex).toBeGreaterThan(-1);
+    expect(planLineIndex).toBeGreaterThan(headerIndex);
+    expect(feedbackLineIndex).toBeGreaterThan(planLineIndex);
   });
 });

--- a/mastracode/src/tui/components/__tests__/plan-approval-inline.test.ts
+++ b/mastracode/src/tui/components/__tests__/plan-approval-inline.test.ts
@@ -82,12 +82,13 @@ describe('PlanApprovalInlineComponent', () => {
     });
 
     const lines = component.render(80);
-    const headerIndex = lines.findIndex(line => line.includes('Changes requested'));
+    const statusIndex = lines.findIndex(line => line.includes('Changes requested'));
     const planLineIndex = lines.findIndex(line => line.includes('Build the feature'));
     const feedbackLineIndex = lines.findIndex(line => line.includes('Requested changes: Add verification steps'));
 
-    expect(headerIndex).toBeGreaterThan(-1);
-    expect(planLineIndex).toBeGreaterThan(headerIndex);
-    expect(feedbackLineIndex).toBeGreaterThan(planLineIndex);
+    expect(statusIndex).toBeGreaterThan(-1);
+    expect(planLineIndex).toBeGreaterThan(-1);
+    expect(statusIndex).toBeGreaterThan(planLineIndex);
+    expect(feedbackLineIndex).toBeGreaterThan(statusIndex);
   });
 });

--- a/mastracode/src/tui/components/judge-display.ts
+++ b/mastracode/src/tui/components/judge-display.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk';
 import stripAnsi from 'strip-ansi';
 
 import type { GoalJudgeResult } from '../goal-manager.js';
-import { BOX_INDENT, getTermWidth, mastraBrand } from '../theme.js';
+import { BOX_INDENT, getTermWidth, mastraBrand, theme } from '../theme.js';
 
 const JUDGE_COLOR = mastraBrand.blue;
 const MUTED_COLOR = '#8a8a8a';
@@ -67,7 +67,7 @@ export class JudgeDisplayComponent extends Container {
     }
 
     for (const line of this.activity) {
-      this.addChild(new Text(this.renderRow(chalk.dim.italic(`• ${line}`), innerWidth, border), BOX_INDENT, 0));
+      this.addChild(new Text(this.renderRow(this.renderActivityLine(line), innerWidth, border), BOX_INDENT, 0));
     }
 
     if (this.activity.length > 0 && this.result) {
@@ -81,6 +81,14 @@ export class JudgeDisplayComponent extends Container {
     }
 
     this.addChild(new Text(`${border('╰')}${border(horizontal)}${border('╯')}`, BOX_INDENT, 0));
+  }
+
+  private renderActivityLine(line: string): string {
+    const toolName = getActivityToolName(line);
+    if (!toolName) return theme.fg('dim', `• ${line}`);
+
+    const rest = line.slice(toolName.length);
+    return `${theme.fg('dim', '• ')}${theme.fg('dim', theme.italic(toolName))}${theme.fg('dim', rest)}`;
   }
 
   private renderHeader(title: string): string {
@@ -126,6 +134,12 @@ export class JudgeDisplayComponent extends Container {
     }
     return text + ' '.repeat(width - visibleLength);
   }
+}
+
+function getActivityToolName(line: string): string | null {
+  if (line.startsWith('find files ')) return 'find files';
+  const [toolName] = line.split(' ');
+  return toolName || null;
 }
 
 function getDecisionText(decision: GoalJudgeResult['decision']): string {

--- a/mastracode/src/tui/components/judge-display.ts
+++ b/mastracode/src/tui/components/judge-display.ts
@@ -67,7 +67,11 @@ export class JudgeDisplayComponent extends Container {
     }
 
     for (const line of this.activity) {
-      this.addChild(new Text(this.renderRow(chalk.dim(`• ${line}`), innerWidth, border), BOX_INDENT, 0));
+      this.addChild(new Text(this.renderRow(chalk.dim.italic(`• ${line}`), innerWidth, border), BOX_INDENT, 0));
+    }
+
+    if (this.activity.length > 0 && this.result) {
+      this.addChild(new Text(this.renderRow('', innerWidth, border), BOX_INDENT, 0));
     }
 
     if (this.result) {

--- a/mastracode/src/tui/components/judge-display.ts
+++ b/mastracode/src/tui/components/judge-display.ts
@@ -15,8 +15,42 @@ const PAUSED_COLOR = '#f5a524';
 const WAITING_COLOR = '#8a8a8a';
 
 export class JudgeDisplayComponent extends Container {
-  constructor(result: GoalJudgeResult, turnsUsed: number, maxTurns: number) {
+  private result: GoalJudgeResult | null;
+  private turnsUsed: number;
+  private maxTurns: number;
+  private activity: string[] = [];
+
+  constructor(result: GoalJudgeResult | null = null, turnsUsed = 0, maxTurns = 0) {
     super();
+    this.result = result;
+    this.turnsUsed = turnsUsed;
+    this.maxTurns = maxTurns;
+    this.renderContent();
+  }
+
+  addActivity(line: string): void {
+    if (this.activity[this.activity.length - 1] !== line) {
+      this.activity.push(line);
+    }
+    if (this.activity.length > 6) {
+      this.activity = this.activity.slice(-6);
+    }
+    this.renderContent();
+  }
+
+  setResult(result: GoalJudgeResult, turnsUsed: number, maxTurns: number): void {
+    this.result = result;
+    this.turnsUsed = turnsUsed;
+    this.maxTurns = maxTurns;
+    this.renderContent();
+  }
+
+  setInterrupted(): void {
+    this.setResult({ decision: 'paused', reason: 'Judge evaluation was interrupted.' }, this.turnsUsed, this.maxTurns);
+  }
+
+  private renderContent(): void {
+    this.clear();
 
     const border = (char: string) => chalk.hex(JUDGE_COLOR)(char);
     const title = chalk.hex(JUDGE_COLOR).bold('Goal');
@@ -24,24 +58,43 @@ export class JudgeDisplayComponent extends Container {
     const innerWidth = Math.max(20, termWidth - BOX_INDENT * 2 - 4);
     const horizontal = '─'.repeat(innerWidth + 1);
 
-    const decisionIcon =
-      result.decision === 'done' ? '●' : result.decision === 'paused' ? '!' : result.decision === 'waiting' ? '◌' : '○';
-    const decisionText = getDecisionText(result.decision);
-    const turnInfo = chalk.hex(MUTED_COLOR)(`(${turnsUsed}/${maxTurns})`);
-
     this.addChild(new Spacer(1));
     this.addChild(new Text(`${border('╭')}${border(horizontal)}${border('╮')}`, BOX_INDENT, 0));
-    this.addChild(
-      new Text(
-        this.renderRow(`${title}  ${decisionIcon} ${decisionText}  ${turnInfo}`, innerWidth, border),
-        BOX_INDENT,
-        0,
-      ),
-    );
-    for (const line of this.wrapLine(result.reason, innerWidth)) {
-      this.addChild(new Text(this.renderRow(chalk.dim(line), innerWidth, border), BOX_INDENT, 0));
+    this.addChild(new Text(this.renderRow(this.renderHeader(title), innerWidth, border), BOX_INDENT, 0));
+
+    if (!this.result && this.activity.length === 0) {
+      this.addChild(new Text(this.renderRow(chalk.dim('evaluating…'), innerWidth, border), BOX_INDENT, 0));
     }
+
+    for (const line of this.activity) {
+      this.addChild(new Text(this.renderRow(chalk.dim(`• ${line}`), innerWidth, border), BOX_INDENT, 0));
+    }
+
+    if (this.result) {
+      for (const line of this.wrapLine(this.result.reason, innerWidth)) {
+        this.addChild(new Text(this.renderRow(chalk.dim(line), innerWidth, border), BOX_INDENT, 0));
+      }
+    }
+
     this.addChild(new Text(`${border('╰')}${border(horizontal)}${border('╯')}`, BOX_INDENT, 0));
+  }
+
+  private renderHeader(title: string): string {
+    if (!this.result) {
+      return `${title}  ◌ ${chalk.hex(WAITING_COLOR).bold('evaluating')}`;
+    }
+
+    const decisionIcon =
+      this.result.decision === 'done'
+        ? '●'
+        : this.result.decision === 'paused'
+          ? '!'
+          : this.result.decision === 'waiting'
+            ? '◌'
+            : '○';
+    const decisionText = getDecisionText(this.result.decision);
+    const turnInfo = this.maxTurns > 0 ? chalk.hex(MUTED_COLOR)(`(${this.turnsUsed}/${this.maxTurns})`) : '';
+    return `${title}  ${decisionIcon} ${decisionText}${turnInfo ? `  ${turnInfo}` : ''}`;
   }
 
   private renderRow(text: string, width: number, border: (char: string) => string): string {

--- a/mastracode/src/tui/components/plan-approval-inline.ts
+++ b/mastracode/src/tui/components/plan-approval-inline.ts
@@ -55,11 +55,11 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
   private contentBox: Box;
   private selectList?: SelectList;
   private feedbackInput?: Input;
-  private onApprove: () => void;
-  private onGoal: () => void;
-  private onReject: (feedback?: string) => void;
+  private onApprove?: () => void;
+  private onGoal?: () => void;
+  private onReject?: (feedback?: string) => void;
   private resolved = false;
-  private mode: 'select' | 'feedback' = 'select';
+  private mode: 'streaming' | 'select' | 'feedback' = 'select';
   private planTitle: string;
   private planContent: string;
 
@@ -76,16 +76,61 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
 
   constructor(options: PlanApprovalInlineOptions, _ui: TUI) {
     super();
+    this.planTitle = options.title;
+    this.planContent = options.plan;
+    this.contentBox = new Box(BOX_INDENT, 0, (text: string) => text);
+    this.addChild(this.contentBox);
+    this.addChild(new Spacer(1));
+    this.activate(options);
+  }
+
+  static createStreaming(ui: TUI): PlanApprovalInlineComponent {
+    const component = new PlanApprovalInlineComponent(
+      {
+        planId: '',
+        title: 'Untitled plan',
+        plan: '',
+        onApprove: () => {},
+        onGoal: () => {},
+        onReject: () => {},
+      },
+      ui,
+    );
+    component.mode = 'streaming';
+    component.resolved = false;
+    component.renderStreaming();
+    return component;
+  }
+
+  activate(options: PlanApprovalInlineOptions): void {
     this.onApprove = options.onApprove;
     this.onGoal = options.onGoal;
     this.onReject = options.onReject;
     this.planTitle = options.title;
     this.planContent = options.plan;
+    this.mode = 'select';
+    this.resolved = false;
+    this.renderSelectable();
+  }
 
-    this.contentBox = new Box(BOX_INDENT, 0, (text: string) => text);
-    this.addChild(this.contentBox);
-    this.addChild(new Spacer(1));
+  updateArgs(args: unknown): void {
+    if (!args || typeof args !== 'object' || this.resolved) return;
+    const partial = args as { title?: unknown; plan?: unknown };
+    if (typeof partial.title === 'string') {
+      this.planTitle = partial.title || 'Untitled plan';
+    }
+    if (typeof partial.plan === 'string') {
+      this.planContent = partial.plan;
+    }
+    if (this.mode === 'streaming') {
+      this.renderStreaming();
+    }
+  }
 
+  private renderSelectable(): void {
+    this.contentBox.clear();
+    this.selectList = undefined;
+    this.feedbackInput = undefined;
     this.renderPlanHeader();
     this.renderPlanContent();
 
@@ -120,6 +165,15 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     this.contentBox.addChild(this.selectList);
     this.contentBox.addChild(new Spacer(1));
     this.contentBox.addChild(new Text(theme.fg('dim', 'Up/Down navigate  Enter select  Esc reject'), 0, 0));
+  }
+
+  private renderStreaming(): void {
+    this.contentBox.clear();
+    this.selectList = undefined;
+    this.feedbackInput = undefined;
+    this.renderPlanHeader();
+    this.renderPlanContent();
+    this.contentBox.addChild(new Text(theme.fg('dim', 'Submitting plan…'), 0, 0));
   }
 
   private renderPlanHeader(prefix = ''): void {
@@ -161,21 +215,21 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     if (this.resolved) return;
     this.resolved = true;
     this.showResult('Approved', true);
-    this.onApprove();
+    this.onApprove?.();
   }
 
   private handleGoal(): void {
     if (this.resolved) return;
     this.resolved = true;
     this.showResult('Set as goal', true);
-    this.onGoal();
+    this.onGoal?.();
   }
 
   private handleReject(feedback?: string): void {
     if (this.resolved) return;
     this.resolved = true;
     this.showResult(feedback ? 'Changes requested' : 'Rejected', false, feedback);
-    this.onReject(feedback);
+    this.onReject?.(feedback);
   }
 
   private switchToFeedbackMode(): void {
@@ -210,10 +264,10 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     this.contentBox.clear();
 
     const icon = isApproved ? theme.fg('success', '✓') : theme.fg('error', '✗');
-    this.renderPlanHeader(`${icon} `);
-    this.contentBox.addChild(new Text(theme.fg('dim', status), 0, 0));
-    this.contentBox.addChild(new Spacer(1));
+    this.renderPlanHeader();
     this.renderPlanContent();
+    this.contentBox.addChild(new Text(`${icon} ${theme.fg('dim', status)}`, 0, 0));
+    this.contentBox.addChild(new Spacer(1));
     this.renderFeedback(feedback);
   }
 
@@ -254,11 +308,11 @@ export class PlanResultComponent extends Container {
     const icon = options.isApproved ? theme.fg('success', '✓') : theme.fg('error', '✗');
     const status = options.isApproved ? 'Approved' : options.feedback ? 'Changes requested' : 'Rejected';
 
-    contentBox.addChild(
-      new Text(`${icon} ${theme.bold(theme.fg('accent', `Plan: ${options.title}`))} ${theme.fg('dim', `— ${status}`)}`, 0, 0),
-    );
+    contentBox.addChild(new Text(theme.bold(theme.fg('accent', `Plan: ${options.title}`)), 0, 0));
     contentBox.addChild(new Spacer(1));
     contentBox.addChild(new PlanContentBox(options.plan));
+    contentBox.addChild(new Spacer(1));
+    contentBox.addChild(new Text(`${icon} ${theme.fg('dim', status)}`, 0, 0));
     contentBox.addChild(new Spacer(1));
 
     if (options.feedback) {

--- a/mastracode/src/tui/components/plan-approval-inline.ts
+++ b/mastracode/src/tui/components/plan-approval-inline.ts
@@ -4,9 +4,20 @@
  * directly in the conversation flow.
  */
 
-import { Box, Container, getEditorKeybindings, Input, Markdown, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
-import type { Focusable, SelectItem, TUI } from '@mariozechner/pi-tui';
-import { BOX_INDENT, theme, getSelectListTheme, getMarkdownTheme } from '../theme.js';
+import {
+  Box,
+  Container,
+  getEditorKeybindings,
+  Input,
+  Markdown,
+  SelectList,
+  Spacer,
+  Text,
+  visibleWidth,
+} from '@mariozechner/pi-tui';
+import type { Component, Focusable, SelectItem, TUI } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
+import { BOX_INDENT, theme, getSelectListTheme, getMarkdownTheme, mastra } from '../theme.js';
 
 export interface PlanApprovalInlineOptions {
   planId: string;
@@ -15,6 +26,29 @@ export interface PlanApprovalInlineOptions {
   onApprove: () => void;
   onGoal: () => void;
   onReject: (feedback?: string) => void;
+}
+
+class PlanContentBox implements Component {
+  constructor(private plan: string) {}
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    const availableWidth = Math.max(24, width - BOX_INDENT);
+    const innerWidth = Math.max(20, availableWidth - 4);
+    const markdown = new Markdown(this.plan, 0, 0, getMarkdownTheme(), {
+      color: (text: string) => theme.fg('text', text),
+    });
+    const rendered = markdown.render(innerWidth).flatMap(line => (line.length > 0 ? [line] : ['']));
+    const border = (text: string) => chalk.hex(mastra.purple)(text);
+    const top = `${border('╭')}${border('─'.repeat(innerWidth + 2))}${border('╮')}`;
+    const bottom = `${border('╰')}${border('─'.repeat(innerWidth + 2))}${border('╯')}`;
+    const body = rendered.map(line => {
+      const padding = ' '.repeat(Math.max(0, innerWidth - visibleWidth(line)));
+      return `${border('│')} ${line}${padding} ${border('│')}`;
+    });
+    return [top, ...body, bottom];
+  }
 }
 
 export class PlanApprovalInlineComponent extends Container implements Focusable {
@@ -48,23 +82,13 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     this.planTitle = options.title;
     this.planContent = options.plan;
 
-    // Main content box - no background, paddingX=1 to align with user message box
     this.contentBox = new Box(BOX_INDENT, 0, (text: string) => text);
     this.addChild(this.contentBox);
     this.addChild(new Spacer(1));
 
-    // Plan title header
-    this.contentBox.addChild(new Text(theme.bold(theme.fg('accent', `Plan: ${options.title}`)), 0, 0));
-    this.contentBox.addChild(new Spacer(1));
+    this.renderPlanHeader();
+    this.renderPlanContent();
 
-    // Render plan as markdown
-    const md = new Markdown(options.plan, 1, 0, getMarkdownTheme(), {
-      color: (text: string) => theme.fg('text', text),
-    });
-    this.contentBox.addChild(md);
-    this.contentBox.addChild(new Spacer(1));
-
-    // Action selector
     const items: SelectItem[] = [
       {
         value: 'approve',
@@ -96,6 +120,22 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     this.contentBox.addChild(this.selectList);
     this.contentBox.addChild(new Spacer(1));
     this.contentBox.addChild(new Text(theme.fg('dim', 'Up/Down navigate  Enter select  Esc reject'), 0, 0));
+  }
+
+  private renderPlanHeader(prefix = ''): void {
+    this.contentBox.addChild(new Text(`${prefix}${theme.bold(theme.fg('accent', `Plan: ${this.planTitle}`))}`, 0, 0));
+    this.contentBox.addChild(new Spacer(1));
+  }
+
+  private renderPlanContent(): void {
+    this.contentBox.addChild(new PlanContentBox(this.planContent));
+    this.contentBox.addChild(new Spacer(1));
+  }
+
+  private renderFeedback(feedback?: string): void {
+    if (!feedback) return;
+    this.contentBox.addChild(new Text(theme.fg('warning', `Requested changes: ${feedback}`), 0, 0));
+    this.contentBox.addChild(new Spacer(1));
   }
 
   private handleSelection(value: string): void {
@@ -134,7 +174,7 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
   private handleReject(feedback?: string): void {
     if (this.resolved) return;
     this.resolved = true;
-    this.showResult(feedback ? `Rejected — ${feedback}` : 'Rejected', false);
+    this.showResult(feedback ? 'Changes requested' : 'Rejected', false, feedback);
     this.onReject(feedback);
   }
 
@@ -142,16 +182,9 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     this.mode = 'feedback';
     this.selectList = undefined;
 
-    // Rebuild content box with feedback input while keeping the plan visible
     this.contentBox.clear();
-    this.contentBox.addChild(new Text(theme.bold(theme.fg('accent', `Plan: ${this.planTitle}`)), 0, 0));
-    this.contentBox.addChild(new Spacer(1));
-
-    const md = new Markdown(this.planContent, 1, 0, getMarkdownTheme(), {
-      color: (text: string) => theme.fg('text', text),
-    });
-    this.contentBox.addChild(md);
-    this.contentBox.addChild(new Spacer(1));
+    this.renderPlanHeader();
+    this.renderPlanContent();
 
     this.contentBox.addChild(new Text(theme.fg('accent', 'Provide feedback for revision:'), 0, 0));
     this.contentBox.addChild(new Spacer(1));
@@ -173,25 +206,15 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     );
   }
 
-  private showResult(status: string, isApproved: boolean): void {
+  private showResult(status: string, isApproved: boolean, feedback?: string): void {
     this.contentBox.clear();
 
-    // Status header with icon
     const icon = isApproved ? theme.fg('success', '✓') : theme.fg('error', '✗');
-    this.contentBox.addChild(
-      new Text(
-        `${icon} ${theme.bold(theme.fg('accent', `Plan: ${this.planTitle}`))} ${theme.fg('dim', `— ${status}`)}`,
-        0,
-        0,
-      ),
-    );
+    this.renderPlanHeader(`${icon} `);
+    this.contentBox.addChild(new Text(theme.fg('dim', status), 0, 0));
     this.contentBox.addChild(new Spacer(1));
-
-    // Re-render plan as markdown
-    const md = new Markdown(this.planContent, 1, 0, getMarkdownTheme(), {
-      color: (text: string) => theme.fg('text', text),
-    });
-    this.contentBox.addChild(md);
+    this.renderPlanContent();
+    this.renderFeedback(feedback);
   }
 
   handleInput(data: string): void {
@@ -228,24 +251,21 @@ export class PlanResultComponent extends Container {
     const contentBox = new Box(BOX_INDENT, 0, (text: string) => text);
     this.addChild(contentBox);
 
-    // Status header with icon
     const icon = options.isApproved ? theme.fg('success', '✓') : theme.fg('error', '✗');
-    const status = options.isApproved ? 'Approved' : options.feedback ? `Rejected — ${options.feedback}` : 'Rejected';
+    const status = options.isApproved ? 'Approved' : options.feedback ? 'Changes requested' : 'Rejected';
 
     contentBox.addChild(
-      new Text(
-        `${icon} ${theme.bold(theme.fg('accent', `Plan: ${options.title}`))} ${theme.fg('dim', `— ${status}`)}`,
-        0,
-        0,
-      ),
+      new Text(`${icon} ${theme.bold(theme.fg('accent', `Plan: ${options.title}`))} ${theme.fg('dim', `— ${status}`)}`, 0, 0),
     );
     contentBox.addChild(new Spacer(1));
+    contentBox.addChild(new PlanContentBox(options.plan));
+    contentBox.addChild(new Spacer(1));
 
-    // Render plan as markdown
-    const md = new Markdown(options.plan, 1, 0, getMarkdownTheme(), {
-      color: (text: string) => theme.fg('text', text),
-    });
-    contentBox.addChild(md);
+    if (options.feedback) {
+      contentBox.addChild(new Text(theme.fg('warning', `Requested changes: ${options.feedback}`), 0, 0));
+      contentBox.addChild(new Spacer(1));
+    }
+
     this.addChild(new Spacer(1));
   }
 }

--- a/mastracode/src/tui/goal-manager.ts
+++ b/mastracode/src/tui/goal-manager.ts
@@ -383,7 +383,7 @@ export class GoalManager {
     }
 
     for await (const chunk of stream.fullStream) {
-      if (chunk?.type === 'tool-call' || chunk?.type === 'tool-result') {
+      if (chunk?.type === 'tool-call') {
         const toolName = getToolName(chunk);
         if (!toolName) continue;
         const line = formatJudgeActivity(toolName, parseToolInput(chunk));

--- a/mastracode/src/tui/goal-manager.ts
+++ b/mastracode/src/tui/goal-manager.ts
@@ -11,9 +11,11 @@ import { randomUUID } from 'node:crypto';
 import { Agent } from '@mastra/core/agent';
 import type { MastraMemory } from '@mastra/core/memory';
 import { PrefillErrorHandler, ProviderHistoryCompat, StreamErrorRetryProcessor } from '@mastra/core/processors';
+import { createWorkspaceTools } from '@mastra/core/workspace';
 import { z } from 'zod';
 
 import { resolveModel } from '../agents/model.js';
+import { MC_TOOLS } from '../tool-names.js';
 
 import type { TUIState } from './state.js';
 
@@ -30,6 +32,7 @@ export interface GoalState {
   turnsUsed: number;
   maxTurns: number;
   judgeModelId: string;
+  startedAt: string;
 }
 
 export interface GoalJudgeResult {
@@ -40,6 +43,11 @@ export interface GoalJudgeResult {
 export interface GoalEvaluationResult {
   continuation: string | null;
   judgeResult: GoalJudgeResult | null;
+}
+
+export interface GoalEvaluationOptions {
+  abortSignal?: AbortSignal;
+  onActivity?: (line: string) => void;
 }
 
 // =============================================================================
@@ -54,7 +62,8 @@ const JUDGE_SYSTEM_PROMPT = `You are the goal judge. Your decision directly cont
 Given a goal and the assistant's latest response, reason about whether the goal's requirements have been satisfied. Compare what the goal asks for against what the assistant has actually produced. Focus on substance, not phrasing.
 
 Use "done" when the goal is fully achieved.
-Use "waiting" only when the goal explicitly requires a user checkpoint, user feedback, human verification, human confirmation, or another external event outside the goal-judge loop before the assistant should continue, and the assistant has correctly stopped at that checkpoint. Do not use "waiting" merely because the assistant asked a question or could benefit from user input.
+Use "waiting" when the goal explicitly requires a user checkpoint, user feedback, human verification, human confirmation, or another external event outside the goal-judge loop before the assistant should continue, and the assistant has correctly stopped at that checkpoint.
+Use "waiting" when the latest user message asks a question or requests clarification and the latest assistant message answers it; let the user acknowledge the answer, ask a follow-up, or otherwise return control before continuing goal work. Use common sense and do not wait if the user explicitly asked the assistant to continue autonomously after answering.
 Use "continue" when the goal is not done and the assistant should keep working autonomously, including when it asked for input that the goal did not explicitly require.
 If your previous decision was "waiting" for an explicit user checkpoint, keep choosing "waiting" when the user's latest response asks a question, requests clarification, or otherwise does not satisfy the checkpoint. Do not continue until the required user feedback/confirmation/verification has actually been provided.
 If the goal says to wait for the goal judge, judge, evaluator, or you to respond, approve, verify, validate, tell the assistant to continue, or otherwise provide the next signal, treat your own decision as that judge response. Verification can be performed by you unless the goal explicitly says it needs human/user verification. Choose "continue" when the assistant should proceed to the next step. Do not choose "waiting" for judge-controlled checkpoints, because that would mean waiting for yourself.
@@ -107,6 +116,7 @@ export class GoalManager {
       turnsUsed: 0,
       maxTurns,
       judgeModelId,
+      startedAt: new Date().toISOString(),
     };
     return this.goal;
   }
@@ -117,7 +127,7 @@ export class GoalManager {
   loadFromThreadMetadata(metadata: Record<string, unknown> | undefined): void {
     const saved = metadata?.[THREAD_GOAL_KEY] as GoalState | undefined;
     if (saved && saved.objective && saved.status) {
-      this.goal = { ...saved, id: saved.id ?? randomUUID() };
+      this.goal = { ...saved, id: saved.id ?? randomUUID(), startedAt: saved.startedAt ?? new Date().toISOString() };
     } else {
       this.goal = null;
     }
@@ -176,7 +186,7 @@ export class GoalManager {
    * Called after each agent turn completes. Evaluates whether to continue.
    * Returns a GoalEvaluationResult with continuation prompt and judge result.
    */
-  async evaluateAfterTurn(state: TUIState): Promise<GoalEvaluationResult> {
+  async evaluateAfterTurn(state: TUIState, options: GoalEvaluationOptions = {}): Promise<GoalEvaluationResult> {
     if (!this.goal || this.goal.status !== 'active') {
       return { continuation: null, judgeResult: null };
     }
@@ -200,11 +210,15 @@ export class GoalManager {
     }
 
     // Call judge — always judge the current turn's response before enforcing budget
-    const result = await this.callJudge(state, {
-      lastUserContent: context.lastUserContent,
-      assistantStepsSinceLastUser: context.assistantStepsSinceLastUser,
-      lastAssistantContent: context.lastAssistantContent,
-    });
+    const result = await this.callJudge(
+      state,
+      {
+        lastUserContent: context.lastUserContent,
+        assistantStepsSinceLastUser: context.assistantStepsSinceLastUser,
+        lastAssistantContent: context.lastAssistantContent,
+      },
+      options,
+    );
     if (!this.goal || this.goal.id !== evaluatedGoalId || this.goal.status !== 'active') {
       return { continuation: null, judgeResult: null };
     }
@@ -266,7 +280,9 @@ export class GoalManager {
 
       const lastUserContent = lastUserIndex >= 0 ? this.extractTextContent(messages[lastUserIndex]!.content) : null;
       const assistantStepsSinceLastUser =
-        lastUserIndex >= 0 ? messages.slice(lastUserIndex + 1).filter(msg => msg.role === 'assistant').length : 0;
+        lastUserIndex >= 0
+          ? messages.slice(lastUserIndex + 1).filter((msg: any) => msg.role === 'assistant').length
+          : 0;
 
       return { lastUserContent, assistantStepsSinceLastUser, lastAssistantContent };
     } catch {
@@ -278,8 +294,13 @@ export class GoalManager {
     if (typeof content === 'string') return content;
     if (Array.isArray(content)) {
       return content
-        .filter((part: any) => part.type === 'text')
-        .map((part: any) => part.text)
+        .map((part: any) => {
+          if (typeof part === 'string') return part;
+          if (typeof part?.text === 'string') return part.text;
+          if (typeof part?.content === 'string') return part.content;
+          return null;
+        })
+        .filter((text: string | null): text is string => Boolean(text))
         .join('\n');
     }
     return String(content ?? '');
@@ -288,40 +309,86 @@ export class GoalManager {
   private async callJudge(
     state: TUIState,
     context: { lastUserContent: string | null; assistantStepsSinceLastUser: number; lastAssistantContent: string },
+    options: GoalEvaluationOptions,
   ): Promise<GoalJudgeResult> {
     try {
       const memory = await this.getJudgeMemory(state);
-      const judgeAgent = this.createJudgeAgent(memory);
+      const tools = await this.createJudgeTools(state);
+      const judgeAgent = this.createJudgeAgent(memory, tools);
       if (!judgeAgent) {
         return { decision: 'paused', reason: 'Judge model could not be initialized.' };
       }
 
-      // Truncate very long messages to keep judge calls fast
-      const truncatedAssistant = truncateForJudge(context.lastAssistantContent);
       const recentUser = context.lastUserContent
         ? `\n\nLatest user message:\n${truncateForJudge(context.lastUserContent)}\n\nAssistant steps since that user message: ${context.assistantStepsSinceLastUser}`
         : '';
 
       const stream = await judgeAgent.stream(
-        `Goal: ${this.goal!.objective}${recentUser}\n\nLatest assistant message:\n${truncatedAssistant}`,
+        `Goal: ${this.goal!.objective}${recentUser}\n\nLatest assistant message:\n${context.lastAssistantContent}`,
         {
           ...(memory
             ? { memory: { thread: this.getJudgeThreadId(state), resource: state.harness.getResourceId() } }
             : {}),
+          abortSignal: options.abortSignal,
           structuredOutput: {
             schema: judgeSchema,
           },
         },
       );
 
-      await stream.consumeStream();
+      await this.consumeJudgeStream(stream, options.onActivity);
       const output = (await stream.getFullOutput()).object as z.infer<typeof judgeSchema> | undefined;
       if (!output) {
         return { decision: 'paused', reason: 'Judge returned no structured decision.' };
       }
       return { decision: output.decision, reason: output.reason };
     } catch (error) {
+      if (options.abortSignal?.aborted) {
+        return { decision: 'paused', reason: 'Judge evaluation was interrupted.' };
+      }
       return { decision: 'paused', reason: `Judge could not evaluate this turn: ${formatError(error)}` };
+    }
+  }
+
+  private async createJudgeTools(state: TUIState): Promise<Record<string, any>> {
+    const workspace = state.harness.getWorkspace?.() ?? state.workspace;
+    if (!workspace) return {};
+
+    const workspaceTools = await createWorkspaceTools(workspace, {
+      requestContext: {},
+      workspace,
+    });
+    const allowedTools = new Set<string>([
+      MC_TOOLS.VIEW,
+      MC_TOOLS.SEARCH_CONTENT,
+      MC_TOOLS.FIND_FILES,
+      MC_TOOLS.FILE_STAT,
+      MC_TOOLS.LSP_INSPECT,
+    ]);
+    const tools: Record<string, any> = {};
+
+    for (const [name, tool] of Object.entries(workspaceTools)) {
+      if (!allowedTools.has(name)) continue;
+      const { needsApprovalFn: _needsApprovalFn, ...toolWithoutApproval } = tool as Record<string, any>;
+      tools[name] = { ...toolWithoutApproval, requireApproval: false };
+    }
+
+    return tools;
+  }
+
+  private async consumeJudgeStream(stream: any, onActivity?: (line: string) => void): Promise<void> {
+    if (!stream.fullStream) {
+      await stream.consumeStream();
+      return;
+    }
+
+    for await (const chunk of stream.fullStream) {
+      if (chunk?.type === 'tool-call' || chunk?.type === 'tool-result') {
+        const toolName = getToolName(chunk);
+        if (!toolName) continue;
+        const line = formatJudgeActivity(toolName, parseToolInput(chunk));
+        if (line) onActivity?.(line);
+      }
     }
   }
 
@@ -354,7 +421,7 @@ export class GoalManager {
     return `${state.harness.getCurrentThreadId() ?? 'no-thread'}-${this.goal!.id}`;
   }
 
-  private createJudgeAgent(memory: MastraMemory | null): Agent | null {
+  private createJudgeAgent(memory: MastraMemory | null, tools: Record<string, any>): Agent | null {
     if (!this.goal?.judgeModelId) return null;
     try {
       const model = resolveModel(this.goal.judgeModelId);
@@ -363,6 +430,7 @@ export class GoalManager {
         name: 'Goal Judge',
         instructions: JUDGE_SYSTEM_PROMPT,
         model,
+        tools,
         ...(memory ? { memory } : {}),
         inputProcessors: [new ProviderHistoryCompat()],
         errorProcessors: [new StreamErrorRetryProcessor(), new PrefillErrorHandler(), new ProviderHistoryCompat()],
@@ -381,6 +449,45 @@ export class GoalManager {
 
 function truncateForJudge(value: string): string {
   return value.length > 4000 ? value.slice(0, 4000) + '\n...[truncated]' : value;
+}
+
+function getToolName(chunk: any): string | null {
+  const toolName = chunk.payload?.toolName ?? chunk.toolName;
+  return typeof toolName === 'string' ? toolName : null;
+}
+
+function parseToolInput(chunk: any): Record<string, any> {
+  const input = chunk.payload?.args ?? chunk.input ?? chunk.args ?? chunk.toolInput;
+  if (!input) return {};
+  if (typeof input === 'string') {
+    try {
+      return JSON.parse(input);
+    } catch {
+      return { input };
+    }
+  }
+  return input as Record<string, any>;
+}
+
+function formatJudgeActivity(toolName: string, input: Record<string, any>): string | null {
+  if (toolName === MC_TOOLS.VIEW) return `read ${formatActivityValue(input.path)}`;
+  if (toolName === MC_TOOLS.SEARCH_CONTENT) return `search ${formatQuotedActivityValue(input.pattern)}`;
+  if (toolName === MC_TOOLS.FIND_FILES) return `find files ${formatActivityValue(input.pattern ?? input.path)}`;
+  if (toolName === MC_TOOLS.FILE_STAT) return `stat ${formatActivityValue(input.path)}`;
+  if (toolName === MC_TOOLS.LSP_INSPECT) return `inspect ${formatActivityValue(input.path)}`;
+  return null;
+}
+
+function formatActivityValue(value: unknown): string {
+  if (typeof value === 'string' && value.length > 0) {
+    return value.length > 80 ? value.slice(0, 77) + '...' : value;
+  }
+  return 'workspace';
+}
+
+function formatQuotedActivityValue(value: unknown): string {
+  const formatted = formatActivityValue(value);
+  return formatted === 'workspace' ? formatted : JSON.stringify(formatted);
 }
 
 function formatError(error: unknown): string {

--- a/mastracode/src/tui/handlers/__tests__/prompts.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/prompts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { PlanApprovalInlineComponent } from '../../components/plan-approval-inline.js';
 import type { TUIState } from '../../state.js';
 import { handleAskQuestion, handlePlanApproval } from '../prompts.js';
 import type { EventHandlerContext } from '../types.js';
@@ -76,9 +77,13 @@ function createPlanApprovalCtx() {
       addChild: vi.fn(function (this: any, child: unknown) {
         this.children.push(child);
       }),
+      clear: vi.fn(function (this: any) {
+        this.children.length = 0;
+      }),
       invalidate: vi.fn(),
     },
     ui: { requestRender: vi.fn() },
+    pendingSubmitPlanComponents: new Map(),
   } as any;
   const ctx = {
     state,
@@ -119,6 +124,20 @@ describe('handlePlanApproval goal mode', () => {
 });
 
 describe('handlePlanApproval regular approval', () => {
+  it('activates an existing streamed submit_plan component in place', async () => {
+    const { state, ctx } = createPlanApprovalCtx();
+    const streamedComponent = PlanApprovalInlineComponent.createStreaming(state.ui);
+    streamedComponent.updateArgs({ title: 'Ship it', plan: 'Build the feature' });
+    state.lastSubmitPlanComponent = streamedComponent;
+    state.chatContainer.children.push(streamedComponent);
+
+    handlePlanApproval(ctx, 'plan-1', 'Ship it', 'Build the feature');
+
+    expect(state.chatContainer.children.filter((child: unknown) => child === streamedComponent)).toHaveLength(1);
+    expect(state.activeInlinePlanApproval).toBe(streamedComponent);
+    expect(streamedComponent.render(80).join('\n')).toContain('Use as /goal');
+  });
+
   it('approves the plan and sends a single begin-executing system-reminder through harness.sendSignal', async () => {
     const { state, ctx, sendSignal } = createPlanApprovalCtx();
 

--- a/mastracode/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/src/tui/handlers/agent-lifecycle.ts
@@ -194,25 +194,39 @@ function maybeGoalContinuation(ctx: EventHandlerContext): void {
       ctx.updateStatusLine();
     });
   }
-  const activeGoalJudge = { modelId: goal.judgeModelId };
+  const abortController = new AbortController();
+  const judgeComponent = new JudgeDisplayComponent(null, goal.turnsUsed, goal.maxTurns);
+  const activeGoalJudge = { modelId: goal.judgeModelId, abortController, component: judgeComponent };
   state.activeGoalJudge = activeGoalJudge;
+  state.chatContainer.addChild(judgeComponent);
   state.gradientAnimator.start();
   ctx.updateStatusLine();
   state.ui.requestRender();
 
   state.goalManager
-    .evaluateAfterTurn(state)
+    .evaluateAfterTurn(state, {
+      abortSignal: abortController.signal,
+      onActivity: line => {
+        if (state.activeGoalJudge === activeGoalJudge) {
+          judgeComponent.addActivity(line);
+          state.ui.requestRender();
+        }
+      },
+    })
     .then(async ({ continuation, judgeResult }) => {
       if (state.activeGoalJudge !== activeGoalJudge) {
         return;
       }
 
-      // Display the judge result in chat if available
       if (judgeResult) {
         const goal = state.goalManager.getGoal()!;
-        const judgeComponent = new JudgeDisplayComponent(judgeResult, goal.turnsUsed, goal.maxTurns);
-        state.chatContainer.addChild(judgeComponent);
+        judgeComponent.setResult(judgeResult, goal.turnsUsed, goal.maxTurns);
         state.ui.requestRender();
+      }
+
+      if (abortController.signal.aborted) {
+        state.userInitiatedAbort = false;
+        return;
       }
 
       if (continuation) {

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -249,70 +249,74 @@ export async function handlePlanApproval(
 ): Promise<void> {
   const { state } = ctx;
   return new Promise(resolve => {
-    const approvalComponent = new PlanApprovalInlineComponent(
-      {
-        planId,
-        title,
-        plan,
-        onApprove: async () => {
-          state.activeInlinePlanApproval = undefined;
-          await approvePlan(ctx, planId, title, plan);
+    const approvalOptions = {
+      planId,
+      title,
+      plan,
+      onApprove: async () => {
+        state.activeInlinePlanApproval = undefined;
+        await approvePlan(ctx, planId, title, plan);
 
-          // Fire a structured system-reminder signal to wake the freshly
-          // switched-to default-mode agent. The signal echoes back as a
-          // `system_reminder` content part and renders through the same
-          // path as any other reminder — no legacy XML regex, no companion
-          // `addUserMessage` call, so the reminder shows up exactly once.
-          //
-          // `approvePlan` (via `respondToPlanApproval` → `switchMode`) waits
-          // for the aborted plan-mode run to fully idle before returning, so
-          // this signal always starts a fresh build-mode run instead of
-          // queuing onto the dying one.
-          try {
-            await state.harness.sendSignal({
-              type: 'system-reminder',
-              contents: 'The user has approved the plan, begin executing.',
-            }).accepted;
-          } catch (err) {
-            ctx.showError(`Failed to start build agent: ${err instanceof Error ? err.message : String(err)}`);
-          }
+        // Fire a structured system-reminder signal to wake the freshly
+        // switched-to default-mode agent. The signal echoes back as a
+        // `system_reminder` content part and renders through the same
+        // path as any other reminder — no legacy XML regex, no companion
+        // `addUserMessage` call, so the reminder shows up exactly once.
+        //
+        // `approvePlan` (via `respondToPlanApproval` → `switchMode`) waits
+        // for the aborted plan-mode run to fully idle before returning, so
+        // this signal always starts a fresh build-mode run instead of
+        // queuing onto the dying one.
+        try {
+          await state.harness.sendSignal({
+            type: 'system-reminder',
+            contents: 'The user has approved the plan, begin executing.',
+          }).accepted;
+        } catch (err) {
+          ctx.showError(`Failed to start build agent: ${err instanceof Error ? err.message : String(err)}`);
+        }
 
-          resolve();
-        },
-        onGoal: async () => {
-          state.activeInlinePlanApproval = undefined;
-          await approvePlan(ctx, planId, title, plan);
-
-          // Hand off to the normal `/goal` flow. `startGoal` (default
-          // `trigger: 'send'`) sets + persists the goal, then fires the
-          // canonical structured goal-reminder via `harness.sendSignal` —
-          // identical to typing `/goal <objective>` by hand. No second
-          // reminder is sent; the goal judge in `handleAgentEnd` keeps the
-          // agent driving toward the goal after its first response.
-          //
-          // `approvePlan` already waited for the aborted plan-mode run to
-          // idle, so this signal starts a fresh build-mode run.
-          const objective = formatPlanGoalObjective(title, plan);
-          await ctx.startGoal(objective, 'Goal cancelled.');
-
-          resolve();
-        },
-        onReject: async (feedback?: string) => {
-          state.activeInlinePlanApproval = undefined;
-          await state.harness.respondToPlanApproval({
-            planId,
-            response: { action: 'rejected', feedback },
-          });
-          resolve();
-        },
+        resolve();
       },
-      state.ui,
-    );
+      onGoal: async () => {
+        state.activeInlinePlanApproval = undefined;
+        await approvePlan(ctx, planId, title, plan);
+
+        // Hand off to the normal `/goal` flow. `startGoal` (default
+        // `trigger: 'send'`) sets + persists the goal, then fires the
+        // canonical structured goal-reminder via `harness.sendSignal` —
+        // identical to typing `/goal <objective>` by hand. No second
+        // reminder is sent; the goal judge in `handleAgentEnd` keeps the
+        // agent driving toward the goal after its first response.
+        //
+        // `approvePlan` already waited for the aborted plan-mode run to
+        // idle, so this signal starts a fresh build-mode run.
+        const objective = formatPlanGoalObjective(title, plan);
+        await ctx.startGoal(objective, 'Goal cancelled.');
+
+        resolve();
+      },
+      onReject: async (feedback?: string) => {
+        state.activeInlinePlanApproval = undefined;
+        await state.harness.respondToPlanApproval({
+          planId,
+          response: { action: 'rejected', feedback },
+        });
+        resolve();
+      },
+    };
+
+    const approvalComponent =
+      state.lastSubmitPlanComponent instanceof PlanApprovalInlineComponent
+        ? state.lastSubmitPlanComponent
+        : new PlanApprovalInlineComponent(approvalOptions, state.ui);
+    approvalComponent.activate(approvalOptions);
 
     // Store as active plan approval
     state.activeInlinePlanApproval = approvalComponent;
 
-    // Insert after the submit_plan tool component (same pattern as ask_user)
+    // Insert after the submit_plan placeholder; if streaming already created the
+    // plan box, activate that component in place instead of rendering a duplicate.
     if (state.lastSubmitPlanComponent) {
       const children = [...state.chatContainer.children];
       const submitPlanIndex = children.indexOf(state.lastSubmitPlanComponent as any);
@@ -321,7 +325,9 @@ export async function handlePlanApproval(
         for (let i = 0; i <= submitPlanIndex; i++) {
           state.chatContainer.addChild(children[i]!);
         }
-        state.chatContainer.addChild(approvalComponent);
+        if (state.lastSubmitPlanComponent !== approvalComponent) {
+          state.chatContainer.addChild(approvalComponent);
+        }
         for (let i = submitPlanIndex + 1; i < children.length; i++) {
           state.chatContainer.addChild(children[i]!);
         }

--- a/mastracode/src/tui/handlers/tool.test.ts
+++ b/mastracode/src/tui/handlers/tool.test.ts
@@ -2,7 +2,7 @@ import { Container } from '@mariozechner/pi-tui';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { TUIState } from '../state.js';
-import { handleToolEnd, handleToolInputStart, handleToolStart } from './tool.js';
+import { handleToolEnd, handleToolInputDelta, handleToolInputStart, handleToolStart } from './tool.js';
 import type { EventHandlerContext } from './types.js';
 
 function createToolHandlerContext(): EventHandlerContext {
@@ -15,10 +15,14 @@ function createToolHandlerContext(): EventHandlerContext {
     seenToolCallIds: new Set(),
     pendingSubagents: new Map(),
     pendingAskUserComponents: new Map(),
+    pendingSubmitPlanComponents: new Map(),
     allToolComponents: [],
     toolOutputExpanded: false,
     hideThinkingBlock: false,
     taskToolInsertIndex: -1,
+    harness: {
+      getDisplayState: vi.fn(() => ({ toolInputBuffers: new Map() })),
+    },
   } as unknown as TUIState;
 
   return {
@@ -67,5 +71,22 @@ describe('task tool rendering', () => {
     expect(ctx.state.pendingTools.get('call-1')).toBe(component);
     expect(ctx.state.pendingTaskToolIds.has('call-1')).toBe(true);
     expect(ctx.state.chatContainer.children).toHaveLength(childCount);
+  });
+
+  it('streams submit_plan args into a plan box instead of rendering a generic tool', () => {
+    const ctx = createToolHandlerContext();
+    const buffers = new Map([
+      ['call-1', { toolName: 'submit_plan', text: '{"title":"Ship it","plan":"Build the feature"}' }],
+    ]);
+    vi.mocked(ctx.state.harness.getDisplayState).mockReturnValue({ toolInputBuffers: buffers } as any);
+
+    handleToolInputStart(ctx, 'call-1', 'submit_plan');
+    handleToolInputDelta(ctx, 'call-1', '{"title":"Ship it","plan":"Build the feature"}');
+
+    expect(ctx.state.pendingTools.has('call-1')).toBe(false);
+    expect(ctx.state.allToolComponents).toHaveLength(0);
+    expect(ctx.state.pendingSubmitPlanComponents.has('call-1')).toBe(true);
+    expect(ctx.state.chatContainer.children).toHaveLength(2);
+    expect(ctx.state.chatContainer.render(80).join('\n')).toContain('Build the feature');
   });
 });

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -40,7 +40,11 @@ function insertTaskToolErrorComponent(ctx: EventHandlerContext, component: unkno
   ctx.addChildBeforeFollowUps(component as never);
 }
 
-function ensureSubmitPlanComponent(ctx: EventHandlerContext, toolCallId: string, args?: unknown): PlanApprovalInlineComponent {
+function ensureSubmitPlanComponent(
+  ctx: EventHandlerContext,
+  toolCallId: string,
+  args?: unknown,
+): PlanApprovalInlineComponent {
   const { state } = ctx;
   let component = state.pendingSubmitPlanComponents.get(toolCallId);
   if (!component) {

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -13,6 +13,7 @@ import { parse as parsePartialJson } from 'partial-json';
 import { getToolCategory, TOOL_CATEGORIES } from '../../permissions.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
 import { AssistantMessageComponent } from '../components/assistant-message.js';
+import { PlanApprovalInlineComponent } from '../components/plan-approval-inline.js';
 import { ToolApprovalDialogComponent } from '../components/tool-approval-dialog.js';
 import type { ApprovalAction } from '../components/tool-approval-dialog.js';
 import { ToolExecutionComponentEnhanced } from '../components/tool-execution-enhanced.js';
@@ -37,6 +38,22 @@ function insertTaskToolErrorComponent(ctx: EventHandlerContext, component: unkno
     }
   }
   ctx.addChildBeforeFollowUps(component as never);
+}
+
+function ensureSubmitPlanComponent(ctx: EventHandlerContext, toolCallId: string, args?: unknown): PlanApprovalInlineComponent {
+  const { state } = ctx;
+  let component = state.pendingSubmitPlanComponents.get(toolCallId);
+  if (!component) {
+    component = PlanApprovalInlineComponent.createStreaming(state.ui);
+    state.pendingSubmitPlanComponents.set(toolCallId, component);
+    state.lastSubmitPlanComponent = component;
+    ctx.addChildBeforeFollowUps(component);
+
+    state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
+    ctx.addChildBeforeFollowUps(state.streamingComponent);
+  }
+  component.updateArgs(args);
+  return component;
 }
 
 /**
@@ -130,10 +147,13 @@ export function handleToolStart(ctx: EventHandlerContext, toolCallId: string, to
   const { state } = ctx;
   // Component may already exist if created early by handleToolInputStart
   const existingComponent = state.pendingTools.get(toolCallId);
+  const existingSubmitPlanComponent = state.pendingSubmitPlanComponents?.get(toolCallId);
 
   if (existingComponent) {
     // Component was created during input streaming — update with final args
     existingComponent.updateArgs(args);
+  } else if (existingSubmitPlanComponent) {
+    existingSubmitPlanComponent.updateArgs(args);
   } else if (!state.seenToolCallIds.has(toolCallId)) {
     state.seenToolCallIds.add(toolCallId);
 
@@ -146,6 +166,12 @@ export function handleToolStart(ctx: EventHandlerContext, toolCallId: string, to
     // Skip creating regular component for ask_user — it uses AskQuestionInlineComponent
     // (normally created by handleToolInputStart, but handleToolStart may fire first)
     if (toolName === 'ask_user') {
+      return;
+    }
+
+    if (toolName === 'submit_plan') {
+      ensureSubmitPlanComponent(ctx, toolCallId, args);
+      state.ui.requestRender();
       return;
     }
 
@@ -182,12 +208,6 @@ export function handleToolStart(ctx: EventHandlerContext, toolCallId: string, to
     ctx.addChildBeforeFollowUps(state.streamingComponent);
 
     state.ui.requestRender();
-  }
-
-  // Track submit_plan tool components for inline plan approval placement
-  const component = state.pendingTools.get(toolCallId);
-  if (component && toolName === 'submit_plan') {
-    state.lastSubmitPlanComponent = component;
   }
 
   // File modification tracking is handled by the Harness display state
@@ -246,7 +266,10 @@ export function handleToolInputStart(ctx: EventHandlerContext, toolCallId: strin
   // Skip for subagent (handled by SubagentExecutionComponent),
   // task tools (they stream to or update the pinned TaskProgressComponent),
   // and ask_user (uses AskQuestionInlineComponent)
-  if (toolName === 'ask_user') {
+  if (toolName === 'submit_plan') {
+    ensureSubmitPlanComponent(ctx, toolCallId);
+    state.ui.requestRender();
+  } else if (toolName === 'ask_user') {
     if (state.goalManager?.isActive()) {
       return;
     }
@@ -333,6 +356,14 @@ export function handleToolInputDelta(ctx: EventHandlerContext, toolCallId: strin
         }
       }
 
+      // For submit_plan, stream the title/plan args into the inline purple plan box.
+      if (buffer.toolName === 'submit_plan') {
+        const planComponent = state.pendingSubmitPlanComponents?.get(toolCallId);
+        if (planComponent) {
+          planComponent.updateArgs(partialArgs);
+        }
+      }
+
       // For task_write, stream partial tasks into the pinned TaskProgressComponent.
       // The last array item is actively being written so its content is unstable.
       // If all existing pinned items are already completed, the list is stable and
@@ -395,6 +426,11 @@ export function handleToolEnd(ctx: EventHandlerContext, toolCallId: string, resu
 
   // Clean up ask_user component tracking
   state.pendingAskUserComponents.delete(toolCallId);
+
+  if (state.pendingSubmitPlanComponents?.has(toolCallId)) {
+    // submit_plan renders through PlanApprovalInlineComponent, not the generic tool box.
+    return;
+  }
 
   const component = state.pendingTools.get(toolCallId);
   if (component) {

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -41,6 +41,10 @@ export function setupKeyboardShortcuts(
     }
     state.lastCtrlCTime = now;
 
+    if (abortActiveGoalJudge(state)) {
+      return;
+    }
+
     if (state.pendingApprovalDismiss) {
       // Dismiss active approval dialog and abort
       state.pendingApprovalDismiss();
@@ -194,6 +198,17 @@ export function setupKeyboardShortcuts(
   });
 }
 
+function abortActiveGoalJudge(state: TUIState): boolean {
+  const activeGoalJudge = state.activeGoalJudge;
+  if (!activeGoalJudge) return false;
+
+  state.userInitiatedAbort = true;
+  activeGoalJudge.abortController.abort();
+  activeGoalJudge.component.setInterrupted();
+  state.ui.requestRender();
+  return true;
+}
+
 // =============================================================================
 // Layout
 // =============================================================================
@@ -324,7 +339,17 @@ export function setupAutocomplete(state: TUIState): void {
     { name: 'update', description: 'Check for and install updates' },
     { name: 'api-keys', description: 'Manage API keys for model providers' },
     { name: 'observability', description: 'Configure cloud observability' },
-    { name: 'goal', description: 'Set/manage persistent goal (Ralph loop)' },
+    {
+      name: 'goal',
+      description: 'Set/manage persistent goal (Ralph loop)',
+      getArgumentCompletions: (argumentPrefix: string) =>
+        [
+          { value: 'status', label: 'status', description: 'Show current goal status' },
+          { value: 'pause', label: 'pause', description: 'Pause the goal continuation loop' },
+          { value: 'resume', label: 'resume', description: 'Resume the current goal' },
+          { value: 'clear', label: 'clear', description: 'Clear the current goal' },
+        ].filter(command => command.value.startsWith(argumentPrefix.toLowerCase())),
+    },
     { name: 'judge', description: 'Set goal judge defaults' },
     { name: 'exit', description: 'Exit the TUI' },
     { name: 'help', description: 'Show available commands' },
@@ -423,6 +448,9 @@ export function setupKeyHandlers(
       process.exit(0);
     }
     state.lastCtrlCTime = now;
+    if (abortActiveGoalJudge(state)) {
+      return;
+    }
     if (state.pendingApprovalDismiss) {
       state.pendingApprovalDismiss();
     }

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -156,7 +156,8 @@ export interface TUIState {
   pendingInlineQuestions: Array<() => void>;
   activeInlinePlanApproval?: PlanApprovalInlineComponent;
   activeOnboarding?: OnboardingInlineComponent;
-  lastSubmitPlanComponent?: IToolExecutionComponent;
+  lastSubmitPlanComponent?: Component;
+  pendingSubmitPlanComponents: Map<string, PlanApprovalInlineComponent>;
   /** User-message follow-ups queued while the agent is running */
   pendingFollowUpMessages: Array<{ content: string; images?: Array<{ data: string; mimeType: string }> }>;
   /** FIFO ordering across queued follow-up messages and slash commands */
@@ -273,6 +274,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
     // Inline interaction
     lastClearedText: '',
     pendingAskUserComponents: new Map(),
+    pendingSubmitPlanComponents: new Map(),
     pendingInlineQuestions: [],
     pendingFollowUpMessages: [],
     pendingQueuedActions: [],

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -18,6 +18,7 @@ import type { SlashCommandMetadata } from '../utils/slash-command-loader.js';
 import type { AskQuestionInlineComponent } from './components/ask-question-inline.js';
 import type { AssistantMessageComponent } from './components/assistant-message.js';
 import { CustomEditor } from './components/custom-editor.js';
+import type { JudgeDisplayComponent } from './components/judge-display.js';
 import type { GradientAnimator } from './components/obi-loader.js';
 import type { OMMarkerComponent } from './components/om-marker.js';
 import type { OMProgressComponent } from './components/om-progress.js';
@@ -131,7 +132,7 @@ export interface TUIState {
   hideThinkingBlock: boolean;
   quietMode: boolean;
   /** Active goal judge status-line override while evaluating the last turn. */
-  activeGoalJudge?: { modelId: string };
+  activeGoalJudge?: { modelId: string; abortController: AbortController; component: JudgeDisplayComponent };
 
   // ── Thread / conversation ─────────────────────────────────────────────
   /** True when we want a new thread but haven't created it yet */

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -24,6 +24,22 @@ function isGenericTitle(title: string): boolean {
   );
 }
 
+function formatGoalDuration(startedAt: string): string {
+  const startedMs = Date.parse(startedAt);
+  if (!Number.isFinite(startedMs)) return '<1m';
+
+  const elapsedMinutes = Math.floor(Math.max(0, Date.now() - startedMs) / 60_000);
+  if (elapsedMinutes < 1) return '<1m';
+
+  const days = Math.floor(elapsedMinutes / 1_440);
+  const hours = Math.floor((elapsedMinutes % 1_440) / 60);
+  const minutes = elapsedMinutes % 60;
+
+  if (days > 0) return hours > 0 ? `${days}days${hours}hr` : `${days}days`;
+  if (hours > 0) return minutes > 0 ? `${hours}hr${minutes}m` : `${hours}hr`;
+  return `${minutes}m`;
+}
+
 /**
  * Update the status line at the bottom of the TUI.
  * Progressively reduces content to fit the terminal width.
@@ -143,9 +159,9 @@ export function updateStatusLine(state: TUIState): void {
   const queuedCount = state.pendingQueuedActions.length + state.harness.getFollowUpCount();
   const queuedLabel = queuedCount > 0 ? `${queuedCount} queued` : null;
   const goalState = state.goalManager?.getGoal();
-  const goalAttempt = goalState ? Math.min(goalState.turnsUsed + 1, goalState.maxTurns) : null;
-  const goalLabel = goalState?.status === 'active' ? `goal attempt ${goalAttempt}/${goalState.maxTurns}` : null;
-  const shortGoalLabel = goalState?.status === 'active' ? `attempt ${goalAttempt}/${goalState.maxTurns}` : null;
+  const goalDuration = goalState?.status === 'active' ? formatGoalDuration(goalState.startedAt) : null;
+  const goalLabel = goalDuration ? `pursuing goal (${goalDuration})` : null;
+  const shortGoalLabel = goalDuration ? `goal (${goalDuration})` : null;
   // Build progressively shorter directory strings for layout fallback
   // Only show branch when not showing thread title (thread title takes priority)
   const dirFull = !threadTitle && branch ? `${displayPath} (${branch})` : displayPath;


### PR DESCRIPTION
This tightens up goal mode so it feels more reliable and easier to follow while the judge is running.

The main changes are that `/goal` now has built-in actions and autocomplete, the judge gets the full assistant response plus readonly workspace tools, judge activity streams into the goal box, Ctrl+C can abort judge evaluation, and goal status shows elapsed time instead of attempt counts.

It also makes plans more goal-aware: the base prompt now explains goal mode, plan mode writes plans that can be executed as goals, and submit_plan previews stream into the purple plan box without duplicated tool output.

After:

```txt
/goal status
/goal pause
/goal resume
/goal clear
```

```txt
Goal  ◌ evaluating
• read src/file.ts
• search "submit_plan"
```

```txt
pursuing goal (30m)
```

Verified with the focused mastracode test coverage for goal mode, submit_plan rendering, status line formatting, judge display, and prompt guidance.
<img width="913" height="206" alt="Screenshot 2026-05-15 at 11 44 02 AM" src="https://github.com/user-attachments/assets/9808c0c1-35ea-42bb-a943-d4bea8639571" />

<img width="327" height="82" alt="Screenshot 2026-05-15 at 12 26 45 PM" src="https://github.com/user-attachments/assets/4706dec6-7e52-4d88-ad77-5d45497985fd" />
<img width="912" height="108" alt="Screenshot 2026-05-15 at 11 46 55 AM" src="https://github.com/user-attachments/assets/e89e450d-c813-41a8-96dd-7e648ceb28a2" />


<img width="920" height="865" alt="Screenshot 2026-05-15 at 11 43 54 AM" src="https://github.com/user-attachments/assets/74995fae-a622-4f51-be0a-270d2250cd27" />

<img width="1019" height="600" alt="image" src="https://github.com/user-attachments/assets/e9ecabca-8bdc-4c33-bd8b-9fd5064bab8d" />
<img width="1023" height="287" alt="image" src="https://github.com/user-attachments/assets/79fdd550-1ec7-4c7c-8875-3a50b8b46259" />
<img width="1048" height="401" alt="image" src="https://github.com/user-attachments/assets/2e2163a4-4535-43e5-83ac-c5fb8a21b40c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes goal mode easier and more reliable: it adds a simple menu to manage goals, shows how long a goal has been running, streams live judge activity into the UI, and lets you cancel goal evaluation with Ctrl+C.

## Overview

Enhances goal mode UX and judge flows: adds built-in /goal actions and autocomplete, refactors judge evaluation to receive full assistant responses with readonly workspace tools and live activity streaming, switches goal status to elapsed-time labels, and improves plan-mode and submit_plan streaming so plans can be started as goals without duplicate output.

## Key Changes

### /goal Command and Autocomplete
- `/goal` without args opens a goal-actions modal; `/goal status` delegates to showGoalStatus.
- Built-in subcommands with completions: status, pause, resume, clear.
- Modal lists contextual actions (resume/clear/judge settings/new goal hint).

### Goal Status & State
- GoalState includes startedAt; status displays elapsed durations (compact variants for narrow terminals).
- Replaces attempt-count status with "pursuing goal (<duration>)" and helper formatGoalDuration.

### Judge Evaluation & Display
- Judge receives the full assistant response and a readonly workspace toolset (filesystem, sandbox, LSP, skills) with approval flags disabled.
- Evaluation accepts AbortSignal (Ctrl+C) and onActivity callback; judge activity streams into the UI.
- judge stream consumption prefers fullStream to derive per-tool activity formatting.
- JudgeDisplayComponent refactored for incremental updates: addActivity, setResult, setInterrupted; keeps recent activity buffer, shows evaluating placeholder, and separates activity from final reason.

### Plan Mode & submit_plan Streaming
- Base prompt includes "Goal Mode Awareness"; plan prompt adds "Goal-Ready Plans" guidance.
- Plan approval UI offers "Start as goal" and renders streamed submit_plan previews into a dedicated PlanContentBox to avoid duplicate tool output.
- PlanApprovalInlineComponent gains streaming factory and explicit activate/update methods; PlanResultComponent reuses PlanContentBox and updates status text for feedback.

### Component, Handler, and State Changes
- Added pendingSubmitPlanComponents map and lastSubmitPlanComponent now a generic Component.
- activeGoalJudge state extended to include abortController and JudgeDisplayComponent.
- Handlers pre-allocate judge UI and animator before evaluation, forward abortSignal and onActivity, and update the judge component via setResult.
- Tool handlers wired submit_plan into the inline streaming component flow (ensureSubmitPlanComponent, streaming deltas).

### Keyboard & Interrupt Handling
- Ctrl+C and clear shortcut attempt to abort an active goal judge via abortActiveGoalJudge, set user-initiated abort flag, mark component interrupted, and request UI re-render.

## Testing
- New and updated tests cover:
  - buildFullPrompt goal-mode behavior and plan-mode approval UI text.
  - Goal autocomplete completions.
  - Goal-manager judge behavior: full assistant content, readonly tool config, activity streaming, abortSignal forwarding.
  - Status-line duration formatting.
  - JudgeDisplay activity separation.
  - PlanApprovalInline and submit_plan streaming rendering and feedback flows.
  - Keyboard shortcut abort behavior for active goal judge.

## Files Touched (high level)
- .changeset/goal-judge-ux.md
- mastracode/src/agents/prompts/{base.ts,plan.ts}
- mastracode/src/tui/{goal-manager.ts,state.ts,status-line.ts,setup.ts,commands/goal.ts,handlers/{agent-lifecycle,prompts,tool}.ts}
- mastracode/src/tui/components/{judge-display.ts,plan-approval-inline.ts}
- Multiple test files across agents, tui, components, and handlers

## Notes for Reviewers
- Significant UI/state refactor around judge lifecycle and plan streaming; focus review on abort handling, readonly tool whitelist, judge stream parsing/formatting, and submit_plan streaming to avoid duplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16654)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->