### PR TITLE
chore(playground): drop cosmetic `as any` casts on `client.options` in auth hooks

### DIFF
--- a/.changeset/playground-auth-options-cast-cleanup.md
+++ b/.changeset/playground-auth-options-cast-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Removed the cosmetic `as any` casts on `client.options` across the Studio auth hooks (`use-auth-actions`, `use-auth-capabilities`, `use-credentials-login`, `use-credentials-signup`, `use-current-user`). `useMastraClient()` already returns a typed `MastraClient` whose `options: ClientOptions` field is public, so the casts were unnecessary. The `makeSSOLoginRequest` and `makeLogoutRequest` helper signatures were also tightened from `{ options: any }` to `MastraClient`. No runtime change. Closes [#16655](https://github.com/mastra-ai/mastra/issues/16655).

--- a/packages/playground/src/domains/auth/hooks/use-auth-actions.ts
+++ b/packages/playground/src/domains/auth/hooks/use-auth-actions.ts
@@ -1,3 +1,4 @@
+import type { MastraClient } from '@mastra/client-js';
 import { useMastraClient } from '@mastra/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -38,10 +39,10 @@ import type { SSOLoginResponse, LogoutResponse } from '../types';
  * @internal
  */
 export async function makeSSOLoginRequest(
-  client: { options: any },
+  client: MastraClient,
   { redirectUri }: { redirectUri?: string },
 ): Promise<SSOLoginResponse> {
-  const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options || {};
+  const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options;
   const raw = (apiPrefix || '/api').trim();
   const prefix = (raw.startsWith('/') ? raw : `/${raw}`).replace(/\/$/, '');
 
@@ -71,7 +72,7 @@ export function useSSOLogin() {
   const client = useMastraClient();
 
   return useMutation<SSOLoginResponse, Error, { redirectUri?: string }>({
-    mutationFn: ({ redirectUri }) => makeSSOLoginRequest(client as any, { redirectUri }),
+    mutationFn: ({ redirectUri }) => makeSSOLoginRequest(client, { redirectUri }),
   });
 }
 
@@ -116,8 +117,8 @@ export function useSSOLogin() {
  *
  * @internal
  */
-export async function makeLogoutRequest(client: { options: any }): Promise<LogoutResponse> {
-  const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options || {};
+export async function makeLogoutRequest(client: MastraClient): Promise<LogoutResponse> {
+  const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options;
   const raw = (apiPrefix || '/api').trim();
   const prefix = (raw.startsWith('/') ? raw : `/${raw}`).replace(/\/$/, '');
 
@@ -142,7 +143,7 @@ export function useLogout() {
   const queryClient = useQueryClient();
 
   return useMutation<LogoutResponse, Error, void>({
-    mutationFn: () => makeLogoutRequest(client as any),
+    mutationFn: () => makeLogoutRequest(client),
     onSuccess: () => {
       // Invalidate all auth-related queries
       void queryClient.invalidateQueries({ queryKey: ['auth'] });

--- a/packages/playground/src/domains/auth/hooks/use-auth-capabilities.ts
+++ b/packages/playground/src/domains/auth/hooks/use-auth-capabilities.ts
@@ -11,7 +11,7 @@ import type { AuthCapabilities } from '../types';
  * @internal
  */
 export async function makeAuthCapabilitiesRequest(client: MastraClient): Promise<AuthCapabilities> {
-  const { baseUrl = '', headers: clientHeaders = {}, apiPrefix } = client.options as any;
+  const { baseUrl = '', headers: clientHeaders = {}, apiPrefix } = client.options;
   const raw = (apiPrefix || '/api').trim();
   const prefix = (raw.startsWith('/') ? raw : `/${raw}`).replace(/\/$/, '');
 

--- a/packages/playground/src/domains/auth/hooks/use-credentials-login.ts
+++ b/packages/playground/src/domains/auth/hooks/use-credentials-login.ts
@@ -1,3 +1,4 @@
+import type { MastraClient } from '@mastra/client-js';
 import { useMastraClient } from '@mastra/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -60,7 +61,7 @@ export type CredentialsLoginResponse = {
  * @internal
  */
 export async function makeCredentialsLoginRequest(
-  client: { options: any },
+  client: MastraClient,
   { email, password }: CredentialsLoginRequest,
 ): Promise<CredentialsLoginResponse> {
   const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options || {};
@@ -93,7 +94,7 @@ export function useCredentialsLogin() {
   const queryClient = useQueryClient();
 
   return useMutation<CredentialsLoginResponse, Error, CredentialsLoginRequest>({
-    mutationFn: ({ email, password }) => makeCredentialsLoginRequest(client as any, { email, password }),
+    mutationFn: ({ email, password }) => makeCredentialsLoginRequest(client, { email, password }),
     onSuccess: () => {
       // Invalidate auth queries to refetch user state
       void queryClient.invalidateQueries({ queryKey: ['auth'] });

--- a/packages/playground/src/domains/auth/hooks/use-credentials-signup.ts
+++ b/packages/playground/src/domains/auth/hooks/use-credentials-signup.ts
@@ -1,3 +1,4 @@
+import type { MastraClient } from '@mastra/client-js';
 import { useMastraClient } from '@mastra/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -63,7 +64,7 @@ export type CredentialsSignUpResponse = {
  * @internal
  */
 export async function makeCredentialsSignUpRequest(
-  client: { options: any },
+  client: MastraClient,
   { email, password, name }: CredentialsSignUpRequest,
 ): Promise<CredentialsSignUpResponse> {
   const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options || {};
@@ -96,7 +97,7 @@ export function useCredentialsSignUp() {
   const queryClient = useQueryClient();
 
   return useMutation<CredentialsSignUpResponse, Error, CredentialsSignUpRequest>({
-    mutationFn: ({ email, password, name }) => makeCredentialsSignUpRequest(client as any, { email, password, name }),
+    mutationFn: ({ email, password, name }) => makeCredentialsSignUpRequest(client, { email, password, name }),
     onSuccess: () => {
       // Invalidate auth queries to refetch user state
       void queryClient.invalidateQueries({ queryKey: ['auth'] });

--- a/packages/playground/src/domains/auth/hooks/use-current-user.ts
+++ b/packages/playground/src/domains/auth/hooks/use-current-user.ts
@@ -34,7 +34,7 @@ import { fetchWithRefresh } from './fetch-with-refresh';
  */
 export function useCurrentUser() {
   const client = useMastraClient();
-  const baseUrl = (client as any).options?.baseUrl || '';
+  const baseUrl = client.options?.baseUrl || '';
 
   return useQuery<CurrentUser>({
     queryKey: ['auth', 'me'],


### PR DESCRIPTION
Closes #16655.

The auth hooks in `packages/playground/src/domains/auth/hooks/` were casting `useMastraClient()` to `any` before accessing `.options`. `MastraClient` already exposes `options: ClientOptions` as a public readonly field, so the casts were purely cosmetic. Removed them across all five hooks and tightened the SSO/logout helper signatures from `{ options: any }` to `MastraClient` so the call sites no longer need `client as any` either. No runtime change.

Before:
```ts
const baseUrl = (client as any).options?.baseUrl || '';
```

After:
```ts
const baseUrl = client.options?.baseUrl || '';
```

Verified with `pnpm --filter ./packages/playground typecheck` (no new errors) and the existing auth hook unit tests (`vitest run src/domains/auth/hooks/__tests__`, 13/13 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR removes unnecessary "trust me" type casts (client as any) in the playground's auth hooks so the code uses the client's real typed options directly—it's just a cleanup that makes the TypeScript types clearer without changing behavior.

## Overview

Replaces cosmetic `(client as any).options` accesses across five playground auth hooks with direct `client.options` and tightens helper signatures to accept `MastraClient` where appropriate. No runtime changes.

## Changes

- Files updated:
  - packages/playground/src/domains/auth/hooks/use-auth-actions.ts
    - makeSSOLoginRequest(client: MastraClient, ...) and makeLogoutRequest(client: MastraClient)
    - Removed `as any` casts and now destructure client.options directly.
  - packages/playground/src/domains/auth/hooks/use-auth-capabilities.ts
    - makeAuthCapabilitiesRequest(client: MastraClient) now reads baseUrl/apiPrefix/headers from client.options without casting.
  - packages/playground/src/domains/auth/hooks/use-credentials-login.ts
    - makeCredentialsLoginRequest(client: MastraClient, ...) and useCredentialsLogin call client directly.
  - packages/playground/src/domains/auth/hooks/use-credentials-signup.ts
    - makeCredentialsSignUpRequest(client: MastraClient, ...) and useCredentialsSignUp call client directly.
  - packages/playground/src/domains/auth/hooks/use-current-user.ts
    - useCurrentUser reads client.options?.baseUrl directly.

- Type changes:
  - Helper signatures tightened from loosely typed `{ options: any }` to MastraClient (type-only imports used where needed).
  - Removed fallback `|| {}` in places where client.options is accessed with appropriate optional chaining/defaults.

## Verification

- Typecheck: pnpm --filter ./packages/playground typecheck (no new errors)
- Unit tests: vitest run src/domains/auth/hooks/__tests__ — 13/13 passing
- No runtime behavior changes.

## Related Issue

Closes #16655

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16656)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->