### PR TITLE
feat(auth-clerk): Add IUserProvider + ISSOProvider + ISessionProvider for Studio login

### DIFF
--- a/.changeset/clerk-iuserprovider.md
+++ b/.changeset/clerk-iuserprovider.md
@@ -2,28 +2,25 @@
 '@mastra/auth-clerk': minor
 ---
 
-Added IUserProvider, ISSOProvider, and ISessionProvider for Studio login support.
+Added full Studio authentication support for Clerk users.
 
-- `getCurrentUser` extracts and verifies JWT tokens from Authorization headers or session cookies
-- `getUser` fetches full user details from the Clerk Users API
-- SSO login via Clerk as OAuth 2.0/OIDC Identity Provider (requires OAuth Application in Clerk Dashboard)
-- Encrypted session cookies (PBKDF2 + AES-GCM) for persistent login
+**What's new:**
+- **Studio SSO login** — your internal team can now sign in to Mastra Studio using their Clerk accounts via OAuth 2.0/OIDC
+- **JWT validation** — API requests with Clerk-issued JWTs are automatically validated
+- **Session persistence** — Studio sessions are maintained with encrypted cookies (no need to log in repeatedly)
+
+**Setup:**
+1. Create an OAuth Application in your Clerk Dashboard
+2. Configure the auth provider with your Clerk credentials
 
 ```typescript
 import { MastraAuthClerk } from '@mastra/auth-clerk';
 
-// Basic usage (IUserProvider only — validates JWTs)
 const auth = new MastraAuthClerk({
   jwksUri: process.env.CLERK_JWKS_URI,
   secretKey: process.env.CLERK_SECRET_KEY,
   publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
-});
-
-// With SSO for Studio login
-const authWithSSO = new MastraAuthClerk({
-  jwksUri: process.env.CLERK_JWKS_URI,
-  secretKey: process.env.CLERK_SECRET_KEY,
-  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+  // For Studio SSO login:
   oauthClientId: process.env.CLERK_OAUTH_CLIENT_ID,
   oauthClientSecret: process.env.CLERK_OAUTH_CLIENT_SECRET,
   session: { cookiePassword: process.env.CLERK_COOKIE_PASSWORD },

--- a/.changeset/clerk-iuserprovider.md
+++ b/.changeset/clerk-iuserprovider.md
@@ -2,4 +2,30 @@
 '@mastra/auth-clerk': minor
 ---
 
-Added IUserProvider implementation for Studio login support. `getCurrentUser` extracts and verifies JWT tokens from Authorization headers or `__session` cookies, and `getUser` fetches full user details from the Clerk Users API. Falls back to JWT claims when the API is unreachable.
+Added IUserProvider, ISSOProvider, and ISessionProvider for Studio login support.
+
+- `getCurrentUser` extracts and verifies JWT tokens from Authorization headers or session cookies
+- `getUser` fetches full user details from the Clerk Users API
+- SSO login via Clerk as OAuth 2.0/OIDC Identity Provider (requires OAuth Application in Clerk Dashboard)
+- Encrypted session cookies (PBKDF2 + AES-GCM) for persistent login
+
+```typescript
+import { MastraAuthClerk } from '@mastra/auth-clerk';
+
+// Basic usage (IUserProvider only — validates JWTs)
+const auth = new MastraAuthClerk({
+  jwksUri: process.env.CLERK_JWKS_URI,
+  secretKey: process.env.CLERK_SECRET_KEY,
+  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+});
+
+// With SSO for Studio login
+const authWithSSO = new MastraAuthClerk({
+  jwksUri: process.env.CLERK_JWKS_URI,
+  secretKey: process.env.CLERK_SECRET_KEY,
+  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+  oauthClientId: process.env.CLERK_OAUTH_CLIENT_ID,
+  oauthClientSecret: process.env.CLERK_OAUTH_CLIENT_SECRET,
+  session: { cookiePassword: process.env.CLERK_COOKIE_PASSWORD },
+});
+```

--- a/.changeset/clerk-iuserprovider.md
+++ b/.changeset/clerk-iuserprovider.md
@@ -1,0 +1,5 @@
+---
+'@mastra/auth-clerk': minor
+---
+
+Added IUserProvider implementation for Studio login support. `getCurrentUser` extracts and verifies JWT tokens from Authorization headers or `__session` cookies, and `getUser` fetches full user details from the Clerk Users API. Falls back to JWT claims when the API is unreachable.

--- a/.changeset/clerk-iuserprovider.md
+++ b/.changeset/clerk-iuserprovider.md
@@ -1,5 +1,7 @@
 ---
 '@mastra/auth-clerk': minor
+'@mastra/core': patch
+'@mastra/server': patch
 ---
 
 Added full Studio authentication support for Clerk users.
@@ -26,3 +28,5 @@ const auth = new MastraAuthClerk({
   session: { cookiePassword: process.env.CLERK_COOKIE_PASSWORD },
 });
 ```
+
+**Note:** This release includes updates to `@mastra/core` (ISSOProvider interface now supports async getLoginUrl) and `@mastra/server` (handles async login URLs). All three packages should be updated together.

--- a/auth/clerk/src/index.test.ts
+++ b/auth/clerk/src/index.test.ts
@@ -465,9 +465,7 @@ describe('MastraAuthClerk', () => {
     it('should throw on invalid state', async () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
-      await expect(auth.handleCallback('code123', 'invalid-state')).rejects.toThrow(
-        'Invalid state token format',
-      );
+      await expect(auth.handleCallback('code123', 'invalid-state')).rejects.toThrow('Invalid state token format');
     });
 
     it('should throw on expired state', async () => {

--- a/auth/clerk/src/index.test.ts
+++ b/auth/clerk/src/index.test.ts
@@ -448,17 +448,20 @@ describe('MastraAuthClerk', () => {
     });
 
     it('should throw on expired state', async () => {
-      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+      vi.useFakeTimers();
+      try {
+        const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
-      // Generate a login URL to store state
-      auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'expired-state');
+        // Generate a login URL to store state
+        auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'expired-state');
 
-      // Manually expire the state
-      // Access the module-level stateStore through the closure
-      // We can test this by calling handleCallback immediately, which should work
-      // unless we make the time check fail.
+        // Advance time past state expiry (10 minutes + 1ms)
+        vi.advanceTimersByTime(10 * 60 * 1000 + 1);
 
-      // Instead, test the happy path with a valid state
+        await expect(auth.handleCallback('code123', 'expired-state')).rejects.toThrow('State parameter has expired');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should exchange code for tokens and return user with session cookie', async () => {

--- a/auth/clerk/src/index.test.ts
+++ b/auth/clerk/src/index.test.ts
@@ -404,9 +404,9 @@ describe('MastraAuthClerk', () => {
   });
 
   describe('SSO - getLoginUrl', () => {
-    it('should generate correct Clerk OAuth authorize URL with signed state token', () => {
+    it('should generate correct Clerk OAuth authorize URL with signed state token', async () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
-      const url = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'test-state-id');
+      const url = await auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'test-state-id');
 
       expect(url).toContain('https://brief-amoeba-71.clerk.accounts.dev/oauth/authorize');
       expect(url).toContain('client_id=test-oauth-client-id');
@@ -423,7 +423,7 @@ describe('MastraAuthClerk', () => {
     it('should produce signed state that round-trips through handleCallback', async () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
       const redirectUri = 'http://localhost:4111/api/auth/sso/callback';
-      const url = auth.getLoginUrl(redirectUri, 'test-uuid|%2Fstudio');
+      const url = await auth.getLoginUrl(redirectUri, 'test-uuid|%2Fstudio');
       const signedState = new URL(url).searchParams.get('state')!;
 
       // Mock token exchange
@@ -476,7 +476,7 @@ describe('MastraAuthClerk', () => {
         const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
         // Generate login URL which returns signed state token
-        const loginUrl = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'expired-state');
+        const loginUrl = await auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'expired-state');
         const signedState = new URL(loginUrl).searchParams.get('state')!;
 
         // Advance time past state expiry (10 minutes + 1ms)
@@ -492,7 +492,7 @@ describe('MastraAuthClerk', () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
       // Generate login URL which returns signed state token
-      const loginUrl = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'valid-state');
+      const loginUrl = await auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'valid-state');
       const signedState = new URL(loginUrl).searchParams.get('state')!;
 
       // Mock token exchange response
@@ -563,7 +563,7 @@ describe('MastraAuthClerk', () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
       // Generate login URL which returns signed state token
-      const loginUrl = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'state-no-idtoken');
+      const loginUrl = await auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'state-no-idtoken');
       const signedState = new URL(loginUrl).searchParams.get('state')!;
 
       // Token exchange - no id_token
@@ -609,7 +609,7 @@ describe('MastraAuthClerk', () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
       // Generate login URL which returns signed state token
-      const loginUrl = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'state-fail');
+      const loginUrl = await auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'state-fail');
       const signedState = new URL(loginUrl).searchParams.get('state')!;
 
       mockFetch.mockResolvedValueOnce({

--- a/auth/clerk/src/index.test.ts
+++ b/auth/clerk/src/index.test.ts
@@ -404,7 +404,7 @@ describe('MastraAuthClerk', () => {
   });
 
   describe('SSO - getLoginUrl', () => {
-    it('should generate correct Clerk OAuth authorize URL', () => {
+    it('should generate correct Clerk OAuth authorize URL with signed state token', () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
       const url = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'test-state-id');
 
@@ -412,16 +412,39 @@ describe('MastraAuthClerk', () => {
       expect(url).toContain('client_id=test-oauth-client-id');
       expect(url).toContain('response_type=code');
       expect(url).toContain('scope=openid+profile+email');
-      expect(url).toContain('state=test-state-id');
       expect(url).toContain('redirect_uri=http%3A%2F%2Flocalhost%3A4111%2Fapi%2Fauth%2Fsso%2Fcallback');
+      // State is now a signed token (payload.signature format)
+      const parsedUrl = new URL(url);
+      const state = parsedUrl.searchParams.get('state');
+      expect(state).toBeTruthy();
+      expect(state!.split('.').length).toBe(2); // payload.signature format
     });
 
-    it('should extract state ID from state with encoded redirect', () => {
+    it('should produce signed state that round-trips through handleCallback', async () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
-      const url = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'uuid-123|%2Fstudio');
+      const redirectUri = 'http://localhost:4111/api/auth/sso/callback';
+      const url = auth.getLoginUrl(redirectUri, 'test-uuid|%2Fstudio');
+      const signedState = new URL(url).searchParams.get('state')!;
 
-      // State should be passed as-is to the URL
-      expect(url).toContain('state=uuid-123%7C%252Fstudio');
+      // Mock token exchange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'at',
+          id_token: 'it',
+          expires_in: 3600,
+          token_type: 'bearer',
+        }),
+      });
+      // Mock verifyJwks for ID token verification
+      (verifyJwks as any).mockResolvedValue({
+        sub: 'clerk|user',
+        email: 'test@example.com',
+      });
+
+      // handleCallback should not throw if state is valid
+      const result = await auth.handleCallback('code', signedState);
+      expect(result.user.id).toBe('clerk|user');
     });
   });
 
@@ -443,7 +466,7 @@ describe('MastraAuthClerk', () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
       await expect(auth.handleCallback('code123', 'invalid-state')).rejects.toThrow(
-        'Invalid or expired state parameter',
+        'Invalid state token format',
       );
     });
 
@@ -452,13 +475,14 @@ describe('MastraAuthClerk', () => {
       try {
         const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
-        // Generate a login URL to store state
-        auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'expired-state');
+        // Generate login URL which returns signed state token
+        const loginUrl = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'expired-state');
+        const signedState = new URL(loginUrl).searchParams.get('state')!;
 
         // Advance time past state expiry (10 minutes + 1ms)
         vi.advanceTimersByTime(10 * 60 * 1000 + 1);
 
-        await expect(auth.handleCallback('code123', 'expired-state')).rejects.toThrow('State parameter has expired');
+        await expect(auth.handleCallback('code123', signedState)).rejects.toThrow('State token has expired');
       } finally {
         vi.useRealTimers();
       }
@@ -467,8 +491,9 @@ describe('MastraAuthClerk', () => {
     it('should exchange code for tokens and return user with session cookie', async () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
-      // First generate login URL to store state
-      auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'valid-state');
+      // Generate login URL which returns signed state token
+      const loginUrl = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'valid-state');
+      const signedState = new URL(loginUrl).searchParams.get('state')!;
 
       // Mock token exchange response
       mockFetch.mockResolvedValueOnce({
@@ -500,7 +525,7 @@ describe('MastraAuthClerk', () => {
         publicMetadata: { role: 'admin' },
       });
 
-      const result = await auth.handleCallback('auth-code-123', 'valid-state');
+      const result = await auth.handleCallback('auth-code-123', signedState);
 
       // Verify token exchange was called
       expect(mockFetch).toHaveBeenCalledWith(
@@ -537,7 +562,9 @@ describe('MastraAuthClerk', () => {
     it('should fall back to userinfo endpoint when no id_token', async () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
-      auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'state-no-idtoken');
+      // Generate login URL which returns signed state token
+      const loginUrl = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'state-no-idtoken');
+      const signedState = new URL(loginUrl).searchParams.get('state')!;
 
       // Token exchange - no id_token
       mockFetch.mockResolvedValueOnce({
@@ -563,7 +590,7 @@ describe('MastraAuthClerk', () => {
       // getUser enrichment fails
       mockClerkClient.users.getUser.mockRejectedValue(new Error('not found'));
 
-      const result = await auth.handleCallback('code-456', 'state-no-idtoken');
+      const result = await auth.handleCallback('code-456', signedState);
 
       expect(result.user.id).toBe('user_456');
       expect(result.user.email).toBe('user@example.com');
@@ -581,14 +608,16 @@ describe('MastraAuthClerk', () => {
     it('should throw on failed token exchange', async () => {
       const auth = new MastraAuthClerk(mockSSOOptions) as any;
 
-      auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'state-fail');
+      // Generate login URL which returns signed state token
+      const loginUrl = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'state-fail');
+      const signedState = new URL(loginUrl).searchParams.get('state')!;
 
       mockFetch.mockResolvedValueOnce({
         ok: false,
         text: async () => 'invalid_grant',
       });
 
-      await expect(auth.handleCallback('bad-code', 'state-fail')).rejects.toThrow('Token exchange failed');
+      await expect(auth.handleCallback('bad-code', signedState)).rejects.toThrow('Token exchange failed');
     });
   });
 

--- a/auth/clerk/src/index.test.ts
+++ b/auth/clerk/src/index.test.ts
@@ -22,6 +22,7 @@ describe('MastraAuthClerk', () => {
   const mockClerkClient = {
     users: {
       getOrganizationMembershipList: vi.fn(),
+      getUser: vi.fn(),
     },
   };
 
@@ -159,6 +160,130 @@ describe('MastraAuthClerk', () => {
       });
       const userWithoutOrg = { sub: 'user456' };
       expect(await clerk.authorizeUser(userWithoutOrg)).toBe(false);
+    });
+  });
+
+  describe('getCurrentUser', () => {
+    it('should return user from Authorization header token', async () => {
+      const mockPayload = { sub: 'user_123', email: 'test@example.com', name: 'Test User' };
+      (verifyJwks as any).mockResolvedValue(mockPayload);
+
+      const mockUserRecord = {
+        id: 'user_123',
+        emailAddresses: [{ emailAddress: 'test@example.com' }],
+        firstName: 'Test',
+        lastName: 'User',
+        imageUrl: 'https://img.clerk.com/avatar.png',
+        publicMetadata: {},
+      };
+      mockClerkClient.users.getUser.mockResolvedValue(mockUserRecord);
+
+      const auth = new MastraAuthClerk(mockOptions);
+      const request = new Request('http://localhost', {
+        headers: { Authorization: 'Bearer test-token' },
+      });
+
+      const user = await auth.getCurrentUser(request);
+
+      expect(user).toEqual({
+        id: 'user_123',
+        email: 'test@example.com',
+        name: 'Test User',
+        avatarUrl: 'https://img.clerk.com/avatar.png',
+        metadata: {},
+      });
+    });
+
+    it('should return null when no token is present', async () => {
+      const auth = new MastraAuthClerk(mockOptions);
+      const request = new Request('http://localhost');
+
+      const user = await auth.getCurrentUser(request);
+      expect(user).toBeNull();
+    });
+
+    it('should return null when token verification fails', async () => {
+      (verifyJwks as any).mockRejectedValue(new Error('Invalid token'));
+
+      const auth = new MastraAuthClerk(mockOptions);
+      const request = new Request('http://localhost', {
+        headers: { Authorization: 'Bearer bad-token' },
+      });
+
+      const user = await auth.getCurrentUser(request);
+      expect(user).toBeNull();
+    });
+
+    it('should fall back to JWT claims when Clerk API fails', async () => {
+      const mockPayload = { sub: 'user_123', email: 'test@example.com', name: 'Test User' };
+      (verifyJwks as any).mockResolvedValue(mockPayload);
+      mockClerkClient.users.getUser.mockRejectedValue(new Error('API error'));
+
+      const auth = new MastraAuthClerk(mockOptions);
+      const request = new Request('http://localhost', {
+        headers: { Authorization: 'Bearer test-token' },
+      });
+
+      const user = await auth.getCurrentUser(request);
+      expect(user).toEqual({
+        id: 'user_123',
+        email: 'test@example.com',
+        name: 'Test User',
+      });
+    });
+
+    it('should extract token from __session cookie', async () => {
+      const mockPayload = { sub: 'user_123' };
+      (verifyJwks as any).mockResolvedValue(mockPayload);
+      mockClerkClient.users.getUser.mockRejectedValue(new Error('API error'));
+
+      const auth = new MastraAuthClerk(mockOptions);
+      const request = new Request('http://localhost', {
+        headers: { Cookie: '__session=cookie-token; other=value' },
+      });
+
+      const user = await auth.getCurrentUser(request);
+      expect(verifyJwks).toHaveBeenCalledWith('cookie-token', mockOptions.jwksUri);
+      expect(user).toEqual({
+        id: 'user_123',
+        email: undefined,
+        name: undefined,
+      });
+    });
+  });
+
+  describe('getUser', () => {
+    it('should return user from Clerk API', async () => {
+      const mockUserRecord = {
+        id: 'user_123',
+        emailAddresses: [{ emailAddress: 'test@example.com' }],
+        firstName: 'Test',
+        lastName: 'User',
+        imageUrl: 'https://img.clerk.com/avatar.png',
+        publicMetadata: { role: 'admin' },
+      };
+      mockClerkClient.users.getUser.mockResolvedValue(mockUserRecord);
+
+      const auth = new MastraAuthClerk(mockOptions);
+      const user = await auth.getUser('user_123');
+
+      expect(mockClerkClient.users.getUser).toHaveBeenCalledWith('user_123');
+      expect(user).toEqual({
+        id: 'user_123',
+        email: 'test@example.com',
+        name: 'Test User',
+        avatarUrl: 'https://img.clerk.com/avatar.png',
+        metadata: { role: 'admin' },
+      });
+    });
+
+    it('should return null when user is not found', async () => {
+      mockClerkClient.users.getUser.mockRejectedValue(new Error('Not found'));
+
+      const auth = new MastraAuthClerk(mockOptions);
+      const user = await auth.getUser('nonexistent');
+
+      expect(user).toBeNull();
     });
   });
 

--- a/auth/clerk/src/index.test.ts
+++ b/auth/clerk/src/index.test.ts
@@ -12,11 +12,25 @@ vi.mock('@mastra/auth', () => ({
   verifyJwks: vi.fn(),
 }));
 
+// Mock global fetch for SSO token exchange and userinfo
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
 describe('MastraAuthClerk', () => {
   const mockOptions = {
     jwksUri: 'https://clerk.jwks.uri',
     secretKey: 'test-secret-key',
-    publishableKey: 'test-publishable-key',
+    // pk_test_ + base64("brief-amoeba-71.clerk.accounts.dev$")
+    publishableKey: 'pk_test_YnJpZWYtYW1vZWJhLTcxLmNsZXJrLmFjY291bnRzLmRldiQ=',
+  };
+
+  const mockSSOOptions = {
+    ...mockOptions,
+    oauthClientId: 'test-oauth-client-id',
+    oauthClientSecret: 'test-oauth-client-secret',
+    session: {
+      cookiePassword: 'a-very-long-cookie-password-that-is-at-least-32-chars',
+    },
   };
 
   const mockClerkClient = {
@@ -29,6 +43,7 @@ describe('MastraAuthClerk', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (createClerkClient as any).mockReturnValue(mockClerkClient);
+    mockFetch.mockReset();
   });
 
   describe('initialization', () => {
@@ -43,6 +58,33 @@ describe('MastraAuthClerk', () => {
 
     it('should throw error when required options are missing', () => {
       expect(() => new MastraAuthClerk({})).toThrow('Clerk JWKS URI, secret key and publishable key are required');
+    });
+
+    it('should derive the correct FAPI URL from publishable key', () => {
+      const auth = new MastraAuthClerk(mockOptions);
+      expect(auth.getFapiUrl()).toBe('https://brief-amoeba-71.clerk.accounts.dev');
+    });
+
+    it('should not have SSO enabled without OAuth credentials', () => {
+      const auth = new MastraAuthClerk(mockOptions);
+      expect(auth.isSSOEnabled()).toBe(false);
+    });
+
+    it('should have SSO enabled with OAuth credentials', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions);
+      expect(auth.isSSOEnabled()).toBe(true);
+    });
+
+    it('should throw when cookie password is too short for SSO', () => {
+      expect(
+        () =>
+          new MastraAuthClerk({
+            ...mockOptions,
+            oauthClientId: 'test-id',
+            oauthClientSecret: 'test-secret',
+            session: { cookiePassword: 'short' },
+          }),
+      ).toThrow('Cookie password must be at least 32 characters');
     });
   });
 
@@ -103,26 +145,21 @@ describe('MastraAuthClerk', () => {
       const clerk = new MastraAuthClerk({
         ...mockOptions,
         async authorizeUser(user: any): Promise<boolean> {
-          // Custom authorization logic that checks for specific permissions
           return user?.permissions?.includes('admin') ?? false;
         },
       });
 
-      // Test with admin user
       const adminUser = { sub: 'user123', permissions: ['admin'] };
       expect(await clerk.authorizeUser(adminUser)).toBe(true);
 
-      // Test with non-admin user
       const regularUser = { sub: 'user456', permissions: ['read'] };
       expect(await clerk.authorizeUser(regularUser)).toBe(false);
 
-      // Test with user without permissions
       const noPermissionsUser = { sub: 'user789' };
       expect(await clerk.authorizeUser(noPermissionsUser)).toBe(false);
     });
 
     it('can use organization-based authorization when organizations are enabled', async () => {
-      // Mock the organization membership API call for this test
       const mockOrgClerkClient = {
         users: {
           getOrganizationMembershipList: vi.fn(),
@@ -141,20 +178,17 @@ describe('MastraAuthClerk', () => {
             });
             return orgs.data.length > 0;
           } catch {
-            // Fallback if organizations are not enabled
             return true;
           }
         },
       });
 
-      // Test with user who has organization membership
       mockOrgClerkClient.users.getOrganizationMembershipList.mockResolvedValue({
         data: [{ id: 'org1' }],
       });
       const userWithOrg = { sub: 'user123' };
       expect(await clerk.authorizeUser(userWithOrg)).toBe(true);
 
-      // Test with user who has no organization memberships
       mockOrgClerkClient.users.getOrganizationMembershipList.mockResolvedValue({
         data: [],
       });
@@ -320,6 +354,310 @@ describe('MastraAuthClerk', () => {
 
       expect(clerk.public).toEqual(publicRoutes);
       expect(clerk.protected).toEqual(protectedRoutes);
+    });
+  });
+
+  // ============================================================================
+  // SSO Tests (ISSOProvider + ISessionProvider)
+  // ============================================================================
+
+  describe('SSO - duck-typing detection', () => {
+    it('should NOT have getLoginUrl when SSO is not configured', () => {
+      const auth = new MastraAuthClerk(mockOptions);
+      expect('getLoginUrl' in auth).toBe(false);
+    });
+
+    it('should have getLoginUrl when SSO is configured', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions);
+      expect('getLoginUrl' in auth).toBe(true);
+    });
+
+    it('should NOT have handleCallback when SSO is not configured', () => {
+      const auth = new MastraAuthClerk(mockOptions);
+      expect('handleCallback' in auth).toBe(false);
+    });
+
+    it('should have handleCallback when SSO is configured', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions);
+      expect('handleCallback' in auth).toBe(true);
+    });
+
+    it('should NOT have createSession when SSO is not configured', () => {
+      const auth = new MastraAuthClerk(mockOptions);
+      expect('createSession' in auth).toBe(false);
+    });
+
+    it('should have createSession when SSO is configured', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions);
+      expect('createSession' in auth).toBe(true);
+    });
+
+    it('should NOT have getClearSessionHeaders when SSO is not configured', () => {
+      const auth = new MastraAuthClerk(mockOptions);
+      expect('getClearSessionHeaders' in auth).toBe(false);
+    });
+
+    it('should have getClearSessionHeaders when SSO is configured', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions);
+      expect('getClearSessionHeaders' in auth).toBe(true);
+    });
+  });
+
+  describe('SSO - getLoginUrl', () => {
+    it('should generate correct Clerk OAuth authorize URL', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+      const url = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'test-state-id');
+
+      expect(url).toContain('https://brief-amoeba-71.clerk.accounts.dev/oauth/authorize');
+      expect(url).toContain('client_id=test-oauth-client-id');
+      expect(url).toContain('response_type=code');
+      expect(url).toContain('scope=openid+profile+email');
+      expect(url).toContain('state=test-state-id');
+      expect(url).toContain('redirect_uri=http%3A%2F%2Flocalhost%3A4111%2Fapi%2Fauth%2Fsso%2Fcallback');
+    });
+
+    it('should extract state ID from state with encoded redirect', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+      const url = auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'uuid-123|%2Fstudio');
+
+      // State should be passed as-is to the URL
+      expect(url).toContain('state=uuid-123%7C%252Fstudio');
+    });
+  });
+
+  describe('SSO - getLoginButtonConfig', () => {
+    it('should return Clerk SSO config', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+      const config = auth.getLoginButtonConfig();
+
+      expect(config).toEqual({
+        provider: 'clerk',
+        text: 'Sign in with Clerk',
+        description: 'Sign in using your Clerk account',
+      });
+    });
+  });
+
+  describe('SSO - handleCallback', () => {
+    it('should throw on invalid state', async () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+
+      await expect(auth.handleCallback('code123', 'invalid-state')).rejects.toThrow(
+        'Invalid or expired state parameter',
+      );
+    });
+
+    it('should throw on expired state', async () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+
+      // Generate a login URL to store state
+      auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'expired-state');
+
+      // Manually expire the state
+      // Access the module-level stateStore through the closure
+      // We can test this by calling handleCallback immediately, which should work
+      // unless we make the time check fail.
+
+      // Instead, test the happy path with a valid state
+    });
+
+    it('should exchange code for tokens and return user with session cookie', async () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+
+      // First generate login URL to store state
+      auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'valid-state');
+
+      // Mock token exchange response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'access-token-123',
+          id_token: 'id-token-123',
+          refresh_token: 'refresh-token-123',
+          expires_in: 3600,
+          token_type: 'bearer',
+        }),
+      });
+
+      // Mock verifyJwks for ID token verification
+      (verifyJwks as any).mockResolvedValue({
+        sub: 'user_123',
+        email: 'test@example.com',
+        name: 'Test User',
+        picture: 'https://img.clerk.com/avatar.png',
+      });
+
+      // Mock getUser for enrichment
+      mockClerkClient.users.getUser.mockResolvedValue({
+        id: 'user_123',
+        emailAddresses: [{ emailAddress: 'test@example.com' }],
+        firstName: 'Test',
+        lastName: 'User',
+        imageUrl: 'https://img.clerk.com/avatar.png',
+        publicMetadata: { role: 'admin' },
+      });
+
+      const result = await auth.handleCallback('auth-code-123', 'valid-state');
+
+      // Verify token exchange was called
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://brief-amoeba-71.clerk.accounts.dev/oauth/token',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/x-www-form-urlencoded',
+          }),
+        }),
+      );
+
+      // Verify user was returned
+      expect(result.user).toEqual({
+        id: 'user_123',
+        email: 'test@example.com',
+        name: 'Test User',
+        avatarUrl: 'https://img.clerk.com/avatar.png',
+        metadata: { role: 'admin' },
+      });
+
+      // Verify tokens
+      expect(result.tokens.accessToken).toBe('access-token-123');
+      expect(result.tokens.refreshToken).toBe('refresh-token-123');
+      expect(result.tokens.idToken).toBe('id-token-123');
+
+      // Verify cookie was set
+      expect(result.cookies).toHaveLength(1);
+      expect(result.cookies[0]).toContain('clerk_session=');
+      expect(result.cookies[0]).toContain('HttpOnly');
+      expect(result.cookies[0]).toContain('SameSite=Lax');
+    });
+
+    it('should fall back to userinfo endpoint when no id_token', async () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+
+      auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'state-no-idtoken');
+
+      // Token exchange - no id_token
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'access-token-456',
+          expires_in: 3600,
+          token_type: 'bearer',
+        }),
+      });
+
+      // Userinfo endpoint
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sub: 'user_456',
+          email: 'user@example.com',
+          name: 'Another User',
+          picture: 'https://img.clerk.com/avatar2.png',
+        }),
+      });
+
+      // getUser enrichment fails
+      mockClerkClient.users.getUser.mockRejectedValue(new Error('not found'));
+
+      const result = await auth.handleCallback('code-456', 'state-no-idtoken');
+
+      expect(result.user.id).toBe('user_456');
+      expect(result.user.email).toBe('user@example.com');
+
+      // Verify userinfo was called
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        'https://brief-amoeba-71.clerk.accounts.dev/oauth/userinfo',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer access-token-456' },
+        }),
+      );
+    });
+
+    it('should throw on failed token exchange', async () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+
+      auth.getLoginUrl('http://localhost:4111/api/auth/sso/callback', 'state-fail');
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        text: async () => 'invalid_grant',
+      });
+
+      await expect(auth.handleCallback('bad-code', 'state-fail')).rejects.toThrow('Token exchange failed');
+    });
+  });
+
+  describe('SSO - session management', () => {
+    it('should create a session with correct expiry', async () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+      const session = await auth.createSession('user_123', { key: 'value' });
+
+      expect(session.userId).toBe('user_123');
+      expect(session.id).toBeDefined();
+      expect(session.createdAt).toBeInstanceOf(Date);
+      expect(session.expiresAt).toBeInstanceOf(Date);
+      expect(session.metadata).toEqual({ key: 'value' });
+    });
+
+    it('should return null for validateSession', async () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+      const result = await auth.validateSession('session-id');
+      expect(result).toBeNull();
+    });
+
+    it('should return clear session headers', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+      const headers = auth.getClearSessionHeaders();
+
+      expect(headers['Set-Cookie']).toContain('clerk_session=');
+      expect(headers['Set-Cookie']).toContain('Max-Age=0');
+    });
+
+    it('should extract session ID from request cookie', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+      const request = new Request('http://localhost', {
+        headers: { Cookie: 'clerk_session=encrypted-data; other=val' },
+      });
+
+      const sessionId = auth.getSessionIdFromRequest(request);
+      expect(sessionId).toBe('encrypted-data');
+    });
+
+    it('should return null when no session cookie', () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+      const request = new Request('http://localhost');
+
+      const sessionId = auth.getSessionIdFromRequest(request);
+      expect(sessionId).toBeNull();
+    });
+  });
+
+  describe('SSO - getLogoutUrl', () => {
+    it('should return null (Clerk does not have OAuth logout URL)', async () => {
+      const auth = new MastraAuthClerk(mockSSOOptions) as any;
+      const result = await auth.getLogoutUrl('http://localhost');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('FAPI URL derivation', () => {
+    it('should derive correct URL for test key', () => {
+      const auth = new MastraAuthClerk({
+        ...mockOptions,
+        publishableKey: 'pk_test_YnJpZWYtYW1vZWJhLTcxLmNsZXJrLmFjY291bnRzLmRldiQ=',
+      });
+      expect(auth.getFapiUrl()).toBe('https://brief-amoeba-71.clerk.accounts.dev');
+    });
+
+    it('should derive correct URL for live key', () => {
+      // Base64 of "clerk.example.com$" is "Y2xlcmsuZXhhbXBsZS5jb20k"
+      const auth = new MastraAuthClerk({
+        ...mockOptions,
+        publishableKey: 'pk_live_Y2xlcmsuZXhhbXBsZS5jb20k',
+      });
+      expect(auth.getFapiUrl()).toBe('https://clerk.example.com');
     });
   });
 });

--- a/auth/clerk/src/index.ts
+++ b/auth/clerk/src/index.ts
@@ -2,22 +2,186 @@ import { createClerkClient } from '@clerk/backend';
 import type { ClerkClient } from '@clerk/backend';
 import { verifyJwks } from '@mastra/auth';
 import type { JwtPayload } from '@mastra/auth';
-import type { IUserProvider } from '@mastra/core/auth';
+import type {
+  ISSOProvider,
+  ISessionProvider,
+  IUserProvider,
+  Session,
+  SSOCallbackResult,
+  SSOLoginConfig,
+} from '@mastra/core/auth';
 import type { EEUser } from '@mastra/core/auth/ee';
 import type { MastraAuthProviderOptions } from '@mastra/core/server';
 import { MastraAuthProvider } from '@mastra/core/server';
 
 type ClerkUser = JwtPayload;
 
+/** Default cookie name for Clerk SSO sessions */
+const DEFAULT_COOKIE_NAME = 'clerk_session';
+
+/** Default cookie max age (24 hours) */
+const DEFAULT_COOKIE_MAX_AGE = 86400;
+
+/** Default OAuth scopes */
+const DEFAULT_SCOPES = ['openid', 'profile', 'email'];
+
+/** PBKDF2 salt length in bytes */
+const SALT_LENGTH = 16;
+
+/** AES-GCM IV length in bytes */
+const IV_LENGTH = 12;
+
+/**
+ * Derive an AES-GCM key from password + salt using PBKDF2.
+ */
+async function deriveKey(password: string, salt: Uint8Array, usage: 'encrypt' | 'decrypt') {
+  const encoder = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey('raw', encoder.encode(password), 'PBKDF2', false, [
+    'deriveBits',
+    'deriveKey',
+  ]);
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    [usage],
+  );
+}
+
+/**
+ * Encrypt session data for cookie storage.
+ * Format: base64(salt || iv || ciphertext)
+ */
+async function encryptSession(data: unknown, password: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+  const key = await deriveKey(password, salt, 'encrypt');
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoder.encode(JSON.stringify(data)));
+  const combined = new Uint8Array(salt.length + iv.length + new Uint8Array(encrypted).length);
+  combined.set(salt);
+  combined.set(iv, salt.length);
+  combined.set(new Uint8Array(encrypted), salt.length + iv.length);
+  return btoa(String.fromCharCode(...combined));
+}
+
+/**
+ * Decrypt session data from cookie.
+ */
+async function decryptSession(encrypted: string, password: string): Promise<unknown> {
+  const combined = Uint8Array.from(atob(encrypted), c => c.charCodeAt(0));
+  const salt = combined.slice(0, SALT_LENGTH);
+  const iv = combined.slice(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+  const data = combined.slice(SALT_LENGTH + IV_LENGTH);
+  const key = await deriveKey(password, salt, 'decrypt');
+  const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+  return JSON.parse(new TextDecoder().decode(decrypted));
+}
+
+/**
+ * In-memory store for OAuth state validation.
+ */
+const stateStore = new Map<string, { expiresAt: number; redirectUri: string }>();
+
+/**
+ * Derive the Frontend API (FAPI) URL from a Clerk publishable key.
+ * The publishable key is: prefix + base64(fapiDomain + "$")
+ */
+function deriveFapiUrl(publishableKey: string): string {
+  const withoutPrefix = publishableKey.replace(/^pk_(test|live)_/, '');
+  const decoded = atob(withoutPrefix);
+  const domain = decoded.replace(/\$$/, '');
+  return `https://${domain}`;
+}
+
+interface MastraAuthClerkSessionOptions {
+  /** Cookie name for the session (default: 'clerk_session') */
+  cookieName?: string;
+  /** Cookie max age in seconds (default: 86400 = 24 hours) */
+  cookieMaxAge?: number;
+  /** Cookie encryption password (min 32 chars). Falls back to CLERK_COOKIE_PASSWORD env var */
+  cookiePassword?: string;
+  /** Use Secure flag on cookies (default: true in production) */
+  secureCookies?: boolean;
+}
+
 interface MastraAuthClerkOptions extends MastraAuthProviderOptions<ClerkUser> {
   jwksUri?: string;
   secretKey?: string;
   publishableKey?: string;
+  /**
+   * OAuth Client ID for Clerk as IdP (SSO).
+   * Create an OAuth Application in the Clerk Dashboard to get this.
+   * Falls back to CLERK_OAUTH_CLIENT_ID env var.
+   */
+  oauthClientId?: string;
+  /**
+   * OAuth Client Secret for Clerk as IdP (SSO).
+   * Falls back to CLERK_OAUTH_CLIENT_SECRET env var.
+   */
+  oauthClientSecret?: string;
+  /**
+   * OAuth redirect URI for the SSO callback.
+   * Falls back to CLERK_OAUTH_REDIRECT_URI env var.
+   * Typically: http://localhost:4111/api/auth/sso/callback
+   */
+  redirectUri?: string;
+  /**
+   * OAuth scopes to request (default: ['openid', 'profile', 'email'])
+   */
+  scopes?: string[];
+  /**
+   * Session configuration for SSO cookie management.
+   */
+  session?: MastraAuthClerkSessionOptions;
 }
 
+/**
+ * Clerk authentication provider for Mastra.
+ *
+ * Always implements IUserProvider for JWT-based user detection.
+ *
+ * When OAuth credentials are configured (oauthClientId + oauthClientSecret),
+ * also dynamically adds ISSOProvider + ISessionProvider methods for Studio login
+ * using Clerk as an OAuth 2.0 / OIDC Identity Provider.
+ *
+ * @example Basic usage (IUserProvider only — validates JWTs)
+ * ```typescript
+ * const auth = new MastraAuthClerk({
+ *   jwksUri: 'https://your-app.clerk.accounts.dev/.well-known/jwks.json',
+ *   secretKey: 'sk_test_...',
+ *   publishableKey: 'pk_test_...',
+ * });
+ * ```
+ *
+ * @example With SSO for Studio login
+ * ```typescript
+ * const auth = new MastraAuthClerk({
+ *   jwksUri: 'https://your-app.clerk.accounts.dev/.well-known/jwks.json',
+ *   secretKey: 'sk_test_...',
+ *   publishableKey: 'pk_test_...',
+ *   oauthClientId: 'your-oauth-client-id',
+ *   oauthClientSecret: 'your-oauth-client-secret',
+ * });
+ * ```
+ */
 export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IUserProvider<EEUser> {
   protected clerk: ClerkClient;
   protected jwksUri: string;
+  protected publishableKey: string;
+  protected fapiUrl: string;
+
+  // SSO fields
+  private oauthClientId: string | null;
+  private oauthClientSecret: string | null;
+  private _redirectUri: string | null;
+  private scopes: string[];
+  private cookieName: string;
+  private cookieMaxAge: number;
+  private cookiePassword: string;
+  private secureCookies: boolean;
+  private ssoEnabled: boolean;
 
   constructor(options?: MastraAuthClerkOptions) {
     super({ name: options?.name ?? 'clerk' });
@@ -33,25 +197,96 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
     }
 
     this.jwksUri = jwksUri;
+    this.publishableKey = publishableKey;
+    this.fapiUrl = deriveFapiUrl(publishableKey);
     this.clerk = createClerkClient({
       secretKey,
       publishableKey,
     });
 
+    // SSO configuration (optional — enables Studio login)
+    const oauthClientId = options?.oauthClientId ?? process.env.CLERK_OAUTH_CLIENT_ID;
+    const oauthClientSecret = options?.oauthClientSecret ?? process.env.CLERK_OAUTH_CLIENT_SECRET;
+    const redirectUri = options?.redirectUri ?? process.env.CLERK_OAUTH_REDIRECT_URI;
+    const cookiePassword =
+      options?.session?.cookiePassword ??
+      process.env.CLERK_COOKIE_PASSWORD ??
+      crypto.randomUUID() + crypto.randomUUID();
+
+    this.oauthClientId = oauthClientId ?? null;
+    this.oauthClientSecret = oauthClientSecret ?? null;
+    this._redirectUri = redirectUri ?? null;
+    this.scopes = options?.scopes ?? DEFAULT_SCOPES;
+    this.cookieName = options?.session?.cookieName ?? DEFAULT_COOKIE_NAME;
+    this.cookieMaxAge = options?.session?.cookieMaxAge ?? DEFAULT_COOKIE_MAX_AGE;
+    this.cookiePassword = cookiePassword;
+    this.secureCookies = options?.session?.secureCookies ?? process.env.NODE_ENV === 'production';
+
+    // SSO is enabled when OAuth credentials are configured
+    this.ssoEnabled = !!(oauthClientId && oauthClientSecret);
+
+    if (this.ssoEnabled) {
+      if (cookiePassword.length < 32) {
+        throw new Error(
+          'Cookie password must be at least 32 characters for SSO. Set CLERK_COOKIE_PASSWORD environment variable.',
+        );
+      }
+
+      if (!options?.session?.cookiePassword && !process.env.CLERK_COOKIE_PASSWORD) {
+        console.warn(
+          '[MastraAuthClerk] No cookie password set — using auto-generated value. Sessions will not survive restarts. Set CLERK_COOKIE_PASSWORD for production use.',
+        );
+      }
+
+      // Dynamically add ISSOProvider + ISessionProvider methods
+      // so that duck-typing detection (implementsInterface) only finds them when SSO is configured
+      this._attachSSOProvider();
+      this._attachSessionProvider();
+    }
+
     this.registerOptions(options);
   }
 
-  async authenticateToken(token: string): Promise<ClerkUser | null> {
-    const user = await verifyJwks(token, this.jwksUri);
-    return user;
+  // ============================================================================
+  // MastraAuthProvider Implementation
+  // ============================================================================
+
+  async authenticateToken(
+    token: string,
+    request?: Request | { header(name: string): string | undefined },
+  ): Promise<ClerkUser | null> {
+    // When SSO is enabled, try the encrypted session cookie first (like Okta pattern).
+    // The auth middleware may call this with an empty token for browser requests
+    // that only carry a session cookie.
+    if (this.ssoEnabled && request) {
+      const sessionUser = await this.getUserFromSessionCookie(request as Request);
+      if (sessionUser) return sessionUser as unknown as ClerkUser;
+    }
+
+    // Fall back to JWT verification from Authorization header
+    if (!token || typeof token !== 'string') {
+      return null;
+    }
+
+    try {
+      const user = await verifyJwks(token, this.jwksUri);
+      return user;
+    } catch {
+      return null;
+    }
   }
 
   async authorizeUser(user: ClerkUser) {
-    return !!user.sub;
+    // Session cookie users have `id`, JWT users have `sub`
+    return !!(user.sub || (user as unknown as EEUser).id);
   }
 
+  // ============================================================================
+  // IUserProvider Implementation
+  // ============================================================================
+
   /**
-   * Extract the bearer token from the request's Authorization header or cookie.
+   * Extract the bearer token from the request's Authorization header or __session cookie.
    */
   private extractToken(request: Request): string | null {
     const authHeader = request.headers.get('Authorization');
@@ -71,6 +306,13 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
   }
 
   async getCurrentUser(request: Request): Promise<EEUser | null> {
+    // First try to get user from our SSO session cookie
+    if (this.ssoEnabled) {
+      const sessionUser = await this.getUserFromSessionCookie(request);
+      if (sessionUser) return sessionUser;
+    }
+
+    // Fall back to token-based auth (Authorization header or __session cookie)
     const token = this.extractToken(request);
     if (!token) return null;
 
@@ -118,5 +360,291 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
 
   getUserProfileUrl(user: EEUser): string {
     return `/user/${user.id}`;
+  }
+
+  // ============================================================================
+  // Helper Methods
+  // ============================================================================
+
+  /**
+   * Check if SSO is enabled (OAuth credentials are configured).
+   */
+  isSSOEnabled(): boolean {
+    return this.ssoEnabled;
+  }
+
+  /**
+   * Get the derived Frontend API URL.
+   */
+  getFapiUrl(): string {
+    return this.fapiUrl;
+  }
+
+  /**
+   * Build consistent cookie attribute string for set/clear operations.
+   */
+  private cookieFlags(maxAge: number): string {
+    const flags = `Path=/; HttpOnly; SameSite=Lax; Max-Age=${maxAge}`;
+    return this.secureCookies ? `${flags}; Secure` : flags;
+  }
+
+  /**
+   * Extract user from the encrypted SSO session cookie.
+   */
+  private async getUserFromSessionCookie(
+    request: Request | { header(name: string): string | undefined },
+  ): Promise<EEUser | null> {
+    // Handle both standard Request and HonoRequest (.header() vs .headers.get())
+    const cookie =
+      'header' in request && typeof (request as any).header === 'function'
+        ? (request as any).header('cookie')
+        : (request as Request).headers?.get('cookie');
+    if (!cookie) return null;
+
+    const match = cookie.match(new RegExp(`${this.cookieName}=([^;]+)`));
+    if (!match?.[1]) return null;
+
+    try {
+      const sessionData = (await decryptSession(decodeURIComponent(match[1]), this.cookiePassword)) as {
+        user: EEUser;
+        expiresAt: number;
+      };
+
+      if (sessionData.expiresAt < Date.now()) {
+        return null; // Session expired
+      }
+
+      return sessionData.user;
+    } catch {
+      return null; // Invalid/corrupt cookie
+    }
+  }
+
+  // ============================================================================
+  // Dynamic ISSOProvider attachment (only when OAuth is configured)
+  // ============================================================================
+
+  /**
+   * Dynamically attach ISSOProvider methods to this instance.
+   * This ensures duck-typing detection only finds these methods when SSO is configured.
+   */
+  private _attachSSOProvider() {
+    const self = this;
+
+    (this as unknown as ISSOProvider<EEUser>).getLoginUrl = function (redirectUri: string, state: string): string {
+      // State format from server: "uuid|encodedRedirect"
+      const stateId = state.includes('|') ? state.split('|')[0]! : state;
+
+      // Store state ID with redirect_uri for validation (expires in 10 minutes)
+      const actualRedirectUri = redirectUri ?? self._redirectUri;
+      stateStore.set(stateId, {
+        expiresAt: Date.now() + 10 * 60 * 1000,
+        redirectUri: actualRedirectUri!,
+      });
+
+      // Clean up expired states
+      for (const [key, value] of stateStore.entries()) {
+        if (value.expiresAt < Date.now()) {
+          stateStore.delete(key);
+        }
+      }
+
+      const params = new URLSearchParams({
+        client_id: self.oauthClientId!,
+        response_type: 'code',
+        scope: self.scopes.join(' '),
+        redirect_uri: actualRedirectUri!,
+        state,
+      });
+
+      return `${self.fapiUrl}/oauth/authorize?${params.toString()}`;
+    };
+
+    (this as unknown as ISSOProvider<EEUser>).handleCallback = async function (
+      code: string,
+      stateId: string,
+    ): Promise<SSOCallbackResult<EEUser>> {
+      // Validate state parameter
+      const stored = stateStore.get(stateId);
+      if (!stored) {
+        throw new Error('Invalid or expired state parameter');
+      }
+      stateStore.delete(stateId);
+
+      if (stored.expiresAt < Date.now()) {
+        throw new Error('State parameter has expired');
+      }
+
+      // Exchange code for tokens using client_secret (confidential client)
+      const tokenResponse = await fetch(`${self.fapiUrl}/oauth/token`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${self.oauthClientId}:${self.oauthClientSecret}`)}`,
+        },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: stored.redirectUri,
+        }),
+      });
+
+      if (!tokenResponse.ok) {
+        const error = await tokenResponse.text();
+        throw new Error(`Token exchange failed: ${error}`);
+      }
+
+      const tokens = (await tokenResponse.json()) as {
+        access_token: string;
+        id_token?: string;
+        refresh_token?: string;
+        expires_in: number;
+        token_type: string;
+      };
+
+      // Get user info — try ID token first, fall back to userinfo endpoint
+      let user: EEUser;
+      if (tokens.id_token) {
+        const payload = await verifyJwks(tokens.id_token, self.jwksUri);
+        user = {
+          id: payload.sub!,
+          email: (payload.email as string) ?? undefined,
+          name: (payload.name as string) ?? undefined,
+          avatarUrl: (payload.picture as string) ?? undefined,
+        };
+      } else {
+        const userInfoResponse = await fetch(`${self.fapiUrl}/oauth/userinfo`, {
+          headers: { Authorization: `Bearer ${tokens.access_token}` },
+        });
+
+        if (!userInfoResponse.ok) {
+          throw new Error('Failed to fetch user info from Clerk');
+        }
+
+        const userInfo = (await userInfoResponse.json()) as {
+          sub: string;
+          email?: string;
+          name?: string;
+          picture?: string;
+        };
+        user = {
+          id: userInfo.sub,
+          email: userInfo.email,
+          name: userInfo.name,
+          avatarUrl: userInfo.picture,
+        };
+      }
+
+      // Try to enrich user with full Clerk data
+      try {
+        const fullUser = await self.getUser(user.id);
+        if (fullUser) {
+          user = fullUser;
+        }
+      } catch {
+        // Use the user info we already have
+      }
+
+      // Create encrypted session cookie
+      const sessionData = {
+        user,
+        expiresAt: Date.now() + self.cookieMaxAge * 1000,
+      };
+
+      const encryptedSession = await encryptSession(sessionData, self.cookiePassword);
+      const cookieValue = `${self.cookieName}=${encodeURIComponent(encryptedSession)}; ${self.cookieFlags(self.cookieMaxAge)}`;
+
+      return {
+        user,
+        tokens: {
+          accessToken: tokens.access_token,
+          refreshToken: tokens.refresh_token,
+          idToken: tokens.id_token,
+          expiresAt: new Date(Date.now() + tokens.expires_in * 1000),
+        },
+        cookies: [cookieValue],
+      };
+    };
+
+    (this as unknown as ISSOProvider<EEUser>).getLoginButtonConfig = function (): SSOLoginConfig {
+      return {
+        provider: 'clerk',
+        text: 'Sign in with Clerk',
+        description: 'Sign in using your Clerk account',
+      };
+    };
+
+    (this as unknown as ISSOProvider<EEUser>).getLoginCookies = function (_state: string): string[] {
+      return [];
+    };
+
+    (this as unknown as ISSOProvider<EEUser>).getLogoutUrl = async function (
+      _redirectUri: string,
+      _request?: Request,
+    ): Promise<string | null> {
+      return null;
+    };
+  }
+
+  // ============================================================================
+  // Dynamic ISessionProvider attachment (only when OAuth is configured)
+  // ============================================================================
+
+  /**
+   * Dynamically attach ISessionProvider methods to this instance.
+   */
+  private _attachSessionProvider() {
+    const self = this;
+
+    (this as unknown as ISessionProvider<Session>).createSession = async function (
+      userId: string,
+      metadata?: Record<string, unknown>,
+    ): Promise<Session> {
+      const now = new Date();
+      return {
+        id: crypto.randomUUID(),
+        userId,
+        createdAt: now,
+        expiresAt: new Date(now.getTime() + self.cookieMaxAge * 1000),
+        metadata,
+      };
+    };
+
+    (this as unknown as ISessionProvider<Session>).validateSession = async function (
+      _sessionId: string,
+    ): Promise<Session | null> {
+      return null;
+    };
+
+    (this as unknown as ISessionProvider<Session>).destroySession = async function (_sessionId: string): Promise<void> {
+      // Session is cleared via cookie
+    };
+
+    (this as unknown as ISessionProvider<Session>).refreshSession = async function (
+      _sessionId: string,
+    ): Promise<Session | null> {
+      return null;
+    };
+
+    (this as unknown as ISessionProvider<Session>).getSessionIdFromRequest = function (
+      request: Request,
+    ): string | null {
+      const cookie = request.headers.get('Cookie');
+      if (!cookie) return null;
+      const match = cookie.match(new RegExp(`${self.cookieName}=([^;]+)`));
+      return match?.[1] ? decodeURIComponent(match[1]) : null;
+    };
+
+    (this as unknown as ISessionProvider<Session>).getSessionHeaders = function (
+      _session: Session,
+    ): Record<string, string> {
+      return {};
+    };
+
+    (this as unknown as ISessionProvider<Session>).getClearSessionHeaders = function (): Record<string, string> {
+      return {
+        'Set-Cookie': `${self.cookieName}=; ${self.cookieFlags(0)}`,
+      };
+    };
   }
 }

--- a/auth/clerk/src/index.ts
+++ b/auth/clerk/src/index.ts
@@ -79,12 +79,109 @@ async function decryptSession(encrypted: string, password: string): Promise<unkn
   return JSON.parse(new TextDecoder().decode(decrypted));
 }
 
+/** OAuth state token expiry (10 minutes) */
+const STATE_TOKEN_EXPIRY_MS = 10 * 60 * 1000;
+
+interface StatePayload {
+  /** Original state from caller */
+  s: string;
+  /** Redirect URI */
+  r: string;
+  /** Expiry timestamp */
+  e: number;
+}
+
 /**
- * In-memory store for OAuth state validation.
- * WARNING: Only works in single-instance deployments.
- * For load-balanced/distributed setups, consider a shared store or signed state tokens.
+ * Simple synchronous HMAC-like signature for state tokens.
+ * Uses FNV-1a inspired hash — good enough for short-lived CSRF tokens.
+ * Returns base64url-encoded signature.
  */
-const stateStore = new Map<string, { expiresAt: number; redirectUri: string }>();
+function hmacSign(data: string, secret: string): string {
+  const encoder = new TextEncoder();
+  const keyBytes = encoder.encode(secret);
+  const dataBytes = encoder.encode(data);
+
+  // Simple HMAC: hash(key + data + key)
+  const combined = new Uint8Array(keyBytes.length + dataBytes.length + keyBytes.length);
+  combined.set(keyBytes);
+  combined.set(dataBytes, keyBytes.length);
+  combined.set(keyBytes, keyBytes.length + dataBytes.length);
+
+  // FNV-1a inspired hash with two accumulators for 64-bit output
+  let h1 = 0x811c9dc5;
+  let h2 = 0x1000193;
+  for (let i = 0; i < combined.length; i++) {
+    h1 ^= combined[i]!;
+    h1 = Math.imul(h1, 0x01000193);
+    h2 ^= combined[i]!;
+    h2 = Math.imul(h2, 0x85ebca6b);
+  }
+
+  // Convert to base64url
+  const sigBytes = new Uint8Array(8);
+  const view = new DataView(sigBytes.buffer);
+  view.setUint32(0, h1 >>> 0);
+  view.setUint32(4, h2 >>> 0);
+  return btoa(String.fromCharCode(...sigBytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+/**
+ * Timing-safe string comparison.
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}
+
+/**
+ * Create a signed state token for OAuth CSRF protection (stateless).
+ * Format: base64(payload).base64url(signature)
+ */
+function createStateToken(originalState: string, redirectUri: string, secret: string): string {
+  const payload: StatePayload = {
+    s: originalState,
+    r: redirectUri,
+    e: Date.now() + STATE_TOKEN_EXPIRY_MS,
+  };
+  const payloadB64 = btoa(JSON.stringify(payload));
+  const signature = hmacSign(payloadB64, secret);
+  return `${payloadB64}.${signature}`;
+}
+
+/**
+ * Verify and decode a state token.
+ * Returns the original state and redirectUri if valid and not expired.
+ */
+function verifyStateToken(stateToken: string, secret: string): { originalState: string; redirectUri: string } {
+  const parts = stateToken.split('.');
+  if (parts.length !== 2) {
+    throw new Error('Invalid state token format');
+  }
+
+  const [payloadB64, signature] = parts;
+  const expectedSig = hmacSign(payloadB64!, secret);
+  if (!timingSafeEqual(signature!, expectedSig)) {
+    throw new Error('Invalid state token signature');
+  }
+
+  const payload = JSON.parse(atob(payloadB64!)) as StatePayload;
+  if (payload.e < Date.now()) {
+    throw new Error('State token has expired');
+  }
+
+  return { originalState: payload.s, redirectUri: payload.r };
+}
+
+/**
+ * Escape special regex characters in a string.
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 /**
  * Derive the Frontend API (FAPI) URL from a Clerk publishable key.
@@ -403,7 +500,7 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
         : (request as Request).headers?.get('cookie');
     if (!cookie) return null;
 
-    const match = cookie.match(new RegExp(`${this.cookieName}=([^;]+)`));
+    const match = cookie.match(new RegExp(`(?:^|;\\s*)${escapeRegex(this.cookieName)}=([^;]+)`));
     if (!match?.[1]) return null;
 
     try {
@@ -434,29 +531,21 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
     const self = this;
 
     (this as unknown as ISSOProvider<EEUser>).getLoginUrl = function (redirectUri: string, state: string): string {
-      // State format from server: "uuid|encodedRedirect"
-      const stateId = state.includes('|') ? state.split('|')[0]! : state;
-
-      // Store state ID with redirect_uri for validation (expires in 10 minutes)
+      // Create signed state token containing redirectUri and expiry
+      // This is stateless — works in serverless and load-balanced environments
       const actualRedirectUri = redirectUri ?? self._redirectUri;
-      stateStore.set(stateId, {
-        expiresAt: Date.now() + 10 * 60 * 1000,
-        redirectUri: actualRedirectUri!,
-      });
-
-      // Clean up expired states
-      for (const [key, value] of stateStore.entries()) {
-        if (value.expiresAt < Date.now()) {
-          stateStore.delete(key);
-        }
+      if (!actualRedirectUri) {
+        throw new Error('Redirect URI is required for SSO login');
       }
+
+      const signedState = createStateToken(state, actualRedirectUri, self.cookiePassword);
 
       const params = new URLSearchParams({
         client_id: self.oauthClientId!,
         response_type: 'code',
         scope: self.scopes.join(' '),
-        redirect_uri: actualRedirectUri!,
-        state,
+        redirect_uri: actualRedirectUri,
+        state: signedState,
       });
 
       return `${self.fapiUrl}/oauth/authorize?${params.toString()}`;
@@ -464,18 +553,10 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
 
     (this as unknown as ISSOProvider<EEUser>).handleCallback = async function (
       code: string,
-      stateId: string,
+      stateToken: string,
     ): Promise<SSOCallbackResult<EEUser>> {
-      // Validate state parameter
-      const stored = stateStore.get(stateId);
-      if (!stored) {
-        throw new Error('Invalid or expired state parameter');
-      }
-      stateStore.delete(stateId);
-
-      if (stored.expiresAt < Date.now()) {
-        throw new Error('State parameter has expired');
-      }
+      // Verify and decode the signed state token (throws if invalid/expired)
+      const { redirectUri } = verifyStateToken(stateToken, self.cookiePassword);
 
       // Exchange code for tokens using client_secret (confidential client)
       const tokenResponse = await fetch(`${self.fapiUrl}/oauth/token`, {
@@ -487,8 +568,9 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
         body: new URLSearchParams({
           grant_type: 'authorization_code',
           code,
-          redirect_uri: stored.redirectUri,
+          redirect_uri: redirectUri,
         }),
+        signal: AbortSignal.timeout(10_000), // 10 second timeout
       });
 
       if (!tokenResponse.ok) {
@@ -517,6 +599,7 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
       } else {
         const userInfoResponse = await fetch(`${self.fapiUrl}/oauth/userinfo`, {
           headers: { Authorization: `Bearer ${tokens.access_token}` },
+          signal: AbortSignal.timeout(10_000), // 10 second timeout
         });
 
         if (!userInfoResponse.ok) {
@@ -636,7 +719,7 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
     ): string | null {
       const cookie = request.headers.get('Cookie');
       if (!cookie) return null;
-      const match = cookie.match(new RegExp(`${self.cookieName}=([^;]+)`));
+      const match = cookie.match(new RegExp(`(?:^|;\\s*)${escapeRegex(self.cookieName)}=([^;]+)`));
       return match?.[1] ? decodeURIComponent(match[1]) : null;
     };
 

--- a/auth/clerk/src/index.ts
+++ b/auth/clerk/src/index.ts
@@ -92,37 +92,26 @@ interface StatePayload {
 }
 
 /**
- * Simple synchronous HMAC-like signature for state tokens.
- * Uses FNV-1a inspired hash — good enough for short-lived CSRF tokens.
+ * Sign data using HMAC-SHA256 (Web Crypto API).
  * Returns base64url-encoded signature.
  */
-function hmacSign(data: string, secret: string): string {
+async function hmacSign(data: string, secret: string): Promise<string> {
   const encoder = new TextEncoder();
-  const keyBytes = encoder.encode(secret);
+  const keyData = encoder.encode(secret);
   const dataBytes = encoder.encode(data);
 
-  // Simple HMAC: hash(key + data + key)
-  const combined = new Uint8Array(keyBytes.length + dataBytes.length + keyBytes.length);
-  combined.set(keyBytes);
-  combined.set(dataBytes, keyBytes.length);
-  combined.set(keyBytes, keyBytes.length + dataBytes.length);
+  // Import the secret key for HMAC-SHA256
+  const cryptoKey = await crypto.subtle.importKey('raw', keyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
 
-  // FNV-1a inspired hash with two accumulators for 64-bit output
-  let h1 = 0x811c9dc5;
-  let h2 = 0x1000193;
-  for (let i = 0; i < combined.length; i++) {
-    h1 ^= combined[i]!;
-    h1 = Math.imul(h1, 0x01000193);
-    h2 ^= combined[i]!;
-    h2 = Math.imul(h2, 0x85ebca6b);
-  }
+  // Sign the data
+  const signature = await crypto.subtle.sign('HMAC', cryptoKey, dataBytes);
 
   // Convert to base64url
-  const sigBytes = new Uint8Array(8);
-  const view = new DataView(sigBytes.buffer);
-  view.setUint32(0, h1 >>> 0);
-  view.setUint32(4, h2 >>> 0);
-  return btoa(String.fromCharCode(...sigBytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  const sigBytes = new Uint8Array(signature);
+  return btoa(String.fromCharCode(...sigBytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
 }
 
 /**
@@ -141,14 +130,14 @@ function timingSafeEqual(a: string, b: string): boolean {
  * Create a signed state token for OAuth CSRF protection (stateless).
  * Format: base64(payload).base64url(signature)
  */
-function createStateToken(originalState: string, redirectUri: string, secret: string): string {
+async function createStateToken(originalState: string, redirectUri: string, secret: string): Promise<string> {
   const payload: StatePayload = {
     s: originalState,
     r: redirectUri,
     e: Date.now() + STATE_TOKEN_EXPIRY_MS,
   };
   const payloadB64 = btoa(JSON.stringify(payload));
-  const signature = hmacSign(payloadB64, secret);
+  const signature = await hmacSign(payloadB64, secret);
   return `${payloadB64}.${signature}`;
 }
 
@@ -156,14 +145,17 @@ function createStateToken(originalState: string, redirectUri: string, secret: st
  * Verify and decode a state token.
  * Returns the original state and redirectUri if valid and not expired.
  */
-function verifyStateToken(stateToken: string, secret: string): { originalState: string; redirectUri: string } {
+async function verifyStateToken(
+  stateToken: string,
+  secret: string,
+): Promise<{ originalState: string; redirectUri: string }> {
   const parts = stateToken.split('.');
   if (parts.length !== 2) {
     throw new Error('Invalid state token format');
   }
 
   const [payloadB64, signature] = parts;
-  const expectedSig = hmacSign(payloadB64!, secret);
+  const expectedSig = await hmacSign(payloadB64!, secret);
   if (!timingSafeEqual(signature!, expectedSig)) {
     throw new Error('Invalid state token signature');
   }
@@ -530,7 +522,10 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
   private _attachSSOProvider() {
     const self = this;
 
-    (this as unknown as ISSOProvider<EEUser>).getLoginUrl = function (redirectUri: string, state: string): string {
+    (this as unknown as ISSOProvider<EEUser>).getLoginUrl = async function (
+      redirectUri: string,
+      state: string,
+    ): Promise<string> {
       // Create signed state token containing redirectUri and expiry
       // This is stateless — works in serverless and load-balanced environments
       const actualRedirectUri = redirectUri ?? self._redirectUri;
@@ -538,7 +533,7 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
         throw new Error('Redirect URI is required for SSO login');
       }
 
-      const signedState = createStateToken(state, actualRedirectUri, self.cookiePassword);
+      const signedState = await createStateToken(state, actualRedirectUri, self.cookiePassword);
 
       const params = new URLSearchParams({
         client_id: self.oauthClientId!,
@@ -556,7 +551,7 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
       stateToken: string,
     ): Promise<SSOCallbackResult<EEUser>> {
       // Verify and decode the signed state token (throws if invalid/expired)
-      const { redirectUri } = verifyStateToken(stateToken, self.cookiePassword);
+      const { redirectUri } = await verifyStateToken(stateToken, self.cookiePassword);
 
       // Exchange code for tokens using client_secret (confidential client)
       const tokenResponse = await fetch(`${self.fapiUrl}/oauth/token`, {

--- a/auth/clerk/src/index.ts
+++ b/auth/clerk/src/index.ts
@@ -81,6 +81,8 @@ async function decryptSession(encrypted: string, password: string): Promise<unkn
 
 /**
  * In-memory store for OAuth state validation.
+ * WARNING: Only works in single-instance deployments.
+ * For load-balanced/distributed setups, consider a shared store or signed state tokens.
  */
 const stateStore = new Map<string, { expiresAt: number; redirectUri: string }>();
 
@@ -610,16 +612,19 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IU
       };
     };
 
+    // Cookie-only sessions — validation happens via decryption in getUserFromSessionCookie/authenticateToken
     (this as unknown as ISessionProvider<Session>).validateSession = async function (
       _sessionId: string,
     ): Promise<Session | null> {
       return null;
     };
 
-    (this as unknown as ISessionProvider<Session>).destroySession = async function (_sessionId: string): Promise<void> {
-      // Session is cleared via cookie
-    };
+    // Cookie-only sessions — destruction happens via getClearSessionHeaders setting Max-Age=0
+    (this as unknown as ISessionProvider<Session>).destroySession = async function (
+      _sessionId: string,
+    ): Promise<void> {};
 
+    // Cookie-only sessions — refresh not supported; user must re-authenticate after expiry
     (this as unknown as ISessionProvider<Session>).refreshSession = async function (
       _sessionId: string,
     ): Promise<Session | null> {

--- a/auth/clerk/src/index.ts
+++ b/auth/clerk/src/index.ts
@@ -2,6 +2,8 @@ import { createClerkClient } from '@clerk/backend';
 import type { ClerkClient } from '@clerk/backend';
 import { verifyJwks } from '@mastra/auth';
 import type { JwtPayload } from '@mastra/auth';
+import type { IUserProvider } from '@mastra/core/auth';
+import type { EEUser } from '@mastra/core/auth/ee';
 import type { MastraAuthProviderOptions } from '@mastra/core/server';
 import { MastraAuthProvider } from '@mastra/core/server';
 
@@ -13,7 +15,7 @@ interface MastraAuthClerkOptions extends MastraAuthProviderOptions<ClerkUser> {
   publishableKey?: string;
 }
 
-export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> {
+export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> implements IUserProvider<EEUser> {
   protected clerk: ClerkClient;
   protected jwksUri: string;
 
@@ -46,5 +48,75 @@ export class MastraAuthClerk extends MastraAuthProvider<ClerkUser> {
 
   async authorizeUser(user: ClerkUser) {
     return !!user.sub;
+  }
+
+  /**
+   * Extract the bearer token from the request's Authorization header or cookie.
+   */
+  private extractToken(request: Request): string | null {
+    const authHeader = request.headers.get('Authorization');
+    if (authHeader) {
+      const token = authHeader.replace(/^Bearer\s+/i, '').trim();
+      if (token) return token;
+    }
+
+    const cookie = request.headers.get('Cookie');
+    if (cookie) {
+      // Clerk's default session cookie is __session
+      const match = cookie.match(/__session=([^;]+)/);
+      if (match?.[1]) return match[1];
+    }
+
+    return null;
+  }
+
+  async getCurrentUser(request: Request): Promise<EEUser | null> {
+    const token = this.extractToken(request);
+    if (!token) return null;
+
+    try {
+      const payload = await this.authenticateToken(token);
+      if (!payload?.sub) return null;
+
+      // Try to fetch full user details from Clerk API
+      try {
+        const clerkUser = await this.clerk.users.getUser(payload.sub);
+        return {
+          id: clerkUser.id,
+          email: clerkUser.emailAddresses?.[0]?.emailAddress,
+          name: [clerkUser.firstName, clerkUser.lastName].filter(Boolean).join(' ') || undefined,
+          avatarUrl: clerkUser.imageUrl,
+          metadata: clerkUser.publicMetadata as Record<string, unknown> | undefined,
+        };
+      } catch {
+        // Fall back to JWT claims if Clerk API call fails
+        return {
+          id: payload.sub,
+          email: (payload.email as string) ?? undefined,
+          name: (payload.name as string) ?? undefined,
+        };
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  async getUser(userId: string): Promise<EEUser | null> {
+    try {
+      const clerkUser = await this.clerk.users.getUser(userId);
+      return {
+        id: clerkUser.id,
+        email: clerkUser.emailAddresses?.[0]?.emailAddress,
+        name: [clerkUser.firstName, clerkUser.lastName].filter(Boolean).join(' ') || undefined,
+        avatarUrl: clerkUser.imageUrl,
+        metadata: clerkUser.publicMetadata as Record<string, unknown> | undefined,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  getUserProfileUrl(user: EEUser): string {
+    return `/user/${user.id}`;
   }
 }

--- a/examples/agent/package.json
+++ b/examples/agent/package.json
@@ -9,6 +9,7 @@
     "@ai-sdk/openai": "^1.3.24",
     "@ai-sdk/provider": "^2.0.0",
     "@mastra/auth-auth0": "latest",
+    "@mastra/auth-clerk": "latest",
     "@mastra/auth-better-auth": "latest",
     "@mastra/auth-cloud": "latest",
     "@mastra/auth-okta": "latest",
@@ -38,6 +39,7 @@
   "pnpm": {
     "overrides": {
       "@mastra/auth-auth0": "link:../../auth/auth0",
+      "@mastra/auth-clerk": "link:../../auth/clerk",
       "@mastra/auth-better-auth": "link:../../auth/better-auth",
       "@mastra/auth-okta": "link:../../auth/okta",
       "@mastra/auth-workos": "link:../../auth/workos",

--- a/examples/agent/src/mastra/auth/clerk.ts
+++ b/examples/agent/src/mastra/auth/clerk.ts
@@ -1,0 +1,31 @@
+/**
+ * Clerk provider - JWT-based authentication via Clerk.
+ *
+ * Required env vars:
+ *   CLERK_PUBLISHABLE_KEY      - Clerk publishable key
+ *   CLERK_SECRET_KEY           - Clerk secret key
+ *   CLERK_JWKS_URI             - Clerk JWKS endpoint
+ *
+ * Optional env vars (for Studio SSO login):
+ *   CLERK_OAUTH_CLIENT_ID      - OAuth Client ID (from Clerk Dashboard → OAuth Applications)
+ *   CLERK_OAUTH_CLIENT_SECRET  - OAuth Client Secret
+ *   CLERK_COOKIE_PASSWORD      - Session cookie encryption password (min 32 chars)
+ */
+
+import { MastraAuthClerk } from '@mastra/auth-clerk';
+
+import type { AuthResult } from './types';
+
+export function initClerk(): AuthResult {
+  const mastraAuth = new MastraAuthClerk({
+    jwksUri: process.env.CLERK_JWKS_URI,
+    secretKey: process.env.CLERK_SECRET_KEY,
+    publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+    // SSO options are auto-read from env vars:
+    // CLERK_OAUTH_CLIENT_ID, CLERK_OAUTH_CLIENT_SECRET, CLERK_COOKIE_PASSWORD
+  });
+
+  const ssoEnabled = mastraAuth.isSSOEnabled();
+  console.log(`[Auth] Using Clerk authentication${ssoEnabled ? ' (SSO enabled)' : ' (JWT only)'}`);
+  return { mastraAuth };
+}

--- a/examples/agent/src/mastra/auth/index.ts
+++ b/examples/agent/src/mastra/auth/index.ts
@@ -7,6 +7,7 @@
  * - workos: Enterprise SSO (SAML, OIDC)
  * - cloud: Mastra platform OAuth with PKCE
  * - composite: Combines SimpleAuth + MastraCloudAuth via CompositeAuth
+ * - clerk: Clerk JWT-based authentication
  * - auth0-okta: Auth0 for authentication + Okta for RBAC (cross-provider)
  * - okta: Full Okta for both authentication and RBAC
  *
@@ -30,6 +31,10 @@ async function initAuth(): Promise<AuthResult> {
     case 'workos': {
       const { initWorkOS } = await import('./workos');
       return initWorkOS();
+    }
+    case 'clerk': {
+      const { initClerk } = await import('./clerk');
+      return initClerk();
     }
     case 'cloud': {
       const { initCloud } = await import('./cloud');

--- a/examples/agent/src/mastra/auth/types.ts
+++ b/examples/agent/src/mastra/auth/types.ts
@@ -22,6 +22,7 @@ export interface AuthResult {
 export type AuthProviderType =
   | 'simple'
   | 'better-auth'
+  | 'clerk'
   | 'workos'
   | 'cloud'
   | 'composite'

--- a/packages/core/src/auth/interfaces/sso.ts
+++ b/packages/core/src/auth/interfaces/sso.ts
@@ -81,9 +81,9 @@ export interface ISSOProvider<TUser = unknown> {
    *
    * @param redirectUri - Callback URL after authentication
    * @param state - CSRF protection state parameter
-   * @returns Full URL to redirect user to
+   * @returns Full URL to redirect user to (sync or async)
    */
-  getLoginUrl(redirectUri: string, state: string): string;
+  getLoginUrl(redirectUri: string, state: string): string | Promise<string>;
 
   /**
    * Handle OAuth callback, exchange code for tokens and user.

--- a/packages/core/src/server/composite-auth.ts
+++ b/packages/core/src/server/composite-auth.ts
@@ -179,7 +179,7 @@ export class CompositeAuth
     }
   }
 
-  getLoginUrl(redirectUri: string, state: string): string {
+  getLoginUrl(redirectUri: string, state: string): string | Promise<string> {
     const sso = this.findProvider(isSSOProvider);
     if (!sso) throw new Error('No SSO provider configured in CompositeAuth');
     return sso.getLoginUrl(redirectUri, state);

--- a/packages/server/src/server/handlers/auth.ts
+++ b/packages/server/src/server/handlers/auth.ts
@@ -380,7 +380,7 @@ export const GET_SSO_LOGIN_ROUTE = createPublicRoute({
       const stateId = crypto.randomUUID();
       const state = `${stateId}|${encodeURIComponent(postLoginRedirect)}`;
 
-      const loginUrl = auth.getLoginUrl(oauthCallbackUri, state);
+      const loginUrl = await Promise.resolve(auth.getLoginUrl(oauthCallbackUri, state));
 
       // Build response with optional PKCE cookies
       const headers = new Headers({ 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Summary

Enables Clerk users to log into Mastra Studio via OAuth SSO. Previously, the Clerk auth provider only supported API token verification — Studio login was not possible because the provider lacked the required `ISSOProvider` and `ISessionProvider` interfaces.

## What Changed

### `auth/clerk/src/index.ts`

- **IUserProvider**: `getCurrentUser` (extracts JWT from Authorization header or `__session` cookie, verifies via JWKS), `getUser` (calls Clerk API `clerk.users.getUser`), `getUserProfileUrl`
- **ISSOProvider**: OAuth 2.0 Authorization Code flow via Clerk OAuth endpoints (`/oauth/authorize`, `/oauth/token`). Includes `getLoginUrl`, `handleCallback`, `getLoginButtonConfig`. Requires a separate Clerk OAuth Application (Client ID + Client Secret) created in the Clerk Dashboard.
- **ISessionProvider**: Encrypted cookie sessions using PBKDF2 key derivation + AES-GCM encryption. Includes `createSession`, `validateSession`, `destroySession`, `refreshSession`, `getSessionIdFromRequest`, `getSessionHeaders`, `getClearSessionHeaders`
- **authenticateToken**: Updated to check session cookie first when SSO is enabled, then falls back to JWT verification
- **authorizeUser**: Accepts both `user.sub` (JWT) and `user.id` (session cookie) fields
- SSO methods are only attached when `oauthClientId` + `oauthClientSecret` are configured, keeping the provider duck-typing safe for `buildCapabilities()` detection

### `auth/clerk/src/index.test.ts`

- 48 tests covering all interfaces (up from 13 original tests)
- Tests for: `authenticateToken`, `authorizeUser`, `getCurrentUser`, `getUser`, `getLoginUrl`, `handleCallback`, `getLoginButtonConfig`, session encryption/decryption, cookie management, state validation

## Configuration

```typescript
import { MastraAuthClerk } from "@mastra/auth-clerk";

const auth = new MastraAuthClerk({
  publishableKey: process.env.CLERK_PUBLISHABLE_KEY!,
  // Required for Studio SSO login (create OAuth app in Clerk Dashboard)
  oauthClientId: process.env.CLERK_OAUTH_CLIENT_ID,
  oauthClientSecret: process.env.CLERK_OAUTH_CLIENT_SECRET,
  cookiePassword: process.env.CLERK_COOKIE_PASSWORD, // min 32 chars
});
```

## Test Plan

1. **Unit tests**: 48 tests passing (`pnpm test` in `auth/clerk`)
2. **Type check**: Zero errors (`tsc --noEmit`)
3. **End-to-end**: Verified Clerk OAuth login flow against live Clerk tenant
   - `/api/auth/capabilities` returns `login.type=sso` with Clerk provider
   - OAuth redirect → Clerk login → callback → session cookie set
   - `/api/auth/me` returns authenticated user
   - `/api/agents` and other protected routes return 200 with session cookie
   - Logout clears session cookie


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR lets Mastra Studio users sign in with Clerk via OAuth and keeps them logged in using secure, encrypted cookies, while still supporting Clerk-issued JWTs for API requests.

---

## Overview
Converts MastraAuthClerk from JWT-only verification into a full Clerk-backed provider implementing IUserProvider and, when OAuth credentials are provided, exposing ISSOProvider and ISessionProvider for Studio SSO. Adds encrypted cookie sessions (PBKDF2 → AES‑GCM), stateless HMAC-signed short-lived OAuth state tokens, OAuth Authorization Code handling (authorize → token → userinfo/id_token), and updates auth logic to prefer session cookies when SSO is enabled.

## Key changes

- auth/clerk/src/index.ts
  - Implements IUserProvider:
    - getCurrentUser(request): prefers encrypted session cookie if SSO enabled; otherwise extracts token from Authorization header or Clerk __session cookie, verifies via JWKS, and optionally enriches via Clerk Users API with a JWT-claims fallback.
    - getUser(userId): fetches user via Clerk API (returns null on error).
    - getUserProfileUrl(user): returns profile path.
    - isSSOEnabled(), getFapiUrl().
  - Adds ISSOProvider (attached only when oauthClientId & oauthClientSecret configured):
    - Full OAuth2 Authorization Code flow against Clerk (/oauth/authorize, /oauth/token).
    - getLoginUrl: async-capable; builds authorize URL and encodes stateless signed+expiring state (HMAC).
    - handleCallback: verifies state, exchanges code for tokens (10s fetch timeout), derives user from id_token (via JWKS) or /oauth/userinfo, optionally enriches via Clerk API, returns encrypted session cookie + tokens.
    - getLoginButtonConfig: login button metadata.
  - Adds ISessionProvider (cookie-backed, attached when SSO enabled):
    - Session encryption/decryption using PBKDF2-derived AES‑GCM key; cookie encoded as base64(salt || iv || ciphertext).
    - createSession returns encrypted cookie headers; validateSession/refreshSession are effectively no-ops for this lightweight model; destroySession clears cookie.
    - getSessionIdFromRequest / getSessionHeaders / getClearSessionHeaders for cookie handling.
    - Enforces minimum 32-character cookie password; warns on auto-generated password (ephemeral across restarts).
  - Authentication behavior:
    - authenticateToken(token, request?): when SSO enabled and request provided, tries session cookie first, then falls back to JWKS verification.
    - authorizeUser accepts both JWT-style (payload.sub) and session-cookie-style (id) users.
  - Utilities:
    - deriveFapiUrl(publishableKey) for Clerk FAPI URL.
    - Timing-safe HMAC-SHA256 state signing/verifying replaces earlier approach.

- Tests
  - auth/clerk/src/index.test.ts expanded from ~13 to 48 tests covering initialization, authenticateToken, authorizeUser (incl. custom/org-based logic), getCurrentUser/getUser, SSO flows (getLoginUrl + state, handleCallback token exchange and userinfo fallback), session encryption/decryption, cookie management, state expiry/validation, and logout cookie clearing.

- Packaging / examples
  - .changeset adds a minor release note documenting Studio SSO, JWT validation, and encrypted sessions.
  - examples/agent: adds `@mastra/auth-clerk` dependency, adds initClerk() example that logs SSO vs JWT-only mode, and registers 'clerk' provider in examples.

- Core interface updates
  - packages/core/src/auth/interfaces/sso.ts: getLoginUrl widened to return string | Promise<string>.
  - CompositeAuth and server SSO handler updated to await/handle async getLoginUrl results.

## Configuration
Dual modes supported:
- JWT-only (API): configure jwksUri + keys.
- Studio SSO: additionally provide oauthClientId, oauthClientSecret, and session.cookiePassword (min 32 chars) or allow auto-generation (with warning that sessions won’t survive restarts).

Example SSO config: publishableKey, jwksUri, secretKey, oauthClientId, oauthClientSecret, session.cookiePassword.

## Verification
- 48 unit tests added (author reports all passing).
- TypeScript type-check: zero errors.
- E2E: author verified Clerk OAuth flow against a live Clerk tenant — OAuth redirect → Clerk login → callback sets encrypted session cookie, /api/auth/me and protected routes succeed with session cookie, logout clears session cookie, and /api/auth/capabilities reports login.type=sso when configured.

## Notes & highlights
- ISSOProvider/ISessionProvider are only attached when oauthClientId and oauthClientSecret are configured (preserves duck-typing for buildCapabilities()).
- State tokens are stateless, HMAC-signed, short-lived, and verified timing-safely (suitable for serverless/load-balanced deployments).
- Token exchange uses fetch with a 10s timeout.
- Session cookie encryption uses PBKDF2 (100k iterations) + AES‑GCM with salt+iv; cookie stores base64(salt||iv||ciphertext).
- validateSession / refreshSession intentionally no-op for this cookie-backed session model.
- Recommended deployment: run separate MastraAuthClerk instances for API (JWT-only) and Studio (SSO-enabled) when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->