### PR TITLE
fix(core): break workflows barrel cycle in signal-drain-step

### DIFF
--- a/.changeset/spicy-icons-lay.md
+++ b/.changeset/spicy-icons-lay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed an ESM circular import that crashed any test or app importing from `@mastra/core/workflows/workflow` with `TypeError: Class extends value undefined is not a constructor or null`. The `signal-drain-step` module now imports `createStep` from `workflows/workflow` directly instead of going through the `workflows` barrel, matching the convention used by every other step in the agentic-execution workflow.

--- a/.changeset/spicy-icons-lay.md
+++ b/.changeset/spicy-icons-lay.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed an ESM circular import that crashed any test or app importing from `@mastra/core/workflows/workflow` with `TypeError: Class extends value undefined is not a constructor or null`. The `signal-drain-step` module now imports `createStep` from `workflows/workflow` directly instead of going through the `workflows` barrel, matching the convention used by every other step in the agentic-execution workflow.
+Fixed a crash when importing `@mastra/core/workflows/workflow` from tests or apps, which previously failed with `TypeError: Class extends value undefined is not a constructor or null` (caused by a circular ESM import through the `workflows` barrel).

--- a/packages/core/src/loop/workflows/agentic-execution/signal-drain-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/signal-drain-step.ts
@@ -1,6 +1,6 @@
 import type { ToolSet } from '@internal/ai-sdk-v5';
 import type { ChunkType } from '../../../stream/types';
-import { createStep } from '../../../workflows';
+import { createStep } from '../../../workflows/workflow';
 import type { OuterLLMRun } from '../../types';
 import { llmIterationOutputSchema } from '../schema';
 import type { LLMIterationData } from '../schema';


### PR DESCRIPTION
Importing from `@mastra/core/workflows/workflow` crashed with `TypeError: Class extends value undefined is not a constructor or null` because `signal-drain-step` pulled `createStep` through the `workflows` barrel. That re-entered the barrel mid-evaluation, hit `import './evented'`, and `EventedWorkflow extends Workflow` blew up since `Workflow` was not yet exported.

Every sibling step in `agentic-execution` already imports from `workflows/workflow` directly; this just brings `signal-drain-step` in line.

```diff
-import { createStep } from '../../../workflows';
+import { createStep } from '../../../workflows/workflow';
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

A file was breaking because it asked for something through a middleman that hadn't finished setting up; the fix makes the file ask the original source directly so it no longer breaks.

## Problem

Importing `@mastra/core/workflows/workflow` could throw "TypeError: Class extends value undefined is not a constructor or null" at runtime. The cause was a circular ESM import: `signal-drain-step` imported `createStep` from the `workflows` barrel, which re-entered the barrel during module evaluation and hit `import './evented'` before `Workflow` had been exported, so `EventedWorkflow extends Workflow` failed.

## Solution

Change the import in `signal-drain-step` to pull `createStep` directly from the concrete module path (`../../../workflows/workflow`) instead of through the `workflows` barrel, matching other sibling steps and preventing the barrel re-entry that caused the runtime error.

## Changes

- `.changeset/spicy-icons-lay.md`: Added a changeset documenting a patch release for `@mastra/core` noting the circular-import fix.
- `packages/core/src/loop/workflows/agentic-execution/signal-drain-step.ts`: Replaced the barrel import `../../../workflows` with a direct import `../../../workflows/workflow` for `createStep`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->