### PR TITLE
fix(core): CompositeAuth duck-typing detection for interface capabilities

### DIFF
--- a/.changeset/goofy-lines-fail.md
+++ b/.changeset/goofy-lines-fail.md
@@ -1,0 +1,6 @@
+---
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Fixed CompositeAuth incorrectly advertising SSO, session, and user provider capabilities when no inner provider supports them. Studio would show an SSO login button even when no provider had SSO configured, leading to 401 errors on login attempts. The duck-typing check now verifies that interface methods are actual functions rather than just present on the prototype chain.

--- a/packages/core/src/auth/ee/capabilities.ts
+++ b/packages/core/src/auth/ee/capabilities.ts
@@ -111,7 +111,7 @@ export function isAuthenticated(
  * Check if an auth provider implements a specific interface.
  */
 function implementsInterface<T>(auth: unknown, method: keyof T): auth is T {
-  return auth !== null && typeof auth === 'object' && method in auth;
+  return auth !== null && typeof auth === 'object' && typeof (auth as any)[method] === 'function';
 }
 
 /**

--- a/packages/core/src/server/auth.test.ts
+++ b/packages/core/src/server/auth.test.ts
@@ -331,5 +331,46 @@ describe('Composite auth', () => {
         expect(authzResult).toBe(false);
       });
     });
+
+    describe('duck-typing detection', () => {
+      it('should NOT advertise SSO when no inner provider has it', () => {
+        const compositeAuth = new CompositeAuth([new MockAuthProvider(true, true)]);
+        expect(typeof (compositeAuth as any).getLoginUrl).not.toBe('function');
+        expect(typeof (compositeAuth as any).handleCallback).not.toBe('function');
+      });
+
+      it('should NOT advertise sessions when no inner provider has it', () => {
+        const compositeAuth = new CompositeAuth([new MockAuthProvider(true, true)]);
+        expect(typeof (compositeAuth as any).createSession).not.toBe('function');
+        expect(typeof (compositeAuth as any).getSessionIdFromRequest).not.toBe('function');
+      });
+
+      it('should NOT advertise user provider when no inner provider has it', () => {
+        const compositeAuth = new CompositeAuth([new MockAuthProvider(true, true)]);
+        expect(typeof (compositeAuth as any).getCurrentUser).not.toBe('function');
+        expect(typeof (compositeAuth as any).getUser).not.toBe('function');
+      });
+
+      it('should advertise SSO when an inner provider supports it', () => {
+        const ssoProvider = new MockAuthProvider(true, true) as any;
+        ssoProvider.getLoginUrl = () => 'https://example.com/login';
+        ssoProvider.handleCallback = async () => ({ user: { id: '1' } });
+        ssoProvider.getLoginButtonConfig = () => ({ provider: 'test', text: 'Sign in' });
+
+        const compositeAuth = new CompositeAuth([ssoProvider]);
+        expect(typeof (compositeAuth as any).getLoginUrl).toBe('function');
+        expect(typeof (compositeAuth as any).handleCallback).toBe('function');
+      });
+
+      it('should advertise user provider when an inner provider supports it', () => {
+        const userProvider = new MockAuthProvider(true, true) as any;
+        userProvider.getCurrentUser = async () => ({ id: '1' });
+        userProvider.getUser = async () => ({ id: '1' });
+
+        const compositeAuth = new CompositeAuth([userProvider]);
+        expect(typeof (compositeAuth as any).getCurrentUser).toBe('function');
+        expect(typeof (compositeAuth as any).getUser).toBe('function');
+      });
+    });
   });
 });

--- a/packages/core/src/server/composite-auth.ts
+++ b/packages/core/src/server/composite-auth.ts
@@ -50,6 +50,25 @@ export class CompositeAuth
     if (providers.some(provider => typeof provider.mapUserToResourceId === 'function')) {
       this.mapUserToResourceId = user => this.mapAuthenticatedUserToResourceId(user);
     }
+
+    // Null out interface methods when no inner provider supports them.
+    // This ensures duck-typing checks (typeof auth.method === 'function')
+    // accurately reflect the composite's actual capabilities — preventing
+    // Studio from showing login options that no provider can handle.
+    if (!providers.some(isSSOProvider)) {
+      this.getLoginUrl = undefined as any;
+      this.handleCallback = undefined as any;
+      this.getLoginButtonConfig = undefined as any;
+    }
+    if (!providers.some(isSessionProvider)) {
+      this.createSession = undefined as any;
+      this.validateSession = undefined as any;
+      this.getSessionIdFromRequest = undefined as any;
+    }
+    if (!providers.some(isUserProvider)) {
+      this.getCurrentUser = undefined as any;
+      this.getUser = undefined as any;
+    }
   }
 
   // Find first provider implementing an interface

--- a/packages/core/src/server/composite-auth.ts
+++ b/packages/core/src/server/composite-auth.ts
@@ -14,15 +14,25 @@ type PrimitiveAuthUser = string | number | boolean | bigint | symbol | null | un
 
 // Type guards for interface detection
 function isSSOProvider(p: unknown): p is ISSOProvider {
-  return p !== null && typeof p === 'object' && 'getLoginUrl' in p && 'handleCallback' in p;
+  return (
+    p !== null &&
+    typeof p === 'object' &&
+    typeof (p as any).getLoginUrl === 'function' &&
+    typeof (p as any).handleCallback === 'function'
+  );
 }
 
 function isSessionProvider(p: unknown): p is ISessionProvider {
-  return p !== null && typeof p === 'object' && 'validateSession' in p && 'createSession' in p;
+  return (
+    p !== null &&
+    typeof p === 'object' &&
+    typeof (p as any).validateSession === 'function' &&
+    typeof (p as any).createSession === 'function'
+  );
 }
 
 function isUserProvider(p: unknown): p is IUserProvider {
-  return p !== null && typeof p === 'object' && 'getCurrentUser' in p;
+  return p !== null && typeof p === 'object' && typeof (p as any).getCurrentUser === 'function';
 }
 
 function isObjectLike(value: unknown): value is object {

--- a/packages/server/src/server/handlers/auth.ts
+++ b/packages/server/src/server/handlers/auth.ts
@@ -122,7 +122,7 @@ function getFGAProvider(mastra: any): IFGAProvider<EEUser> | undefined {
  * Type guard to check if auth provider implements an interface.
  */
 function implementsInterface<T>(auth: unknown, method: keyof T): auth is T {
-  return auth !== null && typeof auth === 'object' && method in auth;
+  return auth !== null && typeof auth === 'object' && typeof (auth as any)[method] === 'function';
 }
 
 // ============================================================================


### PR DESCRIPTION
CompositeAuth was always advertising SSO/session/user provider capabilities to Studio, even when no inner provider actually supported them. This caused Studio to show an SSO login button that would 401 on click.

The root cause: `CompositeAuth` declares `implements ISSOProvider, ISessionProvider, IUserProvider` at the class level, putting all methods on the prototype. The `implementsInterface()` helper used `method in auth` which checks the prototype chain — so it always returned `true`.

The fix is two small changes:

1. `implementsInterface()` now uses `typeof auth[method] === 'function'` instead of `method in auth`
2. CompositeAuth's constructor nulls out interface methods when no inner provider supports them, so the `typeof` check correctly returns `'undefined'`

Before: Studio shows SSO login button → user clicks → 401
After: Studio correctly shows no login option when no provider supports it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
CompositeAuth was showing login buttons (like SSO) even when none of its inner providers actually supported them, causing failed logins. The change makes CompositeAuth only advertise features that are truly implemented (actual functions), so Studio won't show unusable login options.

## Changes

### Core fix
- implementsInterface() (duck-typing) now checks that the property is a callable function via `typeof auth[method] === 'function'` instead of using the `in` operator that looked up the prototype chain. Updated in:
  - packages/core/src/auth/ee/capabilities.ts
  - packages/server/src/server/handlers/auth.ts

### CompositeAuth runtime behavior
- packages/core/src/server/composite-auth.ts: In CompositeAuth’s constructor, interface methods for SSO, session, and user capabilities are explicitly set to undefined when no inner provider implements them, so the new `typeof` check correctly reports absence of those capabilities.
- Guard helpers (isSSOProvider, isSessionProvider, isUserProvider) updated to use `typeof === 'function'`.

### Tests
- packages/core/src/server/auth.test.ts: Added "duck-typing detection" tests asserting CompositeAuth does not expose SSO/session/user methods when no inner provider provides them, and does expose them when at least one inner provider does.

### Release
- .changeset/goofy-lines-fail.md: Patch release entries for `@mastra/server` and `@mastra/core` documenting the fix.

## Impact
Studio and other duck-typing consumers will no longer receive false-positive capability flags (e.g., SSO buttons) from CompositeAuth, preventing actions that previously produced 401 errors when clicked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->