### PR TITLE
fix(core): key suspendedTools/pendingToolApprovals by toolCallId

### DIFF
--- a/.changeset/parallel-same-tool-suspend.md
+++ b/.changeset/parallel-same-tool-suspend.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fixed parallel suspends of the same tool overwriting each other's bookkeeping. When an LLM emitted two `tool_use` blocks for the same tool in one assistant turn and both suspended, the second entry replaced the first in `metadata.suspendedTools` / `metadata.pendingToolApprovals` and only one of the two calls could be resumed.
+
+`addToolMetadata` now keys those records by `toolCallId` instead of `toolName`, so each parallel suspend remains a distinct entry. Readers iterate `Object.values()`, so older runs that persisted entries keyed by `toolName` continue to resolve through a backward-compat fallback. The AIV5 adapter renders one `data-tool-call-suspended` (or `data-tool-call-approval`) part per call, and `removeToolMetadata` clears only the matching `toolCallId` so parallel siblings keep their `resumed: false` flag.
+
+Fixes #16468.

--- a/.changeset/parallel-same-tool-suspend.md
+++ b/.changeset/parallel-same-tool-suspend.md
@@ -2,8 +2,8 @@
 '@mastra/core': patch
 ---
 
-Fixed parallel suspends of the same tool overwriting each other's bookkeeping. When an LLM emitted two `tool_use` blocks for the same tool in one assistant turn and both suspended, the second entry replaced the first in `metadata.suspendedTools` / `metadata.pendingToolApprovals` and only one of the two calls could be resumed.
+Fixed a bug where calling the same tool twice in parallel within a single assistant turn would only let you resume one of the two calls. The other call became orphaned and could never be resumed, even after a restart.
 
-`addToolMetadata` now keys those records by `toolCallId` instead of `toolName`, so each parallel suspend remains a distinct entry. Readers iterate `Object.values()`, so older runs that persisted entries keyed by `toolName` continue to resolve through a backward-compat fallback. The AIV5 adapter renders one `data-tool-call-suspended` (or `data-tool-call-approval`) part per call, and `removeToolMetadata` clears only the matching `toolCallId` so parallel siblings keep their `resumed: false` flag.
+Each suspended tool call (and each pending approval) is now tracked separately, so all parallel calls to the same tool can be resumed independently. Runs that were persisted before this fix continue to resume correctly.
 
 Fixes #16468.

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter-suspended-parts.test.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter-suspended-parts.test.ts
@@ -225,6 +225,74 @@ describe('AIV5Adapter — suspended tool state rehydration', () => {
     expect(approvalParts).toHaveLength(1);
   });
 
+  it('should produce one data-tool-call-suspended part per toolCallId when the same tool suspends twice in parallel', () => {
+    // Regression test for mastra-ai/mastra#16468 — when an LLM emits two parallel tool_use
+    // blocks for the same tool, addToolMetadata used to key the metadata record by toolName
+    // and silently overwrote the first entry. Writes now key by toolCallId so both suspends
+    // remain discoverable. The adapter should render one suspended part per distinct call.
+    const dbMessage: MastraDBMessage = {
+      id: 'msg-parallel',
+      role: 'assistant',
+      createdAt: new Date('2024-01-01'),
+      content: {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              toolCallId: 'tc-parallel-A',
+              toolName: 'workflow-sendEmail',
+              args: { to: 'a@example.com' },
+              state: 'call',
+            },
+          },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              toolCallId: 'tc-parallel-B',
+              toolName: 'workflow-sendEmail',
+              args: { to: 'b@example.com' },
+              state: 'call',
+            },
+          },
+        ],
+        metadata: {
+          suspendedTools: {
+            'tc-parallel-A': {
+              toolCallId: 'tc-parallel-A',
+              toolName: 'workflow-sendEmail',
+              args: { to: 'a@example.com' },
+              type: 'suspension',
+              runId: 'run-A',
+              suspendPayload: { reason: 'awaiting input A' },
+              resumeSchema: '{"type":"object"}',
+            },
+            'tc-parallel-B': {
+              toolCallId: 'tc-parallel-B',
+              toolName: 'workflow-sendEmail',
+              args: { to: 'b@example.com' },
+              type: 'suspension',
+              runId: 'run-B',
+              suspendPayload: { reason: 'awaiting input B' },
+              resumeSchema: '{"type":"object"}',
+            },
+          },
+        },
+      },
+    };
+
+    const uiMessage = AIV5Adapter.toUIMessage(dbMessage);
+
+    const suspendedParts = uiMessage.parts.filter((p: any) => p.type === 'data-tool-call-suspended');
+    expect(suspendedParts).toHaveLength(2);
+
+    const renderedCallIds = suspendedParts.map((p: any) => p.data.toolCallId).sort();
+    expect(renderedCallIds).toEqual(['tc-parallel-A', 'tc-parallel-B']);
+
+    const renderedRunIds = suspendedParts.map((p: any) => p.data.runId).sort();
+    expect(renderedRunIds).toEqual(['run-A', 'run-B']);
+  });
+
   it('should NOT produce data-tool-call-suspended parts for already-resumed tools', () => {
     // When a tool has been resumed/completed, metadata.suspendedTools is cleared,
     // so no data-tool-call-suspended parts should be synthesized

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -935,7 +935,9 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                         (part.type === 'data-tool-call-suspended' || part.type === 'data-tool-call-approval') &&
                         !(part.data as any).resumed
                       ) {
-                        acc[(part.data as any).toolName] = part.data;
+                        // Key by toolCallId so parallel suspends of the same tool stay distinct
+                        // when this fallback runs against legacy parts-only persisted state.
+                        acc[(part.data as any).toolCallId] = part.data;
                       }
                       return acc;
                     },

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -829,3 +829,93 @@ describe('createToolCallStep malformed JSON args (issue #9815)', () => {
     expect(result.error.message).toMatch(/invalid|malformed|json|args|arguments/i);
   });
 });
+
+describe('createToolCallStep parallel same-tool suspensions (issue #16468)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('keys suspendedTools by toolCallId so a second parallel suspend does not overwrite the first', async () => {
+    // Regression: addToolMetadata used to write metadata.suspendedTools[toolName],
+    // so two parallel tool_use blocks targeting the same workflow tool overwrote
+    // each other's bookkeeping. The second resume then failed because the metadata
+    // lookup returned the wrong entry. New writes key by toolCallId, keeping both
+    // entries distinct. See mastra-ai/mastra#16468.
+    const assistantMessage: any = {
+      id: 'm1',
+      role: 'assistant',
+      content: { format: 2, parts: [], metadata: {} },
+      createdAt: new Date(),
+    };
+    const messageList = {
+      get: {
+        input: { aiV5: { model: () => [] } },
+        response: { db: () => [assistantMessage] },
+        all: { db: () => [assistantMessage] },
+      },
+    } as unknown as MessageList;
+
+    const controller = { enqueue: vi.fn() };
+    const streamState = { serialize: vi.fn().mockReturnValue('s') };
+    const flushMessages = vi.fn().mockResolvedValue(undefined);
+    const neverResolve: Promise<never> = new Promise(() => {});
+    const suspend = vi.fn().mockReturnValue(neverResolve);
+
+    const suspendingTool = {
+      execute: vi.fn(async (_args: unknown, opts: MastraToolInvocationOptions) => {
+        await opts.suspend!({ reason: 'awaiting' }, { resumeSchema: '{}' } as any);
+        return 'unreachable';
+      }),
+    };
+    const tools = { 'workflow-sendEmail': suspendingTool } as unknown as ToolSet;
+
+    const toolCallStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'outer-run',
+      streamState,
+      _internal: {
+        saveQueueManager: { flushMessages } as any,
+        memoryConfig: {} as any,
+        threadId: 't1',
+      },
+    } as any);
+
+    const makeParams = (toolCallId: string) => ({
+      runId: 'outer-run',
+      workflowId: 'wf',
+      mastra: {} as any,
+      requestContext: new RequestContext(),
+      state: {},
+      setState: vi.fn(),
+      retryCount: 0,
+      tracingContext: {} as any,
+      getInitData: vi.fn(),
+      getStepResult: vi.fn(),
+      suspend,
+      bail: vi.fn(),
+      abort: vi.fn(),
+      engine: 'default' as any,
+      abortSignal: new AbortController().signal,
+      writer: new ToolStream({ prefix: 'tool', callId: toolCallId, name: 'workflow-sendEmail', runId: 'outer-run' }),
+      validateSchemas: false,
+      inputData: { toolCallId, toolName: 'workflow-sendEmail', args: { to: toolCallId } },
+    });
+
+    // Both calls suspend forever; we only care about the addToolMetadata side-effect
+    void toolCallStep.execute(makeParams('call-A'));
+    await new Promise(resolve => setImmediate(resolve));
+    void toolCallStep.execute(makeParams('call-B'));
+    await new Promise(resolve => setImmediate(resolve));
+
+    const suspended = assistantMessage.content.metadata.suspendedTools as Record<string, any>;
+    expect(suspended).toBeDefined();
+    expect(Object.keys(suspended).sort()).toEqual(['call-A', 'call-B']);
+    expect(suspended['call-A']).toMatchObject({ toolCallId: 'call-A', toolName: 'workflow-sendEmail' });
+    expect(suspended['call-B']).toMatchObject({ toolCallId: 'call-B', toolName: 'workflow-sendEmail' });
+    expect(suspended['call-A'].suspendPayload).toMatchObject({ reason: 'awaiting' });
+    expect(suspended['call-B'].suspendPayload).toMatchObject({ reason: 'awaiting' });
+  });
+});

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -904,15 +904,20 @@ describe('createToolCallStep parallel same-tool suspensions (issue #16468)', () 
       inputData: { toolCallId, toolName: 'workflow-sendEmail', args: { to: toolCallId } },
     });
 
-    // Both calls suspend forever; we only care about the addToolMetadata side-effect
+    // Both calls suspend forever; we only care about the addToolMetadata side-effect.
+    // Use vi.waitFor instead of fixed setImmediate ticks so the assertion fires as soon
+    // as both writes have landed, even if the underlying tool.execute path grows more
+    // awaits later.
     void toolCallStep.execute(makeParams('call-A'));
-    await new Promise(resolve => setImmediate(resolve));
     void toolCallStep.execute(makeParams('call-B'));
-    await new Promise(resolve => setImmediate(resolve));
+
+    await vi.waitFor(() => {
+      const suspended = assistantMessage.content.metadata.suspendedTools as Record<string, any> | undefined;
+      expect(suspended).toBeDefined();
+      expect(Object.keys(suspended!).sort()).toEqual(['call-A', 'call-B']);
+    });
 
     const suspended = assistantMessage.content.metadata.suspendedTools as Record<string, any>;
-    expect(suspended).toBeDefined();
-    expect(Object.keys(suspended).sort()).toEqual(['call-A', 'call-B']);
     expect(suspended['call-A']).toMatchObject({ toolCallId: 'call-A', toolName: 'workflow-sendEmail' });
     expect(suspended['call-B']).toMatchObject({ toolCallId: 'call-B', toolName: 'workflow-sendEmail' });
     expect(suspended['call-A'].suspendPayload).toMatchObject({ reason: 'awaiting' });

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -148,7 +148,10 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               ? (lastAssistantMessage.content.metadata as Record<string, any>)
               : {};
           metadata[metadataKey] = metadata[metadataKey] || {};
-          // Note: We key by toolName rather than toolCallId to track one suspension state per unique tool.
+          // Key by toolCallId rather than toolName so two parallel suspends of the same tool
+          // remain distinct entries. Earlier code keyed by toolName for autoResumeSuspendedTools
+          // lookup, which silently overwrote the first entry when a second call to the same
+          // tool suspended. Consumers iterate Object.values(), so the change is read-compatible.
           const inputTransform = getTransformedToolPayload(
             toolStateTransformMetadata,
             'transcript',
@@ -169,7 +172,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               ? (approvalTransform ?? inputTransform ?? args)
               : (inputTransform ?? suspendTransform ?? args);
           const transformedSuspendPayload = type === 'suspension' ? (suspendTransform ?? suspendPayload) : undefined;
-          metadata[metadataKey][toolName] = {
+          metadata[metadataKey][toolCallId] = {
             toolCallId,
             toolName,
             args: transformedArgs,
@@ -183,7 +186,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         }
       };
 
-      const removeToolMetadata = async (toolName: string, type: 'suspension' | 'approval') => {
+      const removeToolMetadata = async ({ toolCallId }: { toolCallId: string }, type: 'suspension' | 'approval') => {
         const { saveQueueManager, memoryConfig, threadId } = _internal || {};
 
         if (!saveQueueManager || !threadId) {
@@ -202,21 +205,37 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
 
         const metadataKey = type === 'suspension' ? 'suspendedTools' : 'pendingToolApprovals';
 
+        // Locate the entry's key in the suspendedTools/pendingToolApprovals record.
+        // New writes key by toolCallId; runs persisted before that change keyed by toolName,
+        // so fall back to scanning values when the direct lookup misses.
+        const findEntryKey = (record: Record<string, any> | undefined): string | undefined => {
+          if (!record || typeof record !== 'object') return undefined;
+          const direct = record[toolCallId];
+          if (direct && typeof direct === 'object' && direct.toolCallId === toolCallId) {
+            return toolCallId;
+          }
+          for (const [key, value] of Object.entries(record)) {
+            if (value && typeof value === 'object' && (value as any).toolCallId === toolCallId) {
+              return key;
+            }
+          }
+          return undefined;
+        };
+
         // Find and update the assistant message to remove approval metadata
         // At this point, messages have been persisted, so we look in all messages
         const allMessages = messageList.get.all.db();
         const lastAssistantMessage = [...allMessages].reverse().find(msg => {
           const metadata = getMetadata(msg);
           const suspendedTools = metadata?.[metadataKey] as Record<string, any> | undefined;
-          const foundTool = !!suspendedTools?.[toolName];
-          if (foundTool) {
+          if (findEntryKey(suspendedTools)) {
             return true;
           }
           const dataToolSuspendedParts = msg.content.parts?.filter(
             part => part.type === 'data-tool-call-suspended' || part.type === 'data-tool-call-approval',
           );
           if (dataToolSuspendedParts && dataToolSuspendedParts.length > 0) {
-            const foundTool = dataToolSuspendedParts.find((part: any) => part.data.toolName === toolName);
+            const foundTool = dataToolSuspendedParts.find((part: any) => part.data.toolCallId === toolCallId);
             if (foundTool) {
               return true;
             }
@@ -233,7 +252,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               ?.reduce(
                 (acc, part) => {
                   if (part.type === 'data-tool-call-suspended' || part.type === 'data-tool-call-approval') {
-                    acc[(part.data as any).toolName] = part.data;
+                    acc[(part.data as any).toolCallId] = part.data;
                   }
                   return acc;
                 },
@@ -243,23 +262,29 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
 
           if (suspendedTools && typeof suspendedTools === 'object') {
             if (metadata) {
-              delete suspendedTools[toolName];
-            } else {
-              lastAssistantMessage.content.parts = lastAssistantMessage.content.parts?.map(part => {
-                if (part.type === 'data-tool-call-suspended' || part.type === 'data-tool-call-approval') {
-                  if ((part.data as any).toolName === toolName) {
-                    return {
-                      ...part,
-                      data: {
-                        ...(part.data as any),
-                        resumed: true,
-                      },
-                    };
-                  }
-                }
-                return part;
-              });
+              const keyToDelete = findEntryKey(suspendedTools);
+              if (keyToDelete) {
+                delete suspendedTools[keyToDelete];
+              }
             }
+
+            // Mark only the matching toolCallId part as resumed so other parallel suspends
+            // of the same tool (with different toolCallIds) keep their `resumed: false` flag
+            // and remain discoverable by the autoResumeSuspendedTools loop and resume scans.
+            lastAssistantMessage.content.parts = lastAssistantMessage.content.parts?.map(part => {
+              if (part.type === 'data-tool-call-suspended' || part.type === 'data-tool-call-approval') {
+                if ((part.data as any).toolCallId === toolCallId) {
+                  return {
+                    ...part,
+                    data: {
+                      ...(part.data as any),
+                      resumed: true,
+                    },
+                  };
+                }
+              }
+              return part;
+            });
 
             // If no more pending suspensions, remove the whole object
             if (metadata && Object.keys(suspendedTools).length === 0) {
@@ -443,7 +468,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
             );
           } else {
             // Remove approval metadata since we're resuming (either approved or declined)
-            await removeToolMetadata(inputData.toolName, 'approval');
+            await removeToolMetadata({ toolCallId: inputData.toolCallId }, 'approval');
 
             if (!resumeData.approved) {
               return {
@@ -616,10 +641,22 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
 
           for (const message of assistantMessages) {
             const pendingOrSuspendedTools = (message.content.metadata?.suspendedTools ||
-              message.content.metadata?.pendingToolApprovals) as Record<string, any>;
-            if (pendingOrSuspendedTools && pendingOrSuspendedTools[inputData.toolName]) {
-              suspendedToolRunId = pendingOrSuspendedTools[inputData.toolName].runId;
-              break;
+              message.content.metadata?.pendingToolApprovals) as Record<string, any> | undefined;
+            if (pendingOrSuspendedTools) {
+              // New writes key by toolCallId; older persisted runs may key by toolName.
+              // Try the direct toolName slot first for backward compatibility, then iterate
+              // values to find an entry whose toolName matches.
+              const directByToolName = pendingOrSuspendedTools[inputData.toolName];
+              const matchedEntry =
+                directByToolName && (directByToolName as any).toolName === inputData.toolName
+                  ? directByToolName
+                  : Object.values(pendingOrSuspendedTools).find(
+                      (entry: any) => entry && typeof entry === 'object' && entry.toolName === inputData.toolName,
+                    );
+              if (matchedEntry) {
+                suspendedToolRunId = (matchedEntry as any).runId;
+                break;
+              }
             }
 
             if (shouldUsePartsFallback) {
@@ -644,7 +681,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         }
 
         if (!toolRequiresApproval && isResumeToolCall) {
-          await removeToolMetadata(inputData.toolName, 'suspension');
+          await removeToolMetadata({ toolCallId: inputData.toolCallId }, 'suspension');
         }
 
         if (args === null || args === undefined) {


### PR DESCRIPTION
## Description

When an LLM emitted two `tool_use` blocks for the same tool in one assistant turn and both suspended, the second entry silently overwrote the first in `metadata.suspendedTools` (or `metadata.pendingToolApprovals`) because the record was keyed by `toolName`. Only one of the two calls could then be resumed; the other stayed orphaned, even after restart.

The fix keys those records by `toolCallId` so each parallel suspend remains a distinct entry. Readers iterate `Object.values()`, so runs persisted before this change keep resolving through a backward-compat lookup (`findEntryKey` scans values when the direct `[toolCallId]` lookup misses an older `toolName`-keyed write). `removeToolMetadata` clears only the matching `toolCallId` and marks only the matching `data-tool-call-suspended` (or `data-tool-call-approval`) part as `resumed: true`, leaving sibling suspends with their `resumed: false` flag intact so the autoResumeSuspendedTools loop can still find them.

Two regression tests were added: one at the adapter layer asserting the AIV5 adapter synthesizes one `data-tool-call-suspended` part per `toolCallId` when two parallel same-tool suspends exist in metadata, and one at the step layer asserting `addToolMetadata` writes two distinct entries to `metadata.suspendedTools` when the same tool is called twice in parallel.

## Related issue(s)

Fixes #16468.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have added tests that prove my fix is effective

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the AI tried to use the same tool twice at once, the second call erased the first one’s record so it couldn't be resumed. This PR tracks each call by a unique ID so parallel calls are tracked and resumed independently.

---

## Summary

Fixes a bug where parallel suspensions/approvals for the same tool in a single assistant turn overwrote each other because metadata was keyed by toolName. Tool suspension and approval records are now keyed by toolCallId so each parallel call becomes a distinct entry and can be resumed individually. Backward-compatible fallbacks let the system still find older toolName-keyed entries.

## Changes

- tool-call-step.ts
  - Key suspendedTools and pendingToolApprovals by toolCallId instead of toolName.
  - removeToolMetadata now deletes only the matching toolCallId entry and marks only the corresponding part as resumed, leaving sibling suspends intact.
  - Lookup logic updated to prefer direct toolCallId lookup with a fallback scan of values to support older toolName-keyed data.
  - Call sites updated to pass { toolCallId } where applicable.
  - Resume flow updated to derive suspended run IDs from the new shape, with compatibility fallback.

- llm-execution-step.ts
  - Auto-resume prompt augmentation now constructs suspended-tool objects keyed by toolCallId during legacy parts-only fallback.

- Tests
  - Added adapter-layer Vitest ensuring AIV5Adapter synthesizes one data-tool-call-suspended part per distinct toolCallId for parallel same-tool suspends.
  - Added step-layer Vitest verifying addToolMetadata writes two distinct suspendedTools entries keyed by toolCallId for parallel calls.

- Changeset
  - .changeset entry documenting the user-facing fix and compatibility behavior.

## Backward compatibility

- Readers already iterate Object.values(), so they remain compatible with either keying scheme.
- removeToolMetadata includes a fallback that scans stored values for a matching toolCallId when direct lookup by toolCallId fails, preserving resume behavior for runs persisted before this change.

## Impact

- Parallel suspends for the same tool no longer clobber each other.
- Each suspended tool call can be resumed independently via agent.resumeStream({ runId, toolCallId }).
- Auto-resume and existing persisted runs continue to work due to compatibility fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->