### PR TITLE
fix(stagehand): silence browser logs by default

### DIFF
--- a/.changeset/quiet-stagehand-logs.md
+++ b/.changeset/quiet-stagehand-logs.md
@@ -1,0 +1,5 @@
+---
+'@mastra/stagehand': patch
+---
+
+Silence Stagehand console logging by default and route logs through a logger hook to avoid corrupting host TUIs.

--- a/browser/stagehand/src/__tests__/stagehand-browser.test.ts
+++ b/browser/stagehand/src/__tests__/stagehand-browser.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Create mocks BEFORE vi.mock using vi.hoisted so they're available in the mock
-const { mockPage, mockContext, mockStagehand, mockCdpSession } = vi.hoisted(() => {
+const { mockPage, mockContext, mockStagehand, mockCdpSession, mockStagehandConstructor } = vi.hoisted(() => {
+  const mockStagehandConstructor = vi.fn();
   const mockCdpSession = {
     send: vi.fn().mockResolvedValue({}),
     on: vi.fn(),
@@ -44,11 +45,15 @@ const { mockPage, mockContext, mockStagehand, mockCdpSession } = vi.hoisted(() =
     ]),
   };
 
-  return { mockPage, mockContext, mockStagehand, mockCdpSession };
+  return { mockPage, mockContext, mockStagehand, mockCdpSession, mockStagehandConstructor };
 });
 
 vi.mock('@browserbasehq/stagehand', () => ({
   Stagehand: class MockStagehand {
+    constructor(options: unknown) {
+      mockStagehandConstructor(options);
+    }
+
     init = mockStagehand.init;
     close = mockStagehand.close;
     context = mockStagehand.context;
@@ -177,6 +182,45 @@ describe('StagehandBrowser', () => {
       await browser.launch();
       expect(browser.status).toBe('ready');
       expect(mockStagehand.init).toHaveBeenCalled();
+    });
+
+    it('creates Stagehand with TUI-safe logging defaults', async () => {
+      await browser.launch();
+
+      expect(mockStagehandConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          verbose: 0,
+          disablePino: true,
+          logger: expect.any(Function),
+        }),
+      );
+    });
+
+    it('preserves explicit verbose level and custom logger', async () => {
+      const logger = vi.fn();
+      const customBrowser = new StagehandBrowser({ scope: 'shared', verbose: 2, logger });
+      await customBrowser.launch();
+      await customBrowser.close();
+
+      expect(mockStagehandConstructor).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          verbose: 2,
+          disablePino: true,
+          logger,
+        }),
+      );
+    });
+
+    it('preserves explicit disablePino override', async () => {
+      const customBrowser = new StagehandBrowser({ scope: 'shared', disablePino: false });
+      await customBrowser.launch();
+      await customBrowser.close();
+
+      expect(mockStagehandConstructor).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          disablePino: false,
+        }),
+      );
     });
 
     it('should close successfully', async () => {

--- a/browser/stagehand/src/stagehand-browser.ts
+++ b/browser/stagehand/src/stagehand-browser.ts
@@ -116,6 +116,8 @@ export class StagehandBrowser extends MastraBrowser {
     domSettleTimeoutMs?: number;
     verbose?: 0 | 1 | 2;
     systemPrompt?: string;
+    logger?: StagehandBrowserConfig['logger'];
+    disablePino?: boolean;
     apiKey?: string;
     projectId?: string;
     localBrowserLaunchOptions?: {
@@ -136,6 +138,8 @@ export class StagehandBrowser extends MastraBrowser {
       domSettleTimeoutMs?: number;
       verbose?: 0 | 1 | 2;
       systemPrompt?: string;
+      logger?: StagehandBrowserConfig['logger'];
+      disablePino?: boolean;
       apiKey?: string;
       projectId?: string;
       localBrowserLaunchOptions?: {
@@ -152,8 +156,10 @@ export class StagehandBrowser extends MastraBrowser {
       model: typeof config.model === 'string' ? config.model : config.model?.modelName,
       selfHeal: config.selfHeal ?? true,
       domSettleTimeoutMs: config.domSettleTimeout,
-      verbose: (config.verbose ?? 1) as 0 | 1 | 2,
+      verbose: (config.verbose ?? 0) as 0 | 1 | 2,
       systemPrompt: config.systemPrompt,
+      logger: config.logger ?? (() => {}),
+      disablePino: config.disablePino ?? true,
     };
 
     // Handle Browserbase configuration

--- a/browser/stagehand/src/types.ts
+++ b/browser/stagehand/src/types.ts
@@ -19,6 +19,14 @@ export type ModelConfiguration =
 /**
  * Stagehand-specific configuration fields.
  */
+export interface StagehandLogLine {
+  category?: string;
+  message: string;
+  level?: 0 | 1 | 2;
+  timestamp?: string;
+  auxiliary?: Record<string, { value: string; type: string }>;
+}
+
 interface StagehandConfigExtensions {
   /**
    * Environment to run the browser in
@@ -58,13 +66,27 @@ interface StagehandConfigExtensions {
   domSettleTimeout?: number;
 
   /**
-   * Logging verbosity level
-   * - 0: Silent
-   * - 1: Errors only
-   * - 2: Verbose
-   * @default 1
+   * Logging verbosity level.
+   * - 0: Suppress INFO/DEBUG logs
+   * - 1: Include INFO logs
+   * - 2: Include DEBUG logs
+   *
+   * @default 0
    */
   verbose?: 0 | 1 | 2;
+
+  /**
+   * Optional Stagehand logger hook. When provided, Stagehand log lines are
+   * routed here instead of being written directly to the process console.
+   */
+  logger?: (line: StagehandLogLine) => void;
+
+  /**
+   * Disable Stagehand's Pino console logging backend.
+   *
+   * @default true
+   */
+  disablePino?: boolean;
 
   /**
    * Custom system prompt for AI operations (act, extract, observe)


### PR DESCRIPTION
This keeps Stagehand from writing directly to the process console by default, which was breaking TUI rendering when browser tools ran.

Before, Stagehand could fall back to console output like this:

```ts
console.log(line)
```

Now we pass safe defaults into Stagehand instead:

```ts
{
  verbose: 0,
  logger: config.logger ?? (() => {}),
  disablePino: true,
}
```

Explicit logging config is still respected, so callers can opt back into verbose logs, a custom logger, or Pino if they need it.

Tested with:

```bash
pnpm --filter @mastra/stagehand test -- stagehand-browser.test.ts
pnpm --filter @mastra/stagehand build
```

Also verified manually through the Mastra Code browser tools: navigate, observe, extract, and tabs worked without Stagehand log output corrupting the TUI.

before:
<img width="1724" height="423" alt="Screenshot 2026-05-15 at 10 13 38 PM" src="https://github.com/user-attachments/assets/2b6f0f0c-892d-4d77-b4ec-807210303eb6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

Stagehand is a tool that controls web browsers. Before, it would print messages directly to the terminal, which messed up the nice visual interface (TUI) that Mastra uses. This PR makes Stagehand quiet by default so it doesn't break the display anymore, but users can still turn logging back on if they need it.

## Changes Overview

This PR silences Stagehand's console output by default to prevent browser logs from corrupting TUI rendering while still allowing explicit logging configuration. The fix involves routing logs through a logger hook and disabling the Pino console backend by default.

## Key Changes

**Types and Configuration** (`browser/stagehand/src/types.ts`)
- Added `StagehandLogLine` type to standardize log payloads with category, message, level, timestamp, and structured data
- Extended `StagehandConfigExtensions` with:
  - `logger?: (line: StagehandLogLine) => void` – optional callback to receive log lines
  - `disablePino?: boolean` – flag to disable Pino console backend
- Updated `verbose` documentation to clarify 0/1/2 semantics

**Browser Stagehand Implementation** (`browser/stagehand/src/stagehand-browser.ts`)
- Modified `buildStagehandOptions()` to apply safe defaults:
  - `verbose: 0` (down from 1)
  - `disablePino: true` (new)
  - `logger` defaults to a no-op function
- Preserves explicit configuration overrides from callers

**Test Coverage** (`browser/stagehand/src/__tests__/stagehand-browser.test.ts`)
- Added spy tracking for Stagehand constructor options via `mockStagehandConstructor`
- Added three regression tests validating:
  - Defaults apply when not explicitly configured
  - Explicit `verbose` overrides are preserved
  - Custom `logger` and `disablePino` overrides are respected

**Release Documentation** (`.changeset/quiet-stagehand-logs.md`)
- Added Changeset entry documenting the patch-level fix for `@mastra/stagehand`

## Testing and Verification

Manual verification confirmed that Stagehand browser tests and build commands no longer corrupt TUI output, and Mastra Code browser tools (navigate, observe, extract, tabs) function correctly without log noise.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->