### PR TITLE
feat(deployer): add bundler.excludePackages option to drop entries from generated package.json

### DIFF
--- a/.changeset/exclude-packages-bundler-16645.md
+++ b/.changeset/exclude-packages-bundler-16645.md
@@ -1,0 +1,14 @@
+---
+'@mastra/core': minor
+'@mastra/deployer': minor
+---
+
+Added a `bundler.excludePackages` option to force-exclude packages from the generated `package.json` even when dependency analysis flagged them as in use. Useful when conditional dynamic imports (e.g. a dev-only `await import('@mastra/libsql')` gated by `process.env.NODE_ENV`) are tree-shaken out of the production bundle but still surface as dependencies. Addresses the "escape hatch" half of [#16645](https://github.com/mastra-ai/mastra/issues/16645).
+
+```typescript
+export const mastra = new Mastra({
+  bundler: {
+    excludePackages: ['@mastra/libsql'],
+  },
+});
+```

--- a/docs/src/content/en/reference/core/mastra-class.mdx
+++ b/docs/src/content/en/reference/core/mastra-class.mdx
@@ -153,9 +153,10 @@ Visit the [Configuration reference](/reference/configuration) for detailed docum
     name: 'bundler',
     type: 'BundlerConfig',
     description:
-      'Configuration for the asset bundler with options for externals, sourcemap, transpilePackages, and dynamicPackages.',
+      'Configuration for the asset bundler with options for externals, sourcemap, transpilePackages, dynamicPackages, and excludePackages.',
     isOptional: true,
-    defaultValue: '{ externals: [], sourcemap: false, transpilePackages: [], dynamicPackages: [] }',
+    defaultValue:
+      '{ externals: [], sourcemap: false, transpilePackages: [], dynamicPackages: [], excludePackages: [] }',
   },
   {
     name: 'scorers',

--- a/packages/core/src/bundler/types.ts
+++ b/packages/core/src/bundler/types.ts
@@ -31,5 +31,32 @@ export type BundlerConfig = {
    */
   dynamicPackages?: string[];
 
+  /**
+   * Packages to force-exclude from the generated `package.json` even if
+   * dependency analysis flagged them as in use.
+   *
+   * Useful when conditional dynamic imports (e.g. a dev-only
+   * `await import('@mastra/libsql')` gated by `process.env.NODE_ENV`) get
+   * picked up by static analysis but are tree-shaken out of the production
+   * bundle, polluting the output with packages your runtime never actually
+   * needs.
+   *
+   * Entries are matched by package name only — `'@mastra/libsql'` drops the
+   * package even when it was imported via a subpath, but `'@mastra/libsql/vector'`
+   * matches nothing and is silently ignored.
+   *
+   * This affects the generated `package.json` only; the package stays external
+   * to the bundle. Excluding something the runtime does reach therefore surfaces
+   * as a `MODULE_NOT_FOUND` at run time, not as a build error.
+   *
+   * @example
+   * ```typescript
+   * bundler: {
+   *   excludePackages: ['@mastra/libsql']
+   * }
+   * ```
+   */
+  excludePackages?: string[];
+
   [key: symbol]: boolean | undefined;
 };

--- a/packages/deployer/src/build/__fixtures__/with-exclude-packages.js
+++ b/packages/deployer/src/build/__fixtures__/with-exclude-packages.js
@@ -1,0 +1,7 @@
+import { Mastra } from '@mastra/core/mastra';
+
+export const mastra = new Mastra({
+  bundler: {
+    excludePackages: ['@mastra/libsql'],
+  },
+});

--- a/packages/deployer/src/build/__snapshots__/bundlerOptions.test.ts.snap
+++ b/packages/deployer/src/build/__snapshots__/bundlerOptions.test.ts.snap
@@ -16,6 +16,15 @@ export { bundler };
 "
 `;
 
+exports[`getBundlerOptionsConfig > should be able to extract the bundler options config from ./__fixtures__/with-exclude-packages.js 1`] = `
+"const bundler = {
+  excludePackages: ["@mastra/libsql"]
+};
+
+export { bundler };
+"
+`;
+
 exports[`getBundlerOptionsConfig > should be able to extract the bundler options config from ./plugins/__fixtures__/basic.js 1`] = `
 "const bundler = {};
 

--- a/packages/deployer/src/build/bundlerOptions.test.ts
+++ b/packages/deployer/src/build/bundlerOptions.test.ts
@@ -17,6 +17,7 @@ describe('getBundlerOptionsConfig', () => {
     ['./plugins/__fixtures__/empty-mastra.js', false],
     ['./__fixtures__/no-bundler.js', false],
     ['./__fixtures__/with-dynamic-packages.js', true],
+    ['./__fixtures__/with-exclude-packages.js', true],
   ] as [string, boolean][])(
     'should be able to extract the bundler options config from %s',
     async ([fileName, hasCustomConfig]) => {

--- a/packages/deployer/src/build/types.ts
+++ b/packages/deployer/src/build/types.ts
@@ -30,6 +30,15 @@ export interface BundlerOptions {
   enableEsmShim: boolean;
   externals: boolean | string[];
   dynamicPackages?: string[];
+  /**
+   * Packages to force-exclude from the generated `package.json` even if
+   * dependency analysis flagged them as in use. Useful when conditional
+   * dynamic imports (e.g. dev-only `await import('@mastra/libsql')` gated
+   * by `process.env.NODE_ENV`) get picked up by static analysis but are
+   * tree-shaken out of the production bundle. See
+   * https://github.com/mastra-ai/mastra/issues/16645.
+   */
+  excludePackages?: string[];
 }
 
 /**

--- a/packages/deployer/src/bundler/index.test.ts
+++ b/packages/deployer/src/bundler/index.test.ts
@@ -1,8 +1,22 @@
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { analyzeBundle } from '../build/analyze';
+import { collectTransitiveWorkspaceDependencies } from './workspaceDependencies';
 import { Bundler } from './index';
+
+vi.mock('../build/analyze', () => ({
+  analyzeBundle: vi.fn(),
+}));
+
+vi.mock('./workspaceDependencies', () => ({
+  collectTransitiveWorkspaceDependencies: vi.fn(() => ({
+    resolutions: {},
+    usedWorkspacePackages: new Set<string>(),
+  })),
+  packWorkspaceDependencies: vi.fn(),
+}));
 
 const tempDirs: string[] = [];
 
@@ -11,6 +25,34 @@ class TestBundler extends Bundler {
 
   getEnvFiles(): Promise<string[]> {
     return Promise.resolve([]);
+  }
+}
+
+/**
+ * Runs `_bundle` far enough to generate the package.json, then aborts. Rollup itself is
+ * out of scope here — the dependency map handed to `writePackageJson` is what's under test.
+ */
+const STOP_AFTER_PACKAGE_JSON = 'stop-after-package-json';
+
+class ExcludePackagesBundler extends TestBundler {
+  constructor(private readonly excludePackages: string[]) {
+    super('Test');
+  }
+
+  async runBundle(outputDirectory: string) {
+    return this._bundle('server.js', 'mastra.js', { projectRoot: outputDirectory, outputDirectory });
+  }
+
+  protected async getUserBundlerOptions() {
+    return { externals: [], sourcemap: false, transpilePackages: [], excludePackages: this.excludePackages };
+  }
+
+  async listToolsInputOptions() {
+    return {};
+  }
+
+  protected async getBundlerOptions(): Promise<never> {
+    throw new Error(STOP_AFTER_PACKAGE_JSON);
   }
 }
 
@@ -46,5 +88,55 @@ describe('Bundler.writePackageJson', () => {
     });
     expect(pkg.resolutions).toEqual(workspaceResolutions);
     expect(pkg.pnpm).toBeUndefined();
+  });
+});
+
+describe('Bundler._bundle excludePackages', () => {
+  const analyzed = {
+    externalDependencies: new Map([
+      ['@mastra/libsql', { version: '1.0.0' }],
+      ['@mastra/pg', { version: '2.0.0' }],
+    ]),
+    dependencies: new Map(),
+    workspaceMap: new Map(),
+    output: { code: '' },
+    usedExternals: {},
+    invalidChunks: new Set(),
+  };
+
+  async function generatePackageJson(excludePackages: string[]) {
+    const tempDir = await mkdtemp(join(tmpdir(), 'mastra-bundler-exclude-'));
+    tempDirs.push(tempDir);
+
+    vi.mocked(analyzeBundle).mockResolvedValue(analyzed as never);
+
+    await expect(new ExcludePackagesBundler(excludePackages).runBundle(tempDir)).rejects.toThrow(
+      STOP_AFTER_PACKAGE_JSON,
+    );
+
+    return JSON.parse(await readFile(join(tempDir, 'output', 'package.json'), 'utf-8'));
+  }
+
+  it('omits an excluded package from the generated package.json', async () => {
+    const pkg = await generatePackageJson(['@mastra/libsql']);
+
+    expect(pkg.dependencies).toEqual({ '@mastra/pg': '2.0.0' });
+  });
+
+  it('keeps every analyzed dependency when the option is unset', async () => {
+    const pkg = await generatePackageJson([]);
+
+    expect(pkg.dependencies).toEqual({ '@mastra/libsql': '1.0.0', '@mastra/pg': '2.0.0' });
+  });
+
+  it('omits an excluded package that the transitive-workspace step would otherwise re-add', async () => {
+    vi.mocked(collectTransitiveWorkspaceDependencies).mockReturnValueOnce({
+      resolutions: { '@internal/db': 'file:./workspace-module/internal-db-1.0.0.tgz' },
+      usedWorkspacePackages: new Set<string>(),
+    } as never);
+
+    const pkg = await generatePackageJson(['@internal/db']);
+
+    expect(pkg.dependencies).toEqual({ '@mastra/libsql': '1.0.0', '@mastra/pg': '2.0.0' });
   });
 });

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -350,6 +350,7 @@ export abstract class Bundler extends MastraBundler {
       externals: bundlerOptions.externals ?? [],
       enableEsmShim,
       dynamicPackages: bundlerOptions.dynamicPackages,
+      excludePackages: bundlerOptions.excludePackages,
     };
 
     let analyzedBundleInfo;
@@ -384,12 +385,12 @@ export abstract class Bundler extends MastraBundler {
       );
     }
 
+    const excludedPackages = new Set(internalBundlerOptions.excludePackages ?? []);
     const dependenciesToInstall = new Map<string, ExternalDependencyInfo>();
     for (const [dep, depInfo] of analyzedBundleInfo.externalDependencies) {
       if (analyzedBundleInfo.workspaceMap.has(dep) || !isBareModuleSpecifier(dep)) {
         continue;
       }
-
       dependenciesToInstall.set(dep, depInfo);
     }
 
@@ -412,6 +413,17 @@ export abstract class Bundler extends MastraBundler {
         version: analyzedBundleInfo.workspaceMap.get(dep)?.version,
         packageSpec,
       });
+    }
+
+    // User opt-out: dependency analysis is conservative and may flag packages that are
+    // tree-shaken out of the production bundle (e.g. dev-only conditional dynamic imports).
+    // `excludePackages` force-drops those entries from the generated package.json. Applied
+    // to the final map so the transitive-workspace step above cannot re-add an exclusion.
+    // See #16645.
+    for (const dep of excludedPackages) {
+      if (dependenciesToInstall.delete(dep)) {
+        this.logger.debug(`Excluding "${dep}" from generated package.json (excludePackages)`);
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary

Relates to #16645 (escape-hatch portion; the scanner-reachability half stays open).

Dependency analysis is intentionally conservative — packages reachable via conditional dynamic imports (e.g. `process.env.NODE_ENV`-gated branches) get flagged even when tree-shaking removes them from the production bundle. The user's report is the canonical example: dev/prod-branched `await import('@mastra/libsql')` / `await import('@mastra/pg')` leaves both packages in `.mastra/output/package.json`, polluting production installs with native binaries that never run.

## What this PR does

Adds a `bundler.excludePackages: string[]` opt-out on `BundlerConfig`:

```typescript
export const mastra = new Mastra({
  bundler: {
    excludePackages: ['@mastra/libsql'],
  },
});
```

When the bundler builds `dependenciesToInstall`, entries whose import name is in `excludePackages` are dropped before the output `package.json` is written. The exclusion is logged at debug level so users can confirm the filter triggered.

## What this PR does NOT do

The issue also asks the scanner to **stop including** tree-shaken deps in the first place. That's a real bug and worth fixing — but the cause is deeper: `bundleExternals` declares every dep in `depsToOptimize` as its own Rollup entry, so each external gets its own entry chunk regardless of whether it's reachable from the user's actual entry after tree-shaking. The `o.imports` walk in `analyze.ts` then picks the dep up from that virtual entry chunk.

Fixing it cleanly needs reachability analysis on the post-tree-shake bundle that distinguishes user-entry chunks (the real ones) from the virtual entry chunks we created per external (the ones to skip). That's a larger change with bundler-correctness implications I'd rather not bundle into this PR. The escape hatch unblocks the immediate user pain; happy to follow up with the reachability fix in a separate PR.

## Test plan

- [x] `bundlerOptions.test.ts` — added a `with-exclude-packages.js` fixture and a test row verifying the option flows through the bundler-options extractor. New snapshot captured. 11 tests pass.
- [x] All other `packages/deployer/src/build/**` and `packages/deployer/src/bundler/**` tests pass (273 tests, 19 files) — unchanged behavior when `excludePackages` is unset.
- [x] `pnpm exec tsc --noEmit` in `packages/deployer` reports the same pre-existing `@mastra/hono` / `@mastra/server` errors (unrelated to this change) and no new errors. After `pnpm --filter @mastra/core` builds, `excludePackages` resolves cleanly against `BundlerConfig`.

Pre-existing env failures in `src/server/**` and `src/validator/**` tests (require dist of `@mastra/hono`, `@mastra/server`, `dist/validator/loader.js`) are unrelated to this change.

## Docs

JSDoc on `BundlerConfig.excludePackages` (in `packages/core/src/bundler/types.ts`) and `BundlerOptions.excludePackages` (in `packages/deployer/src/build/types.ts`) is the primary source. The reference doc (`docs/src/content/en/reference/core/mastra-class.mdx`) needs a small follow-up to list the option alongside `dynamicPackages` — the local prettier-mdx hook was failing on my machine and I didn't want to block this PR on the docs build env.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets developers remove specific packages from the generated `package.json` when the bundler incorrectly thinks they are needed. It helps with packages used only by code that the production build removes.

## Overview

Adds the optional `bundler.excludePackages: string[]` configuration. The deployer applies exclusions to the final dependency map before writing `.mastra/output/package.json`.

The option supports packages detected through conditional dynamic imports. It does not fix the underlying scanner reachability issue.

## Changes

- Adds `excludePackages` to `BundlerConfig` and `BundlerOptions`.
- Propagates the option through the bundling pipeline.
- Filters excluded packages after dependency analysis completes.
- Prevents workspace-linked packages from being re-added during dependency processing.
- Logs excluded packages at debug level.
- Uses exact package-name matching. Subpaths do not match.
- Keeps excluded packages external and omits them only from `package.json` dependencies.
- Keeps excluded workspace packages in `resolutions` and continues packing them with `packWorkspaceDependencies`.
- Adds JSDoc, reference documentation, a changeset, a fixture, and package-generation tests.

## Usage

```ts
export default {
  bundler: {
    excludePackages: ['`@mastra/libsql`'],
  },
};
```

Incorrect exclusions can cause runtime `MODULE_NOT_FOUND` errors.

## Validation

- 458 tests pass.
- One pre-existing `fs-routing` test fails.
- Tests cover excluded packages, unset configuration, and workspace dependency re-add behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

