### PR TITLE
fix(core): break RequestContext.toJSON infinite recursion on cross-context cycles

### DIFF
--- a/.changeset/request-context-tojson-recursion-fix.md
+++ b/.changeset/request-context-tojson-recursion-fix.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `RequestContext.toJSON()` infinite recursion (100% CPU spin) that
+occurred when two or more `RequestContext` instances were reachable from each
+other's stored values. `isSerializable`'s `JSON.stringify(value)` probe
+re-entered the second context's `toJSON()`, which re-entered the first,
+through fresh V8 builtin frames — bypassing V8's per-call cycle detection
+and blocking the event loop without overflowing the stack.
+
+`toJSON()` now throws a private marker on cyclic re-entry that propagates up
+through nested calls; the outermost `isSerializable` swallows it and filters
+the offending key, consistent with how in-value circular references are
+already filtered. No public API change.

--- a/.changeset/request-context-tojson-recursion-fix.md
+++ b/.changeset/request-context-tojson-recursion-fix.md
@@ -2,14 +2,10 @@
 '@mastra/core': patch
 ---
 
-Fixed `RequestContext.toJSON()` infinite recursion (100% CPU spin) that
-occurred when two or more `RequestContext` instances were reachable from each
-other's stored values. `isSerializable`'s `JSON.stringify(value)` probe
-re-entered the second context's `toJSON()`, which re-entered the first,
-through fresh V8 builtin frames — bypassing V8's per-call cycle detection
-and blocking the event loop without overflowing the stack.
+`@mastra/core`: patch
 
-`toJSON()` now throws a private marker on cyclic re-entry that propagates up
-through nested calls; the outermost `isSerializable` swallows it and filters
-the offending key, consistent with how in-value circular references are
-already filtered. No public API change.
+Fixed infinite recursion in `RequestContext.toJSON()` when multiple 
+`RequestContext` instances reference each other through stored values. 
+Previously, serializing such cross-context cycles would cause a CPU hang. 
+Cyclic references are now detected and omitted from the serialized output, 
+consistent with how circular references within a single context are handled.

--- a/.changeset/request-context-tojson-recursion-fix.md
+++ b/.changeset/request-context-tojson-recursion-fix.md
@@ -2,8 +2,6 @@
 '@mastra/core': patch
 ---
 
-`@mastra/core`: patch
-
 Fixed infinite recursion in `RequestContext.toJSON()` when multiple 
 `RequestContext` instances reference each other through stored values. 
 Previously, serializing such cross-context cycles would cause a CPU hang. 

--- a/packages/core/src/request-context/index.test.ts
+++ b/packages/core/src/request-context/index.test.ts
@@ -167,5 +167,82 @@ describe('RequestContext', () => {
         feature: 'dark-mode',
       });
     });
+
+    it('should skip values that transitively reference another RequestContext that references back (cross-context cycle)', () => {
+      // Without the reentry guard this hangs the Node event loop at 100% CPU.
+      // V8's in-call cycle detection does NOT catch this case because each
+      // `isSerializable(value)` is a fresh `JSON.stringify(value)` call with
+      // a fresh internal cycle stack — recursion happens across calls, not
+      // within one. The pattern appears in real agent runtimes where one
+      // RequestContext stores a service object that references a second
+      // RequestContext (e.g. a sub-agent's), and the second references back.
+      const ctxA = new RequestContext();
+      const ctxB = new RequestContext();
+      ctxA.set('ref', { other: ctxB });
+      ctxB.set('ref', { other: ctxA });
+      ctxA.set('serializable', 'value');
+
+      const start = Date.now();
+      const json = ctxA.toJSON();
+      const elapsed = Date.now() - start;
+
+      // Failure mode is unbounded recursion; even on a slow CI node this
+      // completes in microseconds. The threshold is loose on purpose to
+      // assert "did not hang", not "is fast".
+      expect(elapsed).toBeLessThan(2000);
+      // The serializable key is preserved; the cyclic key is filtered the
+      // same way circular in-value references are.
+      expect(json).toEqual({ serializable: 'value' });
+      expect(json).not.toHaveProperty('ref');
+    });
+
+    it('should skip values that contain a direct self-back-reference to the same context', () => {
+      const ctx = new RequestContext();
+      ctx.set('userId', 'user-123');
+      // Stored value contains a reference back to the owning context.
+      ctx.set('bridge', { ctx });
+
+      const start = Date.now();
+      const json = ctx.toJSON();
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(2000);
+      expect(json).toEqual({ userId: 'user-123' });
+      expect(json).not.toHaveProperty('bridge');
+    });
+
+    it('should skip values in a 3-way cycle A → B → C → A', () => {
+      const A = new RequestContext();
+      const B = new RequestContext();
+      const C = new RequestContext();
+      A.set('userId', 'a-user');
+      A.set('next', { c: B });
+      B.set('next', { c: C });
+      C.set('next', { c: A });
+
+      const start = Date.now();
+      const json = A.toJSON();
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(2000);
+      expect(json).toEqual({ userId: 'a-user' });
+      expect(json).not.toHaveProperty('next');
+    });
+
+    it('should produce a finite, cycle-free JSON string when JSON.stringify is called on a context with cross-context back-references', () => {
+      const ctxA = new RequestContext();
+      const ctxB = new RequestContext();
+      ctxA.set('ref', { other: ctxB });
+      ctxB.set('ref', { other: ctxA });
+      ctxA.set('serializable', 'value');
+
+      const start = Date.now();
+      const serialized = JSON.stringify(ctxA);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(2000);
+      const parsed = JSON.parse(serialized);
+      expect(parsed).toEqual({ serializable: 'value' });
+    });
   });
 });

--- a/packages/core/src/request-context/index.ts
+++ b/packages/core/src/request-context/index.ts
@@ -53,6 +53,45 @@ export const MASTRA_AUTH_TOKEN_KEY = 'mastra__authToken';
 export type { VersionOverrides, VersionSelector } from '../mastra/types';
 export { mergeVersionOverrides } from '../mastra/types';
 
+/**
+ * Marker thrown by `RequestContext.toJSON()` when it detects cyclic re-entry.
+ *
+ * Cyclic re-entry happens when a stored value transitively references another
+ * `RequestContext` whose `toJSON()` is already on the call stack. `JSON.stringify`
+ * inside `isSerializable` then walks into that context, V8 invokes its
+ * `toJSON()`, which iterates its registry and calls `JSON.stringify` on values
+ * that may walk back through the first context — and so on. Each step is a
+ * fresh `JSON.stringify` call with a fresh internal cycle stack, so V8's
+ * built-in cycle detection never trips and the recursion would pin one CPU
+ * core at 100% indefinitely.
+ *
+ * The fix: throw this marker on reentry. The marker propagates upward through
+ * `isSerializable`'s nested catches (which re-throw it) until it reaches the
+ * outermost `toJSON()`'s `isSerializable` — there it is swallowed and the
+ * offending key is filtered, the same way in-value circular references are
+ * filtered today.
+ */
+class CyclicRequestContextToJSONError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CyclicRequestContextToJSONError';
+  }
+}
+
+/**
+ * Tracks `RequestContext` instances whose `toJSON()` is currently on the call
+ * stack. Used to detect cyclic re-entry. Stored as a `WeakSet` so entries are
+ * garbage-collected with their owning context.
+ */
+const _toJSONInProgress = new WeakSet<RequestContext<any>>();
+
+/**
+ * Nesting depth of active `toJSON()` calls. The outermost call (depth === 1
+ * after entry) catches the cyclic marker error and filters the offending
+ * value; inner calls re-throw so the marker propagates to the outermost.
+ */
+let _toJSONDepth = 0;
+
 export class RequestContext<Values extends Record<string, any> | unknown = unknown> {
   private registry = new Map<string, unknown>();
 
@@ -162,21 +201,48 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
   /**
    * Custom JSON serialization method.
    * Converts the internal Map to a plain object for proper JSON serialization.
-   * Non-serializable values (e.g., RPC proxies, functions, circular references)
-   * are skipped to prevent serialization errors when storing to database.
+   * Non-serializable values (functions, symbols, RPC proxies, in-value
+   * circular references, and values whose serialization re-enters this
+   * `toJSON` via cross-context back-references) are skipped to prevent
+   * serialization errors when storing to database.
+   *
+   * Reentry safety: if a stored value's `isSerializable` probe re-enters
+   * `toJSON()` on this same instance (through a chain of RequestContexts
+   * holding references to each other), we throw `CyclicRequestContextToJSONError`.
+   * Inner `isSerializable` calls re-throw the marker; the outermost
+   * `isSerializable` swallows it and filters the offending key, the same
+   * way it filters in-value circular references today.
    */
   public toJSON(): Record<string, any> {
-    const result: Record<string, any> = {};
-    for (const [key, value] of this.registry.entries()) {
-      if (this.isSerializable(value)) {
-        result[key] = value;
-      }
+    if (_toJSONInProgress.has(this)) {
+      throw new CyclicRequestContextToJSONError(
+        'RequestContext.toJSON: detected cyclic re-entry (a stored value transitively references this context)',
+      );
     }
-    return result;
+    _toJSONInProgress.add(this);
+    _toJSONDepth++;
+    try {
+      const result: Record<string, any> = {};
+      for (const [key, value] of this.registry.entries()) {
+        if (this.isSerializable(value)) {
+          result[key] = value;
+        }
+      }
+      return result;
+    } finally {
+      _toJSONInProgress.delete(this);
+      _toJSONDepth--;
+    }
   }
 
   /**
    * Check if a value can be safely serialized to JSON.
+   *
+   * Re-throws `CyclicRequestContextToJSONError` when called from a nested
+   * `toJSON()` (`_toJSONDepth > 1`), so the marker propagates up to the
+   * outermost `toJSON()`'s `isSerializable`, which then swallows it and
+   * filters the offending key. This is what lets the outermost call return
+   * a clean JSON-safe dict for cross-context cycles.
    */
   private isSerializable(value: unknown): boolean {
     if (value === null || value === undefined) return true;
@@ -187,7 +253,10 @@ export class RequestContext<Values extends Record<string, any> | unknown = unkno
     try {
       JSON.stringify(value);
       return true;
-    } catch {
+    } catch (e) {
+      if (e instanceof CyclicRequestContextToJSONError && _toJSONDepth > 1) {
+        throw e;
+      }
       return false;
     }
   }


### PR DESCRIPTION
## Description

`RequestContext.toJSON()` enters infinite recursion (event loop deadlock, 100% CPU) when two or more `RequestContext` instances are reachable from each other's stored values.

`isSerializable(value)` probes serializability with `JSON.stringify(value)`. If `value` transitively references another `RequestContext`, V8 calls that context's `toJSON()`, which iterates its registry and calls `isSerializable`, which calls `JSON.stringify`, … Each step is a **fresh** `JSON.stringify` call with a fresh internal cycle stack, so V8's per-call cycle detection never trips. Each level only adds a few JS frames between V8 builtin frames, so the stack never overflows either — one CPU core just spins at 100% until the process is killed.

Fix: add a module-level reentry guard. On reentry, throw `CyclicRequestContextToJSONError`. Inner `isSerializable` calls re-throw the marker; the outermost `isSerializable` swallows it and filters the offending key — the same way in-value circular references are filtered today. Strictly additive: no public API change, all existing tests pass unchanged.

## Related issue(s)

Fixes #16685

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Problem

`RequestContext.isSerializable` uses `JSON.stringify(value)` as a probe to test if a value is JSON-safe. V8 honors `toJSON` recursively while walking the value. When the value reaches another `RequestContext`, V8 invokes that second context's `toJSON()`, which iterates its registry and calls `isSerializable` on each value, which calls `JSON.stringify`, which walks values that may reach back to the first context — etc. Each `JSON.stringify` call has its own internal cycle stack, so V8's built-in cycle detection doesn't catch the recursion across calls. The stack never overflows because each level is only a few JS frames between V8 builtin frames.

The single-context self-reference case (`ctx.set('x', { ctx })`) is **not** affected by this bug — V8's per-call cycle detection catches it within a single `JSON.stringify`. The bug requires the back-reference chain to traverse two or more `RequestContext` instances. The existing test `should skip objects with circular references` covers only the in-value cycle case (`circular.self = circular`), not the cross-context case.

This manifests in real applications whenever a request-scoped service object stored in a `RequestContext` references another `RequestContext` (e.g. a sub-agent's, or a parent's in nested agents). The most visible symptom is agent streams hanging after the first `tool-call` chunk — the event loop deadlock blocks `setImmediate(toolExecute)` from firing.

## Solution

Two pieces of module-private state:

- `_toJSONInProgress: WeakSet<RequestContext>` — tracks contexts whose `toJSON` is on the stack.
- `_toJSONDepth: number` — tracks how deeply `toJSON` is nested.

On reentry, `toJSON` throws a new `CyclicRequestContextToJSONError` (a private class — not exported, not part of the public API). `isSerializable`'s try/catch re-throws this specific error when `_toJSONDepth > 1` (i.e. we're inside a nested `toJSON`), so the marker propagates up to the outermost `toJSON()`'s `isSerializable`. There it is swallowed and the offending key is filtered.

For all other errors (including the existing `JSON.stringify`-throws-on-circular path), `isSerializable` returns `false` as before — existing behavior preserved.

The state is module-private; no public API change. `WeakSet` keeps the contexts GC-friendly. The `try/finally` ensures clean state even if a serializer throws.

## Changes

- **`packages/core/src/request-context/index.ts`** (+~50, −2)
  - Added private class `CyclicRequestContextToJSONError`
  - Added module-private `_toJSONInProgress: WeakSet<RequestContext<any>>` and `_toJSONDepth: number`
  - Wrapped `toJSON` body with reentry check + depth tracking + `try/finally` cleanup
  - Updated `isSerializable` to re-throw the marker when nested
  - Updated JSDoc on `toJSON` and `isSerializable`
- **`packages/core/src/request-context/index.test.ts`** (+~70, −0)
  - New: cross-context cycle A↔B test (the actual hang scenario, asserts terminate + key filtered)
  - New: single-context self-reference test (documents behavior consistency with in-value circular ref filtering)
  - New: 3-way cycle A→B→C→A test
  - New: `JSON.stringify(ctxA)` direct test (validates the outer-stringify path returns a clean cycle-free string)

## Impact

| Pattern | Before | After |
|---|---|---|
| Single ctx self-ref `{ ctx }` | works (V8 catches it; `self` included with partial-serialization artifact) | works (`self` filtered out, consistent with how in-value circular refs are filtered) |
| Cross-context cycle A↔B | **hangs at 100% CPU** | `A.toJSON()` returns `{ serializable: 'value' }`; `ref` filtered |
| 3-way cycle A→B→C→A | **hangs** | terminates; cyclic key filtered |
| Existing tests (functions, symbols, RPC proxy, in-value circular, …) | pass | pass unchanged |

- Fixes 100% CPU spin in any code path that calls `JSON.stringify` on a structure that transitively contains two or more interlinked `RequestContext` instances. This unblocks downstream paths that use `requestContext.toJSON()` for workflow persistence, observability exporters, or agent stream session serialization.
- No public API change.
- All 12 existing `RequestContext` tests pass unchanged; 4 new tests added (16/16 total).
- Performance: one `WeakSet.has` + `WeakSet.add` + `WeakSet.delete` + 2 counter ops per `toJSON` call — negligible.

## Verification

The unpatched repro hangs on `@mastra/core@1.35.0`:
```
$ npm install @mastra/core@1.35.0
$ timeout 8 node repro.mjs
... (hangs, killed by timeout — exit 124)
```

With the patched source the same repro completes in milliseconds. The new regression tests fail without the fix (hang past vitest's timeout) and pass with it. Locally verified by running `pnpm --filter @mastra/core test:unit src/request-context/index.test.ts` → **16 passed**.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable) — updated JSDoc on `toJSON` and `isSerializable`
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

RequestContext objects could cause the program to get stuck when they pointed to each other (like A → B → A). This PR detects when JSON conversion is already in progress for a context and stops re-entering, so serialization finishes instead of freezing.

## Overview

Fixes an infinite-recursion / 100% CPU hang in RequestContext.toJSON() when two or more RequestContext instances are transitively reachable from each other's stored values (cross-context cycles).

## Root Cause

RequestContext.isSerializable() probes values with JSON.stringify. If that probe reaches another RequestContext, V8 calls its toJSON(), which iterates its registry and calls isSerializable() again, causing fresh JSON.stringify calls whose cycle detection is per-call and thus misses cycles spanning multiple toJSON invocations. This produced unbounded recursion.

## Solution

Module-private re-entry detection and propagation using:
- CyclicRequestContextToJSONError: private marker Error class thrown on reentry.
- _toJSONInProgress: module-level WeakSet<RequestContext> to track contexts currently being serialized.
- _toJSONDepth: numeric nesting counter.

Behavior:
- toJSON() adds the instance to _toJSONInProgress and increments _toJSONDepth; if the instance is already present, it throws the marker.
- isSerializable() wraps JSON.stringify in try/catch; if it catches the marker and _toJSONDepth > 1 it re-throws so the marker propagates; the outermost isSerializable swallows the marker and filters the offending key (matching existing behavior for in-value circular refs).
- All state is cleaned up with try/finally. Implementation is module-private, GC-friendly (WeakSet), and preserves public API.

## Files changed

- packages/core/src/request-context/index.ts (+77/-8)
  - Added CyclicRequestContextToJSONError class, _toJSONInProgress WeakSet, _toJSONDepth counter.
  - Wrapped toJSON() with reentry/depth tracking and cleanup.
  - Updated isSerializable() to propagate/handle the marker based on depth.
  - Updated JSDoc to document reentry behavior.
  - No public API or exported type/signature changes.

- packages/core/src/request-context/index.test.ts (+77/-0)
  - Added 4 Vitest cases covering:
    - Cross-context 2-way cycle (A ↔ B)
    - Direct self-back-reference to same context
    - 3-way cycle (A → B → C → A)
    - JSON.stringify(ctx) direct serialization with cross-context back-references
  - Tests assert termination (elapsed < 2000ms), correct filtering of cyclic keys, and JSON validity.

- .changeset/request-context-tojson-recursion-fix.md (+9/-0)
  - Changeset note describing the fix and behavior.

## Impact

- No public API changes; change is module-private.
- Preserves existing behavior for non-cross-context cases (including in-value circular refs).
- GC-friendly (WeakSet) and uses try/finally for robust cleanup.
- Negligible runtime overhead; tests pass.

## Testing

All existing RequestContext tests pass unchanged. Four new tests added (total increases to 16) and verify termination and correct filtering for 2-way and 3-way cross-context cycles and related cases. Verified the original repro that hung on `@mastra/core`@1.35.0 completes with this patch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->