### PR TITLE
feat(server): support route-specific CORS configuration

### DIFF
--- a/.changeset/seven-boats-like.md
+++ b/.changeset/seven-boats-like.md
@@ -3,17 +3,46 @@
 '@mastra/deployer': minor
 ---
 
-Added path-specific server CORS configuration so credentialed cross-origin access can be limited to selected routes.
+Added route-specific CORS configuration so credentialed cross-origin access can be limited to selected custom routes and channel webhooks.
+
+```ts
+registerApiRoute('/customer-webhook', {
+  method: 'POST',
+  cors: {
+    origin: ['https://customer-saas.example'],
+    credentials: true,
+  },
+  handler: async c => c.json({ ok: true }),
+});
+```
+
+```ts
+new Agent({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: '...',
+  model,
+  channels: {
+    adapters: {
+      web: {
+        adapter: createWebAdapter(),
+        cors: {
+          origin: ['https://customer-saas.example'],
+          credentials: true,
+        },
+      },
+    },
+  },
+});
+```
+
+Use `server.cors` for one global CORS policy across the server:
 
 ```ts
 new Mastra({
   server: {
     cors: {
-      '*': { origin: '*' },
-      '/api/agents/support-agent/channels/web/*': {
-        origin: ['https://customer-saas.example'],
-        credentials: true,
-      },
+      origin: '*',
     },
   },
 });

--- a/.changeset/seven-boats-like.md
+++ b/.changeset/seven-boats-like.md
@@ -1,0 +1,20 @@
+---
+'@mastra/core': minor
+'@mastra/deployer': minor
+---
+
+Added path-specific server CORS configuration so credentialed cross-origin access can be limited to selected routes.
+
+```ts
+new Mastra({
+  server: {
+    cors: {
+      '*': { origin: '*' },
+      '/api/agents/support-agent/channels/web/*': {
+        origin: ['https://customer-saas.example'],
+        credentials: true,
+      },
+    },
+  },
+});
+```

--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ See [LICENSE.md](./LICENSE.md) for the full license mapping and [ee/LICENSE](./e
 ## Security
 
 We are committed to maintaining the security of this repo and of Mastra as a whole. If you discover a security finding we ask you to please responsibly disclose this to us at [security@mastra.ai](mailto:security@mastra.ai) and we will get back to you.
+PLAYGROUND TWO did something else

--- a/README.md
+++ b/README.md
@@ -80,4 +80,3 @@ See [LICENSE.md](./LICENSE.md) for the full license mapping and [ee/LICENSE](./e
 ## Security
 
 We are committed to maintaining the security of this repo and of Mastra as a whole. If you discover a security finding we ask you to please responsibly disclose this to us at [security@mastra.ai](mailto:security@mastra.ai) and we will get back to you.
-PLAYGROUND TWO did something else

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -124,6 +124,10 @@ const agent = new Agent({
       discord: {
         adapter: createDiscordAdapter(),
         cards: false,
+        cors: {
+          origin: ['https://customer-saas.example'],
+          credentials: true,
+        },
         gateway: false,
       },
       slack: createSlackAdapter(), // Plain adapter uses defaults
@@ -155,6 +159,13 @@ const agent = new Agent({
     defaultValue: 'true',
     description:
       'Render tool calls as interactive rich cards with buttons. Set to `false` to use plain text formatting instead. When disabled and a tool requires approval, the agent uses `autoResumeSuspendedTools` to let the LLM decide based on conversation context.',
+  },
+  {
+    name: 'cors',
+    type: 'CorsOptions',
+    isOptional: true,
+    description:
+      'CORS configuration for this adapter webhook route. Use this for browser-based channel adapters that need cross-origin credentials.',
   },
   {
     name: 'formatToolCall',

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -828,7 +828,7 @@ CORS (Cross-Origin Resource Sharing) configuration for the server. Set to `false
 | - | - | - | - |
 | `origin` | `string \| string[]` | `'*'` | Origins for CORS requests |
 | `allowMethods` | `string[]` | `['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']` | HTTP methods |
-| `allowHeaders` | `string[]` | `['Content-Type', 'Authorization', 'x-mastra-client-type']` | Request headers |
+| `allowHeaders` | `string[]` | `['Content-Type', 'Authorization', 'x-mastra-client-type', 'x-mastra-dev-playground']` | Request headers |
 | `exposeHeaders` | `string[]` | `['Content-Length', 'X-Requested-With']` | Browser headers |
 | `credentials` | `boolean` | `false` | Credentials (cookies, authorization headers) |
 | `maxAge` | `number` | `3600` | Preflight request cache duration in seconds |

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -820,9 +820,9 @@ export const mastra = new Mastra({
 
 ### server.cors
 
-**Type:** `CorsOptions | Record<string, CorsOptions> | false`
+**Type:** `CorsOptions | false`
 
-CORS (Cross-Origin Resource Sharing) configuration for the server. Set to `false` to disable CORS entirely. Use a single object for one policy across all routes, or use a path map to apply different policies to different routes. In a path map, `*` is the fallback policy and paths ending in `*` match by prefix. When multiple paths match, Mastra uses the most specific path.
+CORS (Cross-Origin Resource Sharing) configuration for the server. Set to `false` to disable CORS entirely. Use this for one policy across all routes. For a custom route-specific policy, use the `cors` option in [`registerApiRoute()`](/reference/server/register-api-route).
 
 | Property | Type | Default | Description |
 | - | - | - | - |
@@ -843,24 +843,6 @@ export const mastra = new Mastra({
       allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
       allowHeaders: ['Content-Type', 'Authorization'],
       credentials: false,
-    },
-  },
-})
-```
-
-The following example uses a global fallback policy and a credentialed policy for one channel webhook path:
-
-```typescript title="src/mastra/index.ts"
-import { Mastra } from '@mastra/core'
-
-export const mastra = new Mastra({
-  server: {
-    cors: {
-      '*': { origin: '*' },
-      '/api/agents/support-agent/channels/web/*': {
-        origin: ['https://customer-saas.example'],
-        credentials: true,
-      },
     },
   },
 })

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -820,9 +820,9 @@ export const mastra = new Mastra({
 
 ### server.cors
 
-**Type:** `CorsOptions | false`
+**Type:** `CorsOptions | Record<string, CorsOptions> | false`
 
-CORS (Cross-Origin Resource Sharing) configuration for the server. Set to `false` to disable CORS entirely.
+CORS (Cross-Origin Resource Sharing) configuration for the server. Set to `false` to disable CORS entirely. Use a single object for one policy across all routes, or use a path map to apply different policies to different routes. In a path map, `*` is the fallback policy and paths ending in `*` match by prefix. When multiple paths match, Mastra uses the most specific path.
 
 | Property | Type | Default | Description |
 | - | - | - | - |
@@ -843,6 +843,24 @@ export const mastra = new Mastra({
       allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
       allowHeaders: ['Content-Type', 'Authorization'],
       credentials: false,
+    },
+  },
+})
+```
+
+The following example uses a global fallback policy and a credentialed policy for one channel webhook path:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+
+export const mastra = new Mastra({
+  server: {
+    cors: {
+      '*': { origin: '*' },
+      '/api/agents/support-agent/channels/web/*': {
+        origin: ['https://customer-saas.example'],
+        credentials: true,
+      },
     },
   },
 })

--- a/docs/src/content/en/reference/server/register-api-route.mdx
+++ b/docs/src/content/en/reference/server/register-api-route.mdx
@@ -58,6 +58,13 @@ registerApiRoute("/items/:itemId", { ... })
     isOptional: true,
   },
   {
+    name: 'cors',
+    type: 'CorsOptions',
+    description:
+      'Route-specific CORS configuration. Use this when one custom route needs a different cross-origin policy from `server.cors`.',
+    isOptional: true,
+  },
+  {
     name: 'openapi',
     type: 'DescribeRouteOptions',
     description: 'OpenAPI metadata for Swagger UI documentation',
@@ -221,6 +228,23 @@ registerApiRoute('/protected', {
   ],
   handler: async c => {
     return c.json({ data: 'protected content' })
+  },
+})
+```
+
+### Route with CORS
+
+Use route-specific CORS when one custom route needs cross-origin credentials, but the rest of the server should keep the global CORS policy.
+
+```typescript
+registerApiRoute('/customer-webhook', {
+  method: 'POST',
+  cors: {
+    origin: ['https://customer-saas.example'],
+    credentials: true,
+  },
+  handler: async c => {
+    return c.json({ ok: true })
   },
 })
 ```

--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -117,6 +117,28 @@ describe('AgentChannels', () => {
       }
     });
 
+    it('adds adapter CORS config to generated webhook routes', () => {
+      const channels = new AgentChannels({
+        adapters: {
+          web: {
+            adapter: createMockAdapter('web'),
+            cors: {
+              origin: ['https://customer-saas.example'],
+              credentials: true,
+            },
+          },
+        },
+      });
+      channels.__setAgent(mockAgent);
+
+      const route = channels.getWebhookRoutes()[0];
+
+      expect(route?.cors).toEqual({
+        origin: ['https://customer-saas.example'],
+        credentials: true,
+      });
+    });
+
     it('handles Hono contexts without ExecutionContext without throwing', async () => {
       const webhookFn = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
       (agentChannels as any).initPromise = Promise.resolve();

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -9,7 +9,7 @@ import type { StorageThreadType } from '../memory/types';
 import type { InputProcessor, InputProcessorOrWorkflow } from '../processors';
 import { isProcessorWorkflow } from '../processors';
 import { RequestContext } from '../request-context';
-import type { ApiRoute } from '../server/types';
+import type { ApiRoute, CorsOptions } from '../server/types';
 import type { MastraModelOutput } from '../stream/base/output';
 import { createTool } from '../tools/tool';
 import { getChatModule } from './chat-lazy';
@@ -34,6 +34,10 @@ export type PostableMessage = string | CardElement;
 /** Per-adapter configuration. */
 export interface ChannelAdapterConfig {
   adapter: Adapter;
+  /**
+   * CORS configuration for the generated webhook route for this adapter.
+   */
+  cors?: CorsOptions;
   /**
    * Start a persistent Gateway WebSocket listener for this adapter
    * (default: `true`).
@@ -734,6 +738,7 @@ export class AgentChannels {
         method: 'POST',
         requiresAuth: false,
         _mastraInternal: true,
+        cors: this.adapterConfigs[platform]?.cors,
         createHandler: async () => {
           return async c => {
             // Await initialization to handle serverless cold starts where

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -10,6 +10,8 @@ export type {
   A2AAgentCardSigningConfig,
   A2AConfig,
   ContextWithMastra,
+  CorsOptions,
+  CorsPathMap,
   ApiRoute,
   HttpLoggingConfig,
   ValidationErrorContext,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -11,7 +11,6 @@ export type {
   A2AConfig,
   ContextWithMastra,
   CorsOptions,
-  CorsPathMap,
   ApiRoute,
   HttpLoggingConfig,
   ValidationErrorContext,
@@ -62,6 +61,10 @@ type RegisterApiRouteOptions<P extends string> = {
     >
   >;
   middleware?: MiddlewareHandler | MiddlewareHandler[];
+  /**
+   * Route-specific CORS configuration.
+   */
+  cors?: ApiRoute['cors'];
   /**
    * When false, skips Mastra auth for this route (defaults to true)
    */
@@ -132,6 +135,7 @@ export function registerApiRoute<P extends string>(
     createHandler: options.createHandler,
     openapi: options.openapi,
     middleware: options.middleware,
+    cors: options.cors,
     requiresAuth: options.requiresAuth,
     requiresPermission: options.requiresPermission,
     fga: options.fga,

--- a/packages/core/src/server/server.test-d.ts
+++ b/packages/core/src/server/server.test-d.ts
@@ -1,4 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest';
+import { Mastra } from '../mastra';
 import type { RequestContext } from '../request-context';
 import type { MastraAuthProvider } from './auth';
 import { CompositeAuth } from './composite-auth';
@@ -83,5 +84,21 @@ describe('CompositeAuth TUser variance', () => {
 
     const _assignable: MastraAuthProvider<unknown> = typed;
     new CompositeAuth([typed]);
+  });
+});
+
+describe('Server CORS type tests', () => {
+  it('accepts path-specific CORS config', () => {
+    new Mastra({
+      server: {
+        cors: {
+          '*': { origin: '*' },
+          '/api/agents/support-agent/channels/web/*': {
+            origin: ['https://customer-saas.example'],
+            credentials: true,
+          },
+        },
+      },
+    });
   });
 });

--- a/packages/core/src/server/server.test-d.ts
+++ b/packages/core/src/server/server.test-d.ts
@@ -87,17 +87,25 @@ describe('CompositeAuth TUser variance', () => {
   });
 });
 
-describe('Server CORS type tests', () => {
-  it('accepts path-specific CORS config', () => {
+describe('CORS type tests', () => {
+  it('accepts global CORS config', () => {
     new Mastra({
       server: {
         cors: {
-          '*': { origin: '*' },
-          '/api/agents/support-agent/channels/web/*': {
-            origin: ['https://customer-saas.example'],
-            credentials: true,
-          },
+          origin: ['https://app.example'],
+          credentials: true,
         },
+      },
+    });
+  });
+
+  it('accepts route-specific CORS config', () => {
+    registerApiRoute('/webhook', {
+      method: 'POST',
+      handler: async c => c.json({ ok: true }),
+      cors: {
+        origin: ['https://customer-saas.example'],
+        credentials: true,
       },
     });
   });

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -41,6 +41,9 @@ export type ApiRoute =
 
 export type Middleware = MiddlewareHandler | { path: string; handler: MiddlewareHandler };
 
+export type CorsOptions = Parameters<typeof cors>[0];
+export type CorsPathMap = Record<string, CorsOptions>;
+
 export type ContextWithMastra = Context<{
   Variables: {
     mastra: Mastra;
@@ -227,10 +230,11 @@ export type ServerConfig = {
    */
   middleware?: Middleware | Middleware[];
   /**
-   * CORS configuration for the server
+   * CORS configuration for the server. Provide a single config for every route,
+   * or a path map with `*` as the fallback config.
    * @default { origin: '*', allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], allowHeaders: ['Content-Type', 'Authorization', 'x-mastra-client-type'], exposeHeaders: ['Content-Length', 'X-Requested-With'], credentials: false }
    */
-  cors?: Parameters<typeof cors>[0] | false;
+  cors?: CorsOptions | CorsPathMap | false;
   /**
    * Build configuration for the server
    */

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -20,6 +20,7 @@ export type ApiRoute =
       handler: Handler;
       middleware?: MiddlewareHandler | MiddlewareHandler[];
       openapi?: DescribeRouteOptions;
+      cors?: CorsOptions;
       requiresAuth?: boolean;
       requiresPermission?: MastraFGAPermissionInput;
       fga?: RouteFGAConfig;
@@ -32,6 +33,7 @@ export type ApiRoute =
       createHandler: ({ mastra }: { mastra: Mastra }) => Promise<Handler>;
       middleware?: MiddlewareHandler | MiddlewareHandler[];
       openapi?: DescribeRouteOptions;
+      cors?: CorsOptions;
       requiresAuth?: boolean;
       requiresPermission?: MastraFGAPermissionInput;
       fga?: RouteFGAConfig;
@@ -42,7 +44,6 @@ export type ApiRoute =
 export type Middleware = MiddlewareHandler | { path: string; handler: MiddlewareHandler };
 
 export type CorsOptions = Parameters<typeof cors>[0];
-export type CorsPathMap = Record<string, CorsOptions>;
 
 export type ContextWithMastra = Context<{
   Variables: {
@@ -230,11 +231,10 @@ export type ServerConfig = {
    */
   middleware?: Middleware | Middleware[];
   /**
-   * CORS configuration for the server. Provide a single config for every route,
-   * or a path map with `*` as the fallback config.
+   * CORS configuration for the server.
    * @default { origin: '*', allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], allowHeaders: ['Content-Type', 'Authorization', 'x-mastra-client-type', 'x-mastra-dev-playground'], exposeHeaders: ['Content-Length', 'X-Requested-With'], credentials: false }
    */
-  cors?: CorsOptions | CorsPathMap | false;
+  cors?: CorsOptions | false;
   /**
    * Build configuration for the server
    */

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -232,7 +232,7 @@ export type ServerConfig = {
   /**
    * CORS configuration for the server. Provide a single config for every route,
    * or a path map with `*` as the fallback config.
-   * @default { origin: '*', allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], allowHeaders: ['Content-Type', 'Authorization', 'x-mastra-client-type'], exposeHeaders: ['Content-Length', 'X-Requested-With'], credentials: false }
+   * @default { origin: '*', allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], allowHeaders: ['Content-Type', 'Authorization', 'x-mastra-client-type', 'x-mastra-dev-playground'], exposeHeaders: ['Content-Length', 'X-Requested-With'], credentials: false }
    */
   cors?: CorsOptions | CorsPathMap | false;
   /**

--- a/packages/deployer/src/server/__tests__/cors.test.ts
+++ b/packages/deployer/src/server/__tests__/cors.test.ts
@@ -30,16 +30,49 @@ describe('server CORS', () => {
     expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true');
   });
 
-  it('uses path-specific CORS config for preflight requests', async () => {
+  it('uses route-specific CORS config for preflight requests', async () => {
     const mastra = new Mastra({
       server: {
-        cors: {
-          '*': { origin: '*' },
-          '/api/agents/support-agent/channels/web/*': {
-            origin: ['https://customer-saas.example'],
-            credentials: true,
+        apiRoutes: [
+          registerApiRoute('/custom/webhook', {
+            method: 'POST',
+            handler: c => c.json({ ok: true }),
+            requiresAuth: false,
+            cors: {
+              origin: ['https://customer-saas.example'],
+              credentials: true,
+            },
+          }),
+        ],
+      },
+    });
+    const app = await createHonoServer(mastra, { tools: {} });
+
+    const customResponse = await app.request(preflight('/custom/webhook', 'https://customer-saas.example'));
+    const otherResponse = await app.request(preflight('/api/agents', 'https://customer-saas.example'));
+
+    expect(customResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://customer-saas.example');
+    expect(customResponse.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(otherResponse.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(otherResponse.headers.get('Access-Control-Allow-Credentials')).toBeNull();
+  });
+
+  it('uses route-specific CORS config for internal API routes', async () => {
+    const mastra = new Mastra({
+      server: {
+        apiRoutes: [
+          {
+            path: '/api/agents/support-agent/channels/web/webhook',
+            method: 'POST',
+            handler: c => c.json({ ok: true }),
+            requiresAuth: false,
+            _mastraInternal: true,
+            cors: {
+              origin: ['https://customer-saas.example'],
+              credentials: true,
+            },
           },
-        },
+        ],
       },
     });
     const app = await createHonoServer(mastra, { tools: {} });
@@ -55,32 +88,30 @@ describe('server CORS', () => {
     expect(otherResponse.headers.get('Access-Control-Allow-Credentials')).toBeNull();
   });
 
-  it('does not add credentials to an explicit path-map fallback when auth is configured', async () => {
+  it('does not inherit auth credential defaults for route-specific CORS config', async () => {
     const mastra = new Mastra({
       server: {
         auth: {
           authenticateToken: async () => ({ id: 'user' }),
         },
-        cors: {
-          '*': { origin: '*' },
-          '/api/agents/support-agent/channels/web/*': {
-            origin: ['https://customer-saas.example'],
-            credentials: true,
-          },
-        },
+        apiRoutes: [
+          registerApiRoute('/custom/webhook', {
+            method: 'POST',
+            handler: c => c.json({ ok: true }),
+            requiresAuth: false,
+            cors: {
+              origin: ['https://customer-saas.example'],
+            },
+          }),
+        ],
       },
     });
     const app = await createHonoServer(mastra, { tools: {} });
 
-    const channelResponse = await app.request(
-      preflight('/api/agents/support-agent/channels/web/webhook', 'https://customer-saas.example'),
-    );
-    const otherResponse = await app.request(preflight('/api/agents', 'https://customer-saas.example'));
+    const response = await app.request(preflight('/custom/webhook', 'https://customer-saas.example'));
 
-    expect(channelResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://customer-saas.example');
-    expect(channelResponse.headers.get('Access-Control-Allow-Credentials')).toBe('true');
-    expect(otherResponse.headers.get('Access-Control-Allow-Origin')).toBe('*');
-    expect(otherResponse.headers.get('Access-Control-Allow-Credentials')).toBeNull();
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://customer-saas.example');
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBeNull();
   });
 
   it('keeps auth credential defaults for legacy CORS config', async () => {
@@ -99,66 +130,42 @@ describe('server CORS', () => {
     expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true');
   });
 
-  it('uses the most specific matching CORS path', async () => {
+  it('matches dynamic route paths for route-specific CORS config', async () => {
     const mastra = new Mastra({
       server: {
-        cors: {
-          '*': { origin: '*' },
-          '/api/agents/*': { origin: ['https://agents.example'] },
-          '/api/agents/support-agent/channels/web/*': {
-            origin: ['https://customer-saas.example'],
-            credentials: true,
-          },
-        },
+        apiRoutes: [
+          registerApiRoute('/custom/:id/webhook', {
+            method: 'POST',
+            handler: c => c.json({ id: c.req.param('id') }),
+            requiresAuth: false,
+            cors: {
+              origin: ['https://customer-saas.example'],
+              credentials: true,
+            },
+          }),
+        ],
       },
     });
     const app = await createHonoServer(mastra, { tools: {} });
 
-    const response = await app.request(
-      preflight('/api/agents/support-agent/channels/web/webhook', 'https://customer-saas.example'),
-    );
+    const response = await app.request(preflight('/custom/tenant-1/webhook', 'https://customer-saas.example'));
 
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://customer-saas.example');
     expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true');
   });
 
-  it('supports exact CORS path matches', async () => {
+  it('applies default Mastra CORS headers to route-specific config', async () => {
     const mastra = new Mastra({
       server: {
-        cors: {
-          '*': { origin: '*' },
-          '/api/exact-webhook': {
-            origin: ['https://exact.example'],
-            credentials: true,
-          },
-        },
-      },
-    });
-    const app = await createHonoServer(mastra, { tools: {} });
-
-    const exactResponse = await app.request(preflight('/api/exact-webhook', 'https://exact.example'));
-    const nestedResponse = await app.request(preflight('/api/exact-webhook/nested', 'https://exact.example'));
-
-    expect(exactResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://exact.example');
-    expect(exactResponse.headers.get('Access-Control-Allow-Credentials')).toBe('true');
-    expect(nestedResponse.headers.get('Access-Control-Allow-Origin')).toBe('*');
-    expect(nestedResponse.headers.get('Access-Control-Allow-Credentials')).toBeNull();
-  });
-
-  it('applies default Mastra CORS headers to path-specific config', async () => {
-    const mastra = new Mastra({
-      server: {
-        cors: {
-          '/custom/*': {
-            origin: ['https://custom.example'],
-            allowHeaders: ['x-custom-header'],
-          },
-        },
         apiRoutes: [
           registerApiRoute('/custom/webhook', {
             method: 'POST',
             handler: c => c.json({ ok: true }),
             requiresAuth: false,
+            cors: {
+              origin: ['https://custom.example'],
+              allowHeaders: ['x-custom-header'],
+            },
           }),
         ],
       },
@@ -171,5 +178,29 @@ describe('server CORS', () => {
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://custom.example');
     expect(allowHeaders).toContain('x-mastra-client-type');
     expect(allowHeaders).toContain('x-custom-header');
+  });
+
+  it('uses route-specific CORS only for matching methods', async () => {
+    const mastra = new Mastra({
+      server: {
+        apiRoutes: [
+          registerApiRoute('/custom/webhook', {
+            method: 'GET',
+            handler: c => c.json({ ok: true }),
+            requiresAuth: false,
+            cors: {
+              origin: ['https://custom.example'],
+              credentials: true,
+            },
+          }),
+        ],
+      },
+    });
+    const app = await createHonoServer(mastra, { tools: {} });
+
+    const response = await app.request(preflight('/custom/webhook', 'https://custom.example'));
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBeNull();
   });
 });

--- a/packages/deployer/src/server/__tests__/cors.test.ts
+++ b/packages/deployer/src/server/__tests__/cors.test.ts
@@ -1,0 +1,175 @@
+import { Mastra } from '@mastra/core/mastra';
+import { registerApiRoute } from '@mastra/core/server';
+import { describe, expect, it } from 'vitest';
+import { createHonoServer } from '../index';
+
+const preflight = (path: string, origin: string) =>
+  new Request(`http://localhost${path}`, {
+    method: 'OPTIONS',
+    headers: {
+      Origin: origin,
+      'Access-Control-Request-Method': 'POST',
+    },
+  });
+
+describe('server CORS', () => {
+  it('uses the legacy CORS config for every route', async () => {
+    const mastra = new Mastra({
+      server: {
+        cors: {
+          origin: ['https://app.example'],
+          credentials: true,
+        },
+      },
+    });
+    const app = await createHonoServer(mastra, { tools: {} });
+
+    const response = await app.request(preflight('/api/agents', 'https://app.example'));
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example');
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+  });
+
+  it('uses path-specific CORS config for preflight requests', async () => {
+    const mastra = new Mastra({
+      server: {
+        cors: {
+          '*': { origin: '*' },
+          '/api/agents/support-agent/channels/web/*': {
+            origin: ['https://customer-saas.example'],
+            credentials: true,
+          },
+        },
+      },
+    });
+    const app = await createHonoServer(mastra, { tools: {} });
+
+    const channelResponse = await app.request(
+      preflight('/api/agents/support-agent/channels/web/webhook', 'https://customer-saas.example'),
+    );
+    const otherResponse = await app.request(preflight('/api/agents', 'https://customer-saas.example'));
+
+    expect(channelResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://customer-saas.example');
+    expect(channelResponse.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(otherResponse.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(otherResponse.headers.get('Access-Control-Allow-Credentials')).toBeNull();
+  });
+
+  it('does not add credentials to an explicit path-map fallback when auth is configured', async () => {
+    const mastra = new Mastra({
+      server: {
+        auth: {
+          authenticateToken: async () => ({ id: 'user' }),
+        },
+        cors: {
+          '*': { origin: '*' },
+          '/api/agents/support-agent/channels/web/*': {
+            origin: ['https://customer-saas.example'],
+            credentials: true,
+          },
+        },
+      },
+    });
+    const app = await createHonoServer(mastra, { tools: {} });
+
+    const channelResponse = await app.request(
+      preflight('/api/agents/support-agent/channels/web/webhook', 'https://customer-saas.example'),
+    );
+    const otherResponse = await app.request(preflight('/api/agents', 'https://customer-saas.example'));
+
+    expect(channelResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://customer-saas.example');
+    expect(channelResponse.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(otherResponse.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(otherResponse.headers.get('Access-Control-Allow-Credentials')).toBeNull();
+  });
+
+  it('keeps auth credential defaults for legacy CORS config', async () => {
+    const mastra = new Mastra({
+      server: {
+        auth: {
+          authenticateToken: async () => ({ id: 'user' }),
+        },
+      },
+    });
+    const app = await createHonoServer(mastra, { tools: {} });
+
+    const response = await app.request(preflight('/api/agents', 'https://app.example'));
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example');
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+  });
+
+  it('uses the most specific matching CORS path', async () => {
+    const mastra = new Mastra({
+      server: {
+        cors: {
+          '*': { origin: '*' },
+          '/api/agents/*': { origin: ['https://agents.example'] },
+          '/api/agents/support-agent/channels/web/*': {
+            origin: ['https://customer-saas.example'],
+            credentials: true,
+          },
+        },
+      },
+    });
+    const app = await createHonoServer(mastra, { tools: {} });
+
+    const response = await app.request(
+      preflight('/api/agents/support-agent/channels/web/webhook', 'https://customer-saas.example'),
+    );
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://customer-saas.example');
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+  });
+
+  it('supports exact CORS path matches', async () => {
+    const mastra = new Mastra({
+      server: {
+        cors: {
+          '*': { origin: '*' },
+          '/api/exact-webhook': {
+            origin: ['https://exact.example'],
+            credentials: true,
+          },
+        },
+      },
+    });
+    const app = await createHonoServer(mastra, { tools: {} });
+
+    const exactResponse = await app.request(preflight('/api/exact-webhook', 'https://exact.example'));
+    const nestedResponse = await app.request(preflight('/api/exact-webhook/nested', 'https://exact.example'));
+
+    expect(exactResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://exact.example');
+    expect(exactResponse.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(nestedResponse.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(nestedResponse.headers.get('Access-Control-Allow-Credentials')).toBeNull();
+  });
+
+  it('applies default Mastra CORS headers to path-specific config', async () => {
+    const mastra = new Mastra({
+      server: {
+        cors: {
+          '/custom/*': {
+            origin: ['https://custom.example'],
+            allowHeaders: ['x-custom-header'],
+          },
+        },
+        apiRoutes: [
+          registerApiRoute('/custom/webhook', {
+            method: 'POST',
+            handler: c => c.json({ ok: true }),
+            requiresAuth: false,
+          }),
+        ],
+      },
+    });
+    const app = await createHonoServer(mastra, { tools: {} });
+
+    const response = await app.request(preflight('/custom/webhook', 'https://custom.example'));
+    const allowHeaders = response.headers.get('Access-Control-Allow-Headers');
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://custom.example');
+    expect(allowHeaders).toContain('x-mastra-client-type');
+    expect(allowHeaders).toContain('x-custom-header');
+  });
+});

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -61,16 +61,24 @@ function isCorsPathMap(corsConfig: CorsOptions | CorsPathMap | false | undefined
   return Object.keys(corsConfig).some(key => key === '*' || key.startsWith('/'));
 }
 
+function matchesCorsPath(pattern: string, pathname: string) {
+  if (pattern === '*') return true;
+  if (pattern.endsWith('*')) return pathname.startsWith(pattern.slice(0, -1));
+  return pattern === pathname;
+}
+
+function getCorsPathSpecificity(pattern: string) {
+  return pattern === '*' ? 0 : pattern.replace(/\*$/, '').length;
+}
+
 function resolveCorsPathConfig(corsMap: CorsPathMap, pathname: string) {
   let matchedConfig: CorsOptions | undefined;
   let matchedSpecificity = -1;
 
   for (const [pattern, config] of Object.entries(corsMap)) {
-    const matches =
-      pattern === '*' || (pattern.endsWith('*') ? pathname.startsWith(pattern.slice(0, -1)) : pattern === pathname);
-    if (!matches) continue;
+    if (!matchesCorsPath(pattern, pathname)) continue;
 
-    const specificity = pattern === '*' ? 0 : pattern.replace(/\*$/, '').length;
+    const specificity = getCorsPathSpecificity(pattern);
     if (specificity > matchedSpecificity) {
       matchedConfig = config;
       matchedSpecificity = specificity;
@@ -236,7 +244,7 @@ export async function createHonoServer(
     },
   });
 
-  //Global cors config
+  // Global CORS config
   if (server?.cors === false) {
     app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000));
   } else {

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -52,10 +52,6 @@ type Variables = HonoVariables & {
 type CorsOptions = Parameters<typeof cors>[0];
 type CorsPathMap = Record<string, CorsOptions>;
 
-const DEFAULT_CORS_ALLOW_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
-const DEFAULT_CORS_ALLOW_HEADERS = ['Content-Type', 'Authorization', 'x-mastra-client-type', 'x-mastra-dev-playground'];
-const DEFAULT_CORS_EXPOSE_HEADERS = ['Content-Length', 'X-Requested-With'];
-
 function isCorsPathMap(corsConfig: CorsOptions | CorsPathMap | false | undefined): corsConfig is CorsPathMap {
   if (!corsConfig || typeof corsConfig !== 'object') return false;
   return Object.keys(corsConfig).some(key => key === '*' || key.startsWith('/'));
@@ -78,36 +74,6 @@ function resolveCorsPathConfig(corsMap: CorsPathMap, pathname: string) {
   }
 
   return matchedConfig;
-}
-
-function getCorsConfig(serverCors: CorsOptions | CorsPathMap | false | undefined, hasAuth: boolean, pathname?: string) {
-  const isPathMap = isCorsPathMap(serverCors);
-  const routeCors = isPathMap ? resolveCorsPathConfig(serverCors, pathname ?? '') : serverCors;
-  const userCors = routeCors && typeof routeCors === 'object' ? routeCors : undefined;
-  const origin =
-    userCors && 'origin' in userCors && userCors.origin
-      ? userCors.origin
-      : hasAuth
-        ? (requestOrigin: string) => requestOrigin || undefined
-        : '*';
-  const credentials =
-    userCors && 'credentials' in userCors
-      ? userCors.credentials
-      : isPathMap && userCors
-        ? false
-        : hasAuth
-          ? true
-          : false;
-
-  return {
-    origin,
-    allowMethods: DEFAULT_CORS_ALLOW_METHODS,
-    credentials,
-    maxAge: 3600,
-    ...userCors,
-    allowHeaders: [...DEFAULT_CORS_ALLOW_HEADERS, ...(userCors?.allowHeaders ?? [])],
-    exposeHeaders: [...DEFAULT_CORS_EXPOSE_HEADERS, ...(userCors?.exposeHeaders ?? [])],
-  };
 }
 
 export function getToolExports(tools: Record<string, Function>[]) {
@@ -241,9 +207,47 @@ export async function createHonoServer(
     app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000));
   } else {
     const hasAuth = !!server?.auth;
-    app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), async (c, next) =>
-      cors(getCorsConfig(server?.cors, hasAuth, new URL(c.req.url).pathname))(c, next),
-    );
+    app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), async (c, next) => {
+      const isPathMap = isCorsPathMap(server?.cors);
+      const routeCors = isPathMap ? resolveCorsPathConfig(server.cors, new URL(c.req.url).pathname) : server?.cors;
+      const userCors = routeCors && typeof routeCors === 'object' ? routeCors : undefined;
+
+      let corsOrigin: string | string[] | ((origin: string) => string | undefined | null);
+      if (userCors && 'origin' in userCors && userCors.origin) {
+        corsOrigin = userCors.origin as string | string[] | ((origin: string) => string | undefined | null);
+      } else if (hasAuth) {
+        corsOrigin = (origin: string) => origin || undefined;
+      } else {
+        corsOrigin = '*';
+      }
+
+      const credentials =
+        userCors && 'credentials' in userCors
+          ? userCors.credentials
+          : isPathMap && userCors
+            ? false
+            : hasAuth
+              ? true
+              : false;
+
+      const corsConfig = {
+        origin: corsOrigin,
+        allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+        credentials,
+        maxAge: 3600,
+        ...userCors,
+        allowHeaders: [
+          'Content-Type',
+          'Authorization',
+          'x-mastra-client-type',
+          'x-mastra-dev-playground',
+          ...(userCors?.allowHeaders ?? []),
+        ],
+        exposeHeaders: ['Content-Length', 'X-Requested-With', ...(userCors?.exposeHeaders ?? [])],
+      };
+
+      return cors(corsConfig)(c, next);
+    });
   }
 
   // Health check endpoint (before auth middleware so it's publicly accessible)

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -49,6 +49,75 @@ type Variables = HonoVariables & {
   clients: Set<{ controller: ReadableStreamDefaultController }>;
 };
 
+type CorsOptions = Parameters<typeof cors>[0];
+type CorsPathMap = Record<string, CorsOptions>;
+
+const DEFAULT_CORS_ALLOW_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+const DEFAULT_CORS_ALLOW_HEADERS = ['Content-Type', 'Authorization', 'x-mastra-client-type', 'x-mastra-dev-playground'];
+const DEFAULT_CORS_EXPOSE_HEADERS = ['Content-Length', 'X-Requested-With'];
+
+function isCorsPathMap(corsConfig: CorsOptions | CorsPathMap | false | undefined): corsConfig is CorsPathMap {
+  if (!corsConfig || typeof corsConfig !== 'object') return false;
+  return Object.keys(corsConfig).some(key => key === '*' || key.startsWith('/'));
+}
+
+function matchesCorsPath(pattern: string, pathname: string) {
+  if (pattern === '*') return true;
+  if (pattern.endsWith('*')) return pathname.startsWith(pattern.slice(0, -1));
+  return pattern === pathname;
+}
+
+function getCorsPathSpecificity(pattern: string) {
+  return pattern === '*' ? 0 : pattern.replace(/\*$/, '').length;
+}
+
+function resolveCorsPathConfig(corsMap: CorsPathMap, pathname: string) {
+  let matchedConfig: CorsOptions | undefined;
+  let matchedSpecificity = -1;
+
+  for (const [pattern, config] of Object.entries(corsMap)) {
+    if (!matchesCorsPath(pattern, pathname)) continue;
+
+    const specificity = getCorsPathSpecificity(pattern);
+    if (specificity > matchedSpecificity) {
+      matchedConfig = config;
+      matchedSpecificity = specificity;
+    }
+  }
+
+  return matchedConfig;
+}
+
+function getCorsConfig(serverCors: CorsOptions | CorsPathMap | false | undefined, hasAuth: boolean, pathname?: string) {
+  const isPathMap = isCorsPathMap(serverCors);
+  const routeCors = isPathMap ? resolveCorsPathConfig(serverCors, pathname ?? '') : serverCors;
+  const userCors = routeCors && typeof routeCors === 'object' ? routeCors : undefined;
+  const origin =
+    userCors && 'origin' in userCors && userCors.origin
+      ? userCors.origin
+      : hasAuth
+        ? (requestOrigin: string) => requestOrigin || undefined
+        : '*';
+  const credentials =
+    userCors && 'credentials' in userCors
+      ? userCors.credentials
+      : isPathMap && userCors
+        ? false
+        : hasAuth
+          ? true
+          : false;
+
+  return {
+    origin,
+    allowMethods: DEFAULT_CORS_ALLOW_METHODS,
+    credentials,
+    maxAge: 3600,
+    ...userCors,
+    allowHeaders: [...DEFAULT_CORS_ALLOW_HEADERS, ...(userCors?.allowHeaders ?? [])],
+    exposeHeaders: [...DEFAULT_CORS_EXPOSE_HEADERS, ...(userCors?.exposeHeaders ?? [])],
+  };
+}
+
 export function getToolExports(tools: Record<string, Function>[]) {
   try {
     return tools.reduce((acc, toolModule) => {
@@ -175,43 +244,14 @@ export async function createHonoServer(
     },
   });
 
-  //Global cors config
+  // Global CORS config
   if (server?.cors === false) {
     app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000));
   } else {
-    // Check if auth is configured - if so, we need credentials for cookie-based sessions
     const hasAuth = !!server?.auth;
-
-    // When auth + credentials are enabled, origin cannot be '*'.
-    // Use user-configured cors.origin if provided; otherwise fall back to
-    // reflecting the request origin (required for dev/Studio but users should
-    // set an explicit origin in production).
-    let corsOrigin: string | string[] | ((origin: string) => string | undefined | null);
-    if (server?.cors && typeof server.cors === 'object' && 'origin' in server.cors && server.cors.origin) {
-      corsOrigin = server.cors.origin as string | string[] | ((origin: string) => string | undefined | null);
-    } else if (hasAuth) {
-      corsOrigin = (origin: string) => origin || undefined;
-    } else {
-      corsOrigin = '*';
-    }
-
-    const corsConfig = {
-      origin: corsOrigin,
-      allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-      // Enable credentials for cookie-based auth (e.g., Better Auth sessions)
-      credentials: hasAuth ? true : false,
-      maxAge: 3600,
-      ...server?.cors,
-      allowHeaders: [
-        'Content-Type',
-        'Authorization',
-        'x-mastra-client-type',
-        'x-mastra-dev-playground',
-        ...(server?.cors?.allowHeaders ?? []),
-      ],
-      exposeHeaders: ['Content-Length', 'X-Requested-With', ...(server?.cors?.exposeHeaders ?? [])],
-    };
-    app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), cors(corsConfig));
+    app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), async (c, next) =>
+      cors(getCorsConfig(server?.cors, hasAuth, new URL(c.req.url).pathname))(c, next),
+    );
   }
 
   // Health check endpoint (before auth middleware so it's publicly accessible)

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -61,24 +61,16 @@ function isCorsPathMap(corsConfig: CorsOptions | CorsPathMap | false | undefined
   return Object.keys(corsConfig).some(key => key === '*' || key.startsWith('/'));
 }
 
-function matchesCorsPath(pattern: string, pathname: string) {
-  if (pattern === '*') return true;
-  if (pattern.endsWith('*')) return pathname.startsWith(pattern.slice(0, -1));
-  return pattern === pathname;
-}
-
-function getCorsPathSpecificity(pattern: string) {
-  return pattern === '*' ? 0 : pattern.replace(/\*$/, '').length;
-}
-
 function resolveCorsPathConfig(corsMap: CorsPathMap, pathname: string) {
   let matchedConfig: CorsOptions | undefined;
   let matchedSpecificity = -1;
 
   for (const [pattern, config] of Object.entries(corsMap)) {
-    if (!matchesCorsPath(pattern, pathname)) continue;
+    const matches =
+      pattern === '*' || (pattern.endsWith('*') ? pathname.startsWith(pattern.slice(0, -1)) : pattern === pathname);
+    if (!matches) continue;
 
-    const specificity = getCorsPathSpecificity(pattern);
+    const specificity = pattern === '*' ? 0 : pattern.replace(/\*$/, '').length;
     if (specificity > matchedSpecificity) {
       matchedConfig = config;
       matchedSpecificity = specificity;
@@ -244,7 +236,7 @@ export async function createHonoServer(
     },
   });
 
-  // Global CORS config
+  //Global cors config
   if (server?.cors === false) {
     app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000));
   } else {

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -6,10 +6,12 @@ import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { swaggerUI } from '@hono/swagger-ui';
 import type { Mastra } from '@mastra/core/mastra';
+import type { ApiRoute, CorsOptions } from '@mastra/core/server';
 import { Tool } from '@mastra/core/tools';
 import { MastraServer, setupBrowserStream } from '@mastra/hono';
 import type { HonoBindings, HonoVariables } from '@mastra/hono';
 import { InMemoryTaskStore } from '@mastra/server/a2a/store';
+import { findMatchingCustomRoute } from '@mastra/server/auth';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { compress } from 'hono/compress';
@@ -49,63 +51,19 @@ type Variables = HonoVariables & {
   clients: Set<{ controller: ReadableStreamDefaultController }>;
 };
 
-type CorsOptions = Parameters<typeof cors>[0];
-type CorsPathMap = Record<string, CorsOptions>;
-
 const DEFAULT_CORS_ALLOW_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
 const DEFAULT_CORS_ALLOW_HEADERS = ['Content-Type', 'Authorization', 'x-mastra-client-type', 'x-mastra-dev-playground'];
 const DEFAULT_CORS_EXPOSE_HEADERS = ['Content-Length', 'X-Requested-With'];
 
-function isCorsPathMap(corsConfig: CorsOptions | CorsPathMap | false | undefined): corsConfig is CorsPathMap {
-  if (!corsConfig || typeof corsConfig !== 'object') return false;
-  return Object.keys(corsConfig).some(key => key === '*' || key.startsWith('/'));
-}
-
-function matchesCorsPath(pattern: string, pathname: string) {
-  if (pattern === '*') return true;
-  if (pattern.endsWith('*')) return pathname.startsWith(pattern.slice(0, -1));
-  return pattern === pathname;
-}
-
-function getCorsPathSpecificity(pattern: string) {
-  return pattern === '*' ? 0 : pattern.replace(/\*$/, '').length;
-}
-
-function resolveCorsPathConfig(corsMap: CorsPathMap, pathname: string) {
-  let matchedConfig: CorsOptions | undefined;
-  let matchedSpecificity = -1;
-
-  for (const [pattern, config] of Object.entries(corsMap)) {
-    if (!matchesCorsPath(pattern, pathname)) continue;
-
-    const specificity = getCorsPathSpecificity(pattern);
-    if (specificity > matchedSpecificity) {
-      matchedConfig = config;
-      matchedSpecificity = specificity;
-    }
-  }
-
-  return matchedConfig;
-}
-
-function getCorsConfig(serverCors: CorsOptions | CorsPathMap | false | undefined, hasAuth: boolean, pathname?: string) {
-  const isPathMap = isCorsPathMap(serverCors);
-  const routeCors = isPathMap ? resolveCorsPathConfig(serverCors, pathname ?? '') : serverCors;
-  const userCors = routeCors && typeof routeCors === 'object' ? routeCors : undefined;
+function getCorsConfig(serverCors: CorsOptions | false | undefined, credentialsDefault: boolean) {
+  const userCors = serverCors && typeof serverCors === 'object' ? serverCors : undefined;
   const origin =
     userCors && 'origin' in userCors && userCors.origin
       ? userCors.origin
-      : hasAuth
+      : credentialsDefault
         ? (requestOrigin: string) => requestOrigin || undefined
         : '*';
-  const credentials =
-    userCors && 'credentials' in userCors
-      ? userCors.credentials
-      : isPathMap && userCors
-        ? false
-        : hasAuth
-          ? true
-          : false;
+  const credentials = userCors && 'credentials' in userCors ? userCors.credentials : credentialsDefault;
 
   return {
     origin,
@@ -116,6 +74,11 @@ function getCorsConfig(serverCors: CorsOptions | CorsPathMap | false | undefined
     allowHeaders: [...DEFAULT_CORS_ALLOW_HEADERS, ...(userCors?.allowHeaders ?? [])],
     exposeHeaders: [...DEFAULT_CORS_EXPOSE_HEADERS, ...(userCors?.exposeHeaders ?? [])],
   };
+}
+
+function getRouteCorsConfig(apiRoutes: ApiRoute[] | undefined, pathname: string, method: string) {
+  const route = findMatchingCustomRoute(pathname, method, apiRoutes)?.route;
+  return route?.cors;
 }
 
 export function getToolExports(tools: Record<string, Function>[]) {
@@ -249,9 +212,14 @@ export async function createHonoServer(
     app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000));
   } else {
     const hasAuth = !!server?.auth;
-    app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), async (c, next) =>
-      cors(getCorsConfig(server?.cors, hasAuth, new URL(c.req.url).pathname))(c, next),
-    );
+    app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), async (c, next) => {
+      const pathname = new URL(c.req.url).pathname;
+      const method =
+        c.req.method === 'OPTIONS' ? (c.req.header('Access-Control-Request-Method') ?? c.req.method) : c.req.method;
+      const routeCors = getRouteCorsConfig(processedRoutes, pathname, method);
+
+      return cors(routeCors ? getCorsConfig(routeCors, false) : getCorsConfig(server?.cors, hasAuth))(c, next);
+    });
   }
 
   // Health check endpoint (before auth middleware so it's publicly accessible)

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -52,6 +52,10 @@ type Variables = HonoVariables & {
 type CorsOptions = Parameters<typeof cors>[0];
 type CorsPathMap = Record<string, CorsOptions>;
 
+const DEFAULT_CORS_ALLOW_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+const DEFAULT_CORS_ALLOW_HEADERS = ['Content-Type', 'Authorization', 'x-mastra-client-type', 'x-mastra-dev-playground'];
+const DEFAULT_CORS_EXPOSE_HEADERS = ['Content-Length', 'X-Requested-With'];
+
 function isCorsPathMap(corsConfig: CorsOptions | CorsPathMap | false | undefined): corsConfig is CorsPathMap {
   if (!corsConfig || typeof corsConfig !== 'object') return false;
   return Object.keys(corsConfig).some(key => key === '*' || key.startsWith('/'));
@@ -74,6 +78,36 @@ function resolveCorsPathConfig(corsMap: CorsPathMap, pathname: string) {
   }
 
   return matchedConfig;
+}
+
+function getCorsConfig(serverCors: CorsOptions | CorsPathMap | false | undefined, hasAuth: boolean, pathname?: string) {
+  const isPathMap = isCorsPathMap(serverCors);
+  const routeCors = isPathMap ? resolveCorsPathConfig(serverCors, pathname ?? '') : serverCors;
+  const userCors = routeCors && typeof routeCors === 'object' ? routeCors : undefined;
+  const origin =
+    userCors && 'origin' in userCors && userCors.origin
+      ? userCors.origin
+      : hasAuth
+        ? (requestOrigin: string) => requestOrigin || undefined
+        : '*';
+  const credentials =
+    userCors && 'credentials' in userCors
+      ? userCors.credentials
+      : isPathMap && userCors
+        ? false
+        : hasAuth
+          ? true
+          : false;
+
+  return {
+    origin,
+    allowMethods: DEFAULT_CORS_ALLOW_METHODS,
+    credentials,
+    maxAge: 3600,
+    ...userCors,
+    allowHeaders: [...DEFAULT_CORS_ALLOW_HEADERS, ...(userCors?.allowHeaders ?? [])],
+    exposeHeaders: [...DEFAULT_CORS_EXPOSE_HEADERS, ...(userCors?.exposeHeaders ?? [])],
+  };
 }
 
 export function getToolExports(tools: Record<string, Function>[]) {
@@ -207,47 +241,9 @@ export async function createHonoServer(
     app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000));
   } else {
     const hasAuth = !!server?.auth;
-    app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), async (c, next) => {
-      const isPathMap = isCorsPathMap(server?.cors);
-      const routeCors = isPathMap ? resolveCorsPathConfig(server.cors, new URL(c.req.url).pathname) : server?.cors;
-      const userCors = routeCors && typeof routeCors === 'object' ? routeCors : undefined;
-
-      let corsOrigin: string | string[] | ((origin: string) => string | undefined | null);
-      if (userCors && 'origin' in userCors && userCors.origin) {
-        corsOrigin = userCors.origin as string | string[] | ((origin: string) => string | undefined | null);
-      } else if (hasAuth) {
-        corsOrigin = (origin: string) => origin || undefined;
-      } else {
-        corsOrigin = '*';
-      }
-
-      const credentials =
-        userCors && 'credentials' in userCors
-          ? userCors.credentials
-          : isPathMap && userCors
-            ? false
-            : hasAuth
-              ? true
-              : false;
-
-      const corsConfig = {
-        origin: corsOrigin,
-        allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-        credentials,
-        maxAge: 3600,
-        ...userCors,
-        allowHeaders: [
-          'Content-Type',
-          'Authorization',
-          'x-mastra-client-type',
-          'x-mastra-dev-playground',
-          ...(userCors?.allowHeaders ?? []),
-        ],
-        exposeHeaders: ['Content-Length', 'X-Requested-With', ...(userCors?.exposeHeaders ?? [])],
-      };
-
-      return cors(corsConfig)(c, next);
-    });
+    app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), async (c, next) =>
+      cors(getCorsConfig(server?.cors, hasAuth, new URL(c.req.url).pathname))(c, next),
+    );
   }
 
   // Health check endpoint (before auth middleware so it's publicly accessible)


### PR DESCRIPTION
## Description

Adds route-specific CORS configuration for the Mastra server, so credentialed cross-origin access can be scoped to a single route instead of applying one policy to every endpoint. This follows Option A from #16662 (per maintainer feedback on the issue and PR). The existing global `server.cors` config keeps working unchanged, so this is fully backward compatible.

- Added an optional `cors?: CorsOptions` field to `registerApiRoute()`, so a single custom route can carry its own CORS policy
- Added an optional `cors?: CorsOptions` field to channel adapter config (`ChannelAdapterConfig`), forwarded to the auto-generated webhook route for that adapter
- Exported a new `CorsOptions` type from `@mastra/core/server`
- `server.cors` still accepts a single `CorsOptions` object or `false` — no path map, no syntax change
- Replaced the static global CORS middleware in `@mastra/deployer` with a per-request resolver: it looks up the matching route's `cors` and applies it; routes without a `cors` field fall back to the global `server.cors` policy
- Route-level CORS does not silently inherit `credentials: true` from server auth — credentials must be set explicitly on each route's `cors` config
- Added a type test in `@mastra/core` and a CORS preflight test suite in `@mastra/deployer`
- Documented route-level `cors` in `register-api-route.mdx`, per-adapter `cors` in `channels.mdx`, and updated the `server.cors` reference in `configuration.mdx`

## Related Issue(s)

Fixes #16662

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets developers configure CORS for specific routes (or adapters) instead of only a single global rule—so you can allow credentialed cross-origin access for one webhook without opening it for the whole server—while keeping the old global CORS behavior working.

## Overview

Adds route-level CORS configuration and public CORS types, wires route-level CORS through Mastra's server and channel adapter generation, and updates the deployer to resolve and apply per-route CORS during request handling (preserving backward compatibility with a single global CORS object or disabling CORS).

## Changes

### Type definitions & public API
- Exported a new CorsOptions type (derived from hono/cors) from `@mastra/core/server`.
- Added an optional cors?: CorsOptions field to registerApiRoute(...) so routes can carry their own CORS config.
- Channel adapter config (ChannelAdapterConfig) now accepts optional cors?: CorsOptions for generated webhook routes.
- ServerConfig.cors typing narrowed to CorsOptions | false (no path-map type added in this diff).

### Implementation (server & deployer)
- Added per-request CORS resolution in packages/deployer: instead of a single static global CORS middleware, the server now looks up a route's cors option for the incoming request and applies the appropriate CORS policy.
- Introduced local CORS helper functions (default headers/methods, getCorsConfig, getRouteCorsConfig/findMatchingCustomRoute) to build and select CORS options at request time.
- Ensured route-level CORS does not implicitly inherit credentials from server auth—credentials must be set explicitly on each route's CORS config. Legacy/global CORS behavior is preserved.

### Tests
- Added a type-level test in `@mastra/core` verifying CorsOptions usage with Mastra constructor and registerApiRoute.
- Added a comprehensive CORS preflight test suite in `@mastra/deployer` covering legacy/global behavior, route-specific selection, credential handling differences, dynamic route param matching, header merging, and method-specific application.

### Documentation
- Updated configuration and reference docs:
  - Documented CorsOptions usage and route-level cors in registerApiRoute docs and channel adapter docs (example webhook with credentials).
  - Clarified server.cors types and noted route-specific CORS via registerApiRoute.
  - Expanded documented allowHeaders list to include x-mastra-dev-playground.
  - Changeset updated with examples and release notes.

## Notes & context
- The PR implements route-level CORS and per-request resolution; a repository-level path→config map type (CorsPathMap) was not introduced in the types diff included here.
- Related issue: Fixes `#16662`.
- One reviewer comment suggested preferring route-level CORS (registerApiRoute) over a global path map; commits show iteration that culminated in adding route-level CORS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
