### PR TITLE
fix(mastracode): track active goal pursuit time

### DIFF
--- a/.changeset/tasty-hats-grab.md
+++ b/.changeset/tasty-hats-grab.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed goal pursuit timers so they only count active work and stay paused while waiting for user input.

--- a/mastracode/src/tui/__tests__/agent-lifecycle-goal-timer.test.ts
+++ b/mastracode/src/tui/__tests__/agent-lifecycle-goal-timer.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../render-messages.js', () => ({
+  clearPendingUserMessages: vi.fn(),
+}));
+
+vi.mock('../prune-chat.js', () => ({
+  pruneChatContainer: vi.fn(),
+}));
+
+vi.mock('../../utils/project.js', () => ({
+  getCurrentGitBranch: vi.fn(() => 'main'),
+}));
+
+import { handleAgentAborted, handleAgentError } from '../handlers/agent-lifecycle.js';
+import type { EventHandlerContext } from '../handlers/types.js';
+import type { TUIState } from '../state.js';
+
+function createState(overrides: Partial<TUIState> = {}): TUIState {
+  return {
+    goalManager: { stopActiveTimer: vi.fn() },
+    gradientAnimator: { fadeOut: vi.fn() },
+    projectInfo: { rootPath: '.', gitBranch: 'main' },
+    streamingComponent: undefined,
+    streamingMessage: undefined,
+    followUpComponents: [],
+    pendingFollowUpMessages: [],
+    pendingQueuedActions: [],
+    pendingSlashCommands: [],
+    pendingTools: new Map(),
+    chatContainer: { addChild: vi.fn() },
+    ui: { requestRender: vi.fn() },
+    ...overrides,
+  } as unknown as TUIState;
+}
+
+function createContext(state: TUIState): EventHandlerContext {
+  return {
+    state,
+    updateStatusLine: vi.fn(),
+  } as unknown as EventHandlerContext;
+}
+
+describe('agent lifecycle goal timing', () => {
+  it('stops active goal timing when an agent abort ends the turn', () => {
+    const state = createState();
+
+    handleAgentAborted(createContext(state));
+
+    expect(state.goalManager.stopActiveTimer).toHaveBeenCalled();
+  });
+
+  it('stops active goal timing when an agent error ends the turn', () => {
+    const state = createState();
+
+    handleAgentError(createContext(state));
+
+    expect(state.goalManager.stopActiveTimer).toHaveBeenCalled();
+  });
+});

--- a/mastracode/src/tui/__tests__/goal-manager.test.ts
+++ b/mastracode/src/tui/__tests__/goal-manager.test.ts
@@ -85,15 +85,45 @@ describe('GoalManager', () => {
     mocks.createWorkspaceTools.mockReset();
   });
 
-  it('preserves turn count when resuming a paused goal', () => {
+  it('preserves turn count and accumulated active duration when resuming a paused goal', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T10:00:00.000Z'));
     const manager = new GoalManager();
     const goal = manager.setGoal('finish the task', 'openai/gpt-5.5');
     goal.turnsUsed = 3;
+    vi.setSystemTime(new Date('2026-05-15T10:05:00.000Z'));
     manager.pause();
 
+    vi.setSystemTime(new Date('2026-05-15T12:00:00.000Z'));
     manager.resume();
+    vi.setSystemTime(new Date('2026-05-15T12:02:00.000Z'));
+    manager.stopActiveTimer();
 
-    expect(manager.getGoal()).toMatchObject({ status: 'active', turnsUsed: 3 });
+    expect(manager.getGoal()).toMatchObject({ status: 'active', turnsUsed: 3, activeDurationMs: 7 * 60_000 });
+    vi.useRealTimers();
+  });
+
+  it('does not keep counting a persisted active timer after restart', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T15:00:00.000Z'));
+    const manager = new GoalManager();
+
+    manager.loadFromThreadMetadata({
+      goal: {
+        id: 'goal-1',
+        objective: 'finish the task',
+        status: 'active',
+        turnsUsed: 1,
+        maxTurns: 20,
+        judgeModelId: 'openai/gpt-5.5',
+        startedAt: '2026-05-15T10:00:00.000Z',
+        activeStartedAt: '2026-05-15T10:00:00.000Z',
+        activeDurationMs: 10 * 60_000,
+      },
+    });
+
+    expect(manager.getGoal()).toMatchObject({ activeDurationMs: 10 * 60_000, activeStartedAt: undefined });
+    vi.useRealTimers();
   });
 
   it('updates judge defaults on the current goal without resetting progress', () => {
@@ -334,6 +364,29 @@ describe('GoalManager', () => {
     ]);
   });
 
+  it('keeps active goal timing running when the judge says to continue', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T10:00:00.000Z'));
+    mocks.stream.mockResolvedValue({
+      consumeStream: vi.fn().mockResolvedValue(undefined),
+      getFullOutput: vi.fn().mockResolvedValue({ object: { decision: 'continue', reason: 'Need one more step.' } }),
+    });
+    mocks.agentConstructor.mockImplementation(function () {
+      return { stream: mocks.stream };
+    });
+
+    const manager = new GoalManager();
+    manager.setGoal('finish the task', 'openai/gpt-5.5');
+    vi.setSystemTime(new Date('2026-05-15T10:05:00.000Z'));
+
+    const result = await manager.evaluateAfterTurn(createState());
+
+    expect(result.continuation).toContain('Need one more step.');
+    expect(manager.getGoal()).toMatchObject({ status: 'active', turnsUsed: 1, activeDurationMs: 0 });
+    expect(manager.getGoal()?.activeStartedAt).toBe('2026-05-15T10:00:00.000Z');
+    vi.useRealTimers();
+  });
+
   it('does not auto-continue when the judge says the assistant is waiting on the user', async () => {
     mocks.stream.mockResolvedValue({
       consumeStream: vi.fn().mockResolvedValue(undefined),
@@ -360,6 +413,8 @@ describe('GoalManager', () => {
     });
     expect(manager.getGoal()?.status).toBe('active');
     expect(manager.getGoal()?.turnsUsed).toBe(0);
+    expect(manager.getGoal()?.activeStartedAt).toBeUndefined();
+    expect(manager.getGoal()?.activeDurationMs).toBeGreaterThanOrEqual(0);
   });
 
   it('tells the judge to keep waiting when the last waiting checkpoint gets a user question', async () => {

--- a/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -639,6 +639,7 @@ describe('MastraTUI queueing', () => {
       isActive: vi.fn(() => true),
       pause: vi.fn(),
       saveToThread: vi.fn(),
+      stopActiveTimer: vi.fn(),
     };
     const state = createQueueState({
       userInitiatedAbort: true,
@@ -648,6 +649,7 @@ describe('MastraTUI queueing', () => {
 
     handleAgentAborted(ctx);
 
+    expect(goalManager.stopActiveTimer).toHaveBeenCalled();
     expect(goalManager.pause).not.toHaveBeenCalled();
     expect(goalManager.saveToThread).not.toHaveBeenCalled();
     expect(state.userInitiatedAbort).toBe(false);

--- a/mastracode/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/src/tui/__tests__/status-line.test.ts
@@ -216,7 +216,14 @@ describe('updateStatusLine', () => {
     vi.setSystemTime(now);
     const state = createState();
     state.goalManager = {
-      getGoal: vi.fn(() => ({ status: 'active', turnsUsed: 0, maxTurns: 20, startedAt: '2026-05-15T10:50:00.000Z' })),
+      getGoal: vi.fn(() => ({
+        status: 'active',
+        turnsUsed: 0,
+        maxTurns: 20,
+        startedAt: '2026-05-15T10:50:00.000Z',
+        activeStartedAt: '2026-05-15T10:50:00.000Z',
+        activeDurationMs: 0,
+      })),
     };
 
     updateStatusLine(state);
@@ -228,12 +235,41 @@ describe('updateStatusLine', () => {
     vi.useRealTimers();
   });
 
+  it('freezes active goal duration while waiting for user input', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T17:00:00.000Z'));
+    const state = createState();
+    state.goalManager = {
+      getGoal: vi.fn(() => ({
+        status: 'active',
+        turnsUsed: 0,
+        maxTurns: 20,
+        startedAt: '2026-05-15T10:50:00.000Z',
+        activeDurationMs: 10 * 60_000,
+      })),
+    };
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('pursuing goal (10m)');
+    expect(rendered).not.toContain('6hr10m');
+    vi.useRealTimers();
+  });
+
   it('uses a compact active goal duration label on narrow screens', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-15T12:00:00.000Z'));
     const state = createState();
     state.goalManager = {
-      getGoal: vi.fn(() => ({ status: 'active', turnsUsed: 0, maxTurns: 20, startedAt: '2026-05-13T09:00:00.000Z' })),
+      getGoal: vi.fn(() => ({
+        status: 'active',
+        turnsUsed: 0,
+        maxTurns: 20,
+        startedAt: '2026-05-13T09:00:00.000Z',
+        activeStartedAt: '2026-05-13T09:00:00.000Z',
+        activeDurationMs: 0,
+      })),
     };
     process.stdout.columns = 35;
 

--- a/mastracode/src/tui/commands/__tests__/goal.test.ts
+++ b/mastracode/src/tui/commands/__tests__/goal.test.ts
@@ -374,6 +374,8 @@ describe('handleGoalCommand', () => {
   });
 
   it('can activate goal mode without sending a trigger so plan approval can inject through the TUI', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T10:00:00.000Z'));
     const goalManager = new GoalManager();
     const sendMessage = vi.fn().mockResolvedValue(undefined);
 
@@ -392,9 +394,12 @@ describe('handleGoalCommand', () => {
     } as any;
 
     await startGoalWithDefaults(ctx, '# Ship it\n\n1. Build\n2. Test', 'Goal cancelled.', { trigger: 'none' });
+    vi.setSystemTime(new Date('2026-05-15T15:00:00.000Z'));
 
     expect(goalManager.isActive()).toBe(true);
+    expect(goalManager.getGoal()).toMatchObject({ activeDurationMs: 0, activeStartedAt: undefined });
     expect(sendMessage).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it('updates the current goal when judge defaults change', async () => {

--- a/mastracode/src/tui/commands/goal.ts
+++ b/mastracode/src/tui/commands/goal.ts
@@ -6,7 +6,7 @@
  *   /goal             Open goal actions
  *   /goal status      Show current goal status
  *   /goal pause       Pause the continuation loop
- *   /goal resume      Resume (resets turn counter)
+ *   /goal resume      Resume without resetting the turn counter
  *   /goal clear       Drop the goal
  *   /judge            Set global judge model and max-attempt defaults
  */
@@ -307,6 +307,10 @@ async function startGoal(
 
   const shouldPersistToCreatedThread = !state.harness.getCurrentThreadId();
   const goal = goalManager.setGoal(objective, judgeModelId, maxTurns);
+  if (options.trigger === 'none') {
+    goal.activeStartedAt = undefined;
+    goal.activeDurationMs = 0;
+  }
   if (shouldPersistToCreatedThread) {
     goalManager.persistOnNextThreadCreate();
   }

--- a/mastracode/src/tui/goal-manager.ts
+++ b/mastracode/src/tui/goal-manager.ts
@@ -33,6 +33,8 @@ export interface GoalState {
   maxTurns: number;
   judgeModelId: string;
   startedAt: string;
+  activeStartedAt?: string;
+  activeDurationMs?: number;
 }
 
 export interface GoalJudgeResult {
@@ -109,6 +111,7 @@ export class GoalManager {
    * Set a new goal objective. Resets turn counter.
    */
   setGoal(objective: string, judgeModelId: string, maxTurns: number = DEFAULT_MAX_TURNS): GoalState {
+    const now = new Date().toISOString();
     this.goal = {
       id: randomUUID(),
       objective,
@@ -116,7 +119,9 @@ export class GoalManager {
       turnsUsed: 0,
       maxTurns,
       judgeModelId,
-      startedAt: new Date().toISOString(),
+      startedAt: now,
+      activeStartedAt: now,
+      activeDurationMs: 0,
     };
     return this.goal;
   }
@@ -127,7 +132,13 @@ export class GoalManager {
   loadFromThreadMetadata(metadata: Record<string, unknown> | undefined): void {
     const saved = metadata?.[THREAD_GOAL_KEY] as GoalState | undefined;
     if (saved && saved.objective && saved.status) {
-      this.goal = { ...saved, id: saved.id ?? randomUUID(), startedAt: saved.startedAt ?? new Date().toISOString() };
+      this.goal = {
+        ...saved,
+        id: saved.id ?? randomUUID(),
+        startedAt: saved.startedAt ?? new Date().toISOString(),
+        activeStartedAt: undefined,
+        activeDurationMs: saved.activeDurationMs ?? 0,
+      };
     } else {
       this.goal = null;
     }
@@ -151,6 +162,7 @@ export class GoalManager {
 
   pause(): GoalState | null {
     if (this.goal && this.goal.status === 'active') {
+      this.stopActiveTimer();
       this.goal.status = 'paused';
     }
     return this.goal;
@@ -159,8 +171,24 @@ export class GoalManager {
   resume(): GoalState | null {
     if (this.goal && this.goal.status === 'paused') {
       this.goal.status = 'active';
+      this.startActiveTimer();
     }
     return this.goal;
+  }
+
+  startActiveTimer(): void {
+    if (this.goal?.status === 'active' && !this.goal.activeStartedAt) {
+      this.goal.activeStartedAt = new Date().toISOString();
+    }
+  }
+
+  stopActiveTimer(): void {
+    if (!this.goal?.activeStartedAt) return;
+    const activeStartedMs = Date.parse(this.goal.activeStartedAt);
+    if (Number.isFinite(activeStartedMs)) {
+      this.goal.activeDurationMs = (this.goal.activeDurationMs ?? 0) + Math.max(0, Date.now() - activeStartedMs);
+    }
+    this.goal.activeStartedAt = undefined;
   }
 
   updateJudgeDefaults(judgeModelId: string, maxTurns: number): GoalState | null {
@@ -178,6 +206,7 @@ export class GoalManager {
 
   markDone(): void {
     if (this.goal) {
+      this.stopActiveTimer();
       this.goal.status = 'done';
     }
   }
@@ -201,6 +230,7 @@ export class GoalManager {
     if (!context.lastAssistantContent) {
       // No assistant message to judge — continue anyway (but check budget)
       if (this.goal.turnsUsed >= this.goal.maxTurns) {
+        this.stopActiveTimer();
         this.goal.status = 'paused';
         await this.saveToThread(state);
         return { continuation: null, judgeResult: null };
@@ -226,29 +256,34 @@ export class GoalManager {
       this.goal.turnsUsed++;
     }
     if (result.decision === 'paused') {
+      this.stopActiveTimer();
       this.goal.status = 'paused';
       await this.saveToThread(state);
       return { continuation: null, judgeResult: result };
     }
 
     if (result.decision === 'done') {
+      this.stopActiveTimer();
       this.goal.status = 'done';
       await this.saveToThread(state);
       return { continuation: null, judgeResult: result };
     }
 
     if (result.decision === 'waiting') {
+      this.stopActiveTimer();
       await this.saveToThread(state);
       return { continuation: null, judgeResult: result };
     }
 
     // Budget exhaustion (checked after judging so the last turn can still be marked done)
     if (this.goal.turnsUsed >= this.goal.maxTurns) {
+      this.stopActiveTimer();
       this.goal.status = 'paused';
       await this.saveToThread(state);
       return { continuation: null, judgeResult: result };
     }
 
+    this.startActiveTimer();
     await this.saveToThread(state);
     return { continuation: this.buildContinuationPrompt(result.reason), judgeResult: result };
   }

--- a/mastracode/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/src/tui/handlers/agent-lifecycle.ts
@@ -16,6 +16,7 @@ import type { EventHandlerContext } from './types.js';
 
 export function handleAgentStart(ctx: EventHandlerContext): void {
   const { state } = ctx;
+  state.goalManager.startActiveTimer();
 
   // Refresh git branch so status line reflects the current branch
   const freshBranch = getCurrentGitBranch(state.projectInfo.rootPath);
@@ -118,6 +119,7 @@ function drainQueuedAction(ctx: EventHandlerContext): boolean {
 
 export function handleAgentAborted(ctx: EventHandlerContext): void {
   const { state } = ctx;
+  state.goalManager.stopActiveTimer();
   if (state.gradientAnimator) {
     state.gradientAnimator.fadeOut();
   }
@@ -151,6 +153,7 @@ export function handleAgentAborted(ctx: EventHandlerContext): void {
 
 export function handleAgentError(ctx: EventHandlerContext): void {
   const { state } = ctx;
+  state.goalManager.stopActiveTimer();
   if (state.gradientAnimator) {
     state.gradientAnimator.fadeOut();
   }

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -24,11 +24,11 @@ function isGenericTitle(title: string): boolean {
   );
 }
 
-function formatGoalDuration(startedAt: string): string {
-  const startedMs = Date.parse(startedAt);
-  if (!Number.isFinite(startedMs)) return '<1m';
-
-  const elapsedMinutes = Math.floor(Math.max(0, Date.now() - startedMs) / 60_000);
+function formatGoalDuration(goal: { startedAt: string; activeStartedAt?: string; activeDurationMs?: number }): string {
+  const activeStartedAt = goal.activeStartedAt ?? (goal.activeDurationMs === undefined ? goal.startedAt : undefined);
+  const startedMs = activeStartedAt ? Date.parse(activeStartedAt) : NaN;
+  const activeRunMs = Number.isFinite(startedMs) ? Math.max(0, Date.now() - startedMs) : 0;
+  const elapsedMinutes = Math.floor(((goal.activeDurationMs ?? 0) + activeRunMs) / 60_000);
   if (elapsedMinutes < 1) return '<1m';
 
   const days = Math.floor(elapsedMinutes / 1_440);
@@ -159,7 +159,7 @@ export function updateStatusLine(state: TUIState): void {
   const queuedCount = state.pendingQueuedActions.length + state.harness.getFollowUpCount();
   const queuedLabel = queuedCount > 0 ? `${queuedCount} queued` : null;
   const goalState = state.goalManager?.getGoal();
-  const goalDuration = goalState?.status === 'active' ? formatGoalDuration(goalState.startedAt) : null;
+  const goalDuration = goalState?.status === 'active' ? formatGoalDuration(goalState) : null;
   const goalLabel = goalDuration ? `pursuing goal (${goalDuration})` : null;
   const shortGoalLabel = goalDuration ? `goal (${goalDuration})` : null;
   // Build progressively shorter directory strings for layout fallback


### PR DESCRIPTION
Fixes the goal status timer so it shows active pursuit time instead of wall-clock time since the goal started. This keeps the timer from growing while Mastra Code is waiting for user input, after trigger-less goal setup, or after abort/error lifecycle events.

Before:
```text
pursuing goal (5hr10m)
```

After:
```text
pursuing goal (10m)
```

Also adds focused tests around waiting checkpoints, trigger-less activation, abort/error handling, resume behavior, and continue timing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes Mastra Code's goal timer so it only counts time when you're actively working on the goal, not all the time since you started it. Imagine a stopwatch that pauses when you're waiting for something—instead of always running, it now stops during waits, errors, or pauses, so you see how much actual work time you've spent, not just how long ago you started.

## Overview

The PR changes how goal pursuit time is tracked in Mastra Code. Instead of measuring wall-clock elapsed time since a goal was created (`startedAt`), it now tracks only the accumulated time spent while actively working on the goal (`activeStartedAt` and `activeDurationMs`). This prevents the displayed pursuit duration from accumulating while Mastra waits for user input, after error/abort events, or during pause states.

## Key Changes

**Core Timing Logic (`goal-manager.ts`)**
- Updated `GoalState` interface with two new optional fields: `activeStartedAt` (timestamp when active work begins) and `activeDurationMs` (accumulated milliseconds of active work)
- Integrated active timer start/stop calls throughout the goal lifecycle: at initial creation, on resume, and when evaluating after agent turns
- Timer stops for non-continuation outcomes (paused, done, error, abort, budget exhaustion) and restarts for continuation work
- Active timer state is persisted across thread switches via metadata

**Lifecycle Integration (`agent-lifecycle.ts`, `goal.ts`)**
- `handleAgentStart` now starts the active timer when an agent begins
- `handleAgentAborted` and `handleAgentError` stop the active timer before cleanup logic
- Trigger-less goal activation (`trigger === 'none'`) clears `activeStartedAt` and resets `activeDurationMs` to 0 before returning, preventing auto-start of reminder logic

**Status Display (`status-line.ts`)**
- Refactored `formatGoalDuration` to compute elapsed time from `activeStartedAt` and `activeDurationMs` instead of just wall-clock `startedAt`
- Falls back to `startedAt` only when accumulated `activeDurationMs` is unavailable
- Status line now passes the full `goalState` object instead of just the timestamp for richer context

## Test Coverage

New and expanded tests validate the timing behavior:
- **`agent-lifecycle-goal-timer.test.ts`** (new): Verifies `stopActiveTimer` is called on abort and error events
- **`goal-manager.test.ts`**: Enhanced with tests for resume behavior preserving accumulated time, continuation timer restart, and timer pausing during user waits
- **`goal.test.ts`**: Updated to use fake timers and assert active timer initialization on trigger-less activation
- **`mastra-tui-queueing.test.ts`**: Confirms timer stops on user-initiated abort
- **`status-line.test.ts`**: Validates status display shows accumulated active duration and freezes while waiting for user input

## Documentation

Added `.changeset/tasty-hats-grab.md` with patch release notes documenting that goal pursuit timers now count only active work time and pause during user input waits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->