### PR TITLE
fix: inherit env for MastraCode commands

### DIFF
--- a/.changeset/swift-shells-trace.md
+++ b/.changeset/swift-shells-trace.md
@@ -1,0 +1,6 @@
+---
+'mastracode': patch
+'@mastra/core': patch
+---
+
+Restore MastraCode local command execution to inherit parent environment variables while redacting env-shaped and secret-looking workspace trace data.

--- a/mastracode/src/agents/__tests__/workspace-env.test.ts
+++ b/mastracode/src/agents/__tests__/workspace-env.test.ts
@@ -1,0 +1,52 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../onboarding/settings.js', () => ({
+  loadSettings: () => ({}),
+}));
+vi.mock('../../onboarding/settings.js', () => ({
+  loadSettings: () => ({}),
+}));
+
+const originalEnv = { ...process.env };
+
+function createRequestContext(projectPath: string) {
+  return {
+    get: (key: string) =>
+      key === 'harness'
+        ? {
+            modeId: 'build',
+            getState: () => ({
+              projectPath,
+              sandboxAllowedPaths: [],
+            }),
+          }
+        : undefined,
+  };
+}
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.resetModules();
+});
+
+describe('mastracode workspace sandbox environment', () => {
+  it('passes arbitrary parent environment variables to local subprocesses', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-workspace-env-'));
+
+    try {
+      process.env.MASTRACODE_TEST_ENV = 'works';
+      const { getDynamicWorkspace } = await import('../workspace.js');
+      const workspace = getDynamicWorkspace({ requestContext: createRequestContext(tempDir) as any });
+
+      const result = await workspace.sandbox!.executeCommand!('node -e "console.log(process.env.MASTRACODE_TEST_ENV)"');
+
+      expect(result.success).toBe(true);
+      expect(result.stdout.trim()).toBe('works');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -16,83 +16,17 @@ import { TOOL_NAME_OVERRIDES } from '../tool-names.js';
 // Sandbox Environment
 // =============================================================================
 
-/**
- * Allowlist of env vars to inherit into the sandbox.
- * We avoid spreading all of process.env to prevent secrets from leaking
- * into observability traces and scorer data.
- */
-const SANDBOX_ENV_ALLOWLIST = [
-  // System essentials
-  'PATH',
-  'HOME',
-  'SHELL',
-  'USER',
-  'LOGNAME',
-  'TMPDIR',
-  'TEMP',
-  'TMP',
-  // Locale
-  'LANG',
-  'LC_ALL',
-  'LC_CTYPE',
-  // Terminal
-  'TERM',
-  'COLORTERM',
-  'TERM_PROGRAM',
-  // Node.js
-  'NODE_PATH',
-  'NODE_OPTIONS',
-  'NODE_ENV',
-  // Package managers
-  'NPM_CONFIG_PREFIX',
-  'NPM_CONFIG_CACHE',
-  'PNPM_HOME',
-  'YARN_GLOBAL_FOLDER',
-  'BUN_INSTALL',
-  // Version managers
-  'NVM_DIR',
-  'FNM_DIR',
-  'VOLTA_HOME',
-  'N_PREFIX',
-  // Build tools
-  'CARGO_HOME',
-  'GOPATH',
-  'GOROOT',
-  'RUSTUP_HOME',
-  'JAVA_HOME',
-  'ANDROID_HOME',
-  // Editor
-  'EDITOR',
-  'VISUAL',
-  // Git
-  'GIT_AUTHOR_NAME',
-  'GIT_AUTHOR_EMAIL',
-  'GIT_COMMITTER_NAME',
-  'GIT_COMMITTER_EMAIL',
-  // Platform specifics (macOS)
-  'XPC_FLAGS',
-  'XPC_SERVICE_NAME',
-  '__CF_USER_TEXT_ENCODING',
-];
-
 function buildSandboxEnv(): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {};
-
-  for (const key of SANDBOX_ENV_ALLOWLIST) {
-    if (process.env[key] !== undefined) {
-      env[key] = process.env[key];
-    }
-  }
-
-  // Explicit overrides for non-interactive subprocess execution
-  env.FORCE_COLOR = '1';
-  env.CLICOLOR_FORCE = '1';
-  env.TERM = process.env.TERM || 'xterm-256color';
-  env.CI = 'true';
-  env.NONINTERACTIVE = '1';
-  env.DEBIAN_FRONTEND = 'noninteractive';
-
-  return env;
+  return {
+    ...process.env,
+    // Explicit overrides for non-interactive subprocess execution
+    FORCE_COLOR: '1',
+    CLICOLOR_FORCE: '1',
+    TERM: process.env.TERM || 'xterm-256color',
+    CI: 'true',
+    NONINTERACTIVE: '1',
+    DEBIAN_FRONTEND: 'noninteractive',
+  };
 }
 
 // =============================================================================

--- a/packages/core/src/workspace/tools/__tests__/tracing.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tracing.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { startWorkspaceSpan } from '../tracing';
+
+describe('startWorkspaceSpan', () => {
+  it('redacts env-shaped fields and secret-looking keys from span input and output', () => {
+    const end = vi.fn();
+    const createChildSpan = vi.fn(() => ({ end, error: vi.fn() }));
+    const context = {
+      tracing: {
+        currentSpan: { createChildSpan },
+      },
+    } as any;
+    const workspace = { id: 'workspace-1', name: 'Workspace 1' } as any;
+
+    const span = startWorkspaceSpan(context, workspace, {
+      category: 'sandbox',
+      operation: 'executeCommand',
+      input: {
+        command: 'npm test',
+        env: {
+          MASTRACODE_TEST_ENV: 'works',
+          API_KEY: 'secret-key',
+        },
+        nested: {
+          authorization: 'Bearer secret',
+          safe: 'visible',
+        },
+      },
+    });
+
+    span.end(
+      { success: true },
+      {
+        exitCode: 0,
+        processEnv: {
+          TOKEN: 'secret-token',
+        },
+        nested: [{ password: 'secret-password', value: 'kept' }],
+      },
+    );
+
+    expect(createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: {
+          command: 'npm test',
+          env: {
+            redacted: true,
+            keys: ['API_KEY', 'MASTRACODE_TEST_ENV'],
+          },
+          nested: {
+            authorization: '[redacted]',
+            safe: 'visible',
+          },
+        },
+      }),
+    );
+    expect(end).toHaveBeenCalledWith({
+      output: {
+        exitCode: 0,
+        processEnv: {
+          redacted: true,
+          keys: ['TOKEN'],
+        },
+        nested: [{ password: '[redacted]', value: 'kept' }],
+      },
+      attributes: { success: true },
+    });
+  });
+});

--- a/packages/core/src/workspace/tools/tracing.ts
+++ b/packages/core/src/workspace/tools/tracing.ts
@@ -42,6 +42,43 @@ export interface WorkspaceSpanHandle {
   error(err: unknown, attrs?: Partial<WorkspaceActionAttributes>): void;
 }
 
+const ENV_FIELD_NAMES = new Set(['env', 'environment', 'processEnv']);
+const SECRET_FIELD_PATTERN =
+  /(^|_)(api[_-]?key|key|token|secret|password|passwd|pwd|credential|credentials|auth|authorization|cookie|session)(_|$)/i;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function redactEnv(value: unknown) {
+  return {
+    redacted: true,
+    keys: isPlainObject(value) || Array.isArray(value) ? Object.keys(value).sort() : undefined,
+  };
+}
+
+function sanitizeWorkspaceTraceData(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(item => sanitizeWorkspaceTraceData(item));
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => {
+      if (ENV_FIELD_NAMES.has(key)) {
+        return [key, redactEnv(entry)];
+      }
+      if (SECRET_FIELD_PATTERN.test(key)) {
+        return [key, '[redacted]'];
+      }
+      return [key, sanitizeWorkspaceTraceData(entry)];
+    }),
+  );
+}
+
 /**
  * Start a WORKSPACE_ACTION child span from the tool execution context.
  *
@@ -82,7 +119,7 @@ export function startWorkspaceSpan(
   const span = currentSpan.createChildSpan<SpanType.WORKSPACE_ACTION>({
     type: SpanType.WORKSPACE_ACTION,
     name: `workspace:${category}:${operation}`,
-    input,
+    input: sanitizeWorkspaceTraceData(input),
     attributes: {
       category,
       workspaceId: workspace?.id,
@@ -95,7 +132,7 @@ export function startWorkspaceSpan(
     span,
     end(attrs?: Partial<WorkspaceActionAttributes>, output?: unknown) {
       span?.end({
-        output,
+        output: sanitizeWorkspaceTraceData(output),
         attributes: {
           ...attrs,
         },


### PR DESCRIPTION
This restores MastraCode command execution so subprocesses inherit the user's environment again, while keeping traces from storing env values or obvious secrets.

Before, only allowlisted env vars reached commands, so exported values needed by tests or scripts were missing:

```ts
const env: NodeJS.ProcessEnv = {};
for (const key of SANDBOX_ENV_ALLOWLIST) {
  env[key] = process.env[key];
}
```

Now the sandbox receives the full parent env, and workspace tracing redacts env-shaped fields plus secret-looking keys before spans are recorded:

```ts
const env = {
  ...process.env,
  CI: 'true',
  NONINTERACTIVE: '1',
};
```

I added coverage for both sides: MastraCode subprocess env inheritance and core workspace trace redaction.

Verified with:

```bash
pnpm i
pnpm run prettier:changed
pnpm run lint
pnpm --dir mastracode exec vitest run src/agents/__tests__/workspace-env.test.ts
pnpm --dir packages/core exec vitest run src/workspace/tools/__tests__/tracing.test.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets sandboxed code run commands with all the environment variables from your computer (like API keys and config settings), instead of just a few pre-approved ones. However, to keep things secure, it hides all those environment variables from being recorded in logs and traces—so sensitive information doesn't accidentally get stored or leaked.

## Changes

### MastraCode Sandbox Environment Inheritance

The `buildSandboxEnv()` function in `workspace.ts` was refactored to inherit the full parent environment instead of using an allowlist. Previously, only whitelisted keys (defined in `SANDBOX_ENV_ALLOWLIST`) were copied to the sandbox. Now, the implementation spreads all of `process.env` into the sandbox environment and explicitly sets non-interactive/CI flags (`FORCE_COLOR`, `CLICOLOR_FORCE`, `TERM`, `CI`, `NONINTERACTIVE`, `DEBIAN_FRONTEND`).

### Workspace Trace Data Sanitization

Added sanitization utilities in `packages/core/src/workspace/tools/tracing.ts` that detect and redact:
- Environment variable fields (both keys and values)
- Common credential field names (password, secret, token, key, authorization, etc.)

The `startWorkspaceSpan` function now sanitizes both input and output data before recording them in traces, ensuring sensitive information isn't stored.

### Testing

Added comprehensive test coverage:
- **`workspace-env.test.ts`**: Verifies that sandboxed commands inherit parent environment variables (tests that a custom env var set in the parent is accessible within the sandbox)
- **`tracing.test.ts`**: Verifies that `startWorkspaceSpan` properly redacts environment variables and credential-like fields from trace input and output

### Packaging

Updated the changeset (`swift-shells-trace.md`) to mark both `mastracode` and `@mastra/core` as patch releases, documenting the behavior change and security improvement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->