### PR TITLE
fix: preserve streamed messages during stale initial sync

### DIFF
--- a/.changeset/preserve-streamed-messages.md
+++ b/.changeset/preserve-streamed-messages.md
@@ -1,0 +1,5 @@
+---
+@mastra/react: patch
+---
+
+Preserve locally streamed chat messages when a same-thread initial messages refresh is stale.

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -8,6 +8,7 @@ import type { ChunkType, NetworkChunkType } from '@mastra/core/stream';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MastraUIMessage } from '../lib/ai-sdk';
 import { extractRunIdFromMessages } from './extractRunIdFromMessages';
+import { resolveInitialMessagesSync } from './initial-messages-sync';
 import { convertSignalDataToBase64String } from './signal-data';
 import type { ModelSettings } from './types';
 import { finishStreamingAssistantMessage, toUIMessage } from '@/lib/ai-sdk';
@@ -109,11 +110,19 @@ export const useChat = ({
   const baseClient = useMastraClient();
   const [isRunning, setIsRunning] = useState(false);
 
+  const _lastInitialMessagesThreadId = useRef(threadId);
+
   useEffect(() => {
     const formattedMessages = resolveInitialMessages(initialMessages || []);
-    setMessages(formattedMessages);
-    _currentRunId.current = extractRunIdFromMessages(formattedMessages);
-  }, [initialMessages]);
+    const threadChanged = _lastInitialMessagesThreadId.current !== threadId;
+    _lastInitialMessagesThreadId.current = threadId;
+
+    setMessages(currentMessages => {
+      const nextMessages = resolveInitialMessagesSync({ currentMessages, formattedMessages, threadChanged });
+      _currentRunId.current = extractRunIdFromMessages(nextMessages);
+      return nextMessages;
+    });
+  }, [initialMessages, threadId]);
 
   useEffect(() => {
     _requestContext.current = propsRequestContext;

--- a/client-sdks/react/src/agent/initial-messages-sync.test.ts
+++ b/client-sdks/react/src/agent/initial-messages-sync.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { MastraUIMessage } from '../lib/ai-sdk';
+import { resolveInitialMessagesSync } from './initial-messages-sync';
+
+const message = (id: string): MastraUIMessage =>
+  ({ id, role: 'assistant', parts: [{ type: 'text', text: id }] }) as MastraUIMessage;
+
+describe('resolveInitialMessagesSync', () => {
+  it('keeps locally streamed messages when a same-thread initialMessages refresh is stale', () => {
+    const currentMessages = [message('user-1'), message('assistant-streaming')];
+    const formattedMessages = [message('user-1')];
+
+    expect(resolveInitialMessagesSync({ currentMessages, formattedMessages, threadChanged: false })).toBe(
+      currentMessages,
+    );
+  });
+
+  it('uses fetched messages when they catch up', () => {
+    const currentMessages = [message('user-1')];
+    const formattedMessages = [message('user-1'), message('assistant-persisted')];
+
+    expect(resolveInitialMessagesSync({ currentMessages, formattedMessages, threadChanged: false })).toBe(
+      formattedMessages,
+    );
+  });
+
+  it('does not preserve local messages across thread changes', () => {
+    const currentMessages = [message('old-user'), message('old-assistant')];
+    const formattedMessages = [message('new-user')];
+
+    expect(resolveInitialMessagesSync({ currentMessages, formattedMessages, threadChanged: true })).toBe(
+      formattedMessages,
+    );
+  });
+});

--- a/client-sdks/react/src/agent/initial-messages-sync.ts
+++ b/client-sdks/react/src/agent/initial-messages-sync.ts
@@ -1,0 +1,17 @@
+import type { MastraUIMessage } from '../lib/ai-sdk';
+
+export const resolveInitialMessagesSync = ({
+  currentMessages,
+  formattedMessages,
+  threadChanged,
+}: {
+  currentMessages: MastraUIMessage[];
+  formattedMessages: MastraUIMessage[];
+  threadChanged: boolean;
+}) => {
+  if (!threadChanged && currentMessages.length > formattedMessages.length) {
+    return currentMessages;
+  }
+
+  return formattedMessages;
+};


### PR DESCRIPTION
## Summary
- preserve locally streamed chat messages when a same-thread `initialMessages` refresh is stale
- keep the existing reset behavior when switching threads
- add regression coverage for stale refreshes, caught-up refreshes, and thread changes

## Why
When Mastra Studio creates a new chat thread, the route moves from `/chat/new` to the persisted thread id while the first assistant response can still be streaming or not yet fully reflected in memory. A same-thread `initialMessages` refresh with fewer messages can replace the local `useChat` state and make the first assistant response disappear from the UI.

This keeps the local streamed messages if the incoming same-thread initial sync is shorter than the current local state, while still accepting fetched messages once they catch up and still resetting normally across thread changes.

Fixes #16650.

## Tests
- `corepack pnpm --filter ./client-sdks/react test src/agent/initial-messages-sync.test.ts`
- `git diff --check HEAD~1..HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR fixes a bug where AI chat responses would flash on screen then disappear in Mastra Studio. The problem happened because the chat was being refreshed while the AI was still sending its response. The fix is simple: when the chat refreshes, it checks whether the new messages are more complete than what's already showing; if not, it keeps the current messages instead of replacing them with incomplete data.

## Changes

### New module: `resolveInitialMessagesSync`

Added a new utility function in `client-sdks/react/src/agent/initial-messages-sync.ts` that intelligently decides which message list to use:
- If the thread hasn't changed and the current local messages are more complete than the incoming messages (e.g., while streaming), it preserves the local messages
- If the incoming messages have caught up or the thread has changed, it uses the incoming messages
- This prevents loss of streamed messages during stale initial-sync refreshes while maintaining normal reset behavior on thread switches

### Updated `useChat` hook

Modified `client-sdks/react/src/agent/hooks.ts` to:
- Track the current `threadId` to detect when the user switches to a different thread
- Use `resolveInitialMessagesSync` to conditionally update messages based on whether messages are stale or the thread has changed
- Update `_currentRunId` based on the resolved message list

### Test coverage

Added comprehensive test suite in `client-sdks/react/src/agent/initial-messages-sync.test.ts` covering:
- Preserving messages when same-thread refresh is stale (fewer messages than current state)
- Accepting messages when incoming data has caught up
- Normal reset behavior when switching threads

### Documentation

Added Changeset entry for `@mastra/react` (patch release) documenting the fix.

## Related Issue

Fixes `#16650`: First assistant response disappearing in newly created chat threads after using tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->