### PR TITLE
feat(editor): add ScalekitToolProvider for AgentKit connected accounts

### DIFF
--- a/docs/src/content/en/docs/editor/tools.mdx
+++ b/docs/src/content/en/docs/editor/tools.mdx
@@ -11,7 +11,7 @@ packages:
 The editor gives you three ways to add tools to agents:
 
 - **Code tools**: Tools already registered in your Mastra instance.
-- **Integration providers**: Third-party tool platforms like Composio and Arcade.
+- **Integration providers**: Third-party tool platforms like Composio, Arcade, and Scalekit.
 - **MCP clients**: Tools from MCP servers, configured as reusable client definitions.
 
 You can manage all three sources through the Studio UI or programmatically through the server API. Non-technical team members can browse tool catalogs, add tools to agents, and test different tool combinations without code changes. Tool configurations are versioned alongside the rest of the agent, so you can roll back tool changes, compare versions, and experiment safely.
@@ -112,6 +112,37 @@ Integration providers connect external tool platforms to the editor. Once regist
 
    Arcade tools use a `Toolkit.ToolName` format (for example, `Github.GetRepository`). The provider pre-seeds common toolkits to reduce API calls during browsing.
 
+### Scalekit
+
+[Scalekit](https://scalekit.com) provides access to third-party tools through connected accounts. Uses plain HTTP with no external SDK — authentication is handled via OAuth 2.0 client credentials.
+
+1. Get credentials from your Scalekit dashboard (environment URL, client ID, and client secret).
+
+1. Register the provider in your Editor configuration:
+
+   ```typescript title="src/mastra/index.ts"
+   import { Mastra } from '@mastra/core'
+   import { MastraEditor } from '@mastra/editor'
+   import { ScalekitToolProvider } from '@mastra/editor/scalekit'
+
+   export const mastra = new Mastra({
+     agents: {
+       /* your agents */
+     },
+     editor: new MastraEditor({
+       toolProviders: {
+         scalekit: new ScalekitToolProvider({
+           envURL: process.env.SCALEKIT_ENVIRONMENT_URL!,
+           clientId: process.env.SCALEKIT_CLIENT_ID!,
+           clientSecret: process.env.SCALEKIT_CLIENT_SECRET!,
+         }),
+       },
+     }),
+   })
+   ```
+
+   Scalekit tools use a `provider_action` format (for example, `gmail_send_email`). When a user hasn't connected their third-party account, the tool execution returns an authorization URL that the user can visit to connect. Tool calls are scoped to the `resourceId` passed through request context for per-user authentication.
+
 ## MCP clients
 
 The editor lets you create stored MCP client configurations that connect to MCP servers. Once created, you can reference these clients in any agent to give it access to the server's tools.
@@ -160,5 +191,5 @@ See the [ToolProvider reference](/reference/editor/tool-provider) for the full p
 
 - [Editor overview](/docs/editor/overview): Setup and versioning.
 - [Prompts](/docs/editor/prompts): Display conditions reference for prompt blocks.
-- [ToolProvider reference](/reference/editor/tool-provider): Composio and Arcade API details.
+- [ToolProvider reference](/reference/editor/tool-provider): Composio, Arcade, and Scalekit API details.
 - [MCP overview](/docs/mcp/overview): General MCP documentation.

--- a/docs/src/content/en/reference/editor/mastra-editor.mdx
+++ b/docs/src/content/en/reference/editor/mastra-editor.mdx
@@ -47,7 +47,7 @@ export const mastra = new Mastra({
     name: 'toolProviders',
     type: 'Record<string, ToolProvider>',
     description:
-      'Integration tool providers keyed by ID (for example, Composio or Arcade). Lets agents use third-party tools added through the editor.',
+      'Integration tool providers keyed by ID (for example, Composio, Arcade, or Scalekit). Lets agents use third-party tools added through the editor.',
     isOptional: true,
     defaultValue: '{}',
   },

--- a/docs/src/content/en/reference/editor/tool-provider.mdx
+++ b/docs/src/content/en/reference/editor/tool-provider.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Reference: ToolProvider | Editor"
-description: "Documentation for the ToolProvider interface and the built-in Composio and Arcade implementations."
+description: "Documentation for the ToolProvider interface and the built-in Composio, Arcade, and Scalekit implementations."
 packages:
   - "@mastra/editor"
 ---

--- a/docs/src/content/en/reference/editor/tool-provider.mdx
+++ b/docs/src/content/en/reference/editor/tool-provider.mdx
@@ -7,7 +7,7 @@ packages:
 
 # ToolProvider
 
-The `ToolProvider` interface defines how the editor discovers and resolves integration tools from external platforms. Mastra ships with two built-in implementations: `ComposioToolProvider` and `ArcadeToolProvider`.
+The `ToolProvider` interface defines how the editor discovers and resolves integration tools from external platforms. Mastra ships with three built-in implementations: `ComposioToolProvider`, `ArcadeToolProvider`, and `ScalekitToolProvider`.
 
 See [Tools](/docs/editor/tools) for a guide on setting up tool providers.
 
@@ -128,3 +128,74 @@ Arcade tools use `Toolkit.ToolName` format: `Github.GetRepository`, `Slack.SendM
 ### Authentication
 
 Like Composio, tool execution uses `resourceId` from request context for per-user authorization. The provider maps that value to the user identity required by Arcade's auth flow.
+
+---
+
+## ScalekitToolProvider
+
+Connects to [Scalekit](https://scalekit.com) for access to third-party tools via Scalekit's AgentKit connected accounts API. Unlike the other providers, this uses plain `fetch` with no external SDK dependencies.
+
+### Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+import { ScalekitToolProvider } from '@mastra/editor/scalekit'
+
+const editor = new MastraEditor({
+  toolProviders: {
+    scalekit: new ScalekitToolProvider({
+      envURL: process.env.SCALEKIT_ENVIRONMENT_URL!,
+      clientId: process.env.SCALEKIT_CLIENT_ID!,
+      clientSecret: process.env.SCALEKIT_CLIENT_SECRET!,
+    }),
+  },
+})
+```
+
+### Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'envURL',
+    type: 'string',
+    description: 'Your Scalekit environment URL (e.g. `https://acme.scalekit.dev`).',
+  },
+  {
+    name: 'clientId',
+    type: 'string',
+    description: 'Scalekit client ID (`SCALEKIT_CLIENT_ID`).',
+  },
+  {
+    name: 'clientSecret',
+    type: 'string',
+    description: 'Scalekit client secret (`SCALEKIT_CLIENT_SECRET`).',
+  },
+]}
+/>
+
+### Tool slugs
+
+Scalekit tools use `provider_action` format: `gmail_send_email`, `slack_chat_postMessage`, `notion_create_page`.
+
+### Authentication
+
+Scalekit uses a two-layer auth model:
+
+1. **Server-to-server** — OAuth 2.0 `client_credentials` grant using `clientId` and `clientSecret`. Tokens are cached and refreshed automatically.
+1. **End-user to third-party** — When a user's tool execution fails because they haven't connected their account, the provider generates a magic link URL for account authorization. The execute function returns an object with `__authRequired: true` and an `authUrl` that the user can visit to connect their account.
+
+Like Composio and Arcade, tool execution uses `resourceId` from request context as the user identifier for per-user tool access.
+
+### Additional methods
+
+The provider exposes one method beyond the `ToolProvider` interface:
+
+```typescript
+// Generate a magic link for connecting a user's third-party account
+const { link, expiry } = await scalekit.getAuthorizationURL({
+  connector: 'gmail',
+  identifier: 'user@example.com',
+  redirectURL: 'https://myapp.com/callback', // optional
+})
+```

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -37,6 +37,16 @@
         "default": "./dist/arcade.cjs"
       }
     },
+    "./scalekit": {
+      "import": {
+        "types": "./dist/scalekit.d.ts",
+        "default": "./dist/scalekit.js"
+      },
+      "require": {
+        "types": "./dist/scalekit.d.ts",
+        "default": "./dist/scalekit.cjs"
+      }
+    },
     "./storage": {
       "import": {
         "types": "./dist/storage/index.d.ts",
@@ -53,8 +63,8 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/composio.ts src/arcade.ts src/storage/index.ts --format cjs,esm --dts",
-    "dev": "tsup src/index.ts src/composio.ts src/arcade.ts src/storage/index.ts --format cjs,esm --dts --watch",
+    "build": "tsup src/index.ts src/composio.ts src/arcade.ts src/scalekit.ts src/storage/index.ts --format cjs,esm --dts",
+    "dev": "tsup src/index.ts src/composio.ts src/arcade.ts src/scalekit.ts src/storage/index.ts --format cjs,esm --dts --watch",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/editor/src/editor-integration-tools.test.ts
+++ b/packages/editor/src/editor-integration-tools.test.ts
@@ -17,6 +17,7 @@ import { LibSQLStore } from '@mastra/libsql';
 import { MastraEditor } from './index';
 import { ComposioToolProvider } from './providers/composio';
 import { ArcadeToolProvider } from './providers/arcade';
+import { ScalekitToolProvider } from './providers/scalekit';
 
 /**
  * A mock tool provider for tests. Implements the full ToolProvider interface.
@@ -754,5 +755,127 @@ describe.skipIf(!process.env.ARCADE_API_KEY)('ArcadeToolProvider e2e (real API)'
     const tools = await agent!.listTools();
     expect(tools['Github.GetRepository']).toBeDefined();
     expect(tools['Github.GetRepository'].description).toBe('Arcade hydrated override');
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// Scalekit e2e tests — skipped unless SCALEKIT_CLIENT_ID is set
+// ---------------------------------------------------------------------------
+describe.skipIf(!process.env.SCALEKIT_CLIENT_ID)('ScalekitToolProvider e2e (real API)', () => {
+  let provider: InstanceType<typeof ScalekitToolProvider>;
+
+  beforeEach(() => {
+    provider = new ScalekitToolProvider({
+      envURL: process.env.SCALEKIT_ENV_URL ?? process.env.SCALEKIT_ENVIRONMENT_URL!,
+      clientId: process.env.SCALEKIT_CLIENT_ID!,
+      clientSecret: process.env.SCALEKIT_CLIENT_SECRET!,
+    });
+  });
+
+  it('should list toolkits (providers)', async () => {
+    const result = await provider.listToolkits();
+    expect(result.data.length).toBeGreaterThan(0);
+    for (const tk of result.data.slice(0, 3)) {
+      expect(tk.slug).toBeTruthy();
+      expect(tk.name).toBeTruthy();
+    }
+  }, 30_000);
+
+  it('should list tools with pagination', async () => {
+    const result = await provider.listTools({ perPage: 5 });
+    expect(result.data.length).toBeGreaterThan(0);
+    expect(result.data.length).toBeLessThanOrEqual(5);
+    expect(result.data[0]!.slug).toBeTruthy();
+    expect(result.pagination?.hasMore).toBeDefined();
+  }, 30_000);
+
+  it('should search tools via filter.query', async () => {
+    const result = await provider.listTools({ search: 'send', perPage: 10 });
+    expect(result.data).toBeDefined();
+  }, 30_000);
+
+  it('should get a tool schema via filter.tool_name', async () => {
+    const tools = await provider.listTools({ perPage: 1 });
+    if (tools.data.length === 0) return;
+
+    const slug = tools.data[0]!.slug;
+    const schema = await provider.getToolSchema(slug);
+    // Schema may be null for tools without input_schema
+    if (schema) {
+      expect(typeof schema).toBe('object');
+    }
+  }, 30_000);
+
+  it('should return null for nonexistent tool schema', async () => {
+    const schema = await provider.getToolSchema('fake_tool_99999');
+    expect(schema).toBeNull();
+  }, 30_000);
+
+  it('should resolve tools with description overrides', async () => {
+    const tools = await provider.listTools({ perPage: 1 });
+    if (tools.data.length === 0) return;
+
+    const slug = tools.data[0]!.slug;
+    const resolved = await provider.resolveTools(
+      [slug],
+      { [slug]: { description: 'Scalekit test override' } },
+      { userId: 'test-user@example.com' },
+    );
+
+    expect(resolved[slug]).toBeDefined();
+    expect(resolved[slug]!.id).toBe(slug);
+    expect(resolved[slug]!.description).toBe('Scalekit test override');
+    expect(typeof resolved[slug]!.execute).toBe('function');
+    expect(resolved[slug]!.inputSchema).toBeDefined();
+  }, 30_000);
+
+  it('should return empty for empty tool slugs', async () => {
+    const result = await provider.resolveTools([]);
+    expect(Object.keys(result).length).toBe(0);
+  });
+
+  it('should generate a magic link', async () => {
+    const result = await provider.getAuthorizationURL({
+      connector: 'gmail',
+      identifier: 'test-user@example.com',
+    });
+    expect(result.link).toBeTruthy();
+    expect(result.link).toMatch(/^https?:\/\//);
+  }, 30_000);
+
+  it('should hydrate a stored agent with Scalekit integration tools', async () => {
+    const tools = await provider.listTools({ perPage: 1 });
+    if (tools.data.length === 0) return;
+
+    const slug = tools.data[0]!.slug;
+    const _storage = new LibSQLStore({ id: `scalekit-e2e-${randomUUID()}`, url: ':memory:' });
+    const _editor = new MastraEditor({ toolProviders: { scalekit: provider } });
+    const _mastra = new Mastra({ storage: _storage, editor: _editor });
+    await _storage.init();
+
+    const agentsStore = await _storage.getStore('agents');
+    await agentsStore?.create({
+      agent: {
+        id: 'scalekit-e2e-agent',
+        name: 'Scalekit E2E Agent',
+        instructions: 'Test agent',
+        model: { provider: 'openai', name: 'gpt-4' },
+        integrationTools: {
+          scalekit: {
+            tools: {
+              [slug]: { description: 'Scalekit hydrated override' },
+            },
+          },
+        },
+      },
+    });
+
+    const agent = await _editor.agent.getById('scalekit-e2e-agent');
+    expect(agent).toBeInstanceOf(Agent);
+
+    const agentTools = await agent!.listTools();
+    expect(agentTools[slug]).toBeDefined();
+    expect(agentTools[slug]!.description).toBe('Scalekit hydrated override');
+    expect(typeof agentTools[slug]!.execute).toBe('function');
   }, 60_000);
 });

--- a/packages/editor/src/editor-integration-tools.test.ts
+++ b/packages/editor/src/editor-integration-tools.test.ts
@@ -759,14 +759,19 @@ describe.skipIf(!process.env.ARCADE_API_KEY)('ArcadeToolProvider e2e (real API)'
 });
 
 // ---------------------------------------------------------------------------
-// Scalekit e2e tests — skipped unless SCALEKIT_CLIENT_ID is set
+// Scalekit e2e tests — skipped unless all three env vars are set
 // ---------------------------------------------------------------------------
-describe.skipIf(!process.env.SCALEKIT_CLIENT_ID)('ScalekitToolProvider e2e (real API)', () => {
+const SCALEKIT_ENV_URL = process.env.SCALEKIT_ENV_URL ?? process.env.SCALEKIT_ENVIRONMENT_URL;
+const hasScalekitE2EEnv = Boolean(
+  SCALEKIT_ENV_URL && process.env.SCALEKIT_CLIENT_ID && process.env.SCALEKIT_CLIENT_SECRET,
+);
+
+describe.skipIf(!hasScalekitE2EEnv)('ScalekitToolProvider e2e (real API)', () => {
   let provider: InstanceType<typeof ScalekitToolProvider>;
 
   beforeEach(() => {
     provider = new ScalekitToolProvider({
-      envURL: process.env.SCALEKIT_ENV_URL ?? process.env.SCALEKIT_ENVIRONMENT_URL!,
+      envURL: SCALEKIT_ENV_URL!,
       clientId: process.env.SCALEKIT_CLIENT_ID!,
       clientSecret: process.env.SCALEKIT_CLIENT_SECRET!,
     });

--- a/packages/editor/src/providers/index.ts
+++ b/packages/editor/src/providers/index.ts
@@ -2,3 +2,5 @@ export { ComposioToolProvider } from './composio';
 export type { ComposioToolProviderConfig } from './composio';
 export { ArcadeToolProvider } from './arcade';
 export type { ArcadeToolProviderConfig } from './arcade';
+export { ScalekitToolProvider } from './scalekit';
+export type { ScalekitToolProviderConfig } from './scalekit';

--- a/packages/editor/src/providers/scalekit.ts
+++ b/packages/editor/src/providers/scalekit.ts
@@ -93,15 +93,25 @@ export class ScalekitToolProvider implements ToolProvider {
   }
 
   private async apiFetch(path: string, init?: RequestInit): Promise<Response> {
-    const token = await this.getToken();
-    return fetch(`${this.config.envURL}${path}`, {
-      ...init,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        ...(init?.headers ?? {}),
-      },
-    });
+    const doFetch = async () => {
+      const token = await this.getToken();
+      return fetch(`${this.config.envURL}${path}`, {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          ...(init?.headers ?? {}),
+        },
+      });
+    };
+
+    let res = await doFetch();
+    if (res.status === 401) {
+      this.token = null;
+      this.tokenExpiry = 0;
+      res = await doFetch();
+    }
+    return res;
   }
 
   // ── Discovery: list toolkits (providers) ────────────────────────────────
@@ -140,7 +150,7 @@ export class ScalekitToolProvider implements ToolProvider {
     const res = await this.apiFetch(`/api/v1/tools?${qs}`);
     if (!res.ok) throw new Error(`listTools failed (${res.status}): ${await res.text()}`);
 
-    const body = await res.json();
+    let body = await res.json();
     let tools: ScalekitRawTool[] = body.tools ?? [];
 
     // Provider filter fallback: if filter.provider returned 0 results,
@@ -156,6 +166,7 @@ export class ScalekitToolProvider implements ToolProvider {
         tools = (retryBody.tools ?? []).filter(
           (t: ScalekitRawTool) => t.provider?.toUpperCase().includes(upper),
         );
+        body = retryBody;
       }
     }
 
@@ -228,7 +239,7 @@ export class ScalekitToolProvider implements ToolProvider {
     }
 
     const res = await this.apiFetch(`/api/v1/tools?${qs}`);
-    if (!res.ok) return {};
+    if (!res.ok) throw new Error(`resolveTools failed (${res.status}): ${await res.text()}`);
 
     const body = await res.json();
     const rawTools: ScalekitRawTool[] = body.tools ?? [];

--- a/packages/editor/src/providers/scalekit.ts
+++ b/packages/editor/src/providers/scalekit.ts
@@ -1,0 +1,355 @@
+import type {
+  ToolProvider,
+  ToolProviderInfo,
+  ToolProviderToolkit,
+  ToolProviderToolInfo,
+  ToolProviderListResult,
+  ListToolProviderToolsOptions,
+  ResolveToolProviderToolsOptions,
+} from '@mastra/core/tool-provider';
+import type { ToolAction } from '@mastra/core/tools';
+import type { StorageToolConfig } from '@mastra/core/storage';
+import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
+import { convertSchemaToZod } from '@mastra/schema-compat';
+
+export interface ScalekitToolProviderConfig {
+  /** Scalekit environment URL (e.g. https://acme.scalekit.dev) */
+  envURL: string;
+  /** Scalekit client ID */
+  clientId: string;
+  /** Scalekit client secret */
+  clientSecret: string;
+}
+
+/** Raw tool object from the Scalekit API. */
+interface ScalekitRawTool {
+  id: string;
+  provider: string;
+  definition?: {
+    name?: string;
+    display_name?: string;
+    description?: string;
+    input_schema?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Scalekit tool provider adapter.
+ *
+ * Uses plain `fetch` against the Scalekit AgentKit REST API — zero external
+ * SDK dependencies. Auth is OAuth 2.0 client_credentials with cached tokens.
+ *
+ * Discovery methods use filter params discovered from the Scalekit Node SDK
+ * protobuf types and MCP server source:
+ *   - `filter.provider`   — toolkit filter (with client-side fallback)
+ *   - `filter.query`      — server-side text search
+ *   - `filter.tool_name`  — exact tool name lookup (eliminates schema cache)
+ *
+ * Runtime method (`resolveTools`) fetches tool definitions in a single batch
+ * call, converts JSON Schema inputs to Zod via `@mastra/schema-compat`, and
+ * wraps each tool as a Mastra `ToolAction` with an execute-or-authorize pattern.
+ */
+export class ScalekitToolProvider implements ToolProvider {
+  readonly info: ToolProviderInfo = {
+    id: 'scalekit',
+    name: 'Scalekit',
+    description: 'Access third-party tools via Scalekit connected accounts',
+  };
+
+  private config: ScalekitToolProviderConfig;
+  private token: string | null = null;
+  private tokenExpiry: number = 0;
+
+  constructor(config: ScalekitToolProviderConfig) {
+    this.config = config;
+  }
+
+  // ── OAuth token management ──────────────────────────────────────────────
+
+  private async getToken(): Promise<string> {
+    if (this.token && Date.now() < this.tokenExpiry) return this.token;
+
+    const res = await fetch(`${this.config.envURL}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: this.config.clientId,
+        client_secret: this.config.clientSecret,
+        grant_type: 'client_credentials',
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Scalekit token request failed (${res.status}): ${body}`);
+    }
+
+    const data = await res.json();
+    this.token = data.access_token;
+    this.tokenExpiry = Date.now() + (data.expires_in - 60) * 1000;
+    return this.token!;
+  }
+
+  private async apiFetch(path: string, init?: RequestInit): Promise<Response> {
+    const token = await this.getToken();
+    return fetch(`${this.config.envURL}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        ...(init?.headers ?? {}),
+      },
+    });
+  }
+
+  // ── Discovery: list toolkits (providers) ────────────────────────────────
+
+  async listToolkits(): Promise<ToolProviderListResult<ToolProviderToolkit>> {
+    const res = await this.apiFetch('/api/v1/providers?page_size=100');
+    if (!res.ok) throw new Error(`listToolkits failed (${res.status}): ${await res.text()}`);
+
+    const body = await res.json();
+    const providers = body.providers ?? [];
+    const data: ToolProviderToolkit[] = providers.map((p: any) => ({
+      slug: p.identifier,
+      name: p.display_name,
+      description: p.description ?? '',
+      icon: p.icon_src,
+    }));
+
+    return {
+      data,
+      pagination: {
+        total: body.total_size,
+        hasMore: !!body.next_page_token,
+      },
+    };
+  }
+
+  // ── Discovery: list tools ───────────────────────────────────────────────
+
+  async listTools(options?: ListToolProviderToolsOptions): Promise<ToolProviderListResult<ToolProviderToolInfo>> {
+    const perPage = options?.perPage ?? 50;
+    const qs = new URLSearchParams({ page_size: String(perPage) });
+
+    if (options?.toolkit) qs.set('filter.provider', options.toolkit);
+    if (options?.search) qs.set('filter.query', options.search);
+
+    const res = await this.apiFetch(`/api/v1/tools?${qs}`);
+    if (!res.ok) throw new Error(`listTools failed (${res.status}): ${await res.text()}`);
+
+    const body = await res.json();
+    let tools: ScalekitRawTool[] = body.tools ?? [];
+
+    // Provider filter fallback: if filter.provider returned 0 results,
+    // retry without it and match client-side (from MCP server pattern).
+    if (options?.toolkit && tools.length === 0) {
+      const retryQs = new URLSearchParams({ page_size: String(perPage) });
+      if (options?.search) retryQs.set('filter.query', options.search);
+
+      const retryRes = await this.apiFetch(`/api/v1/tools?${retryQs}`);
+      if (retryRes.ok) {
+        const retryBody = await retryRes.json();
+        const upper = options.toolkit.toUpperCase();
+        tools = (retryBody.tools ?? []).filter(
+          (t: ScalekitRawTool) => t.provider?.toUpperCase().includes(upper),
+        );
+      }
+    }
+
+    let mapped: ToolProviderToolInfo[] = tools.map(t => ({
+      slug: t.definition?.name ?? t.id,
+      name: t.definition?.display_name ?? t.definition?.name ?? t.id,
+      description: t.definition?.description ?? '',
+      toolkit: t.provider,
+    }));
+
+    // Client-side search as safety net alongside server-side filter.query
+    if (options?.search) {
+      const q = options.search.toLowerCase();
+      mapped = mapped.filter(
+        t =>
+          t.slug.toLowerCase().includes(q) ||
+          t.name.toLowerCase().includes(q) ||
+          (t.description?.toLowerCase().includes(q) ?? false),
+      );
+    }
+
+    return {
+      data: mapped,
+      pagination: {
+        total: body.total_size,
+        perPage,
+        hasMore: !!body.next_page_token,
+      },
+    };
+  }
+
+  // ── Discovery: get tool schema ──────────────────────────────────────────
+
+  async getToolSchema(toolSlug: string): Promise<Record<string, unknown> | null> {
+    try {
+      const qs = new URLSearchParams({
+        page_size: '1',
+        'filter.tool_name': toolSlug,
+      });
+      const res = await this.apiFetch(`/api/v1/tools?${qs}`);
+      if (!res.ok) return null;
+
+      const body = await res.json();
+      const tools: ScalekitRawTool[] = body.tools ?? [];
+      const match = tools.find(t => t.definition?.name === toolSlug) ?? tools[0];
+      if (!match?.definition?.input_schema) return null;
+
+      return match.definition.input_schema as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Runtime: resolve executable tools ───────────────────────────────────
+
+  async resolveTools(
+    toolSlugs: string[],
+    toolConfigs?: Record<string, StorageToolConfig>,
+    options?: ResolveToolProviderToolsOptions,
+  ): Promise<Record<string, ToolAction<any, any, any>>> {
+    if (toolSlugs.length === 0) return {};
+
+    const resourceId = options?.requestContext?.[MASTRA_RESOURCE_ID_KEY];
+    const identifier = typeof resourceId === 'string' ? resourceId : (options?.userId ?? 'default');
+
+    // Batch-fetch tool definitions using repeated filter.tool_name params
+    const qs = new URLSearchParams({ page_size: String(Math.max(toolSlugs.length, 20)) });
+    for (const name of toolSlugs) {
+      qs.append('filter.tool_name', name);
+    }
+
+    const res = await this.apiFetch(`/api/v1/tools?${qs}`);
+    if (!res.ok) return {};
+
+    const body = await res.json();
+    const rawTools: ScalekitRawTool[] = body.tools ?? [];
+
+    // Index by definition name for O(1) lookup
+    const toolsByName = new Map<string, ScalekitRawTool>();
+    for (const t of rawTools) {
+      const name = t.definition?.name;
+      if (name) toolsByName.set(name, t);
+    }
+
+    const result: Record<string, ToolAction<any, any, any>> = {};
+
+    for (const slug of toolSlugs) {
+      const raw = toolsByName.get(slug);
+      if (!raw?.definition) continue;
+
+      const descOverride = toolConfigs?.[slug]?.description;
+      const description = descOverride ?? raw.definition.description ?? '';
+      const connector = raw.provider;
+
+      // Convert JSON Schema to Zod using @mastra/schema-compat
+      const inputSchema = raw.definition.input_schema
+        ? convertSchemaToZod(raw.definition.input_schema as Record<string, unknown>)
+        : undefined;
+
+      result[slug] = {
+        id: slug,
+        description,
+        inputSchema: inputSchema as ToolAction<any, any, any>['inputSchema'],
+        execute: async ({ context }: { context: Record<string, unknown> }) => {
+          return this.executeToolInternal({
+            toolName: slug,
+            input: context,
+            identifier,
+            connector,
+          });
+        },
+      };
+    }
+
+    return result;
+  }
+
+  // ── Internal: execute with execute-or-authorize pattern ─────────────────
+
+  private async executeToolInternal(params: {
+    toolName: string;
+    input: Record<string, unknown>;
+    identifier: string;
+    connector?: string;
+  }): Promise<unknown> {
+    const res = await this.apiFetch('/api/v1/execute_tool', {
+      method: 'POST',
+      body: JSON.stringify({
+        tool_name: params.toolName,
+        identifier: params.identifier,
+        params: params.input,
+        ...(params.connector && { connector: params.connector }),
+      }),
+    });
+
+    if (!res.ok) {
+      const errorBody = await res.text();
+
+      // Check if this is an auth error — try to generate a magic link
+      const isAuthError = res.status === 400 || res.status === 404 || res.status === 403;
+      const errLower = errorBody.toLowerCase();
+      const looksLikeAuthIssue =
+        errLower.includes('connected_account') ||
+        errLower.includes('not_found') ||
+        errLower.includes('not found') ||
+        errLower.includes('authorization') ||
+        errLower.includes('not authorized') ||
+        errLower.includes('identifier');
+
+      if (isAuthError && looksLikeAuthIssue) {
+        const connector = params.connector ?? params.toolName.split('_')[0] ?? 'unknown';
+        try {
+          const authResult = await this.getAuthorizationURL({
+            connector,
+            identifier: params.identifier,
+          });
+          return {
+            __authRequired: true,
+            authUrl: authResult.link,
+            expiry: authResult.expiry,
+            connector,
+            message: `User "${params.identifier}" needs to connect their ${connector} account.`,
+          };
+        } catch {
+          // Magic link generation also failed — throw the original error
+        }
+      }
+
+      throw new Error(`executeTool(${params.toolName}) failed (${res.status}): ${errorBody}`);
+    }
+
+    const result = await res.json();
+    return result.data ?? result;
+  }
+
+  // ── Auth: magic link for connecting accounts ────────────────────────────
+
+  async getAuthorizationURL(params: {
+    connector: string;
+    identifier: string;
+    redirectURL?: string;
+    state?: string;
+  }): Promise<{ link: string; expiry: string }> {
+    const res = await this.apiFetch('/api/v1/connected_accounts/magic_link', {
+      method: 'POST',
+      body: JSON.stringify({
+        connector: params.connector,
+        identifier: params.identifier,
+        ...(params.redirectURL && { redirect_url: params.redirectURL }),
+        ...(params.state && { state: params.state }),
+      }),
+    });
+
+    if (!res.ok) throw new Error(`magic_link failed (${res.status}): ${await res.text()}`);
+    return await res.json();
+  }
+}

--- a/packages/editor/src/scalekit.ts
+++ b/packages/editor/src/scalekit.ts
@@ -1,0 +1,2 @@
+export { ScalekitToolProvider } from './providers/scalekit';
+export type { ScalekitToolProviderConfig } from './providers/scalekit';


### PR DESCRIPTION
Closes #16703

## What

Adds Scalekit as a third tool provider in `@mastra/editor`, alongside Composio and Arcade. Enables Mastra agents to discover and execute third-party tools (Gmail, Slack, Notion, etc.) via Scalekit's AgentKit connected accounts API.

## Why

Scalekit provides connected accounts infrastructure for AI agents. Adding it as a built-in provider lets Mastra users browse toolkits, select tools in Studio, and execute them on behalf of end-users through Scalekit's OAuth-managed connections.

## How

A `ScalekitToolProvider` class that implements the `ToolProvider` interface using plain `fetch` — **zero new npm dependencies**.

```typescript
import { ScalekitToolProvider } from '@mastra/editor/scalekit'

const editor = new MastraEditor({
  toolProviders: {
    scalekit: new ScalekitToolProvider({
      envURL: process.env.SCALEKIT_ENVIRONMENT_URL!,
      clientId: process.env.SCALEKIT_CLIENT_ID!,
      clientSecret: process.env.SCALEKIT_CLIENT_SECRET!,
    }),
  },
})
```

### Key design choices

- **Zero external dependencies** — pure `fetch` + OAuth 2.0 `client_credentials` 
- **`filter.tool_name`** for direct single-tool lookup — no schema cache needed
- **`filter.query`** for server-side search with client-side fallback
- **Provider filter fallback** when `filter.provider` returns 0 results (retry without filter, match client-side)
- **Execute-or-authorize pattern** — on auth error, generates a magic link URL instead of throwing
- **JSON Schema → Zod** via `@mastra/schema-compat` (already a dependency)

## Files changed

| File | Change |
|------|--------|
| `packages/editor/src/providers/scalekit.ts` | New — provider implementation (~270 lines) |
| `packages/editor/src/scalekit.ts` | New — barrel export |
| `packages/editor/src/providers/index.ts` | Added re-export |
| `packages/editor/package.json` | Added `./scalekit` export entry + build script |
| `packages/editor/src/editor-integration-tools.test.ts` | Added 9 e2e tests (gated on `SCALEKIT_CLIENT_ID` env var) |
| `docs/.../tool-provider.mdx` | Added ScalekitToolProvider reference docs |
| `docs/.../tools.mdx` | Added Scalekit guide section alongside Composio/Arcade |
| `docs/.../mastra-editor.mdx` | Updated toolProviders description |

## Testing

- All existing editor tests pass (372 passed, 22 skipped)
- 9 Scalekit e2e tests pass against live environment when `SCALEKIT_*` env vars are set
- Tested via external project importing from `@mastra/editor/scalekit` (10/10 passed)
- TypeScript compiles clean (`tsc --noEmit`)
- Build produces `scalekit.js`, `scalekit.cjs`, `scalekit.d.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR adds Scalekit as a new "tool provider" to Mastra's editor—think of it like adding a new app store where AI agents can discover and use tools like Gmail, Slack, and Notion. Users can browse these tools, pick the ones they want, and the AI agent gets permission to use them on their behalf (via secure login links).

---

## Changes Overview

This pull request adds **Scalekit** as a built-in tool provider in `@mastra/editor`, the third provider alongside Composio and Arcade. It enables Mastra agents to discover, search, and execute third-party tools (Gmail, Slack, Notion, etc.) through Scalekit's AgentKit REST API.

### Key Features

- **Zero new runtime dependencies**: Uses plain `fetch` with OAuth 2.0 client_credentials flow for authentication
- **Intelligent search and filtering**: Server-side search with client-side fallback; provider-filter fallback when queries return zero results
- **Authorization handling**: Execute-or-authorize pattern that returns a magic link URL when users lack connected accounts
- **Schema conversion**: Converts Scalekit's JSON Schema tool definitions to Zod via `@mastra/schema-compat`
- **Comprehensive toolkit discovery**: Methods to list toolkits, list tools with pagination, search, and fetch tool schemas

### Code Changes

**New Files:**
- `packages/editor/src/providers/scalekit.ts`: Core `ScalekitToolProvider` implementation (366 lines)
  - OAuth 2.0 client_credentials authentication with cached tokens
  - REST API methods: `listToolkits()`, `listTools()`, `getToolSchema()`, `resolveTools()`, `getAuthorizationURL()`
  - Tool execution with auth fallback handling
- `packages/editor/src/scalekit.ts`: Public re-export module

**Modified Files:**
- `packages/editor/package.json`: Added subpath export `./scalekit` with ESM/CJS entrypoints; updated build/dev scripts to include `src/scalekit.ts`
- `packages/editor/src/providers/index.ts`: Added re-exports for `ScalekitToolProvider` and `ScalekitToolProviderConfig`
- `packages/editor/src/editor-integration-tools.test.ts`: Added 9 gated e2e tests exercising toolkit listing, tool search, schema fetching, tool resolution, and magic link generation (requires `SCALEKIT_ENV_URL`/`SCALEKIT_ENVIRONMENT_URL`, `SCALEKIT_CLIENT_ID`, `SCALEKIT_CLIENT_SECRET` env vars)

**Documentation Updates:**
- `docs/src/content/en/docs/editor/tools.mdx`: Added Scalekit integration section with installation, configuration, and behavior documentation (+33 lines)
- `docs/src/content/en/reference/editor/tool-provider.mdx`: Added `ScalekitToolProvider` reference documentation including usage example, constructor parameters, authentication model, and tool slug format (+73 lines)
- `docs/src/content/en/reference/editor/mastra-editor.mdx`: Updated `MastraEditor` constructor docs to include Scalekit as example tool-provider ID

### Public API

**New Exported Entities:**
- `ScalekitToolProvider` class implementing `ToolProvider` interface
- `ScalekitToolProviderConfig` type with fields: `envURL`, `clientId`, `clientSecret`

### Testing

- E2E test suite validates: toolkit listing, tool pagination, search, schema retrieval, tool resolution with description overrides, authorization URL generation, and agent hydration with Scalekit tools
- Tests are gated on all required Scalekit environment variables
- Existing tests pass (372 passed, 22 skipped); new tests pass against live environment when env vars are set

### Notable Design Decisions

1. **Filter behavior**: Uses `filter.tool_name` for single-tool lookup; `filter.query` for server-side search; falls back to provider-filtered queries when zero results returned
2. **Auth errors**: Returns structured `{ __authRequired, authUrl, expiry, connector, message }` response to guide user auth flow instead of throwing immediately
3. **Token caching**: Implements cached OAuth token refresh to minimize API calls
4. **No external deps**: All functionality achieved with platform-level APIs and existing `@mastra/schema-compat` dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->