### PR TITLE
draft: Add observability capabilities endpoint

### DIFF
--- a/.changeset/quick-cats-hide.md
+++ b/.changeset/quick-cats-hide.md
@@ -4,4 +4,17 @@
 'mastra': patch
 ---
 
-Added GET /observability/capabilities endpoint that reports which observability features the connected storage provider supports. The response includes the store class name and a boolean map keyed by storage method names (such as getEntityNames, getMetricAggregate, getTags). UIs can use this to disable or hide filters and panels that the connected store does not implement, rather than discovering unsupported features through 500 errors on the /observability/discovery/\* endpoints.
+Added `GET /observability/capabilities` endpoint that returns the list of observability HTTP endpoints supported by the current server configuration. Support is determined by combining the installed `@mastra/core` feature flags, the installed `@mastra/observability` feature flags, and the methods implemented by the connected observability storage adapter. UIs can call this once on load and hide or disable filters and panels that the server cannot back, instead of waiting for 500 errors from `/observability/discovery/*` calls.
+
+```ts
+// Example response shape
+{
+  storeProvider: 'ObservabilityPG',
+  endpoints: [
+    { method: 'GET', path: '/observability/traces' },
+    { method: 'GET', path: '/observability/traces/:traceId' },
+    { method: 'GET', path: '/observability/discovery/tags' },
+    // ...only endpoints whose dependencies are satisfied
+  ]
+}
+```

--- a/.changeset/quick-cats-hide.md
+++ b/.changeset/quick-cats-hide.md
@@ -1,0 +1,7 @@
+---
+'@mastra/server': minor
+'@mastra/client-js': patch
+'mastra': patch
+---
+
+Added GET /observability/capabilities endpoint that reports which observability features the connected storage provider supports. The response includes the store class name and a boolean map keyed by storage method names (such as getEntityNames, getMetricAggregate, getTags). UIs can use this to disable or hide filters and panels that the connected store does not implement, rather than discovering unsupported features through 500 errors on the /observability/discovery/\* endpoints.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -16737,6 +16737,33 @@ export interface GetObservabilityDiscoveryTags_RouteContract {
 }
 
 // ============================================================================
+// Route: GET /observability/capabilities
+// ============================================================================
+export type GetObservabilityCapabilities_Response = {
+  /** Constructor name of the connected observability store, or null if no observability storage is configured */
+  storeProvider: string | null;
+  /** Map of observability method names to whether the connected storage provider supports them */
+  features: {
+    [key: string]: boolean;
+  };
+};
+
+export type GetObservabilityCapabilities_Request = Simplify<
+  (never extends never ? {} : { params: never }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface GetObservabilityCapabilities_RouteContract {
+  pathParams: never;
+  queryParams: never;
+  body: never;
+  request: GetObservabilityCapabilities_Request;
+  response: GetObservabilityCapabilities_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
 // Route: GET /logs/transports
 // ============================================================================
 export type GetLogsTransports_Response = {
@@ -75151,6 +75178,7 @@ export interface RouteTypes {
   'GET /observability/discovery/service-names': GetObservabilityDiscoveryServiceNames_RouteContract;
   'GET /observability/discovery/environments': GetObservabilityDiscoveryEnvironments_RouteContract;
   'GET /observability/discovery/tags': GetObservabilityDiscoveryTags_RouteContract;
+  'GET /observability/capabilities': GetObservabilityCapabilities_RouteContract;
   'GET /logs/transports': GetLogsTransports_RouteContract;
   'GET /logs': GetLogs_RouteContract;
   'GET /logs/:runId': GetLogsRunId_RouteContract;
@@ -75656,6 +75684,9 @@ export interface Client {
   };
   '/observability/branches': {
     GET: GetObservabilityBranches_RouteContract;
+  };
+  '/observability/capabilities': {
+    GET: GetObservabilityCapabilities_RouteContract;
   };
   '/observability/discovery/entity-names': {
     GET: GetObservabilityDiscoveryEntityNames_RouteContract;

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -16740,12 +16740,15 @@ export interface GetObservabilityDiscoveryTags_RouteContract {
 // Route: GET /observability/capabilities
 // ============================================================================
 export type GetObservabilityCapabilities_Response = {
-  /** Constructor name of the connected observability store, or null if no observability storage is configured */
+  /** Constructor name of the connected observability storage adapter, or null when no observability storage is configured */
   storeProvider: string | null;
-  /** Map of observability method names to whether the connected storage provider supports them */
-  features: {
-    [key: string]: boolean;
-  };
+  /** Observability HTTP endpoints supported by the current server configuration. Considers installed @mastra/core features, installed @mastra/observability features, and the methods implemented by the connected observability storage adapter. */
+  endpoints: {
+    /** HTTP method for the endpoint */
+    method: string;
+    /** HTTP path for the endpoint (relative to the server base, e.g. /observability/traces) */
+    path: string;
+  }[];
 };
 
 export type GetObservabilityCapabilities_Request = Simplify<

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -2342,7 +2342,8 @@ export const API_ROUTE_METADATA = {
     "hasQuery": false,
     "hasBody": false,
     "responseShape": {
-      "kind": "single"
+      "kind": "object-property",
+      "listProperty": "endpoints"
     }
   },
   "GET /logs/transports": {

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -2333,6 +2333,18 @@ export const API_ROUTE_METADATA = {
       "listProperty": "tags"
     }
   },
+  "GET /observability/capabilities": {
+    "method": "GET",
+    "path": "/observability/capabilities",
+    "pathParams": [],
+    "queryParams": [],
+    "bodyParams": [],
+    "hasQuery": false,
+    "hasBody": false,
+    "responseShape": {
+      "kind": "single"
+    }
+  },
   "GET /logs/transports": {
     "method": "GET",
     "path": "/logs/transports",

--- a/packages/server/src/server/handlers/observability-new-endpoints.ts
+++ b/packages/server/src/server/handlers/observability-new-endpoints.ts
@@ -65,8 +65,8 @@ import type { InferParams, ServerContext, ServerRouteHandler } from '../server-a
 import { createRoute, pickParams, wrapSchemaForQueryParams } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
 import {
-  detectObservabilityFeatures,
   getObservabilityStore,
+  getSupportedObservabilityEndpoints,
   NEW_ROUTE_DEFS,
   tryGetObservabilityStore,
 } from './observability-shared';
@@ -419,28 +419,46 @@ export const GET_TAGS = createNewRoute(NEW_ROUTE_DEFS.GET_TAGS, {
 // Capabilities Route
 // ============================================================================
 
-const observabilityFeatureMapSchema = z.record(z.string(), z.boolean());
+const observabilityEndpointSchema = z.object({
+  method: z.string().describe('HTTP method for the endpoint'),
+  path: z.string().describe('HTTP path for the endpoint (relative to the server base, e.g. /observability/traces)'),
+});
 
 const observabilityCapabilitiesResponseSchema = z.object({
   storeProvider: z
     .string()
     .nullable()
     .describe(
-      'Constructor name of the connected observability store, or null if no observability storage is configured',
+      'Constructor name of the connected observability storage adapter, or null when no observability storage is configured',
     ),
-  features: observabilityFeatureMapSchema.describe(
-    'Map of observability method names to whether the connected storage provider supports them',
-  ),
+  endpoints: z
+    .array(observabilityEndpointSchema)
+    .describe(
+      'Observability HTTP endpoints supported by the current server configuration. Considers installed @mastra/core features, installed @mastra/observability features, and the methods implemented by the connected observability storage adapter.',
+    ),
 });
 
-export const GET_CAPABILITIES = createNewRoute(NEW_ROUTE_DEFS.GET_CAPABILITIES, {
+// Defined via createRoute (not createNewRoute) so it remains callable on older
+// @mastra/core versions that lack the `observability:v1.13.2` feature flag --
+// otherwise the UI couldn't ask "is the new API supported?" without already
+// knowing the answer.
+export const GET_CAPABILITIES = createRoute({
+  ...NEW_ROUTE_DEFS.GET_CAPABILITIES,
+  responseType: 'json',
   responseSchema: observabilityCapabilitiesResponseSchema,
+  tags: ['Observability'],
+  requiresAuth: true,
   handler: async ({ mastra }) => {
-    const store = await tryGetObservabilityStore(mastra);
-    return {
-      storeProvider: store ? store.constructor.name : null,
-      features: detectObservabilityFeatures(store),
-    };
+    try {
+      const store = await tryGetObservabilityStore(mastra);
+      const endpoints = await getSupportedObservabilityEndpoints(mastra);
+      return {
+        storeProvider: store ? store.constructor.name : null,
+        endpoints,
+      };
+    } catch (error) {
+      return handleError(error, "Error calling: 'get observability capabilities'");
+    }
   },
 });
 

--- a/packages/server/src/server/handlers/observability-new-endpoints.ts
+++ b/packages/server/src/server/handlers/observability-new-endpoints.ts
@@ -64,7 +64,12 @@ import { HTTPException } from '../http-exception';
 import type { InferParams, ServerContext, ServerRouteHandler } from '../server-adapter/routes';
 import { createRoute, pickParams, wrapSchemaForQueryParams } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
-import { getObservabilityStore, NEW_ROUTE_DEFS } from './observability-shared';
+import {
+  detectObservabilityFeatures,
+  getObservabilityStore,
+  NEW_ROUTE_DEFS,
+  tryGetObservabilityStore,
+} from './observability-shared';
 import type { RouteDetails } from './observability-shared';
 
 function createNewRoute<
@@ -410,6 +415,35 @@ export const GET_TAGS = createNewRoute(NEW_ROUTE_DEFS.GET_TAGS, {
   },
 });
 
+// ============================================================================
+// Capabilities Route
+// ============================================================================
+
+const observabilityFeatureMapSchema = z.record(z.string(), z.boolean());
+
+const observabilityCapabilitiesResponseSchema = z.object({
+  storeProvider: z
+    .string()
+    .nullable()
+    .describe(
+      'Constructor name of the connected observability store, or null if no observability storage is configured',
+    ),
+  features: observabilityFeatureMapSchema.describe(
+    'Map of observability method names to whether the connected storage provider supports them',
+  ),
+});
+
+export const GET_CAPABILITIES = createNewRoute(NEW_ROUTE_DEFS.GET_CAPABILITIES, {
+  responseSchema: observabilityCapabilitiesResponseSchema,
+  handler: async ({ mastra }) => {
+    const store = await tryGetObservabilityStore(mastra);
+    return {
+      storeProvider: store ? store.constructor.name : null,
+      features: detectObservabilityFeatures(store),
+    };
+  },
+});
+
 export const NEW_ROUTES = {
   LIST_LOGS,
   LIST_SCORES,
@@ -437,4 +471,5 @@ export const NEW_ROUTES = {
   GET_SERVICE_NAMES,
   GET_ENVIRONMENTS,
   GET_TAGS,
+  GET_CAPABILITIES,
 };

--- a/packages/server/src/server/handlers/observability-shared.ts
+++ b/packages/server/src/server/handlers/observability-shared.ts
@@ -1,5 +1,6 @@
 import type { Mastra } from '@mastra/core';
-import { ObservabilityStorage } from '@mastra/core/storage';
+import { coreFeatures } from '@mastra/core/features';
+import { ObservabilityStorage, ScoresStorage } from '@mastra/core/storage';
 import type { MastraCompositeStore } from '@mastra/core/storage';
 import { HTTPException } from '../http-exception';
 import type { ServerRoute } from '../server-adapter/routes';
@@ -33,103 +34,334 @@ export async function tryGetObservabilityStore(mastra: Mastra): Promise<Observab
   return storage.getStore('observability');
 }
 
-/**
- * Methods on ObservabilityStorage whose default base-class implementation throws
- * NOT_IMPLEMENTED. A storage adapter "supports" a method when its prototype
- * entry differs from the base class entry (i.e. the subclass overrode it).
- *
- * Note: `getStructure` and `getTraceLight` are aliases that delegate to each
- * other; overriding either one provides both. `getBranch` has a default
- * implementation that works when the underlying methods it delegates to are
- * implemented, so it's reported separately based on its direct override status.
- */
-const OBSERVABILITY_METHOD_NAMES = [
-  // Tracing - reads
-  'listTraces',
-  'listTracesLight',
-  'listBranches',
-  'getTrace',
-  'getStructure',
-  'getTraceLight',
-  'getSpan',
-  'getSpans',
-  'getRootSpan',
-  'getBranch',
-  // Tracing - writes
-  'createSpan',
-  'updateSpan',
-  'batchCreateSpans',
-  'batchUpdateSpans',
-  'batchDeleteTraces',
-  // Logs
-  'listLogs',
-  'batchCreateLogs',
-  // Metrics
-  'listMetrics',
-  'batchCreateMetrics',
-  'getMetricAggregate',
-  'getMetricBreakdown',
-  'getMetricTimeSeries',
-  'getMetricPercentiles',
-  // Scores
-  'listScores',
-  'createScore',
-  'batchCreateScores',
-  'getScoreById',
-  'getScoreAggregate',
-  'getScoreBreakdown',
-  'getScoreTimeSeries',
-  'getScorePercentiles',
-  // Feedback
-  'listFeedback',
-  'createFeedback',
-  'batchCreateFeedback',
-  'getFeedbackAggregate',
-  'getFeedbackBreakdown',
-  'getFeedbackTimeSeries',
-  'getFeedbackPercentiles',
-  // Discovery
-  'getMetricNames',
-  'getMetricLabelKeys',
-  'getMetricLabelValues',
-  'getEntityTypes',
-  'getEntityNames',
-  'getServiceNames',
-  'getEnvironments',
-  'getTags',
-] as const satisfies ReadonlyArray<keyof ObservabilityStorage>;
-
-export type ObservabilityFeatureName = (typeof OBSERVABILITY_METHOD_NAMES)[number];
-export type ObservabilityFeatureMap = Record<ObservabilityFeatureName, boolean>;
-
-/**
- * Detects which observability features the connected store supports by
- * comparing method references against the base ObservabilityStorage prototype.
- *
- * The base class provides default `throw NOT_IMPLEMENTED` stubs for every
- * method; subclasses override only what they support. When `store` is
- * undefined (no observability storage configured), every feature reports as
- * unsupported.
- */
-export function detectObservabilityFeatures(store: ObservabilityStorage | undefined): ObservabilityFeatureMap {
-  const basePrototype = ObservabilityStorage.prototype as unknown as Record<string, unknown>;
-  const features = {} as ObservabilityFeatureMap;
-  for (const method of OBSERVABILITY_METHOD_NAMES) {
-    if (!store) {
-      features[method] = false;
-      continue;
-    }
-    const concrete = (store as unknown as Record<string, unknown>)[method];
-    features[method] = typeof concrete === 'function' && concrete !== basePrototype[method];
-  }
-  // getStructure and getTraceLight delegate to each other in the base class:
-  // overriding either provides the capability for both.
-  if (features.getStructure || features.getTraceLight) {
-    features.getStructure = true;
-    features.getTraceLight = true;
-  }
-  return features;
+/** Retrieves the scores storage domain, or undefined if not configured. Does not throw. */
+async function tryGetScoresStore(mastra: Mastra): Promise<ScoresStorage | undefined> {
+  const storage = mastra.getStorage();
+  if (!storage) return undefined;
+  return storage.getStore('scores');
 }
+
+/**
+ * Returns true when the concrete observability store overrides the named
+ * method (i.e. its prototype entry differs from the base class entry).
+ *
+ * The base class throws NOT_IMPLEMENTED for every method; subclasses override
+ * only what they implement, so a prototype-level override is the canonical
+ * signal that the adapter actually supports the operation.
+ *
+ * `getStructure` and `getTraceLight` are aliases -- the base class
+ * implementations delegate to each other -- so overriding either is treated
+ * as supporting both.
+ */
+function isStorageMethodSupported(
+  store: ObservabilityStorage | undefined,
+  method: keyof ObservabilityStorage,
+): boolean {
+  if (!store) return false;
+  const basePrototype = ObservabilityStorage.prototype as unknown as Record<string, unknown>;
+  const concrete = (store as unknown as Record<string, unknown>)[method as string];
+  const overridden = typeof concrete === 'function' && concrete !== basePrototype[method as string];
+  if (overridden) return true;
+  if (method === 'getStructure') return isStorageMethodSupported(store, 'getTraceLight');
+  if (method === 'getTraceLight') {
+    const altConcrete = (store as unknown as Record<string, unknown>).getStructure;
+    return typeof altConcrete === 'function' && altConcrete !== basePrototype.getStructure;
+  }
+  return false;
+}
+
+/**
+ * Returns true when the concrete scores store overrides the named method.
+ * Mirrors {@link isStorageMethodSupported} but for the scores domain.
+ *
+ * `listScoresBySpan` is the only non-abstract method on ScoresStorage with a
+ * throwing default; the other methods are abstract and therefore always
+ * implemented by any concrete subclass.
+ */
+function isScoresMethodSupported(store: ScoresStorage | undefined, method: keyof ScoresStorage): boolean {
+  if (!store) return false;
+  const basePrototype = ScoresStorage.prototype as unknown as Record<string, unknown>;
+  const concrete = (store as unknown as Record<string, unknown>)[method as string];
+  return typeof concrete === 'function' && concrete !== basePrototype[method as string];
+}
+
+/**
+ * Feature flag set exported by @mastra/observability. The server package does
+ * not depend on @mastra/observability directly, so this is resolved lazily
+ * via dynamic import. Missing exports (older versions) are treated as an
+ * empty set.
+ */
+let cachedObservabilityFeatures: ReadonlySet<string> | undefined;
+let observabilityFeaturesLoaded = false;
+async function loadObservabilityFeatures(): Promise<ReadonlySet<string>> {
+  if (observabilityFeaturesLoaded) return cachedObservabilityFeatures ?? new Set();
+  try {
+    const mod: { observabilityFeatures?: ReadonlySet<string> } = await import(
+      /* @vite-ignore */ '@mastra/observability'
+    );
+    cachedObservabilityFeatures = mod.observabilityFeatures;
+  } catch {
+    cachedObservabilityFeatures = undefined;
+  }
+  observabilityFeaturesLoaded = true;
+  return cachedObservabilityFeatures ?? new Set();
+}
+
+/**
+ * Requirements that gate whether an observability HTTP endpoint is callable
+ * for the current configuration.
+ *
+ * - `observabilityStorageMethod`: the method on the observability storage
+ *   domain that the route ultimately invokes. The route is unsupported when
+ *   the connected adapter has not overridden this method.
+ * - `scoresStorageMethod`: same idea, but for the scores storage domain
+ *   (only used by the legacy /traces/:traceId/:spanId/scores route).
+ * - `coreFeature`: a feature flag from `@mastra/core/features` that must be
+ *   present. The new observability endpoints all require
+ *   `observability:v1.13.2`; legacy trace routes have no core gate.
+ * - `observabilityFeature`: a feature flag from `@mastra/observability`'s
+ *   `observabilityFeatures`. None of the current routes require one; this
+ *   field is here so future endpoints that depend on a specific span shape
+ *   (e.g. `model-inference-span`) can opt in without a contract change.
+ */
+export interface ObservabilityEndpointRequirements {
+  observabilityStorageMethod?: keyof ObservabilityStorage;
+  scoresStorageMethod?: keyof ScoresStorage;
+  coreFeature?: string;
+  observabilityFeature?: string;
+}
+
+/** Identifier for an observability endpoint exposed by the server. */
+export interface ObservabilityEndpoint {
+  method: ServerRoute['method'];
+  path: string;
+}
+
+const NEW_CORE_FEATURE = 'observability:v1.13.2';
+
+/**
+ * Single source of truth that maps every observability HTTP endpoint to the
+ * dependencies that make it callable. Kept in sync by hand with the route
+ * definitions in this file (NEW_ROUTE_DEFS) and in ./observability.ts
+ * (legacy routes); the `observability.test.ts` suite asserts coverage.
+ */
+const OBSERVABILITY_ENDPOINT_REQUIREMENTS: ReadonlyArray<ObservabilityEndpoint & ObservabilityEndpointRequirements> = [
+  // Legacy trace routes
+  { method: 'GET', path: '/observability/traces', observabilityStorageMethod: 'listTraces' },
+  { method: 'GET', path: '/observability/traces/light', observabilityStorageMethod: 'listTracesLight' },
+  { method: 'GET', path: '/observability/branches', observabilityStorageMethod: 'listBranches' },
+  { method: 'GET', path: '/observability/traces/:traceId', observabilityStorageMethod: 'getTrace' },
+  { method: 'GET', path: '/observability/traces/:traceId/light', observabilityStorageMethod: 'getTraceLight' },
+  {
+    method: 'GET',
+    path: '/observability/traces/:traceId/branches/:spanId',
+    observabilityStorageMethod: 'getBranch',
+  },
+  { method: 'GET', path: '/observability/traces/:traceId/spans/:spanId', observabilityStorageMethod: 'getSpan' },
+  {
+    method: 'GET',
+    path: '/observability/traces/:traceId/trajectory',
+    observabilityStorageMethod: 'getTrace',
+  },
+  { method: 'POST', path: '/observability/traces/score', observabilityStorageMethod: 'getTrace' },
+  {
+    method: 'GET',
+    path: '/observability/traces/:traceId/:spanId/scores',
+    scoresStorageMethod: 'listScoresBySpan',
+  },
+
+  // New endpoints (require core feature flag)
+  { method: 'GET', path: '/observability/logs', observabilityStorageMethod: 'listLogs', coreFeature: NEW_CORE_FEATURE },
+  {
+    method: 'GET',
+    path: '/observability/scores',
+    observabilityStorageMethod: 'listScores',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/scores',
+    observabilityStorageMethod: 'createScore',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'GET',
+    path: '/observability/scores/:scoreId',
+    observabilityStorageMethod: 'getScoreById',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/scores/aggregate',
+    observabilityStorageMethod: 'getScoreAggregate',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/scores/breakdown',
+    observabilityStorageMethod: 'getScoreBreakdown',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/scores/timeseries',
+    observabilityStorageMethod: 'getScoreTimeSeries',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/scores/percentiles',
+    observabilityStorageMethod: 'getScorePercentiles',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'GET',
+    path: '/observability/feedback',
+    observabilityStorageMethod: 'listFeedback',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/feedback',
+    observabilityStorageMethod: 'createFeedback',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/feedback/aggregate',
+    observabilityStorageMethod: 'getFeedbackAggregate',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/feedback/breakdown',
+    observabilityStorageMethod: 'getFeedbackBreakdown',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/feedback/timeseries',
+    observabilityStorageMethod: 'getFeedbackTimeSeries',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/feedback/percentiles',
+    observabilityStorageMethod: 'getFeedbackPercentiles',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/metrics/aggregate',
+    observabilityStorageMethod: 'getMetricAggregate',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/metrics/breakdown',
+    observabilityStorageMethod: 'getMetricBreakdown',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/metrics/timeseries',
+    observabilityStorageMethod: 'getMetricTimeSeries',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'POST',
+    path: '/observability/metrics/percentiles',
+    observabilityStorageMethod: 'getMetricPercentiles',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'GET',
+    path: '/observability/discovery/metric-names',
+    observabilityStorageMethod: 'getMetricNames',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'GET',
+    path: '/observability/discovery/metric-label-keys',
+    observabilityStorageMethod: 'getMetricLabelKeys',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'GET',
+    path: '/observability/discovery/metric-label-values',
+    observabilityStorageMethod: 'getMetricLabelValues',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'GET',
+    path: '/observability/discovery/entity-types',
+    observabilityStorageMethod: 'getEntityTypes',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'GET',
+    path: '/observability/discovery/entity-names',
+    observabilityStorageMethod: 'getEntityNames',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'GET',
+    path: '/observability/discovery/service-names',
+    observabilityStorageMethod: 'getServiceNames',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'GET',
+    path: '/observability/discovery/environments',
+    observabilityStorageMethod: 'getEnvironments',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+  {
+    method: 'GET',
+    path: '/observability/discovery/tags',
+    observabilityStorageMethod: 'getTags',
+    coreFeature: NEW_CORE_FEATURE,
+  },
+];
+
+/**
+ * Computes the subset of observability HTTP endpoints that are callable for
+ * the current Mastra configuration. An endpoint is supported when ALL of its
+ * gates pass:
+ *   - the required `@mastra/core` feature flag is present (if any);
+ *   - the required `@mastra/observability` feature flag is present (if any);
+ *   - the connected observability/scores storage adapter implements the
+ *     underlying method (if any).
+ *
+ * The `/observability/capabilities` route itself is not included in the
+ * response -- callers reach it before they know what's supported, so listing
+ * it would be redundant.
+ */
+export async function getSupportedObservabilityEndpoints(mastra: Mastra): Promise<ObservabilityEndpoint[]> {
+  const observabilityStore = await tryGetObservabilityStore(mastra);
+  const scoresStore = await tryGetScoresStore(mastra);
+  const observabilityFeatures = await loadObservabilityFeatures();
+
+  const supported: ObservabilityEndpoint[] = [];
+  for (const route of OBSERVABILITY_ENDPOINT_REQUIREMENTS) {
+    if (route.coreFeature && !coreFeatures.has(route.coreFeature)) continue;
+    if (route.observabilityFeature && !observabilityFeatures.has(route.observabilityFeature)) continue;
+    if (
+      route.observabilityStorageMethod &&
+      !isStorageMethodSupported(observabilityStore, route.observabilityStorageMethod)
+    )
+      continue;
+    if (route.scoresStorageMethod && !isScoresMethodSupported(scoresStore, route.scoresStorageMethod)) continue;
+    supported.push({ method: route.method, path: route.path });
+  }
+  return supported;
+}
+
+/**
+ * Test-only export of the full requirements table so the test suite can
+ * assert that every registered observability route is represented.
+ */
+export const OBSERVABILITY_ENDPOINT_REQUIREMENTS_FOR_TESTS = OBSERVABILITY_ENDPOINT_REQUIREMENTS;
 
 export interface RouteDetails {
   method: ServerRoute['method'];
@@ -339,7 +571,7 @@ export const NEW_ROUTE_DEFS = {
     path: '/observability/capabilities',
     summary: 'Get observability capabilities',
     description:
-      'Returns the observability features supported by the connected storage provider so clients can hide or disable unsupported UI affordances',
+      'Returns the list of observability endpoints supported by the current server configuration (installed core features, installed observability features, and the connected observability storage provider).',
   },
 } as const satisfies Record<string, RouteDetails>;
 

--- a/packages/server/src/server/handlers/observability-shared.ts
+++ b/packages/server/src/server/handlers/observability-shared.ts
@@ -1,5 +1,6 @@
 import type { Mastra } from '@mastra/core';
-import type { MastraCompositeStore, ObservabilityStorage } from '@mastra/core/storage';
+import { ObservabilityStorage } from '@mastra/core/storage';
+import type { MastraCompositeStore } from '@mastra/core/storage';
 import { HTTPException } from '../http-exception';
 import type { ServerRoute } from '../server-adapter/routes';
 
@@ -23,6 +24,111 @@ export async function getObservabilityStore(mastra: Mastra): Promise<Observabili
     throw new HTTPException(500, { message: 'Observability storage domain is not available' });
   }
   return observability;
+}
+
+/** Retrieves the observability storage domain, or undefined if not configured. Does not throw. */
+export async function tryGetObservabilityStore(mastra: Mastra): Promise<ObservabilityStorage | undefined> {
+  const storage = mastra.getStorage();
+  if (!storage) return undefined;
+  return storage.getStore('observability');
+}
+
+/**
+ * Methods on ObservabilityStorage whose default base-class implementation throws
+ * NOT_IMPLEMENTED. A storage adapter "supports" a method when its prototype
+ * entry differs from the base class entry (i.e. the subclass overrode it).
+ *
+ * Note: `getStructure` and `getTraceLight` are aliases that delegate to each
+ * other; overriding either one provides both. `getBranch` has a default
+ * implementation that works when the underlying methods it delegates to are
+ * implemented, so it's reported separately based on its direct override status.
+ */
+const OBSERVABILITY_METHOD_NAMES = [
+  // Tracing - reads
+  'listTraces',
+  'listTracesLight',
+  'listBranches',
+  'getTrace',
+  'getStructure',
+  'getTraceLight',
+  'getSpan',
+  'getSpans',
+  'getRootSpan',
+  'getBranch',
+  // Tracing - writes
+  'createSpan',
+  'updateSpan',
+  'batchCreateSpans',
+  'batchUpdateSpans',
+  'batchDeleteTraces',
+  // Logs
+  'listLogs',
+  'batchCreateLogs',
+  // Metrics
+  'listMetrics',
+  'batchCreateMetrics',
+  'getMetricAggregate',
+  'getMetricBreakdown',
+  'getMetricTimeSeries',
+  'getMetricPercentiles',
+  // Scores
+  'listScores',
+  'createScore',
+  'batchCreateScores',
+  'getScoreById',
+  'getScoreAggregate',
+  'getScoreBreakdown',
+  'getScoreTimeSeries',
+  'getScorePercentiles',
+  // Feedback
+  'listFeedback',
+  'createFeedback',
+  'batchCreateFeedback',
+  'getFeedbackAggregate',
+  'getFeedbackBreakdown',
+  'getFeedbackTimeSeries',
+  'getFeedbackPercentiles',
+  // Discovery
+  'getMetricNames',
+  'getMetricLabelKeys',
+  'getMetricLabelValues',
+  'getEntityTypes',
+  'getEntityNames',
+  'getServiceNames',
+  'getEnvironments',
+  'getTags',
+] as const satisfies ReadonlyArray<keyof ObservabilityStorage>;
+
+export type ObservabilityFeatureName = (typeof OBSERVABILITY_METHOD_NAMES)[number];
+export type ObservabilityFeatureMap = Record<ObservabilityFeatureName, boolean>;
+
+/**
+ * Detects which observability features the connected store supports by
+ * comparing method references against the base ObservabilityStorage prototype.
+ *
+ * The base class provides default `throw NOT_IMPLEMENTED` stubs for every
+ * method; subclasses override only what they support. When `store` is
+ * undefined (no observability storage configured), every feature reports as
+ * unsupported.
+ */
+export function detectObservabilityFeatures(store: ObservabilityStorage | undefined): ObservabilityFeatureMap {
+  const basePrototype = ObservabilityStorage.prototype as unknown as Record<string, unknown>;
+  const features = {} as ObservabilityFeatureMap;
+  for (const method of OBSERVABILITY_METHOD_NAMES) {
+    if (!store) {
+      features[method] = false;
+      continue;
+    }
+    const concrete = (store as unknown as Record<string, unknown>)[method];
+    features[method] = typeof concrete === 'function' && concrete !== basePrototype[method];
+  }
+  // getStructure and getTraceLight delegate to each other in the base class:
+  // overriding either provides the capability for both.
+  if (features.getStructure || features.getTraceLight) {
+    features.getStructure = true;
+    features.getTraceLight = true;
+  }
+  return features;
 }
 
 export interface RouteDetails {
@@ -226,6 +332,14 @@ export const NEW_ROUTE_DEFS = {
     path: '/observability/discovery/tags',
     summary: 'Get tags',
     description: 'Returns distinct tags with optional entity type filtering',
+  },
+
+  GET_CAPABILITIES: {
+    method: 'GET',
+    path: '/observability/capabilities',
+    summary: 'Get observability capabilities',
+    description:
+      'Returns the observability features supported by the connected storage provider so clients can hide or disable unsupported UI affordances',
   },
 } as const satisfies Record<string, RouteDetails>;
 

--- a/packages/server/src/server/handlers/observability.test.ts
+++ b/packages/server/src/server/handlers/observability.test.ts
@@ -10,6 +10,7 @@ import type {
 } from '@mastra/core/storage';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HTTPException } from '../http-exception';
+import { OBSERVABILITY_ROUTES } from '../server-adapter/routes/observability';
 import * as errorHandler from './error';
 import {
   LIST_TRACES_ROUTE,
@@ -23,6 +24,7 @@ import {
   LIST_SCORES_BY_SPAN_ROUTE,
 } from './observability';
 import { NEW_ROUTES } from './observability-new-endpoints';
+import { OBSERVABILITY_ENDPOINT_REQUIREMENTS_FOR_TESTS } from './observability-shared';
 import { createTestServerContext } from './test-utils';
 
 // Mock scoreTraces
@@ -2784,7 +2786,10 @@ describe('Observability Handlers', () => {
   });
 
   describe('GET_CAPABILITIES_ROUTE', () => {
-    it('reports features as supported when the store overrides discovery methods', async () => {
+    const matches = (endpoints: Array<{ method: string; path: string }>, method: string, path: string) =>
+      endpoints.some(e => e.method === method && e.path === path);
+
+    it('reports only the endpoints whose backing storage methods the adapter overrides', async () => {
       const { ObservabilityStorage } = await import('@mastra/core/storage');
 
       class PartialStore extends ObservabilityStorage {
@@ -2796,6 +2801,9 @@ describe('Observability Handlers', () => {
         }
         override async getServiceNames() {
           return { serviceNames: [] };
+        }
+        override async listTraces() {
+          return { traces: [], pagination: { total: 0, page: 0, perPage: 100, hasMore: false } };
         }
       }
 
@@ -2811,17 +2819,19 @@ describe('Observability Handlers', () => {
       });
 
       expect(result.storeProvider).toBe('PartialStore');
-      expect(result.features.getEntityNames).toBe(true);
-      expect(result.features.getEntityTypes).toBe(true);
-      expect(result.features.getServiceNames).toBe(true);
-      // Methods the subclass did not override fall back to the base class throw,
-      // so capabilities should report them as unsupported.
-      expect(result.features.getTags).toBe(false);
-      expect(result.features.getEnvironments).toBe(false);
-      expect(result.features.getMetricAggregate).toBe(false);
+      expect(matches(result.endpoints, 'GET', '/observability/discovery/entity-names')).toBe(true);
+      expect(matches(result.endpoints, 'GET', '/observability/discovery/entity-types')).toBe(true);
+      expect(matches(result.endpoints, 'GET', '/observability/discovery/service-names')).toBe(true);
+      expect(matches(result.endpoints, 'GET', '/observability/traces')).toBe(true);
+      // Endpoints backed by methods the subclass did not override should not appear.
+      expect(matches(result.endpoints, 'GET', '/observability/discovery/tags')).toBe(false);
+      expect(matches(result.endpoints, 'GET', '/observability/discovery/environments')).toBe(false);
+      expect(matches(result.endpoints, 'POST', '/observability/metrics/aggregate')).toBe(false);
+      // Capabilities endpoint itself is never listed.
+      expect(matches(result.endpoints, 'GET', '/observability/capabilities')).toBe(false);
     });
 
-    it('treats getStructure and getTraceLight as aliases', async () => {
+    it('treats getStructure and getTraceLight as aliases for the light-trace endpoint', async () => {
       const { ObservabilityStorage } = await import('@mastra/core/storage');
 
       class StructureOnly extends ObservabilityStorage {
@@ -2845,12 +2855,11 @@ describe('Observability Handlers', () => {
         const result = await NEW_ROUTES.GET_CAPABILITIES.handler({
           ...createTestServerContext({ mastra }),
         });
-        expect(result.features.getStructure).toBe(true);
-        expect(result.features.getTraceLight).toBe(true);
+        expect(matches(result.endpoints, 'GET', '/observability/traces/:traceId/light')).toBe(true);
       }
     });
 
-    it('returns all features as unsupported when no observability store is configured', async () => {
+    it('returns no observability storage endpoints when no observability store is configured', async () => {
       const storage: Partial<MastraCompositeStore> = {
         getStore: vi.fn(() => Promise.resolve(undefined)) as MastraCompositeStore['getStore'],
       };
@@ -2861,10 +2870,11 @@ describe('Observability Handlers', () => {
       });
 
       expect(result.storeProvider).toBeNull();
-      expect(Object.values(result.features).every(v => v === false)).toBe(true);
+      // No observability storage + no scores storage => no endpoints supported.
+      expect(result.endpoints).toEqual([]);
     });
 
-    it('returns all features as unsupported when no storage is configured', async () => {
+    it('returns no endpoints when no storage is configured at all', async () => {
       const mastra = createMockMastra(undefined);
 
       const result = await NEW_ROUTES.GET_CAPABILITIES.handler({
@@ -2872,7 +2882,34 @@ describe('Observability Handlers', () => {
       });
 
       expect(result.storeProvider).toBeNull();
-      expect(Object.values(result.features).every(v => v === false)).toBe(true);
+      expect(result.endpoints).toEqual([]);
+    });
+
+    it('includes the legacy scores-by-span endpoint when the scores store implements it', async () => {
+      const { ObservabilityStorage } = await import('@mastra/core/storage');
+      class EmptyStore extends ObservabilityStorage {}
+      const storage = createMockStorage(
+        new EmptyStore() as unknown as ReturnType<typeof createMockObservabilityStore>,
+        mockScoresStore,
+      );
+      const mastra = createMockMastra(storage);
+
+      const result = await NEW_ROUTES.GET_CAPABILITIES.handler({
+        ...createTestServerContext({ mastra }),
+      });
+
+      expect(matches(result.endpoints, 'GET', '/observability/traces/:traceId/:spanId/scores')).toBe(true);
+    });
+
+    it('lists every registered observability route in the requirements table', () => {
+      // The capabilities endpoint itself is intentionally excluded -- callers
+      // hit it before they know what's supported, so listing it would be
+      // redundant.
+      const expected = OBSERVABILITY_ROUTES.map(r => `${r.method} ${r.path}`).filter(
+        key => key !== 'GET /observability/capabilities',
+      );
+      const declared = OBSERVABILITY_ENDPOINT_REQUIREMENTS_FOR_TESTS.map(r => `${r.method} ${r.path}`);
+      expect(new Set(declared)).toEqual(new Set(expected));
     });
   });
 });

--- a/packages/server/src/server/handlers/observability.test.ts
+++ b/packages/server/src/server/handlers/observability.test.ts
@@ -2782,4 +2782,97 @@ describe('Observability Handlers', () => {
       expect(handleErrorSpy).toHaveBeenCalledWith(storageError, "Error calling: 'get tags'");
     });
   });
+
+  describe('GET_CAPABILITIES_ROUTE', () => {
+    it('reports features as supported when the store overrides discovery methods', async () => {
+      const { ObservabilityStorage } = await import('@mastra/core/storage');
+
+      class PartialStore extends ObservabilityStorage {
+        override async getEntityNames() {
+          return { names: [] };
+        }
+        override async getEntityTypes() {
+          return { entityTypes: [] };
+        }
+        override async getServiceNames() {
+          return { serviceNames: [] };
+        }
+      }
+
+      const partialStore = new PartialStore();
+      const storage = createMockStorage(
+        partialStore as unknown as ReturnType<typeof createMockObservabilityStore>,
+        mockScoresStore,
+      );
+      const mastra = createMockMastra(storage);
+
+      const result = await NEW_ROUTES.GET_CAPABILITIES.handler({
+        ...createTestServerContext({ mastra }),
+      });
+
+      expect(result.storeProvider).toBe('PartialStore');
+      expect(result.features.getEntityNames).toBe(true);
+      expect(result.features.getEntityTypes).toBe(true);
+      expect(result.features.getServiceNames).toBe(true);
+      // Methods the subclass did not override fall back to the base class throw,
+      // so capabilities should report them as unsupported.
+      expect(result.features.getTags).toBe(false);
+      expect(result.features.getEnvironments).toBe(false);
+      expect(result.features.getMetricAggregate).toBe(false);
+    });
+
+    it('treats getStructure and getTraceLight as aliases', async () => {
+      const { ObservabilityStorage } = await import('@mastra/core/storage');
+
+      class StructureOnly extends ObservabilityStorage {
+        override async getStructure() {
+          return null;
+        }
+      }
+
+      class TraceLightOnly extends ObservabilityStorage {
+        override async getTraceLight() {
+          return null;
+        }
+      }
+
+      for (const Ctor of [StructureOnly, TraceLightOnly]) {
+        const storage = createMockStorage(
+          new Ctor() as unknown as ReturnType<typeof createMockObservabilityStore>,
+          mockScoresStore,
+        );
+        const mastra = createMockMastra(storage);
+        const result = await NEW_ROUTES.GET_CAPABILITIES.handler({
+          ...createTestServerContext({ mastra }),
+        });
+        expect(result.features.getStructure).toBe(true);
+        expect(result.features.getTraceLight).toBe(true);
+      }
+    });
+
+    it('returns all features as unsupported when no observability store is configured', async () => {
+      const storage: Partial<MastraCompositeStore> = {
+        getStore: vi.fn(() => Promise.resolve(undefined)) as MastraCompositeStore['getStore'],
+      };
+      const mastra = createMockMastra(storage);
+
+      const result = await NEW_ROUTES.GET_CAPABILITIES.handler({
+        ...createTestServerContext({ mastra }),
+      });
+
+      expect(result.storeProvider).toBeNull();
+      expect(Object.values(result.features).every(v => v === false)).toBe(true);
+    });
+
+    it('returns all features as unsupported when no storage is configured', async () => {
+      const mastra = createMockMastra(undefined);
+
+      const result = await NEW_ROUTES.GET_CAPABILITIES.handler({
+        ...createTestServerContext({ mastra }),
+      });
+
+      expect(result.storeProvider).toBeNull();
+      expect(Object.values(result.features).every(v => v === false)).toBe(true);
+    });
+  });
 });

--- a/packages/server/src/server/server-adapter/routes/observability.ts
+++ b/packages/server/src/server/server-adapter/routes/observability.ts
@@ -37,6 +37,7 @@ import {
   GET_SERVICE_NAMES,
   GET_ENVIRONMENTS,
   GET_TAGS,
+  GET_CAPABILITIES,
 } from '../../handlers/observability-new-endpoints';
 
 export const OBSERVABILITY_ROUTES = [
@@ -51,7 +52,7 @@ export const OBSERVABILITY_ROUTES = [
   GET_TRACE_TRAJECTORY_ROUTE,
   SCORE_TRACES_ROUTE,
   LIST_SCORES_BY_SPAN_ROUTE,
-  // New (17 routes)
+  // New
   LIST_LOGS,
   LIST_SCORES,
   CREATE_SCORE,
@@ -78,4 +79,5 @@ export const OBSERVABILITY_ROUTES = [
   GET_SERVICE_NAMES,
   GET_ENVIRONMENTS,
   GET_TAGS,
+  GET_CAPABILITIES,
 ] as const;


### PR DESCRIPTION
## Description

Adds `GET /observability/capabilities`, a discovery endpoint that returns the list of observability HTTP endpoints the server can actually serve under the current configuration.

Today, when the Studio loads against a storage provider that hasn't implemented the new discovery contract (e.g. Postgres, libSQL), the UI fires `/observability/discovery/*` calls that produce 500-error spam in production logs — exactly the symptom in #16304. With this endpoint, the UI can ask once on load and hide or disable filters and panels that the server cannot back, instead of relying on errors to discover what's supported.

```ts
// Example response
{
  storeProvider: 'ObservabilityPG',
  endpoints: [
    { method: 'GET', path: '/observability/traces' },
    { method: 'GET', path: '/observability/traces/:traceId' },
    { method: 'GET', path: '/observability/discovery/tags' },
    // ...only endpoints whose dependencies are satisfied
  ]
}
```

The UI side will be done in a follow-up by another team member.

## Related issue(s)

Fixes #16304

## How "supported" is computed

Each entry in `OBSERVABILITY_ENDPOINT_REQUIREMENTS` (single source of truth in `packages/server/src/server/handlers/observability-shared.ts`) declares the gates that must pass for that endpoint to be listed:

1. **`coreFeature`** — required `@mastra/core/features` flag is present (e.g. `observability:v1.13.2` for the new endpoints; legacy trace routes have no core gate).
2. **`observabilityFeature`** — required `@mastra/observability` feature flag is present. Loaded via lazy dynamic import so `@mastra/server` doesn't need a hard dep on `@mastra/observability`; older versions / missing exports are treated as an empty set. No current route requires one — the field is wired in so future routes that depend on a specific span shape (e.g. `model-inference-span`) can opt in without a contract change.
3. **`observabilityStorageMethod` / `scoresStorageMethod`** — the connected storage adapter actually implements the underlying method, detected by comparing the instance method against `ObservabilityStorage.prototype` / `ScoresStorage.prototype`. Both base classes throw `NOT_IMPLEMENTED` by default, so a prototype-level override is the canonical signal that the adapter actually supports the operation. `getStructure` and `getTraceLight` are treated as aliases (the base class delegates between them).

The capabilities endpoint itself is registered with `createRoute` (not `createNewRoute`), so it's callable on older `@mastra/core` versions that lack the new feature flag — otherwise the UI couldn't ask "is the new API supported?" without already knowing the answer.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test coverage

`packages/server/src/server/handlers/observability.test.ts` adds a `GET_CAPABILITIES_ROUTE` suite covering:

- Correct endpoints reported when a storage subclass overrides specific methods (and **only** those — methods the subclass didn't override are absent from the list).
- Alias handling for `getStructure` / `getTraceLight` — overriding either reports `/observability/traces/:traceId/light` as supported.
- Empty `endpoints` list and `storeProvider: null` when no observability storage or no storage at all is configured.
- Legacy `/observability/traces/:traceId/:spanId/scores` appears when the scores storage adapter implements `listScoresBySpan`.
- **Coverage test**: asserts that every entry in `OBSERVABILITY_ROUTES` (except `/observability/capabilities` itself) has a row in `OBSERVABILITY_ENDPOINT_REQUIREMENTS`, so the table can't silently drift when new observability routes are added.

Full server suite: **1256 passed**, 4 skipped, 1 todo. Lint clean. `check:core-imports` clean (the new `ObservabilityStorage` / `ScoresStorage` value imports are compatible with the `@mastra/core@1.32.0` peer-dep floor).

## Files changed

- `packages/server/src/server/handlers/observability-shared.ts` — requirements table, `getSupportedObservabilityEndpoints`, `tryGetObservabilityStore`, prototype-override helpers for both observability and scores domains, lazy dynamic loader for `observabilityFeatures`, route definition for `GET_CAPABILITIES`.
- `packages/server/src/server/handlers/observability-new-endpoints.ts` — `GET_CAPABILITIES` handler (registered with `createRoute` to skip the new-API feature gate).
- `packages/server/src/server/server-adapter/routes/observability.ts` — route registration.
- `packages/server/src/server/handlers/observability.test.ts` — new tests.
- `client-sdks/client-js/src/route-types.generated.ts` + `packages/cli/src/commands/api/route-metadata.generated.ts` — regenerated.
- `.changeset/quick-cats-hide.md` — minor bump for `@mastra/server`, patch for `@mastra/client-js` and `mastra`.

https://claude.ai/code/session_01MSdmKj8yjMS1sCws3DFPEs

## ELI5

The UI keeps poking observability endpoints that don't work on every storage backend, which fills production logs with noise. This adds a "menu" endpoint the UI can read once on load to see which observability endpoints the server actually supports, so it can hide the ones it shouldn't call.