### PR TITLE
feat(playground): surface Evaluation dashboard as sidebar item

### DIFF
--- a/packages/playground/src/lib/nav/nav-items.tsx
+++ b/packages/playground/src/lib/nav/nav-items.tsx
@@ -2,6 +2,7 @@ import {
   AgentIcon,
   DatasetsIcon,
   ExperimentsIcon,
+  HomeIcon,
   LogsIcon,
   McpServerIcon,
   MetricsIcon,
@@ -34,7 +35,7 @@ export interface NavItem {
 export interface NavSection {
   key: string;
   title: string;
-  href: string;
+  href?: string;
   items: NavItem[];
 }
 
@@ -42,7 +43,6 @@ export const mainNav: NavSection[] = [
   {
     key: 'primitives',
     title: 'Primitives',
-    href: '/primitives',
     items: [
       {
         name: 'Agents',
@@ -113,8 +113,13 @@ export const mainNav: NavSection[] = [
   {
     key: 'evaluation',
     title: 'Evaluation',
-    href: '/evaluation',
     items: [
+      {
+        name: 'Overview',
+        url: '/evaluation',
+        Icon: HomeIcon,
+        isOnMastraPlatform: true,
+      },
       {
         name: 'Scorers',
         url: '/scorers',
@@ -147,7 +152,6 @@ export const mainNav: NavSection[] = [
   {
     key: 'observability',
     title: 'Observability',
-    href: '/observability-overview',
     items: [
       {
         name: 'Metrics',
@@ -183,7 +187,7 @@ export const bottomNav: NavItem[] = [
   { name: 'Resources', url: '/resources', Icon: BookIcon, isOnMastraPlatform: true },
 ];
 
-/** Section-level evaluation/observability/overview crumbs the sidebar headers link to. */
+/** Section-level entries used to resolve breadcrumb label + icon for the overview routes. */
 export const sectionNav: NavItem[] = [
   {
     name: 'Evaluation',
@@ -204,7 +208,9 @@ export const sectionNav: NavItem[] = [
   },
 ];
 
-const allItems: NavItem[] = [...mainNav.flatMap(s => s.items), ...bottomNav, ...sectionNav];
+// sectionNav comes first so /evaluation resolves to "Evaluation" (section crumb) rather than the
+// in-section "Overview" NavLink which shares the same url.
+const allItems: NavItem[] = [...sectionNav, ...mainNav.flatMap(s => s.items), ...bottomNav];
 
 export function findNavItem(url: string): NavItem | undefined {
   return allItems.find(i => i.url === url);

--- a/packages/playground/src/pages/evaluation/index.tsx
+++ b/packages/playground/src/pages/evaluation/index.tsx
@@ -69,7 +69,7 @@ export default function Evaluation() {
 
   return (
     <PageLayout width="wide" height="full">
-      <div className="flex flex-col gap-6 pt-6">
+      <div className="flex flex-col gap-6">
         <MetricsFlexGrid>
           <EvaluationKpiCards
             scorers={scorers}


### PR DESCRIPTION
## Summary

- **New "Overview" sidebar item** under the **Evaluation** section, pointing to `/evaluation`. The dashboard (KPIs, scores-over-time, dataset health, experiment status, review pipeline) was previously only reachable by clicking the section title — a low-affordance interaction most users missed.
- **Section titles are no longer clickable links.** `Primitives`, `Evaluation`, and `Observability` headers now render as plain labels. `href` made optional on `NavSection`; existing `MainSidebar.NavHeader` already handles `href === undefined` by rendering children without a link.
- **Breadcrumb collision fix.** `/evaluation` is now declared twice in the nav registry (`sectionNav` for the breadcrumb identity "Evaluation", and `mainNav.evaluation.items` for the sidebar "Overview" entry). `allItems` reordered so `findNavItem('/evaluation')` resolves to the section crumb first, keeping `navHandle('/evaluation')` rendering as "Evaluation" not "Overview".
- **Trim leading `pt-6`** from the `/evaluation` page wrapper — `PageLayout` already provides top spacing, the extra padding produced a doubled top gap.

## Out of scope

- `/primitives` and `/observability-overview` routes still exist and remain reachable by direct URL. They are no longer linked from the sidebar but were kept as fallback (simple grids of section sub-tabs).
- No changes to the dashboard composition itself.

## Test plan

- [ ] Open `http://localhost:5173` — Evaluation section shows **Overview** as the first item (Home icon)
- [ ] Click Overview → dashboard renders at `/evaluation` with no double top-padding
- [ ] Section headers (Primitives / Evaluation / Observability) render as plain text, no hover/cursor affordance
- [ ] Active highlight: only the Overview item highlights on `/evaluation`; header does not double-highlight
- [ ] Scorers / Datasets / Experiments still work and highlight correctly
- [ ] Sidebar collapsed state renders Overview icon
- [ ] Breadcrumb on `/evaluation` reads "Evaluation" (not "Overview")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the evaluation dashboard (which shows key metrics and performance data) easier to find by adding an "Overview" link in the sidebar under the Evaluation section. It also changes section headers in the sidebar from being clickable links to just plain text labels.

## Changes

### Navigation Structure (`nav-items.tsx`)
- Made `NavSection`'s `href` property optional to support section titles as non-clickable labels
- Moved the Evaluation section's redirect from a section-level link to an in-section "Overview" item with a home icon pointing to `/evaluation`
- Removed the section-level `href` from the Observability section to make its header non-clickable
- Reordered the internal `allItems` construction to place `sectionNav` before `mainNav` and `bottomNav`, ensuring `findNavItem(url)` correctly prioritizes section breadcrumbs when multiple nav entries share the same URL (fixes breadcrumb rendering for `/evaluation` to display "Evaluation" instead of "Overview")

### Page Layout (`evaluation/index.tsx`)
- Removed leading `pt-6` (top padding) from the Evaluation page container to avoid doubled spacing, since `PageLayout` already provides appropriate top padding

## Out of Scope
- `/primitives` and `/observability-overview` routes remain accessible via direct URL but are no longer linked in the sidebar
- No changes to the dashboard components themselves

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->