### PR TITLE
feat(playground-ui): move Level icon into Name column on traces list

### DIFF
--- a/.changeset/moody-bottles-turn.md
+++ b/.changeset/moody-bottles-turn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Moved the Level icon from its own column into the Name column, next to the trace name, on the Observability traces list.

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -1,5 +1,4 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { CornerDownRightIcon, ListTreeIcon } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { getInputPreview } from '../utils/span-utils';
 import { DataListSkeleton, TracesDataList } from '@/ds/components/DataList';
@@ -31,7 +30,7 @@ export type TracesListViewTrace = {
 };
 
 // Fixed widths on non-flex columns prevent track shifts as the virtualizer swaps rows in/out.
-const COLUMNS = '4rem 6rem 9rem 14rem minmax(8rem,1fr) 14rem 6rem';
+const COLUMNS = '6rem 9rem 14rem minmax(8rem,1fr) 14rem 6rem';
 
 const ROW_HEIGHT = 36;
 const OVERSCAN = 8;
@@ -50,6 +49,9 @@ export type TracesListViewProps = {
    * a row is featured only when both `traceId` and `spanId` match.
    */
   featuredSpanId?: string | null;
+  /** Branches mode mixes root traces with subtraces — enables the Trace/Subtrace tooltip on the
+   *  level icon in the Name column, which is meaningless when every row is a root. */
+  isBranchesMode?: boolean;
   /** Called when a row is clicked. The current selection logic (toggle on same id) is the consumer's call. */
   onTraceClick: (trace: TracesListViewTrace) => void;
 };
@@ -67,6 +69,7 @@ export function TracesListView({
   filtersApplied,
   featuredTraceId,
   featuredSpanId,
+  isBranchesMode,
   onTraceClick,
 }: TracesListViewProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -109,22 +112,6 @@ export function TracesListView({
   return (
     <TracesDataList columns={COLUMNS} scrollRef={scrollRef} className="min-w-0">
       <TracesDataList.Top>
-        <TracesDataList.TopCellWithTooltip
-          tooltip={
-            <div className="grid gap-1">
-              <span className="flex items-center gap-1.5">
-                <ListTreeIcon className="size-4 shrink-0" aria-hidden />
-                Trace
-              </span>
-              <span className="flex items-center gap-1.5">
-                <CornerDownRightIcon className="size-4 shrink-0" aria-hidden />
-                Subtrace
-              </span>
-            </div>
-          }
-        >
-          Level
-        </TracesDataList.TopCellWithTooltip>
         <TracesDataList.TopCell>Date</TracesDataList.TopCell>
         <TracesDataList.TopCell>Time</TracesDataList.TopCell>
         <TracesDataList.TopCell>Name</TracesDataList.TopCell>
@@ -158,10 +145,13 @@ export function TracesListView({
                 onClick={() => onTraceClick(trace)}
                 className={cn(isFeatured && 'bg-surface4')}
               >
-                <TracesDataList.KindCell parentSpanId={trace.parentSpanId} />
                 <TracesDataList.DateCell timestamp={displayDate} />
                 <TracesDataList.TimeCell timestamp={displayDate} />
-                <TracesDataList.NameCell name={trace.name} />
+                <TracesDataList.NameCell
+                  name={trace.name}
+                  parentSpanId={trace.parentSpanId}
+                  showLevelTooltip={isBranchesMode}
+                />
                 <TracesDataList.InputCell input={getInputPreview(trace.input)} />
                 <TracesDataList.EntityCell entityType={trace.entityType} entityName={entityName} />
                 <TracesDataList.StatusCell status={trace.attributes?.status} />

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
@@ -97,7 +97,7 @@ export function TracesDataListNameCell({ name, parentSpanId, showLevelTooltip }:
   const label = isRoot ? 'Trace' : 'Subtrace';
   const icon = (
     <span aria-label={label} className="inline-flex shrink-0">
-      <Icon className={cn('shrink-0 text-neutral3', isRoot ? 'size-4' : 'size-3')} aria-hidden />
+      <Icon className={cn('size-4 shrink-0', isRoot ? 'text-neutral3' : 'text-neutral2')} aria-hidden />
     </span>
   );
   return (

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
@@ -1,9 +1,9 @@
 import { format, isToday } from 'date-fns';
 import { CornerDownRightIcon, ListTreeIcon } from 'lucide-react';
 import { DataListCell } from '../data-list-cells';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { WorkflowIcon } from '@/ds/icons/WorkflowIcon';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { Colors } from '@/ds/tokens/colors';
 import { cn } from '@/lib/utils';
 

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
@@ -3,6 +3,7 @@ import { CornerDownRightIcon, ListTreeIcon } from 'lucide-react';
 import { DataListCell } from '../data-list-cells';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { WorkflowIcon } from '@/ds/icons/WorkflowIcon';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { Colors } from '@/ds/tokens/colors';
 import { cn } from '@/lib/utils';
 
@@ -32,28 +33,6 @@ export function TracesDataListIdCell({ traceId }: TracesDataListIdCellProps) {
   return (
     <DataListCell height="compact" className="text-ui-smd font-mono text-neutral3">
       {getShortId(traceId)}
-    </DataListCell>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// KindCell
-// ---------------------------------------------------------------------------
-
-export interface TracesDataListKindCellProps {
-  /** `null`/missing → root span (Trace). Set → nested span (Subtrace). */
-  parentSpanId?: string | null;
-}
-
-export function TracesDataListKindCell({ parentSpanId }: TracesDataListKindCellProps) {
-  const isRoot = parentSpanId == null;
-  const Icon = isRoot ? ListTreeIcon : CornerDownRightIcon;
-  const label = isRoot ? 'Trace' : 'Subtrace';
-  return (
-    <DataListCell height="compact" className="flex items-center justify-center">
-      <span title={label} aria-label={label} className="inline-flex">
-        <Icon className={cn('shrink-0', isRoot ? 'size-4 text-neutral3' : 'size-3 text-neutral3')} aria-hidden />
-      </span>
     </DataListCell>
   );
 }
@@ -105,12 +84,33 @@ export function TracesDataListTimeCell({ timestamp }: TracesDataListTimeCellProp
 
 export interface TracesDataListNameCellProps {
   name?: string | null;
+  /** `null`/missing → root span (Trace). Set → nested span (Subtrace). Drives the leading level icon. */
+  parentSpanId?: string | null;
+  /** When true, the leading level icon is wrapped in a Trace/Subtrace tooltip. Off by default —
+   *  only meaningful in branches mode, where rows mix root traces and subtraces. */
+  showLevelTooltip?: boolean;
 }
 
-export function TracesDataListNameCell({ name }: TracesDataListNameCellProps) {
+export function TracesDataListNameCell({ name, parentSpanId, showLevelTooltip }: TracesDataListNameCellProps) {
+  const isRoot = parentSpanId == null;
+  const Icon = isRoot ? ListTreeIcon : CornerDownRightIcon;
+  const label = isRoot ? 'Trace' : 'Subtrace';
+  const icon = (
+    <span aria-label={label} className="inline-flex shrink-0">
+      <Icon className={cn('shrink-0 text-neutral3', isRoot ? 'size-4' : 'size-3')} aria-hidden />
+    </span>
+  );
   return (
-    <DataListCell height="compact" className="text-neutral4 text-ui-smd min-w-0 truncate">
-      {name || '-'}
+    <DataListCell height="compact" className="text-neutral4 text-ui-smd min-w-0 flex items-center gap-2">
+      {showLevelTooltip ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{icon}</TooltipTrigger>
+          <TooltipContent>{label}</TooltipContent>
+        </Tooltip>
+      ) : (
+        icon
+      )}
+      <span className="min-w-0 truncate">{name || '-'}</span>
     </DataListCell>
   );
 }

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
@@ -10,7 +10,6 @@ import { DataListTop } from '../data-list-top';
 import { DataListTopCell, DataListTopCellWithTooltip } from '../data-list-top-cell';
 import {
   TracesDataListIdCell,
-  TracesDataListKindCell,
   TracesDataListDateCell,
   TracesDataListTimeCell,
   TracesDataListNameCell,
@@ -33,7 +32,6 @@ export const TracesDataList = Object.assign(TracesDataListRoot, {
   SubHeading: DataListSubHeading,
   Spacer: DataListSpacer,
   IdCell: TracesDataListIdCell,
-  KindCell: TracesDataListKindCell,
   DateCell: TracesDataListDateCell,
   TimeCell: TracesDataListTimeCell,
   NameCell: TracesDataListNameCell,

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -376,6 +376,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
             // In branches mode the row identity is (traceId, anchorSpanId) — spanIdParam may
             // have drifted via intra-panel span nav and shouldn't decide which row is featured.
             featuredSpanId={url.listMode === 'branches' ? url.anchorSpanIdParam : null}
+            isBranchesMode={url.listMode === 'branches'}
             onTraceClick={trace => {
               const isBranches = url.listMode === 'branches';
               const isSameRow = isBranches


### PR DESCRIPTION

<img width="1438" height="940" alt="Screenshot 2026-05-18 at 10 45 25" src="https://github.com/user-attachments/assets/5bb71489-1565-4a92-8788-56dd8abcb613" />


## Summary
- Drop the dedicated **Level** column on the Observability traces list; render the Trace/Subtrace icon inline in the **Name** column, just before the trace name.
- The Trace/Subtrace tooltip on the icon is wired only in **branches mode** (Show subtraces toggle on), where rows can be a mix of roots and subtraces. In default mode every row is a top-level trace, so the icon shows plain.
- Remove the now-unused `TracesDataList.KindCell` from the DS namespace.

## Test plan
- [ ] Open Observability → Traces. Confirm the Level column is gone and the icon now sits immediately to the left of the trace name.
- [ ] Default mode (Show subtraces off): hover the icon — no tooltip; every row uses the Trace icon.
- [ ] Toggle Show subtraces on: hover a top-level row → tooltip says "Trace"; hover a nested row → tooltip says "Subtrace".
- [ ] Toggle Show subtraces off again: tooltip disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The traces list no longer has a separate "Level" column; the trace/subtrace icon is now shown directly before each trace name to make the table cleaner. When "Show subtraces" is on the icon shows a tooltip ("Trace" or "Subtrace"); when it's off the icon shows without a tooltip.

## Changes

### Overview
- Removed the dedicated "Level" (Trace/Subtrace) column and rendered the level icon inline immediately before the trace name in the Name cell.
- Tooltip for the icon is enabled only in branches mode (Show subtraces on); in default mode every row is a top-level trace so the icon renders without a tooltip.
- Minor visual consistency tweaks for icon sizing/contrast.
- Removed the now-unused KindCell export from the Traces data list DS API.

### Files changed (high level)
- packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
  - Removed Level column/header and adjusted grid columns.
  - Added isBranchesMode?: boolean to TracesListViewProps.
  - Passes parentSpanId and showLevelTooltip (derived from isBranchesMode) into the Name cell when rendering rows.
  - Eliminated prior KindCell usage in row rendering.
- packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
  - Updated TracesDataListNameCell to render the Trace/Subtrace icon inline and optionally wrap it in a tooltip when showLevelTooltip is true.
  - Extended TracesDataListNameCellProps to include parentSpanId?: string | null and showLevelTooltip?: boolean.
  - Removed TracesDataListKindCell and its props/exports.
  - Adjusted layout/ellipsis behavior for name text.
- packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
  - Removed TracesDataList.KindCell from the exported component namespace.
- packages/playground/src/pages/traces/index.tsx
  - Passes isBranchesMode={url.listMode === 'branches'} to TracesListView.
- .changeset/moody-bottles-turn.md
  - Patch changeset for `@mastra/playground-ui` describing the UI update.

### Public API / surface changes
- Added: TracesListViewProps.isBranchesMode?: boolean
- Updated: TracesDataListNameCellProps now includes parentSpanId?: string | null and showLevelTooltip?: boolean; TracesDataListNameCell signature updated accordingly.
- Removed: TracesDataListKindCell and TracesDataListKindCellProps exports.
- Removed: TracesDataList.KindCell from the exported component namespace.

### Testing notes (manual QA)
- Open Observability → Traces: confirm Level column is gone and icon appears immediately left of the trace name.
- Default mode (Show subtraces off): icon shown for each row; hovering the icon shows no tooltip.
- Branches mode (Show subtraces on): hover a top-level row → tooltip "Trace"; hover a nested row → tooltip "Subtrace".
- Toggle Show subtraces off again: tooltip disappears.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->