### PR TITLE
fix(playground): make Prompts and Workflows top bar responsive

### DIFF
--- a/.changeset/responsive-prompts-workflows-toparea.md
+++ b/.changeset/responsive-prompts-workflows-toparea.md
@@ -1,5 +1,13 @@
 ---
+'@mastra/playground-ui': patch
 '@internal/playground': patch
 ---
 
-Aligned the Prompts and Workflows top bars so the search field and primary action share a single row, and stack vertically on narrow viewports.
+Added `align` and `stack` variants to `PageLayout.Row`. Use `stack="responsive"` for top bars that should collapse to a vertical stack on narrow viewports, and `align="center"` to vertically center children. Applied the new variants to the Prompts and Workflows top bars so the search field and primary action share a single row on desktop and stack on mobile.
+
+```tsx
+<PageLayout.Row align="center" stack="responsive">
+  <ListSearch ... />
+  <Button ...>Create</Button>
+</PageLayout.Row>
+```

--- a/.changeset/responsive-prompts-workflows-toparea.md
+++ b/.changeset/responsive-prompts-workflows-toparea.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Aligned the Prompts and Workflows top bars so the search field and primary action share a single row, and stack vertically on narrow viewports.

--- a/packages/playground-ui/src/ds/components/PageLayout/page-layout-row.tsx
+++ b/packages/playground-ui/src/ds/components/PageLayout/page-layout-row.tsx
@@ -1,10 +1,41 @@
+import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
+
+const pageLayoutRowVariants = cva('flex justify-between gap-3', {
+  variants: {
+    align: {
+      start: 'items-start',
+      center: 'items-center',
+    },
+    stack: {
+      horizontal: 'flex-row',
+      responsive: 'flex-col items-stretch sm:flex-row',
+    },
+  },
+  compoundVariants: [
+    {
+      stack: 'responsive',
+      align: 'start',
+      class: 'sm:items-start',
+    },
+    {
+      stack: 'responsive',
+      align: 'center',
+      class: 'sm:items-center',
+    },
+  ],
+  defaultVariants: {
+    align: 'start',
+    stack: 'horizontal',
+  },
+});
 
 export type PageLayoutRowProps = {
   children?: React.ReactNode;
   className?: string;
-};
+} & VariantProps<typeof pageLayoutRowVariants>;
 
-export function PageLayoutRow({ children, className }: PageLayoutRowProps) {
-  return <div className={cn('flex items-start justify-between', className)}>{children}</div>;
+export function PageLayoutRow({ children, className, align, stack }: PageLayoutRowProps) {
+  return <div className={cn(pageLayoutRowVariants({ align, stack }), className)}>{children}</div>;
 }

--- a/packages/playground/src/domains/datasets/components/datasets-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-toolbar.tsx
@@ -40,7 +40,7 @@ export function DatasetsToolbar({
 }: DatasetsToolbarProps) {
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <div className="max-w-120 flex-1">
+      <div className="min-w-64 max-w-120 flex-1">
         <ListSearch
           label="Search datasets"
           placeholder="Filter by dataset name"
@@ -85,7 +85,12 @@ export function DatasetsToolbar({
         )}
       </ButtonsGroup>
       {onCreateClick && (
-        <ButtonWithTooltip onClick={onCreateClick} tooltipContent={createTooltip} className="ml-auto">
+        <ButtonWithTooltip
+          onClick={onCreateClick}
+          tooltipContent={createTooltip}
+          variant="primary"
+          className="ml-auto shrink-0"
+        >
           <Plus />
         </ButtonWithTooltip>
       )}

--- a/packages/playground/src/domains/datasets/components/datasets-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-toolbar.tsx
@@ -40,12 +40,14 @@ export function DatasetsToolbar({
 }: DatasetsToolbarProps) {
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <ListSearch
-        label="Search datasets"
-        placeholder="Filter by dataset name"
-        value={search}
-        onSearch={onSearchChange}
-      />
+      <div className="max-w-120 flex-1">
+        <ListSearch
+          label="Search datasets"
+          placeholder="Filter by dataset name"
+          value={search}
+          onSearch={onSearchChange}
+        />
+      </div>
       <ButtonsGroup>
         <SelectFieldBlock
           label="Target"

--- a/packages/playground/src/pages/prompt-blocks/index.tsx
+++ b/packages/playground/src/pages/prompt-blocks/index.tsx
@@ -59,16 +59,18 @@ export default function PromptBlocks() {
   return (
     <PageLayout>
       <PageLayout.TopArea>
-        <PageLayout.Row className="justify-end">
+        <div className="flex flex-col items-stretch justify-between gap-3 sm:flex-row sm:items-center">
+          <div className="max-w-120 flex-1">
+            <ListSearch onSearch={setSearch} label="Filter prompts" placeholder="Filter by name or description" />
+          </div>
           {isCmsAvailable && (
-            <Button as={Link} to={paths.cmsPromptBlockCreateLink()} variant="primary">
-              <Plus />
-              Create Prompt
-            </Button>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button as={Link} to={paths.cmsPromptBlockCreateLink()} variant="primary">
+                <Plus />
+                Create Prompt
+              </Button>
+            </div>
           )}
-        </PageLayout.Row>
-        <div className="max-w-120">
-          <ListSearch onSearch={setSearch} label="Filter prompts" placeholder="Filter by name or description" />
         </div>
       </PageLayout.TopArea>
 

--- a/packages/playground/src/pages/prompt-blocks/index.tsx
+++ b/packages/playground/src/pages/prompt-blocks/index.tsx
@@ -59,19 +59,17 @@ export default function PromptBlocks() {
   return (
     <PageLayout>
       <PageLayout.TopArea>
-        <div className="flex flex-col items-stretch justify-between gap-3 sm:flex-row sm:items-center">
+        <PageLayout.Row align="center" stack="responsive">
           <div className="max-w-120 flex-1">
             <ListSearch onSearch={setSearch} label="Filter prompts" placeholder="Filter by name or description" />
           </div>
           {isCmsAvailable && (
-            <div className="flex shrink-0 items-center gap-2">
-              <Button as={Link} to={paths.cmsPromptBlockCreateLink()} variant="primary">
-                <Plus />
-                Create Prompt
-              </Button>
-            </div>
+            <Button as={Link} to={paths.cmsPromptBlockCreateLink()} variant="primary" className="shrink-0">
+              <Plus />
+              Create Prompt
+            </Button>
           )}
-        </div>
+        </PageLayout.Row>
       </PageLayout.TopArea>
 
       <PromptsList promptBlocks={promptBlocks} isLoading={isLoading} search={search} />

--- a/packages/playground/src/pages/workflows/index.tsx
+++ b/packages/playground/src/pages/workflows/index.tsx
@@ -59,7 +59,7 @@ function Workflows() {
           <div className="max-w-120 flex-1">
             <ListSearch onSearch={setSearch} label="Filter workflows" placeholder="Filter by name or description" />
           </div>
-          <Button as={Link} to="/workflows/schedules" variant="ghost" className="shrink-0">
+          <Button as={Link} to="/workflows/schedules" variant="primary" className="shrink-0">
             <CalendarClockIcon />
             Schedules
           </Button>

--- a/packages/playground/src/pages/workflows/index.tsx
+++ b/packages/playground/src/pages/workflows/index.tsx
@@ -55,17 +55,15 @@ function Workflows() {
   return (
     <PageLayout>
       <PageLayout.TopArea>
-        <div className="flex flex-col items-stretch justify-between gap-3 sm:flex-row sm:items-center">
+        <PageLayout.Row align="center" stack="responsive">
           <div className="max-w-120 flex-1">
             <ListSearch onSearch={setSearch} label="Filter workflows" placeholder="Filter by name or description" />
           </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <Button as={Link} to="/workflows/schedules" variant="ghost">
-              <CalendarClockIcon />
-              Schedules
-            </Button>
-          </div>
-        </div>
+          <Button as={Link} to="/workflows/schedules" variant="ghost" className="shrink-0">
+            <CalendarClockIcon />
+            Schedules
+          </Button>
+        </PageLayout.Row>
       </PageLayout.TopArea>
 
       <WorkflowsList workflows={workflows || {}} isLoading={isLoading} search={search} />

--- a/packages/playground/src/pages/workflows/index.tsx
+++ b/packages/playground/src/pages/workflows/index.tsx
@@ -55,7 +55,7 @@ function Workflows() {
   return (
     <PageLayout>
       <PageLayout.TopArea>
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-col items-stretch justify-between gap-3 sm:flex-row sm:items-center">
           <div className="max-w-120 flex-1">
             <ListSearch onSearch={setSearch} label="Filter workflows" placeholder="Filter by name or description" />
           </div>


### PR DESCRIPTION
## Summary
- Move the **Create Prompt** button into the same `justify-between` row as the search field on `/prompts`, mirroring the existing `/workflows` pattern.
- Both pages now stack their top bar vertically below the `sm:` breakpoint (`flex-col items-stretch sm:flex-row sm:items-center`), so search and the primary action stay full-width on narrow viewports.

## Test plan
- [ ] Visit `/prompts` and `/workflows` at desktop width — search left, action right, single row.
- [ ] Resize below `sm:` — search and action stack vertically, both full-width.
- [ ] `/prompts` without CMS available — search renders on its own row, no orphan flex slot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR fixes the top bars on Prompts and Workflows so the search box and main action sit side-by-side on desktop but stack and become full-width on small screens, avoiding cramped or orphaned controls.

## Changes

### Responsive PageLayout.Row variants
- Added `align` and `stack` variants to PageLayout.Row via `pageLayoutRowVariants` (cva).
  - align: `start` | `center` (controls items-start / items-center).
  - stack: `horizontal` | `responsive` (responsive = `flex-col items-stretch sm:flex-row`).
  - Compound variants ensure correct sm: alignment.
- `PageLayoutRowProps` now includes `VariantProps<typeof pageLayoutRowVariants>`.
- `PageLayoutRow` accepts `align` and `stack` and applies computed classes.

### Prompts page header
- Replaced custom header layout with:
  - <PageLayout.Row align="center" stack="responsive">
- Wrapped `ListSearch` in `<div className="max-w-120 flex-1">` so the search can flex-grow and be full-width on narrow viewports.
- Moved CMS-gated "Create Prompt" button into the same row and marked it `className="shrink-0"`. When CMS is unavailable, the search renders alone without leaving an orphan flex slot.

### Workflows page header
- Switched to `PageLayout.Row align="center" stack="responsive"` so search and the "Schedules" action stack below `sm:`.
- Updated the "Schedules" button variant from `ghost` to `primary` and kept it `className="shrink-0"`.

### Datasets toolbar
- Wrapped the datasets `ListSearch` in `min-w-64 max-w-120 flex-1` so the input keeps a sensible minimum before wrapping.
- Changed the create-dataset control (`ButtonWithTooltip`) to `variant="primary"` and `className="ml-auto shrink-0"` for consistent appearance and to avoid orphan flex gaps.

### Changeset
- .changeset/responsive-prompts-workflows-toparea.md updated to publish `@mastra/playground-ui` (patch) and `@internal/playground` (patch), documenting the PageLayout.Row `align`/`stack` variants and the Prompts/Workflows top bar layout changes.

## Test plan
- Desktop: verify `/prompts` and `/workflows` show search at left and action at right in a single row.
- Narrow (< sm): verify search and action stack vertically and are full-width.
- `/prompts` when CMS is unavailable: verify the search renders alone on its own row (no orphan flex slot).

## Notes for reviewers
- Public API change: `PageLayoutRowProps` now exposes `align` and `stack` variant props (prop type/signature updated).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->