### PR TITLE
fix(mcp): close and clear transport in InternalMastraMCPClient.onclose (#16693)

### DIFF
--- a/.changeset/fix-mcp-client-onclose-transport-leak.md
+++ b/.changeset/fix-mcp-client-onclose-transport-leak.md
@@ -2,4 +2,6 @@
 '@mastra/mcp': patch
 ---
 
-Close and clear the previous transport inside `InternalMastraMCPClient`'s `client.onclose` handler so it mirrors the cleanup already done by `forceReconnect()`. Previously the implicit-close path (server restart, network blip, idle timeout) left `this.transport` set, so the underlying `EventSource` kept retrying on its built-in 3-second loop and the next `connect()` overwrote `this.transport` without releasing the previous one. Under sustained server churn the server-side session map could grow to tens of thousands of entries. See #16693.
+Fixed a transport leak when the MCP server closes the connection.
+The client now cleans up the previous transport before reconnecting.
+This prevents repeated retry loops and avoids server session buildup during repeated disconnects. See `#16693`.

--- a/.changeset/fix-mcp-client-onclose-transport-leak.md
+++ b/.changeset/fix-mcp-client-onclose-transport-leak.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Close and clear the previous transport inside `InternalMastraMCPClient`'s `client.onclose` handler so it mirrors the cleanup already done by `forceReconnect()`. Previously the implicit-close path (server restart, network blip, idle timeout) left `this.transport` set, so the underlying `EventSource` kept retrying on its built-in 3-second loop and the next `connect()` overwrote `this.transport` without releasing the previous one. Under sustained server churn the server-side session map could grow to tens of thousands of entries. See #16693.

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -3039,11 +3039,16 @@ describe('MastraMCPClient - custom fetch failure modes (auth-token loop)', () =>
  * transport.onclose → client.onclose is a no-op).
  */
 describe('InternalMastraMCPClient - onclose transport cleanup (issue #16693)', () => {
-  it('closes and clears the previous transport when the server triggers onclose', async () => {
-    // Stand up an MCP server we can shut down to provoke an implicit close.
+  // Stand up a minimal Streamable HTTP MCP server and a connected client.
+  // Returns the client plus a teardown fn. The connection drop itself is
+  // simulated by invoking the transport's `onclose` directly (see below) —
+  // a server-side `close()` does NOT reliably propagate to a Streamable
+  // HTTP client's `onclose` within a test window, since that transport has
+  // no persistent receive channel; it only notices on the next request.
+  async function setupConnectedClient(name: string) {
     const httpServer: HttpServer = createServer();
     const mcpServer = new McpServer(
-      { name: 'onclose-cleanup-test-server', version: '1.0.0' },
+      { name: `${name}-server`, version: '1.0.0' },
       { capabilities: { logging: {}, tools: {} } },
     );
     mcpServer.tool('noop', 'no-op', {}, async (): Promise<CallToolResult> => ({
@@ -3061,76 +3066,67 @@ describe('InternalMastraMCPClient - onclose transport cleanup (issue #16693)', (
       });
     });
 
-    const client = new InternalMastraMCPClient({
-      name: 'onclose-cleanup-test',
-      server: { url: baseUrl },
-    });
+    const client = new InternalMastraMCPClient({ name, server: { url: baseUrl } });
     await client.connect();
 
+    const teardown = async () => {
+      await client.disconnect().catch(() => {});
+      await serverTransport.close().catch(() => {});
+      await mcpServer.close().catch(() => {});
+      httpServer.close();
+    };
+    return { client, teardown };
+  }
+
+  it('closes and clears the previous transport when the connection drops', async () => {
+    const { client, teardown } = await setupConnectedClient('onclose-cleanup-test');
+
     // Snapshot the active transport + spy on its close().
-    const transportBeforeClose = (client as unknown as { transport: { close: () => Promise<void> } }).transport;
+    const internals = client as unknown as {
+      transport?: { close: () => Promise<void>; onclose?: () => void };
+    };
+    const transportBeforeClose = internals.transport;
     expect(transportBeforeClose).toBeDefined();
-    const closeSpy = vi.spyOn(transportBeforeClose, 'close');
+    const closeSpy = vi.spyOn(transportBeforeClose!, 'close');
 
-    // Trigger an implicit close from the server side. This fires the client's
-    // onclose handler — the path the original bug leaks under.
-    await serverTransport.close();
-    await mcpServer.close();
+    // Simulate an implicit connection drop (server restart / network blip /
+    // idle timeout). The MCP SDK wires `transport.onclose` to the Protocol,
+    // which calls `client.onclose` — the handler under test. Triggering it
+    // directly is the faithful reproduction of the leak in #16693.
+    transportBeforeClose!.onclose?.();
 
-    // onclose runs synchronously off the transport event, but the close()
-    // promise we kick inside it resolves on a microtask; give it a tick.
-    await new Promise(resolve => setTimeout(resolve, 50));
+    // The handler runs synchronously and kicks `transport.close()` as a
+    // fire-and-forget call, so the spy is recorded immediately. Give the
+    // close() promise a tick to settle for good measure.
+    await new Promise(resolve => setTimeout(resolve, 10));
 
-    // Contract: previous transport had .close() invoked, and this.transport
-    // was cleared so the next connect() can't accidentally overwrite a still-
-    // running EventSource (the SSE leak vector).
+    // Contract: the previous transport had close() invoked, and this.transport
+    // was cleared so the next connect() can't overwrite a still-running
+    // EventSource (the SSE leak vector).
     expect(closeSpy).toHaveBeenCalledTimes(1);
-    expect((client as unknown as { transport: unknown }).transport).toBeUndefined();
+    expect(internals.transport).toBeUndefined();
 
-    httpServer.close();
+    await teardown();
   }, 15000);
 
   it('does not re-enter onclose when transport.close() bubbles back through it', async () => {
-    // Re-entry guard: if transport.close() synchronously fires its own
-    // onclose -> client.onclose, the snapshot-and-clear ordering should
-    // mean the second pass sees this.transport === undefined and skips the
-    // recursive close() call (so close() is only invoked once, not N times).
-    const httpServer: HttpServer = createServer();
-    const mcpServer = new McpServer(
-      { name: 'onclose-reentry-test-server', version: '1.0.0' },
-      { capabilities: { logging: {}, tools: {} } },
-    );
-    mcpServer.tool('noop', 'no-op', {}, async (): Promise<CallToolResult> => ({
-      content: [{ type: 'text', text: 'ok' }],
-    }));
-    const serverTransport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
-    await mcpServer.connect(serverTransport);
-    httpServer.on('request', async (req, res) => {
-      await serverTransport.handleRequest(req, res);
-    });
-    const baseUrl = await new Promise<URL>(resolve => {
-      httpServer.listen(0, '127.0.0.1', () => {
-        const addr = httpServer.address() as AddressInfo;
-        resolve(new URL(`http://127.0.0.1:${addr.port}/mcp`));
-      });
-    });
+    const { client, teardown } = await setupConnectedClient('onclose-reentry-test');
 
-    const client = new InternalMastraMCPClient({
-      name: 'onclose-reentry-test',
-      server: { url: baseUrl },
-    });
-    await client.connect();
-
-    const transportBeforeClose = (client as unknown as { transport: { close: () => Promise<void> } }).transport;
+    const internals = client as unknown as {
+      transport?: { close: () => Promise<void>; onclose?: () => void };
+    };
+    const transportBeforeClose = internals.transport!;
     const closeSpy = vi.spyOn(transportBeforeClose, 'close');
 
-    await serverTransport.close();
-    await mcpServer.close();
-    await new Promise(resolve => setTimeout(resolve, 50));
+    // Re-entry guard: transport.close() typically fires the transport's own
+    // onclose again -> client.onclose. The snapshot-and-clear ordering means
+    // the second pass sees this.transport === undefined and skips the
+    // recursive close() — so close() runs exactly once, not N times.
+    transportBeforeClose.onclose?.();
+    await new Promise(resolve => setTimeout(resolve, 10));
 
-    // close() called exactly once even if the SDK re-fires onclose.
     expect(closeSpy).toHaveBeenCalledTimes(1);
 
-    httpServer.close();
+    await teardown();
   }, 15000);
 });

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -3022,3 +3022,115 @@ describe('MastraMCPClient - custom fetch failure modes (auth-token loop)', () =>
     tokenWaiters.forEach(cancel => cancel());
   }, 20000);
 });
+
+/**
+ * Issue #16693: SSE transport leak on implicit close.
+ *
+ * When the MCP server triggers a connection close (server restart, network
+ * blip, idle timeout — anything that fires client.onclose), the previous
+ * client.onclose handler only cleared isConnected. It did NOT call
+ * this.transport.close() or clear this.transport. The orphaned transport's
+ * resources (EventSource for SSE, fetch reader for Streamable HTTP) then
+ * kept running, with SSE in particular spinning its built-in retry loop
+ * forever — a leak we saw blow a server-side session map to 30k+ entries.
+ *
+ * The fix mirrors the cleanup in forceReconnect(): in onclose, snapshot the
+ * transport, null it on `this`, then call close() (so re-entry through
+ * transport.onclose → client.onclose is a no-op).
+ */
+describe('InternalMastraMCPClient - onclose transport cleanup (issue #16693)', () => {
+  it('closes and clears the previous transport when the server triggers onclose', async () => {
+    // Stand up an MCP server we can shut down to provoke an implicit close.
+    const httpServer: HttpServer = createServer();
+    const mcpServer = new McpServer(
+      { name: 'onclose-cleanup-test-server', version: '1.0.0' },
+      { capabilities: { logging: {}, tools: {} } },
+    );
+    mcpServer.tool('noop', 'no-op', {}, async (): Promise<CallToolResult> => ({
+      content: [{ type: 'text', text: 'ok' }],
+    }));
+    const serverTransport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
+    await mcpServer.connect(serverTransport);
+    httpServer.on('request', async (req, res) => {
+      await serverTransport.handleRequest(req, res);
+    });
+    const baseUrl = await new Promise<URL>(resolve => {
+      httpServer.listen(0, '127.0.0.1', () => {
+        const addr = httpServer.address() as AddressInfo;
+        resolve(new URL(`http://127.0.0.1:${addr.port}/mcp`));
+      });
+    });
+
+    const client = new InternalMastraMCPClient({
+      name: 'onclose-cleanup-test',
+      server: { url: baseUrl },
+    });
+    await client.connect();
+
+    // Snapshot the active transport + spy on its close().
+    const transportBeforeClose = (client as unknown as { transport: { close: () => Promise<void> } }).transport;
+    expect(transportBeforeClose).toBeDefined();
+    const closeSpy = vi.spyOn(transportBeforeClose, 'close');
+
+    // Trigger an implicit close from the server side. This fires the client's
+    // onclose handler — the path the original bug leaks under.
+    await serverTransport.close();
+    await mcpServer.close();
+
+    // onclose runs synchronously off the transport event, but the close()
+    // promise we kick inside it resolves on a microtask; give it a tick.
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // Contract: previous transport had .close() invoked, and this.transport
+    // was cleared so the next connect() can't accidentally overwrite a still-
+    // running EventSource (the SSE leak vector).
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect((client as unknown as { transport: unknown }).transport).toBeUndefined();
+
+    httpServer.close();
+  }, 15000);
+
+  it('does not re-enter onclose when transport.close() bubbles back through it', async () => {
+    // Re-entry guard: if transport.close() synchronously fires its own
+    // onclose -> client.onclose, the snapshot-and-clear ordering should
+    // mean the second pass sees this.transport === undefined and skips the
+    // recursive close() call (so close() is only invoked once, not N times).
+    const httpServer: HttpServer = createServer();
+    const mcpServer = new McpServer(
+      { name: 'onclose-reentry-test-server', version: '1.0.0' },
+      { capabilities: { logging: {}, tools: {} } },
+    );
+    mcpServer.tool('noop', 'no-op', {}, async (): Promise<CallToolResult> => ({
+      content: [{ type: 'text', text: 'ok' }],
+    }));
+    const serverTransport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
+    await mcpServer.connect(serverTransport);
+    httpServer.on('request', async (req, res) => {
+      await serverTransport.handleRequest(req, res);
+    });
+    const baseUrl = await new Promise<URL>(resolve => {
+      httpServer.listen(0, '127.0.0.1', () => {
+        const addr = httpServer.address() as AddressInfo;
+        resolve(new URL(`http://127.0.0.1:${addr.port}/mcp`));
+      });
+    });
+
+    const client = new InternalMastraMCPClient({
+      name: 'onclose-reentry-test',
+      server: { url: baseUrl },
+    });
+    await client.connect();
+
+    const transportBeforeClose = (client as unknown as { transport: { close: () => Promise<void> } }).transport;
+    const closeSpy = vi.spyOn(transportBeforeClose, 'close');
+
+    await serverTransport.close();
+    await mcpServer.close();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // close() called exactly once even if the SDK re-fires onclose.
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+
+    httpServer.close();
+  }, 15000);
+});

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -3116,12 +3116,26 @@ describe('InternalMastraMCPClient - onclose transport cleanup (issue #16693)', (
       transport?: { close: () => Promise<void>; onclose?: () => void };
     };
     const transportBeforeClose = internals.transport!;
-    const closeSpy = vi.spyOn(transportBeforeClose, 'close');
 
-    // Re-entry guard: transport.close() typically fires the transport's own
-    // onclose again -> client.onclose. The snapshot-and-clear ordering means
-    // the second pass sees this.transport === undefined and skips the
-    // recursive close() — so close() runs exactly once, not N times.
+    // Deterministically force the re-entry path: make close() itself fire
+    // onclose again (once), exactly as StreamableHTTPClientTransport.close()
+    // does. Whether a given transport re-fires onclose from close() is
+    // transport-dependent in @modelcontextprotocol/sdk, so we don't rely on
+    // the real implementation to reproduce it.
+    let reentered = false;
+    const closeSpy = vi
+      .spyOn(transportBeforeClose, 'close')
+      .mockImplementation(async () => {
+        if (!reentered) {
+          reentered = true;
+          transportBeforeClose.onclose?.();
+        }
+      });
+
+    // Re-entry guard: close() fires the transport's onclose again ->
+    // client.onclose. The snapshot-and-clear ordering means the second pass
+    // sees this.transport === undefined and skips the recursive close() — so
+    // close() runs exactly once, not N times.
     transportBeforeClose.onclose?.();
     await new Promise(resolve => setTimeout(resolve, 10));
 

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -500,6 +500,23 @@ export class InternalMastraMCPClient extends MastraBase {
         this.client.onclose = () => {
           this.log('debug', `MCP server connection closed`);
           this.isConnected = null;
+          // Tear down the underlying transport's resources (EventSource for
+          // SSE, fetch reader for Streamable HTTP). Without this the SSE
+          // EventSource's built-in retry loop reopens connections forever
+          // and the next connect() overwrites this.transport without
+          // closing the previous one. See #16693.
+          //
+          // Snapshot + clear before calling close() to prevent re-entry
+          // through transport.onclose -> client.onclose.
+          if (this.transport) {
+            const previousTransport = this.transport;
+            this.transport = undefined;
+            void previousTransport.close().catch(error => {
+              this.log('debug', 'Error closing transport in onclose handler (ignored)', {
+                error: error instanceof Error ? error.message : String(error),
+              });
+            });
+          }
           if (typeof originalOnClose === 'function') {
             originalOnClose();
           }


### PR DESCRIPTION
Fixes #16693.

## Problem

When the MCP server triggers an implicit connection close (server restart, network blip, idle timeout — anything that fires `client.onclose`), the previous `onclose` handler set inside `InternalMastraMCPClient.connect()` only cleared `isConnected`. It did **not** call `this.transport.close()` and did **not** clear `this.transport`.

The orphaned transport's underlying resources kept running:

- For **SSE**, the underlying `EventSource` spins its built-in retry loop every `reconnectInterval` (3 s default per the W3C spec / `eventsource` polyfill), opening fresh handshakes against the server forever.
- For **Streamable HTTP**, the long-lived GET-SSE listener stream stayed open.

The next `connect()` then overwrote `this.transport` in `connectHttp()` without releasing the previous one. In the originating user's environment, sustained server churn caused the server-side session map to grow to ~30 k entries over a few days.

## Why the explicit path was fine

`forceReconnect()` (lines ~613-634 in `packages/mcp/src/client/client.ts`) already does the right thing:

```ts
if (this.transport) {
  await this.transport.close();
}
this.transport = undefined;
this.isConnected = null;
```

Only the **implicit** `onclose → connect()` path leaked.

## The fix

Bring the implicit path to parity with `forceReconnect()`. In the `client.onclose` handler set inside `connect()`:

1. Snapshot the active transport.
2. Clear `this.transport` before calling `close()` so re-entry through `transport.onclose → client.onclose` sees `this.transport === undefined` and skips the recursive call.
3. Call `close()` fire-and-forget with a `.catch` handler — the SDK's `onclose` contract is synchronous, so we cannot `await` here, but we still need to surface close errors at debug level.

```ts
if (this.transport) {
  const previousTransport = this.transport;
  this.transport = undefined;
  void previousTransport.close().catch(error => {
    this.log('debug', 'Error closing transport in onclose handler (ignored)', {
      error: error instanceof Error ? error.message : String(error),
    });
  });
}
```

## Tests

Adds two tests under a new `describe('InternalMastraMCPClient - onclose transport cleanup (issue #16693)')` block at the end of `packages/mcp/src/client/client.test.ts`:

1. **`closes and clears the previous transport when the server triggers onclose`** — stands up an MCP server, connects a client, spies on the current transport's `close()`, then closes the server. Asserts `close()` was called once and `this.transport` is `undefined` after the handler runs.
2. **`does not re-enter onclose when transport.close() bubbles back through it`** — same setup; proves the snapshot-and-clear ordering means `close()` is called exactly once even if the SDK re-fires `onclose` recursively.

## Changeset

`.changeset/fix-mcp-client-onclose-transport-leak.md` (`@mastra/mcp` patch).

## Risk

- The change is contained to the `onclose` handler. No new public API, no behavior change on the success path.
- The snapshot-before-close pattern is the canonical fix for re-entrant close handlers in JS; it is what `forceReconnect()` effectively achieves by clearing `this.transport = undefined` after its `await close()`.
- For users whose servers were depending on the old leaky behavior, the new behavior is strictly more correct: any caller that wants reconnection after an implicit close should be calling `connect()` again explicitly.

## Checklist

- [x] Fix is minimal and focused on a single behavior change
- [x] Unit tests added that fail before the fix and pass after
- [x] Changeset added (`@mastra/mcp` patch)
- [x] PR title and commit follow the conventional `fix(mcp):` format
- [x] Linked the originating issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Imagine your walkie-talkie keeps an old line open and it keeps trying to call forever after your friend drops. This PR makes the walkie-talkie hang up the old line first so it stops creating "ghost" connections that waste resources.

## Summary of changes

This PR fixes issue `#16693` by updating InternalMastraMCPClient’s implicit client.onclose handler so it properly closes and clears the previous transport when the MCP server closes the connection.

### Problem

When the MCP server triggered an implicit client close (e.g., server restart, network blip, idle timeout), the onclose handler only cleared isConnected but left this.transport set. That allowed the underlying transport (EventSource for SSE or stream readers for Streamable HTTP) to remain active and continue retrying, causing unbounded server-side session growth (~30k entries in production).

### Solution

The onclose handler now:
1. Snapshots the active transport.
2. Sets this.transport = undefined to avoid re-entrancy.
3. Calls previousTransport.close() fire-and-forget and logs any close errors at debug level.

This ensures orphaned transports are cleaned up and prevents re-entrant onclose recursion.

### Changes

- packages/mcp/src/client/client.ts
  - Modified InternalMastraMCPClient.connect()'s client.onclose handler to snapshot, clear, and close the previous transport.

- packages/mcp/src/client/client.test.ts
  - Added Vitest suite "InternalMastraMCPClient - onclose transport cleanup (issue `#16693`)" with two tests:
    - Verifies the previous transport’s close() is invoked and client.transport is undefined after a server-triggered onclose.
    - Verifies non-reentrancy: if transport.close() triggers onclose again, the cleanup logic does not recursively re-run and close() is still called only once.

- .changeset/fix-mcp-client-onclose-transport-leak.md
  - Added a changeset describing the patch release for `@mastra/mcp`.

### Impact

- Scope: change confined to the implicit onclose handler; no public API changes.
- Risk: Low; behavior aligns with existing forceReconnect() pattern.
- Benefit: Prevents EventSource/stream transports from remaining active and retrying after server-triggered closes, avoiding resource leaks and server-side session growth.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->