### PR TITLE
fix(core): only expose saved subagent memory threads

### DIFF
--- a/.changeset/humble-days-grin.md
+++ b/.changeset/humble-days-grin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed subagent memory thread metadata so it is only returned when messages are saved.

--- a/packages/core/src/a2a/a2a-agent.test.ts
+++ b/packages/core/src/a2a/a2a-agent.test.ts
@@ -271,6 +271,47 @@ describe('A2AAgent', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('does not expose memory thread identifiers for a memoryless remote subagent', async () => {
+    const fetchMock = createFetchMock([
+      new Response(JSON.stringify({ ...baseCard, capabilities: { ...baseCard.capabilities, streaming: false } }), {
+        status: 200,
+      }),
+      jsonRpcResult(createMessage('Remote subagent response')),
+    ]);
+
+    const remote = new A2AAgent({
+      url: 'https://remote.example.com',
+      fetch: fetchMock as typeof fetch,
+    });
+
+    const parent = new Agent({
+      id: 'parent-agent',
+      name: 'Parent Agent',
+      instructions: 'Delegate to subagents when needed.',
+      model: createParentModel(),
+      agents: {
+        remote,
+      },
+    });
+
+    const tools = await parent['convertTools']({
+      requestContext: new RequestContext(),
+      methodType: 'generate',
+    });
+
+    const agentTool = tools['agent-remote'];
+    expect(agentTool).toBeDefined();
+
+    const result = await agentTool.execute!({ prompt: 'Do the remote thing' }, {
+      toolCallId: 'call-1',
+      messages: [],
+    } as any);
+
+    expect(result.text).toBe('Remote subagent response');
+    expect(result.subAgentThreadId).toBeUndefined();
+    expect(result.subAgentResourceId).toBeUndefined();
+  });
+
   it('streams through the generated subagent tool when the parent agent uses stream mode', async () => {
     const fetchMock = createFetchMock([
       new Response(JSON.stringify(baseCard), { status: 200 }),
@@ -332,6 +373,8 @@ describe('A2AAgent', () => {
     } as any);
 
     expect(result.text).toBe('Hello from remote stream');
+    expect(result.subAgentThreadId).toBeUndefined();
+    expect(result.subAgentResourceId).toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/core/src/agent/__tests__/tool-handling.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/tool-handling.e2e.test.ts
@@ -61,8 +61,6 @@ function toolhandlingE2ETests(version: 'v1' | 'v2' | 'v3') {
         ...(version === 'v1'
           ? {}
           : {
-              subAgentResourceId: expect.any(String),
-              subAgentThreadId: expect.any(String),
               subAgentToolResults: expect.any(Array),
             }),
         text: 'Dummy response',

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3720,6 +3720,7 @@ export class Agent<
                     }
 
                     // Save rejection messages to sub-agent's memory so the UI can display them
+                    let savedSubAgentMessages = false;
                     const memory = await resolvedAgent.getMemory({ requestContext });
                     if (memory) {
                       try {
@@ -3769,6 +3770,8 @@ export class Agent<
                         await memory.saveMessages({
                           messages: [userMessage, assistantMessage],
                         });
+
+                        savedSubAgentMessages = true;
                       } catch (memoryError) {
                         this.logger.error('Failed to save rejection to sub-agent memory', {
                           agent: this.name,
@@ -3786,8 +3789,7 @@ export class Agent<
 
                     return {
                       text: `[Delegation Rejected] ${rejectionMessage}`,
-                      subAgentThreadId,
-                      subAgentResourceId,
+                      ...(savedSubAgentMessages ? { subAgentThreadId, subAgentResourceId } : {}),
                     };
                   }
                   // Apply modifications
@@ -3941,6 +3943,7 @@ export class Agent<
                 fullSubAgentMessages = [userMessage, ...agentResponseMessages];
 
                 // Save response messages to sub-agent's memory so the UI can display them
+                let savedSubAgentMessages = false;
                 const memory = await resolvedAgent.getMemory({ requestContext });
                 if (memory) {
                   try {
@@ -3952,6 +3955,8 @@ export class Agent<
                     await memory.saveMessages({
                       messages: fullSubAgentMessages,
                     });
+
+                    savedSubAgentMessages = true;
                   } catch (memoryError) {
                     this.logger.error('Failed to save messages to sub-agent memory', {
                       agent: this.name,
@@ -3974,7 +3979,11 @@ export class Agent<
                   });
                 }
 
-                result = { text: generateResult.text, subAgentThreadId, subAgentResourceId, subAgentToolResults };
+                result = {
+                  text: generateResult.text,
+                  ...(savedSubAgentMessages ? { subAgentThreadId, subAgentResourceId } : {}),
+                  subAgentToolResults,
+                };
               } else if (
                 (methodType === 'generate' || methodType === 'generateLegacy') &&
                 resolvedModelVersion === 'v1'
@@ -4096,6 +4105,7 @@ export class Agent<
                 fullSubAgentMessages = [userMessage, ...agentResponseMessages];
 
                 // Save response messages to sub-agent's memory so the UI can display them
+                let savedSubAgentMessages = false;
                 const streamMemory = await resolvedAgent.getMemory({ requestContext });
                 if (streamMemory) {
                   try {
@@ -4107,6 +4117,8 @@ export class Agent<
                     await streamMemory.saveMessages({
                       messages: fullSubAgentMessages,
                     });
+
+                    savedSubAgentMessages = true;
                   } catch (memoryError) {
                     this.logger.error('Failed to save messages to sub-agent memory', {
                       agent: this.name,
@@ -4135,8 +4147,7 @@ export class Agent<
                 const processedText = await streamResult.text;
                 result = {
                   text: processedText,
-                  subAgentThreadId,
-                  subAgentResourceId,
+                  ...(savedSubAgentMessages ? { subAgentThreadId, subAgentResourceId } : {}),
                   subAgentToolResults,
                 };
               } else {


### PR DESCRIPTION
This fixes subagent tool results so they only include subAgentThreadId and subAgentResourceId after Mastra actually saves the local subagent transcript.

Before, memoryless subagents could return a generated thread id even though no memory thread existed, so Studio or custom UIs could later fetch that thread and hit Thread not found.

After, remote or memoryless subagents still run normally, but they do not advertise memory thread metadata unless there is a saved thread to read.

Validated with:

pnpm --filter ./packages/core check
pnpm --filter ./packages/core test -- src/a2a/a2a-agent.test.ts
pnpm --filter ./packages/core test -- src/agent/__tests__/tool-handling.e2e.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

Imagine you ask a helper (subagent) to do a task and they give you a claim ticket saying "here's where you can find what I did." But sometimes that ticket number doesn't actually exist—you can't find anything at that location. This PR fixes that problem by making helpers only hand out ticket numbers when they've actually saved their work, not just when they *plan to*.

## Overview

This PR fixes a bug where subagent delegation could return fake memory thread metadata (`subAgentThreadId` and `subAgentResourceId`) even when the subagent's conversation transcript was never actually saved to memory. This caused downstream failures when attempting to fetch a thread using the advertised ID, only to receive a "Thread not found" error.

The fix ensures these IDs are only returned after Mastra has confirmed the subagent's messages were successfully persisted. Remote or memoryless subagents continue to function normally—they just won't advertise phantom memory thread identifiers.

## Changes

### Core Implementation (`packages/core/src/agent/agent.ts`)

Modified `Agent.listAgentTools()`'s delegation handling to conditionally include memory thread metadata:
- Added tracking of whether sub-agent messages were successfully persisted (`savedSubAgentMessages` flag)
- For failed delegations (rejection path): only returns `subAgentThreadId` and `subAgentResourceId` after `memory.saveMessages()` succeeds
- For successful delegations (both `generate` and streaming): only includes these IDs in the tool result after memory persistence is confirmed
- Previously, these IDs were always returned regardless of save success

### Test Updates

**`packages/core/src/a2a/a2a-agent.test.ts`**
- Added test case verifying that memoryless remote subagent invocations do not return `subAgentThreadId` or `subAgentResourceId` in tool results
- Extended streaming test to assert these fields are `undefined` in streamed tool results

**`packages/core/src/agent/__tests__/tool-handling.e2e.test.ts`**
- Updated "agents as tools" e2e assertion to reflect that `subAgentResourceId` and `subAgentThreadId` are no longer unconditionally included in tool results

### Changeset
- `@mastra/core` patch version bump documenting the fix

## Validation

Changes were validated with:
- Type checking: `pnpm --filter ./packages/core check`
- Unit tests: `pnpm --filter ./packages/core test -- src/a2a/a2a-agent.test.ts`
- E2E tests: `pnpm --filter ./packages/core test -- src/agent/__tests__/tool-handling.e2e.test.ts`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->