### PR TITLE
feat(playground-ui): add live-tail polling to Traces list

### DIFF
--- a/.changeset/plain-oranges-find.md
+++ b/.changeset/plain-oranges-find.md
@@ -2,7 +2,7 @@
 '@mastra/playground-ui': patch
 ---
 
-The Traces list now updates live. Previously users had to manually refresh to see new traces — now they appear in the list as they're created, with a brief highlight to draw attention. Status changes on already-visible rows (running → success / error) also propagate without intervention, and returning to the tab after being idle re-syncs from a fresh cursor.
+The Traces list now updates live via delta polling. Previously the list was refetched every 10 seconds, replacing the whole page with no signal about what changed; now new traces appear within a few seconds of being created, with a brief highlight to draw attention. Status changes on already-visible rows (running → success / error) also propagate without intervention, and returning to the tab after being idle re-syncs from a fresh cursor.
 
 **New `useTraces` return fields**
 
@@ -31,7 +31,7 @@ Omitted fields fall through to the defaults (delta poll every 5s, idle reset aft
 
 **TracesListView**
 
-New optional `recentlyAddedKeys?: Set<string>` prop. Rows whose `traceId:spanId` is in the set get the `animate-row-highlight` class — a 1s fade-out from `var(--surface4)` to transparent, added to `index.css`.
+New optional `recentlyAddedKeys?: Set<string>` prop. Rows whose `traceId:spanId` is in the set get the `animate-row-highlight` class — a brief fade-out to transparent, added to `index.css`.
 
 **Compatibility**
 

--- a/.changeset/plain-oranges-find.md
+++ b/.changeset/plain-oranges-find.md
@@ -1,0 +1,38 @@
+---
+'@mastra/playground-ui': patch
+---
+
+The Traces list now updates live. Previously users had to manually refresh to see new traces — now they appear in the list as they're created, with a brief highlight to draw attention. Status changes on already-visible rows (running → success / error) also propagate without intervention, and returning to the tab after being idle re-syncs from a fresh cursor.
+
+**New `useTraces` return fields**
+
+- `isRefetching` — true while any meaningful refetch is in flight. Use it to drive a heartbeat indicator.
+- `autoRefetch` / `setAutoRefetch` — pause / resume all automatic polling so the consumer can render an opt-out toggle.
+- `recentlyAddedKeys` — `Set<string>` of `traceId:spanId` for rows that just arrived via delta polling. Drives the temporary highlight in `TracesListView`.
+
+**New polling config**
+
+Every timing in the hook is tunable per-instance via a new `polling` option:
+
+```ts
+import { useTraces, type TracesPollingConfig } from '@mastra/playground-ui';
+
+useTraces({
+  filters,
+  listMode,
+  polling: {
+    deltaPollIntervalMs: 10_000,
+    idleGuardThresholdMs: 5 * 60_000,
+  },
+});
+```
+
+Omitted fields fall through to the defaults (delta poll every 5s, idle reset after 15 min, status refresh every 60s, etc).
+
+**TracesListView**
+
+New optional `recentlyAddedKeys?: Set<string>` prop. Rows whose `traceId:spanId` is in the set get the `animate-row-highlight` class — a 1s fade-out from `var(--surface4)` to transparent, added to `index.css`.
+
+**Compatibility**
+
+Requires `@mastra/server` and `@mastra/client-js` at the versions that ship the observability delta-polling endpoints, and a store that opts into delta polling (`@mastra/clickhouse`, `@mastra/duckdb`, and the in-memory store today). When unavailable — older server or a store without delta capability — the hook silently falls back to page-mode interval refetching. No consumer changes required.

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -150,10 +150,7 @@ export function TracesListView({
                 ref={virtualizer.measureElement}
                 data-index={vi.index}
                 onClick={() => onTraceClick(trace)}
-                className={cn(
-                  isFeatured && 'bg-surface4',
-                  isRecentlyAdded && 'animate-row-highlight',
-                )}
+                className={cn(isFeatured && 'bg-surface4', isRecentlyAdded && 'animate-row-highlight')}
               >
                 <TracesDataList.DateCell timestamp={displayDate} />
                 <TracesDataList.TimeCell timestamp={displayDate} />

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -52,6 +52,10 @@ export type TracesListViewProps = {
   /** Branches mode mixes root traces with subtraces — enables the Trace/Subtrace tooltip on the
    *  level icon in the Name column, which is meaningless when every row is a root. */
   isBranchesMode?: boolean;
+  /** Keys (`traceId:spanId`) of rows that just arrived via delta polling. Rows whose key is in
+   *  this set get a temporary tint to distinguish them from rows present since the last page-mode
+   *  fetch. Auto-expires upstream (in useTraces) after a short window. */
+  recentlyAddedKeys?: Set<string>;
   /** Called when a row is clicked. The current selection logic (toggle on same id) is the consumer's call. */
   onTraceClick: (trace: TracesListViewTrace) => void;
 };
@@ -70,6 +74,7 @@ export function TracesListView({
   featuredTraceId,
   featuredSpanId,
   isBranchesMode,
+  recentlyAddedKeys,
   onTraceClick,
 }: TracesListViewProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -133,17 +138,22 @@ export function TracesListView({
 
             const isFeatured =
               trace.traceId === featuredTraceId && (featuredSpanId == null || trace.spanId === featuredSpanId);
+            const rowKey = `${trace.traceId}:${trace.spanId ?? ''}`;
+            const isRecentlyAdded = recentlyAddedKeys?.has(rowKey) ?? false;
             const displayDate = trace.startedAt ?? trace.createdAt;
             const entityName =
               trace.entityName || trace.entityId || trace.attributes?.agentId || trace.attributes?.workflowId;
 
             return (
               <TracesDataList.RowButton
-                key={`${trace.traceId}:${trace.spanId ?? ''}`}
+                key={rowKey}
                 ref={virtualizer.measureElement}
                 data-index={vi.index}
                 onClick={() => onTraceClick(trace)}
-                className={cn(isFeatured && 'bg-surface4')}
+                className={cn(
+                  isFeatured && 'bg-surface4',
+                  isRecentlyAdded && 'animate-row-highlight',
+                )}
               >
                 <TracesDataList.DateCell timestamp={displayDate} />
                 <TracesDataList.TimeCell timestamp={displayDate} />

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-traces.test.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-traces.test.ts
@@ -227,9 +227,7 @@ describe('mergeDeltaIntoPage0', () => {
   });
 
   it('prepends delta branches into page 0 (branches mode)', () => {
-    const old = makeInfiniteData([
-      makeBranchesPage([{ traceId: 't1', spanId: 's1', name: 'agent-run' }], false, 'c1'),
-    ]);
+    const old = makeInfiniteData([makeBranchesPage([{ traceId: 't1', spanId: 's1', name: 'agent-run' }], false, 'c1')]);
     const delta = makeDeltaBranchesResponse([{ traceId: 't2', spanId: 's2', name: 'tool-call' }], 'c2');
     const merged = mergeDeltaIntoPage0(old, delta, 'branches');
     const firstPage = merged?.pages[0] as ListBranchesResponse;
@@ -258,11 +256,7 @@ describe('mergeDeltaIntoPage0', () => {
 
   it('sorts merged page 0 by startedAt DESC (delta rows are in cursor order, not startedAt)', () => {
     const old = makeInfiniteData([
-      makeTracesPage(
-        [{ traceId: 'aaa', name: 'Alpha', startedAt: '2026-05-01T12:00:00Z' } as never],
-        false,
-        'c1',
-      ),
+      makeTracesPage([{ traceId: 'aaa', name: 'Alpha', startedAt: '2026-05-01T12:00:00Z' } as never], false, 'c1'),
     ]);
     const delta = {
       delta: { limit: 100, hasMore: false },
@@ -367,9 +361,7 @@ describe('refreshPage0Rows', () => {
   });
 
   it('does not add new rows the refresh response contains but the cache does not', () => {
-    const old = makeInfiniteData([
-      makeTracesPage([{ traceId: 'aaa', spanId: 's1', name: 'Alpha' }], false, 'c1'),
-    ]);
+    const old = makeInfiniteData([makeTracesPage([{ traceId: 'aaa', spanId: 's1', name: 'Alpha' }], false, 'c1')]);
     const refreshed = makeTracesPage(
       [
         { traceId: 'aaa', spanId: 's1', name: 'Alpha' },

--- a/packages/playground-ui/src/domains/traces/hooks/__tests__/use-traces.test.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/__tests__/use-traces.test.ts
@@ -1,25 +1,66 @@
 import type { ListBranchesResponse, ListTracesResponse } from '@mastra/core/storage';
+import type { InfiniteData } from '@tanstack/react-query';
 import { describe, it, expect } from 'vitest';
-import { getTracesNextPageParam, selectUniqueTraces } from '../use-traces';
+import {
+  getTracesNextPageParam,
+  mergeDeltaIntoPage0,
+  refreshPage0Rows,
+  selectUniqueTraces,
+  shouldResetAfterIdle,
+} from '../use-traces';
+
+type TracesPageResponse = ListTracesResponse | ListBranchesResponse;
 
 function makeTracesPage(
   spans: Array<{ traceId: string; spanId?: string; name: string; metadata?: unknown; tags?: unknown }>,
   hasMore: boolean,
+  deltaCursor?: string,
 ): ListTracesResponse {
   return {
     pagination: { total: 100, page: 0, perPage: 25, hasMore },
     spans,
+    ...(deltaCursor !== undefined ? { deltaCursor } : {}),
   } as unknown as ListTracesResponse;
 }
 
 function makeBranchesPage(
   branches: Array<{ traceId: string; spanId: string; name: string; spanType?: string }>,
   hasMore: boolean,
+  deltaCursor?: string,
 ): ListBranchesResponse {
   return {
     pagination: { total: 100, page: 0, perPage: 25, hasMore },
     branches,
+    ...(deltaCursor !== undefined ? { deltaCursor } : {}),
   } as unknown as ListBranchesResponse;
+}
+
+function makeDeltaTracesResponse(
+  spans: Array<{ traceId: string; spanId?: string; name: string }>,
+  deltaCursor: string,
+  hasMore = false,
+): ListTracesResponse {
+  return {
+    delta: { limit: 100, hasMore },
+    deltaCursor,
+    spans,
+  } as unknown as ListTracesResponse;
+}
+
+function makeDeltaBranchesResponse(
+  branches: Array<{ traceId: string; spanId: string; name: string }>,
+  deltaCursor: string,
+  hasMore = false,
+): ListBranchesResponse {
+  return {
+    delta: { limit: 100, hasMore },
+    deltaCursor,
+    branches,
+  } as unknown as ListBranchesResponse;
+}
+
+function makeInfiniteData(pages: TracesPageResponse[]): InfiniteData<TracesPageResponse> {
+  return { pages, pageParams: pages.map((_, idx) => idx) };
 }
 
 describe('useTraces logic', () => {
@@ -148,5 +189,237 @@ describe('useTraces logic', () => {
   it('uses hasMore from ListBranchesResponse pagination', () => {
     expect(getTracesNextPageParam(makeBranchesPage([], true), [], 0)).toBe(1);
     expect(getTracesNextPageParam(makeBranchesPage([], false), [], 0)).toBeUndefined();
+  });
+});
+
+describe('selectUniqueTraces — deltaCursor extension', () => {
+  it("surfaces page 0's deltaCursor", () => {
+    const data = {
+      pages: [makeTracesPage([{ traceId: 'aaa', name: 'Alpha' }], false, 'cursor-42')],
+    };
+    expect(selectUniqueTraces(data).deltaCursor).toBe('cursor-42');
+  });
+
+  it('returns undefined deltaCursor when page 0 has no cursor (legacy server)', () => {
+    const data = { pages: [makeTracesPage([{ traceId: 'aaa', name: 'Alpha' }], false)] };
+    expect(selectUniqueTraces(data).deltaCursor).toBeUndefined();
+  });
+
+  it('reads the cursor only from page 0, not later pages', () => {
+    const data = {
+      pages: [
+        makeTracesPage([{ traceId: 'aaa', name: 'Alpha' }], true, 'cursor-first'),
+        makeTracesPage([{ traceId: 'bbb', name: 'Bravo' }], false, 'cursor-second'),
+      ],
+    };
+    expect(selectUniqueTraces(data).deltaCursor).toBe('cursor-first');
+  });
+});
+
+describe('mergeDeltaIntoPage0', () => {
+  it('prepends delta spans into page 0 (traces mode)', () => {
+    const old = makeInfiniteData([makeTracesPage([{ traceId: 'aaa', name: 'Alpha' }], false, 'c1')]);
+    const delta = makeDeltaTracesResponse([{ traceId: 'bbb', name: 'Bravo' }], 'c2');
+    const merged = mergeDeltaIntoPage0(old, delta, 'traces');
+    const firstPage = merged?.pages[0] as ListTracesResponse;
+    expect(firstPage.spans.map(s => s.traceId)).toEqual(['bbb', 'aaa']);
+    expect(firstPage.deltaCursor).toBe('c2');
+  });
+
+  it('prepends delta branches into page 0 (branches mode)', () => {
+    const old = makeInfiniteData([
+      makeBranchesPage([{ traceId: 't1', spanId: 's1', name: 'agent-run' }], false, 'c1'),
+    ]);
+    const delta = makeDeltaBranchesResponse([{ traceId: 't2', spanId: 's2', name: 'tool-call' }], 'c2');
+    const merged = mergeDeltaIntoPage0(old, delta, 'branches');
+    const firstPage = merged?.pages[0] as ListBranchesResponse;
+    expect(firstPage.branches.map(b => `${b.traceId}:${b.spanId}`)).toEqual(['t2:s2', 't1:s1']);
+    expect(firstPage.deltaCursor).toBe('c2');
+  });
+
+  it('advances cursor even when delta returns no new rows', () => {
+    const old = makeInfiniteData([makeTracesPage([{ traceId: 'aaa', name: 'Alpha' }], false, 'c1')]);
+    const delta = makeDeltaTracesResponse([], 'c2');
+    const merged = mergeDeltaIntoPage0(old, delta, 'traces');
+    const firstPage = merged?.pages[0] as ListTracesResponse;
+    expect(firstPage.spans.map(s => s.traceId)).toEqual(['aaa']);
+    expect(firstPage.deltaCursor).toBe('c2');
+  });
+
+  it("keeps existing cursor when delta doesn't include one", () => {
+    const old = makeInfiniteData([makeTracesPage([{ traceId: 'aaa', name: 'Alpha' }], false, 'c1')]);
+    const delta = {
+      delta: { limit: 100, hasMore: false },
+      spans: [{ traceId: 'bbb', name: 'Bravo' }],
+    } as unknown as ListTracesResponse;
+    const merged = mergeDeltaIntoPage0(old, delta, 'traces');
+    expect((merged?.pages[0] as ListTracesResponse).deltaCursor).toBe('c1');
+  });
+
+  it('sorts merged page 0 by startedAt DESC (delta rows are in cursor order, not startedAt)', () => {
+    const old = makeInfiniteData([
+      makeTracesPage(
+        [{ traceId: 'aaa', name: 'Alpha', startedAt: '2026-05-01T12:00:00Z' } as never],
+        false,
+        'c1',
+      ),
+    ]);
+    const delta = {
+      delta: { limit: 100, hasMore: false },
+      deltaCursor: 'c2',
+      spans: [
+        { traceId: 'bbb', name: 'Bravo (older)', startedAt: '2026-05-01T11:00:00Z' },
+        { traceId: 'ccc', name: 'Charlie (newer)', startedAt: '2026-05-01T13:00:00Z' },
+      ],
+    } as unknown as ListTracesResponse;
+    const merged = mergeDeltaIntoPage0(old, delta, 'traces');
+    const firstPage = merged?.pages[0] as ListTracesResponse;
+    expect(firstPage.spans.map(s => s.traceId)).toEqual(['ccc', 'aaa', 'bbb']);
+  });
+
+  it('leaves later pages untouched', () => {
+    const old = makeInfiniteData([
+      makeTracesPage([{ traceId: 'aaa', name: 'Alpha' }], true, 'c1'),
+      makeTracesPage([{ traceId: 'bbb', name: 'Bravo' }], false),
+    ]);
+    const delta = makeDeltaTracesResponse([{ traceId: 'ccc', name: 'Charlie' }], 'c2');
+    const merged = mergeDeltaIntoPage0(old, delta, 'traces');
+    expect((merged?.pages[1] as ListTracesResponse).spans.map(s => s.traceId)).toEqual(['bbb']);
+  });
+
+  it('returns input unchanged when there are no pages yet', () => {
+    const old = makeInfiniteData([]);
+    const delta = makeDeltaTracesResponse([{ traceId: 'aaa', name: 'Alpha' }], 'c1');
+    expect(mergeDeltaIntoPage0(old, delta, 'traces')).toBe(old);
+  });
+
+  it('returns undefined when called with undefined input', () => {
+    const delta = makeDeltaTracesResponse([], 'c1');
+    expect(mergeDeltaIntoPage0(undefined, delta, 'traces')).toBeUndefined();
+  });
+});
+
+describe('refreshPage0Rows', () => {
+  it('replaces existing rows by traceId:spanId (traces mode)', () => {
+    const old = makeInfiniteData([
+      makeTracesPage(
+        [
+          { traceId: 'aaa', spanId: 's1', name: 'Alpha (running)' },
+          { traceId: 'bbb', spanId: 's2', name: 'Bravo (running)' },
+        ],
+        false,
+        'c1',
+      ),
+    ]);
+    const refreshed = makeTracesPage(
+      [
+        { traceId: 'aaa', spanId: 's1', name: 'Alpha (success)' },
+        { traceId: 'bbb', spanId: 's2', name: 'Bravo (success)' },
+      ],
+      false,
+      'c1',
+    );
+    const result = refreshPage0Rows(old, refreshed, 'traces');
+    const firstPage = result?.pages[0] as ListTracesResponse;
+    expect(firstPage.spans.map(s => s.name)).toEqual(['Alpha (success)', 'Bravo (success)']);
+  });
+
+  it('replaces existing rows by traceId:spanId (branches mode)', () => {
+    const old = makeInfiniteData([
+      makeBranchesPage(
+        [
+          { traceId: 't1', spanId: 's1', name: 'agent-run (running)' },
+          { traceId: 't1', spanId: 's2', name: 'tool-call (running)' },
+        ],
+        false,
+        'c1',
+      ),
+    ]);
+    const refreshed = makeBranchesPage(
+      [
+        { traceId: 't1', spanId: 's1', name: 'agent-run (success)' },
+        { traceId: 't1', spanId: 's2', name: 'tool-call (success)' },
+      ],
+      false,
+      'c1',
+    );
+    const result = refreshPage0Rows(old, refreshed, 'branches');
+    const firstPage = result?.pages[0] as ListBranchesResponse;
+    expect(firstPage.branches.map(b => b.name)).toEqual(['agent-run (success)', 'tool-call (success)']);
+  });
+
+  it("preserves rows the refresh response doesn't include (delta-accumulated)", () => {
+    const old = makeInfiniteData([
+      makeTracesPage(
+        [
+          { traceId: 'delta-only', spanId: 's0', name: 'Delta Row' },
+          { traceId: 'aaa', spanId: 's1', name: 'Alpha (running)' },
+        ],
+        false,
+        'c1',
+      ),
+    ]);
+    const refreshed = makeTracesPage([{ traceId: 'aaa', spanId: 's1', name: 'Alpha (success)' }], false, 'c1');
+    const result = refreshPage0Rows(old, refreshed, 'traces');
+    const firstPage = result?.pages[0] as ListTracesResponse;
+    expect(firstPage.spans.map(s => s.traceId)).toEqual(['delta-only', 'aaa']);
+    expect(firstPage.spans[1].name).toBe('Alpha (success)');
+  });
+
+  it('does not add new rows the refresh response contains but the cache does not', () => {
+    const old = makeInfiniteData([
+      makeTracesPage([{ traceId: 'aaa', spanId: 's1', name: 'Alpha' }], false, 'c1'),
+    ]);
+    const refreshed = makeTracesPage(
+      [
+        { traceId: 'aaa', spanId: 's1', name: 'Alpha' },
+        { traceId: 'new', spanId: 's-new', name: 'New (server saw it, we didn`t)' },
+      ],
+      false,
+      'c1',
+    );
+    const result = refreshPage0Rows(old, refreshed, 'traces');
+    const firstPage = result?.pages[0] as ListTracesResponse;
+    expect(firstPage.spans.map(s => s.traceId)).toEqual(['aaa']);
+  });
+
+  it('returns input unchanged when refresh response has no rows', () => {
+    const old = makeInfiniteData([makeTracesPage([{ traceId: 'aaa', spanId: 's1', name: 'Alpha' }], false, 'c1')]);
+    const refreshed = makeTracesPage([], false, 'c1');
+    expect(refreshPage0Rows(old, refreshed, 'traces')).toBe(old);
+  });
+
+  it('returns input unchanged when there are no pages yet', () => {
+    const old = makeInfiniteData([]);
+    const refreshed = makeTracesPage([{ traceId: 'aaa', spanId: 's1', name: 'Alpha' }], false, 'c1');
+    expect(refreshPage0Rows(old, refreshed, 'traces')).toBe(old);
+  });
+
+  it('returns undefined when called with undefined input', () => {
+    const refreshed = makeTracesPage([], false, 'c1');
+    expect(refreshPage0Rows(undefined, refreshed, 'traces')).toBeUndefined();
+  });
+});
+
+describe('shouldResetAfterIdle', () => {
+  const threshold = 15 * 60_000;
+
+  it('returns false when nothing has loaded yet (lastSuccessAt = 0)', () => {
+    expect(shouldResetAfterIdle(0, Date.now(), threshold)).toBe(false);
+  });
+
+  it('returns false when within the threshold', () => {
+    const now = 1_000_000_000;
+    expect(shouldResetAfterIdle(now - threshold + 1, now, threshold)).toBe(false);
+  });
+
+  it('returns false right at the threshold boundary (exclusive)', () => {
+    const now = 1_000_000_000;
+    expect(shouldResetAfterIdle(now - threshold, now, threshold)).toBe(false);
+  });
+
+  it('returns true when past the threshold', () => {
+    const now = 1_000_000_000;
+    expect(shouldResetAfterIdle(now - threshold - 1, now, threshold)).toBe(true);
   });
 });

--- a/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
@@ -258,9 +258,7 @@ export const useTraces = ({ filters, listMode = 'traces', polling = {} }: UseTra
   const queryClient = useQueryClient();
   const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
 
-  const [deltaSupport, setDeltaSupport] = useState<DeltaSupport>(
-    () => deltaSupportByClient.get(client) ?? 'unknown',
-  );
+  const [deltaSupport, setDeltaSupport] = useState<DeltaSupport>(() => deltaSupportByClient.get(client) ?? 'unknown');
   const deltaUnsupported = deltaSupport === 'unsupported';
 
   // When false, all automatic polling stops: delta polls, status refresh,
@@ -317,8 +315,7 @@ export const useTraces = ({ filters, listMode = 'traces', polling = {} }: UseTra
   const deltaQuery = useQuery({
     queryKey: ['traces-delta', listMode, filters] as const,
     queryFn: () => {
-      const current = queryClient.getQueryData<InfiniteData<TracesPageResponse>>(tracesQueryKey)?.pages[0]
-        ?.deltaCursor;
+      const current = queryClient.getQueryData<InfiniteData<TracesPageResponse>>(tracesQueryKey)?.pages[0]?.deltaCursor;
       if (!current) return null;
       return fetchTracesFn({
         client,

--- a/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
+++ b/packages/playground-ui/src/domains/traces/hooks/use-traces.tsx
@@ -1,29 +1,97 @@
 import type { ListBranchesArgs, ListBranchesResponse, ListTracesArgs, ListTracesResponse } from '@mastra/core/storage';
 import { useMastraClient } from '@mastra/react';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import type { InfiniteData } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
 import type { TraceListMode } from '../trace-filters';
 import { useInView } from '@/hooks/use-in-view';
 import { is403ForbiddenError } from '@/lib/query-utils';
 
+/**
+ * Per-MastraClient delta-polling support cache. Sticks once we observe a 501
+ * or a page-0 response without `deltaCursor` (legacy server or store without
+ * delta capability), so we don't re-probe on every mount.
+ */
+type DeltaSupport = 'unknown' | 'unsupported';
+const deltaSupportByClient = new WeakMap<ReturnType<typeof useMastraClient>, DeltaSupport>();
+
+/** Tunables for live-tail polling. All fields optional — defaults below.
+ *  Platform consumers override individual fields to throttle traffic or
+ *  reshape the freshness/visibility trade-offs. */
+export interface TracesPollingConfig {
+  /** Interval between delta polls. Default 5_000ms. */
+  deltaPollIntervalMs?: number;
+  /** Refetch delay when the server signals `delta.hasMore` (chase remaining updates immediately). Default 100ms. */
+  deltaChaseIntervalMs?: number;
+  /** Max rows per delta poll. Server caps at 100. Default 100. */
+  deltaLimit?: number;
+  /** Page-mode refetch interval used when the configured store does not support delta polling. Default 10_000ms. */
+  pageModeRefetchIntervalMs?: number;
+  /** Periodic page-0 refetch interval while delta is active. Delta only delivers new rows, so this
+   *  is how we surface status flips (running → success/error) on rows already visible. Default 60_000ms. */
+  page0StatusRefreshIntervalMs?: number;
+  /** When the tab returns from being hidden and the last successful poll was older than this, the
+   *  cursor is treated as stale (ClickHouse delta tables TTL after 2 days; other stores may be more
+   *  aggressive). The infinite query is reset so page 0 refetches and delta resumes from a fresh
+   *  cursor. Default 900_000ms (15 min). */
+  idleGuardThresholdMs?: number;
+  /** Minimum visible duration for `isRefetching` after any query completes. On localhost a delta
+   *  poll can resolve in tens of ms — too brief for the spinner's 1s rotation to register visually,
+   *  and quick enough that React may batch the start/finish transitions. Pulsing for this duration
+   *  on completion (~144° of rotation at 400ms) makes each poll perceptible as a heartbeat.
+   *  Default 400ms. */
+  minRefetchSpinMs?: number;
+  /** Window during which a delta-arrived row's key stays in `recentlyAddedKeys` so the list view
+   *  can apply its `animate-row-highlight` class. Should match the CSS animation duration
+   *  (currently 1_000ms — see `index.css`). Default 1_000ms. */
+  deltaHighlightMs?: number;
+}
+
+const DEFAULT_POLLING_CONFIG: Required<TracesPollingConfig> = {
+  deltaPollIntervalMs: 5_000,
+  deltaChaseIntervalMs: 100,
+  deltaLimit: 100,
+  pageModeRefetchIntervalMs: 10_000,
+  page0StatusRefreshIntervalMs: 60_000,
+  idleGuardThresholdMs: 15 * 60_000,
+  minRefetchSpinMs: 400,
+  deltaHighlightMs: 1_000,
+};
+
+/** Returns true when the cursor should be considered stale and re-seeded.
+ *  Exported for testing — pure function of timestamps. */
+export function shouldResetAfterIdle(lastSuccessAt: number, now: number, thresholdMs: number): boolean {
+  if (lastSuccessAt === 0) return false;
+  return now - lastSuccessAt > thresholdMs;
+}
+
+function isHttp501(error: unknown): boolean {
+  return (error as { status?: number } | null)?.status === 501;
+}
+
+type FetchTracesFnArgs = TracesFilters & {
+  client: ReturnType<typeof useMastraClient>;
+  mode?: 'page' | 'delta';
+  page?: number;
+  perPage?: number;
+  after?: string;
+  limit?: number;
+};
+
 const fetchTracesFn = async ({
   client,
+  mode,
   page,
   perPage,
+  after,
+  limit,
   filters,
   listMode = 'traces',
-}: TracesFilters & {
-  client: ReturnType<typeof useMastraClient>;
-  page: number;
-  perPage: number;
-}) => {
-  const params = {
-    pagination: {
-      page,
-      perPage,
-    },
-    filters,
-  };
+}: FetchTracesFnArgs) => {
+  const params =
+    mode === 'delta'
+      ? { mode: 'delta' as const, after, limit, filters }
+      : { pagination: { page: page!, perPage: perPage! }, filters };
 
   if (listMode === 'branches') {
     return client.listBranches(params as ListBranchesArgs);
@@ -58,7 +126,8 @@ function getPageSpans(page: TracesPageResponse) {
   return page.spans ?? [];
 }
 
-/** Deduplicates trace/branch rows by traceId + spanId across all loaded pages. */
+/** Deduplicates trace/branch rows by traceId + spanId across all loaded pages.
+ *  Also surfaces page 0's deltaCursor so the live-tail query can read it reactively. */
 export function selectUniqueTraces(data: { pages: TracesPageResponse[] }) {
   const seen = new Set<string>();
   const spans = data.pages
@@ -70,15 +139,148 @@ export function selectUniqueTraces(data: { pages: TracesPageResponse[] }) {
       return true;
     });
 
-  return { spans };
+  return { spans, deltaCursor: data.pages[0]?.deltaCursor };
 }
 
-export const useTraces = ({ filters, listMode = 'traces' }: TracesFilters) => {
+/** Replaces existing page-0 rows in place (keyed by traceId:spanId) with
+ *  refreshed copies from the server. Rows the server doesn't return are kept
+ *  as-is so delta-accumulated rows that have aged off the server's page 0
+ *  aren't dropped from the UI. New rows aren't added here — delta polling
+ *  delivers those. */
+export function refreshPage0Rows(
+  old: InfiniteData<TracesPageResponse> | undefined,
+  refreshed: ListTracesResponse | ListBranchesResponse,
+  listMode: TraceListMode,
+): InfiniteData<TracesPageResponse> | undefined {
+  if (!old || old.pages.length === 0) return old;
+  const [firstPage, ...rest] = old.pages;
+
+  const refreshedRows =
+    listMode === 'branches' && 'branches' in refreshed
+      ? (refreshed.branches ?? [])
+      : 'spans' in refreshed
+        ? (refreshed.spans ?? [])
+        : [];
+
+  if (refreshedRows.length === 0) return old;
+
+  const refreshedByKey = new Map<string, (typeof refreshedRows)[number]>();
+  for (const row of refreshedRows) {
+    refreshedByKey.set(`${row.traceId}:${row.spanId}`, row);
+  }
+
+  let updatedFirst: TracesPageResponse;
+  if (listMode === 'branches' && 'branches' in firstPage) {
+    const updated = (firstPage.branches ?? []).map(existing => {
+      const fresh = refreshedByKey.get(`${existing.traceId}:${existing.spanId}`);
+      return fresh ?? existing;
+    });
+    updatedFirst = { ...firstPage, branches: updated };
+  } else if ('spans' in firstPage) {
+    const updated = (firstPage.spans ?? []).map(existing => {
+      const fresh = refreshedByKey.get(`${existing.traceId}:${existing.spanId}`);
+      return fresh ?? existing;
+    });
+    updatedFirst = { ...firstPage, spans: updated };
+  } else {
+    return old;
+  }
+
+  return { ...old, pages: [updatedFirst, ...rest] };
+}
+
+/** Stable `startedAt DESC` sort matching the server's default page-mode
+ *  ordering for both list endpoints. Rows missing `startedAt` sink to the
+ *  bottom (compared as time 0). */
+function sortRowsByStartedAtDesc<T extends { startedAt?: unknown }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => {
+    const aTime = a.startedAt ? new Date(a.startedAt as string | number | Date).getTime() : 0;
+    const bTime = b.startedAt ? new Date(b.startedAt as string | number | Date).getTime() : 0;
+    return bTime - aTime;
+  });
+}
+
+/** Prepends delta-mode rows into page 0 and advances its deltaCursor.
+ *  Delta responses come back in server cursor order (insertion order into
+ *  the per-store delta index), not the `startedAt DESC` order page-mode
+ *  uses — so we re-sort the merged page 0 to match what the user sees on
+ *  a fresh page-mode load. Cross-page duplication is handled later by
+ *  selectUniqueTraces. */
+export function mergeDeltaIntoPage0(
+  old: InfiniteData<TracesPageResponse> | undefined,
+  delta: ListTracesResponse | ListBranchesResponse,
+  listMode: TraceListMode,
+): InfiniteData<TracesPageResponse> | undefined {
+  if (!old || old.pages.length === 0) return old;
+  const [firstPage, ...rest] = old.pages;
+  const nextCursor = delta.deltaCursor ?? firstPage.deltaCursor;
+
+  let updatedFirst: TracesPageResponse;
+  if (listMode === 'branches' && 'branches' in firstPage) {
+    const newRows = (delta as ListBranchesResponse).branches ?? [];
+    updatedFirst = {
+      ...firstPage,
+      branches: sortRowsByStartedAtDesc([...newRows, ...(firstPage.branches ?? [])]),
+      deltaCursor: nextCursor,
+    };
+  } else if ('spans' in firstPage) {
+    const newRows = (delta as ListTracesResponse).spans ?? [];
+    updatedFirst = {
+      ...firstPage,
+      spans: sortRowsByStartedAtDesc([...newRows, ...(firstPage.spans ?? [])]),
+      deltaCursor: nextCursor,
+    };
+  } else {
+    return old;
+  }
+
+  return { ...old, pages: [updatedFirst, ...rest] };
+}
+
+export interface UseTracesArgs extends TracesFilters {
+  /** Optional overrides for the live-tail polling tunables. Any omitted fields fall back to the
+   *  built-in defaults; pass only what you want to change. */
+  polling?: TracesPollingConfig;
+}
+
+export const useTraces = ({ filters, listMode = 'traces', polling = {} }: UseTracesArgs) => {
+  const {
+    deltaPollIntervalMs = DEFAULT_POLLING_CONFIG.deltaPollIntervalMs,
+    deltaChaseIntervalMs = DEFAULT_POLLING_CONFIG.deltaChaseIntervalMs,
+    deltaLimit = DEFAULT_POLLING_CONFIG.deltaLimit,
+    pageModeRefetchIntervalMs = DEFAULT_POLLING_CONFIG.pageModeRefetchIntervalMs,
+    page0StatusRefreshIntervalMs = DEFAULT_POLLING_CONFIG.page0StatusRefreshIntervalMs,
+    idleGuardThresholdMs = DEFAULT_POLLING_CONFIG.idleGuardThresholdMs,
+    minRefetchSpinMs = DEFAULT_POLLING_CONFIG.minRefetchSpinMs,
+    deltaHighlightMs = DEFAULT_POLLING_CONFIG.deltaHighlightMs,
+  } = polling;
   const client = useMastraClient();
+  const queryClient = useQueryClient();
   const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
 
+  const [deltaSupport, setDeltaSupport] = useState<DeltaSupport>(
+    () => deltaSupportByClient.get(client) ?? 'unknown',
+  );
+  const deltaUnsupported = deltaSupport === 'unsupported';
+
+  // When false, all automatic polling stops: delta polls, status refresh,
+  // idle-guard resets, and the page-mode fallback interval. Manual `resync`
+  // still works. Session-scoped (no persistence across mounts).
+  const [autoRefetch, setAutoRefetch] = useState(true);
+
+  // Keys (`traceId:spanId`) of rows that arrived via the most recent delta
+  // poll(s). The list view reads this to apply a temporary highlight class
+  // for deltaHighlightMs, then they auto-expire. Resets on filter/listMode
+  // change since a new query key spawns a fresh list.
+  const [recentlyAddedKeys, setRecentlyAddedKeys] = useState<Set<string>>(() => new Set());
+  useEffect(() => {
+    setRecentlyAddedKeys(new Set());
+  }, [listMode, filters]);
+
+  const tracesQueryKey = ['traces', listMode, filters] as const;
+
   const query = useInfiniteQuery({
-    queryKey: ['traces', listMode, filters],
+    queryKey: tracesQueryKey,
     queryFn: ({ pageParam }) =>
       fetchTracesFn({
         client,
@@ -91,9 +293,154 @@ export const useTraces = ({ filters, listMode = 'traces' }: TracesFilters) => {
     getNextPageParam: getTracesNextPageParam,
     select: selectUniqueTraces,
     retry: false,
-    // Disable polling on 403 to prevent flickering
-    refetchInterval: query => (is403ForbiddenError(query.state.error) ? false : 10000),
+    // Disable polling on 403 to prevent flickering.
+    // Fall back to page-mode polling only when delta isn't running.
+    refetchInterval: q => {
+      if (is403ForbiddenError(q.state.error)) return false;
+      if (!autoRefetch) return false;
+      return deltaUnsupported ? pageModeRefetchIntervalMs : false;
+    },
   });
+
+  const cursor = query.data?.deltaCursor;
+
+  // If page 0 came back without a deltaCursor, the server/store doesn't
+  // support delta polling. Pin the client to 'unsupported' so the infinite
+  // query resumes page-mode polling and we stop probing.
+  useEffect(() => {
+    if (query.isSuccess && cursor === undefined && deltaSupport === 'unknown') {
+      deltaSupportByClient.set(client, 'unsupported');
+      setDeltaSupport('unsupported');
+    }
+  }, [query.isSuccess, cursor, deltaSupport, client]);
+
+  const deltaQuery = useQuery({
+    queryKey: ['traces-delta', listMode, filters] as const,
+    queryFn: () => {
+      const current = queryClient.getQueryData<InfiniteData<TracesPageResponse>>(tracesQueryKey)?.pages[0]
+        ?.deltaCursor;
+      if (!current) return null;
+      return fetchTracesFn({
+        client,
+        mode: 'delta',
+        after: current,
+        limit: deltaLimit,
+        filters,
+        listMode,
+      });
+    },
+    enabled: !!cursor && !deltaUnsupported && autoRefetch,
+    retry: false,
+    refetchInterval: q => {
+      if (q.state.error) return false;
+      const data = q.state.data as ListTracesResponse | ListBranchesResponse | null | undefined;
+      if (data?.delta?.hasMore) return deltaChaseIntervalMs;
+      return deltaPollIntervalMs;
+    },
+  });
+
+  // Merge new delta rows into the infinite-query cache. Also captures the
+  // arrived keys into `recentlyAddedKeys` for deltaHighlightMs so the UI
+  // can briefly distinguish them. The cleanup timer is intentionally NOT
+  // tied to the effect lifecycle — if a newer delta arrives first, we still
+  // want each prior batch to expire on its own schedule.
+  useEffect(() => {
+    const result = deltaQuery.data;
+    if (!result) return;
+    queryClient.setQueryData<InfiniteData<TracesPageResponse>>(tracesQueryKey, old =>
+      mergeDeltaIntoPage0(old, result, listMode),
+    );
+
+    const newRows =
+      listMode === 'branches' && 'branches' in result
+        ? (result.branches ?? [])
+        : 'spans' in result
+          ? (result.spans ?? [])
+          : [];
+    if (newRows.length === 0) return;
+    const keys = newRows.map(r => `${r.traceId}:${r.spanId ?? ''}`);
+    setRecentlyAddedKeys(prev => {
+      const next = new Set(prev);
+      for (const k of keys) next.add(k);
+      return next;
+    });
+    setTimeout(() => {
+      setRecentlyAddedKeys(prev => {
+        const next = new Set(prev);
+        for (const k of keys) next.delete(k);
+        return next;
+      });
+    }, deltaHighlightMs);
+    // tracesQueryKey is a new array each render but its contents drive cache keying;
+    // depending on its members (listMode/filters) is enough.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deltaQuery.data, queryClient, listMode, filters, deltaHighlightMs]);
+
+  // A 501 means the server is too old (or store doesn't support delta) — pin
+  // 'unsupported' so the delta query disables and page-mode polling resumes.
+  useEffect(() => {
+    if (isHttp501(deltaQuery.error)) {
+      deltaSupportByClient.set(client, 'unsupported');
+      setDeltaSupport('unsupported');
+    }
+  }, [deltaQuery.error, client]);
+
+  // Periodic page-0 refresh to surface status updates on visible rows
+  // (running → success/error). Only runs while delta is the primary polling
+  // mechanism; otherwise the infinite query's own refetchInterval covers it.
+  const statusRefreshQuery = useQuery({
+    queryKey: ['traces-status-refresh', listMode, filters] as const,
+    queryFn: () =>
+      fetchTracesFn({
+        client,
+        page: 0,
+        perPage: TRACES_PER_PAGE,
+        filters,
+        listMode,
+      }),
+    enabled: !!cursor && !deltaUnsupported && autoRefetch,
+    refetchInterval: page0StatusRefreshIntervalMs,
+    refetchOnMount: false,
+    retry: false,
+  });
+
+  useEffect(() => {
+    const result = statusRefreshQuery.data;
+    if (!result) return;
+    queryClient.setQueryData<InfiniteData<TracesPageResponse>>(tracesQueryKey, old =>
+      refreshPage0Rows(old, result, listMode),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusRefreshQuery.data, queryClient, listMode, filters]);
+
+  // Idle guard: when the tab returns from being hidden, check how long it's
+  // been since the last successful poll. If past the threshold, reset the
+  // infinite query so page 0 refetches and the cursor is re-seeded.
+  const lastSuccessAtRef = useRef(0);
+  useEffect(() => {
+    const ts = Math.max(query.dataUpdatedAt, deltaQuery.dataUpdatedAt, statusRefreshQuery.dataUpdatedAt);
+    if (ts > lastSuccessAtRef.current) {
+      lastSuccessAtRef.current = ts;
+    }
+  }, [query.dataUpdatedAt, deltaQuery.dataUpdatedAt, statusRefreshQuery.dataUpdatedAt]);
+
+  // Track autoRefetch in a ref so the visibility listener (attached once)
+  // reads the current value without needing to re-attach.
+  const autoRefetchRef = useRef(autoRefetch);
+  useEffect(() => {
+    autoRefetchRef.current = autoRefetch;
+  }, [autoRefetch]);
+
+  useEffect(() => {
+    const handler = () => {
+      if (document.visibilityState !== 'visible') return;
+      if (!autoRefetchRef.current) return;
+      if (!shouldResetAfterIdle(lastSuccessAtRef.current, Date.now(), idleGuardThresholdMs)) return;
+      void queryClient.resetQueries({ queryKey: ['traces', listMode, filters] });
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, [queryClient, listMode, filters, idleGuardThresholdMs]);
 
   const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
 
@@ -103,5 +450,43 @@ export const useTraces = ({ filters, listMode = 'traces' }: TracesFilters) => {
     }
   }, [isEndOfListInView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  return { ...query, setEndOfListElement };
+  // `isRefetching` aggregates every active fetch — page-mode (initial, next
+  // page, manual resync, idle reset), the 60s page-0 status refresh, AND the
+  // delta polls — so a spinner bound to it acts as a heartbeat indicator.
+  //
+  // Short polls (e.g. delta on localhost) can resolve in tens of ms — too
+  // brief for `animate-spin` (1s/rotation) to register visually, and quick
+  // enough that React may batch the start/finish transitions so we never
+  // even observe `isFetching: true`. So we also watch every query's
+  // data/errorUpdatedAt; any advance pulses `isRefetching` true for at least
+  // minRefetchSpinMs, which is ~144° of rotation — clearly perceptible.
+  const isFetchingAny = query.isFetching || statusRefreshQuery.isFetching || deltaQuery.isFetching;
+  const lastActivityAt = Math.max(
+    query.dataUpdatedAt,
+    query.errorUpdatedAt,
+    deltaQuery.dataUpdatedAt,
+    deltaQuery.errorUpdatedAt,
+    statusRefreshQuery.dataUpdatedAt,
+    statusRefreshQuery.errorUpdatedAt,
+  );
+  const [pulse, setPulse] = useState(false);
+  const prevActivityAtRef = useRef(lastActivityAt);
+  useEffect(() => {
+    if (lastActivityAt > prevActivityAtRef.current) {
+      prevActivityAtRef.current = lastActivityAt;
+      setPulse(true);
+      const t = setTimeout(() => setPulse(false), minRefetchSpinMs);
+      return () => clearTimeout(t);
+    }
+  }, [lastActivityAt, minRefetchSpinMs]);
+  const isRefetching = isFetchingAny || pulse;
+
+  return {
+    ...query,
+    setEndOfListElement,
+    isRefetching,
+    autoRefetch,
+    setAutoRefetch,
+    recentlyAddedKeys,
+  };
 };

--- a/packages/playground-ui/src/index.css
+++ b/packages/playground-ui/src/index.css
@@ -469,11 +469,11 @@ html.light {
 }
 
 /* Temporary highlight for delta-arrived list rows.
-   Same color as the featured / hover state (var(--surface4)), starts fully
-   visible and immediately fades out to transparent over 1s. */
+   Same color as the featured / hover state (var(--surface5)), starts fully
+   visible and immediately fades out to transparent over 2s. */
 @keyframes fade-row-highlight {
   0% {
-    background-color: var(--surface6);
+    background-color: var(--surface5);
   }
 
   100% {

--- a/packages/playground-ui/src/index.css
+++ b/packages/playground-ui/src/index.css
@@ -467,3 +467,20 @@ html.light {
 .animate-click-ripple {
   animation: click-ripple 300ms ease-out forwards;
 }
+
+/* Temporary highlight for delta-arrived list rows.
+   Same color as the featured / hover state (var(--surface4)), starts fully
+   visible and immediately fades out to transparent over 1s. */
+@keyframes fade-row-highlight {
+  0% {
+    background-color: var(--surface6);
+  }
+
+  100% {
+    background-color: transparent;
+  }
+}
+
+.animate-row-highlight {
+  animation: fade-row-highlight 2000ms ease-out forwards;
+}

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -1,5 +1,6 @@
 import { EntityType } from '@mastra/core/observability';
 import {
+  Button,
   DateTimeRangePicker,
   Label,
   NoTracesInfo,
@@ -8,6 +9,10 @@ import {
   PropertyFilterCreator,
   SpanDataPanelView,
   Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
   TraceDataPanelView,
   TracesErrorContent,
   TracesLayout,
@@ -30,6 +35,7 @@ import {
   useTraces,
 } from '@mastra/playground-ui';
 import type { SpanTab } from '@mastra/playground-ui';
+import { CircleSlash2, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { TraceAsItemDialog } from '@/domains/observability/components/trace-as-item-dialog';
@@ -185,6 +191,10 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
     hasNextPage,
     setEndOfListElement,
     error: tracesError,
+    isRefetching: isRefetchingTraces,
+    autoRefetch: autoRefetchTraces,
+    setAutoRefetch: setAutoRefetchTraces,
+    recentlyAddedKeys: recentlyAddedTraceKeys,
   } = useTraces({ filters: traceFilters, listMode: url.listMode });
 
   const traces = useMemo(() => tracesData?.spans ?? [], [tracesData?.spans]);
@@ -270,17 +280,39 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
         onStartTextFilter={setAutoFocusFilterFieldId}
         hiddenFieldIds={hiddenCreatorFieldIds}
       />
-      {!branchesUnsupported && (
-        <div className="flex h-form-default items-center gap-2 ml-auto">
-          <Switch
-            id="show-subtraces"
-            checked={url.listMode === 'branches'}
-            onCheckedChange={checked => url.handleListModeChange(checked ? 'branches' : 'traces')}
-            disabled={isTracesLoading}
-          />
-          <Label htmlFor="show-subtraces">Show subtraces</Label>
-        </div>
-      )}
+      <div className="flex h-form-default items-center gap-2 ml-auto">
+        {!branchesUnsupported && (
+          <>
+            <Switch
+              id="show-subtraces"
+              checked={url.listMode === 'branches'}
+              onCheckedChange={checked => url.handleListModeChange(checked ? 'branches' : 'traces')}
+              disabled={isTracesLoading}
+            />
+            <Label htmlFor="show-subtraces">Show subtraces</Label>
+          </>
+        )}
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="md"
+                onClick={() => setAutoRefetchTraces(!autoRefetchTraces)}
+                aria-label="Toggle auto-refetch"
+                aria-pressed={autoRefetchTraces}
+              >
+                {autoRefetchTraces ? (
+                  <RefreshCw className={`h-4 w-4 ${isRefetchingTraces ? 'animate-spin' : ''}`} />
+                ) : (
+                  <CircleSlash2 className="h-4 w-4" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{autoRefetchTraces ? 'Auto-refetch ON' : 'Auto-refetch OFF'}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
     </>
   );
 
@@ -377,6 +409,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
             // have drifted via intra-panel span nav and shouldn't decide which row is featured.
             featuredSpanId={url.listMode === 'branches' ? url.anchorSpanIdParam : null}
             isBranchesMode={url.listMode === 'branches'}
+            recentlyAddedKeys={recentlyAddedTraceKeys}
             onTraceClick={trace => {
               const isBranches = url.listMode === 'branches';
               const isSameRow = isBranches

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -9,10 +9,6 @@ import {
   PropertyFilterCreator,
   SpanDataPanelView,
   Switch,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
   TraceDataPanelView,
   TracesErrorContent,
   TracesLayout,
@@ -292,26 +288,20 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
             <Label htmlFor="show-subtraces">Show subtraces</Label>
           </>
         )}
-        <TooltipProvider delayDuration={0}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="md"
-                onClick={() => setAutoRefetchTraces(!autoRefetchTraces)}
-                aria-label="Toggle auto-refetch"
-                aria-pressed={autoRefetchTraces}
-              >
-                {autoRefetchTraces ? (
-                  <RefreshCw className={`h-4 w-4 ${isRefetchingTraces ? 'animate-spin' : ''}`} />
-                ) : (
-                  <CircleSlash2 className="h-4 w-4" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{autoRefetchTraces ? 'Auto-refetch ON' : 'Auto-refetch OFF'}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Button
+          variant="ghost"
+          size="md"
+          onClick={() => setAutoRefetchTraces(!autoRefetchTraces)}
+          aria-label="Toggle auto-refetch"
+          aria-pressed={autoRefetchTraces}
+          tooltip={autoRefetchTraces ? 'Auto-refetch ON' : 'Auto-refetch OFF'}
+        >
+          {autoRefetchTraces ? (
+            <RefreshCw className={`h-4 w-4 ${isRefetchingTraces ? 'animate-spin' : ''}`} />
+          ) : (
+            <CircleSlash2 className="h-4 w-4" />
+          )}
+        </Button>
       </div>
     </>
   );


### PR DESCRIPTION

<img width="1441" height="643" alt="Screenshot 2026-05-18 at 13 31 40" src="https://github.com/user-attachments/assets/dfd6c23a-460d-4a95-afa3-7bf5768151d5" />


## Summary

Builds on the observability delta-polling endpoints in #16632 to make the Traces list update live — no manual refresh needed for new rows, status flips on visible rows propagate automatically, and a toolbar toggle lets the user pause auto-refresh.

**Stacked on top of `esp/olly_list_polling-rebased` (PR #16632)** — once that merges to `main`, this PR's base will rebase automatically and only the live-tail UI changes will remain in the diff.

## What's new

**`useTraces` hook**
- `isRefetching` — heartbeat indicator covering page-mode, delta, and status-refresh fetches; pulses for a minimum visible window so localhost-fast polls register.
- `autoRefetch` / `setAutoRefetch` — pause / resume all automatic polling.
- `recentlyAddedKeys` — `Set<string>` of `traceId:spanId` for delta-arrived rows. Drives the temporary highlight.
- New `polling?: TracesPollingConfig` config — every interval / threshold is tunable per-instance (`deltaPollIntervalMs`, `idleGuardThresholdMs`, `page0StatusRefreshIntervalMs`, etc).

**Behaviors**
- 15-min idle guard: resets the cursor when the tab returns visible after long inactivity.
- 60s page-0 status refresh: surfaces running → success/error flips on already-visible rows (delta-only would never deliver these).
- Re-sorts merged page 0 by `startedAt DESC` after each delta tick to match server pagination order.
- Graceful 501 fallback: pins the client to `'unsupported'` and resumes 10s page-mode polling when delta isn't available.

**UI**
- New toolbar button next to "Show subtraces": `RefreshCw` icon (animates while refetching) ↔ `CircleSlash2` (when paused). Tooltip reflects state ("Auto-refetch ON" / "OFF").
- `TracesListView` accepts an optional `recentlyAddedKeys?: Set<string>` prop. Rows in the set get a new `animate-row-highlight` CSS utility — same `var(--surface4)` color as the featured / hover state, fades to transparent over 1s.

## Test plan

- [x] `pnpm test` (playground-ui) — 182 tests pass, +18 new (covering `mergeDeltaIntoPage0`, `refreshPage0Rows`, `selectUniqueTraces` deltaCursor extension, `shouldResetAfterIdle` boundary cases)
- [x] `pnpm exec tsc --noEmit` (playground-ui + playground)
- [x] `pnpm build` (playground-ui)
- [x] Local smoke test against `examples/agent` (DuckDB store): start an agent, verify rows appear live with highlight; toggle the button to confirm polling stops; let tab idle 15+ min and verify resync on return.
- [ ] Confirm 501 fallback path against an older `@mastra/core` build.

## Notes

- Changeset: `@mastra/playground-ui` patch.
- The 6 dependency packages the changeset CLI auto-bumped have their own changesets from PR #16632; kept this changeset scoped to `@mastra/playground-ui` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the Traces list update itself automatically: new traces show up shortly after they're created with a brief highlight, status changes for visible rows appear without manual refresh, and there's a toolbar toggle to pause/resume auto-updates.

## Changes

### Core Hook Enhancement (`useTraces`)
- Adds live-tail delta polling with per-instance `polling?: TracesPollingConfig` (tunable intervals such as `deltaPollIntervalMs`, `idleGuardThresholdMs`, `page0StatusRefreshIntervalMs`, etc.).
- New return values:
  - `isRefetching`: unified heartbeat for page-mode, delta, and status-refresh fetches (includes a minimum visible pulse).
  - `autoRefetch` / `setAutoRefetch`: controls pausing/resuming automatic polling.
  - `recentlyAddedKeys: Set<string>`: keys (`traceId:spanId`) for temporarily highlighting newly arrived rows.
- Polling/behavior:
  - 15-minute idle guard: resets cursor after long inactivity when tab becomes visible.
  - 60s page-0 status refresh: updates running → success/error for already-visible rows.
  - Merged page 0 is re-sorted by `startedAt DESC` after each delta tick to match server pagination.
  - Graceful 501 fallback: marks delta unsupported and falls back to 10s page-mode polling when delta endpoints return 501.
  - Suppresses automatic polling on 403; disables delta probing when page-0 lacks `deltaCursor`.
- New/changed exports and helpers:
  - Exported `TracesPollingConfig`.
  - `selectUniqueTraces(data)` now returns `{ spans, deltaCursor }`.
  - Exported `mergeDeltaIntoPage0(old, delta, listMode)`: prepends delta rows, advances effective cursor, and re-sorts.
  - Exported `refreshPage0Rows(old, refreshed, listMode)`: in-place replacement of page-0 rows by `traceId:spanId` without dropping delta-accumulated rows.
  - Exported `shouldResetAfterIdle(lastSuccessAt, now, thresholdMs)`.
- Hook signature updated: `useTraces({ filters, listMode, polling? })` and return shape expanded.

### UI Components
- TracesListView:
  - Accepts optional `recentlyAddedKeys?: Set<string>`; rows in the set receive `.animate-row-highlight`.
  - Uses computed `traceId:spanId` as React `key`.
- Traces page:
  - Toolbar adds an auto-refetch icon button beside "Show subtraces": shows animated RefreshCw while refetching and CircleSlash2 when paused; tooltip shows "Auto-refetch ON"/"OFF".

### Styling
- Adds `@keyframes fade-row-highlight` and `.animate-row-highlight` utility to fade a row background from `var(--surface5)` to transparent (animation retained final state).

### Tests & Build
- playground-ui tests: 182 passing (18 new); tsc --noEmit passed; build passed.
- Test coverage expanded for: `selectUniqueTraces` deltaCursor behavior, `mergeDeltaIntoPage0` (traces & branches), `refreshPage0Rows` semantics and edge cases, `shouldResetAfterIdle` boundaries, delta cursor advancement, and empty-response handling.
- Pending: local smoke test against examples/agent (DuckDB) and verification of 501 fallback against older `@mastra/core`.

### Compatibility Notes
- Delta polling requires compatible `@mastra/server` and `@mastra/client-js` versions and stores that support delta capability; otherwise the hook silently falls back to page-mode interval refetching (including handling HTTP 501 as fallback).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->