### PR TITLE
Fix metrics dashboard model cost alignment

### DIFF
--- a/.changeset/spicy-falcons-eat.md
+++ b/.changeset/spicy-falcons-eat.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed the Metrics dashboard total model cost so it includes cache token costs and matches the Model Usage & Cost total.
+Fixed the Metrics dashboard Model Usage & Cost total so it uses aggregate input and output costs without double-counting cache token costs.

--- a/.changeset/spicy-falcons-eat.md
+++ b/.changeset/spicy-falcons-eat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed the Metrics dashboard total model cost so it includes cache token costs and matches the Model Usage & Cost total.

--- a/packages/playground-ui/src/domains/metrics/hooks/model-cost-metrics.ts
+++ b/packages/playground-ui/src/domains/metrics/hooks/model-cost-metrics.ts
@@ -1,6 +1,7 @@
-export const MODEL_COST_METRICS = [
-  'mastra_model_total_input_tokens',
-  'mastra_model_total_output_tokens',
+export const MODEL_COST_TOTAL_METRICS = ['mastra_model_total_input_tokens', 'mastra_model_total_output_tokens'] as const;
+
+export const MODEL_USAGE_TOKEN_METRICS = [
+  ...MODEL_COST_TOTAL_METRICS,
   'mastra_model_input_cache_read_tokens',
   'mastra_model_input_cache_write_tokens',
 ] as const;

--- a/packages/playground-ui/src/domains/metrics/hooks/model-cost-metrics.ts
+++ b/packages/playground-ui/src/domains/metrics/hooks/model-cost-metrics.ts
@@ -1,0 +1,6 @@
+export const MODEL_COST_METRICS = [
+  'mastra_model_total_input_tokens',
+  'mastra_model_total_output_tokens',
+  'mastra_model_input_cache_read_tokens',
+  'mastra_model_input_cache_write_tokens',
+] as const;

--- a/packages/playground-ui/src/domains/metrics/hooks/use-model-cost-kpi-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-model-cost-kpi-metrics.tsx
@@ -1,9 +1,9 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
-import { MODEL_COST_METRICS } from './model-cost-metrics';
+import { MODEL_COST_TOTAL_METRICS } from './model-cost-metrics';
 import { useMetricsFilters } from './use-metrics-filters';
 
-/** Total Model Cost — sum of estimatedCost across the same token metrics shown in Model Usage & Cost */
+/** Total Model Cost — sum of estimatedCost across aggregate input and output token metrics */
 export function useModelCostKpiMetrics() {
   const client = useMastraClient();
   const { filters, filterKey } = useMetricsFilters();
@@ -12,7 +12,7 @@ export function useModelCostKpiMetrics() {
     queryKey: ['metrics', 'model-cost-kpi', filterKey],
     queryFn: async () => {
       const res = await client.getMetricAggregate({
-        name: [...MODEL_COST_METRICS],
+        name: [...MODEL_COST_TOTAL_METRICS],
         aggregation: 'sum',
         filters,
         comparePeriod: 'previous_period',

--- a/packages/playground-ui/src/domains/metrics/hooks/use-model-cost-kpi-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-model-cost-kpi-metrics.tsx
@@ -1,8 +1,9 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
+import { MODEL_COST_METRICS } from './model-cost-metrics';
 import { useMetricsFilters } from './use-metrics-filters';
 
-/** Total Model Cost — sum of estimatedCost across input and output token metrics */
+/** Total Model Cost — sum of estimatedCost across the same token metrics shown in Model Usage & Cost */
 export function useModelCostKpiMetrics() {
   const client = useMastraClient();
   const { filters, filterKey } = useMetricsFilters();
@@ -11,7 +12,7 @@ export function useModelCostKpiMetrics() {
     queryKey: ['metrics', 'model-cost-kpi', filterKey],
     queryFn: async () => {
       const res = await client.getMetricAggregate({
-        name: ['mastra_model_total_input_tokens', 'mastra_model_total_output_tokens'],
+        name: [...MODEL_COST_METRICS],
         aggregation: 'sum',
         filters,
         comparePeriod: 'previous_period',

--- a/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
@@ -1,7 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { formatCompact } from '../components/metrics-utils';
-import { MODEL_COST_METRICS } from './model-cost-metrics';
+import { MODEL_USAGE_TOKEN_METRICS } from './model-cost-metrics';
 import { useMetricsFilters } from './use-metrics-filters';
 
 export interface ModelUsageRow {
@@ -22,7 +22,7 @@ export function useModelUsageCostMetrics() {
     queryKey: ['metrics', 'model-usage-cost', filterKey],
     queryFn: async (): Promise<ModelUsageRow[]> => {
       const [inputRes, outputRes, cacheReadRes, cacheWriteRes] = await Promise.all(
-        MODEL_COST_METRICS.map(name =>
+        MODEL_USAGE_TOKEN_METRICS.map(name =>
           client.getMetricBreakdown({
             name: [name],
             groupBy: ['model'],
@@ -74,13 +74,11 @@ export function useModelUsageCostMetrics() {
         const m = group.dimensions.model ?? 'unknown';
         const entry = ensureModel(m);
         entry.cacheRead = group.value;
-        addCost(entry, group);
       }
       for (const group of cacheWriteRes.groups) {
         const m = group.dimensions.model ?? 'unknown';
         const entry = ensureModel(m);
         entry.cacheWrite = group.value;
-        addCost(entry, group);
       }
 
       return Array.from(modelMap.entries())

--- a/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
@@ -1,6 +1,7 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { formatCompact } from '../components/metrics-utils';
+import { MODEL_COST_METRICS } from './model-cost-metrics';
 import { useMetricsFilters } from './use-metrics-filters';
 
 export interface ModelUsageRow {
@@ -20,15 +21,8 @@ export function useModelUsageCostMetrics() {
   return useQuery({
     queryKey: ['metrics', 'model-usage-cost', filterKey],
     queryFn: async (): Promise<ModelUsageRow[]> => {
-      const metrics = [
-        'mastra_model_total_input_tokens',
-        'mastra_model_total_output_tokens',
-        'mastra_model_input_cache_read_tokens',
-        'mastra_model_input_cache_write_tokens',
-      ] as const;
-
       const [inputRes, outputRes, cacheReadRes, cacheWriteRes] = await Promise.all(
-        metrics.map(name =>
+        MODEL_COST_METRICS.map(name =>
           client.getMetricBreakdown({
             name: [name],
             groupBy: ['model'],


### PR DESCRIPTION
## Summary
- align the Total Model Cost KPI and Model Usage & Cost card around the same cost semantics
- use aggregate total input and output metrics for estimated cost so cache token costs are not double-counted
- continue fetching cache read and cache write token counts for display in the Model Usage & Cost table
- add a patch changeset for @mastra/playground-ui

## Test plan
- pnpm --filter ./packages/playground-ui exec vitest run src/domains/metrics/drilldown.test.ts
- pnpm --filter ./packages/playground-ui build

## Notes
- CodeRabbit CLI was not installed locally, so no local CodeRabbit review was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes inconsistent model cost numbers on the Metrics dashboard by introducing shared metric lists and using them consistently — the dashboard total now uses aggregate input/output costs, while cache read/write token counts are still shown per-model without being double-counted in the total.

## Changes

### New shared metric constants
- Added `MODEL_COST_TOTAL_METRICS` (['mastra_model_total_input_tokens', 'mastra_model_total_output_tokens']) and `MODEL_USAGE_TOKEN_METRICS` (spreads the totals and adds 'mastra_model_input_cache_read_tokens' and 'mastra_model_input_cache_write_tokens') in packages/playground-ui/src/domains/metrics/hooks/model-cost-metrics.ts.

### Updated KPI calculation
- useModelCostKpiMetrics now sums estimatedCost across `MODEL_COST_TOTAL_METRICS` (aggregate input + output token metrics) via client.getMetricAggregate, ensuring the KPI uses the same total-input/output definition.

### Updated usage metrics calculation
- useModelUsageCostMetrics now requests breakdowns using `MODEL_USAGE_TOKEN_METRICS`. It accumulates estimatedCost for input and output groups only (avoiding adding cache read/write costs into the per-model cost total), while still returning cacheRead and cacheWrite token counts for display in the Model Usage & Cost table.

### Changeset
- Added a patch changeset (.changeset/spicy-falcons-eat.md) for `@mastra/playground-ui` documenting the fix.

## Testing
- Build and test steps included in PR description:
  - pnpm --filter `@mastra/client-js` build:lib
  - pnpm --filter `@mastra/react` build:js
  - pnpm --filter ./packages/playground-ui exec vitest run src/domains/metrics/drilldown.test.ts
  - pnpm --filter ./packages/playground-ui build

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->