### PR TITLE
feat(convex): add server cache

### DIFF
--- a/.changeset/empty-days-clean.md
+++ b/.changeset/empty-days-clean.md
@@ -1,0 +1,17 @@
+---
+'@mastra/convex': minor
+---
+
+Added `ConvexServerCache` so Convex-backed Mastra apps can keep durable stream replay and response cache state in Convex.
+
+```ts
+import { ConvexServerCache } from '@mastra/convex';
+
+const cache = new ConvexServerCache({
+  deploymentUrl: process.env.CONVEX_URL!,
+  adminAuthToken: process.env.CONVEX_ADMIN_KEY!,
+});
+```
+
+The package also exports the Convex cache schema tables and server mutation for mounting the cache handler in a Convex app.
+Existing Convex users who adopt the cache must add `mastra_cache` and `mastra_cache_list_items` to their Convex schema, mount the `mastraCache` handler, and deploy the schema update.

--- a/docs/src/content/en/reference/storage/convex.mdx
+++ b/docs/src/content/en/reference/storage/convex.mdx
@@ -27,7 +27,8 @@ npm install @mastra/convex@latest
 
 ## Convex setup
 
-Before using `ConvexStore`, you need to set up the Convex schema and storage handler in your Convex project.
+Before using `ConvexStore`, set up the Convex schema and storage handler in your Convex project.
+If you also use `ConvexServerCache`, add the cache tables and cache handler.
 
 ### 1. Set up Convex Schema
 
@@ -43,6 +44,8 @@ import {
   mastraScoresTable,
   mastraVectorIndexesTable,
   mastraVectorsTable,
+  mastraCacheTable,
+  mastraCacheListItemsTable,
   mastraDocumentsTable,
 } from '@mastra/convex/schema'
 
@@ -54,6 +57,8 @@ export default defineSchema({
   mastra_scorers: mastraScoresTable,
   mastra_vector_indexes: mastraVectorIndexesTable,
   mastra_vectors: mastraVectorsTable,
+  mastra_cache: mastraCacheTable,
+  mastra_cache_list_items: mastraCacheListItemsTable,
   mastra_documents: mastraDocumentsTable,
 })
 ```
@@ -68,6 +73,14 @@ import { mastraStorage } from '@mastra/convex/server'
 export const handle = mastraStorage
 ```
 
+If you use `ConvexServerCache`, create `convex/mastra/cache.ts`:
+
+```typescript
+import { mastraCache } from '@mastra/convex/server'
+
+export const handle = mastraCache
+```
+
 ### 3. Deploy to Convex
 
 ```bash
@@ -79,16 +92,21 @@ npx convex deploy
 ## Usage
 
 ```typescript
-import { ConvexStore } from '@mastra/convex'
+import { ConvexServerCache, ConvexStore } from '@mastra/convex'
 
 const storage = new ConvexStore({
   id: 'convex-storage',
   deploymentUrl: process.env.CONVEX_URL!,
   adminAuthToken: process.env.CONVEX_ADMIN_KEY!,
 })
+
+const cache = new ConvexServerCache({
+  deploymentUrl: process.env.CONVEX_URL!,
+  adminAuthToken: process.env.CONVEX_ADMIN_KEY!,
+})
 ```
 
-## Parameters
+## ConvexStore parameters
 
 <PropertiesTable
   content={[
@@ -114,10 +132,50 @@ const storage = new ConvexStore({
 ]}
 />
 
+## ConvexServerCache parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'deploymentUrl',
+    type: 'string',
+    description: 'Convex deployment URL (e.g., https://your-project.convex.cloud)',
+    isOptional: false,
+  },
+  {
+    name: 'adminAuthToken',
+    type: 'string',
+    description: 'Convex admin authentication token for backend access',
+    isOptional: false,
+  },
+  {
+    name: 'cacheFunction',
+    type: 'string',
+    description: "Path to the cache mutation function for ConvexServerCache (default: 'mastra/cache:handle')",
+    isOptional: true,
+    defaultValue: 'mastra/cache:handle',
+  },
+  {
+    name: 'keyPrefix',
+    type: 'string',
+    description: 'Prefix applied to ConvexServerCache keys. clear() removes rows whose stored prefix exactly matches this value.',
+    isOptional: true,
+    defaultValue: 'mastra:cache:',
+  },
+  {
+    name: 'ttlMs',
+    type: 'number',
+    description: 'Default ConvexServerCache TTL in milliseconds. Set to 0 to disable expiry.',
+    isOptional: true,
+    defaultValue: 300000,
+  },
+]}
+/>
+
 ## Constructor examples
 
 ```ts
-import { ConvexStore } from '@mastra/convex'
+import { ConvexServerCache, ConvexStore } from '@mastra/convex'
 
 // Basic configuration
 const store = new ConvexStore({
@@ -133,7 +191,34 @@ const storeCustom = new ConvexStore({
   adminAuthToken: 'your-admin-token',
   storageFunction: 'custom/path:handler',
 })
+
+// Server cache for durable stream replay and response caching
+const cache = new ConvexServerCache({
+  deploymentUrl: 'https://your-project.convex.cloud',
+  adminAuthToken: 'your-admin-token',
+  cacheFunction: 'mastra/cache:handle',
+})
 ```
+
+## Server cache
+
+`ConvexServerCache` implements Mastra's server cache contract with Convex. Use it when you want durable cache state for features such as resumable durable-agent streams, workflow stream replay, or response caching.
+
+`ConvexServerCache` stores list entries as separate Convex documents. This avoids growing a stream replay list inside one document and helps stay within Convex's record size limit.
+
+Each scalar cache value and each list item is stored as one Convex row and must stay within Convex's row-size limits. Very large lists are still bounded by Convex query limits when replaying a range.
+
+Cache cleanup and `clear()` run in bounded batches. A single client call can loop through up to 1,000 Convex mutations, with each mutation handling up to 25 list items. Clear very large cache namespaces incrementally or use narrower prefixes. While `clear()` is cleaning a key, reads for that key can return empty results until cleanup finishes.
+
+During batched cleanup, cache metadata can temporarily use an internal `deleted` state. The next cleanup pass removes those rows. Avoid writing new values with the same prefix until `clear()` finishes.
+
+`clear()` only removes rows whose stored `keyPrefix` exactly matches the configured `keyPrefix`. It does not clear nested prefixes by string prefix matching. Each `listPush()` refreshes the list TTL using the cache's configured `ttlMs`.
+
+Use a non-empty `keyPrefix` unless you intentionally want `clear()` to remove every cache key in the deployment. Expired list rows are reclaimed incrementally during reads and writes; `clear()` removes all rows for the prefix.
+
+`ConvexServerCache` works best for durable replay of moderate-frequency events. For high-frequency token streams, prefer batching events or using a lower-latency cache backend.
+
+`ConvexServerCache` does not replace a distributed pub/sub transport. If your app needs live cross-process event delivery, configure a production pub/sub backend separately.
 
 ## Additional notes
 
@@ -148,6 +233,8 @@ The storage implementation uses typed Convex tables for each Mastra domain:
 | Resources | `mastra_resources` | User working memory |
 | Workflows | `mastra_workflow_snapshots` | Workflow state |
 | Scorers | `mastra_scorers` | Evaluation data |
+| Cache | `mastra_cache` | Cache values, counters, and list metadata |
+| Cache Items | `mastra_cache_list_items` | Cache list entries |
 | Fallback | `mastra_documents` | Unknown tables |
 
 ### Architecture

--- a/docs/src/content/en/reference/storage/convex.mdx
+++ b/docs/src/content/en/reference/storage/convex.mdx
@@ -28,7 +28,7 @@ npm install @mastra/convex@latest
 ## Convex setup
 
 Before using `ConvexStore`, set up the Convex schema and storage handler in your Convex project.
-If you also use `ConvexServerCache`, add the cache tables and cache handler.
+The schema example below includes the full `ConvexStore` and `ConvexServerCache` setup. If you only use `ConvexStore`, omit `mastraCacheTable` and `mastraCacheListItemsTable`; if you use `ConvexServerCache`, include those tables and create the cache handler.
 
 ### 1. Set up Convex Schema
 
@@ -215,7 +215,9 @@ const cache = new ConvexServerCache({
 
 Each scalar cache value and each list item is stored as one Convex row and must stay within Convex's row-size limits. Very large lists are still bounded by Convex query limits when replaying a range.
 
-Cache cleanup and `clear()` run in bounded batches. A single client call can loop through up to 1,000 Convex mutations, with each mutation handling up to 25 list items. Clear very large cache namespaces incrementally or use narrower prefixes. While `clear()` is cleaning a key, reads for that key can return empty results until cleanup finishes.
+Cache cleanup and `clear()` run in bounded batches. A single client call can loop through up to 1,000 Convex mutations, with each mutation handling up to 25 list items. While `clear()` is cleaning a key, reads for that key can return empty results until cleanup finishes.
+
+For very large cache namespaces, clear incrementally or use narrower prefixes to avoid long-running cleanup operations.
 
 During batched cleanup, cache metadata can temporarily use an internal `deleted` state. The next cleanup pass removes those rows. Avoid writing new values with the same prefix until `clear()` finishes.
 

--- a/docs/src/content/en/reference/storage/convex.mdx
+++ b/docs/src/content/en/reference/storage/convex.mdx
@@ -158,14 +158,16 @@ const cache = new ConvexServerCache({
   {
     name: 'requestTimeoutMs',
     type: 'number',
-    description: 'Timeout for Convex cache mutation requests in milliseconds. Set to 0 to disable the client-side timeout.',
+    description:
+      'Timeout for Convex cache mutation requests in milliseconds. Set to 0 to disable the client-side timeout.',
     isOptional: true,
     defaultValue: 30000,
   },
   {
     name: 'keyPrefix',
     type: 'string',
-    description: 'Prefix applied to ConvexServerCache keys. clear() removes rows whose stored prefix exactly matches this value.',
+    description:
+      'Prefix applied to ConvexServerCache keys. clear() removes rows whose stored prefix exactly matches this value.',
     isOptional: true,
     defaultValue: 'mastra:cache:',
   },

--- a/docs/src/content/en/reference/storage/convex.mdx
+++ b/docs/src/content/en/reference/storage/convex.mdx
@@ -156,6 +156,13 @@ const cache = new ConvexServerCache({
     defaultValue: 'mastra/cache:handle',
   },
   {
+    name: 'requestTimeoutMs',
+    type: 'number',
+    description: 'Timeout for Convex cache mutation requests in milliseconds. Set to 0 to disable the client-side timeout.',
+    isOptional: true,
+    defaultValue: 30000,
+  },
+  {
     name: 'keyPrefix',
     type: 'string',
     description: 'Prefix applied to ConvexServerCache keys. clear() removes rows whose stored prefix exactly matches this value.',

--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/lodash.ts
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/lodash.ts
@@ -2,7 +2,7 @@ import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
 import get from 'lodash/fp/get';
 import { get as getFp } from 'lodash/fp';
-import endOfDay from 'date-fns/endOfDay';
+import { endOfDay } from 'date-fns/endOfDay';
 
 export const lodashTool = createTool({
   id: 'lodash',

--- a/stores/convex/README.md
+++ b/stores/convex/README.md
@@ -90,6 +90,7 @@ const cache = new ConvexServerCache({
   deploymentUrl: process.env.CONVEX_URL!,
   adminAuthToken: process.env.CONVEX_ADMIN_KEY!,
   cacheFunction: 'mastra/cache:handle', // default
+  requestTimeoutMs: 30_000, // default
 });
 ```
 

--- a/stores/convex/README.md
+++ b/stores/convex/README.md
@@ -4,6 +4,7 @@ Convex adapters for Mastra:
 
 - `ConvexStore` implements the Mastra storage contract (threads, messages, workflows, scores, resources).
 - `ConvexVector` stores embeddings inside Convex and performs cosine similarity search.
+- `ConvexServerCache` stores Mastra server cache entries in Convex for durable stream replay and response caching.
 - `@mastra/convex/server` exposes the required Convex table definitions and storage mutation.
 
 ## Quick start
@@ -28,6 +29,8 @@ import {
   mastraScoresTable,
   mastraVectorIndexesTable,
   mastraVectorsTable,
+  mastraCacheTable,
+  mastraCacheListItemsTable,
   mastraDocumentsTable,
 } from '@mastra/convex/schema';
 
@@ -39,11 +42,13 @@ export default defineSchema({
   mastra_scorers: mastraScoresTable,
   mastra_vector_indexes: mastraVectorIndexesTable,
   mastra_vectors: mastraVectorsTable,
+  mastra_cache: mastraCacheTable,
+  mastra_cache_list_items: mastraCacheListItemsTable,
   mastra_documents: mastraDocumentsTable,
 });
 ```
 
-### 3. Create the storage handler
+### 3. Create the storage and cache handlers
 
 In `convex/mastra/storage.ts`:
 
@@ -51,6 +56,14 @@ In `convex/mastra/storage.ts`:
 import { mastraStorage } from '@mastra/convex/server';
 
 export const handle = mastraStorage;
+```
+
+In `convex/mastra/cache.ts`:
+
+```ts
+import { mastraCache } from '@mastra/convex/server';
+
+export const handle = mastraCache;
 ```
 
 ### 4. Deploy to Convex
@@ -64,7 +77,7 @@ npx convex deploy
 ### 5. Use in Mastra
 
 ```ts
-import { ConvexStore } from '@mastra/convex';
+import { ConvexServerCache, ConvexStore } from '@mastra/convex';
 
 const storage = new ConvexStore({
   id: 'convex',
@@ -72,7 +85,16 @@ const storage = new ConvexStore({
   adminAuthToken: process.env.CONVEX_ADMIN_KEY!,
   storageFunction: 'mastra/storage:handle', // default
 });
+
+const cache = new ConvexServerCache({
+  deploymentUrl: process.env.CONVEX_URL!,
+  adminAuthToken: process.env.CONVEX_ADMIN_KEY!,
+  cacheFunction: 'mastra/cache:handle', // default
+});
 ```
+
+`clear()` removes rows whose stored prefix exactly matches the configured cache prefix. Cleanup runs in bounded batches, so reads for a key being cleared can return empty results until cleanup finishes. During cleanup, cache metadata can briefly use an internal `deleted` state before the next cleanup pass removes it. List pushes refresh the configured cache TTL.
+Use this cache for durable replay of moderate-frequency events; batch high-frequency token streams or use a lower-latency cache backend.
 
 For vectors:
 
@@ -99,6 +121,8 @@ This adapter uses **typed Convex tables** for each Mastra domain:
 | Scorers        | `mastra_scorers`            | Evaluation data      |
 | Vector Indexes | `mastra_vector_indexes`     | Index metadata       |
 | Vectors        | `mastra_vectors`            | Embeddings           |
+| Cache          | `mastra_cache`              | Cache metadata       |
+| Cache Items    | `mastra_cache_list_items`   | Cache list entries   |
 | Fallback       | `mastra_documents`          | Unknown tables       |
 
 All typed tables include:

--- a/stores/convex/src/cache/client.ts
+++ b/stores/convex/src/cache/client.ts
@@ -15,6 +15,14 @@ export type RawCacheResult<T = unknown> = {
 const DEFAULT_CACHE_FUNCTION = 'mastra/cache:handle';
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
+const trimTrailingSlashes = (value: string): string => {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+};
+
 export class ConvexCacheClient {
   private readonly deploymentUrl: string;
   private readonly adminAuthToken: string;
@@ -38,7 +46,7 @@ export class ConvexCacheClient {
       throw new Error('ConvexCacheClient: requestTimeoutMs must be greater than or equal to 0.');
     }
 
-    this.deploymentUrl = normalizedDeploymentUrl.replace(/\/+$/, '');
+    this.deploymentUrl = trimTrailingSlashes(normalizedDeploymentUrl);
     this.adminAuthToken = normalizedAdminAuthToken;
     this.cacheFunction = normalizedCacheFunction || DEFAULT_CACHE_FUNCTION;
     this.requestTimeoutMs = requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;

--- a/stores/convex/src/cache/client.ts
+++ b/stores/convex/src/cache/client.ts
@@ -22,11 +22,15 @@ export class ConvexCacheClient {
   private readonly requestTimeoutMs: number;
 
   constructor({ deploymentUrl, adminAuthToken, cacheFunction, requestTimeoutMs }: ConvexCacheClientConfig) {
-    if (!deploymentUrl) {
+    const normalizedDeploymentUrl = deploymentUrl.trim();
+    const normalizedAdminAuthToken = adminAuthToken.trim();
+    const normalizedCacheFunction = cacheFunction?.trim();
+
+    if (!normalizedDeploymentUrl) {
       throw new Error('ConvexCacheClient: deploymentUrl is required.');
     }
 
-    if (!adminAuthToken) {
+    if (!normalizedAdminAuthToken) {
       throw new Error('ConvexCacheClient: adminAuthToken is required.');
     }
 
@@ -34,9 +38,9 @@ export class ConvexCacheClient {
       throw new Error('ConvexCacheClient: requestTimeoutMs must be greater than or equal to 0.');
     }
 
-    this.deploymentUrl = deploymentUrl.replace(/\/$/, '');
-    this.adminAuthToken = adminAuthToken;
-    this.cacheFunction = cacheFunction ?? DEFAULT_CACHE_FUNCTION;
+    this.deploymentUrl = normalizedDeploymentUrl.replace(/\/+$/, '');
+    this.adminAuthToken = normalizedAdminAuthToken;
+    this.cacheFunction = normalizedCacheFunction || DEFAULT_CACHE_FUNCTION;
     this.requestTimeoutMs = requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   }
 
@@ -77,12 +81,15 @@ export class ConvexCacheClient {
       status?: string;
       errorMessage?: string;
       errorCode?: string;
+      code?: string;
+      details?: Record<string, unknown>;
       value?: CacheResponse;
     };
 
     if (result.status === 'error') {
       const error = new Error(result.errorMessage || 'Unknown Convex error');
-      (error as any).code = result.errorCode;
+      (error as any).code = result.errorCode ?? result.code;
+      (error as any).details = result.details;
       throw error;
     }
 

--- a/stores/convex/src/cache/client.ts
+++ b/stores/convex/src/cache/client.ts
@@ -4,6 +4,7 @@ export type ConvexCacheClientConfig = {
   deploymentUrl: string;
   adminAuthToken: string;
   cacheFunction?: string;
+  requestTimeoutMs?: number;
 };
 
 export type RawCacheResult<T = unknown> = {
@@ -12,13 +13,15 @@ export type RawCacheResult<T = unknown> = {
 };
 
 const DEFAULT_CACHE_FUNCTION = 'mastra/cache:handle';
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
 export class ConvexCacheClient {
   private readonly deploymentUrl: string;
   private readonly adminAuthToken: string;
   private readonly cacheFunction: string;
+  private readonly requestTimeoutMs: number;
 
-  constructor({ deploymentUrl, adminAuthToken, cacheFunction }: ConvexCacheClientConfig) {
+  constructor({ deploymentUrl, adminAuthToken, cacheFunction, requestTimeoutMs }: ConvexCacheClientConfig) {
     if (!deploymentUrl) {
       throw new Error('ConvexCacheClient: deploymentUrl is required.');
     }
@@ -27,24 +30,43 @@ export class ConvexCacheClient {
       throw new Error('ConvexCacheClient: adminAuthToken is required.');
     }
 
+    if (requestTimeoutMs !== undefined && requestTimeoutMs < 0) {
+      throw new Error('ConvexCacheClient: requestTimeoutMs must be greater than or equal to 0.');
+    }
+
     this.deploymentUrl = deploymentUrl.replace(/\/$/, '');
     this.adminAuthToken = adminAuthToken;
     this.cacheFunction = cacheFunction ?? DEFAULT_CACHE_FUNCTION;
+    this.requestTimeoutMs = requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   }
 
   async callCacheRaw<T = unknown>(request: CacheRequest): Promise<RawCacheResult<T>> {
-    const response = await fetch(`${this.deploymentUrl}/api/mutation`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Convex ${this.adminAuthToken}`,
-      },
-      body: JSON.stringify({
-        path: this.cacheFunction,
-        args: request,
-        format: 'json',
-      }),
-    });
+    const controller = this.requestTimeoutMs > 0 ? new AbortController() : undefined;
+    const timeoutId = controller ? setTimeout(() => controller.abort(), this.requestTimeoutMs) : undefined;
+    let response: Response;
+
+    try {
+      response = await fetch(`${this.deploymentUrl}/api/mutation`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Convex ${this.adminAuthToken}`,
+        },
+        body: JSON.stringify({
+          path: this.cacheFunction,
+          args: request,
+          format: 'json',
+        }),
+        signal: controller?.signal,
+      });
+    } catch (error) {
+      if (controller?.signal.aborted) {
+        throw new Error(`Convex cache request timed out after ${this.requestTimeoutMs} ms.`);
+      }
+      throw error;
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
+    }
 
     if (!response.ok) {
       const text = await response.text();

--- a/stores/convex/src/cache/client.ts
+++ b/stores/convex/src/cache/client.ts
@@ -1,0 +1,86 @@
+import type { CacheRequest, CacheResponse } from './types';
+
+export type ConvexCacheClientConfig = {
+  deploymentUrl: string;
+  adminAuthToken: string;
+  cacheFunction?: string;
+};
+
+export type RawCacheResult<T = unknown> = {
+  result: T;
+  hasMore?: boolean;
+};
+
+const DEFAULT_CACHE_FUNCTION = 'mastra/cache:handle';
+
+export class ConvexCacheClient {
+  private readonly deploymentUrl: string;
+  private readonly adminAuthToken: string;
+  private readonly cacheFunction: string;
+
+  constructor({ deploymentUrl, adminAuthToken, cacheFunction }: ConvexCacheClientConfig) {
+    if (!deploymentUrl) {
+      throw new Error('ConvexCacheClient: deploymentUrl is required.');
+    }
+
+    if (!adminAuthToken) {
+      throw new Error('ConvexCacheClient: adminAuthToken is required.');
+    }
+
+    this.deploymentUrl = deploymentUrl.replace(/\/$/, '');
+    this.adminAuthToken = adminAuthToken;
+    this.cacheFunction = cacheFunction ?? DEFAULT_CACHE_FUNCTION;
+  }
+
+  async callCacheRaw<T = unknown>(request: CacheRequest): Promise<RawCacheResult<T>> {
+    const response = await fetch(`${this.deploymentUrl}/api/mutation`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Convex ${this.adminAuthToken}`,
+      },
+      body: JSON.stringify({
+        path: this.cacheFunction,
+        args: request,
+        format: 'json',
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Convex API error: ${response.status} ${text}`);
+    }
+
+    const result = (await response.json()) as {
+      status?: string;
+      errorMessage?: string;
+      errorCode?: string;
+      value?: CacheResponse;
+    };
+
+    if (result.status === 'error') {
+      const error = new Error(result.errorMessage || 'Unknown Convex error');
+      (error as any).code = result.errorCode;
+      throw error;
+    }
+
+    const cacheResponse = result.value as CacheResponse;
+    if (!cacheResponse?.ok) {
+      const errResponse = cacheResponse as { ok: false; error: string; code?: string; details?: Record<string, any> };
+      const error = new Error(errResponse?.error || 'Unknown Convex cache error');
+      (error as any).code = errResponse?.code;
+      (error as any).details = errResponse?.details;
+      throw error;
+    }
+
+    return {
+      result: cacheResponse.result as T,
+      hasMore: cacheResponse.hasMore,
+    };
+  }
+
+  async callCache<T = unknown>(request: CacheRequest): Promise<T> {
+    const { result } = await this.callCacheRaw<T>(request);
+    return result;
+  }
+}

--- a/stores/convex/src/cache/index.test.ts
+++ b/stores/convex/src/cache/index.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CacheRequest } from './types';
-import type { ConvexCacheClient } from './index';
-import { ConvexServerCache } from './index';
+import { ConvexCacheClient, ConvexServerCache } from './index';
 
 class MockConvexCacheClient {
   calls: CacheRequest[] = [];
@@ -123,5 +122,58 @@ describe('ConvexServerCache', () => {
         expiresAt: Date.now() + 300_000,
       },
     ]);
+  });
+});
+
+describe('ConvexCacheClient', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('times out hung Convex mutation requests', async () => {
+    vi.useFakeTimers();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+        });
+      }),
+    );
+
+    const client = new ConvexCacheClient({
+      deploymentUrl: 'https://example.convex.cloud',
+      adminAuthToken: 'token',
+      requestTimeoutMs: 1,
+    });
+
+    const call = client.callCacheRaw({ op: 'get', key: 'key' });
+    const assertion = expect(call).rejects.toThrow('Convex cache request timed out after 1 ms.');
+    await vi.advanceTimersByTimeAsync(1);
+
+    await assertion;
+  });
+
+  it('passes Convex mutation requests through with an abort signal', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ value: { ok: true, result: 'cached' } }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new ConvexCacheClient({
+      deploymentUrl: 'https://example.convex.cloud/',
+      adminAuthToken: 'token',
+    });
+
+    await expect(client.callCache({ op: 'get', key: 'key' })).resolves.toBe('cached');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.convex.cloud/api/mutation',
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+    );
   });
 });

--- a/stores/convex/src/cache/index.test.ts
+++ b/stores/convex/src/cache/index.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CacheRequest } from './types';
+import type { ConvexCacheClient } from './index';
+import { ConvexServerCache } from './index';
+
+class MockConvexCacheClient {
+  calls: CacheRequest[] = [];
+  rawResponses: Array<{ result: unknown; hasMore?: boolean }> = [];
+
+  async callCache<T = unknown>(request: CacheRequest): Promise<T> {
+    this.calls.push(request);
+    return undefined as T;
+  }
+
+  async callCacheRaw<T = unknown>(request: CacheRequest): Promise<{ result: T; hasMore?: boolean }> {
+    this.calls.push(request);
+    return (this.rawResponses.shift() ?? { result: undefined }) as { result: T; hasMore?: boolean };
+  }
+}
+
+describe('ConvexServerCache', () => {
+  let client: MockConvexCacheClient;
+  let cache: ConvexServerCache;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    client = new MockConvexCacheClient();
+    cache = new ConvexServerCache({ client: client as unknown as ConvexCacheClient });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('writes scalar values with prefixed keys and default TTL', async () => {
+    await cache.set('run:1', { status: 'streaming' });
+
+    expect(client.calls).toEqual([
+      {
+        op: 'set',
+        key: 'mastra:cache:run:1',
+        keyPrefix: 'mastra:cache:',
+        value: { status: 'streaming' },
+        expiresAt: Date.now() + 300_000,
+      },
+    ]);
+  });
+
+  it('supports custom prefixes and disabled TTL', async () => {
+    cache = new ConvexServerCache({
+      client: client as unknown as ConvexCacheClient,
+      keyPrefix: 'tenant-a:',
+      ttlMs: 0,
+    });
+
+    await cache.listPush('events', { id: 'evt-1' });
+
+    expect(client.calls).toEqual([
+      {
+        op: 'listPush',
+        key: 'tenant-a:events',
+        keyPrefix: 'tenant-a:',
+        value: { id: 'evt-1' },
+        expiresAt: null,
+      },
+    ]);
+  });
+
+  it('uses Redis-compatible inclusive list ranges', async () => {
+    await cache.listFromTo('events', 5, 10);
+
+    expect(client.calls).toEqual([
+      {
+        op: 'listFromTo',
+        key: 'mastra:cache:events',
+        from: 5,
+        to: 10,
+      },
+    ]);
+  });
+
+  it('loops delete and clear while the server reports remaining rows', async () => {
+    client.rawResponses = [{ result: undefined, hasMore: true }, { result: undefined }];
+
+    await cache.delete('events');
+
+    expect(client.calls).toEqual([
+      { op: 'delete', key: 'mastra:cache:events' },
+      { op: 'delete', key: 'mastra:cache:events' },
+    ]);
+
+    client.calls = [];
+    client.rawResponses = [{ result: undefined, hasMore: true }, { result: undefined }];
+
+    await cache.clear();
+
+    expect(client.calls).toEqual([
+      { op: 'clear', keyPrefix: 'mastra:cache:' },
+      { op: 'clear', keyPrefix: 'mastra:cache:' },
+    ]);
+  });
+
+  it('loops listPush while cleanup is still settling', async () => {
+    client.rawResponses = [{ result: undefined, hasMore: true }, { result: undefined }];
+
+    await cache.listPush('events', { id: 'evt-1' });
+
+    expect(client.calls).toEqual([
+      {
+        op: 'listPush',
+        key: 'mastra:cache:events',
+        keyPrefix: 'mastra:cache:',
+        value: { id: 'evt-1' },
+        expiresAt: Date.now() + 300_000,
+      },
+      {
+        op: 'listPush',
+        key: 'mastra:cache:events',
+        keyPrefix: 'mastra:cache:',
+        value: { id: 'evt-1' },
+        expiresAt: Date.now() + 300_000,
+      },
+    ]);
+  });
+});

--- a/stores/convex/src/cache/index.test.ts
+++ b/stores/convex/src/cache/index.test.ts
@@ -176,4 +176,126 @@ describe('ConvexCacheClient', () => {
       }),
     );
   });
+
+  it('normalizes config values before sending requests', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ value: { ok: true, result: 'cached' } }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new ConvexCacheClient({
+      deploymentUrl: ' https://example.convex.cloud/// ',
+      adminAuthToken: ' token ',
+      cacheFunction: ' ',
+    });
+
+    await client.callCache({ op: 'get', key: 'key' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.convex.cloud/api/mutation',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Convex token',
+        }),
+        body: JSON.stringify({
+          path: 'mastra/cache:handle',
+          args: { op: 'get', key: 'key' },
+          format: 'json',
+        }),
+      }),
+    );
+  });
+
+  it('rejects blank required config values', () => {
+    expect(
+      () =>
+        new ConvexCacheClient({
+          deploymentUrl: ' ',
+          adminAuthToken: 'token',
+        }),
+    ).toThrow('ConvexCacheClient: deploymentUrl is required.');
+
+    expect(
+      () =>
+        new ConvexCacheClient({
+          deploymentUrl: 'https://example.convex.cloud',
+          adminAuthToken: ' ',
+        }),
+    ).toThrow('ConvexCacheClient: adminAuthToken is required.');
+  });
+
+  it('throws non-2xx Convex API errors with status text', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 503,
+        text: async () => 'service unavailable',
+      })),
+    );
+
+    const client = new ConvexCacheClient({
+      deploymentUrl: 'https://example.convex.cloud',
+      adminAuthToken: 'token',
+    });
+
+    await expect(client.callCache({ op: 'get', key: 'key' })).rejects.toThrow(
+      'Convex API error: 503 service unavailable',
+    );
+  });
+
+  it('propagates top-level Convex errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          status: 'error',
+          errorMessage: 'mutation failed',
+          code: 'ConvexMutationFailed',
+          details: { retryable: false },
+        }),
+      })),
+    );
+
+    const client = new ConvexCacheClient({
+      deploymentUrl: 'https://example.convex.cloud',
+      adminAuthToken: 'token',
+    });
+
+    await expect(client.callCache({ op: 'get', key: 'key' })).rejects.toMatchObject({
+      message: 'mutation failed',
+      code: 'ConvexMutationFailed',
+      details: { retryable: false },
+    });
+  });
+
+  it('propagates nested cache errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          value: {
+            ok: false,
+            error: 'Wrong cache value type',
+            code: 'CACHE_TYPE_CONFLICT',
+            details: { expected: 'list', actual: 'value' },
+          },
+        }),
+      })),
+    );
+
+    const client = new ConvexCacheClient({
+      deploymentUrl: 'https://example.convex.cloud',
+      adminAuthToken: 'token',
+    });
+
+    await expect(client.callCache({ op: 'listLength', key: 'key' })).rejects.toMatchObject({
+      message: 'Wrong cache value type',
+      code: 'CACHE_TYPE_CONFLICT',
+      details: { expected: 'list', actual: 'value' },
+    });
+  });
 });

--- a/stores/convex/src/cache/index.ts
+++ b/stores/convex/src/cache/index.ts
@@ -1,0 +1,126 @@
+import { MastraServerCache } from '@mastra/core/cache';
+
+import { ConvexCacheClient } from './client';
+import type { ConvexCacheClientConfig } from './client';
+
+export type ConvexServerCacheConfig = {
+  /**
+   * Prefix applied to all cache keys. `clear()` removes rows whose stored
+   * prefix exactly matches this value.
+   */
+  keyPrefix?: string;
+  /**
+   * Default cache TTL in milliseconds. Set to 0 to disable expiry.
+   */
+  ttlMs?: number;
+} & ({ client: ConvexCacheClient } | ConvexCacheClientConfig);
+
+const DEFAULT_KEY_PREFIX = 'mastra:cache:';
+const DEFAULT_TTL_MS = 300_000;
+const MAX_CACHE_OPERATION_BATCHES = 1000;
+
+const isClientConfig = (
+  config: ConvexServerCacheConfig,
+): config is ConvexServerCacheConfig & { client: ConvexCacheClient } => 'client' in config;
+
+export class ConvexServerCache extends MastraServerCache {
+  private readonly client: ConvexCacheClient;
+  private readonly keyPrefix: string;
+  private readonly ttlMs: number;
+
+  constructor(config: ConvexServerCacheConfig) {
+    super({ name: 'ConvexServerCache' });
+
+    this.client = isClientConfig(config) ? config.client : new ConvexCacheClient(config);
+    this.keyPrefix = config.keyPrefix ?? DEFAULT_KEY_PREFIX;
+    this.ttlMs = config.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  private getKey(key: string): string {
+    return `${this.keyPrefix}${key}`;
+  }
+
+  private getExpiresAt(ttlMs?: number): number | null {
+    const effectiveTtlMs = ttlMs ?? this.ttlMs;
+    return effectiveTtlMs > 0 ? Date.now() + effectiveTtlMs : null;
+  }
+
+  private async callUntilSettled<T>(request: () => Parameters<ConvexCacheClient['callCacheRaw']>[0]): Promise<T> {
+    for (let batch = 0; batch < MAX_CACHE_OPERATION_BATCHES; batch += 1) {
+      const response = await this.client.callCacheRaw({
+        ...request(),
+      });
+      if (!response.hasMore) return response.result as T;
+    }
+
+    throw new Error(`ConvexServerCache operation exceeded ${MAX_CACHE_OPERATION_BATCHES} batches.`);
+  }
+
+  async get(key: string): Promise<unknown> {
+    return this.callUntilSettled(() => ({
+      op: 'get',
+      key: this.getKey(key),
+    }));
+  }
+
+  async set(key: string, value: unknown, ttlMs?: number): Promise<void> {
+    await this.callUntilSettled(() => ({
+      op: 'set',
+      key: this.getKey(key),
+      keyPrefix: this.keyPrefix,
+      value,
+      expiresAt: this.getExpiresAt(ttlMs),
+    }));
+  }
+
+  async listLength(key: string): Promise<number> {
+    return this.callUntilSettled(() => ({
+      op: 'listLength',
+      key: this.getKey(key),
+    }));
+  }
+
+  async listPush(key: string, value: unknown): Promise<void> {
+    await this.callUntilSettled(() => ({
+      op: 'listPush',
+      key: this.getKey(key),
+      keyPrefix: this.keyPrefix,
+      value,
+      expiresAt: this.getExpiresAt(),
+    }));
+  }
+
+  async listFromTo(key: string, from: number, to: number = -1): Promise<unknown[]> {
+    return this.callUntilSettled(() => ({
+      op: 'listFromTo',
+      key: this.getKey(key),
+      from,
+      to,
+    }));
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.callUntilSettled(() => ({
+      op: 'delete',
+      key: this.getKey(key),
+    }));
+  }
+
+  async clear(): Promise<void> {
+    await this.callUntilSettled(() => ({
+      op: 'clear',
+      keyPrefix: this.keyPrefix,
+    }));
+  }
+
+  async increment(key: string): Promise<number> {
+    return this.callUntilSettled(() => ({
+      op: 'increment',
+      key: this.getKey(key),
+      keyPrefix: this.keyPrefix,
+      expiresAt: this.getExpiresAt(),
+    }));
+  }
+}
+
+export { ConvexCacheClient, type ConvexCacheClientConfig };

--- a/stores/convex/src/cache/types.ts
+++ b/stores/convex/src/cache/types.ts
@@ -1,0 +1,56 @@
+export type CacheRequest =
+  | {
+      op: 'get';
+      key: string;
+    }
+  | {
+      op: 'set';
+      key: string;
+      keyPrefix: string;
+      value: unknown;
+      expiresAt: number | null;
+    }
+  | {
+      op: 'listLength';
+      key: string;
+    }
+  | {
+      op: 'listPush';
+      key: string;
+      keyPrefix: string;
+      value: unknown;
+      expiresAt: number | null;
+    }
+  | {
+      op: 'listFromTo';
+      key: string;
+      from: number;
+      to: number;
+    }
+  | {
+      op: 'delete';
+      key: string;
+    }
+  | {
+      op: 'clear';
+      keyPrefix: string;
+    }
+  | {
+      op: 'increment';
+      key: string;
+      keyPrefix: string;
+      expiresAt: number | null;
+    };
+
+export type CacheResponse =
+  | {
+      ok: true;
+      result?: unknown;
+      hasMore?: boolean;
+    }
+  | {
+      ok: false;
+      error: string;
+      code?: string;
+      details?: Record<string, unknown>;
+    };

--- a/stores/convex/src/index.ts
+++ b/stores/convex/src/index.ts
@@ -1,3 +1,9 @@
+export {
+  ConvexServerCache,
+  ConvexCacheClient,
+  type ConvexServerCacheConfig,
+  type ConvexCacheClientConfig,
+} from './cache';
 export { ConvexStore, type ConvexStoreConfig } from './storage';
 export { ConvexVector, type ConvexVectorConfig } from './vector';
 export * from './server';

--- a/stores/convex/src/schema.ts
+++ b/stores/convex/src/schema.ts
@@ -164,6 +164,38 @@ export const mastraVectorsTable = defineTable({
   .index('by_index', ['indexName']);
 
 // ============================================================================
+// Server Cache Tables - Used by ConvexServerCache
+// ============================================================================
+
+/**
+ * Cache metadata table - stores scalar cache values, list counters, and numeric
+ * counters used by ConvexServerCache.
+ */
+export const mastraCacheTable = defineTable({
+  key: v.string(),
+  keyPrefix: v.string(),
+  kind: v.union(v.literal('value'), v.literal('list'), v.literal('counter'), v.literal('deleted')),
+  value: v.optional(v.string()),
+  counter: v.optional(v.number()),
+  expiresAt: v.union(v.number(), v.null()),
+})
+  .index('by_key', ['key'])
+  .index('by_key_prefix', ['keyPrefix']);
+
+/**
+ * Cache list item table - stores each list entry as its own row so replay
+ * history does not grow into a single large Convex document.
+ */
+export const mastraCacheListItemsTable = defineTable({
+  key: v.string(),
+  keyPrefix: v.string(),
+  index: v.number(),
+  value: v.string(),
+})
+  .index('by_key_prefix', ['keyPrefix'])
+  .index('by_key_index', ['key', 'index']);
+
+// ============================================================================
 // Fallback Table - For unknown/custom tables
 // ============================================================================
 

--- a/stores/convex/src/server/cache.test.ts
+++ b/stores/convex/src/server/cache.test.ts
@@ -1,0 +1,504 @@
+import { describe, expect, it } from 'vitest';
+
+import { handleCacheOperation, mastraCache } from './cache';
+
+type Row = Record<string, any> & { _id: string };
+
+function createCtx(options: { failListItemInsert?: boolean } = {}) {
+  let nextId = 0;
+  const tables = new Map<string, Row[]>();
+
+  const rows = (table: string) => {
+    if (!tables.has(table)) tables.set(table, []);
+    return tables.get(table)!;
+  };
+
+  const db = {
+    async insert(table: string, record: Record<string, any>) {
+      if (options.failListItemInsert && table === 'mastra_cache_list_items') {
+        throw new Error('list item insert failed');
+      }
+
+      const doc = { _id: `${table}:${++nextId}`, ...record };
+      rows(table).push(doc);
+      return doc._id;
+    },
+    async delete(id: string) {
+      for (const docs of tables.values()) {
+        const index = docs.findIndex(doc => doc._id === id);
+        if (index !== -1) docs.splice(index, 1);
+      }
+    },
+    async patch(id: string, patch: Record<string, any>) {
+      for (const docs of tables.values()) {
+        const doc = docs.find(row => row._id === id);
+        if (doc) Object.assign(doc, patch);
+      }
+    },
+    query(table: string) {
+      const filters: Array<(row: Row) => boolean> = [];
+
+      const query = {
+        withIndex(_index: string, cb: (q: any) => any) {
+          const builder = {
+            eq(field: string, value: unknown) {
+              filters.push(row => row[field] === value);
+              return builder;
+            },
+            gte(field: string, value: unknown) {
+              filters.push(row => row[field] >= (value as any));
+              return builder;
+            },
+            lte(field: string, value: unknown) {
+              filters.push(row => row[field] <= (value as any));
+              return builder;
+            },
+          };
+          cb(builder);
+          return query;
+        },
+        async collect() {
+          return rows(table)
+            .filter(row => filters.every(filter => filter(row)))
+            .sort((a, b) => {
+              if (a.key !== b.key) return String(a.key).localeCompare(String(b.key));
+              return (a.index ?? 0) - (b.index ?? 0);
+            });
+        },
+        async first() {
+          return (await query.collect())[0] ?? null;
+        },
+        async take(count: number) {
+          return (await query.collect()).slice(0, count);
+        },
+      };
+
+      return query;
+    },
+  };
+
+  return { db, tables };
+}
+
+async function clearUntilSettled(ctx: ReturnType<typeof createCtx>, keyPrefix: string) {
+  for (let attempts = 0; attempts < 10; attempts += 1) {
+    const result = await handleCacheOperation(ctx as any, { op: 'clear', keyPrefix });
+    if (!result.ok) throw new Error(result.error);
+    if (!result.hasMore) return result;
+  }
+
+  throw new Error('clear did not settle');
+}
+
+describe('mastraCache server handler', () => {
+  it('lets mutation write failures propagate for Convex rollback', async () => {
+    const ctx = createCtx({ failListItemInsert: true });
+
+    await expect(
+      (mastraCache as any)._handler(ctx, {
+        op: 'listPush',
+        key: 'mastra:cache:events',
+        keyPrefix: 'mastra:cache:',
+        value: 'event',
+        expiresAt: null,
+      }),
+    ).rejects.toThrow('list item insert failed');
+  });
+
+  it('stores scalar values and expires them', async () => {
+    const ctx = createCtx();
+
+    await handleCacheOperation(ctx as any, {
+      op: 'set',
+      key: 'mastra:cache:key',
+      keyPrefix: 'mastra:cache:',
+      value: { ok: true },
+      expiresAt: Date.now() + 1_000,
+    });
+
+    await expect(handleCacheOperation(ctx as any, { op: 'get', key: 'mastra:cache:key' })).resolves.toEqual({
+      ok: true,
+      result: { ok: true },
+    });
+
+    await handleCacheOperation(ctx as any, {
+      op: 'set',
+      key: 'mastra:cache:expired',
+      keyPrefix: 'mastra:cache:',
+      value: 'old',
+      expiresAt: Date.now() - 1,
+    });
+
+    await expect(handleCacheOperation(ctx as any, { op: 'get', key: 'mastra:cache:expired' })).resolves.toEqual({
+      ok: true,
+      result: null,
+    });
+  });
+
+  it('stores list values as separate ordered rows', async () => {
+    const ctx = createCtx();
+
+    await handleCacheOperation(ctx as any, {
+      op: 'listPush',
+      key: 'mastra:cache:events',
+      keyPrefix: 'mastra:cache:',
+      value: 'a',
+      expiresAt: null,
+    });
+    await handleCacheOperation(ctx as any, {
+      op: 'listPush',
+      key: 'mastra:cache:events',
+      keyPrefix: 'mastra:cache:',
+      value: 'b',
+      expiresAt: null,
+    });
+    await handleCacheOperation(ctx as any, {
+      op: 'listPush',
+      key: 'mastra:cache:events',
+      keyPrefix: 'mastra:cache:',
+      value: 'c',
+      expiresAt: null,
+    });
+
+    await expect(handleCacheOperation(ctx as any, { op: 'listLength', key: 'mastra:cache:events' })).resolves.toEqual({
+      ok: true,
+      result: 3,
+    });
+    await expect(
+      handleCacheOperation(ctx as any, { op: 'listFromTo', key: 'mastra:cache:events', from: 1, to: -1 }),
+    ).resolves.toEqual({ ok: true, result: ['b', 'c'] });
+    await expect(
+      handleCacheOperation(ctx as any, { op: 'listFromTo', key: 'mastra:cache:events', from: 0, to: -2 }),
+    ).resolves.toEqual({ ok: true, result: ['a', 'b'] });
+    await expect(
+      handleCacheOperation(ctx as any, { op: 'listFromTo', key: 'mastra:cache:events', from: -2, to: -1 }),
+    ).resolves.toEqual({ ok: true, result: ['b', 'c'] });
+  });
+
+  it('refreshes list TTL on each push', async () => {
+    const ctx = createCtx();
+    const firstExpiresAt = Date.now() + 100_000;
+    const secondExpiresAt = Date.now() + 200_000;
+
+    await handleCacheOperation(ctx as any, {
+      op: 'listPush',
+      key: 'mastra:cache:events',
+      keyPrefix: 'mastra:cache:',
+      value: 'a',
+      expiresAt: firstExpiresAt,
+    });
+    await handleCacheOperation(ctx as any, {
+      op: 'listPush',
+      key: 'mastra:cache:events',
+      keyPrefix: 'mastra:cache:',
+      value: 'b',
+      expiresAt: secondExpiresAt,
+    });
+
+    expect(ctx.tables.get('mastra_cache')?.[0]).toMatchObject({
+      key: 'mastra:cache:events',
+      counter: 2,
+      expiresAt: secondExpiresAt,
+    });
+  });
+
+  it('increments counters and rejects type conflicts', async () => {
+    const ctx = createCtx();
+
+    await expect(
+      handleCacheOperation(ctx as any, {
+        op: 'increment',
+        key: 'mastra:cache:counter',
+        keyPrefix: 'mastra:cache:',
+        expiresAt: null,
+      }),
+    ).resolves.toEqual({ ok: true, result: 1 });
+    await expect(
+      handleCacheOperation(ctx as any, {
+        op: 'increment',
+        key: 'mastra:cache:counter',
+        keyPrefix: 'mastra:cache:',
+        expiresAt: null,
+      }),
+    ).resolves.toEqual({ ok: true, result: 2 });
+
+    await handleCacheOperation(ctx as any, {
+      op: 'set',
+      key: 'mastra:cache:value',
+      keyPrefix: 'mastra:cache:',
+      value: 'not-list',
+      expiresAt: null,
+    });
+
+    await expect(
+      handleCacheOperation(ctx as any, {
+        op: 'listPush',
+        key: 'mastra:cache:value',
+        keyPrefix: 'mastra:cache:',
+        value: 'item',
+        expiresAt: null,
+      }),
+    ).resolves.toEqual({ ok: false, error: 'mastra:cache:value exists but is not an array' });
+
+    await expect(
+      handleCacheOperation(ctx as any, {
+        op: 'increment',
+        key: 'mastra:cache:value',
+        keyPrefix: 'mastra:cache:',
+        expiresAt: null,
+      }),
+    ).resolves.toEqual({ ok: false, error: 'mastra:cache:value exists but is not a number' });
+
+    await handleCacheOperation(ctx as any, {
+      op: 'listPush',
+      key: 'mastra:cache:list',
+      keyPrefix: 'mastra:cache:',
+      value: 'item',
+      expiresAt: null,
+    });
+
+    await expect(
+      handleCacheOperation(ctx as any, {
+        op: 'increment',
+        key: 'mastra:cache:list',
+        keyPrefix: 'mastra:cache:',
+        expiresAt: null,
+      }),
+    ).resolves.toEqual({ ok: false, error: 'mastra:cache:list exists but is not a number' });
+  });
+
+  it('clears metadata and list rows by prefix', async () => {
+    const ctx = createCtx();
+
+    await handleCacheOperation(ctx as any, {
+      op: 'set',
+      key: 'mastra:cache:value',
+      keyPrefix: 'mastra:cache:',
+      value: 'cached',
+      expiresAt: null,
+    });
+    await handleCacheOperation(ctx as any, {
+      op: 'listPush',
+      key: 'mastra:cache:events',
+      keyPrefix: 'mastra:cache:',
+      value: 'a',
+      expiresAt: null,
+    });
+    await handleCacheOperation(ctx as any, {
+      op: 'set',
+      key: 'other:value',
+      keyPrefix: 'other:',
+      value: 'kept',
+      expiresAt: null,
+    });
+
+    await expect(clearUntilSettled(ctx, 'mastra:cache:')).resolves.toEqual({ ok: true, hasMore: false });
+    await expect(handleCacheOperation(ctx as any, { op: 'get', key: 'mastra:cache:value' })).resolves.toEqual({
+      ok: true,
+      result: null,
+    });
+    await expect(handleCacheOperation(ctx as any, { op: 'listLength', key: 'mastra:cache:events' })).resolves.toEqual({
+      ok: true,
+      result: 0,
+    });
+    await expect(handleCacheOperation(ctx as any, { op: 'get', key: 'other:value' })).resolves.toEqual({
+      ok: true,
+      result: 'kept',
+    });
+  });
+
+  it('continues clear across multiple batches', async () => {
+    const ctx = createCtx();
+
+    for (let index = 0; index < 27; index += 1) {
+      await handleCacheOperation(ctx as any, {
+        op: 'set',
+        key: `mastra:cache:value:${index}`,
+        keyPrefix: 'mastra:cache:',
+        value: index,
+        expiresAt: null,
+      });
+    }
+
+    await expect(handleCacheOperation(ctx as any, { op: 'clear', keyPrefix: 'mastra:cache:' })).resolves.toEqual({
+      ok: true,
+      hasMore: true,
+    });
+    expect(ctx.tables.get('mastra_cache')).toHaveLength(2);
+
+    await expect(handleCacheOperation(ctx as any, { op: 'clear', keyPrefix: 'mastra:cache:' })).resolves.toEqual({
+      ok: true,
+      hasMore: false,
+    });
+    expect(ctx.tables.get('mastra_cache')).toHaveLength(0);
+  });
+
+  it('settles clear on an exact scalar batch boundary', async () => {
+    const ctx = createCtx();
+
+    for (let index = 0; index < 25; index += 1) {
+      await handleCacheOperation(ctx as any, {
+        op: 'set',
+        key: `mastra:cache:value:${index}`,
+        keyPrefix: 'mastra:cache:',
+        value: index,
+        expiresAt: null,
+      });
+    }
+
+    await expect(handleCacheOperation(ctx as any, { op: 'clear', keyPrefix: 'mastra:cache:' })).resolves.toEqual({
+      ok: true,
+      hasMore: false,
+    });
+    expect(ctx.tables.get('mastra_cache')).toHaveLength(0);
+  });
+
+  it('continues expired large-list cleanup across reads', async () => {
+    const ctx = createCtx();
+
+    for (let index = 0; index < 27; index += 1) {
+      await handleCacheOperation(ctx as any, {
+        op: 'listPush',
+        key: 'mastra:cache:events',
+        keyPrefix: 'mastra:cache:',
+        value: `event-${index}`,
+        expiresAt: Date.now() + 1_000,
+      });
+    }
+
+    const cacheDocs = ctx.tables.get('mastra_cache')!;
+    cacheDocs[0]!.expiresAt = Date.now() - 1;
+
+    await expect(handleCacheOperation(ctx as any, { op: 'listLength', key: 'mastra:cache:events' })).resolves.toEqual({
+      ok: true,
+      result: 0,
+      hasMore: true,
+    });
+    expect(ctx.tables.get('mastra_cache_list_items')).toHaveLength(2);
+    expect(ctx.tables.get('mastra_cache')).toHaveLength(1);
+
+    await expect(handleCacheOperation(ctx as any, { op: 'listLength', key: 'mastra:cache:events' })).resolves.toEqual({
+      ok: true,
+      result: 0,
+    });
+    expect(ctx.tables.get('mastra_cache_list_items')).toHaveLength(0);
+    expect(ctx.tables.get('mastra_cache')).toHaveLength(0);
+  });
+
+  it('sets a scalar over an existing large list across cleanup batches', async () => {
+    const ctx = createCtx();
+
+    for (let index = 0; index < 27; index += 1) {
+      await handleCacheOperation(ctx as any, {
+        op: 'listPush',
+        key: 'mastra:cache:events',
+        keyPrefix: 'mastra:cache:',
+        value: `event-${index}`,
+        expiresAt: null,
+      });
+    }
+
+    const request = {
+      op: 'set' as const,
+      key: 'mastra:cache:events',
+      keyPrefix: 'mastra:cache:',
+      value: 'done',
+      expiresAt: null,
+    };
+
+    await expect(handleCacheOperation(ctx as any, request)).resolves.toEqual({ ok: true, hasMore: true });
+    expect(ctx.tables.get('mastra_cache_list_items')).toHaveLength(2);
+
+    await expect(handleCacheOperation(ctx as any, request)).resolves.toEqual({ ok: true });
+    await expect(handleCacheOperation(ctx as any, { op: 'get', key: 'mastra:cache:events' })).resolves.toEqual({
+      ok: true,
+      result: 'done',
+    });
+    expect(ctx.tables.get('mastra_cache_list_items')).toHaveLength(0);
+  });
+
+  it('does not replay stale list rows after prefix clear and same-key rewrite', async () => {
+    const ctx = createCtx();
+
+    for (let index = 0; index < 60; index += 1) {
+      await handleCacheOperation(ctx as any, {
+        op: 'listPush',
+        key: 'mastra:cache:events',
+        keyPrefix: 'mastra:cache:',
+        value: `old-${index}`,
+        expiresAt: null,
+      });
+    }
+
+    await expect(handleCacheOperation(ctx as any, { op: 'clear', keyPrefix: 'mastra:cache:' })).resolves.toEqual({
+      ok: true,
+      hasMore: true,
+    });
+
+    await expect(
+      handleCacheOperation(ctx as any, {
+        op: 'listPush',
+        key: 'mastra:cache:events',
+        keyPrefix: 'mastra:cache:',
+        value: 'new',
+        expiresAt: null,
+      }),
+    ).resolves.toEqual({ ok: true, hasMore: true });
+
+    await expect(
+      handleCacheOperation(ctx as any, {
+        op: 'listPush',
+        key: 'mastra:cache:events',
+        keyPrefix: 'mastra:cache:',
+        value: 'new',
+        expiresAt: null,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    await expect(
+      handleCacheOperation(ctx as any, { op: 'listFromTo', key: 'mastra:cache:events', from: 0, to: -1 }),
+    ).resolves.toEqual({ ok: true, result: ['new'] });
+    expect(ctx.tables.get('mastra_cache_list_items')).toHaveLength(1);
+  });
+
+  it('replaces expired list and counter entries after cleanup completes', async () => {
+    const ctx = createCtx();
+
+    await handleCacheOperation(ctx as any, {
+      op: 'listPush',
+      key: 'mastra:cache:events',
+      keyPrefix: 'mastra:cache:',
+      value: 'old',
+      expiresAt: Date.now() - 1,
+    });
+
+    await expect(
+      handleCacheOperation(ctx as any, {
+        op: 'listPush',
+        key: 'mastra:cache:events',
+        keyPrefix: 'mastra:cache:',
+        value: 'new',
+        expiresAt: null,
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      handleCacheOperation(ctx as any, { op: 'listFromTo', key: 'mastra:cache:events', from: 0, to: -1 }),
+    ).resolves.toEqual({ ok: true, result: ['new'] });
+
+    await handleCacheOperation(ctx as any, {
+      op: 'increment',
+      key: 'mastra:cache:counter',
+      keyPrefix: 'mastra:cache:',
+      expiresAt: Date.now() - 1,
+    });
+
+    await expect(
+      handleCacheOperation(ctx as any, {
+        op: 'increment',
+        key: 'mastra:cache:counter',
+        keyPrefix: 'mastra:cache:',
+        expiresAt: null,
+      }),
+    ).resolves.toEqual({ ok: true, result: 1 });
+  });
+});

--- a/stores/convex/src/server/cache.ts
+++ b/stores/convex/src/server/cache.ts
@@ -1,0 +1,287 @@
+import type { GenericMutationCtx as MutationCtx } from 'convex/server';
+import { mutationGeneric } from 'convex/server';
+import type { GenericId } from 'convex/values';
+
+import type { CacheRequest, CacheResponse } from '../cache/types';
+
+const CACHE_TABLE = 'mastra_cache';
+const CACHE_LIST_TABLE = 'mastra_cache_list_items';
+const CACHE_MUTATION_BATCH_SIZE = 25;
+
+type CacheKind = 'value' | 'list' | 'counter' | 'deleted';
+type CacheDoc = {
+  _id: GenericId<string>;
+  key: string;
+  keyPrefix: string;
+  kind: CacheKind;
+  value?: string;
+  counter?: number;
+  expiresAt: number | null;
+};
+type CacheListItem = {
+  _id: GenericId<string>;
+  key: string;
+  keyPrefix: string;
+  index: number;
+  value: string;
+};
+type DeleteBatchResult = {
+  hasMore: boolean;
+};
+
+function encodeValue(value: unknown): string {
+  // The cache wire format stores JSON strings; undefined is represented as null.
+  return JSON.stringify(value === undefined ? null : value);
+}
+
+function decodeValue(value: string): unknown {
+  return JSON.parse(value);
+}
+
+function isExpired(doc: { expiresAt: number | null }, now: number): boolean {
+  return doc.expiresAt !== null && doc.expiresAt <= now;
+}
+
+function normalizeListRange(from: number, to: number, length: number): { from: number; to: number } | null {
+  const normalizedFrom = from < 0 ? Math.max(length + from, 0) : from;
+  const normalizedTo = to < 0 ? length + to : to;
+  if (normalizedTo < normalizedFrom || normalizedFrom >= length) return null;
+  return { from: normalizedFrom, to: normalizedTo };
+}
+
+async function findCacheDoc(ctx: MutationCtx<any>, key: string): Promise<CacheDoc | null> {
+  return (await ctx.db
+    .query(CACHE_TABLE)
+    .withIndex('by_key', (q: any) => q.eq('key', key))
+    .first()) as CacheDoc | null;
+}
+
+async function deleteCacheKey(ctx: MutationCtx<any>, key: string): Promise<DeleteBatchResult> {
+  const [doc, listItems] = await Promise.all([
+    findCacheDoc(ctx, key),
+    ctx.db
+      .query(CACHE_LIST_TABLE)
+      .withIndex('by_key_index', (q: any) => q.eq('key', key))
+      .take(CACHE_MUTATION_BATCH_SIZE + 1),
+  ]);
+
+  if (doc && doc.kind !== 'deleted') {
+    await ctx.db.patch(doc._id, { kind: 'deleted' });
+  }
+
+  for (const item of listItems.slice(0, CACHE_MUTATION_BATCH_SIZE) as CacheListItem[]) {
+    await ctx.db.delete(item._id);
+  }
+
+  const hasMore = listItems.length > CACHE_MUTATION_BATCH_SIZE;
+  if (doc && !hasMore) {
+    await ctx.db.delete(doc._id);
+  }
+
+  return {
+    hasMore,
+  };
+}
+
+async function getLiveCacheDoc(
+  ctx: MutationCtx<any>,
+  key: string,
+  now: number,
+): Promise<{ doc: CacheDoc | null; hasMore: boolean }> {
+  const doc = await findCacheDoc(ctx, key);
+  if (!doc) return { doc: null, hasMore: false };
+  if (doc.kind === 'deleted') {
+    const cleanup = await deleteCacheKey(ctx, key);
+    return { doc: null, hasMore: cleanup.hasMore };
+  }
+  if (!isExpired(doc, now)) return { doc, hasMore: false };
+
+  const cleanup = await deleteCacheKey(ctx, key);
+  return { doc: null, hasMore: cleanup.hasMore };
+}
+
+async function writeCacheDoc(
+  ctx: MutationCtx<any>,
+  key: string,
+  existing: CacheDoc | null,
+  patch: Omit<CacheDoc, '_id' | 'key'>,
+): Promise<CacheDoc> {
+  if (existing) {
+    await ctx.db.patch(existing._id, patch);
+    return { ...existing, ...patch };
+  }
+
+  const _id = await ctx.db.insert(CACHE_TABLE, { key, ...patch });
+  return { _id, key, ...patch };
+}
+
+async function clearPrefix(ctx: MutationCtx<any>, keyPrefix: string): Promise<boolean> {
+  const [docs, orphanListItems] = await Promise.all([
+    ctx.db
+      .query(CACHE_TABLE)
+      .withIndex('by_key_prefix', (q: any) => q.eq('keyPrefix', keyPrefix))
+      .take(CACHE_MUTATION_BATCH_SIZE + 1),
+    ctx.db
+      .query(CACHE_LIST_TABLE)
+      .withIndex('by_key_prefix', (q: any) => q.eq('keyPrefix', keyPrefix))
+      .take(1),
+  ]);
+
+  if (docs.length > 0) {
+    for (const doc of docs.slice(0, CACHE_MUTATION_BATCH_SIZE) as CacheDoc[]) {
+      if (doc.kind === 'list' || doc.kind === 'deleted') {
+        const cleanup = await deleteCacheKey(ctx, doc.key);
+        return cleanup.hasMore || docs.length > 1 || orphanListItems.length > 0;
+      }
+
+      await ctx.db.delete(doc._id);
+    }
+
+    return docs.length > CACHE_MUTATION_BATCH_SIZE || orphanListItems.length > 0;
+  }
+
+  const listItems = (await ctx.db
+    .query(CACHE_LIST_TABLE)
+    .withIndex('by_key_prefix', (q: any) => q.eq('keyPrefix', keyPrefix))
+    .take(CACHE_MUTATION_BATCH_SIZE + 1)) as CacheListItem[];
+
+  for (const item of listItems.slice(0, CACHE_MUTATION_BATCH_SIZE)) {
+    await ctx.db.delete(item._id);
+  }
+
+  return listItems.length > CACHE_MUTATION_BATCH_SIZE;
+}
+
+export async function handleCacheOperation(ctx: MutationCtx<any>, request: CacheRequest): Promise<CacheResponse> {
+  const now = Date.now();
+
+  switch (request.op) {
+    case 'get': {
+      const { doc, hasMore } = await getLiveCacheDoc(ctx, request.key, now);
+      if (hasMore) return { ok: true, result: null, hasMore: true };
+      if (!doc || doc.kind !== 'value') return { ok: true, result: null };
+      return { ok: true, result: decodeValue(doc.value ?? 'null') };
+    }
+
+    case 'set': {
+      let existing = await findCacheDoc(ctx, request.key);
+      if (existing && (isExpired(existing, now) || existing.kind !== 'value')) {
+        const cleanup = await deleteCacheKey(ctx, request.key);
+        if (cleanup.hasMore) {
+          return { ok: true, hasMore: true };
+        }
+        existing = null;
+      }
+
+      await writeCacheDoc(ctx, request.key, existing, {
+        keyPrefix: request.keyPrefix,
+        kind: 'value',
+        value: encodeValue(request.value),
+        expiresAt: request.expiresAt,
+      });
+      return { ok: true };
+    }
+
+    case 'listLength': {
+      const { doc, hasMore } = await getLiveCacheDoc(ctx, request.key, now);
+      if (hasMore) return { ok: true, result: 0, hasMore: true };
+      if (!doc) return { ok: true, result: 0 };
+      if (doc.kind !== 'list') return { ok: false, error: `${request.key} exists but is not an array` };
+
+      return { ok: true, result: doc.counter ?? 0 };
+    }
+
+    case 'listPush': {
+      let existing = await findCacheDoc(ctx, request.key);
+      if (existing && (isExpired(existing, now) || existing.kind === 'deleted')) {
+        const cleanup = await deleteCacheKey(ctx, request.key);
+        if (cleanup.hasMore) {
+          return { ok: true, hasMore: true };
+        }
+        existing = null;
+      }
+      if (existing && existing.kind !== 'list') {
+        return { ok: false, error: `${request.key} exists but is not an array` };
+      }
+
+      const doc = existing
+        ? await writeCacheDoc(ctx, request.key, existing, {
+            kind: 'list',
+            keyPrefix: request.keyPrefix,
+            counter: (existing.counter ?? 0) + 1,
+            expiresAt: request.expiresAt,
+          })
+        : await writeCacheDoc(ctx, request.key, null, {
+            kind: 'list',
+            keyPrefix: request.keyPrefix,
+            counter: 1,
+            expiresAt: request.expiresAt,
+          });
+
+      await ctx.db.insert(CACHE_LIST_TABLE, {
+        key: request.key,
+        keyPrefix: request.keyPrefix,
+        index: (doc.counter ?? 1) - 1,
+        value: encodeValue(request.value),
+      });
+
+      return { ok: true };
+    }
+
+    case 'listFromTo': {
+      const { doc, hasMore } = await getLiveCacheDoc(ctx, request.key, now);
+      if (hasMore) return { ok: true, result: [], hasMore: true };
+      if (!doc || doc.kind !== 'list') return { ok: true, result: [] };
+
+      const range = normalizeListRange(request.from, request.to, doc.counter ?? 0);
+      if (!range) return { ok: true, result: [] };
+
+      const query = ctx.db.query(CACHE_LIST_TABLE).withIndex('by_key_index', (q: any) => {
+        return q.eq('key', request.key).gte('index', range.from).lte('index', range.to);
+      });
+      const items = (await query.collect()) as CacheListItem[];
+
+      return { ok: true, result: items.map(item => decodeValue(item.value)) };
+    }
+
+    case 'delete': {
+      const cleanup = await deleteCacheKey(ctx, request.key);
+      return { ok: true, hasMore: cleanup.hasMore };
+    }
+
+    case 'clear': {
+      const hasMore = await clearPrefix(ctx, request.keyPrefix);
+      return { ok: true, hasMore };
+    }
+
+    case 'increment': {
+      let existing = await findCacheDoc(ctx, request.key);
+      if (existing && (isExpired(existing, now) || existing.kind === 'deleted')) {
+        const cleanup = await deleteCacheKey(ctx, request.key);
+        if (cleanup.hasMore) {
+          return { ok: true, hasMore: true };
+        }
+        existing = null;
+      }
+      if (existing && existing.kind !== 'counter') {
+        return { ok: false, error: `${request.key} exists but is not a number` };
+      }
+
+      const nextCounter = (existing?.counter ?? 0) + 1;
+      await writeCacheDoc(ctx, request.key, existing, {
+        kind: 'counter',
+        keyPrefix: request.keyPrefix,
+        counter: nextCounter,
+        expiresAt: request.expiresAt,
+      });
+
+      return { ok: true, result: nextCounter };
+    }
+  }
+
+  return { ok: false, error: `Unsupported operation ${(request as any).op}` };
+}
+
+export const mastraCache = mutationGeneric(
+  async (ctx, request: CacheRequest): Promise<CacheResponse> => handleCacheOperation(ctx, request),
+);

--- a/stores/convex/src/server/index.ts
+++ b/stores/convex/src/server/index.ts
@@ -1,3 +1,4 @@
+export { mastraCache } from './cache';
 export { mastraStorage } from './storage';
 
 // Re-export schema definitions for backward compatibility
@@ -11,6 +12,8 @@ export {
   mastraScoresTable,
   mastraVectorIndexesTable,
   mastraVectorsTable,
+  mastraCacheTable,
+  mastraCacheListItemsTable,
   mastraDocumentsTable,
   // Table name constants
   TABLE_WORKFLOW_SNAPSHOT,

--- a/stores/convex/src/storage/index.test.ts
+++ b/stores/convex/src/storage/index.test.ts
@@ -167,6 +167,30 @@ describe('Convex Schema Sync', () => {
     const convexFields = convexValidator ? Object.keys(convexValidator.fields || {}) : [];
     expect(convexFields).toContain('id');
   });
+
+  it('cache tables should include indexes used by ConvexServerCache', async () => {
+    const { mastraCacheTable, mastraCacheListItemsTable } = await import('../schema');
+    const normalizeIndexes = (indexes: any[]) =>
+      indexes.map(index =>
+        Array.isArray(index) ? index : [index.indexDescriptor ?? index.name, index.fields ?? index.indexFields],
+      );
+
+    const cacheIndexes = normalizeIndexes((mastraCacheTable as any).indexes ?? []);
+    expect(cacheIndexes).toEqual(
+      expect.arrayContaining([
+        ['by_key', ['key']],
+        ['by_key_prefix', ['keyPrefix']],
+      ]),
+    );
+
+    const listIndexes = normalizeIndexes((mastraCacheListItemsTable as any).indexes ?? []);
+    expect(listIndexes).toEqual(
+      expect.arrayContaining([
+        ['by_key_prefix', ['keyPrefix']],
+        ['by_key_index', ['key', 'index']],
+      ]),
+    );
+  });
 });
 
 // Configuration validation tests (run even without credentials)


### PR DESCRIPTION
## Description

Adds a Convex-backed `ConvexServerCache` for `@mastra/convex`, including client helpers, the Convex server mutation, schema tables, tests, docs, and a changeset.

This lets Convex-backed Mastra apps persist server cache state for durable stream replay and response cache use cases without requiring a separate cache service.

## Related issue(s)

Fixes #16735

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This adds a Convex-backed server cache so Mastra apps can store cache state (replay state, lists, counters) inside Convex—so cached data survives restarts and multiple instances without a separate cache service. It includes the server-side handler, an HTTP client, schema, tests, docs, and examples so caches are TTL-aware, paginated, and type-safe.

---

## New exports

- ConvexServerCache — Mastra server-cache implementation backed by Convex  
- ConvexServerCacheConfig — config type for the server cache (keyPrefix, ttlMs, or provide a client)  
- ConvexCacheClient — HTTP client that invokes a Convex mutation endpoint  
- ConvexCacheClientConfig — client config (deploymentUrl, adminAuthToken, optional cacheFunction, optional requestTimeoutMs; defaults to 30_000ms)  
- mastraCacheTable, mastraCacheListItemsTable — Convex typed tables for metadata and per-item list rows  
- mastraCache — Convex mutation handler to mount in a Convex app

---

## What was implemented

- Full server-cache API: get, set, delete, clear (prefix-based), listPush, listFromTo, listLength, increment  
- TTL support: configurable per-cache or per-call; server enforces expiry and cleanup is paginated  
- Lists stored as separate indexed rows to avoid unbounded documents; listPush refreshes TTL  
- Type-safe semantics: scalar / list / counter conflicts surface errors  
- Batching/pagination: server returns hasMore when cleanup spans a batch; client loops until settled with a MAX_CACHE_OPERATION_BATCHES safety bound  
- ConvexCacheClient: trims/validates config, defaults cacheFunction & requestTimeoutMs, uses AbortController for timeouts, surfaces non-2xx, Convex-level, and nested cache errors  
- ConvexServerCache: wraps the client, applies key prefixes, computes expiresAt (or null when TTL disabled), and retries paginated operations until settled  
- Server mutation (mastraCache): implements storage, expiry checks, cleanup, paginated delete/clear semantics, and serialization helpers

---

## Tests

- Client tests: timeout/abort handling, AbortSignal propagation, config normalization/validation, non-2xx/Convex error propagation, nested cache error propagation  
- ConvexServerCache unit tests: key prefixing, default/custom/disabled TTL, inclusive listFromTo semantics, retry/settling when hasMore is returned for delete/clear/listPush  
- Server handler tests: rollback on write failure, scalar/list/counter semantics and conflicts, list ordering and slicing, list TTL refresh on push, clear batching and settling, prevention of stale list replay after prefix clears, expiry/cleanup across cycles, overwriting lists with scalars across cleanup  
- Schema test: verifies required indexes exist on the new tables (by_key, by_key_prefix, by_key_index)

---

## Documentation & changeset

- Docs updated with ConvexServerCache usage and constructor params (deploymentUrl, adminAuthToken, cacheFunction, requestTimeoutMs, keyPrefix, ttlMs), behavioral notes (bounded cleanup, temporary deleted markers, list TTL refresh, exact keyPrefix semantics), and instructions to mount mastraCache and add the required schema  
- README updated with examples for instantiating ConvexServerCache and mounting mastraCache; notes on clear() behavior and cleanup batching  
- Changeset added documenting the new export and required schema/handler deployment steps

---

## Notable implementation details & guidance

- requestTimeoutMs defaults to 30_000 ms; the client aborts fetch on timeout and surfaces a timeout-specific error  
- Large clears/deletes and list cleanup are paginated; the client repeatedly calls until hasMore is false or a MAX_CACHE_OPERATION_BATCHES limit is reached  
- clear() by prefix is best-effort across batches; reads during cleanup may observe temporary deleted markers or intermediate states  
- List items are stored as separate rows for bounded document growth and indexed slicing; listPush refreshes TTL for the list  
- Intended to enable durable/resumable server-side behaviors (stream replay, response caching) in multi-instance deployments; not a drop-in replacement for high-frequency pub/sub live delivery without performance planning

---

## Issue fixed

- Fixes `#16735`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->