### PR TITLE
Fix double-counted cache token costs in Metrics dashboard

### DIFF
--- a/.changeset/slick-games-stand.md
+++ b/.changeset/slick-games-stand.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed double-counted cache token costs in the Metrics dashboard. The Model Usage & Cost table and the Token Usage by Agent table were summing cache read/write costs on top of the total input cost, which already includes them — now they only sum total input + total output cost.

--- a/.changeset/slick-games-stand.md
+++ b/.changeset/slick-games-stand.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed double-counted cache token costs in the Metrics dashboard. The Model Usage & Cost table and the Token Usage by Agent table were summing cache read/write costs on top of the total input cost, which already includes them — now they only sum total input + total output cost.
+Fixed double-counted cache token costs in the Metrics dashboard. The Model Usage & Cost table and the Token Usage by Agent table were summing cache read/write costs on top of the total input cost, which already includes them.

--- a/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
@@ -57,9 +57,11 @@ export function useModelUsageCostMetrics() {
         return modelMap.get(model)!;
       };
 
-      // total_input / total_output already roll up cache read/write costs server-side,
-      // so the row cost is just total_input + total_output — cache_read/cache_write
-      // breakdowns are fetched only for their token counts.
+      // The estimatedCost on total_input and total_output already includes every
+      // input/output detail cost (cache read, cache write, image, audio, ...), so
+      // the row cost only accumulates from those two breakdowns. The cache_read
+      // and cache_write breakdowns are fetched purely for their token counts,
+      // which the table displays in dedicated columns.
       const addCost = (entry: ModelEntry, group: { estimatedCost?: number | null; costUnit?: string | null }) => {
         if (group.estimatedCost != null) {
           entry.cost = (entry.cost ?? 0) + group.estimatedCost;

--- a/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
@@ -57,11 +57,8 @@ export function useModelUsageCostMetrics() {
         return modelMap.get(model)!;
       };
 
-      // The estimatedCost on total_input and total_output already includes every
-      // input/output detail cost (cache read, cache write, image, audio, ...), so
-      // the row cost only accumulates from those two breakdowns. The cache_read
-      // and cache_write breakdowns are fetched purely for their token counts,
-      // which the table displays in dedicated columns.
+      // total_input/total_output estimatedCost already rolls up cache + other detail
+      // costs. The cache breakdowns are kept for their token counts only.
       const addCost = (entry: ModelEntry, group: { estimatedCost?: number | null; costUnit?: string | null }) => {
         if (group.estimatedCost != null) {
           entry.cost = (entry.cost ?? 0) + group.estimatedCost;

--- a/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
@@ -20,15 +20,15 @@ export function useModelUsageCostMetrics() {
   return useQuery({
     queryKey: ['metrics', 'model-usage-cost', filterKey],
     queryFn: async (): Promise<ModelUsageRow[]> => {
-      const metrics = [
-        'mastra_model_total_input_tokens',
-        'mastra_model_total_output_tokens',
-        'mastra_model_input_cache_read_tokens',
-        'mastra_model_input_cache_write_tokens',
-      ] as const;
-
       const [inputRes, outputRes, cacheReadRes, cacheWriteRes] = await Promise.all(
-        metrics.map(name =>
+        (
+          [
+            'mastra_model_total_input_tokens',
+            'mastra_model_total_output_tokens',
+            'mastra_model_input_cache_read_tokens',
+            'mastra_model_input_cache_write_tokens',
+          ] as const
+        ).map(name =>
           client.getMetricBreakdown({
             name: [name],
             groupBy: ['model'],
@@ -57,6 +57,9 @@ export function useModelUsageCostMetrics() {
         return modelMap.get(model)!;
       };
 
+      // total_input / total_output already roll up cache read/write costs server-side,
+      // so the row cost is just total_input + total_output — cache_read/cache_write
+      // breakdowns are fetched only for their token counts.
       const addCost = (entry: ModelEntry, group: { estimatedCost?: number | null; costUnit?: string | null }) => {
         if (group.estimatedCost != null) {
           entry.cost = (entry.cost ?? 0) + group.estimatedCost;
@@ -80,13 +83,11 @@ export function useModelUsageCostMetrics() {
         const m = group.dimensions.model ?? 'unknown';
         const entry = ensureModel(m);
         entry.cacheRead = group.value;
-        addCost(entry, group);
       }
       for (const group of cacheWriteRes.groups) {
         const m = group.dimensions.model ?? 'unknown';
         const entry = ensureModel(m);
         entry.cacheWrite = group.value;
-        addCost(entry, group);
       }
 
       return Array.from(modelMap.entries())

--- a/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
@@ -24,11 +24,11 @@ export function useTokenUsageByAgentMetrics() {
         orderDirection: 'DESC' as const,
         filters,
       };
-      const [inputRes, outputRes, cacheReadRes, cacheWriteRes] = await Promise.all([
+      // total_input / total_output already roll up cache read/write costs server-side,
+      // so summing those two is enough — no need to fetch the cache breakdowns.
+      const [inputRes, outputRes] = await Promise.all([
         client.getMetricBreakdown({ ...breakdownBase, name: ['mastra_model_total_input_tokens'] }),
         client.getMetricBreakdown({ ...breakdownBase, name: ['mastra_model_total_output_tokens'] }),
-        client.getMetricBreakdown({ ...breakdownBase, name: ['mastra_model_input_cache_read_tokens'] }),
-        client.getMetricBreakdown({ ...breakdownBase, name: ['mastra_model_input_cache_write_tokens'] }),
       ]);
 
       type AgentEntry = { input: number; output: number; cost: number | null; costUnit: string | null };
@@ -59,16 +59,6 @@ export function useTokenUsageByAgentMetrics() {
         const name = group.dimensions.entityName ?? 'unknown';
         const entry = ensure(name);
         entry.output = group.value;
-        addCost(entry, group);
-      }
-      for (const group of cacheReadRes.groups) {
-        const name = group.dimensions.entityName ?? 'unknown';
-        const entry = ensure(name);
-        addCost(entry, group);
-      }
-      for (const group of cacheWriteRes.groups) {
-        const name = group.dimensions.entityName ?? 'unknown';
-        const entry = ensure(name);
         addCost(entry, group);
       }
 

--- a/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
@@ -24,8 +24,10 @@ export function useTokenUsageByAgentMetrics() {
         orderDirection: 'DESC' as const,
         filters,
       };
-      // total_input / total_output already roll up cache read/write costs server-side,
-      // so summing those two is enough — no need to fetch the cache breakdowns.
+      // The estimatedCost on total_input and total_output already includes every
+      // input/output detail cost (cache read, cache write, image, audio, ...), so
+      // summing those two breakdowns gives the full per-agent cost. No need to
+      // fetch the cache breakdowns since this table does not display them.
       const [inputRes, outputRes] = await Promise.all([
         client.getMetricBreakdown({ ...breakdownBase, name: ['mastra_model_total_input_tokens'] }),
         client.getMetricBreakdown({ ...breakdownBase, name: ['mastra_model_total_output_tokens'] }),

--- a/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
@@ -24,10 +24,7 @@ export function useTokenUsageByAgentMetrics() {
         orderDirection: 'DESC' as const,
         filters,
       };
-      // The estimatedCost on total_input and total_output already includes every
-      // input/output detail cost (cache read, cache write, image, audio, ...), so
-      // summing those two breakdowns gives the full per-agent cost. No need to
-      // fetch the cache breakdowns since this table does not display them.
+      // total_input/total_output estimatedCost already rolls up cache + other detail costs.
       const [inputRes, outputRes] = await Promise.all([
         client.getMetricBreakdown({ ...breakdownBase, name: ['mastra_model_total_input_tokens'] }),
         client.getMetricBreakdown({ ...breakdownBase, name: ['mastra_model_total_output_tokens'] }),


### PR DESCRIPTION
## Description

Fixed a bug where cache token costs were being double-counted in the Metrics dashboard. The Model Usage & Cost table and Token Usage by Agent table were summing cache read/write token costs on top of the total input cost, which already includes them server-side.

**Changes:**
- **use-model-usage-cost-metrics.tsx**: Removed `addCost()` calls for cache read/write breakdowns since they're already rolled up in total input/output costs. Kept the cache breakdown fetches only for their token count values.
- **use-token-usage-by-agent-metrics.tsx**: Removed the cache read/write metric fetches entirely and their corresponding cost aggregation loops, since total input/output already includes cache costs server-side.
- Added clarifying comments explaining that total_input/total_output metrics already roll up cache costs.

## Related issue(s)

<!-- Please link to the issue this fixes -->

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

https://claude.ai/code/session_014UncdwmZqGE6z3XVhCCP1w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The dashboard was accidentally counting some cache-related costs twice. This PR removes the extra additions so costs are only counted once while still showing cache token counts.

## Summary of Changes

### Changeset
- Added a changeset for `@mastra/playground-ui` (patch) documenting the fix for double-counted cache costs in the Metrics dashboard.

### Code changes
- packages/playground-ui/src/domains/metrics/hooks/use-model-usage-cost-metrics.tsx
  - Constructed token metric names inline in the Promise.all mapping.
  - Added comments clarifying that total_input/total_output already include cache read/write costs; cache breakdowns are fetched only to obtain token counts.
  - Removed addCost() calls for cache read/write breakdowns — now only record cacheRead/cacheWrite token counts without adding their estimatedCost to per-model cost totals.

- packages/playground-ui/src/domains/metrics/hooks/use-token-usage-by-agent-metrics.tsx
  - Removed fetches and cost-aggregation for cache read/write metrics (they were redundant because total_input/total_output already include cache costs).
  - Simplified aggregation logic to use only input/output breakdowns returned from getMetricBreakdown; removed loops that previously added cache read/write costs per agent.

These changes eliminate double-counting of cache token costs in the Model Usage & Cost table and the Token Usage by Agent table while preserving the display of cache token counts where applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16737?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->