### PR TITLE
fix(core): avoid mutating tool input schemas for resume fields

### DIFF
--- a/.changeset/tough-peaches-feel.md
+++ b/.changeset/tough-peaches-feel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed auto-resume and background tool schema fields so they no longer mix Zod versions or bypass tool input validation.

--- a/packages/core/src/agent/__tests__/tools.test.ts
+++ b/packages/core/src/agent/__tests__/tools.test.ts
@@ -1399,6 +1399,7 @@ describe('sub-agent prompt input normalization (GitHub #14154)', () => {
     resourceId: z.string().nullish().describe('Resource ID'),
     instructions: z.string().nullish().describe('Additional instructions'),
     maxSteps: z.number().min(3).nullish().describe('Max steps'),
+    suspendedToolRunId: z.string().nullish().describe('Suspended tool run ID'),
   });
 
   it('should normalize "query" to "prompt" through validateToolInput', async () => {
@@ -1457,5 +1458,20 @@ describe('sub-agent prompt input normalization (GitHub #14154)', () => {
     const subAgentTool = tools['agent-subAgent'];
     expect(subAgentTool).toBeDefined();
     expect(subAgentTool.description).toContain('subAgent');
+
+    const validation = await (subAgentTool.parameters as any).validate({
+      prompt: 'resume the child',
+      suspendedToolRunId: 'suspended-run',
+      resumeData: { approved: true },
+    });
+
+    expect(validation).toMatchObject({
+      success: true,
+      value: {
+        prompt: 'resume the child',
+        suspendedToolRunId: 'suspended-run',
+        resumeData: { approved: true },
+      },
+    });
   });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3836,6 +3836,7 @@ export class Agent<
           maxSteps: z.number().min(3).nullish().describe('Maximum number of execution steps for the sub-agent'),
           // using minimum of 3 to ensure if the agent has a tool call, the llm gets executed again after the tool call step, using the tool call result
           // to return a proper llm response
+          suspendedToolRunId: z.string().nullish().describe('The runId of the suspended tool'),
         });
 
         const agentOutputSchema = z.object({
@@ -4729,6 +4730,7 @@ export class Agent<
 
         const inputProperties: Record<string, JSONSchema7> = {
           inputData: inputDataJsonSchema,
+          suspendedToolRunId: { type: ['string', 'null'], description: 'The runId of the suspended tool' },
         };
         const inputRequired = ['inputData'];
 

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -1,6 +1,7 @@
 import { anthropic } from '@ai-sdk/anthropic-v5';
 import { openai } from '@ai-sdk/openai-v6';
 import { describe, expect, it, vi } from 'vitest';
+import { z as z3 } from 'zod/v3';
 import { z } from 'zod/v4';
 import { SpanType } from '../../observability';
 import type { AnySpan } from '../../observability';
@@ -436,6 +437,151 @@ describe('Provider-defined Tool Handling', () => {
   });
 });
 
+describe('Auto-resume tool schema injection', () => {
+  const model = {
+    modelId: 'gemini-3-flash-preview',
+    provider: 'google',
+    specificationVersion: 'v2',
+    supportsStructuredOutputs: false,
+  } as any;
+
+  const options = {
+    name: 'test-tool',
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trackException: vi.fn(),
+    } as any,
+    description: 'Test tool',
+    requestContext: new RequestContext(),
+    tracingContext: {},
+    model,
+    runId: 'run-id',
+  };
+
+  it('adds resume fields to the model schema for Zod v3 tools without mutating the runtime schema', async () => {
+    const execute = vi.fn(async input => ({ input }));
+    const tool = createTool({
+      id: 'test-tool',
+      description: 'Test tool',
+      inputSchema: z3
+        .object({
+          query: z3.string(),
+          limit: z3.number().optional(),
+        })
+        .strict(),
+      execute,
+    });
+
+    const builtTool = new CoreToolBuilder({
+      originalTool: tool,
+      options,
+      autoResumeSuspendedTools: true,
+    }).build();
+
+    const properties = (builtTool.parameters as any).jsonSchema.properties;
+    expect(properties.query).toBeDefined();
+    expect(properties.limit).toBeDefined();
+    expect(properties.suspendedToolRunId).toBeDefined();
+    expect(properties.resumeData).toBeDefined();
+    expect(properties.resumeData.type).toEqual(['string', 'number', 'integer', 'boolean', 'object', 'null']);
+    expect((tool.inputSchema as any).shape.suspendedToolRunId).toBeUndefined();
+
+    const validation = await (builtTool.parameters as any).validate({
+      query: 'hello',
+      suspendedToolRunId: 'suspended-run',
+      resumeData: { approved: true },
+    });
+
+    expect(validation).toEqual({
+      success: true,
+      value: {
+        query: 'hello',
+        suspendedToolRunId: 'suspended-run',
+        resumeData: { approved: true },
+      },
+    });
+
+    const result = await builtTool.execute?.(validation.value, {
+      toolCallId: 'tool-call-id',
+      messages: [],
+      resumeData: { approved: true },
+    });
+
+    expect(result).toEqual({ input: { query: 'hello' } });
+    expect(execute).toHaveBeenCalledWith({ query: 'hello' }, expect.any(Object));
+  });
+
+  it('runs injected control fields through provider schema compatibility', () => {
+    const tool = createTool({
+      id: 'openai-tool',
+      description: 'OpenAI tool',
+      inputSchema: z.object({
+        query: z.string().optional(),
+      }),
+      execute: async input => ({ input }),
+    });
+
+    const builtTool = new CoreToolBuilder({
+      originalTool: tool,
+      options: {
+        ...options,
+        name: 'openai-tool',
+        description: 'OpenAI tool',
+        model: {
+          modelId: 'gpt-4.1-mini',
+          provider: 'openai',
+          specificationVersion: 'v2',
+          supportsStructuredOutputs: false,
+        } as any,
+      },
+      autoResumeSuspendedTools: true,
+      backgroundTaskEnabled: true,
+    }).build();
+
+    const schema = (builtTool.parameters as any).jsonSchema;
+    expect(schema.additionalProperties).toBe(false);
+    expect(schema.required).toEqual(
+      expect.arrayContaining(['query', '_background', 'suspendedToolRunId', 'resumeData']),
+    );
+    expect(schema.required).toEqual(expect.arrayContaining(Object.keys(schema.properties)));
+
+    const backgroundSchema = schema.properties._background.anyOf.find((entry: any) => entry.type === 'object');
+    expect(backgroundSchema).toMatchObject({
+      additionalProperties: false,
+    });
+    expect(backgroundSchema.required).toEqual(expect.arrayContaining(['enabled', 'timeoutMs', 'maxRetries']));
+  });
+
+  it('does not ignore missing suspendedToolRunId when resumeData was provided', async () => {
+    const execute = vi.fn(async input => ({ input }));
+    const tool = createTool({
+      id: 'workflow-required-run-id',
+      description: 'Workflow wrapper requiring a suspended run id',
+      inputSchema: z.object({
+        query: z.string(),
+        suspendedToolRunId: z.string(),
+      }),
+      execute,
+    });
+
+    const builtTool = new CoreToolBuilder({
+      originalTool: tool,
+      options: { ...options, name: 'workflow-required-run-id', description: 'Workflow wrapper requiring a run id' },
+      autoResumeSuspendedTools: true,
+    }).build();
+
+    const result = await builtTool.execute?.(
+      { query: 'hello', resumeData: false },
+      { toolCallId: 'tool-call-id', messages: [], resumeData: false },
+    );
+
+    expect(result).toMatchObject({ error: true });
+    expect(execute).not.toHaveBeenCalled();
+  });
+});
+
 describe('CoreToolBuilder strict', () => {
   it('should pass through strict when building a tool', () => {
     const strictTool = createTool({
@@ -522,6 +668,7 @@ describe('CoreToolBuilder background task schema injection', () => {
         .refine(d => !!d.a || !!d.b, { message: 'pass a or b' }),
       execute: async () => ({ ok: true }),
     });
+    const originalInputSchema = refinedTool.inputSchema;
 
     const build = () =>
       new CoreToolBuilder({
@@ -530,11 +677,11 @@ describe('CoreToolBuilder background task schema injection', () => {
         backgroundTaskEnabled: true,
       }).build();
 
-    // The builder mutates originalTool.inputSchema, so the second build re-injects
-    // `_background` onto the already-refined schema. With `.extend()` Zod v4 threw
-    // "Cannot overwrite keys on object schemas containing refinements"; safeExtend fixes it.
+    // Control fields are injected only into the model-facing schema, so repeated
+    // builds should not mutate an already-refined runtime schema.
     expect(() => build()).not.toThrow();
     expect(() => build()).not.toThrow();
+    expect(refinedTool.inputSchema).toBe(originalInputSchema);
     expect((refinedTool.inputSchema as z.ZodTypeAny).safeParse({}).success).toBe(false);
   });
 });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -13,7 +13,7 @@ import {
 } from '@mastra/schema-compat';
 import { z } from 'zod/v4';
 import { MastraFGAPermissions } from '../../auth/ee';
-import { backgroundOverrideJsonSchema, backgroundOverrideZodSchema } from '../../background-tasks';
+import { backgroundOverrideJsonSchema } from '../../background-tasks';
 import { MastraBase } from '../../base';
 import { ErrorCategory, MastraError, ErrorDomain } from '../../error';
 import type { Mastra } from '../../mastra';
@@ -26,7 +26,6 @@ import type { StandardSchemaWithJSON } from '../../schema';
 import { isVercelTool, isProviderDefinedTool } from '../../tools/toolchecks';
 import type { ToolOptions } from '../../utils';
 import { safeStringify } from '../../utils';
-import { isZodObject, safeExtendZodObject } from '../../utils/zod-utils';
 
 import type { SuspendOptions } from '../../workflows';
 import { ToolStream } from '../stream';
@@ -40,6 +39,132 @@ import type {
 } from '../types';
 import { noopObserve } from '../types';
 import { validateToolInput, validateToolOutput, validateToolSuspendData } from '../validation';
+
+const injectedToolInputKeys = ['_background', 'suspendedToolRunId', 'resumeData'] as const;
+const resumeDataJsonSchema = {
+  type: ['string', 'number', 'integer', 'boolean', 'object', 'null'],
+  description: 'The resumeData object created from the resumeSchema of suspended tool',
+};
+
+function injectToolInputFields(schema: Record<string, any>, isBackgroundEligible: boolean, isResumableTool: boolean) {
+  if (schema.type !== 'object') {
+    return schema;
+  }
+
+  const properties = schema.properties && typeof schema.properties === 'object' ? { ...schema.properties } : {};
+
+  if (isBackgroundEligible) {
+    properties._background = backgroundOverrideJsonSchema;
+  }
+
+  if (isResumableTool) {
+    properties.suspendedToolRunId = {
+      type: ['string', 'null'],
+      description: 'The runId of the suspended tool',
+    };
+    properties.resumeData = resumeDataJsonSchema;
+  }
+
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter(name => !injectedToolInputKeys.includes(name))
+    : schema.required;
+
+  return {
+    ...schema,
+    properties,
+    ...(required ? { required } : {}),
+  };
+}
+
+function stripModelOnlyToolInputFields(
+  value: unknown,
+  isBackgroundEligible: boolean,
+  isResumableTool: boolean,
+  forwardsResumeRunId: boolean,
+) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+
+  const stripped = { ...(value as Record<string, unknown>) };
+
+  if (isBackgroundEligible) {
+    delete stripped._background;
+  }
+
+  if (isResumableTool) {
+    delete stripped.resumeData;
+    if (!forwardsResumeRunId) {
+      delete stripped.suspendedToolRunId;
+    }
+  }
+
+  return stripped;
+}
+
+function mergeModelOnlyToolInputFields(
+  originalValue: unknown,
+  validatedValue: unknown,
+  isBackgroundEligible: boolean,
+  isResumableTool: boolean,
+  forwardsResumeRunId: boolean,
+) {
+  if (
+    !originalValue ||
+    typeof originalValue !== 'object' ||
+    Array.isArray(originalValue) ||
+    !validatedValue ||
+    typeof validatedValue !== 'object' ||
+    Array.isArray(validatedValue)
+  ) {
+    return validatedValue;
+  }
+
+  const source = originalValue as Record<string, unknown>;
+  const merged = { ...(validatedValue as Record<string, unknown>) };
+
+  if (isBackgroundEligible && '_background' in source) {
+    merged._background = source._background;
+  }
+
+  if (isResumableTool) {
+    if ('resumeData' in source) {
+      merged.resumeData = source.resumeData;
+    }
+    if (!forwardsResumeRunId && 'suspendedToolRunId' in source) {
+      merged.suspendedToolRunId = source.suspendedToolRunId;
+    }
+  }
+
+  return merged;
+}
+
+function wrapSchemaValidation(
+  validate: NonNullable<Schema['validate']>,
+  isBackgroundEligible: boolean,
+  isResumableTool: boolean,
+  forwardsResumeRunId: boolean,
+) {
+  return async (value: unknown) => {
+    const input = stripModelOnlyToolInputFields(value, isBackgroundEligible, isResumableTool, forwardsResumeRunId);
+    const validationResult = await validate(input);
+
+    if (!validationResult.success) {
+      return validationResult;
+    }
+
+    return {
+      ...validationResult,
+      value: mergeModelOnlyToolInputFields(
+        value,
+        validationResult.value,
+        isBackgroundEligible,
+        isResumableTool,
+        forwardsResumeRunId,
+      ),
+    };
+  };
+}
 
 /**
  * Types that can be converted to Mastra tools.
@@ -64,6 +189,9 @@ export class CoreToolBuilder extends MastraBase {
   private originalTool: ToolToConvert;
   private options: ToolOptions;
   private logType?: LogType;
+  private isBackgroundEligible = false;
+  private isResumableTool = false;
+  private forwardsResumeRunId = false;
 
   constructor(input: {
     originalTool: ToolToConvert;
@@ -77,71 +205,14 @@ export class CoreToolBuilder extends MastraBase {
     this.options = input.options;
     this.logType = input.logType;
 
-    // Only inject the `_background` override schema for tools that are actually
-    // eligible for background execution — otherwise every user tool's input
-    // schema would be mutated with a v4 Zod field, which breaks v3-authored
-    // tools (keyValidator._parse crashes in schema-compat validation).
-    const isBackgroundEligible = !!input.backgroundTaskEnabled;
-    const isResumableTool =
-      input.autoResumeSuspendedTools ||
+    const supportsInjectedInputFields = !isVercelTool(this.originalTool) && !isProviderDefinedTool(this.originalTool);
+    const isGeneratedResumeTool =
       (this.originalTool as unknown as ToolAction<any, any>).id?.startsWith('agent-') ||
       (this.originalTool as unknown as ToolAction<any, any>).id?.startsWith('workflow-');
 
-    if (!isVercelTool(this.originalTool) && !isProviderDefinedTool(this.originalTool)) {
-      if (isBackgroundEligible || isResumableTool) {
-        let schema = this.originalTool.inputSchema;
-        if (typeof schema === 'function') {
-          schema = schema();
-        }
-        if (!schema) {
-          schema = z.object({});
-        }
-
-        if (isZodObject(schema)) {
-          let nextSchema = schema;
-          if (isBackgroundEligible) {
-            nextSchema = safeExtendZodObject(nextSchema, {
-              _background: backgroundOverrideZodSchema,
-            });
-          }
-          if (isResumableTool) {
-            nextSchema = safeExtendZodObject(nextSchema, {
-              suspendedToolRunId: z.string().describe('The runId of the suspended tool').nullable().optional(),
-              resumeData: z
-                .any()
-                .describe('The resumeData object created from the resumeSchema of suspended tool')
-                .optional(),
-            });
-          }
-          this.originalTool.inputSchema = nextSchema;
-        } else {
-          // Non-Zod StandardSchemaWithJSON (e.g. JsonSchemaWrapper from JSONSchema7).
-          // Extract JSON Schema, add suspend/resume fields, re-wrap.
-          const jsonSchema = standardSchemaToJSONSchema(schema as any, { io: 'input' });
-          if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
-            if (isBackgroundEligible) {
-              jsonSchema.properties = {
-                ...jsonSchema.properties,
-                _background: backgroundOverrideJsonSchema,
-              };
-            }
-            if (isResumableTool) {
-              jsonSchema.properties = {
-                ...jsonSchema.properties,
-                suspendedToolRunId: {
-                  type: ['string', 'null'],
-                  description: 'The runId of the suspended tool',
-                },
-                resumeData: {
-                  description: 'The resumeData object created from the resumeSchema of suspended tool',
-                },
-              };
-            }
-            this.originalTool.inputSchema = toStandardSchema(jsonSchema) as any;
-          }
-        }
-      }
-    }
+    this.isBackgroundEligible = supportsInjectedInputFields && !!input.backgroundTaskEnabled;
+    this.isResumableTool = supportsInjectedInputFields && (input.autoResumeSuspendedTools || isGeneratedResumeTool);
+    this.forwardsResumeRunId = supportsInjectedInputFields && isGeneratedResumeTool;
   }
 
   // Helper to get parameters based on tool type
@@ -611,12 +682,36 @@ export class CoreToolBuilder extends MastraBase {
         logger.debug(start, { ...logData, ...rest, model: logModelObject, args });
 
         // Validate input parameters if schema exists
-        // Use the processed schema for validation if available, otherwise fall back to original
+        // Runtime validation uses the original tool schema. Model-only control
+        // fields are stripped here so they do not weaken user-defined validators.
+        const originalArgs = args;
+        if (
+          args &&
+          typeof args === 'object' &&
+          !Array.isArray(args) &&
+          (this.isBackgroundEligible || this.isResumableTool)
+        ) {
+          args = stripModelOnlyToolInputFields(
+            args,
+            this.isBackgroundEligible,
+            this.isResumableTool,
+            this.forwardsResumeRunId,
+          );
+        }
+
         const parameters = this.getParameters();
         const { data, error } = validateToolInput(parameters, args, options.name);
         //suspendedToolRunId is only required when resumeData is provided
+        const hasResumeData =
+          !!(execOptions && Object.prototype.hasOwnProperty.call(execOptions, 'resumeData')) ||
+          !!(
+            originalArgs &&
+            typeof originalArgs === 'object' &&
+            !Array.isArray(originalArgs) &&
+            Object.prototype.hasOwnProperty.call(originalArgs, 'resumeData')
+          );
         const suspendedToolRunIdErrToIgnore =
-          error?.message?.includes('suspendedToolRunId: Required') && !(args as Record<string, unknown>)?.resumeData;
+          error?.message?.includes('suspendedToolRunId: Required') && !hasResumeData;
         if (error && !suspendedToolRunIdErrToIgnore) {
           logger.warn('Tool input validation failed', { ...logData, validationError: error.message });
           toolSpan?.end({ output: error, attributes: { success: false } });
@@ -727,25 +822,44 @@ export class CoreToolBuilder extends MastraBase {
     const originalSchema = this.getParameters();
     let processedInputSchema: Schema | undefined;
 
-    if (originalSchema) {
-      if (isStandardSchemaWithJSON(originalSchema)) {
+    const modelInputSchema =
+      originalSchema ?? (this.isBackgroundEligible || this.isResumableTool ? z.object({}) : null);
+
+    if (modelInputSchema) {
+      if (isStandardSchemaWithJSON(modelInputSchema)) {
         // Find the first applicable compatibility layer
         const applicableLayer = schemaCompatLayers.find(layer => layer.shouldApply());
 
         let schemaToUse: StandardSchemaWithJSON;
         if (applicableLayer) {
-          schemaToUse = applicableLayer.processToCompatSchema(originalSchema as any);
+          schemaToUse = applicableLayer.processToCompatSchema(modelInputSchema as any);
         } else {
-          schemaToUse = toStandardSchema(originalSchema);
+          schemaToUse = toStandardSchema(modelInputSchema);
         }
 
-        processedInputSchema = jsonSchema(
-          standardSchemaToJSONSchema(schemaToUse, {
+        const injectedJsonSchema = injectToolInputFields(
+          standardSchemaToJSONSchema(toStandardSchema(modelInputSchema), {
             io: 'input',
           }),
+          this.isBackgroundEligible,
+          this.isResumableTool,
+        );
+
+        const modelJsonSchema = applicableLayer
+          ? applicableLayer.processToJSONSchema(injectedJsonSchema, 'input')
+          : injectedJsonSchema;
+
+        processedInputSchema = jsonSchema(
+          modelJsonSchema,
           {
             validate: (value: unknown) => {
-              const result = schemaToUse['~standard'].validate(value);
+              const input = stripModelOnlyToolInputFields(
+                value,
+                this.isBackgroundEligible,
+                this.isResumableTool,
+                this.forwardsResumeRunId,
+              );
+              const result = schemaToUse['~standard'].validate(input);
               // standard-schema validate may return a Promise
               if (result instanceof Promise) {
                 return result.then(r => {
@@ -755,7 +869,16 @@ export class CoreToolBuilder extends MastraBase {
                       error: new Error(r.issues.map((i: any) => i.message).join(', ')),
                     };
                   }
-                  return { success: true as const, value: (r as { value: unknown }).value };
+                  return {
+                    success: true as const,
+                    value: mergeModelOnlyToolInputFields(
+                      value,
+                      (r as { value: unknown }).value,
+                      this.isBackgroundEligible,
+                      this.isResumableTool,
+                      this.forwardsResumeRunId,
+                    ),
+                  };
                 });
               }
               // standard-schema returns { value } on success or { issues } on failure,
@@ -766,16 +889,58 @@ export class CoreToolBuilder extends MastraBase {
                   error: new Error(result.issues.map((i: any) => i.message).join(', ')),
                 };
               }
-              return { success: true as const, value: (result as { value: unknown }).value };
+              return {
+                success: true as const,
+                value: mergeModelOnlyToolInputFields(
+                  value,
+                  (result as { value: unknown }).value,
+                  this.isBackgroundEligible,
+                  this.isResumableTool,
+                  this.forwardsResumeRunId,
+                ),
+              };
             },
           },
         );
       } else {
+        const applicableLayer = schemaCompatLayers.find(layer => layer.shouldApply());
         processedInputSchema = applyCompatLayer({
-          schema: originalSchema,
+          schema: modelInputSchema,
           compatLayers: schemaCompatLayers,
           mode: 'aiSdkSchema',
         });
+        if (processedInputSchema) {
+          const validate = processedInputSchema.validate;
+          const injectedJsonSchema = injectToolInputFields(
+            standardSchemaToJSONSchema(toStandardSchema(modelInputSchema), {
+              io: 'input',
+            }),
+            this.isBackgroundEligible,
+            this.isResumableTool,
+          );
+          const modelJsonSchema = applicableLayer
+            ? applicableLayer.processToJSONSchema(injectedJsonSchema, 'input')
+            : injectedJsonSchema;
+
+          processedInputSchema = {
+            ...processedInputSchema,
+            ...(validate
+              ? {
+                  validate: wrapSchemaValidation(
+                    validate,
+                    this.isBackgroundEligible,
+                    this.isResumableTool,
+                    this.forwardsResumeRunId,
+                  ),
+                }
+              : {}),
+            ...('jsonSchema' in processedInputSchema
+              ? {
+                  jsonSchema: modelJsonSchema,
+                }
+              : {}),
+          };
+        }
       }
     }
 


### PR DESCRIPTION
## Description

Fixes #16179 by keeping Mastra-only auto-resume/background control fields out of the original tool input schema.

CoreToolBuilder now injects `_background`, `suspendedToolRunId`, and `resumeData` only into the model-facing JSON schema, runs that injected schema through provider compatibility, then strips the control fields before runtime validation/execution. This preserves user-defined Zod v3/Zod v4 schemas, refinements, transforms, and strict runtime validation while still giving models the metadata needed for background execution and suspended-tool resume.

Generated agent/workflow wrapper tools explicitly accept `suspendedToolRunId` because their executors consume it when resuming suspended runs.

## Related issue(s)

Fixes #16179

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## CodeRabbit follow-up

- Integrated the inline CodeRabbit feedback by wrapping the non-StandardSchema path with the same strip-before-validation / merge-after-validation behavior as the StandardSchema path.
- Integrated the outside-diff feedback by basing the `suspendedToolRunId` required-field guard on the original unstripped args and `execOptions.resumeData`, including falsy resume values.

## Validation

- `../../node_modules/.bin/vitest run src/tools/tool-builder --config vitest.config.ts --reporter=verbose --testTimeout=30000`
- `../../node_modules/.bin/vitest run src/agent/__tests__/tools.test.ts --config vitest.config.ts --reporter=verbose --testTimeout=30000`
- `../../node_modules/.bin/tsc --noEmit`
- `../../node_modules/.bin/tsc --noEmit -p tsconfig.build.json`
- `git diff --check upstream/main...HEAD`

Notes: the Zod-specific scripts mentioned in `packages/core/AGENTS.md` are not present in the current root or `packages/core` scripts. The local CodeRabbit CLI is not installed, so I verified and integrated the GitHub PR CodeRabbit comments directly.

## Maintainer notes

- Rebased onto current upstream `main` at `9a33d81f01`.
- The PR branch is a single fix commit on top of `main`.
- The PR diff is limited to `@mastra/core` implementation/tests plus one changeset.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all CodeRabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When Mastra tried to auto-resume paused tool calls it was adding extra hidden fields directly into tools' input definitions, which broke compatibility between different schema library versions and some provider conversions. This PR stops changing the original tool schemas and instead only adds those extra fields to the schema the model sees, then removes them before actually validating or running the tool.

## Overview

This PR fixes issue `#16179` by preventing CoreToolBuilder from mutating original tool input schemas to add Mastra-only resume/background control fields. Control fields are now injected only into the model-facing JSON schema and stripped before runtime validation and execution. This preserves schema-version safety (Zod v3 vs v4), keeps user validators and schema transforms intact, and retains auto-resume metadata for workflow/agent resumption.

## Changes

- .changeset/tough-peaches-feel.md  
  Adds a patch changeset for `@mastra/core` describing the fix for auto-resume/background schema injection.

- packages/core/src/agent/agent.ts  
  Generated agent/workflow tool schemas now include a model-facing suspendedToolRunId field (nullable/optional string) so resumption can carry the suspended run identifier for workflow/agent tools.

- packages/core/src/tools/tool-builder/builder.ts  
  CoreToolBuilder no longer mutates input schemas. Key changes:
  - Introduces internal build-time flags (isBackgroundEligible, isResumableTool, forwardsResumeRunId) to mark tools that should receive injected fields.
  - Produces a model-facing JSON schema with injected fields (_background, suspendedToolRunId, resumeData) while leaving the original runtime schema untouched.
  - At execution, strips injected control fields from args before validateToolInput so user validators and refinements run against the original schema.
  - After successful validation, merges control fields back into the validated result (respecting resume-run-id forwarding).
  - Adjusts suspendedToolRunId validation to ignore "required" when resumeData is present in execOptions or original args.
  - Ensures a modelInputSchema is generated for eligible/resumable tools even if no original parameters schema exists.

- packages/core/src/tools/tool-builder/builder.test.ts  
  Adds focused tests verifying:
  - Control fields appear only in the model-facing JSON schema and are not mutating original input schemas.
  - Validation/refinements remain enforced at runtime and across Zod v3/v4.
  - Resume/background injection behaves correctly with transforms and custom schemas, and that missing or invalid suspendedToolRunId is handled as intended.

- packages/core/src/agent/__tests__/tools.test.ts  
  Extends agent tool tests to assert generated sub-agent tool parameters validate payloads containing prompt, suspendedToolRunId, and resumeData.

## Testing & Validation

- Local validation reported by the author: pnpm install, pnpm build:core, focused tests (45 tests passed across the specified suites), pnpm --filter ./packages/core check, prettier checks, and git diff lint.
- PR is a single commit rebased onto current main; scope limited to the builder, generated agent/workflow schemas, focused tests, and changeset.

## Impact

- Fixes schema mutation that caused Zod 3/4 mixing and provider JSON-schema conversion failures.
- Keeps user validation strict and unchanged while enabling model-facing resume/background control fields.
- Restores compatibility with provider conversions (e.g., Google/Gemini) and preserves workflow/agent resumption metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->