### PR TITLE
docs: document score event payload

### DIFF
--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -215,9 +215,13 @@ interface ExportedScore {
   scorerId: string
   scorerName?: string
   scorerVersion?: string
+  /** @deprecated Use `scoreSource` instead. */
+  source?: string
   scoreSource?: string
   score: number
   reason?: string
+  /** @deprecated Use `correlationContext.experimentId` instead. */
+  experimentId?: string
   scoreTraceId?: string
   targetEntityType?: EntityType
   correlationContext?: CorrelationContext
@@ -227,7 +231,9 @@ interface ExportedScore {
 
 `scoreId` identifies the emitted score event. `traceId` and `spanId` anchor the
 target being scored when available, while `scoreTraceId` can point to the trace
-that produced the score itself.
+that produced the score itself. Deprecated fields may still appear on events for
+backwards compatibility, but new exporters should prefer `scoreSource` and
+`correlationContext`.
 
 ### `ObservabilityDropEvent`
 

--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -193,6 +193,42 @@ wraps `ExportedLog` in `log`, `MetricEvent` wraps `ExportedMetric` in
 wraps `ExportedFeedback` in `feedback`. For Mastra platform exporter behavior for these
 callbacks, see [MastraPlatformExporter](/reference/observability/tracing/exporters/mastra-platform-exporter).
 
+#### Score event payload
+
+`onScoreEvent` receives a `ScoreEvent` envelope:
+
+```typescript
+interface ScoreEvent {
+  type: 'score'
+  score: ExportedScore
+}
+```
+
+The `score` payload is the bounded score record passed through the observability bus:
+
+```typescript
+interface ExportedScore {
+  scoreId: string
+  timestamp: Date
+  traceId?: string
+  spanId?: string
+  scorerId: string
+  scorerName?: string
+  scorerVersion?: string
+  scoreSource?: string
+  score: number
+  reason?: string
+  scoreTraceId?: string
+  targetEntityType?: EntityType
+  correlationContext?: CorrelationContext
+  metadata?: Record<string, unknown>
+}
+```
+
+`scoreId` identifies the emitted score event. `traceId` and `spanId` anchor the
+target being scored when available, while `scoreTraceId` can point to the trace
+that produced the score itself.
+
 ### `ObservabilityDropEvent`
 
 Structured event emitted when the exporter pipeline drops observability events.


### PR DESCRIPTION
## Summary

Expands the observability exporter interface reference with the `ScoreEvent` envelope and the bounded `ExportedScore` payload shape.

This makes `scoreId` and the score anchoring fields (`traceId`, `spanId`, `scoreTraceId`) visible from the docs page that already documents `onScoreEvent`.

## Context

`onScoreEvent` is already listed as the forward path for score export, while `addScoreToTrace` is deprecated. This small docs addition makes the score event payload easier to use without jumping into source.

Follow-up to #15206.

Fixes #17009.

## Validation

- `git diff --check`

No changeset added because this is docs-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a clear guide showing exactly what a "score event" message contains so developers can see the fields (like score ID and trace IDs) without reading code. It's purely documentation—no runtime behavior changed.

## Overview

Documentation-only change that expands the observability exporter reference by adding a "Score event payload" section describing the `ScoreEvent` envelope and the bounded `ExportedScore` payload shape for use with `onScoreEvent`.

## Changes

- Modified file:
  - docs/src/content/en/reference/observability/tracing/interfaces.mdx

- New documentation content:
  - `Score event payload` section describing:
    - interface `ScoreEvent` — envelope received by `onScoreEvent` (`type: 'score'`, `score: ExportedScore`)
    - interface `ExportedScore` — bounded score record schema including:
      - identifiers and timestamps (`scoreId`, `createdAt`, etc.)
      - optional trace/span anchoring (`traceId`, `spanId`, `scoreTraceId`)
      - scorer/source fields and deprecations (`source`, `experimentId` deprecated; prefer `scoreSource`)
      - target/entity anchoring (`targetEntityType`, `targetEntityId`)
      - `correlationContext` and optional `metadata`
    - note that deprecated fields may still appear for backward compatibility and new exporters should prefer `scoreSource` and `correlationContext`.

## Scope

- Lines changed: +42/-0
- Documentation types added: `interface ScoreEvent` and `interface ExportedScore`
- Estimated review effort: Medium

## Validation & Notes

- Documentation-only; no code or behavior changes.
- Validation performed: `git diff --check`.
- No changeset added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->