### PR TITLE
fix(studio): prevent assistant message remount storm during streaming

### DIFF
--- a/.changeset/fix-studio-fiber-unmount-crash.md
+++ b/.changeset/fix-studio-fiber-unmount-crash.md
@@ -1,0 +1,5 @@
+---
+"mastra": patch
+---
+
+Fixed a React component identity bug in Studio that caused "Tried to unmount a fiber that is already unmounted" crashes during long-running agent operations. The assistant message component was being redefined on every render, forcing React to remount the entire message subtree instead of updating it. This was especially visible with agents using high `maxSteps` values.

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -2,7 +2,7 @@ import type { MessagePrimitive } from '@assistant-ui/react';
 import { ComposerPrimitive, ThreadPrimitive, useComposer, useComposerRuntime } from '@assistant-ui/react';
 import { Avatar, Button, ButtonsGroup, cn, useAutoscroll } from '@mastra/playground-ui';
 import { ArrowUp, EyeIcon, Mic, PlusIcon } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AttachFileDialog } from './attachments/attach-file-dialog';
 import { ComposerAttachments } from './attachments/attachment';
 import { BracketOverlay } from './components/bracket-overlay';
@@ -40,9 +40,13 @@ export const Thread = ({ agentName, agentId, threadId, hasMemory, hasModelList, 
   // 3. NOT currently viewing browser in sidebar
   const showThumbnailInChat = hasSession && (viewMode === 'collapsed' || viewMode === 'expanded') && !isInSidebar;
 
-  const WrappedAssistantMessage = (props: MessagePrimitive.Root.Props) => {
-    return <AssistantMessage {...props} hasModelList={hasModelList} />;
-  };
+  const WrappedAssistantMessage = useMemo(
+    () =>
+      function AssistantMessageWrapper(props: MessagePrimitive.Root.Props) {
+        return <AssistantMessage {...props} hasModelList={hasModelList} />;
+      },
+    [hasModelList],
+  );
 
   return (
     <ThreadWrapper>


### PR DESCRIPTION
## Summary

Fixes #15275 — "Tried to unmount a fiber that is already unmounted" crash in Studio when running long agent operations.

## Root Cause

`WrappedAssistantMessage` was defined **inside** the `Thread` component body:

```tsx
// Before — new function reference on every render
const WrappedAssistantMessage = (props: MessagePrimitive.Root.Props) => {
  return <AssistantMessage {...props} hasModelList={hasModelList} />;
};
```

React identifies component types by reference identity. A new function on every render means React sees a **different component type** on each re-render and **unmounts + remounts the entire assistant message subtree** instead of updating it in place.

Under high-frequency streaming (e.g. `maxSteps=100`), `Thread` re-renders hundreds of times, causing a remount storm that surfaces as the internal React invariant failure: _"Tried to unmount a fiber that is already unmounted"_. The error also persists after a page refresh because the same rendering path is hit when replaying historical messages.

## Fix

Wrap the component in `useMemo` with `[hasModelList]` as the dependency, so its identity is stable across re-renders and only changes when the prop actually changes (which is rare):

```tsx
// After — stable identity across re-renders
const WrappedAssistantMessage = useMemo(
  () =>
    function AssistantMessageWrapper(props: MessagePrimitive.Root.Props) {
      return <AssistantMessage {...props} hasModelList={hasModelList} />;
    },
  [hasModelList],
);
```

## Verification

- This is a violation of [React's rule against defining components inside other components](https://react.dev/learn/your-first-component#nesting-and-organizing-components), documented to cause exactly this class of reconciliation failure
- `pnpm --filter ./packages/playground lint` passes with 0 errors
- The fix is a pure refactor — identical render output, no behavior change

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a bug in Mastra Studio where streaming long agent conversations would crash. The problem was that React kept destroying and rebuilding the message display component unnecessarily. The fix tells React "keep using the same message display" instead of rebuilding it every time, which stops the crashes.

## Changes

### Changed Files

1. **packages/playground/src/lib/ai-ui/thread.tsx** (+8/-4)
   - Added `useMemo` to the React imports
   - Converted `WrappedAssistantMessage` from an inline function definition to a memoized component
   - Set `hasModelList` as the dependency, ensuring the wrapper reference only updates when this value changes
   - This prevents React from treating the assistant message component as a new component on each re-render

2. **.changeset/fix-studio-fiber-unmount-crash.md** (+5/-0)
   - Added a Changesets release note documenting the fix as a patch for `mastra`

## Root Cause

The `WrappedAssistantMessage` component was defined inside the `Thread` component body, causing React to create a new function reference on every render. React would interpret this as a completely different component structure and trigger unnecessary unmount/remount cycles. During high-frequency streaming operations (especially with large `maxSteps` values), this cascade of mount/unmount events would crash the UI with the React invariant error "Tried to unmount a fiber that is already unmounted."

## Solution

By wrapping the component definition in `useMemo` with `hasModelList` as the dependency, the component reference now remains stable across re-renders. React will only remount when `hasModelList` actually changes, preventing the spurious mount/unmount cycles that were causing the crash.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->