### PR TITLE
fix(observability): pause exporter uploads after auth failures

### DIFF
--- a/.changeset/thirty-bags-begin.md
+++ b/.changeset/thirty-bags-begin.md
@@ -2,4 +2,4 @@
 '@mastra/observability': patch
 ---
 
-Improved MastraPlatformExporter and CloudExporter handling of invalid credentials to avoid repeated unauthorized upload attempts.
+Paused observability uploads after invalid credentials so exporters stop repeatedly sending unauthorized requests.

--- a/.changeset/thirty-bags-begin.md
+++ b/.changeset/thirty-bags-begin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Improved MastraPlatformExporter and CloudExporter handling of invalid credentials to avoid repeated unauthorized upload attempts.

--- a/observability/mastra/src/exporters/auth-failure-cooldown.ts
+++ b/observability/mastra/src/exporters/auth-failure-cooldown.ts
@@ -1,0 +1,116 @@
+import type { IMastraLogger } from '@mastra/core/logger';
+import { fetchWithRetry } from '@mastra/core/utils';
+
+const AUTH_FAILURE_STATUSES = new Set([401, 403]);
+const AUTH_COOLDOWN_BASE_MS = 60_000;
+// Target cap before jitter; positive jitter can exceed this to avoid synchronized retry probes.
+const AUTH_COOLDOWN_MAX_MS = 15 * 60_000;
+const AUTH_COOLDOWN_JITTER_RATIO = 0.1;
+
+export class AuthFailureError extends Error {
+  readonly status: number;
+
+  constructor(status: number, cause?: unknown) {
+    super(`Request failed with authentication status: ${status}`, { cause });
+    this.name = 'AuthFailureError';
+    this.status = status;
+  }
+}
+
+export function isAuthFailureError(error: unknown): error is AuthFailureError {
+  return error instanceof AuthFailureError;
+}
+
+function isAuthFailureStatus(status: number): boolean {
+  return AUTH_FAILURE_STATUSES.has(status);
+}
+
+export async function fetchWithAuthFailureHandling(
+  url: string,
+  options: RequestInit,
+  maxRetries: number,
+): Promise<void> {
+  let authFailureStatus: number | undefined;
+
+  try {
+    await fetchWithRetry(url, options, maxRetries, {
+      shouldRetryResponse: response => {
+        if (isAuthFailureStatus(response.status)) {
+          authFailureStatus = response.status;
+          return false;
+        }
+
+        return true;
+      },
+    });
+  } catch (error) {
+    if (authFailureStatus !== undefined) {
+      throw new AuthFailureError(authFailureStatus, error);
+    }
+
+    throw error;
+  }
+}
+
+export class AuthFailureCooldown {
+  private failureCount = 0;
+  private cooldownUntilMs = 0;
+  private droppedEventsDuringCooldown = 0;
+
+  constructor(
+    private readonly exporterName: string,
+    private readonly getLogger: () => IMastraLogger,
+  ) {}
+
+  private shouldDropEvents(): boolean {
+    return Date.now() < this.cooldownUntilMs;
+  }
+
+  dropEventIfCoolingDown(): boolean {
+    return this.dropEventsIfCoolingDown(1);
+  }
+
+  dropEventsIfCoolingDown(count: number): boolean {
+    if (!this.shouldDropEvents()) {
+      return false;
+    }
+
+    this.droppedEventsDuringCooldown += count;
+    return true;
+  }
+
+  reset(): number {
+    const droppedEventsDuringCooldown = this.droppedEventsDuringCooldown;
+
+    this.failureCount = 0;
+    this.cooldownUntilMs = 0;
+    this.droppedEventsDuringCooldown = 0;
+
+    return droppedEventsDuringCooldown;
+  }
+
+  recordFailure(args: { status: number; failedSignals: string[]; droppedBatchSize: number }): void {
+    this.failureCount++;
+    const droppedEventsDuringCooldown = this.droppedEventsDuringCooldown;
+    this.droppedEventsDuringCooldown = 0;
+
+    const targetCooldownMs = Math.min(AUTH_COOLDOWN_BASE_MS * Math.pow(2, this.failureCount - 1), AUTH_COOLDOWN_MAX_MS);
+    const jitterMs = Math.floor(targetCooldownMs * AUTH_COOLDOWN_JITTER_RATIO * (Math.random() - 0.5) * 2);
+    const cooldownMs = Math.max(AUTH_COOLDOWN_BASE_MS, targetCooldownMs + jitterMs);
+    const cooldownSeconds = Math.ceil(cooldownMs / 1000);
+
+    this.cooldownUntilMs = Date.now() + cooldownMs;
+
+    this.getLogger().warn(
+      `${this.exporterName} received an authentication failure; pausing uploads for ${cooldownSeconds}s`,
+      {
+        status: args.status,
+        failedSignals: args.failedSignals,
+        droppedBatchSize: args.droppedBatchSize,
+        droppedEventsDuringCooldown,
+        authFailureCount: this.failureCount,
+        cooldownMs,
+      },
+    );
+  }
+}

--- a/observability/mastra/src/exporters/cloud.test.ts
+++ b/observability/mastra/src/exporters/cloud.test.ts
@@ -153,6 +153,15 @@ function getMockFeedbackEvent(overrides: Partial<FeedbackEvent['feedback']> = {}
   };
 }
 
+function mockAuthFailure(status: 401 | 403): void {
+  const statusText = status === 401 ? 'Unauthorized' : 'Forbidden';
+
+  mockFetchWithRetry.mockImplementation(async (_url, _options, _maxRetries, retryOptions) => {
+    retryOptions?.shouldRetryResponse?.(new Response('auth failure', { status, statusText }));
+    throw new Error(`Request failed with status: ${status} ${statusText}`);
+  });
+}
+
 describe('CloudExporter', () => {
   let exporter: CloudExporter;
   const testJWT = createTestJWT({ teamId: 'team-123', projectId: 'project-456' });
@@ -779,6 +788,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         },
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
     });
 
@@ -920,6 +930,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1019,6 +1030,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1041,6 +1053,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1067,6 +1080,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
       expect(mockFetchWithRetry).toHaveBeenCalledWith(
         'https://collector.example.com/custom/metrics/publish',
@@ -1075,6 +1089,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1102,6 +1117,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
       expect(mockFetchWithRetry).toHaveBeenCalledWith(
         'https://collector.example.com/projects/project-workos/ai/metrics/publish',
@@ -1110,6 +1126,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1132,6 +1149,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1159,6 +1177,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
       expect(mockFetchWithRetry).toHaveBeenCalledWith(
         'https://logs.example.com/custom/logs/publish',
@@ -1167,6 +1186,7 @@ describe('CloudExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1190,6 +1210,7 @@ describe('CloudExporter', () => {
             body: expect.any(String),
           }),
           3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
         );
       } finally {
         await derivedExporter.shutdown();
@@ -1216,6 +1237,7 @@ describe('CloudExporter', () => {
             body: expect.any(String),
           }),
           3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
         );
       } finally {
         await derivedExporter.shutdown();
@@ -1243,6 +1265,7 @@ describe('CloudExporter', () => {
             body: expect.any(String),
           }),
           3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
         );
       } finally {
         await derivedExporter.shutdown();
@@ -1269,6 +1292,7 @@ describe('CloudExporter', () => {
             body: expect.any(String),
           }),
           3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
         );
       } finally {
         await derivedExporter.shutdown();
@@ -1328,6 +1352,7 @@ describe('CloudExporter', () => {
             body: expect.any(String),
           }),
           3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
         );
       } finally {
         await derivedExporter.shutdown();
@@ -1414,6 +1439,7 @@ describe('CloudExporter', () => {
         'http://localhost:3000/ai/spans/publish',
         expect.any(Object),
         3, // maxRetries passed to fetchWithRetry
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
       await retryExporter.shutdown();
     });
@@ -1438,8 +1464,154 @@ describe('CloudExporter', () => {
         expect.any(String),
         expect.any(Object),
         5, // Custom maxRetries value
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
       await customRetryExporter.shutdown();
+    });
+
+    it('should drop events during auth cooldown and probe again after cooldown expires', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const cooldownExporter = new CloudExporter({
+        accessToken: createTestJWT({ teamId: 'auth-team', projectId: 'auth-project' }),
+        endpoint: 'http://localhost:3000',
+        maxBatchSize: 1,
+      });
+      const loggerWarnSpy = vi.spyOn((cooldownExporter as any).logger, 'warn');
+      const loggerDebugSpy = vi.spyOn((cooldownExporter as any).logger, 'debug');
+
+      try {
+        mockAuthFailure(401);
+
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await (cooldownExporter as any).flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+        expect(loggerWarnSpy).toHaveBeenCalledWith(
+          'CloudExporter received an authentication failure; pausing uploads for 60s',
+          expect.objectContaining({
+            status: 401,
+            authFailureCount: 1,
+            cooldownMs: 60_000,
+            droppedEventsDuringCooldown: 0,
+          }),
+        );
+
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+        await cooldownExporter.onMetricEvent(getMockMetricEvent());
+        await cooldownExporter.onScoreEvent(getMockScoreEvent());
+        await cooldownExporter.onFeedbackEvent(getMockFeedbackEvent());
+        await (cooldownExporter as any).flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+        expect((cooldownExporter as any).buffer.totalSize).toBe(0);
+        expect((cooldownExporter as any).authFailureCooldown.droppedEventsDuringCooldown).toBe(5);
+
+        nowSpy.mockReturnValue(61_001);
+        mockAuthFailure(403);
+
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await (cooldownExporter as any).flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+        expect(loggerWarnSpy).toHaveBeenCalledWith(
+          'CloudExporter received an authentication failure; pausing uploads for 120s',
+          expect.objectContaining({
+            status: 403,
+            authFailureCount: 2,
+            cooldownMs: 120_000,
+            droppedEventsDuringCooldown: 5,
+          }),
+        );
+        expect((cooldownExporter as any).authFailureCooldown.droppedEventsDuringCooldown).toBe(0);
+
+        nowSpy.mockReturnValue(61_002);
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+        await (cooldownExporter as any).flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+        expect((cooldownExporter as any).authFailureCooldown.droppedEventsDuringCooldown).toBe(1);
+
+        nowSpy.mockReturnValue(181_002);
+        mockFetchWithRetry.mockResolvedValue(new Response('{}', { status: 200 }));
+
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await (cooldownExporter as any).flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(3);
+        expect(loggerDebugSpy).toHaveBeenCalledWith(
+          'Batch flushed successfully',
+          expect.objectContaining({
+            droppedEventsDuringAuthCooldown: 1,
+          }),
+        );
+        expect((cooldownExporter as any).authFailureCooldown.failureCount).toBe(0);
+        expect((cooldownExporter as any).authFailureCooldown.cooldownUntilMs).toBe(0);
+        expect((cooldownExporter as any).authFailureCooldown.droppedEventsDuringCooldown).toBe(0);
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+        await cooldownExporter.shutdown();
+      }
+    });
+
+    it('should drop events buffered during an in-flight auth failure before retrying', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const deferredUpload = createDeferred<Response>();
+      let shouldRetryResponse: ((response: Response) => boolean) | undefined;
+      const cooldownExporter = new CloudExporter({
+        accessToken: createTestJWT({ teamId: 'auth-team', projectId: 'auth-project' }),
+        endpoint: 'http://localhost:3000',
+      });
+
+      mockFetchWithRetry.mockImplementation(async (_url, _options, _maxRetries, retryOptions) => {
+        shouldRetryResponse = retryOptions?.shouldRetryResponse;
+        return deferredUpload.promise;
+      });
+
+      try {
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+
+        const flushPromise = (cooldownExporter as any).flush();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+
+        expect((cooldownExporter as any).buffer.totalSize).toBe(1);
+
+        shouldRetryResponse?.(new Response('auth failure', { status: 401, statusText: 'Unauthorized' }));
+        deferredUpload.reject(new Error('Request failed with status: 401 Unauthorized'));
+
+        await flushPromise;
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+        expect((cooldownExporter as any).buffer.totalSize).toBe(0);
+        expect((cooldownExporter as any).authFailureCooldown.failureCount).toBe(1);
+        expect((cooldownExporter as any).authFailureCooldown.droppedEventsDuringCooldown).toBe(1);
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+        await cooldownExporter.shutdown();
+      }
     });
 
     it('should drop batch after fetchWithRetry exhausts all retries', async () => {

--- a/observability/mastra/src/exporters/cloud.ts
+++ b/observability/mastra/src/exporters/cloud.ts
@@ -9,7 +9,7 @@ import type {
   ScoreEvent,
   FeedbackEvent,
 } from '@mastra/core/observability';
-import { fetchWithRetry } from '@mastra/core/utils';
+import { AuthFailureCooldown, fetchWithAuthFailureHandling, isAuthFailureError } from './auth-failure-cooldown';
 import { BaseExporter } from './base';
 import type { BaseExporterConfig } from './base';
 
@@ -234,6 +234,7 @@ export class CloudExporter extends BaseExporter {
   name = 'mastra-cloud-observability-exporter';
 
   private readonly cloudConfig: Readonly<ResolvedCloudConfig>;
+  private readonly authFailureCooldown: AuthFailureCooldown;
   private buffer: MastraCloudBuffer;
   private flushTimer: NodeJS.Timeout | null = null;
   private inFlightFlushes = new Set<Promise<void>>();
@@ -292,6 +293,8 @@ export class CloudExporter extends BaseExporter {
       feedbackEndpoint: resolveConfiguredSignalEndpoint('feedback', config.feedbackEndpoint),
     };
 
+    this.authFailureCooldown = new AuthFailureCooldown('CloudExporter', () => this.logger);
+
     this.buffer = {
       spans: [],
       logs: [],
@@ -312,6 +315,10 @@ export class CloudExporter extends BaseExporter {
       return;
     }
 
+    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      return;
+    }
+
     this.addToBuffer(event);
 
     await this.handleBufferedEvent();
@@ -319,6 +326,10 @@ export class CloudExporter extends BaseExporter {
 
   async onLogEvent(event: LogEvent): Promise<void> {
     if (this.isDisabled) {
+      return;
+    }
+
+    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
       return;
     }
 
@@ -331,6 +342,10 @@ export class CloudExporter extends BaseExporter {
       return;
     }
 
+    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      return;
+    }
+
     this.addMetricToBuffer(event);
     await this.handleBufferedEvent();
   }
@@ -340,12 +355,20 @@ export class CloudExporter extends BaseExporter {
       return;
     }
 
+    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      return;
+    }
+
     this.addScoreToBuffer(event);
     await this.handleBufferedEvent();
   }
 
   async onFeedbackEvent(event: FeedbackEvent): Promise<void> {
     if (this.isDisabled) {
+      return;
+    }
+
+    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
       return;
     }
 
@@ -494,6 +517,11 @@ export class CloudExporter extends BaseExporter {
       return; // Nothing to flush
     }
 
+    if (this.authFailureCooldown.dropEventsIfCoolingDown(this.buffer.totalSize)) {
+      this.resetBuffer();
+      return;
+    }
+
     const startTime = Date.now();
     const spansCopy = [...this.buffer.spans];
     const logsCopy = [...this.buffer.logs];
@@ -515,16 +543,32 @@ export class CloudExporter extends BaseExporter {
     ]);
 
     const failedSignals = results.filter(result => !result.succeeded).map(result => result.signal);
+    const authFailure = results.find(result => result.authFailureStatus !== undefined);
 
     const elapsed = Date.now() - startTime;
 
     if (failedSignals.length === 0) {
-      this.logger.debug('Batch flushed successfully', {
+      const droppedEventsDuringAuthCooldown = this.authFailureCooldown.reset();
+      const logData: Record<string, number | string> = {
         batchSize,
         flushReason,
         durationMs: elapsed,
-      });
+      };
+
+      if (droppedEventsDuringAuthCooldown > 0) {
+        logData.droppedEventsDuringAuthCooldown = droppedEventsDuringAuthCooldown;
+      }
+
+      this.logger.debug('Batch flushed successfully', logData);
       return;
+    }
+
+    if (authFailure?.authFailureStatus !== undefined) {
+      this.authFailureCooldown.recordFailure({
+        status: authFailure.authFailureStatus,
+        failedSignals,
+        droppedBatchSize: batchSize,
+      });
     }
 
     this.logger.warn('Batch flush completed with dropped signal batches', {
@@ -558,13 +602,13 @@ export class CloudExporter extends BaseExporter {
       body: JSON.stringify({ [SIGNAL_PUBLISH_SEGMENTS[signal]]: records }),
     };
 
-    await fetchWithRetry(endpointMap[signal], options, this.cloudConfig.maxRetries);
+    await fetchWithAuthFailureHandling(endpointMap[signal], options, this.cloudConfig.maxRetries);
   }
 
   private async flushSignalBatch<T>(
     signal: CloudSignal,
     records: T[],
-  ): Promise<{ signal: CloudSignal; succeeded: boolean }> {
+  ): Promise<{ signal: CloudSignal; succeeded: boolean; authFailureStatus?: number }> {
     if (records.length === 0) {
       return { signal, succeeded: true };
     }
@@ -573,6 +617,10 @@ export class CloudExporter extends BaseExporter {
       await this.batchUpload(signal, records);
       return { signal, succeeded: true };
     } catch (error) {
+      if (isAuthFailureError(error)) {
+        return { signal, succeeded: false, authFailureStatus: error.status };
+      }
+
       const errorId = `CLOUD_EXPORTER_FAILED_TO_BATCH_UPLOAD_${signal.toUpperCase()}` as Uppercase<string>;
       const mastraError = new MastraError(
         {

--- a/observability/mastra/src/exporters/mastra-platform.test.ts
+++ b/observability/mastra/src/exporters/mastra-platform.test.ts
@@ -11,6 +11,7 @@ import { EntityType, SpanType, TracingEventType } from '@mastra/core/observabili
 
 import { fetchWithRetry } from '@mastra/core/utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AuthFailureCooldown } from './auth-failure-cooldown';
 import { MastraPlatformExporter } from './mastra-platform';
 
 // Mock fetchWithRetry
@@ -19,6 +20,37 @@ vi.mock('@mastra/core/utils', () => ({
 }));
 
 const mockFetchWithRetry = vi.mocked(fetchWithRetry);
+
+describe('AuthFailureCooldown', () => {
+  it('should keep jitter when the exponential cooldown reaches the cap', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    const logger = {
+      warn: vi.fn(),
+    };
+    const cooldown = new AuthFailureCooldown('TestExporter', () => logger as any);
+
+    try {
+      for (let i = 0; i < 5; i++) {
+        cooldown.recordFailure({
+          status: 401,
+          failedSignals: ['traces'],
+          droppedBatchSize: 1,
+        });
+      }
+
+      expect(logger.warn).toHaveBeenLastCalledWith(
+        'TestExporter received an authentication failure; pausing uploads for 810s',
+        expect.objectContaining({
+          cooldownMs: 810_000,
+        }),
+      );
+    } finally {
+      nowSpy.mockRestore();
+      randomSpy.mockRestore();
+    }
+  });
+});
 
 // Helper to create a valid JWT token for testing
 function createTestJWT(payload: { teamId: string; projectId: string }): string {
@@ -151,6 +183,15 @@ function getMockFeedbackEvent(overrides: Partial<FeedbackEvent['feedback']> = {}
       ...overrides,
     },
   };
+}
+
+function mockAuthFailure(status: 401 | 403): void {
+  const statusText = status === 401 ? 'Unauthorized' : 'Forbidden';
+
+  mockFetchWithRetry.mockImplementation(async (_url, _options, _maxRetries, retryOptions) => {
+    retryOptions?.shouldRetryResponse?.(new Response('auth failure', { status, statusText }));
+    throw new Error(`Request failed with status: ${status} ${statusText}`);
+  });
 }
 
 describe('MastraPlatformExporter', () => {
@@ -779,6 +820,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         },
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
     });
 
@@ -1027,6 +1069,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1126,6 +1169,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1148,6 +1192,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1174,6 +1219,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
       expect(mockFetchWithRetry).toHaveBeenCalledWith(
         'https://collector.example.com/custom/metrics/publish',
@@ -1182,6 +1228,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1209,6 +1256,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
       expect(mockFetchWithRetry).toHaveBeenCalledWith(
         'https://collector.example.com/projects/project-workos/ai/metrics/publish',
@@ -1217,6 +1265,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1239,6 +1288,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1266,6 +1316,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
       expect(mockFetchWithRetry).toHaveBeenCalledWith(
         'https://logs.example.com/custom/logs/publish',
@@ -1274,6 +1325,7 @@ describe('MastraPlatformExporter', () => {
           body: expect.any(String),
         }),
         3,
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
 
       await derivedExporter.shutdown();
@@ -1297,6 +1349,7 @@ describe('MastraPlatformExporter', () => {
             body: expect.any(String),
           }),
           3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
         );
       } finally {
         await derivedExporter.shutdown();
@@ -1323,6 +1376,7 @@ describe('MastraPlatformExporter', () => {
             body: expect.any(String),
           }),
           3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
         );
       } finally {
         await derivedExporter.shutdown();
@@ -1350,6 +1404,7 @@ describe('MastraPlatformExporter', () => {
             body: expect.any(String),
           }),
           3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
         );
       } finally {
         await derivedExporter.shutdown();
@@ -1376,6 +1431,7 @@ describe('MastraPlatformExporter', () => {
             body: expect.any(String),
           }),
           3,
+          expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
         );
       } finally {
         await derivedExporter.shutdown();
@@ -1488,6 +1544,52 @@ describe('MastraPlatformExporter', () => {
       mockFetchWithRetry.mockResolvedValue(new Response('{}', { status: 200 }));
     });
 
+    it('should log auth cooldown warnings through the injected exporter logger', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const cooldownExporter = new MastraPlatformExporter({
+        accessToken: createTestJWT({ teamId: 'auth-team', projectId: 'auth-project' }),
+        endpoint: 'http://localhost:3000',
+        maxBatchSize: 1,
+      });
+      const originalWarnSpy = vi.spyOn((cooldownExporter as any).logger, 'warn');
+      const injectedLogger = {
+        debug: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        trackException: vi.fn(),
+      };
+
+      try {
+        cooldownExporter.__setLogger(injectedLogger as any);
+        mockAuthFailure(401);
+
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await (cooldownExporter as any).flush();
+
+        expect(injectedLogger.warn).toHaveBeenCalledWith(
+          'MastraPlatformExporter received an authentication failure; pausing uploads for 60s',
+          expect.objectContaining({
+            status: 401,
+            authFailureCount: 1,
+            cooldownMs: 60_000,
+          }),
+        );
+        expect(originalWarnSpy).not.toHaveBeenCalledWith(
+          'MastraPlatformExporter received an authentication failure; pausing uploads for 60s',
+          expect.any(Object),
+        );
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+        await cooldownExporter.shutdown();
+      }
+    });
+
     it('should retry on API failures using fetchWithRetry', async () => {
       const retryExporter = new MastraPlatformExporter({
         accessToken: createTestJWT({ teamId: 'retry-team', projectId: 'retry-project' }),
@@ -1513,6 +1615,7 @@ describe('MastraPlatformExporter', () => {
         'http://localhost:3000/ai/spans/publish',
         expect.any(Object),
         3, // maxRetries passed to fetchWithRetry
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
       await retryExporter.shutdown();
     });
@@ -1537,8 +1640,154 @@ describe('MastraPlatformExporter', () => {
         expect.any(String),
         expect.any(Object),
         5, // Custom maxRetries value
+        expect.objectContaining({ shouldRetryResponse: expect.any(Function) }),
       );
       await customRetryExporter.shutdown();
+    });
+
+    it('should drop events during auth cooldown and probe again after cooldown expires', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const cooldownExporter = new MastraPlatformExporter({
+        accessToken: createTestJWT({ teamId: 'auth-team', projectId: 'auth-project' }),
+        endpoint: 'http://localhost:3000',
+        maxBatchSize: 1,
+      });
+      const loggerWarnSpy = vi.spyOn((cooldownExporter as any).logger, 'warn');
+      const loggerDebugSpy = vi.spyOn((cooldownExporter as any).logger, 'debug');
+
+      try {
+        mockAuthFailure(401);
+
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await (cooldownExporter as any).flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+        expect(loggerWarnSpy).toHaveBeenCalledWith(
+          'MastraPlatformExporter received an authentication failure; pausing uploads for 60s',
+          expect.objectContaining({
+            status: 401,
+            authFailureCount: 1,
+            cooldownMs: 60_000,
+            droppedEventsDuringCooldown: 0,
+          }),
+        );
+
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+        await cooldownExporter.onMetricEvent(getMockMetricEvent());
+        await cooldownExporter.onScoreEvent(getMockScoreEvent());
+        await cooldownExporter.onFeedbackEvent(getMockFeedbackEvent());
+        await (cooldownExporter as any).flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+        expect((cooldownExporter as any).buffer.totalSize).toBe(0);
+        expect((cooldownExporter as any).authFailureCooldown.droppedEventsDuringCooldown).toBe(5);
+
+        nowSpy.mockReturnValue(61_001);
+        mockAuthFailure(403);
+
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await (cooldownExporter as any).flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+        expect(loggerWarnSpy).toHaveBeenCalledWith(
+          'MastraPlatformExporter received an authentication failure; pausing uploads for 120s',
+          expect.objectContaining({
+            status: 403,
+            authFailureCount: 2,
+            cooldownMs: 120_000,
+            droppedEventsDuringCooldown: 5,
+          }),
+        );
+        expect((cooldownExporter as any).authFailureCooldown.droppedEventsDuringCooldown).toBe(0);
+
+        nowSpy.mockReturnValue(61_002);
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+        await (cooldownExporter as any).flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(2);
+        expect((cooldownExporter as any).authFailureCooldown.droppedEventsDuringCooldown).toBe(1);
+
+        nowSpy.mockReturnValue(181_002);
+        mockFetchWithRetry.mockResolvedValue(new Response('{}', { status: 200 }));
+
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await (cooldownExporter as any).flush();
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(3);
+        expect(loggerDebugSpy).toHaveBeenCalledWith(
+          'Batch flushed successfully',
+          expect.objectContaining({
+            droppedEventsDuringAuthCooldown: 1,
+          }),
+        );
+        expect((cooldownExporter as any).authFailureCooldown.failureCount).toBe(0);
+        expect((cooldownExporter as any).authFailureCooldown.cooldownUntilMs).toBe(0);
+        expect((cooldownExporter as any).authFailureCooldown.droppedEventsDuringCooldown).toBe(0);
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+        await cooldownExporter.shutdown();
+      }
+    });
+
+    it('should drop events buffered during an in-flight auth failure before retrying', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const deferredUpload = createDeferred<Response>();
+      let shouldRetryResponse: ((response: Response) => boolean) | undefined;
+      const cooldownExporter = new MastraPlatformExporter({
+        accessToken: createTestJWT({ teamId: 'auth-team', projectId: 'auth-project' }),
+        endpoint: 'http://localhost:3000',
+      });
+
+      mockFetchWithRetry.mockImplementation(async (_url, _options, _maxRetries, retryOptions) => {
+        shouldRetryResponse = retryOptions?.shouldRetryResponse;
+        return deferredUpload.promise;
+      });
+
+      try {
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+
+        const flushPromise = (cooldownExporter as any).flush();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+
+        expect((cooldownExporter as any).buffer.totalSize).toBe(1);
+
+        shouldRetryResponse?.(new Response('auth failure', { status: 401, statusText: 'Unauthorized' }));
+        deferredUpload.reject(new Error('Request failed with status: 401 Unauthorized'));
+
+        await flushPromise;
+
+        expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+        expect((cooldownExporter as any).buffer.totalSize).toBe(0);
+        expect((cooldownExporter as any).authFailureCooldown.failureCount).toBe(1);
+        expect((cooldownExporter as any).authFailureCooldown.droppedEventsDuringCooldown).toBe(1);
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+        await cooldownExporter.shutdown();
+      }
     });
 
     it('should drop batch after fetchWithRetry exhausts all retries', async () => {

--- a/observability/mastra/src/exporters/mastra-platform.ts
+++ b/observability/mastra/src/exporters/mastra-platform.ts
@@ -9,7 +9,7 @@ import type {
   ScoreEvent,
   FeedbackEvent,
 } from '@mastra/core/observability';
-import { fetchWithRetry } from '@mastra/core/utils';
+import { AuthFailureCooldown, fetchWithAuthFailureHandling, isAuthFailureError } from './auth-failure-cooldown';
 import { BaseExporter } from './base';
 import type { BaseExporterConfig } from './base';
 
@@ -221,6 +221,7 @@ export class MastraPlatformExporter extends BaseExporter {
   name = 'mastra-platform-exporter';
 
   private readonly platformConfig: Readonly<ResolvedPlatformConfig>;
+  private readonly authFailureCooldown: AuthFailureCooldown;
   private buffer: MastraPlatformBuffer;
   private flushTimer: NodeJS.Timeout | null = null;
   private inFlightFlushes = new Set<Promise<void>>();
@@ -286,6 +287,8 @@ export class MastraPlatformExporter extends BaseExporter {
       feedbackEndpoint: resolveConfiguredSignalEndpoint('feedback', config.feedbackEndpoint),
     };
 
+    this.authFailureCooldown = new AuthFailureCooldown('MastraPlatformExporter', () => this.logger);
+
     this.buffer = {
       spans: [],
       logs: [],
@@ -305,6 +308,10 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
+    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      return;
+    }
+
     this.addToBuffer(event);
 
     await this.handleBufferedEvent();
@@ -312,6 +319,10 @@ export class MastraPlatformExporter extends BaseExporter {
 
   async onLogEvent(event: LogEvent): Promise<void> {
     if (this.isDisabled) {
+      return;
+    }
+
+    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
       return;
     }
 
@@ -324,6 +335,10 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
+    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      return;
+    }
+
     this.addMetricToBuffer(event);
     await this.handleBufferedEvent();
   }
@@ -333,12 +348,20 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
+    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      return;
+    }
+
     this.addScoreToBuffer(event);
     await this.handleBufferedEvent();
   }
 
   async onFeedbackEvent(event: FeedbackEvent): Promise<void> {
     if (this.isDisabled) {
+      return;
+    }
+
+    if (this.authFailureCooldown.dropEventIfCoolingDown()) {
       return;
     }
 
@@ -484,6 +507,11 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
+    if (this.authFailureCooldown.dropEventsIfCoolingDown(this.buffer.totalSize)) {
+      this.resetBuffer();
+      return;
+    }
+
     const startTime = Date.now();
     const spansCopy = [...this.buffer.spans];
     const logsCopy = [...this.buffer.logs];
@@ -504,16 +532,32 @@ export class MastraPlatformExporter extends BaseExporter {
     ]);
 
     const failedSignals = results.filter(result => !result.succeeded).map(result => result.signal);
+    const authFailure = results.find(result => result.authFailureStatus !== undefined);
 
     const elapsed = Date.now() - startTime;
 
     if (failedSignals.length === 0) {
-      this.logger.debug('Batch flushed successfully', {
+      const droppedEventsDuringAuthCooldown = this.authFailureCooldown.reset();
+      const logData: Record<string, number | string> = {
         batchSize,
         flushReason,
         durationMs: elapsed,
-      });
+      };
+
+      if (droppedEventsDuringAuthCooldown > 0) {
+        logData.droppedEventsDuringAuthCooldown = droppedEventsDuringAuthCooldown;
+      }
+
+      this.logger.debug('Batch flushed successfully', logData);
       return;
+    }
+
+    if (authFailure?.authFailureStatus !== undefined) {
+      this.authFailureCooldown.recordFailure({
+        status: authFailure.authFailureStatus,
+        failedSignals,
+        droppedBatchSize: batchSize,
+      });
     }
 
     this.logger.warn('Batch flush completed with dropped signal batches', {
@@ -547,13 +591,13 @@ export class MastraPlatformExporter extends BaseExporter {
       body: JSON.stringify({ [SIGNAL_PUBLISH_SEGMENTS[signal]]: records }),
     };
 
-    await fetchWithRetry(endpointMap[signal], options, this.platformConfig.maxRetries);
+    await fetchWithAuthFailureHandling(endpointMap[signal], options, this.platformConfig.maxRetries);
   }
 
   private async flushSignalBatch<T>(
     signal: PlatformSignal,
     records: T[],
-  ): Promise<{ signal: PlatformSignal; succeeded: boolean }> {
+  ): Promise<{ signal: PlatformSignal; succeeded: boolean; authFailureStatus?: number }> {
     if (records.length === 0) {
       return { signal, succeeded: true };
     }
@@ -562,6 +606,10 @@ export class MastraPlatformExporter extends BaseExporter {
       await this.batchUpload(signal, records);
       return { signal, succeeded: true };
     } catch (error) {
+      if (isAuthFailureError(error)) {
+        return { signal, succeeded: false, authFailureStatus: error.status };
+      }
+
       const errorId = `MASTRA_PLATFORM_EXPORTER_FAILED_TO_BATCH_UPLOAD_${signal.toUpperCase()}` as Uppercase<string>;
       const mastraError = new MastraError(
         {


### PR DESCRIPTION
## Description

Adds an auth-failure cooldown for MastraPlatformExporter and CloudExporter so invalid credentials do not keep repeatedly uploading to the observability API.

Auth failures now stop retries immediately, drop events during the cooldown window, and probe again with exponential backoff plus jitter. Cooldown warnings and dropped-event counts are logged through the active injected exporter logger.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an exporter tries to upload data but gets rejected because of bad credentials, it now takes a break instead of immediately trying again. It waits longer each time it fails, and during that wait time it stops sending data. Once enough time has passed, it tries again. This prevents wasting effort sending requests that will always fail.

## Overview

This PR adds an authentication-failure cooldown mechanism to the observability exporters (`MastraPlatformExporter` and `CloudExporter`) to gracefully handle repeated authorization failures. When an exporter encounters a 401 or 403 response, it enters a cooldown period during which:

- New events are dropped instead of buffered
- No upload attempts are made
- After the cooldown expires, probing resumes with exponential backoff and symmetric jitter
- A warning log includes the failure status, retry count, and cooldown duration

## Technical Changes

**New Module:** `auth-failure-cooldown.ts`
- `AuthFailureError`: Custom error class for authentication failures with HTTP status
- `isAuthFailureError`: Type guard to identify authentication failures
- `fetchWithAuthFailureHandling`: Wrapper around `fetchWithRetry` that stops retrying immediately on 401/403 responses and throws `AuthFailureError`
- `AuthFailureCooldown`: Class that tracks consecutive auth failures, manages cooldown timestamps, and counts dropped events. Provides methods to:
  - Drop events during cooldown with `dropEventIfCoolingDown()` and `dropEventsIfCoolingDown(count)`
  - Record new failures with exponential backoff (capped) plus jitter via `recordFailure()`
  - Reset counters and return dropped event count via `reset()`

**CloudExporter Updates:**
- Integrates `AuthFailureCooldown` instance
- Drops events early in signal handlers when actively cooling down
- Uses `fetchWithAuthFailureHandling` instead of `fetchWithRetry` for batch uploads
- Detects auth failures in `flushSignalBatch()` and records them with dropped event counts
- On successful flush, resets cooldown and logs enriched metadata including `droppedEventsDuringAuthCooldown`

**MastraPlatformExporter Updates:**
- Identical auth-cooldown integration pattern as CloudExporter
- Drops incoming events when cooling down
- Switches to `fetchWithAuthFailureHandling` for batch uploads
- Records auth failures with status, failed signals, and dropped batch size

**Testing:**
- Added `mockAuthFailure` helper in both test files to configure authentication failure scenarios
- Extended existing tests to assert `shouldRetryResponse` function presence in `fetchWithRetry` calls
- New auth-cooldown test blocks verify:
  - Events are dropped during in-flight cooldown, then resume after expiration
  - Retry count and cooldown state reset properly
  - Dropped event accounting works correctly
  - Events buffered during auth failure are dropped appropriately

**Documentation:**
- Added Changesets entry documenting the pause in observability uploads when invalid credentials are detected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->