### PR TITLE
Revise LICENSE with updated copyright and terms

### DIFF
--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,35 +1,43 @@
 Mastra Enterprise Edition (EE) License
 
-Copyright (c) 2025 Kepler Software, Inc.
+Copyright (c) 2026 Kepler Software, Inc.
 
 With regard to the Mastra Software:
 
 This software and associated documentation files (the "Software") may only be
-used in production if you (and any entity that you represent) have agreed to,
-and are in compliance with, the Mastra Terms of Service, available at
-https://mastra.ai/terms (the "Terms"), or other agreements governing the use
-of the Software, as mutually agreed by you and Kepler Software, Inc. ("Kepler"),
-and otherwise have a valid Mastra Enterprise License for the correct number of
-user seats. Subject to the foregoing sentence, you are free to modify this
-Software and publish patches to the Software. You agree that Kepler and/or its
-licensors (as applicable) retain all right, title, and interest in and to all
-such modifications. You are not granted any other rights beyond what is
-expressly stated herein. Subject to the foregoing, it is forbidden to copy,
-merge, publish, distribute, sublicense, and/or sell the Software.
+used in production if you (and any entity that you represent) have entered into,
+and remain in compliance with, a written agreement with Kepler Software, Inc.
+("Kepler") explicitly permitting the use of the Software in production, including
+any additional restrictions set forth therein with respect to such use.
+Subject to the foregoing sentence, you are free to modify this Software for your
+own internal development and testing purposes, and submit patches to Kepler for
+inclusion in the upstream Mastra Software. You agree that Kepler and/or its
+licensors (as applicable) retain all right, title, and interest in and to all such
+modifications. You are not granted any other rights beyond what is expressly
+stated herein. Subject to the foregoing, it is forbidden to copy, merge, publish,
+distribute, sublicense, and/or sell the Software.
+Your rights under this License terminate automatically, without notice, if you fail
+to comply with any of its terms. If the violation is curable, your rights will be
+reinstated upon cure of the violation within thirty (30) days after you become
+aware (or should reasonably have become aware) of the violation. Upon
+termination, you must immediately cease all production use of the Software.
 
 For purposes of the foregoing, "production" means any use of the Software
-beyond development and testing on your own systems. "Development and testing"
-includes running the Software locally or in a staging environment for the
+beyond development and testing on your own systems. "Development and
+testing" includes running the Software locally or in a staging environment for the
 purpose of evaluating, developing, or testing modifications to the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS" AND “WITH ALL FAULTS” WITHOUT
+WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS, OR KEPLER, OR ITS OR THEIR AFFILIATES, OFFICERS,
+DIRECTORS, EMPLOYEES, OR OTHER LICENSORS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-For all third-party components incorporated into the Mastra Software, those
-components are licensed under the original license provided by the owner of
-the applicable component.
+For all third-party components incorporated into the Software, those components
+are licensed under the original license provided by the owner of the applicable
+component and nothing set forth herein is intended to supersede such third-party
+license.


### PR DESCRIPTION
Updated copyright year and clarified terms for production use of enterprise features

## Description
Worked with our team to update our enterprise license for clarity around what changes are needed and what kind of agreement is required with our team. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mastra-ai/mastra/pull/16744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR updates the license agreement for Mastra's Enterprise Edition to reflect the current year (2026) and clarifies the rules for using enterprise features in production. Instead of referencing specific license seat requirements, companies now need to get a custom written agreement directly from Kepler Software to use it in production.

## Changes

### License Text Updates (`ee/LICENSE`)

The Enterprise Edition license has been revised with the following key changes:

**Copyright & Effective Date**
- Updated copyright year to 2026

**Production Use Requirements**
- Replaced the generic production restriction with a requirement for an explicitly written agreement from Kepler Software that permits production use
- Removed specific references to Mastra Terms of Service URLs
- Removed specific reference to "valid Mastra Enterprise License for the correct number of user seats"

**Modifications & Patches**
- Changed the permitted action from "publishing patches" to "submitting patches to Kepler for upstream inclusion"

**Warranty & Liability**
- Updated the "AS IS" warranty disclaimer to include "WITH ALL FAULTS"
- Expanded liability language to explicitly reference Kepler or its licensors (as applicable), including affiliates
- Refined third-party component licensing language for clarity

**Impact**: 32 lines added, 24 lines removed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->