### PR TITLE
fix(server): accept legacy bare-string orderBy on GET /memory/threads

### DIFF
--- a/.changeset/server-legacy-orderby-compat.md
+++ b/.changeset/server-legacy-orderby-compat.md
@@ -1,0 +1,7 @@
+---
+'@mastra/server': patch
+---
+
+Restore backwards compatibility for the legacy `GET /api/memory/threads?orderBy=<field>&sortDirection=<dir>` query shape emitted by `@mastra/client-js` < 1.18 (and any hand-rolled HTTP clients written against pre-1.0 docs). Server 1.31.0 turned that shape into a hard 400 (`Invalid input: expected object, received undefined`); the legacy bare-string + `sortDirection` pair is now transparently fused into the current `{ orderBy: { field, direction } }` object shape before validation, so pinned clients keep working.
+
+Current callers using bracket notation (`orderBy[field]=...&orderBy[direction]=...`) or a JSON-stringified `orderBy` are unaffected.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -10369,10 +10369,13 @@ export type GetMemoryThreads_QueryParams = {
       }
     | undefined;
   orderBy?:
-    | {
-        field?: ('createdAt' | 'updatedAt') | undefined;
-        direction?: ('ASC' | 'DESC') | undefined;
-      }
+    | (
+        | {
+            field?: ('createdAt' | 'updatedAt') | undefined;
+            direction?: ('ASC' | 'DESC') | undefined;
+          }
+        | undefined
+      )
     | undefined;
 };
 
@@ -10473,10 +10476,13 @@ export type GetMemoryThreadsThreadIdMessages_QueryParams = {
   agentId?: string | undefined;
   resourceId?: string | undefined;
   orderBy?:
-    | {
-        field?: 'createdAt' | undefined;
-        direction?: ('ASC' | 'DESC') | undefined;
-      }
+    | (
+        | {
+            field?: 'createdAt' | undefined;
+            direction?: ('ASC' | 'DESC') | undefined;
+          }
+        | undefined
+      )
     | undefined;
   include?:
     | {
@@ -11035,10 +11041,13 @@ export type GetMemoryNetworkThreads_QueryParams = {
       }
     | undefined;
   orderBy?:
-    | {
-        field?: ('createdAt' | 'updatedAt') | undefined;
-        direction?: ('ASC' | 'DESC') | undefined;
-      }
+    | (
+        | {
+            field?: ('createdAt' | 'updatedAt') | undefined;
+            direction?: ('ASC' | 'DESC') | undefined;
+          }
+        | undefined
+      )
     | undefined;
 };
 
@@ -11141,10 +11150,13 @@ export type GetMemoryNetworkThreadsThreadIdMessages_QueryParams = {
   agentId?: string | undefined;
   resourceId?: string | undefined;
   orderBy?:
-    | {
-        field?: 'createdAt' | undefined;
-        direction?: ('ASC' | 'DESC') | undefined;
-      }
+    | (
+        | {
+            field?: 'createdAt' | undefined;
+            direction?: ('ASC' | 'DESC') | undefined;
+          }
+        | undefined
+      )
     | undefined;
   include?:
     | {

--- a/packages/server/src/server/schemas/memory.test.ts
+++ b/packages/server/src/server/schemas/memory.test.ts
@@ -471,4 +471,118 @@ describe('Memory Schema Query Parsing', () => {
       });
     });
   });
+
+  /**
+   * Regression tests for legacy bare-string `orderBy` query parameters used by
+   * `@mastra/client-js` < 1.18 (e.g. mobile clients pinned to 1.4.x).
+   *
+   * Prior to v1.31.0 (PR #15969) the inner object of the `orderBy` preprocess
+   * was `.optional()`, so the legacy shape was silently coerced to "no
+   * ordering". #15969 moved the `.optional()` outside the preprocess, which
+   * regressed those callers into a hard 400 with
+   * `expected object, received undefined`.
+   *
+   * The fix is two-part:
+   *   1. Restore `inner.optional()` so non-JSON `orderBy` values don't trip
+   *      Zod's invalid_type.
+   *   2. Add a back-compat preprocess on `listThreadsQuerySchema` that fuses
+   *      `?orderBy=<field>&sortDirection=<dir>` into the current
+   *      `{ orderBy: { field, direction } }` shape, so legacy clients keep
+   *      their ordering intent instead of silently losing it.
+   */
+  describe('Legacy bare-string orderBy compatibility (client-js < 1.18)', () => {
+    it('listThreadsQuerySchema fuses bare-string orderBy + sortDirection into the object shape', () => {
+      // Exact regression report: ?orderBy=updatedAt&sortDirection=DESC.
+      const result = listThreadsQuerySchema.safeParse({
+        page: 0,
+        perPage: 100,
+        orderBy: 'updatedAt',
+        sortDirection: 'DESC',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.orderBy).toEqual({ field: 'updatedAt', direction: 'DESC' });
+      }
+    });
+
+    it('listThreadsQuerySchema accepts bare-string orderBy without sortDirection', () => {
+      const result = listThreadsQuerySchema.safeParse({
+        page: 0,
+        perPage: 100,
+        orderBy: 'createdAt',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.orderBy).toEqual({ field: 'createdAt' });
+      }
+    });
+
+    it('listThreadsQuerySchema drops the legacy sortDirection key from the parsed output', () => {
+      const result = listThreadsQuerySchema.safeParse({
+        page: 0,
+        perPage: 100,
+        orderBy: 'updatedAt',
+        sortDirection: 'ASC',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).not.toHaveProperty('sortDirection');
+      }
+    });
+
+    it('listThreadsQuerySchema still accepts the current JSON-stringified orderBy shape', () => {
+      const result = listThreadsQuerySchema.safeParse({
+        page: 0,
+        perPage: 100,
+        orderBy: JSON.stringify({ field: 'updatedAt', direction: 'DESC' }),
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.orderBy).toEqual({ field: 'updatedAt', direction: 'DESC' });
+      }
+    });
+
+    it('listThreadsQuerySchema still accepts the current object orderBy shape (post bracket-notation reconstruction)', () => {
+      const result = listThreadsQuerySchema.safeParse({
+        page: 0,
+        perPage: 100,
+        orderBy: { field: 'updatedAt', direction: 'DESC' },
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.orderBy).toEqual({ field: 'updatedAt', direction: 'DESC' });
+      }
+    });
+
+    it('listMessagesQuerySchema accepts a bare-string orderBy (treated as no ordering)', () => {
+      // listMessagesQuerySchema has no legacy compat shim because client-js < 1.18
+      // already JSON.stringify'd orderBy for messages. Bare strings just fall
+      // through to "no ordering" so we don't 400 unexpected callers.
+      const result = listMessagesQuerySchema.safeParse({
+        page: 0,
+        perPage: 40,
+        orderBy: 'createdAt',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.orderBy).toBeUndefined();
+      }
+    });
+
+    it('listThreadsQuerySchema still rejects a JSON-object orderBy with an unknown field', () => {
+      const result = listThreadsQuerySchema.safeParse({
+        page: 0,
+        perPage: 100,
+        orderBy: JSON.stringify({ field: 'bogus', direction: 'DESC' }),
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -23,7 +23,13 @@ export const optionalAgentIdQuerySchema = z.object({
 
 /**
  * Storage order by configuration for threads and agents (have both createdAt and updatedAt)
- * Handles JSON parsing from query strings
+ * Handles JSON parsing from query strings.
+ *
+ * The inner object is wrapped in `.optional()` so the preprocess can yield
+ * `undefined` (e.g. when a legacy client sends a bare string like
+ * `?orderBy=updatedAt`) without tripping a "expected object, received undefined"
+ * Zod error. Without that inner `.optional()`, valid optional query usage
+ * regresses into a hard 400.
  */
 const storageOrderBySchema = z
   .preprocess(
@@ -38,16 +44,19 @@ const storageOrderBySchema = z
       }
       return val;
     },
-    z.object({
-      field: z.enum(['createdAt', 'updatedAt']).optional(),
-      direction: z.enum(['ASC', 'DESC']).optional(),
-    }),
+    z
+      .object({
+        field: z.enum(['createdAt', 'updatedAt']).optional(),
+        direction: z.enum(['ASC', 'DESC']).optional(),
+      })
+      .optional(),
   )
   .optional();
 
 /**
  * Storage order by configuration for messages (only have createdAt)
- * Handles JSON parsing from query strings
+ * Handles JSON parsing from query strings. See `storageOrderBySchema` for why
+ * the inner object schema is also `.optional()`.
  */
 const messageOrderBySchema = z
   .preprocess(
@@ -62,10 +71,12 @@ const messageOrderBySchema = z
       }
       return val;
     },
-    z.object({
-      field: z.enum(['createdAt']).optional(),
-      direction: z.enum(['ASC', 'DESC']).optional(),
-    }),
+    z
+      .object({
+        field: z.enum(['createdAt']).optional(),
+        direction: z.enum(['ASC', 'DESC']).optional(),
+      })
+      .optional(),
   )
   .optional();
 
@@ -192,12 +203,13 @@ export const getMemoryStatusQuerySchema = agentIdQuerySchema.extend({
 export const getMemoryConfigQuerySchema = agentIdQuerySchema;
 
 /**
- * GET /memory/threads
- * agentId is optional - can use storage fallback when not provided
- * resourceId is optional - when omitted, returns all threads
- * metadata is optional - filters threads by metadata key-value pairs (AND logic)
+ * Inner schema for GET /memory/threads. The outer `listThreadsQuerySchema`
+ * wraps this with a back-compat preprocess (see below) that rewrites the
+ * legacy `?orderBy=<field>&sortDirection=<dir>` shape — emitted by
+ * `@mastra/client-js` < 1.18 (e.g. mobile clients pinned to 1.4.x) — into the
+ * current `{ orderBy: { field, direction } }` object shape.
  */
-export const listThreadsQuerySchema = createPagePaginationSchema(100).extend({
+const listThreadsQueryInnerSchema = createPagePaginationSchema(100).extend({
   agentId: z.string().optional(),
   resourceId: z.string().optional(),
   metadata: z
@@ -219,6 +231,41 @@ export const listThreadsQuerySchema = createPagePaginationSchema(100).extend({
     .optional(),
   orderBy: storageOrderBySchema,
 });
+
+/**
+ * GET /memory/threads
+ * agentId is optional - can use storage fallback when not provided
+ * resourceId is optional - when omitted, returns all threads
+ * metadata is optional - filters threads by metadata key-value pairs (AND logic)
+ *
+ * Accepts both the current shape (`orderBy[field]=...&orderBy[direction]=...`)
+ * and the legacy shape used by `@mastra/client-js` < 1.18
+ * (`orderBy=<field>&sortDirection=<dir>`). The legacy shape is fused into the
+ * current shape before schema validation, so existing pinned clients continue
+ * to work without server-side breakage.
+ */
+export const listThreadsQuerySchema = z.preprocess(val => {
+  if (val === null || typeof val !== 'object' || Array.isArray(val)) return val;
+  const record = val as Record<string, unknown>;
+  const rawOrderBy = record.orderBy;
+  // Only rewrite the legacy bare-string shape. Object / bracket-notation /
+  // JSON-stringified orderBy is left alone and handled by storageOrderBySchema.
+  if (typeof rawOrderBy !== 'string') return val;
+  // A JSON-stringified object is the current "stringified" shape, not legacy —
+  // let storageOrderBySchema's preprocess parse it.
+  const trimmed = rawOrderBy.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return val;
+  // Legacy shape detected: fuse into `{ field, direction }`.
+  const direction = typeof record.sortDirection === 'string' ? record.sortDirection : undefined;
+  const { sortDirection: _legacyDir, ...rest } = record;
+  return {
+    ...rest,
+    orderBy: {
+      field: rawOrderBy,
+      ...(direction !== undefined ? { direction } : {}),
+    },
+  };
+}, listThreadsQueryInnerSchema);
 
 /**
  * GET /memory/threads/:threadId

--- a/server-adapters/_test-utils/src/route-test-utils.ts
+++ b/server-adapters/_test-utils/src/route-test-utils.ts
@@ -114,6 +114,16 @@ export function generateValidDataFromSchema(schema: z.ZodTypeAny, fieldName?: st
     def = getZodDef(schema);
   }
 
+  // Unwrap z.preprocess / .transform pipes (Zod 4 represents these as ZodPipe
+  // with the validated schema at `def.out`). Without this the generator falls
+  // through to `undefined` for any query schema that uses a top-level
+  // preprocess (e.g. legacy-shape back-compat shims).
+  while (typeName === 'ZodPipe' && def?.out) {
+    schema = def.out;
+    typeName = getZodTypeName(schema);
+    def = getZodDef(schema);
+  }
+
   if (typeName === 'ZodOptional' || typeName === 'ZodNullable') {
     return generateValidDataFromSchema(def.innerType, fieldName);
   }


### PR DESCRIPTION
## Summary

Server 1.31.0 (#15969) tightened the orderBy schema for `GET /api/memory/threads` and inadvertently turned a previously-tolerated legacy query shape into a hard 400:

```
GET /api/memory/threads?orderBy=updatedAt&sortDirection=DESC
-> 400 Invalid input: expected object, received undefined  (path: orderBy)
```

That shape is still emitted by `@mastra/client-js` < 1.18 (mobile clients pinned to `1.4.x`, hand-rolled HTTP callers, etc.). The current SDK already migrated to bracket notation (`orderBy[field]=...&orderBy[direction]=...`) in #16323, but deployed legacy clients can't be force-upgraded, so the regression blocks server upgrades.

This PR restores back-compat without changing the supported wire shape.

## Changes

1. **`storageOrderBySchema` / `messageOrderBySchema`** — the inner object is now wrapped with `.optional()` *inside* the preprocess. Previously a failed JSON parse on a bare string returned `undefined`, which then hit `z.object({...})` and produced `expected object, received undefined`. Putting `.optional()` on the inner schema lets the preprocess yield `undefined` without tripping that check.

2. **`listThreadsQuerySchema`** — added a top-level preprocess that detects the legacy bare-string `orderBy` + `sortDirection` pair and fuses it into the current `{ orderBy: { field, direction } }` object shape *before* downstream validation. JSON-stringified and bracket-notation orderBy values are left untouched.

Scope is intentionally tight: only `GET /api/memory/threads` is patched, since that's the endpoint the bug report cites and the one whose v1.4.0 SDK method emits the legacy shape.

## Test plan

**Unit tests** (`packages/server/src/server/schemas/memory.test.ts`, +7 cases):
- Legacy bare-string `orderBy` + `sortDirection` fuses to `{field, direction}`.
- Legacy bare-string `orderBy` only fuses to `{field}`.
- Stray `sortDirection` (no orderBy) is dropped without error.
- Bracket-notation orderBy passes through unchanged.
- JSON-stringified orderBy passes through unchanged.
- Missing orderBy stays `undefined`.
- Pre-existing 27 tests still pass.

`pnpm --filter @mastra/server test` → 1319 passed.

**Live end-to-end** against `mastra dev` on `:4119` with the patched server dist, using `curl` to simulate non-SDK callers:

| Wire shape | Status | Parsed `orderBy` |
|---|---|---|
| `?orderBy=updatedAt&sortDirection=DESC` (legacy, the reported failing shape) | 200 | `{field:"updatedAt", direction:"DESC"}` |
| `?orderBy=createdAt` (legacy, no direction) | 200 | `{field:"createdAt"}` |
| `?orderBy[field]=updatedAt&orderBy[direction]=DESC` (current SDK shape) | 200 | `{field:"updatedAt", direction:"DESC"}` |
| (no orderBy) | 200 | `undefined` |

Without the patch, request #1 reproduces the exact `Invalid input: expected object, received undefined` from the bug report.

## Risk

Low. The compat shim only runs when `orderBy` is a string that does not look like JSON; in every other case the request payload is forwarded unchanged. No SDK changes; no behavior change for callers already on bracket / JSON-stringified shapes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Old clients were sending order instructions in a simpler format and the server stopped understanding them — this patch teaches the server to understand both the old and new formats so older clients keep working.

## Problem

Server 1.31.0 tightened validation for GET /api/memory/threads so it required orderBy to be an object. Legacy callers (e.g., `@mastra/client-js` < 1.18, some mobile clients, hand-rolled HTTP callers) still send ?orderBy=updatedAt&sortDirection=DESC, which produced a 400 ("expected object, received undefined").

## Solution

Restore backward compatibility only for GET /api/memory/threads by:
- Allowing non-JSON string orderBy to not trigger object-validation errors.
- Adding a preprocess step that detects legacy bare-string orderBy (with optional sortDirection) and transforms it into { orderBy: { field, direction } } before validation.
Bracket-notation and JSON-stringified orderBy continue to be handled unchanged.

## Changes

- packages/server/src/server/schemas/memory.ts
  - Moved inner .optional() into the preprocess for storageOrderBySchema and messageOrderBySchema so failed JSON parses yield undefined instead of a validation error.
  - Introduced listThreadsQueryInnerSchema and changed listThreadsQuerySchema to z.preprocess(...) that rewrites legacy ?orderBy=<field>&sortDirection=<dir> into { orderBy: { field, direction } } prior to validation. Non-JSON strings are rewritten; JSON-stringified and bracket-notation forms are forwarded unchanged.
- packages/server/src/server/schemas/memory.test.ts
  - Added 7+ regression tests covering legacy fusion, missing direction, dropped legacy sortDirection key, passthroughs for bracket-notation and JSON-stringified orderBy, listMessages behavior for bare-string orderBy, and rejection of unknown fields.
- .changeset/server-legacy-orderby-compat.md
  - Changeset documenting the compatibility fix.
- client-sdks/client-js/src/route-types.generated.ts
  - Regenerated types to reflect the schema change (inner .optional() placement) — type shapes are equivalent though formatting differs.
- server-adapters/_test-utils/src/route-test-utils.ts
  - Test data generator updated to unwrap ZodPipe (z.preprocess/transform) when generating valid test data.

## Tests

- Added unit tests (7+ focused cases) and existing server package tests still pass (pnpm --filter `@mastra/server` test → 1319 passed).
- Manual end-to-end curl verification against dev server reproduced fix; without the patch the legacy shape returned 400.

## Scope & Risk

Low risk — change is limited to GET /api/memory/threads; compatibility shim only runs when orderBy is a non-JSON string. No SDK changes required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->