### PR TITLE
docs(guides): add OpenUI integration guide

### DIFF
--- a/docs/src/content/en/guides/build-your-ui/openui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/openui.mdx
@@ -1,0 +1,303 @@
+---
+title: "Using OpenUI | Frameworks"
+description: "Learn how to integrate OpenUI with Mastra"
+---
+
+import Steps from "@site/src/components/Steps";
+import StepItem from "@site/src/components/StepItem";
+
+# Using OpenUI
+
+[OpenUI](https://openui.com) is an open standard for generative UI. It pairs a compact streaming-first language (OpenUI Lang) with a React runtime and built-in component libraries, so model output can render as structured UI as it streams.
+
+OpenUI connects to Mastra through the [AG-UI protocol](https://docs.ag-ui.com). The `@ag-ui/mastra` adapter wraps a Mastra `Agent` and emits AG-UI events, which OpenUI's `agUIAdapter()` parses on the client.
+
+:::tip
+
+For a complete working example, see the [`mastra-chat`](https://github.com/thesysdev/openui/tree/main/examples/mastra-chat) example in the OpenUI repository.
+
+:::
+
+## Integration guide
+
+Embed Mastra in your Next.js API route and connect an OpenUI `<FullScreen />` chat surface to it through the AG-UI protocol.
+
+<Steps>
+  <StepItem>
+    Scaffold a new OpenUI app:
+
+    ```bash npm2yarn
+    npx @openuidev/cli@latest create --name openui-mastra-chat
+    ```
+
+    Navigate to your newly created project directory:
+
+    ```bash
+    cd openui-mastra-chat
+    ```
+
+    The scaffolded app is a Next.js project with the following structure:
+
+    ```bash
+    openui-mastra-chat
+    └── src
+        ├── app
+        │   ├── api
+        │   │   └── chat
+        │   │       └── route.ts
+        │   ├── globals.css
+        │   ├── layout.tsx
+        │   └── page.tsx
+        ├── generated
+        │   └── system-prompt.txt
+        └── library.ts
+    ```
+
+    The chat route lives in `src/app/api/chat/route.ts`, the chat surface in `src/app/page.tsx`, and the component library in `src/library.ts`. The OpenUI CLI writes `src/generated/system-prompt.txt` from your library; regenerate it whenever the library changes.
+
+    Add your OpenAI key to `.env.local`:
+
+    ```bash title=".env.local"
+    OPENAI_API_KEY=sk-...
+    ```
+
+    :::note
+
+    OpenUI requires a model provider key. Use any provider supported by Mastra and adjust the agent configuration in the next step.
+
+    :::
+  </StepItem>
+
+  <StepItem>
+    Install the Mastra packages and the AG-UI adapter for Mastra:
+
+    ```bash npm2yarn
+    npm install @mastra/core @ag-ui/mastra @ag-ui/core zod
+    ```
+
+    `@ag-ui/mastra` wraps a Mastra `Agent` in a `MastraAgent` that emits [AG-UI protocol](https://docs.ag-ui.com) events. OpenUI's `agUIAdapter()` consumes those events on the client.
+  </StepItem>
+
+  <StepItem>
+    Open `src/app/api/chat/route.ts`. Define any tools your agent needs with `createTool` from `@mastra/core/tools`:
+
+    ```typescript title="src/app/api/chat/route.ts"
+    import { createTool } from '@mastra/core/tools'
+    import { z } from 'zod'
+
+    const getWeather = createTool({
+      id: 'get_weather',
+      description: 'Get current weather for a city.',
+      inputSchema: z.object({ location: z.string().describe('City name') }),
+      execute: async ({ location }) => {
+        return { location, temperature_celsius: 22, condition: 'Clear' }
+      },
+    })
+    ```
+
+    Wrap a Mastra `Agent` in `MastraAgent`. Inject the generated system prompt so the agent knows how to use the OpenUI component library:
+
+    ```typescript title="src/app/api/chat/route.ts"
+    import { MastraAgent } from '@ag-ui/mastra'
+    import { Agent } from '@mastra/core/agent'
+    import { readFileSync } from 'fs'
+    import { join } from 'path'
+
+    const systemPrompt = readFileSync(join(process.cwd(), 'src/generated/system-prompt.txt'), 'utf-8')
+
+    const agent = new MastraAgent({
+      agent: new Agent({
+        id: 'openui-agent',
+        name: 'OpenUI Agent',
+        instructions: `You are a helpful assistant. Use tools when relevant.\n\n${systemPrompt}`,
+        model: {
+          id: 'openai/gpt-4o',
+          apiKey: process.env.OPENAI_API_KEY,
+        },
+        tools: { getWeather },
+      }),
+      resourceId: 'chat-user',
+    })
+    ```
+
+    Export a `POST` handler that streams the agent's AG-UI events as Server-Sent Events (SSE):
+
+    ```typescript title="src/app/api/chat/route.ts"
+    import type { Message } from '@ag-ui/core'
+    import { NextRequest } from 'next/server'
+
+    export async function POST(req: NextRequest) {
+      const { messages, threadId }: { messages: Message[]; threadId: string } = await req.json()
+      const encoder = new TextEncoder()
+
+      const stream = new ReadableStream({
+        start(controller) {
+          const subscription = agent
+            .run({ messages, threadId, runId: crypto.randomUUID(), tools: [], context: [] })
+            .subscribe({
+              next: event => {
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+              },
+              complete: () => {
+                controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+                controller.close()
+              },
+              error: error => {
+                controller.enqueue(
+                  encoder.encode(`data: ${JSON.stringify({ error: error.message })}\n\n`),
+                )
+                controller.close()
+              },
+            })
+
+          req.signal.addEventListener('abort', () => subscription.unsubscribe())
+        },
+      })
+
+      return new Response(stream, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache, no-transform',
+          Connection: 'keep-alive',
+        },
+      })
+    }
+    ```
+  </StepItem>
+
+  <StepItem>
+    Wire the OpenUI `<FullScreen />` chat surface to the route. Set `streamProtocol` to `agUIAdapter()` so OpenUI knows to parse AG-UI events.
+
+    ```tsx title="src/app/page.tsx" {5,11-13,20}
+    'use client'
+
+    import '@openuidev/react-ui/components.css'
+
+    import { agUIAdapter } from '@openuidev/react-headless'
+    import { FullScreen } from '@openuidev/react-ui'
+    import { openuiChatLibrary } from '@openuidev/react-ui/genui-lib'
+
+    export default function Page() {
+      return (
+        <div className="relative h-screen w-screen overflow-hidden">
+          <FullScreen
+            processMessage={async ({ messages, threadId, abortController }) => {
+              return fetch('/api/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ messages, threadId }),
+                signal: abortController.signal,
+              })
+            }}
+            streamProtocol={agUIAdapter()}
+            componentLibrary={openuiChatLibrary}
+            agentName="OpenUI + Mastra Chat"
+          />
+        </div>
+      )
+    }
+    ```
+
+    The `componentLibrary` prop controls which components the model can generate. Replace `openuiChatLibrary` with your own library to restrict or extend the output.
+  </StepItem>
+
+  <StepItem>
+    Start the development server:
+
+    ```bash npm2yarn
+    npm run dev
+    ```
+
+    Open [http://localhost:3000](http://localhost:3000). You can now chat with your Mastra agent through the OpenUI chat surface, with structured UI rendered progressively as the model streams.
+  </StepItem>
+</Steps>
+
+## Streaming with AG-UI
+
+OpenUI consumes the [AG-UI protocol](https://docs.ag-ui.com), a transport-agnostic stream of typed events for AI agents. `@ag-ui/mastra` translates a Mastra `Agent` into this protocol:
+
+- The server calls `agent.run({ messages, threadId, runId, ... })` and serializes each emitted event as an SSE message.
+- The client passes `streamProtocol={agUIAdapter()}` to `<FullScreen />`, which parses the SSE stream into the internal events that drive OpenUI Lang rendering.
+
+`threadId` ties a conversation together across requests, and `runId` identifies a single execution. Generate a fresh `runId` per request and persist `threadId` on the client.
+
+## Component libraries
+
+OpenUI generates UI from a component library. The library defines which components are available, their props, and how the model is instructed to use them.
+
+### Built-in libraries
+
+`@openuidev/react-ui` ships two libraries you can use as-is:
+
+- `openuiChatLibrary`: components for chat interfaces (cards, forms, tables, charts).
+- `openuiDashboardLibrary`: components for dashboards and data-heavy surfaces.
+
+Pass the library to `<FullScreen componentLibrary={...} />` to make its components available to the model.
+
+### Customizing the library
+
+To restrict or extend the output, define your own library in `src/library.ts` and export a subset of components. Pass that library to `<FullScreen />` and regenerate the system prompt whenever the library changes:
+
+```bash npm2yarn
+npx @openuidev/cli generate src/library.ts --out src/generated/system-prompt.txt
+```
+
+The generated prompt is read by the API route and merged into the agent's `instructions`, so the agent knows exactly which components it can emit.
+
+## Recipes
+
+### Adding tools
+
+Define more tools with `createTool` and pass them in the agent's `tools` map. The model will call them through AG-UI's tool-call events, and OpenUI renders the resulting UI inline.
+
+```typescript title="src/app/api/chat/route.ts"
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+const getStockPrice = createTool({
+  id: 'get_stock_price',
+  description: 'Get current stock price for a ticker symbol.',
+  inputSchema: z.object({ symbol: z.string() }),
+  execute: async ({ symbol }) => {
+    return { symbol: symbol.toUpperCase(), price: 189.84 }
+  },
+})
+
+// Pass alongside other tools when constructing the Agent
+// tools: { getWeather, getStockPrice }
+```
+
+### Conversation starters
+
+`<FullScreen />` accepts a `conversationStarters` prop to render suggested prompts on an empty thread:
+
+```tsx title="src/app/page.tsx"
+<FullScreen
+  // ...other props
+  conversationStarters={{
+    variant: 'short',
+    options: [
+      { displayText: 'Weather in Tokyo', prompt: "What's the weather like in Tokyo right now?" },
+      {
+        displayText: 'Contact form',
+        prompt: 'Build me a contact form with name, email, and message.',
+      },
+    ],
+  }}
+/>
+```
+
+### Light and dark themes
+
+Pass a `theme` prop with the desired mode to control the chat surface's appearance:
+
+```tsx title="src/app/page.tsx"
+<FullScreen
+  // ...other props
+  theme={{ mode: 'dark' }}
+/>
+```
+
+To follow the user's system preference, derive `mode` from a media query and pass it in.
+
+For a complete implementation with multiple tools, conversation starters, and theme support, see the [\`mastra-chat'](https://github.com/thesysdev/openui/tree/main/examples/mastra-chat) example in the OpenUI repository.

--- a/docs/src/content/en/guides/sidebars.js
+++ b/docs/src/content/en/guides/sidebars.js
@@ -109,6 +109,11 @@ const sidebars = {
           id: 'build-your-ui/assistant-ui',
           label: 'Assistant UI',
         },
+        {
+          type: 'doc',
+          id: 'build-your-ui/openui',
+          label: 'OpenUI',
+        },
       ],
     },
     {


### PR DESCRIPTION
Adds a new "Using OpenUI" page under guides/build-your-ui/ that documents how to wire a Mastra agent into an OpenUI generative-UI app via the AG-UI protocol (@ag-ui/mastra + agUIAdapter). Registers the page in the Agentic UIs sidebar group.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR accidentally adds a guide that teaches developers how to connect Mastra AI agents with OpenUI (a tool for building smart interfaces). The author opened it by mistake and intended to work on their own fork instead, but the guide itself explains how to set up and use these two tools together.

## Changes

**New Documentation**
- Added comprehensive OpenUI integration guide (`openui.mdx`) under `guides/build-your-ui/`
  - End-to-end Next.js integration walkthrough covering app scaffolding, package installation, tool definition, and agent wrapping with `MastraAgent`
  - Instructions for exposing a streaming SSE POST route
  - Client-side wiring guide using OpenUI's `<FullScreen />` component with `streamProtocol={agUIAdapter()}` and `componentLibrary={openuiChatLibrary}`
  - Guidance on regenerating system prompts when custom component libraries change
  - Explanations of AG-UI streaming concepts (`threadId`/`runId`) and available built-in libraries
  - Recipes for adding tools, conversation starters, and light/dark theming with references to the `mastra-chat` example

**Documentation Registry**
- Updated `sidebars.js` to register the new OpenUI guide under the Agentic UIs category

## Note

This PR was opened unintentionally—the author intended to push the branch to their own fork. The branch has been closed on their side.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->