### PR TITLE
Add drop event emission to MastraStorageExporter

### DIFF
--- a/.changeset/easy-rivers-cry.md
+++ b/.changeset/easy-rivers-cry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed a bug in `DefaultExporter` and `MastraStorageExporter` where a transient error during a span-end flush would silently drop span updates that had been deferred earlier in the same flush cycle (e.g. while waiting for their parent span to be created).

--- a/.changeset/easy-rivers-cry.md
+++ b/.changeset/easy-rivers-cry.md
@@ -1,5 +1,0 @@
----
-'@mastra/observability': patch
----
-
-Fixed a bug in `DefaultExporter` and `MastraStorageExporter` where a transient error during a span-end flush would silently drop span updates that had been deferred earlier in the same flush cycle (e.g. while waiting for their parent span to be created).

--- a/.changeset/young-lizards-joke.md
+++ b/.changeset/young-lizards-joke.md
@@ -2,4 +2,6 @@
 '@mastra/observability': minor
 ---
 
-`MastraStorageExporter` now emits structured drop events through `onDroppedEvent` so custom exporters and integrations can observe unsupported-storage and retry-exhausted drops. This mirrors the existing `DefaultExporter` behavior.
+`MastraStorageExporter` now notifies custom exporters and connected integrations when it cannot persist observability events, such as unsupported storage or retries being exceeded. This matches the behavior already available on `DefaultExporter`.
+
+Also fixed an issue in both exporters where span updates waiting on their parent span could be silently lost if a later flush in the same cycle failed.

--- a/.changeset/young-lizards-joke.md
+++ b/.changeset/young-lizards-joke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': minor
+---
+
+`MastraStorageExporter` now emits structured drop events through `onDroppedEvent` so custom exporters and integrations can observe unsupported-storage and retry-exhausted drops. This mirrors the existing `DefaultExporter` behavior.

--- a/observability/mastra/src/exporters/default.test.ts
+++ b/observability/mastra/src/exporters/default.test.ts
@@ -627,6 +627,40 @@ describe('DefaultExporter', () => {
         );
       });
 
+      it('should preserve prior-call deferred updates when a later flushSpanUpdates call hits a transient error', async () => {
+        const exporter = new DefaultExporter({
+          strategy: 'batch-with-updates',
+          maxRetries: 3,
+          maxBatchSize: 10,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra });
+
+        // span-a is started + flushed so it lives in the created-spans set
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'span-a'));
+        await exporter.flush();
+        mockObservabilityStore.batchUpdateSpans.mockClear();
+
+        // span-b's update arrives before its create — gets deferred by flushSpanUpdates call 1
+        // span-a's end arrives — flushSpanUpdates call 2 batch-updates and fails transiently
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_UPDATED, 'trace-1', 'span-b'));
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_ENDED, 'trace-1', 'span-a'));
+
+        mockObservabilityStore.batchUpdateSpans.mockRejectedValueOnce(new Error('Transient failure'));
+        await exporter.flush();
+
+        // span-b's deferred update must NOT have been wiped by the call-2 error path.
+        // Now create span-b and flush — the update should be processed.
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'span-b'));
+        await exporter.flush();
+
+        const allUpdateRecords = mockObservabilityStore.batchUpdateSpans.mock.calls.flatMap(
+          (call: any) => call[0].records,
+        );
+        const spanBUpdates = allUpdateRecords.filter((u: any) => u.spanId === 'span-b');
+        expect(spanBUpdates.length).toBeGreaterThanOrEqual(1);
+      });
+
       it('should emit drop events when deferred updates exhaust retries', async () => {
         const emitDropEvent = vi.fn();
         const exporter = new DefaultExporter({

--- a/observability/mastra/src/exporters/default.ts
+++ b/observability/mastra/src/exporters/default.ts
@@ -347,8 +347,14 @@ export class DefaultExporter extends BaseExporter {
         deferredUpdates.length = 0;
         this.emitDrop('tracing', 'unsupported-storage', events.length + deferredCountAtEntry, error);
       } else {
-        // Clear deferred to avoid double-adding — re-add all original events instead
-        deferredUpdates.length = 0;
+        // `events` includes both partials-bound and newly-deferred entries, so
+        // re-adding it would double-add the newly-deferred ones if they stayed
+        // in deferredUpdates. Splice off only what this call appended — entries
+        // from a prior flushSpanUpdates call must survive.
+        const newlyDeferred = deferredUpdates.length - deferredCountAtEntry;
+        if (newlyDeferred > 0) {
+          deferredUpdates.splice(deferredUpdates.length - newlyDeferred, newlyDeferred);
+        }
         const dropped = this.#eventBuffer.reAddUpdates(events);
         this.emitDrop('tracing', 'retry-exhausted', dropped.length, error);
       }

--- a/observability/mastra/src/exporters/mastra-storage.test.ts
+++ b/observability/mastra/src/exporters/mastra-storage.test.ts
@@ -1,3 +1,4 @@
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { SpanType, TracingEventType, EntityType } from '@mastra/core/observability';
 import type {
   ModelGenerationAttributes,
@@ -165,6 +166,7 @@ describe('MastraStorageExporter', () => {
         batchUpdateSpans: vi.fn().mockResolvedValue(undefined),
         createSpan: vi.fn().mockResolvedValue(undefined),
         updateSpan: vi.fn().mockResolvedValue(undefined),
+        constructor: { name: 'MockObservabilityStore' },
       };
 
       // Create mock storage with getStore method
@@ -175,7 +177,7 @@ describe('MastraStorageExporter', () => {
           }
           return Promise.resolve(null);
         }),
-        constructor: { name: 'MockStorage' },
+        constructor: { name: 'MockCompositeStorage' },
       };
 
       mockMastra.getStorage.mockReturnValue(mockStorage);
@@ -195,7 +197,7 @@ describe('MastraStorageExporter', () => {
           expect.objectContaining({
             strategy: 'batch-with-updates',
             source: 'auto',
-            storageAdapter: 'MockStorage',
+            storageAdapter: 'MockCompositeStorage',
           }),
         );
       });
@@ -566,6 +568,86 @@ describe('MastraStorageExporter', () => {
         // Fourth flush — nothing left in buffer
         await exporter.flush();
         expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(3); // Not called again
+      });
+
+      it('should emit drop events when create retries are exhausted', async () => {
+        const emitDropEvent = vi.fn();
+        const exporter = new MastraStorageExporter({
+          strategy: 'batch-with-updates',
+          maxRetries: 0,
+          maxBatchSize: 10,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra, emitDropEvent });
+
+        mockObservabilityStore.batchCreateSpans.mockRejectedValue(new Error('Persistent error'));
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED));
+        await exporter.flush();
+
+        expect(emitDropEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'drop',
+            signal: 'tracing',
+            reason: 'retry-exhausted',
+            count: 1,
+            exporterName: 'mastra-storage-exporter',
+            storageName: 'MockObservabilityStore',
+            error: { message: 'Persistent error' },
+          }),
+        );
+        expect(emitDropEvent.mock.calls[0][0].timestamp).toBeInstanceOf(Date);
+      });
+
+      it('should emit drop events when span update retries are exhausted', async () => {
+        const emitDropEvent = vi.fn();
+        const exporter = new MastraStorageExporter({
+          strategy: 'batch-with-updates',
+          maxRetries: 0,
+          maxBatchSize: 10,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra, emitDropEvent });
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'span-1'));
+        await exporter.flush();
+
+        mockObservabilityStore.batchUpdateSpans.mockRejectedValue(new Error('Update failed'));
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_UPDATED, 'trace-1', 'span-1'));
+        await exporter.flush();
+
+        expect(emitDropEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            signal: 'tracing',
+            reason: 'retry-exhausted',
+            count: 1,
+            error: { message: 'Update failed' },
+          }),
+        );
+      });
+
+      it('should emit drop events when deferred updates exhaust retries', async () => {
+        const emitDropEvent = vi.fn();
+        const exporter = new MastraStorageExporter({
+          strategy: 'batch-with-updates',
+          maxRetries: 0,
+          maxBatchSize: 10,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra, emitDropEvent });
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_UPDATED, 'trace-1', 'missing-span'));
+        await exporter.flush();
+
+        expect(emitDropEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            signal: 'tracing',
+            reason: 'retry-exhausted',
+            count: 1,
+          }),
+        );
+        expect(emitDropEvent.mock.calls[0][0]).not.toHaveProperty('error');
       });
     });
 
@@ -1194,6 +1276,126 @@ describe('MastraStorageExporter', () => {
         await exporter.shutdown();
       });
 
+      it('should emit drop events for unsupported log storage and later skipped log batches', async () => {
+        const emitDropEvent = vi.fn();
+        const notImplementedError = new MastraError({
+          id: 'OBSERVABILITY_STORAGE_BATCH_CREATE_LOGS_NOT_IMPLEMENTED',
+          domain: ErrorDomain.MASTRA_OBSERVABILITY,
+          category: ErrorCategory.SYSTEM,
+          text: 'This storage provider does not support batch creating logs',
+        });
+        mockObservabilityStore.batchCreateLogs = vi.fn().mockRejectedValue(notImplementedError);
+        const exporter = new MastraStorageExporter({ maxBatchSize: 10, logger: mockLogger });
+        await exporter.init({ mastra: mockMastra, emitDropEvent });
+
+        await exporter.onLogEvent(createLogEvent('log-1'));
+        await exporter.flush();
+
+        await exporter.onLogEvent(createLogEvent('log-2'));
+        await exporter.flush();
+
+        expect(mockObservabilityStore.batchCreateLogs).toHaveBeenCalledTimes(1);
+        expect(emitDropEvent).toHaveBeenCalledTimes(2);
+        expect(emitDropEvent).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            signal: 'log',
+            reason: 'unsupported-storage',
+            count: 1,
+            error: {
+              id: 'OBSERVABILITY_STORAGE_BATCH_CREATE_LOGS_NOT_IMPLEMENTED',
+              domain: ErrorDomain.MASTRA_OBSERVABILITY,
+              message: 'This storage provider does not support batch creating logs',
+            },
+          }),
+        );
+        expect(emitDropEvent).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            signal: 'log',
+            reason: 'unsupported-storage',
+            count: 1,
+          }),
+        );
+        expect(emitDropEvent.mock.calls[1][0]).not.toHaveProperty('error');
+      });
+
+      it('should emit drop events for unsupported tracing updates', async () => {
+        const emitDropEvent = vi.fn();
+        const notImplementedError = new MastraError({
+          id: 'OBSERVABILITY_STORAGE_BATCH_UPDATE_SPANS_NOT_IMPLEMENTED',
+          domain: ErrorDomain.MASTRA_OBSERVABILITY,
+          category: ErrorCategory.SYSTEM,
+          text: 'This storage provider does not support batch updating spans',
+        });
+        const exporter = new MastraStorageExporter({
+          strategy: 'batch-with-updates',
+          maxBatchSize: 10,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra, emitDropEvent });
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'span-1'));
+        await exporter.flush();
+
+        mockObservabilityStore.batchUpdateSpans.mockRejectedValue(notImplementedError);
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_UPDATED, 'trace-1', 'span-1'));
+        await exporter.flush();
+
+        expect(emitDropEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            signal: 'tracing',
+            reason: 'unsupported-storage',
+            count: 1,
+            error: {
+              id: 'OBSERVABILITY_STORAGE_BATCH_UPDATE_SPANS_NOT_IMPLEMENTED',
+              domain: ErrorDomain.MASTRA_OBSERVABILITY,
+              message: 'This storage provider does not support batch updating spans',
+            },
+          }),
+        );
+      });
+
+      it('should emit unsupported-storage for deferred updates carried into an unsupported tracing update', async () => {
+        const emitDropEvent = vi.fn();
+        const notImplementedError = new MastraError({
+          id: 'OBSERVABILITY_STORAGE_BATCH_UPDATE_SPANS_NOT_IMPLEMENTED',
+          domain: ErrorDomain.MASTRA_OBSERVABILITY,
+          category: ErrorCategory.SYSTEM,
+          text: 'This storage provider does not support batch updating spans',
+        });
+        const exporter = new MastraStorageExporter({
+          strategy: 'batch-with-updates',
+          maxRetries: 0,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra, emitDropEvent });
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'span-1'));
+        await exporter.flush();
+
+        mockObservabilityStore.batchUpdateSpans.mockRejectedValue(notImplementedError);
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_UPDATED, 'trace-1', 'missing-span'));
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_ENDED, 'trace-1', 'span-1'));
+        await exporter.flush();
+
+        expect(emitDropEvent).toHaveBeenCalledTimes(1);
+        expect(emitDropEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            signal: 'tracing',
+            reason: 'unsupported-storage',
+            count: 2,
+            error: {
+              id: 'OBSERVABILITY_STORAGE_BATCH_UPDATE_SPANS_NOT_IMPLEMENTED',
+              domain: ErrorDomain.MASTRA_OBSERVABILITY,
+              message: 'This storage provider does not support batch updating spans',
+            },
+          }),
+        );
+      });
+
       it('signal handlers should be no-ops when storage not initialized', async () => {
         const exporter = new MastraStorageExporter({ logger: mockLogger });
         // Don't call init — storage is not available
@@ -1231,6 +1433,18 @@ describe('MastraStorageExporter', () => {
           input: 'test input',
           output: type === TracingEventType.SPAN_ENDED ? 'test output' : undefined,
         } as any as AnyExportedSpan,
+      };
+    }
+
+    function createLogEvent(logId: string): LogEvent {
+      return {
+        type: 'log',
+        log: {
+          logId,
+          timestamp: new Date('2026-01-01T00:00:00Z'),
+          level: 'info',
+          message: 'test log',
+        },
       };
     }
   });

--- a/observability/mastra/src/exporters/mastra-storage.test.ts
+++ b/observability/mastra/src/exporters/mastra-storage.test.ts
@@ -627,6 +627,40 @@ describe('MastraStorageExporter', () => {
         );
       });
 
+      it('should preserve prior-call deferred updates when a later flushSpanUpdates call hits a transient error', async () => {
+        const exporter = new MastraStorageExporter({
+          strategy: 'batch-with-updates',
+          maxRetries: 3,
+          maxBatchSize: 10,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra });
+
+        // span-a is started + flushed so it lives in the created-spans set
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'span-a'));
+        await exporter.flush();
+        mockObservabilityStore.batchUpdateSpans.mockClear();
+
+        // span-b's update arrives before its create — gets deferred by flushSpanUpdates call 1
+        // span-a's end arrives — flushSpanUpdates call 2 batch-updates and fails transiently
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_UPDATED, 'trace-1', 'span-b'));
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_ENDED, 'trace-1', 'span-a'));
+
+        mockObservabilityStore.batchUpdateSpans.mockRejectedValueOnce(new Error('Transient failure'));
+        await exporter.flush();
+
+        // span-b's deferred update must NOT have been wiped by the call-2 error path.
+        // Now create span-b and flush — the update should be processed.
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'span-b'));
+        await exporter.flush();
+
+        const allUpdateRecords = mockObservabilityStore.batchUpdateSpans.mock.calls.flatMap(
+          (call: any) => call[0].records,
+        );
+        const spanBUpdates = allUpdateRecords.filter((u: any) => u.spanId === 'span-b');
+        expect(spanBUpdates.length).toBeGreaterThanOrEqual(1);
+      });
+
       it('should emit drop events when deferred updates exhaust retries', async () => {
         const emitDropEvent = vi.fn();
         const exporter = new MastraStorageExporter({

--- a/observability/mastra/src/exporters/mastra-storage.ts
+++ b/observability/mastra/src/exporters/mastra-storage.ts
@@ -7,6 +7,9 @@ import type {
   LogEvent,
   ScoreEvent,
   FeedbackEvent,
+  ObservabilityDropEvent,
+  ObservabilityDropReason,
+  ObservabilityDropSignal,
 } from '@mastra/core/observability';
 import { TracingEventType } from '@mastra/core/observability';
 import type { ObservabilityStorage, TracingStorageStrategy, MastraCompositeStore } from '@mastra/core/storage';
@@ -78,9 +81,10 @@ export class MastraStorageExporter extends BaseExporter {
   #observabilityStorage?: ObservabilityStorage;
   #resolvedStrategy?: TracingStorageStrategy;
   #flushTimer?: NodeJS.Timeout;
+  #emitDropEvent?: (event: ObservabilityDropEvent) => void;
 
   // Signals whose storage methods threw "not implemented" — skip on future flushes
-  #unsupportedSignals: Set<string> = new Set();
+  #unsupportedSignals: Set<ObservabilityDropSignal> = new Set();
 
   constructor(config: MastraStorageExporterConfig = {}) {
     super(config);
@@ -105,6 +109,7 @@ export class MastraStorageExporter extends BaseExporter {
   async init(options: InitExporterOptions): Promise<void> {
     try {
       this.#isInitializing = true;
+      this.#emitDropEvent = options.emitDropEvent;
 
       this.#storage = options.mastra?.getStorage();
       if (!this.#storage) {
@@ -211,17 +216,60 @@ export class MastraStorageExporter extends BaseExporter {
     }
   }
 
+  private sanitizeDropError(error: unknown): ObservabilityDropEvent['error'] {
+    if (error instanceof MastraError) {
+      return {
+        id: error.id,
+        domain: String(error.domain),
+        message: error.message,
+      };
+    }
+
+    if (error instanceof Error) {
+      return { message: error.message };
+    }
+
+    return { message: String(error) };
+  }
+
+  private emitDrop(
+    signal: ObservabilityDropSignal,
+    reason: ObservabilityDropReason,
+    count: number,
+    error?: unknown,
+  ): void {
+    if (count === 0) return;
+
+    const dropEvent: ObservabilityDropEvent = {
+      type: 'drop',
+      signal,
+      reason,
+      count,
+      timestamp: new Date(),
+      exporterName: this.name,
+      ...(this.#observabilityStorage ? { storageName: this.#observabilityStorage.constructor.name } : {}),
+      ...(error === undefined ? {} : { error: this.sanitizeDropError(error) }),
+    };
+
+    this.#emitDropEvent?.(dropEvent);
+  }
+
   /**
    * Flush a batch of create events for a single signal type.
    * On "not implemented" errors, disables the signal for future flushes.
    * On other errors, re-adds events to the buffer for retry.
    */
   private async flushCreates<T extends BufferedEvent>(
-    signal: string,
+    signal: ObservabilityDropSignal,
     events: T[],
     storageCall: (events: T[]) => Promise<void>,
   ): Promise<void> {
-    if (this.#unsupportedSignals.has(signal) || events.length === 0) return;
+    if (events.length === 0) return;
+    if (this.#unsupportedSignals.has(signal)) {
+      this.emitDrop(signal, 'unsupported-storage', events.length);
+      return;
+    }
+
     try {
       await storageCall(events);
     } catch (error) {
@@ -232,8 +280,10 @@ export class MastraStorageExporter extends BaseExporter {
       ) {
         this.logger.warn(error.message);
         this.#unsupportedSignals.add(signal);
+        this.emitDrop(signal, 'unsupported-storage', events.length, error);
       } else {
-        this.#eventBuffer.reAddCreates(events);
+        const dropped = this.#eventBuffer.reAddCreates(events);
+        this.emitDrop(signal, 'retry-exhausted', dropped.length, error);
       }
     }
   }
@@ -247,7 +297,12 @@ export class MastraStorageExporter extends BaseExporter {
     deferredUpdates: BufferedEvent[],
     isEnd: boolean,
   ): Promise<void> {
-    if (this.#unsupportedSignals.has('tracing') || events.length === 0) return;
+    const deferredCountAtEntry = deferredUpdates.length;
+    if (events.length === 0) return;
+    if (this.#unsupportedSignals.has('tracing')) {
+      this.emitDrop('tracing', 'unsupported-storage', events.length);
+      return;
+    }
 
     const partials: UpdateSpanPartial[] = [];
     for (const event of events) {
@@ -278,10 +333,13 @@ export class MastraStorageExporter extends BaseExporter {
       ) {
         this.logger.warn(error.message);
         this.#unsupportedSignals.add('tracing');
+        deferredUpdates.length = 0;
+        this.emitDrop('tracing', 'unsupported-storage', events.length + deferredCountAtEntry, error);
       } else {
         // Clear deferred to avoid double-adding — re-add all original events instead
         deferredUpdates.length = 0;
-        this.#eventBuffer.reAddUpdates(events);
+        const dropped = this.#eventBuffer.reAddUpdates(events);
+        this.emitDrop('tracing', 'retry-exhausted', dropped.length, error);
       }
     }
   }
@@ -367,13 +425,13 @@ export class MastraStorageExporter extends BaseExporter {
       this.flushCreates('feedback', createFeedbackEvents, events =>
         this.#observabilityStorage!.batchCreateFeedback({ feedbacks: events.map(f => buildFeedbackRecord(f)) }),
       ),
-      this.flushCreates('logs', createLogEvents, events =>
+      this.flushCreates('log', createLogEvents, events =>
         this.#observabilityStorage!.batchCreateLogs({ logs: events.map(l => buildLogRecord(l)) }),
       ),
-      this.flushCreates('metrics', createMetricEvents, events =>
+      this.flushCreates('metric', createMetricEvents, events =>
         this.#observabilityStorage!.batchCreateMetrics({ metrics: events.map(m => buildMetricRecord(m)) }),
       ),
-      this.flushCreates('scores', createScoreEvents, events =>
+      this.flushCreates('score', createScoreEvents, events =>
         this.#observabilityStorage!.batchCreateScores({ scores: events.map(s => buildScoreRecord(s)) }),
       ),
       this.flushCreates('tracing', createSpanEvents, async events => {
@@ -390,7 +448,13 @@ export class MastraStorageExporter extends BaseExporter {
     await this.flushSpanUpdates(endSpanEvents, deferredUpdates, true);
 
     if (deferredUpdates.length > 0) {
-      this.#eventBuffer.reAddUpdates(deferredUpdates);
+      if (this.#unsupportedSignals.has('tracing')) {
+        this.emitDrop('tracing', 'unsupported-storage', deferredUpdates.length);
+        deferredUpdates.length = 0;
+      } else {
+        const dropped = this.#eventBuffer.reAddUpdates(deferredUpdates);
+        this.emitDrop('tracing', 'retry-exhausted', dropped.length);
+      }
     }
 
     const elapsed = Date.now() - startTime;

--- a/observability/mastra/src/exporters/mastra-storage.ts
+++ b/observability/mastra/src/exporters/mastra-storage.ts
@@ -336,8 +336,14 @@ export class MastraStorageExporter extends BaseExporter {
         deferredUpdates.length = 0;
         this.emitDrop('tracing', 'unsupported-storage', events.length + deferredCountAtEntry, error);
       } else {
-        // Clear deferred to avoid double-adding — re-add all original events instead
-        deferredUpdates.length = 0;
+        // `events` includes both partials-bound and newly-deferred entries, so
+        // re-adding it would double-add the newly-deferred ones if they stayed
+        // in deferredUpdates. Splice off only what this call appended — entries
+        // from a prior flushSpanUpdates call must survive.
+        const newlyDeferred = deferredUpdates.length - deferredCountAtEntry;
+        if (newlyDeferred > 0) {
+          deferredUpdates.splice(deferredUpdates.length - newlyDeferred, newlyDeferred);
+        }
         const dropped = this.#eventBuffer.reAddUpdates(events);
         this.emitDrop('tracing', 'retry-exhausted', dropped.length, error);
       }


### PR DESCRIPTION
## Description

`MastraStorageExporter` now emits structured drop events through the `emitDropEvent` callback, allowing custom exporters and integrations to observe when telemetry data is dropped due to unsupported storage features or exhausted retries. This brings `MastraStorageExporter` to feature parity with `DefaultExporter` for drop event handling.

### Changes

- Added `#emitDropEvent` field to store the drop event callback from initialization options
- Implemented `emitDrop()` helper method to emit structured `ObservabilityDropEvent` objects with:
  - Signal type (tracing, log, metric, score, feedback)
  - Drop reason (unsupported-storage, retry-exhausted)
  - Event count and timestamp
  - Exporter and storage names
  - Sanitized error information (for MastraError and generic errors)
- Updated `flushCreates()` to emit drops when storage methods are unsupported or retries exhausted
- Updated `flushSpanUpdates()` to emit drops for tracing updates with proper error categorization
- Added handling for deferred updates that fail due to unsupported storage
- Corrected signal names in flush calls to match ObservabilityDropSignal enum (e.g., 'log' instead of 'logs')
- Updated mock storage constructor name in tests for consistency

### Test Coverage

Added comprehensive test cases covering:
- Drop events when create retries are exhausted
- Drop events when span update retries are exhausted
- Drop events for deferred updates that exhaust retries
- Drop events for unsupported log storage with subsequent skipped batches
- Drop events for unsupported tracing updates
- Drop events for deferred updates carried into unsupported tracing updates

All new tests verify the structure and content of emitted drop events, including error details and event counts.

## Related issue(s)

<!-- Link to the issue this addresses -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

https://claude.ai/code/session_01MXSyKec5CM3tjB7qqubQvL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR teaches the storage exporter (a tool that saves monitoring data) to tell other systems when it can't save something - either because the storage doesn't support that feature, or because it tried too many times and gave up. It also makes sure important updates don't accidentally disappear when errors happen.

## Overview

This PR adds structured drop event emission to `MastraStorageExporter`, enabling custom exporters and integrations to observe when observability events (traces, logs, metrics, scores, feedback) cannot be persisted due to unsupported storage or exhausted retries. It mirrors behavior already present in `DefaultExporter` and prevents deferred updates from being silently lost during error handling.

## Key Changes

**Drop Event Infrastructure:**
- Added `#emitDropEvent` field to store the drop-event callback from initialization options
- Implemented `sanitizeDropError()` helper to normalize errors into a structured drop event format (supports `MastraError` and generic errors)
- Implemented `emitDrop()` helper that constructs and emits `ObservabilityDropEvent` objects containing: signal type, drop reason (`unsupported-storage` or `retry-exhausted`), event count, timestamp, exporter and storage names, and sanitized error details

**Flush Logic Updates:**
- `flushCreates()`: Now typed to accept `ObservabilityDropSignal`. Emits `unsupported-storage` when storage adapter doesn't support the operation; emits `retry-exhausted` when retries are exhausted
- `flushSpanUpdates()`: Tracks deferred update count at entry to prevent loss of previously-deferred updates. For unsupported operations, clears only newly-deferred entries and emits `unsupported-storage`. For retries, re-adds combined deferred and current batch updates and emits `retry-exhausted`
- Signal name corrections: Changed plural signal names (e.g., `logs`) to singular (e.g., `log`) to match `ObservabilityDropSignal` enum
- `flushBuffer()`: Remaining deferred updates after trace flush attempts are now either cleared with `unsupported-storage` drop or re-added with `retry-exhausted` drop (instead of unconditionally re-adding)

**Deferred Update Preservation:**
- Both `MastraStorageExporter` and `DefaultExporter` now preserve previously-deferred updates when "not implemented" storage failures occur, only removing the newly-deferred entries from the current flush attempt. This prevents double-adding and silent data loss

## Test Coverage

Added comprehensive test assertions for:
- Drop events with `reason: 'retry-exhausted'` when batch span creation, span updates, or deferred updates exhaust `maxRetries`
- Drop events with `reason: 'unsupported-storage'` when storage adapter rejects operations (log batch creation, tracing updates, deferred tracing updates)
- Aggregated drop counts for multiple affected updates (e.g., `count: 2` for combined current batch and deferred entries)
- Preservation of deferred update records across transient flush failures
- Mock storage constructor name updates and corresponding expected metadata during initialization

## Impact

- Custom exporters and integrations can now react to dropped events (e.g., logging, alerting, alternative persistence paths)
- Observability data integrity is improved by preventing silent loss of deferred updates during error conditions
- Consistent behavior between `MastraStorageExporter` and `DefaultExporter` regarding drop event notifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->