### PR TITLE
fix date-fns fixed import

### DIFF
--- a/e2e-tests/monorepo/template/apps/custom/package.json
+++ b/e2e-tests/monorepo/template/apps/custom/package.json
@@ -17,7 +17,7 @@
     "@mastra/core": "monorepo-test",
     "@inner/inner-tools": "workspace:*",
     "@inner/hello-world": "workspace:*",
-    "date-fns": "^4.1.0",
+    "date-fns": "2.30.0",
     "lodash": "^4.18.1",
     "hono": "^4.12.14",
     "unicorn-magic": "0.4.0",

--- a/renovate.json
+++ b/renovate.json
@@ -33,7 +33,15 @@
     "schedule": ["before 6am on wednesday"],
     "automerge": true
   },
-  "ignorePaths": ["docs/**", "explorations/**", ".github/scripts", "templates/**", "**/examples/**", "**/_examples/**", "e2e-tests/**/template/package.json"],
+  "ignorePaths": [
+    "docs/**",
+    "explorations/**",
+    ".github/scripts",
+    "templates/**",
+    "**/examples/**",
+    "**/_examples/**",
+    "e2e-tests/**/template/package.json"
+  ],
   "packageRules": [
     {
       "matchDepTypes": ["engines"],

--- a/renovate.json
+++ b/renovate.json
@@ -120,6 +120,7 @@
       "commitMessageTopic": "e2e-tests",
       "matchFileNames": ["e2e-tests/**/package.json"],
       "matchDepTypes": ["dependencies", "devDependencies"],
+      "ignoreDeps": ["date-fns"],
       "dependencyDashboardApproval": false,
       "automerge": true
     },

--- a/renovate.json
+++ b/renovate.json
@@ -33,7 +33,7 @@
     "schedule": ["before 6am on wednesday"],
     "automerge": true
   },
-  "ignorePaths": ["docs/**", "explorations/**", ".github/scripts", "templates/**", "**/examples/**", "**/_examples/**"],
+  "ignorePaths": ["docs/**", "explorations/**", ".github/scripts", "templates/**", "**/examples/**", "**/_examples/**", "e2e-tests/**/template/package.json"],
   "packageRules": [
     {
       "matchDepTypes": ["engines"],
@@ -120,7 +120,6 @@
       "commitMessageTopic": "e2e-tests",
       "matchFileNames": ["e2e-tests/**/package.json"],
       "matchDepTypes": ["dependencies", "devDependencies"],
-      "ignoreDeps": ["date-fns"],
       "dependencyDashboardApproval": false,
       "automerge": true
     },


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->
Add fixed version of date-fns to test bundling issue. THis got lost with renovate

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR pins the date-fns library to a specific version so tests use the exact code needed to reproduce a bundling issue, and tells the automated updater to stop changing that template package.json so the pinned version stays in place.

## Changes

### package.json Update
- e2e-tests/monorepo/template/apps/custom/package.json: changed `date-fns` from `^4.1.0` to the fixed version `2.30.0`.

### Renovate Configuration
- renovate.json: added `e2e-tests/**/template/package.json` to the `ignorePaths` list so Renovate will ignore that template package.json going forward.

## Context
- A previous Renovate update removed the fixed import/version; this PR restores the pinned `date-fns` version and excludes the template package.json from Renovate to prevent future automatic updates that could reintroduce the issue.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->