### PR TITLE
fix postgres pool

### DIFF
--- a/packages/memory/integration-tests/src/shared/with-pg-storage.ts
+++ b/packages/memory/integration-tests/src/shared/with-pg-storage.ts
@@ -161,8 +161,6 @@ export function getPgStorageTests(connectionString: string) {
   // Track all PG pools created during tests so they can be closed before Docker teardown
   const allStorages: PostgresStore[] = [];
   const allVectors: PgVector[] = [];
-  const storesToClose: PostgresStore[] = [];
-  const vectorsToClose: PgVector[] = [];
 
   afterAll(async () => {
     // Close every PG pool we opened so the container can shut down cleanly
@@ -182,8 +180,6 @@ export function getPgStorageTests(connectionString: string) {
         ...config,
         ...poolLimits,
       });
-      storesToClose.push(storage);
-
       // The stores.memory should be defined immediately after construction
       expect(storage.stores).toBeDefined();
       expect(storage.stores.memory).toBeDefined();
@@ -198,8 +194,9 @@ export function getPgStorageTests(connectionString: string) {
     const storage = new PostgresStore({
       id: randomUUID(),
       ...config,
+      ...poolLimits,
     });
-    const vector = new PgVector({ connectionString, id: 'test-vector' });
+    const vector = new PgVector({ connectionString, id: 'test-vector', ...poolLimits });
     allStorages.push(storage);
     allVectors.push(vector);
 
@@ -220,17 +217,13 @@ export function getPgStorageTests(connectionString: string) {
     };
   });
 
-  const integrationStorage = new PostgresStore({ id: randomUUID(), ...config, ...poolLimits });
-  const integrationVector = new PgVector({ connectionString, id: 'test-vector', ...poolLimits });
-  storesToClose.push(integrationStorage);
-  vectorsToClose.push(integrationVector);
-
   describe('Memory with PostgresStore Integration', () => {
     const integrationStorage = new PostgresStore({
       id: randomUUID(),
       ...config,
+      ...poolLimits,
     });
-    const integrationVector = new PgVector({ connectionString, id: 'test-vector' });
+    const integrationVector = new PgVector({ connectionString, id: 'test-vector', ...poolLimits });
     allStorages.push(integrationStorage);
     allVectors.push(integrationVector);
 
@@ -662,8 +655,8 @@ export function getPgStorageTests(connectionString: string) {
     describe('PostgreSQL Vector Index Configuration', () => {
       it('should support HNSW index configuration', async () => {
         const hnswMemory = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID() }),
-          vector: new PgVector({ connectionString, id: 'test-vector' }),
+          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
             lastMessages: 5,
@@ -718,8 +711,8 @@ export function getPgStorageTests(connectionString: string) {
 
       it('should support IVFFlat index configuration with custom lists', async () => {
         const ivfflatMemory = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID() }),
-          vector: new PgVector({ connectionString, id: 'test-vector' }),
+          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
             lastMessages: 5,
@@ -773,8 +766,8 @@ export function getPgStorageTests(connectionString: string) {
 
       it('should support flat (no index) configuration', async () => {
         const flatMemory = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID() }),
-          vector: new PgVector({ connectionString, id: 'test-vector' }),
+          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
             lastMessages: 5,
@@ -826,8 +819,8 @@ export function getPgStorageTests(connectionString: string) {
       it('should handle index configuration changes', async () => {
         // Start with IVFFlat
         const memory1 = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID() }),
-          vector: new PgVector({ connectionString, id: 'test-vector' }),
+          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
             semanticRecall: {
@@ -861,8 +854,8 @@ export function getPgStorageTests(connectionString: string) {
 
         // Now switch to HNSW - should trigger index recreation
         const memory2 = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID() }),
-          vector: new PgVector({ connectionString, id: 'test-vector' }),
+          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
             semanticRecall: {
@@ -902,8 +895,8 @@ export function getPgStorageTests(connectionString: string) {
       it('should preserve existing index when no config provided', async () => {
         // First, create with HNSW
         const memory1 = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID() }),
-          vector: new PgVector({ connectionString, id: 'test-vector' }),
+          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
             semanticRecall: {
@@ -938,8 +931,8 @@ export function getPgStorageTests(connectionString: string) {
 
         // Create another memory instance without index config - should preserve HNSW
         const memory2 = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID() }),
-          vector: new PgVector({ connectionString, id: 'test-vector' }),
+          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
             semanticRecall: {
@@ -1229,7 +1222,7 @@ CRITICAL RULES:
         // This breaks conversation history for any thread that exceeds lastMessages.
 
         const memoryWithLimit = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID() }),
+          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
           options: {
             lastMessages: 3, // Limit to 3 messages
           },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When running tests with a PostgreSQL database, the system was trying to create too many connections at once (like too many people trying to log in simultaneously), which caused tests to fail. This PR fixes that by setting a limit on how many connections the tests can create at the same time - kind of like saying "only 2 people can log in at once" - and making sure all these connections are properly cleaned up when tests finish.

## Summary

This PR updates the PostgreSQL integration test setup to prevent "too many clients" connection failures by implementing consistent connection pool limits across all test instances.

### Key Changes

**Pool Limit Configuration**: Introduced `poolLimits` constant (`max: 2, idleTimeoutMillis: 5000`) that is now applied to all `PostgresStore` and `PgVector` instances created during tests, ensuring no test exceeds the configured connection limits.

**Centralized Resource Tracking**: Replaced individual test-level cleanup arrays with test-suite-level `allStorages` and `allVectors` arrays. These collections track all database instances created during the test run, with an `afterAll` hook that properly closes all connections before Docker container teardown.

**Helper Function Addition**: Added `createMemoryWithCleanup()` utility function that wraps `Memory` instance creation and automatically registers cleanup handlers via `onTestFinished()`. This simplifies individual test cleanup and ensures `PostgresStore.close()` and `PgVector.disconnect()` are called for each memory instance.

**Consistent Pool Wiring**: Applied the pool limits across:
- Initial "stores initialization" test for `PostgresStore` instantiation
- Reusable test setup used by multiple test suites
- "Memory with PostgresStore Integration" suite and all its sub-suites (Thread Operations, Message Operations, Semantic Search, Pagination Bug tests)
- All PostgreSQL Vector Index Configuration tests (HNSW, IVFFlat, flat, index configuration changes, preserving existing index behavior)
- Standalone "lastMessages should return newest messages" regression test

### No API Changes

No exported API signatures were modified. All changes are internal to the test infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->