### PR TITLE
fix(openai-realtime): support output audio events

### DIFF
--- a/.changeset/afraid-monkeys-buy.md
+++ b/.changeset/afraid-monkeys-buy.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-openai-realtime': patch
+---
+
+Fixed OpenAI Realtime voice output streaming for current audio event names.

--- a/voice/openai-realtime-api/src/index.test.ts
+++ b/voice/openai-realtime-api/src/index.test.ts
@@ -18,11 +18,13 @@ vi.mock('openai-realtime-api', () => {
 
 vi.mock('ws', () => {
   return {
-    WebSocket: vi.fn().mockImplementation(() => ({
-      send: vi.fn(),
-      close: vi.fn(),
-      on: vi.fn(),
-    })),
+    WebSocket: vi.fn().mockImplementation(function () {
+      return {
+        send: vi.fn(),
+        close: vi.fn(),
+        on: vi.fn(),
+      };
+    }),
   };
 });
 
@@ -104,6 +106,121 @@ describe('OpenAIRealtimeVoice', () => {
       (voice as any).emit('speak', 'test');
 
       expect(mockCallback).not.toHaveBeenCalled();
+    });
+
+    it('should handle current OpenAI output audio events', async () => {
+      let handleMessage: ((message: Buffer) => void) | undefined;
+      (voice as any).ws = {
+        on: vi.fn((event, callback) => {
+          if (event === 'message') handleMessage = callback;
+        }),
+        close: vi.fn(),
+      };
+
+      const speakingCallback = vi.fn();
+      const speakingDoneCallback = vi.fn();
+      let speakerStream: NodeJS.ReadableStream | undefined;
+      voice.on('speaking', speakingCallback);
+      voice.on('speaking.done', speakingDoneCallback);
+      voice.on('speaker', stream => {
+        speakerStream = stream;
+      });
+      (voice as any).setupEventListeners();
+
+      handleMessage?.(
+        Buffer.from(
+          JSON.stringify({
+            type: 'response.created',
+            response: { id: 'response_123' },
+          }),
+        ),
+      );
+
+      const audio = Buffer.from('audio data');
+      const streamChunks: Buffer[] = [];
+      speakerStream?.on('data', chunk => {
+        streamChunks.push(chunk);
+      });
+      const streamEnded = new Promise(resolve => {
+        speakerStream?.on('end', resolve);
+      });
+      handleMessage?.(
+        Buffer.from(
+          JSON.stringify({
+            type: 'response.output_audio.delta',
+            response_id: 'response_123',
+            item_id: 'item_123',
+            content_index: 0,
+            output_index: 0,
+            delta: audio.toString('base64'),
+          }),
+        ),
+      );
+      handleMessage?.(
+        Buffer.from(
+          JSON.stringify({
+            type: 'response.output_audio.done',
+            response_id: 'response_123',
+            item_id: 'item_123',
+            content_index: 0,
+            output_index: 0,
+          }),
+        ),
+      );
+
+      expect(speakingCallback).toHaveBeenCalledWith({ audio, response_id: 'response_123' });
+      expect(speakingDoneCallback).toHaveBeenCalledWith({ response_id: 'response_123' });
+      await streamEnded;
+      expect(Buffer.concat(streamChunks)).toEqual(audio);
+    });
+
+    it('should handle current OpenAI output audio transcript events', () => {
+      let handleMessage: ((message: Buffer) => void) | undefined;
+      (voice as any).ws = {
+        on: vi.fn((event, callback) => {
+          if (event === 'message') handleMessage = callback;
+        }),
+        close: vi.fn(),
+      };
+
+      const writingCallback = vi.fn();
+      voice.on('writing', writingCallback);
+      (voice as any).setupEventListeners();
+
+      handleMessage?.(
+        Buffer.from(
+          JSON.stringify({
+            type: 'response.output_audio_transcript.delta',
+            response_id: 'response_123',
+            item_id: 'item_123',
+            content_index: 0,
+            output_index: 0,
+            delta: 'Hello',
+          }),
+        ),
+      );
+      handleMessage?.(
+        Buffer.from(
+          JSON.stringify({
+            type: 'response.output_audio_transcript.done',
+            response_id: 'response_123',
+            item_id: 'item_123',
+            content_index: 0,
+            output_index: 0,
+          }),
+        ),
+      );
+
+      expect(writingCallback).toHaveBeenNthCalledWith(1, {
+        text: 'Hello',
+        response_id: 'response_123',
+        role: 'assistant',
+      });
+      expect(writingCallback).toHaveBeenNthCalledWith(2, {
+        text: '\n',
+        response_id: 'response_123',
+        role: 'assistant',
+      });
     });
   });
 });

--- a/voice/openai-realtime-api/src/index.ts
+++ b/voice/openai-realtime-api/src/index.ts
@@ -73,6 +73,10 @@ type RealtimeClientServerEventMap = {
 } & {
   ['conversation.item.input_audio_transcription.delta']: [{ delta: string; response_id: string }];
   ['conversation.item.input_audio_transcription.done']: [{ response_id: string }];
+  ['response.output_audio.delta']: [{ delta: string; response_id: string }];
+  ['response.output_audio.done']: [{ response_id: string }];
+  ['response.output_audio_transcript.delta']: [{ delta: string; response_id: string }];
+  ['response.output_audio_transcript.done']: [{ response_id: string }];
 };
 
 /**
@@ -588,25 +592,33 @@ export class OpenAIRealtimeVoice extends MastraVoice {
     this.client.on('conversation.item.input_audio_transcription.done', ev => {
       this.emit('writing', { text: '\n', response_id: ev.response_id, role: 'user' });
     });
-    this.client.on('response.audio.delta', ev => {
+    const handleAudioDelta = (ev: { delta: string; response_id: string }) => {
       const audio = Buffer.from(ev.delta, 'base64');
       this.emit('speaking', { audio, response_id: ev.response_id });
 
       const stream = speakerStreams.get(ev.response_id);
       stream?.write(audio);
-    });
-    this.client.on('response.audio.done', ev => {
+    };
+    const handleAudioDone = (ev: { response_id: string }) => {
       this.emit('speaking.done', { response_id: ev.response_id });
 
       const stream = speakerStreams.get(ev.response_id);
       stream?.end();
-    });
-    this.client.on('response.audio_transcript.delta', ev => {
+    };
+    const handleAudioTranscriptDelta = (ev: { delta: string; response_id: string }) => {
       this.emit('writing', { text: ev.delta, response_id: ev.response_id, role: 'assistant' });
-    });
-    this.client.on('response.audio_transcript.done', ev => {
+    };
+    const handleAudioTranscriptDone = (ev: { response_id: string }) => {
       this.emit('writing', { text: '\n', response_id: ev.response_id, role: 'assistant' });
-    });
+    };
+    this.client.on('response.audio.delta', handleAudioDelta);
+    this.client.on('response.output_audio.delta', handleAudioDelta);
+    this.client.on('response.audio.done', handleAudioDone);
+    this.client.on('response.output_audio.done', handleAudioDone);
+    this.client.on('response.audio_transcript.delta', handleAudioTranscriptDelta);
+    this.client.on('response.output_audio_transcript.delta', handleAudioTranscriptDelta);
+    this.client.on('response.audio_transcript.done', handleAudioTranscriptDone);
+    this.client.on('response.output_audio_transcript.done', handleAudioTranscriptDone);
     this.client.on('response.text.delta', ev => {
       this.emit('writing', { text: ev.delta, response_id: ev.response_id, role: 'assistant' });
     });


### PR DESCRIPTION
## Description

Adds support for the current OpenAI Realtime output audio event names in `OpenAIRealtimeVoice`.

The provider now handles both legacy and current event names for assistant audio and assistant audio transcripts:

- `response.audio.delta` and `response.output_audio.delta`
- `response.audio.done` and `response.output_audio.done`
- `response.audio_transcript.delta` and `response.output_audio_transcript.delta`
- `response.audio_transcript.done` and `response.output_audio_transcript.done`

This preserves existing behavior while allowing sessions that emit the current event names to continue producing Mastra `speaking`, `speaking.done`, `speaker` stream, and assistant `writing` events.

## Related issue(s)

Fixes #16762.
Related to #16697.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

OpenAI recently changed the names of some events it sends during voice conversations. This PR makes sure the OpenAI voice feature in Mastra recognizes both the old event names and the new ones, so everything continues to work properly regardless of which naming convention OpenAI uses.

## Summary

This PR fixes the `OpenAIRealtimeVoice` implementation to support both legacy and current OpenAI Realtime event names for output audio and transcript handling, ensuring proper event emission and backward compatibility.

### Changes

**Implementation (`src/index.ts`)**
- Added support for current OpenAI Realtime output audio event types (`response.output_audio.*` and `response.output_audio_transcript.*`) alongside legacy event types (`response.audio.*` and `response.audio_transcript.*`)
- Refactored event handling to use named handler functions (`handleAudioDelta`, `handleAudioDone`, `handleAudioTranscriptDelta`, `handleAudioTranscriptDone`) that can be reused for multiple event types
- Registered WebSocket listeners for both legacy and current event names, allowing both to trigger identical behavior
- Updated the TypeScript event map type to include the new event types: `response.output_audio.delta`, `response.output_audio.done`, `response.output_audio_transcript.delta`, and `response.output_audio_transcript.done`

**Tests (`src/index.test.ts`)**
- Added test case verifying that `response.output_audio.delta` and `response.output_audio.done` events trigger `speaking` and `speaking.done` callbacks and properly write audio data to the speaker stream
- Added test case verifying that `response.output_audio_transcript.delta` and `.done` events trigger `writing` callbacks with correct transcript text and metadata (response_id, role)
- Updated WebSocket mock to use explicit implementation form for better mock control

**Changelog (`.changeset/afraid-monkeys-buy.md`)**
- Documented the patch-level fix for OpenAI Realtime voice output streaming support for current audio event names

### Impact
Users relying on sessions that emit current OpenAI Realtime event names will now properly receive Mastra's `speaking`, `speaking.done`, and `writing` events, with audio data correctly written to the speaker stream. Existing sessions using legacy event names continue to work as before.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->