### PR TITLE
feat(core): add agent runs storage domain

### DIFF
--- a/.changeset/kind-hounds-take.md
+++ b/.changeset/kind-hounds-take.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added core agent run lifecycle storage interfaces and an in-memory implementation for queryable run UIs.

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -1,6 +1,7 @@
 import { MastraBase } from '../base';
 
 import type {
+  AgentRunsStorage,
   AgentsStorage,
   PromptBlocksStorage,
   ScorerDefinitionsStorage,
@@ -41,6 +42,7 @@ export type StorageDomains = {
   blobs?: BlobStore;
   backgroundTasks?: BackgroundTasksStorage;
   schedules?: SchedulesStorage;
+  agentRuns?: AgentRunsStorage;
 };
 
 /**
@@ -298,6 +300,7 @@ export class MastraCompositeStore extends MastraBase {
         backgroundTasks: resolve('backgroundTasks'),
         schedules: resolve('schedules'),
         channels: resolve('channels'),
+        agentRuns: resolve('agentRuns'),
       } as StorageDomains;
     }
     // Otherwise, subclasses set stores themselves
@@ -404,6 +407,10 @@ export class MastraCompositeStore extends MastraBase {
 
     if (this.stores?.channels) {
       initTasks.push(this.stores.channels.init());
+    }
+
+    if (this.stores?.agentRuns) {
+      initTasks.push(this.stores.agentRuns.init());
     }
 
     this.hasInitialized = Promise.all(initTasks).then(() => true);

--- a/packages/core/src/storage/domains/agent-runs/__tests__/inmemory.test.ts
+++ b/packages/core/src/storage/domains/agent-runs/__tests__/inmemory.test.ts
@@ -209,7 +209,7 @@ describe('InMemoryAgentRunsStorage', () => {
 
     // These stream-style event names are representative UI payloads, not a
     // canonical stream taxonomy. The stream package owns that vocabulary.
-    it('stores a realistic support copilot event timeline', async () => {
+    it('stores a realistic support assistant event timeline', async () => {
       await storage.appendEvents([
         makeEvent({ type: 'run-start', data: { input: 'Investigate invoice inv_123' } }),
         makeEvent({ type: 'text-start', data: { id: 'text-1' } }),

--- a/packages/core/src/storage/domains/agent-runs/__tests__/inmemory.test.ts
+++ b/packages/core/src/storage/domains/agent-runs/__tests__/inmemory.test.ts
@@ -17,6 +17,8 @@ function makeRun(overrides: Partial<AgentRun> = {}): AgentRun {
     finishedAt: null,
     error: null,
     finalMessageId: null,
+    lastEventIndex: null,
+    eventCount: 0,
     ...overrides,
   };
 }
@@ -60,7 +62,7 @@ describe('InMemoryAgentRunsStorage', () => {
       await storage.createRun(makeRun({ metadata: { nested: { value: 'original' } } }));
 
       const run = await storage.getRun('run-1');
-      run!.status = 'finished';
+      run!.status = 'completed';
       (run!.metadata!.nested as { value: string }).value = 'mutated';
 
       const stored = await storage.getRun('run-1');
@@ -128,7 +130,7 @@ describe('InMemoryAgentRunsStorage', () => {
           runId: 'run-2',
           agentId: 'agent-1',
           threadId: 'thread-2',
-          status: 'finished',
+          status: 'completed',
           updatedAt: new Date('2026-01-01T00:00:02.000Z'),
         }),
       );
@@ -136,7 +138,7 @@ describe('InMemoryAgentRunsStorage', () => {
         makeRun({
           runId: 'run-3',
           agentId: 'agent-2',
-          status: 'error',
+          status: 'failed',
           updatedAt: new Date('2026-01-01T00:00:03.000Z'),
         }),
       );
@@ -145,12 +147,21 @@ describe('InMemoryAgentRunsStorage', () => {
       expect(byAgent.total).toBe(2);
       expect(byAgent.runs.map(run => run.runId)).toEqual(['run-2', 'run-1']);
 
-      const active = await storage.listRuns({ status: ['running', 'error'] });
+      const active = await storage.listRuns({ status: ['running', 'failed'] });
       expect(active.runs.map(run => run.runId)).toEqual(['run-3', 'run-1']);
 
       const secondPage = await storage.listRuns({ orderDirection: 'asc', perPage: 1, page: 1 });
       expect(secondPage.total).toBe(3);
+      expect(secondPage.page).toBe(1);
+      expect(secondPage.perPage).toBe(1);
+      expect(secondPage.hasMore).toBe(true);
       expect(secondPage.runs.map(run => run.runId)).toEqual(['run-2']);
+
+      const allRuns = await storage.listRuns({ perPage: false });
+      expect(allRuns.total).toBe(3);
+      expect(allRuns.perPage).toBe(false);
+      expect(allRuns.hasMore).toBe(false);
+      expect(allRuns.runs).toHaveLength(3);
     });
 
     it('does not match runs missing the selected lifecycle date in date filters', async () => {
@@ -158,7 +169,7 @@ describe('InMemoryAgentRunsStorage', () => {
       await storage.createRun(
         makeRun({
           runId: 'finished',
-          status: 'finished',
+          status: 'completed',
           finishedAt: new Date('2026-01-01T00:00:05.000Z'),
         }),
       );
@@ -189,7 +200,7 @@ describe('InMemoryAgentRunsStorage', () => {
     });
 
     it('assigns monotonic indexes when appending events', async () => {
-      const first = await storage.appendEvent(makeEvent({ type: 'run-start' }));
+      const first = await storage.appendEvent(makeEvent({ type: 'start' }));
       const next = await storage.appendEvents([
         makeEvent({ type: 'step-start' }),
         makeEvent({ type: 'tool-call', data: { toolName: 'lookup' } }),
@@ -199,7 +210,7 @@ describe('InMemoryAgentRunsStorage', () => {
       expect(next.map(event => event.index)).toEqual([1, 2]);
 
       const listed = await storage.listEvents('run-1');
-      expect(listed.events.map(event => event.type)).toEqual(['run-start', 'step-start', 'tool-call']);
+      expect(listed.events.map(event => event.type)).toEqual(['start', 'step-start', 'tool-call']);
 
       const run = await storage.getRun('run-1');
       expect(run?.lastEventIndex).toBe(2);
@@ -211,7 +222,7 @@ describe('InMemoryAgentRunsStorage', () => {
     // canonical stream taxonomy. The stream package owns that vocabulary.
     it('stores a realistic support assistant event timeline', async () => {
       await storage.appendEvents([
-        makeEvent({ type: 'run-start', data: { input: 'Investigate invoice inv_123' } }),
+        makeEvent({ type: 'start', data: { input: 'Investigate invoice inv_123' } }),
         makeEvent({ type: 'text-start', data: { id: 'text-1' } }),
         makeEvent({
           type: 'text-delta',
@@ -231,7 +242,7 @@ describe('InMemoryAgentRunsStorage', () => {
           type: 'tool-call-approval',
           data: { toolCallId: 'call-2', toolName: 'issueRefund', args: { amount: 42_00 } },
         }),
-        makeEvent({ type: 'suspended', data: { reason: 'approval-required', toolCallId: 'call-2' } }),
+        makeEvent({ type: 'tool-call-suspended', data: { reason: 'approval-required', toolCallId: 'call-2' } }),
       ]);
 
       await storage.updateRun('run-1', {
@@ -251,7 +262,7 @@ describe('InMemoryAgentRunsStorage', () => {
         'tool-call',
         'tool-result',
         'tool-call-approval',
-        'suspended',
+        'tool-call-suspended',
       ]);
 
       const run = await storage.getRun('run-1');
@@ -263,7 +274,7 @@ describe('InMemoryAgentRunsStorage', () => {
 
     it('stores Mastra background task and resumed run events', async () => {
       await storage.appendEvents([
-        makeEvent({ type: 'run-start' }),
+        makeEvent({ type: 'start' }),
         makeEvent({ type: 'background-task-started', data: { taskId: 'task-1', toolName: 'crawlDocs' } }),
         makeEvent({ type: 'background-task-progress', data: { taskId: 'task-1', progress: 0.5 } }),
         makeEvent({
@@ -272,17 +283,17 @@ describe('InMemoryAgentRunsStorage', () => {
         }),
         makeEvent({ type: 'background-task-resumed', data: { taskId: 'task-1' } }),
         makeEvent({ type: 'background-task-completed', data: { taskId: 'task-1', output: { pages: 12 } } }),
-        makeEvent({ type: 'resumed', data: { taskId: 'task-1' } }),
+        makeEvent({ type: 'start', data: { taskId: 'task-1', resumed: true } }),
         makeEvent({ type: 'finish', data: { finishReason: 'stop', finalMessageId: 'msg-1' } }),
       ]);
 
       await storage.updateRun('run-1', {
-        status: 'finished',
+        status: 'completed',
         finishedAt: new Date('2026-01-01T00:00:10.000Z'),
         finalMessageId: 'msg-1',
       });
 
-      const backgroundEvents = await storage.listEvents('run-1', { fromIndex: 1, toIndex: 5 });
+      const backgroundEvents = await storage.listEvents('run-1', { afterIndex: 0, toIndex: 5 });
       expect(backgroundEvents.events.map(event => event.type)).toEqual([
         'background-task-started',
         'background-task-progress',
@@ -292,7 +303,7 @@ describe('InMemoryAgentRunsStorage', () => {
       ]);
 
       const run = await storage.getRun('run-1');
-      expect(run?.status).toBe('finished');
+      expect(run?.status).toBe('completed');
       expect(run?.finalMessageId).toBe('msg-1');
       expect(run?.lastEventIndex).toBe(7);
     });
@@ -324,13 +335,13 @@ describe('InMemoryAgentRunsStorage', () => {
 
     it('supports explicit indexes and tails after an index', async () => {
       await storage.appendEvents([
-        makeEvent({ type: 'run-start', index: 5 }),
+        makeEvent({ type: 'start', index: 0 }),
         makeEvent({ type: 'step-start' }),
         makeEvent({ type: 'finish' }),
       ]);
 
-      const listed = await storage.listEvents('run-1', { afterIndex: 5 });
-      expect(listed.events.map(event => event.index)).toEqual([6, 7]);
+      const listed = await storage.listEvents('run-1', { afterIndex: 0 });
+      expect(listed.events.map(event => event.index)).toEqual([1, 2]);
     });
 
     it('does not move aggregate updatedAt backwards when appending older events', async () => {
@@ -344,26 +355,26 @@ describe('InMemoryAgentRunsStorage', () => {
     });
 
     it('throws on duplicate event indexes without partial writes', async () => {
-      await storage.appendEvent(makeEvent({ index: 1 }));
+      await storage.appendEvent(makeEvent({ index: 0 }));
 
       await expect(
         storage.appendEvents([makeEvent({ index: 2, type: 'step-start' }), makeEvent({ index: 1, type: 'finish' })]),
-      ).rejects.toThrow('Agent run event already exists');
+      ).rejects.toThrow('Agent run event index must be contiguous');
 
       const listed = await storage.listEvents('run-1');
-      expect(listed.events.map(event => event.index)).toEqual([1]);
+      expect(listed.events.map(event => event.index)).toEqual([0]);
     });
 
     it('lists events by range, limit, and descending order', async () => {
       await storage.appendEvents([
-        makeEvent({ type: 'run-start' }),
+        makeEvent({ type: 'start' }),
         makeEvent({ type: 'step-start' }),
         makeEvent({ type: 'step-finish' }),
         makeEvent({ type: 'finish' }),
       ]);
 
       const listed = await storage.listEvents('run-1', {
-        fromIndex: 1,
+        afterIndex: 0,
         toIndex: 3,
         limit: 2,
         orderDirection: 'desc',
@@ -393,14 +404,14 @@ describe('InMemoryAgentRunsStorage', () => {
       await storage.createRun(
         makeRun({
           runId: 'old-finished',
-          status: 'finished',
+          status: 'completed',
           finishedAt: new Date('2026-01-01T00:00:00.000Z'),
         }),
       );
       await storage.createRun(
         makeRun({
           runId: 'new-finished',
-          status: 'finished',
+          status: 'completed',
           finishedAt: new Date('2026-01-02T00:00:00.000Z'),
         }),
       );
@@ -408,7 +419,7 @@ describe('InMemoryAgentRunsStorage', () => {
       await storage.appendEvent(makeEvent({ runId: 'old-finished' }));
 
       const deleted = await storage.deleteRuns({
-        status: 'finished',
+        status: 'completed',
         dateFilterBy: 'finishedAt',
         beforeDate: new Date('2026-01-02T00:00:00.000Z'),
       });
@@ -424,7 +435,7 @@ describe('InMemoryAgentRunsStorage', () => {
       await storage.createRun(
         makeRun({
           runId: 'finished',
-          status: 'finished',
+          status: 'completed',
           finishedAt: new Date('2026-01-01T00:00:00.000Z'),
         }),
       );

--- a/packages/core/src/storage/domains/agent-runs/__tests__/inmemory.test.ts
+++ b/packages/core/src/storage/domains/agent-runs/__tests__/inmemory.test.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { InMemoryDB } from '../../inmemory-db';
+import type { AgentRun, AgentRunEventInput } from '../base';
+import { InMemoryAgentRunsStorage } from '../inmemory';
+
+function makeRun(overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    runId: 'run-1',
+    agentId: 'agent-1',
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+    status: 'created',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    startedAt: null,
+    finishedAt: null,
+    error: null,
+    finalMessageId: null,
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<AgentRunEventInput> = {}): AgentRunEventInput {
+  return {
+    runId: 'run-1',
+    type: 'step-start',
+    data: { stepId: 'step-1' },
+    createdAt: new Date('2026-01-01T00:00:01.000Z'),
+    ...overrides,
+  };
+}
+
+describe('InMemoryAgentRunsStorage', () => {
+  let db: InMemoryDB;
+  let storage: InMemoryAgentRunsStorage;
+
+  beforeEach(() => {
+    db = new InMemoryDB();
+    storage = new InMemoryAgentRunsStorage({ db });
+  });
+
+  describe('runs', () => {
+    it('creates and retrieves a run', async () => {
+      const run = makeRun();
+
+      await storage.createRun(run);
+
+      await expect(storage.getRun('run-1')).resolves.toEqual(run);
+    });
+
+    it('throws when creating a duplicate run', async () => {
+      const run = makeRun();
+      await storage.createRun(run);
+
+      await expect(storage.createRun(run)).rejects.toThrow('Agent run already exists');
+    });
+
+    it('returns clones so callers cannot mutate stored runs', async () => {
+      await storage.createRun(makeRun({ metadata: { nested: { value: 'original' } } }));
+
+      const run = await storage.getRun('run-1');
+      run!.status = 'finished';
+      (run!.metadata!.nested as { value: string }).value = 'mutated';
+
+      const stored = await storage.getRun('run-1');
+      expect(stored!.status).toBe('created');
+      expect(stored!.metadata).toEqual({ nested: { value: 'original' } });
+    });
+
+    it('updates specific fields without replacing the whole aggregate', async () => {
+      await storage.createRun(makeRun());
+
+      const updated = await storage.updateRun('run-1', {
+        status: 'running',
+        startedAt: new Date('2026-01-01T00:00:02.000Z'),
+      });
+
+      expect(updated.status).toBe('running');
+      expect(updated.startedAt).toEqual(new Date('2026-01-01T00:00:02.000Z'));
+      expect(updated.agentId).toBe('agent-1');
+      expect(updated.threadId).toBe('thread-1');
+    });
+
+    it('stores pending tool approval state on the aggregate for reloadable UIs', async () => {
+      await storage.createRun(makeRun({ status: 'running' }));
+
+      const updated = await storage.updateRun('run-1', {
+        status: 'suspended',
+        pendingToolCalls: [
+          {
+            toolCallId: 'refund-approval-1',
+            toolName: 'issueRefund',
+            status: 'awaiting-approval',
+            args: { amount: 42_00, currency: 'USD' },
+            createdAt: new Date('2026-01-01T00:00:02.000Z'),
+          },
+        ],
+      });
+
+      expect(updated.status).toBe('suspended');
+      expect(updated.pendingToolCalls).toEqual([
+        {
+          toolCallId: 'refund-approval-1',
+          toolName: 'issueRefund',
+          status: 'awaiting-approval',
+          args: { amount: 42_00, currency: 'USD' },
+          createdAt: new Date('2026-01-01T00:00:02.000Z'),
+        },
+      ]);
+    });
+
+    it('throws when updating a missing run', async () => {
+      await expect(storage.updateRun('missing', { status: 'running' })).rejects.toThrow('Agent run not found');
+    });
+
+    it('lists runs with common UI filters and pagination', async () => {
+      await storage.createRun(
+        makeRun({
+          runId: 'run-1',
+          agentId: 'agent-1',
+          status: 'running',
+          updatedAt: new Date('2026-01-01T00:00:01.000Z'),
+        }),
+      );
+      await storage.createRun(
+        makeRun({
+          runId: 'run-2',
+          agentId: 'agent-1',
+          threadId: 'thread-2',
+          status: 'finished',
+          updatedAt: new Date('2026-01-01T00:00:02.000Z'),
+        }),
+      );
+      await storage.createRun(
+        makeRun({
+          runId: 'run-3',
+          agentId: 'agent-2',
+          status: 'error',
+          updatedAt: new Date('2026-01-01T00:00:03.000Z'),
+        }),
+      );
+
+      const byAgent = await storage.listRuns({ agentId: 'agent-1' });
+      expect(byAgent.total).toBe(2);
+      expect(byAgent.runs.map(run => run.runId)).toEqual(['run-2', 'run-1']);
+
+      const active = await storage.listRuns({ status: ['running', 'error'] });
+      expect(active.runs.map(run => run.runId)).toEqual(['run-3', 'run-1']);
+
+      const secondPage = await storage.listRuns({ orderDirection: 'asc', perPage: 1, page: 1 });
+      expect(secondPage.total).toBe(3);
+      expect(secondPage.runs.map(run => run.runId)).toEqual(['run-2']);
+    });
+
+    it('does not match runs missing the selected lifecycle date in date filters', async () => {
+      await storage.createRun(makeRun({ runId: 'unfinished', status: 'running', finishedAt: null }));
+      await storage.createRun(
+        makeRun({
+          runId: 'finished',
+          status: 'finished',
+          finishedAt: new Date('2026-01-01T00:00:05.000Z'),
+        }),
+      );
+
+      const result = await storage.listRuns({
+        dateFilterBy: 'finishedAt',
+        toDate: new Date('2026-01-01T00:00:10.000Z'),
+      });
+
+      expect(result.runs.map(run => run.runId)).toEqual(['finished']);
+    });
+
+    it('can filter runs with null thread or resource ids', async () => {
+      await storage.createRun(makeRun({ runId: 'with-thread', threadId: 'thread-1' }));
+      await storage.createRun(makeRun({ runId: 'without-thread', threadId: null, resourceId: null }));
+
+      const withoutThread = await storage.listRuns({ threadId: null });
+      expect(withoutThread.runs.map(run => run.runId)).toEqual(['without-thread']);
+
+      const withoutResource = await storage.listRuns({ resourceId: null });
+      expect(withoutResource.runs.map(run => run.runId)).toEqual(['without-thread']);
+    });
+  });
+
+  describe('events', () => {
+    beforeEach(async () => {
+      await storage.createRun(makeRun());
+    });
+
+    it('assigns monotonic indexes when appending events', async () => {
+      const first = await storage.appendEvent(makeEvent({ type: 'run-start' }));
+      const next = await storage.appendEvents([
+        makeEvent({ type: 'step-start' }),
+        makeEvent({ type: 'tool-call', data: { toolName: 'lookup' } }),
+      ]);
+
+      expect(first.index).toBe(0);
+      expect(next.map(event => event.index)).toEqual([1, 2]);
+
+      const listed = await storage.listEvents('run-1');
+      expect(listed.events.map(event => event.type)).toEqual(['run-start', 'step-start', 'tool-call']);
+
+      const run = await storage.getRun('run-1');
+      expect(run?.lastEventIndex).toBe(2);
+      expect(run?.eventCount).toBe(3);
+      expect(run?.updatedAt).toEqual(new Date('2026-01-01T00:00:01.000Z'));
+    });
+
+    // These stream-style event names are representative UI payloads, not a
+    // canonical stream taxonomy. The stream package owns that vocabulary.
+    it('stores a realistic support copilot event timeline', async () => {
+      await storage.appendEvents([
+        makeEvent({ type: 'run-start', data: { input: 'Investigate invoice inv_123' } }),
+        makeEvent({ type: 'text-start', data: { id: 'text-1' } }),
+        makeEvent({
+          type: 'text-delta',
+          data: { id: 'text-1', delta: 'I will check the invoice and payment history.' },
+        }),
+        makeEvent({ type: 'text-end', data: { id: 'text-1' } }),
+        makeEvent({ type: 'step-start', data: { stepIndex: 0 } }),
+        makeEvent({
+          type: 'tool-call',
+          data: { toolCallId: 'call-1', toolName: 'lookupInvoice', args: { invoiceId: 'inv_123' } },
+        }),
+        makeEvent({
+          type: 'tool-result',
+          data: { toolCallId: 'call-1', result: { status: 'overpaid', amount: 42_00 } },
+        }),
+        makeEvent({
+          type: 'tool-call-approval',
+          data: { toolCallId: 'call-2', toolName: 'issueRefund', args: { amount: 42_00 } },
+        }),
+        makeEvent({ type: 'suspended', data: { reason: 'approval-required', toolCallId: 'call-2' } }),
+      ]);
+
+      await storage.updateRun('run-1', {
+        status: 'suspended',
+        pendingToolCalls: [
+          {
+            toolCallId: 'call-2',
+            toolName: 'issueRefund',
+            status: 'awaiting-approval',
+            args: { amount: 42_00 },
+          },
+        ],
+      });
+
+      const events = await storage.listEvents('run-1', { afterIndex: 4 });
+      expect(events.events.map(event => event.type)).toEqual([
+        'tool-call',
+        'tool-result',
+        'tool-call-approval',
+        'suspended',
+      ]);
+
+      const run = await storage.getRun('run-1');
+      expect(run?.status).toBe('suspended');
+      expect(run?.pendingToolCalls?.[0]?.toolName).toBe('issueRefund');
+      expect(run?.lastEventIndex).toBe(8);
+      expect(run?.eventCount).toBe(9);
+    });
+
+    it('stores Mastra background task and resumed run events', async () => {
+      await storage.appendEvents([
+        makeEvent({ type: 'run-start' }),
+        makeEvent({ type: 'background-task-started', data: { taskId: 'task-1', toolName: 'crawlDocs' } }),
+        makeEvent({ type: 'background-task-progress', data: { taskId: 'task-1', progress: 0.5 } }),
+        makeEvent({
+          type: 'background-task-suspended',
+          data: { taskId: 'task-1', reason: 'waiting-for-long-running-tool' },
+        }),
+        makeEvent({ type: 'background-task-resumed', data: { taskId: 'task-1' } }),
+        makeEvent({ type: 'background-task-completed', data: { taskId: 'task-1', output: { pages: 12 } } }),
+        makeEvent({ type: 'resumed', data: { taskId: 'task-1' } }),
+        makeEvent({ type: 'finish', data: { finishReason: 'stop', finalMessageId: 'msg-1' } }),
+      ]);
+
+      await storage.updateRun('run-1', {
+        status: 'finished',
+        finishedAt: new Date('2026-01-01T00:00:10.000Z'),
+        finalMessageId: 'msg-1',
+      });
+
+      const backgroundEvents = await storage.listEvents('run-1', { fromIndex: 1, toIndex: 5 });
+      expect(backgroundEvents.events.map(event => event.type)).toEqual([
+        'background-task-started',
+        'background-task-progress',
+        'background-task-suspended',
+        'background-task-resumed',
+        'background-task-completed',
+      ]);
+
+      const run = await storage.getRun('run-1');
+      expect(run?.status).toBe('finished');
+      expect(run?.finalMessageId).toBe('msg-1');
+      expect(run?.lastEventIndex).toBe(7);
+    });
+
+    it('stores structured output, file, source, and reasoning UI events', async () => {
+      await storage.appendEvents([
+        makeEvent({ type: 'reasoning-start', data: { id: 'reasoning-1' } }),
+        makeEvent({ type: 'reasoning-delta', data: { id: 'reasoning-1', delta: 'Checking policy.' } }),
+        makeEvent({ type: 'reasoning-end', data: { id: 'reasoning-1' } }),
+        makeEvent({ type: 'source', data: { title: 'Refund policy', url: 'https://docs.example.com/refunds' } }),
+        makeEvent({ type: 'file', data: { mediaType: 'application/pdf', filename: 'invoice.pdf' } }),
+        makeEvent({ type: 'object', data: { object: { eligible: true } } }),
+        makeEvent({ type: 'object-result', data: { object: { eligible: true, amount: 42_00 } } }),
+        makeEvent({ type: 'finish', data: { finishReason: 'stop' } }),
+      ]);
+
+      const events = await storage.listEvents('run-1');
+      expect(events.events.map(event => event.type)).toEqual([
+        'reasoning-start',
+        'reasoning-delta',
+        'reasoning-end',
+        'source',
+        'file',
+        'object',
+        'object-result',
+        'finish',
+      ]);
+    });
+
+    it('supports explicit indexes and tails after an index', async () => {
+      await storage.appendEvents([
+        makeEvent({ type: 'run-start', index: 5 }),
+        makeEvent({ type: 'step-start' }),
+        makeEvent({ type: 'finish' }),
+      ]);
+
+      const listed = await storage.listEvents('run-1', { afterIndex: 5 });
+      expect(listed.events.map(event => event.index)).toEqual([6, 7]);
+    });
+
+    it('does not move aggregate updatedAt backwards when appending older events', async () => {
+      const updatedAt = new Date('2026-01-01T00:10:00.000Z');
+      await storage.updateRun('run-1', { status: 'running', updatedAt });
+
+      await storage.appendEvent(makeEvent({ createdAt: new Date('2026-01-01T00:00:01.000Z') }));
+
+      const run = await storage.getRun('run-1');
+      expect(run?.updatedAt).toEqual(updatedAt);
+    });
+
+    it('throws on duplicate event indexes without partial writes', async () => {
+      await storage.appendEvent(makeEvent({ index: 1 }));
+
+      await expect(
+        storage.appendEvents([makeEvent({ index: 2, type: 'step-start' }), makeEvent({ index: 1, type: 'finish' })]),
+      ).rejects.toThrow('Agent run event already exists');
+
+      const listed = await storage.listEvents('run-1');
+      expect(listed.events.map(event => event.index)).toEqual([1]);
+    });
+
+    it('lists events by range, limit, and descending order', async () => {
+      await storage.appendEvents([
+        makeEvent({ type: 'run-start' }),
+        makeEvent({ type: 'step-start' }),
+        makeEvent({ type: 'step-finish' }),
+        makeEvent({ type: 'finish' }),
+      ]);
+
+      const listed = await storage.listEvents('run-1', {
+        fromIndex: 1,
+        toIndex: 3,
+        limit: 2,
+        orderDirection: 'desc',
+      });
+
+      expect(listed.total).toBe(3);
+      expect(listed.events.map(event => event.index)).toEqual([3, 2]);
+    });
+
+    it('throws when appending events for a missing run', async () => {
+      await expect(storage.appendEvent(makeEvent({ runId: 'missing' }))).rejects.toThrow('Agent run not found');
+    });
+  });
+
+  describe('cleanup', () => {
+    it('deletes a run and its events', async () => {
+      await storage.createRun(makeRun());
+      await storage.appendEvent(makeEvent());
+
+      await storage.deleteRun('run-1');
+
+      await expect(storage.getRun('run-1')).resolves.toBeNull();
+      await expect(storage.listEvents('run-1')).resolves.toEqual({ events: [], total: 0 });
+    });
+
+    it('deletes runs matching a retention filter', async () => {
+      await storage.createRun(
+        makeRun({
+          runId: 'old-finished',
+          status: 'finished',
+          finishedAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      );
+      await storage.createRun(
+        makeRun({
+          runId: 'new-finished',
+          status: 'finished',
+          finishedAt: new Date('2026-01-02T00:00:00.000Z'),
+        }),
+      );
+      await storage.createRun(makeRun({ runId: 'old-running', status: 'running' }));
+      await storage.appendEvent(makeEvent({ runId: 'old-finished' }));
+
+      const deleted = await storage.deleteRuns({
+        status: 'finished',
+        dateFilterBy: 'finishedAt',
+        beforeDate: new Date('2026-01-02T00:00:00.000Z'),
+      });
+
+      expect(deleted).toBe(1);
+      expect(await storage.getRun('old-finished')).toBeNull();
+      expect((await storage.listEvents('old-finished')).total).toBe(0);
+      expect((await storage.listRuns({})).runs.map(run => run.runId)).toEqual(['new-finished', 'old-running']);
+    });
+
+    it('does not delete runs missing the selected retention date', async () => {
+      await storage.createRun(makeRun({ runId: 'unfinished', status: 'running', finishedAt: null }));
+      await storage.createRun(
+        makeRun({
+          runId: 'finished',
+          status: 'finished',
+          finishedAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      );
+
+      const deleted = await storage.deleteRuns({
+        dateFilterBy: 'finishedAt',
+        beforeDate: new Date('2026-01-02T00:00:00.000Z'),
+      });
+
+      expect(deleted).toBe(1);
+      expect(await storage.getRun('unfinished')).toMatchObject({ runId: 'unfinished', status: 'running' });
+      expect(await storage.getRun('finished')).toBeNull();
+    });
+
+    it('clears all runs and events', async () => {
+      await storage.createRun(makeRun());
+      await storage.appendEvent(makeEvent());
+
+      await storage.dangerouslyClearAll();
+
+      expect((await storage.listRuns()).total).toBe(0);
+      expect((await storage.listEvents('run-1')).total).toBe(0);
+    });
+  });
+});

--- a/packages/core/src/storage/domains/agent-runs/base.ts
+++ b/packages/core/src/storage/domains/agent-runs/base.ts
@@ -1,25 +1,17 @@
+import type { PaginationInfo } from '../../types';
 import { StorageDomain } from '../base';
 
 /** Current lifecycle state of an agent run. */
-export type AgentRunStatus = 'created' | 'running' | 'suspended' | 'finished' | 'error' | 'cancelled';
+export type AgentRunStatus = 'created' | 'running' | 'suspended' | 'completed' | 'failed' | 'canceled';
 
 /**
- * Storage-owned lifecycle events.
+ * Event type stored for a run.
  *
- * Stream chunk names such as `text-delta`, `tool-call`, `file`, or
- * `background-task-completed` can also be stored in `AgentRunEvent.type`, but
- * the stream package remains the source of truth for that vocabulary.
+ * This storage domain intentionally does not own the event taxonomy. Runtime
+ * stream chunks, durable execution events, or adapter-specific semantic events
+ * can be persisted here, but their source package remains the source of truth.
  */
-export type AgentRunLifecycleEventType =
-  | 'run-start'
-  | 'run-finish'
-  | 'run-error'
-  | 'run-suspended'
-  | 'run-resumed'
-  | 'approval-required'
-  | 'approval-resolved';
-
-export type AgentRunEventType = AgentRunLifecycleEventType | (string & {});
+export type AgentRunEventType = string & {};
 
 /** Structured error summary stored on the run aggregate. */
 export type AgentRunError = {
@@ -32,7 +24,7 @@ export type AgentRunError = {
 export type AgentRunToolCall = {
   toolCallId: string;
   toolName: string;
-  status: 'pending' | 'running' | 'awaiting-approval' | 'suspended';
+  status: 'pending' | 'running' | 'awaiting-approval' | 'suspended' | (string & {});
   args?: unknown;
   createdAt?: Date;
   updatedAt?: Date;
@@ -84,6 +76,9 @@ export type AgentRunUpdate = Partial<
   >
 >;
 
+/** Input for creating a run aggregate. Projection fields are storage-managed. */
+export type AgentRunCreateInput = Omit<AgentRun, 'lastEventIndex' | 'eventCount'>;
+
 /** Append-only event row for a run. */
 export type AgentRunEvent = {
   runId: string;
@@ -98,8 +93,9 @@ export type AgentRunEvent = {
 };
 
 /** Event write payload. Storage assigns the next per-run index when omitted. */
-export type AgentRunEventInput = Omit<AgentRunEvent, 'index'> & {
+export type AgentRunEventInput = Omit<AgentRunEvent, 'index' | 'createdAt'> & {
   index?: number;
+  createdAt?: Date;
 };
 
 /** Filter and pagination options for listing agent runs. */
@@ -116,20 +112,17 @@ export type AgentRunListFilter = {
   orderBy?: 'createdAt' | 'updatedAt' | 'startedAt' | 'finishedAt';
   orderDirection?: 'asc' | 'desc';
   page?: number;
-  perPage?: number;
+  perPage?: number | false;
 };
 
-export type AgentRunListResult = {
+export type AgentRunListResult = PaginationInfo & {
   runs: AgentRun[];
-  total: number;
 };
 
 /** Options for tailing a run's ordered event log. */
 export type AgentRunEventListOptions = {
   /** Return events with index greater than this value. */
   afterIndex?: number;
-  /** Return events with index greater than or equal to this value. */
-  fromIndex?: number;
   /** Return events with index less than or equal to this value. */
   toIndex?: number;
   limit?: number;
@@ -147,7 +140,7 @@ export type AgentRunDeleteFilter = {
   resourceId?: string | null;
   status?: AgentRunStatus | AgentRunStatus[];
   beforeDate?: Date;
-  dateFilterBy?: 'createdAt' | 'updatedAt' | 'finishedAt';
+  dateFilterBy?: 'createdAt' | 'updatedAt' | 'startedAt' | 'finishedAt';
 };
 
 /**
@@ -165,7 +158,7 @@ export abstract class AgentRunsStorage extends StorageDomain {
   }
 
   /** Insert a new run aggregate. Throws if a run with the same runId already exists. */
-  abstract createRun(run: AgentRun): Promise<AgentRun>;
+  abstract createRun(run: AgentRunCreateInput): Promise<AgentRun>;
 
   /**
    * Partially update a run aggregate. Throws if the run does not exist.

--- a/packages/core/src/storage/domains/agent-runs/base.ts
+++ b/packages/core/src/storage/domains/agent-runs/base.ts
@@ -1,0 +1,210 @@
+import { StorageDomain } from '../base';
+
+/** Current lifecycle state of an agent run. */
+export type AgentRunStatus = 'created' | 'running' | 'suspended' | 'finished' | 'error' | 'cancelled';
+
+/**
+ * Storage-owned lifecycle events.
+ *
+ * Stream chunk names such as `text-delta`, `tool-call`, `file`, or
+ * `background-task-completed` can also be stored in `AgentRunEvent.type`, but
+ * the stream package remains the source of truth for that vocabulary.
+ */
+export type AgentRunLifecycleEventType =
+  | 'run-start'
+  | 'run-finish'
+  | 'run-error'
+  | 'run-suspended'
+  | 'run-resumed'
+  | 'approval-required'
+  | 'approval-resolved';
+
+export type AgentRunEventType = AgentRunLifecycleEventType | (string & {});
+
+/** Structured error summary stored on the run aggregate. */
+export type AgentRunError = {
+  message: string;
+  code?: string;
+  stack?: string;
+  details?: unknown;
+};
+
+export type AgentRunToolCall = {
+  toolCallId: string;
+  toolName: string;
+  status: 'pending' | 'running' | 'awaiting-approval' | 'suspended';
+  args?: unknown;
+  createdAt?: Date;
+  updatedAt?: Date;
+  metadata?: Record<string, unknown>;
+};
+
+/** Compact, queryable projection of the current state for a single agent run. */
+export type AgentRun = {
+  runId: string;
+  agentId: string;
+  threadId?: string | null;
+  resourceId?: string | null;
+  status: AgentRunStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  startedAt?: Date | null;
+  finishedAt?: Date | null;
+  error?: AgentRunError | null;
+  finalMessageId?: string | null;
+  finalOutput?: unknown;
+  /**
+   * Denormalized UI state for reload/reconnect paths. The append-only event log
+   * remains the history; this field prevents reactive UIs from scanning events
+   * just to render current approvals or suspended tools.
+   */
+  pendingToolCalls?: AgentRunToolCall[];
+  /** Highest event index currently persisted for this run. Storage-managed. */
+  lastEventIndex?: number | null;
+  /** Number of events currently persisted for this run. Storage-managed. */
+  eventCount?: number;
+  metadata?: Record<string, unknown>;
+};
+
+/** Fields that can be patched on an existing run aggregate. */
+export type AgentRunUpdate = Partial<
+  Pick<
+    AgentRun,
+    | 'threadId'
+    | 'resourceId'
+    | 'status'
+    | 'updatedAt'
+    | 'startedAt'
+    | 'finishedAt'
+    | 'error'
+    | 'finalMessageId'
+    | 'finalOutput'
+    | 'pendingToolCalls'
+    | 'metadata'
+  >
+>;
+
+/** Append-only event row for a run. */
+export type AgentRunEvent = {
+  runId: string;
+  /**
+   * Monotonic per-run position. This mirrors the PubSub `Event.index` field so
+   * storage-backed UIs can tail events with the same offset vocabulary.
+   */
+  index: number;
+  type: AgentRunEventType;
+  data?: unknown;
+  createdAt: Date;
+};
+
+/** Event write payload. Storage assigns the next per-run index when omitted. */
+export type AgentRunEventInput = Omit<AgentRunEvent, 'index'> & {
+  index?: number;
+};
+
+/** Filter and pagination options for listing agent runs. */
+export type AgentRunListFilter = {
+  agentId?: string;
+  threadId?: string | null;
+  resourceId?: string | null;
+  status?: AgentRunStatus | AgentRunStatus[];
+  dateFilterBy?: 'createdAt' | 'updatedAt' | 'startedAt' | 'finishedAt';
+  /** Start of the date range, inclusive. */
+  fromDate?: Date;
+  /** End of the date range, exclusive. */
+  toDate?: Date;
+  orderBy?: 'createdAt' | 'updatedAt' | 'startedAt' | 'finishedAt';
+  orderDirection?: 'asc' | 'desc';
+  page?: number;
+  perPage?: number;
+};
+
+export type AgentRunListResult = {
+  runs: AgentRun[];
+  total: number;
+};
+
+/** Options for tailing a run's ordered event log. */
+export type AgentRunEventListOptions = {
+  /** Return events with index greater than this value. */
+  afterIndex?: number;
+  /** Return events with index greater than or equal to this value. */
+  fromIndex?: number;
+  /** Return events with index less than or equal to this value. */
+  toIndex?: number;
+  limit?: number;
+  orderDirection?: 'asc' | 'desc';
+};
+
+export type AgentRunEventListResult = {
+  events: AgentRunEvent[];
+  total: number;
+};
+
+export type AgentRunDeleteFilter = {
+  agentId?: string;
+  threadId?: string | null;
+  resourceId?: string | null;
+  status?: AgentRunStatus | AgentRunStatus[];
+  beforeDate?: Date;
+  dateFilterBy?: 'createdAt' | 'updatedAt' | 'finishedAt';
+};
+
+/**
+ * Storage domain for agent run lifecycle state.
+ *
+ * This domain is a durable, queryable projection for application UIs. It does
+ * not replace PubSub/SSE streaming or observability traces.
+ */
+export abstract class AgentRunsStorage extends StorageDomain {
+  constructor() {
+    super({
+      component: 'STORAGE',
+      name: 'AGENT_RUNS',
+    });
+  }
+
+  /** Insert a new run aggregate. Throws if a run with the same runId already exists. */
+  abstract createRun(run: AgentRun): Promise<AgentRun>;
+
+  /**
+   * Partially update a run aggregate. Throws if the run does not exist.
+   *
+   * The run ID, agent ID, last event index, and event count are storage-owned
+   * identity/projection fields and must not be patched through this method.
+   */
+  abstract updateRun(runId: string, update: AgentRunUpdate): Promise<AgentRun>;
+
+  /** Get a single run aggregate by ID. Returns null if not found. */
+  abstract getRun(runId: string): Promise<AgentRun | null>;
+
+  /** List run aggregates by common UI-facing filters. */
+  abstract listRuns(filter?: AgentRunListFilter): Promise<AgentRunListResult>;
+
+  /**
+   * Append one ordered event. Storage assigns the next per-run index when omitted.
+   *
+   * Throws if the run does not exist. Appending an older replayed event must not
+   * move the run aggregate's `updatedAt` backwards.
+   */
+  abstract appendEvent(event: AgentRunEventInput): Promise<AgentRunEvent>;
+
+  /**
+   * Append multiple ordered events for one run. Storage assigns missing per-run
+   * indexes in input order.
+   *
+   * Implementations should reject mixed-run batches and duplicate indexes
+   * without partially writing the batch. Appending older replayed events must not
+   * move the run aggregate's `updatedAt` backwards.
+   */
+  abstract appendEvents(events: AgentRunEventInput[]): Promise<AgentRunEvent[]>;
+
+  /** List ordered events for a run. */
+  abstract listEvents(runId: string, opts?: AgentRunEventListOptions): Promise<AgentRunEventListResult>;
+
+  /** Delete a run and its events. */
+  abstract deleteRun(runId: string): Promise<void>;
+
+  /** Delete runs matching a retention/cleanup filter. Returns the number of deleted runs. */
+  abstract deleteRuns(filter: AgentRunDeleteFilter): Promise<number>;
+}

--- a/packages/core/src/storage/domains/agent-runs/index.ts
+++ b/packages/core/src/storage/domains/agent-runs/index.ts
@@ -1,6 +1,7 @@
 export {
   AgentRunsStorage,
   type AgentRun,
+  type AgentRunCreateInput,
   type AgentRunDeleteFilter,
   type AgentRunError,
   type AgentRunEvent,
@@ -8,7 +9,6 @@ export {
   type AgentRunEventListOptions,
   type AgentRunEventListResult,
   type AgentRunEventType,
-  type AgentRunLifecycleEventType,
   type AgentRunListFilter,
   type AgentRunListResult,
   type AgentRunStatus,

--- a/packages/core/src/storage/domains/agent-runs/index.ts
+++ b/packages/core/src/storage/domains/agent-runs/index.ts
@@ -1,0 +1,18 @@
+export {
+  AgentRunsStorage,
+  type AgentRun,
+  type AgentRunDeleteFilter,
+  type AgentRunError,
+  type AgentRunEvent,
+  type AgentRunEventInput,
+  type AgentRunEventListOptions,
+  type AgentRunEventListResult,
+  type AgentRunEventType,
+  type AgentRunLifecycleEventType,
+  type AgentRunListFilter,
+  type AgentRunListResult,
+  type AgentRunStatus,
+  type AgentRunToolCall,
+  type AgentRunUpdate,
+} from './base';
+export { InMemoryAgentRunsStorage } from './inmemory';

--- a/packages/core/src/storage/domains/agent-runs/inmemory.ts
+++ b/packages/core/src/storage/domains/agent-runs/inmemory.ts
@@ -170,7 +170,9 @@ export class InMemoryAgentRunsStorage extends AgentRunsStorage {
     for (const event of events) {
       const index = event.index ?? nextIndex;
       if (index !== nextIndex) {
-        throw new Error(`Agent run event index must be contiguous for run ${runId}: expected ${nextIndex}, received ${index}`);
+        throw new Error(
+          `Agent run event index must be contiguous for run ${runId}: expected ${nextIndex}, received ${index}`,
+        );
       }
       if (usedIndexes.has(index)) {
         throw new Error(`Agent run event already exists for run ${runId} at index ${index}`);

--- a/packages/core/src/storage/domains/agent-runs/inmemory.ts
+++ b/packages/core/src/storage/domains/agent-runs/inmemory.ts
@@ -1,6 +1,8 @@
+import { calculatePagination, normalizePerPage } from '../../base';
 import type { InMemoryDB } from '../inmemory-db';
 import type {
   AgentRun,
+  AgentRunCreateInput,
   AgentRunDeleteFilter,
   AgentRunEvent,
   AgentRunEventInput,
@@ -46,6 +48,12 @@ function maxDate(dates: Date[]): Date | undefined {
   return new Date(Math.max(...dates.map(date => date.getTime())));
 }
 
+function assertValidPage(page: number): void {
+  if (page < 0) {
+    throw new Error('page must be >= 0');
+  }
+}
+
 export class InMemoryAgentRunsStorage extends AgentRunsStorage {
   private db: InMemoryDB;
 
@@ -59,12 +67,16 @@ export class InMemoryAgentRunsStorage extends AgentRunsStorage {
     this.db.agentRunEvents.clear();
   }
 
-  async createRun(run: AgentRun): Promise<AgentRun> {
+  async createRun(run: AgentRunCreateInput): Promise<AgentRun> {
     if (this.db.agentRuns.has(run.runId)) {
       throw new Error(`Agent run already exists: ${run.runId}`);
     }
 
-    const stored = cloneRun(run);
+    const stored = cloneRun({
+      ...run,
+      lastEventIndex: null,
+      eventCount: 0,
+    });
     this.db.agentRuns.set(run.runId, stored);
     return cloneRun(stored);
   }
@@ -75,7 +87,8 @@ export class InMemoryAgentRunsStorage extends AgentRunsStorage {
       throw new Error(`Agent run not found: ${runId}`);
     }
 
-    const updated = cloneRun({ ...existing, ...update, runId });
+    const updatedAt = maxDate([existing.updatedAt, update.updatedAt ?? new Date()]) ?? existing.updatedAt;
+    const updated = cloneRun({ ...existing, ...update, runId, updatedAt });
     this.db.agentRuns.set(runId, updated);
     return cloneRun(updated);
   }
@@ -86,6 +99,10 @@ export class InMemoryAgentRunsStorage extends AgentRunsStorage {
   }
 
   async listRuns(filter: AgentRunListFilter = {}): Promise<AgentRunListResult> {
+    const { page = 0, perPage: perPageInput } = filter;
+    assertValidPage(page);
+    const perPage = normalizePerPage(perPageInput, 100);
+
     let runs = Array.from(this.db.agentRuns.values());
 
     if (filter.agentId) {
@@ -117,14 +134,16 @@ export class InMemoryAgentRunsStorage extends AgentRunsStorage {
     });
 
     const total = runs.length;
-    if (filter.page != null && filter.perPage != null) {
-      const start = filter.page * filter.perPage;
-      runs = runs.slice(start, start + filter.perPage);
-    } else if (filter.perPage != null) {
-      runs = runs.slice(0, filter.perPage);
-    }
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+    const paginatedRuns = runs.slice(offset, offset + perPage);
 
-    return { runs: runs.map(cloneRun), total };
+    return {
+      runs: paginatedRuns.map(cloneRun),
+      total,
+      page,
+      perPage: perPageForResponse,
+      hasMore: offset + perPage < total,
+    };
   }
 
   async appendEvent(event: AgentRunEventInput): Promise<AgentRunEvent> {
@@ -150,13 +169,16 @@ export class InMemoryAgentRunsStorage extends AgentRunsStorage {
     const storedEvents: AgentRunEvent[] = [];
     for (const event of events) {
       const index = event.index ?? nextIndex;
+      if (index !== nextIndex) {
+        throw new Error(`Agent run event index must be contiguous for run ${runId}: expected ${nextIndex}, received ${index}`);
+      }
       if (usedIndexes.has(index)) {
         throw new Error(`Agent run event already exists for run ${runId} at index ${index}`);
       }
 
       usedIndexes.add(index);
       nextIndex = Math.max(nextIndex, index + 1);
-      storedEvents.push(cloneEvent({ ...event, index }));
+      storedEvents.push(cloneEvent({ ...event, index, createdAt: event.createdAt ?? new Date() }));
     }
 
     const allEvents = [...existing, ...storedEvents].sort((a, b) => a.index - b.index);
@@ -178,9 +200,6 @@ export class InMemoryAgentRunsStorage extends AgentRunsStorage {
 
     if (opts.afterIndex != null) {
       events = events.filter(event => event.index > opts.afterIndex!);
-    }
-    if (opts.fromIndex != null) {
-      events = events.filter(event => event.index >= opts.fromIndex!);
     }
     if (opts.toIndex != null) {
       events = events.filter(event => event.index <= opts.toIndex!);

--- a/packages/core/src/storage/domains/agent-runs/inmemory.ts
+++ b/packages/core/src/storage/domains/agent-runs/inmemory.ts
@@ -1,0 +1,225 @@
+import type { InMemoryDB } from '../inmemory-db';
+import type {
+  AgentRun,
+  AgentRunDeleteFilter,
+  AgentRunEvent,
+  AgentRunEventInput,
+  AgentRunEventListOptions,
+  AgentRunEventListResult,
+  AgentRunListFilter,
+  AgentRunListResult,
+  AgentRunStatus,
+  AgentRunUpdate,
+} from './base';
+import { AgentRunsStorage } from './base';
+
+function cloneValue<T>(value: T): T {
+  if (value == null) return value;
+  return structuredClone(value);
+}
+
+function cloneRun(run: AgentRun): AgentRun {
+  return cloneValue(run);
+}
+
+function cloneEvent(event: AgentRunEvent): AgentRunEvent {
+  return cloneValue(event);
+}
+
+function matchesNullable(value: string | null | undefined, filter: string | null | undefined): boolean {
+  if (filter === undefined) return true;
+  return (value ?? null) === filter;
+}
+
+function matchesStatus(status: AgentRunStatus, filter: AgentRunStatus | AgentRunStatus[] | undefined): boolean {
+  if (!filter) return true;
+  const statuses = Array.isArray(filter) ? filter : [filter];
+  return statuses.includes(status);
+}
+
+function dateValue(date: Date | null | undefined): number {
+  return date?.getTime() ?? 0;
+}
+
+function maxDate(dates: Date[]): Date | undefined {
+  if (dates.length === 0) return undefined;
+  return new Date(Math.max(...dates.map(date => date.getTime())));
+}
+
+export class InMemoryAgentRunsStorage extends AgentRunsStorage {
+  private db: InMemoryDB;
+
+  constructor({ db }: { db: InMemoryDB }) {
+    super();
+    this.db = db;
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    this.db.agentRuns.clear();
+    this.db.agentRunEvents.clear();
+  }
+
+  async createRun(run: AgentRun): Promise<AgentRun> {
+    if (this.db.agentRuns.has(run.runId)) {
+      throw new Error(`Agent run already exists: ${run.runId}`);
+    }
+
+    const stored = cloneRun(run);
+    this.db.agentRuns.set(run.runId, stored);
+    return cloneRun(stored);
+  }
+
+  async updateRun(runId: string, update: AgentRunUpdate): Promise<AgentRun> {
+    const existing = this.db.agentRuns.get(runId);
+    if (!existing) {
+      throw new Error(`Agent run not found: ${runId}`);
+    }
+
+    const updated = cloneRun({ ...existing, ...update, runId });
+    this.db.agentRuns.set(runId, updated);
+    return cloneRun(updated);
+  }
+
+  async getRun(runId: string): Promise<AgentRun | null> {
+    const run = this.db.agentRuns.get(runId);
+    return run ? cloneRun(run) : null;
+  }
+
+  async listRuns(filter: AgentRunListFilter = {}): Promise<AgentRunListResult> {
+    let runs = Array.from(this.db.agentRuns.values());
+
+    if (filter.agentId) {
+      runs = runs.filter(run => run.agentId === filter.agentId);
+    }
+    runs = runs.filter(run => matchesNullable(run.threadId, filter.threadId));
+    runs = runs.filter(run => matchesNullable(run.resourceId, filter.resourceId));
+    runs = runs.filter(run => matchesStatus(run.status, filter.status));
+
+    const dateField = filter.dateFilterBy ?? 'createdAt';
+    if (filter.fromDate) {
+      runs = runs.filter(run => {
+        const value = run[dateField];
+        return value != null && value >= filter.fromDate!;
+      });
+    }
+    if (filter.toDate) {
+      runs = runs.filter(run => {
+        const value = run[dateField];
+        return value != null && value < filter.toDate!;
+      });
+    }
+
+    const orderBy = filter.orderBy ?? 'updatedAt';
+    const direction = filter.orderDirection ?? 'desc';
+    runs.sort((a, b) => {
+      const diff = dateValue(a[orderBy]) - dateValue(b[orderBy]);
+      return direction === 'asc' ? diff : -diff;
+    });
+
+    const total = runs.length;
+    if (filter.page != null && filter.perPage != null) {
+      const start = filter.page * filter.perPage;
+      runs = runs.slice(start, start + filter.perPage);
+    } else if (filter.perPage != null) {
+      runs = runs.slice(0, filter.perPage);
+    }
+
+    return { runs: runs.map(cloneRun), total };
+  }
+
+  async appendEvent(event: AgentRunEventInput): Promise<AgentRunEvent> {
+    const [stored] = await this.appendEvents([event]);
+    return stored!;
+  }
+
+  async appendEvents(events: AgentRunEventInput[]): Promise<AgentRunEvent[]> {
+    if (events.length === 0) return [];
+
+    const runId = events[0]!.runId;
+    if (!this.db.agentRuns.has(runId)) {
+      throw new Error(`Agent run not found: ${runId}`);
+    }
+    if (events.some(event => event.runId !== runId)) {
+      throw new Error('appendEvents only supports one runId per call');
+    }
+
+    const existing = this.db.agentRunEvents.get(runId) ?? [];
+    const usedIndexes = new Set(existing.map(event => event.index));
+    let nextIndex = existing.reduce((max, event) => Math.max(max, event.index), -1) + 1;
+
+    const storedEvents: AgentRunEvent[] = [];
+    for (const event of events) {
+      const index = event.index ?? nextIndex;
+      if (usedIndexes.has(index)) {
+        throw new Error(`Agent run event already exists for run ${runId} at index ${index}`);
+      }
+
+      usedIndexes.add(index);
+      nextIndex = Math.max(nextIndex, index + 1);
+      storedEvents.push(cloneEvent({ ...event, index }));
+    }
+
+    const allEvents = [...existing, ...storedEvents].sort((a, b) => a.index - b.index);
+    this.db.agentRunEvents.set(runId, allEvents);
+
+    const run = this.db.agentRuns.get(runId)!;
+    this.db.agentRuns.set(runId, {
+      ...run,
+      updatedAt: maxDate([run.updatedAt, ...storedEvents.map(event => event.createdAt)]) ?? run.updatedAt,
+      lastEventIndex: allEvents.at(-1)?.index ?? null,
+      eventCount: allEvents.length,
+    });
+
+    return storedEvents.map(cloneEvent);
+  }
+
+  async listEvents(runId: string, opts: AgentRunEventListOptions = {}): Promise<AgentRunEventListResult> {
+    let events = [...(this.db.agentRunEvents.get(runId) ?? [])];
+
+    if (opts.afterIndex != null) {
+      events = events.filter(event => event.index > opts.afterIndex!);
+    }
+    if (opts.fromIndex != null) {
+      events = events.filter(event => event.index >= opts.fromIndex!);
+    }
+    if (opts.toIndex != null) {
+      events = events.filter(event => event.index <= opts.toIndex!);
+    }
+
+    const direction = opts.orderDirection ?? 'asc';
+    events.sort((a, b) => (direction === 'asc' ? a.index - b.index : b.index - a.index));
+
+    const total = events.length;
+    if (opts.limit != null) {
+      events = events.slice(0, opts.limit);
+    }
+
+    return { events: events.map(cloneEvent), total };
+  }
+
+  async deleteRun(runId: string): Promise<void> {
+    this.db.agentRuns.delete(runId);
+    this.db.agentRunEvents.delete(runId);
+  }
+
+  async deleteRuns(filter: AgentRunDeleteFilter): Promise<number> {
+    const dateField = filter.dateFilterBy ?? 'updatedAt';
+    const runs = Array.from(this.db.agentRuns.values()).filter(run => {
+      if (filter.agentId && run.agentId !== filter.agentId) return false;
+      if (!matchesNullable(run.threadId, filter.threadId)) return false;
+      if (!matchesNullable(run.resourceId, filter.resourceId)) return false;
+      if (!matchesStatus(run.status, filter.status)) return false;
+      if (filter.beforeDate) {
+        const value = run[dateField];
+        if (value == null || value >= filter.beforeDate) return false;
+      }
+      return true;
+    });
+
+    for (const run of runs) {
+      await this.deleteRun(run.runId);
+    }
+
+    return runs.length;
+  }
+}

--- a/packages/core/src/storage/domains/index.ts
+++ b/packages/core/src/storage/domains/index.ts
@@ -1,5 +1,6 @@
 export * from './base';
 export * from './versioned';
+export * from './agent-runs';
 export * from './agents';
 export * from './channels';
 export * from './prompt-blocks';
@@ -20,5 +21,4 @@ export * from './shared';
 export * from './datasets';
 export * from './experiments';
 export * from './background-tasks';
-export * from './schedules';
 export * from './schedules';

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -21,6 +21,7 @@ import type {
   ExperimentResult,
 } from '../types';
 import type { AgentVersion } from './agents';
+import type { AgentRun, AgentRunEvent } from './agent-runs';
 import type { MCPClientVersion } from './mcp-clients';
 import type { MCPServerVersion } from './mcp-servers';
 import type { TraceEntry } from './observability';
@@ -80,6 +81,8 @@ export class InMemoryDB {
    * within the same synchronous block.
    */
   readonly favorites = new Map<string, StorageFavoriteType>();
+  readonly agentRuns = new Map<string, AgentRun>();
+  readonly agentRunEvents = new Map<string, AgentRunEvent[]>();
   /** Observational memory records, keyed by resourceId, each holding array of records (generations) */
   readonly observationalMemory = new Map<string, ObservationalMemoryRecord[]>();
 
@@ -136,6 +139,8 @@ export class InMemoryDB {
     this.skills.clear();
     this.skillVersions.clear();
     this.favorites.clear();
+    this.agentRuns.clear();
+    this.agentRunEvents.clear();
     this.observationalMemory.clear();
     this.datasets.clear();
     this.datasetItems.clear();

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -20,8 +20,8 @@ import type {
   Experiment,
   ExperimentResult,
 } from '../types';
-import type { AgentVersion } from './agents';
 import type { AgentRun, AgentRunEvent } from './agent-runs';
+import type { AgentVersion } from './agents';
 import type { MCPClientVersion } from './mcp-clients';
 import type { MCPServerVersion } from './mcp-servers';
 import type { TraceEntry } from './observability';

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -1,5 +1,6 @@
 import { MastraCompositeStore } from './base';
 import type { StorageDomains } from './base';
+import { InMemoryAgentRunsStorage } from './domains/agent-runs/inmemory';
 import { InMemoryAgentsStorage } from './domains/agents/inmemory';
 import { BackgroundTasksInMemory } from './domains/background-tasks/inmemory';
 import { InMemoryBlobStore } from './domains/blobs/inmemory';
@@ -76,6 +77,7 @@ export class InMemoryStore extends MastraCompositeStore {
       blobs: new InMemoryBlobStore(),
       backgroundTasks: new BackgroundTasksInMemory({ db: this.#db }),
       schedules: new InMemorySchedulesStorage({ db: this.#db }),
+      agentRuns: new InMemoryAgentRunsStorage({ db: this.#db }),
     };
   }
 


### PR DESCRIPTION
## Description

Adds a core `agentRuns` storage domain as the first step toward storage-backed agent run state for queryable/reactive UIs.

This PR intentionally keeps the scope core-only:
- adds `AgentRunsStorage` for run aggregates and ordered run events
- wires the domain into `StorageDomains`, `MastraCompositeStore`, and `InMemoryStore`
- keeps PubSub/SSE streaming and observability untouched
- leaves runtime persistence, server routes, docs, and adapter support such as Convex for follow-up PRs

The event type only owns storage lifecycle events. Stream chunk names can still be stored as event types, but the stream package remains the source of truth for that vocabulary.

Next steps after this merges:
- Wire agent runtime/stream events into `agentRuns` behind a persistence policy.
- Add batching/compaction so text deltas do not become token-level storage writes by default.
- Add server/query surfaces for reading run state and ordered events.
- Implement the Convex adapter with native tables, indexes, and reactive query helpers.
- Add docs once runtime persistence and at least one durable adapter are available.

Validation:
- `pnpm --filter ./packages/core exec vitest run src/storage/domains/agent-runs/__tests__/inmemory.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm build:core`

## Related issue(s)

Part of #16761.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a built-in place to store each "agent run" and its ordered timeline of events so UIs can query and display what an agent did and when. It provides an abstract storage API and a full in-memory implementation for testing/local use; durable adapters, server wiring, and docs come later.

## Overview
Introduces a new core storage domain, agentRuns, to hold denormalized run projections and ordered per-run events to enable queryable/reactive run UIs. Adds domain types and an abstract storage interface, a comprehensive in-memory implementation wired into composite and mock/in-memory stores, and extensive tests. Runtime persistence, server routes, external adapters, batching/compaction, and docs are deferred to follow-ups.

## Key Changes

- New storage domain and API
  - packages/core/src/storage/domains/agent-runs/base.ts
    - New exported types: AgentRunStatus, AgentRunEventType, AgentRunError, AgentRunToolCall, AgentRun, AgentRunUpdate, AgentRunCreateInput, AgentRunEvent, AgentRunEventInput, AgentRunListFilter, AgentRunListResult, AgentRunEventListOptions, AgentRunEventListResult, AgentRunDeleteFilter
    - New abstract class AgentRunsStorage with methods: createRun, updateRun, getRun, listRuns, appendEvent, appendEvents, listEvents, deleteRun, deleteRuns

- In-memory implementation
  - packages/core/src/storage/domains/agent-runs/inmemory.ts
    - InMemoryAgentRunsStorage backed by InMemoryDB with defensive deep-cloning
    - Full run lifecycle: create (uniqueness), update (updatedAt maxing), get (null on miss), delete (removes run + events)
    - listRuns: filter by agentId, nullable threadId/resourceId, single/multi status, date-range on selectable date field; supports sorting and pagination
    - appendEvents/appendEvent: single-run-per-call, errors if run missing, assigns monotonic per-run indexes when omitted, rejects duplicate/non-contiguous indexes, sorts events, updates run metadata (updatedAt, lastEventIndex, eventCount)
    - listEvents: supports after/from/to index filters, limit, sort direction, returns total before limiting
    - deleteRuns: filtered/retention deletes and returns count
    - dangerouslyClearAll for testing

- Integration into core storage
  - packages/core/src/storage/base.ts
    - StorageDomains type now optionally includes agentRuns?: AgentRunsStorage
    - MastraCompositeStore conditionally composes/initializes agentRuns alongside other domains
  - packages/core/src/storage/domains/inmemory-db.ts
    - InMemoryDB adds agentRuns: Map<string, AgentRun> and agentRunEvents: Map<string, AgentRunEvent[]>, cleared by clear()
  - packages/core/src/storage/mock.ts
    - InMemoryStore (MockStore) wired to expose agentRuns via InMemoryAgentRunsStorage
  - packages/core/src/storage/domains/index.ts
    - Re-exports agent-runs barrel (export ordering around schedules adjusted)

- Tests and changeset
  - packages/core/src/storage/domains/agent-runs/__tests__/inmemory.test.ts
    - Comprehensive tests covering run lifecycle, defensive cloning, partial updates, pendingToolCalls persistence, listRuns filtering/pagination/sorting, event semantics (index assignment, deduplication, ordering, range queries, updatedAt invariants), and cleanup (single deletes, retention deletes, clear)
  - .changeset/kind-hounds-take.md
    - Marks `@mastra/core` for a minor release and notes inclusion of core agent run lifecycle storage interfaces and in-memory implementation

## Validation
Referenced commands used by author for validation:
- pnpm --filter ./packages/core exec vitest run src/storage/domains/agent-runs/__tests__/inmemory.test.ts
- pnpm --filter ./packages/core check
- pnpm build:core

## Notes & Scope
- PubSub/SSE streaming and observability are unchanged.
- This domain stores run lifecycle projections and ordered events; the stream package remains authoritative for stream chunk naming/taxonomy.
- Deferred work: wiring runtime/stream events into agentRuns behind persistence policies, batching/compaction to avoid token-level text-delta writes, server/query surfaces for run state/events, durable adapters (e.g., Convex) with indexes/reactive helpers, and documentation once runtime persistence and at least one durable adapter exist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->