### PR TITLE
feat: agent builder frontend helpers

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -89,6 +89,7 @@
     "superjson": "^2.2.6",
     "use-debounce": "^10.1.0",
     "zod": "^3.25.0",
+    "zod-v4": "npm:zod@^4.3.6",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
@@ -109,6 +110,7 @@
     "react-grab": "^0.1.32",
     "tailwindcss": "4.2.2",
     "tw-animate-css": "^1.4.0",
+    "msw": "^2.6.0",
     "typescript": "catalog:",
     "vite": "^7.3.1"
   }

--- a/packages/playground/src/domains/agent-builder/hooks/__tests__/builder-hooks.test.tsx
+++ b/packages/playground/src/domains/agent-builder/hooks/__tests__/builder-hooks.test.tsx
@@ -1,0 +1,312 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import type { PropsWithChildren } from 'react';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getBuilderSettings = vi.fn(async () => {
+  const response = await fetch('http://localhost/api/builder/settings');
+  if (!response.ok) throw new Error('Failed to load builder settings');
+  return response.json();
+});
+
+vi.mock('@mastra/react', () => ({
+  useMastraClient: () => ({ getBuilderSettings }),
+}));
+
+import { useBuilderAgentFeatures } from '../use-builder-agent-features';
+import {
+  useBuilderModelPolicy,
+  useBuilderPickerVisibility,
+  useBuilderSettings,
+  useIsBuilderEnabled,
+} from '../use-builder-settings';
+
+const builderSettings = {
+  enabled: true,
+  features: {
+    agent: {
+      tools: true,
+      memory: true,
+      workflows: true,
+      agents: true,
+      avatarUpload: true,
+      skills: true,
+      model: true,
+      favorites: true,
+      browser: true,
+    },
+  },
+  modelPolicy: {
+    active: true,
+    allowed: [{ provider: 'openai', model: 'gpt-4o' }],
+    default: { provider: 'openai', model: 'gpt-4o' },
+  },
+  picker: {
+    visibleTools: ['tool-a', 'tool-b'],
+    visibleAgents: ['agent-a'],
+    visibleWorkflows: ['workflow-a', 'workflow-b'],
+  },
+};
+
+const server = setupServer(http.get('http://localhost/api/builder/settings', () => HttpResponse.json(builderSettings)));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+
+afterEach(() => {
+  server.resetHandlers();
+  getBuilderSettings.mockClear();
+});
+
+afterAll(() => server.close());
+
+beforeEach(() => {
+  getBuilderSettings.mockClear();
+});
+
+describe('useBuilderSettings', () => {
+  it('fetches builder settings through the Mastra client', async () => {
+    const { result } = renderHook(() => useBuilderSettings(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getBuilderSettings).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual(builderSettings);
+  });
+
+  it('does not fetch when disabled', () => {
+    const { result } = renderHook(() => useBuilderSettings({ enabled: false }), { wrapper: createWrapper() });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getBuilderSettings).not.toHaveBeenCalled();
+  });
+
+  it('returns query errors from failed settings requests', async () => {
+    server.use(
+      http.get('http://localhost/api/builder/settings', () => HttpResponse.json({ message: 'nope' }, { status: 500 })),
+    );
+
+    const { result } = renderHook(() => useBuilderSettings(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe('useIsBuilderEnabled', () => {
+  it('reports enabled when the server returns enabled true', async () => {
+    const { result } = renderHook(() => useIsBuilderEnabled(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current).toMatchObject({ isEnabled: true, error: null });
+  });
+
+  it('reports disabled for missing or false enabled values', async () => {
+    server.use(http.get('http://localhost/api/builder/settings', () => HttpResponse.json({ enabled: false })));
+
+    const { result, rerender } = renderHook(() => useIsBuilderEnabled(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isEnabled).toBe(false);
+
+    server.use(http.get('http://localhost/api/builder/settings', () => HttpResponse.json({})));
+    rerender();
+
+    expect(result.current.isEnabled).toBe(false);
+  });
+
+  it('exposes errors while treating the builder as disabled', async () => {
+    server.use(http.get('http://localhost/api/builder/settings', () => new HttpResponse(null, { status: 500 })));
+
+    const { result } = renderHook(() => useIsBuilderEnabled(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.isEnabled).toBe(false);
+  });
+});
+
+describe('useBuilderModelPolicy', () => {
+  it('returns the server-provided model policy', async () => {
+    const { result } = renderHook(() => useBuilderModelPolicy(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.active).toBe(true));
+
+    expect(result.current).toEqual(builderSettings.modelPolicy);
+  });
+
+  it('returns the inactive policy when the server omits modelPolicy', async () => {
+    server.use(http.get('http://localhost/api/builder/settings', () => HttpResponse.json({ enabled: true })));
+
+    const { result } = renderHook(() => useBuilderModelPolicy(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(getBuilderSettings).toHaveBeenCalledTimes(1));
+
+    expect(result.current).toEqual({ active: false });
+  });
+});
+
+describe('useBuilderPickerVisibility', () => {
+  it('returns unrestricted picker visibility before data loads and when picker is omitted', async () => {
+    server.use(http.get('http://localhost/api/builder/settings', () => HttpResponse.json({ enabled: true })));
+
+    const { result } = renderHook(() => useBuilderPickerVisibility(), { wrapper: createWrapper() });
+
+    expect(result.current).toEqual({ visibleTools: null, visibleAgents: null, visibleWorkflows: null });
+    await waitFor(() => expect(getBuilderSettings).toHaveBeenCalledTimes(1));
+    expect(result.current).toEqual({ visibleTools: null, visibleAgents: null, visibleWorkflows: null });
+  });
+
+  it('converts picker allowlists to sets and preserves null unrestricted values', async () => {
+    server.use(
+      http.get('http://localhost/api/builder/settings', () =>
+        HttpResponse.json({
+          enabled: true,
+          picker: {
+            visibleTools: null,
+            visibleAgents: ['agent-a', 'agent-b'],
+            visibleWorkflows: [],
+          },
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useBuilderPickerVisibility(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.visibleAgents).toBeInstanceOf(Set));
+
+    expect(result.current.visibleTools).toBeNull();
+    expect([...result.current.visibleAgents!]).toEqual(['agent-a', 'agent-b']);
+    expect([...result.current.visibleWorkflows!]).toEqual([]);
+  });
+
+  it('supports restricted tools with unrestricted agents and workflows', async () => {
+    server.use(
+      http.get('http://localhost/api/builder/settings', () =>
+        HttpResponse.json({
+          enabled: true,
+          picker: {
+            visibleTools: ['tool-a'],
+            visibleAgents: null,
+            visibleWorkflows: null,
+          },
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useBuilderPickerVisibility(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.visibleTools).toBeInstanceOf(Set));
+
+    expect([...result.current.visibleTools!]).toEqual(['tool-a']);
+    expect(result.current.visibleAgents).toBeNull();
+    expect(result.current.visibleWorkflows).toBeNull();
+  });
+});
+
+describe('useBuilderAgentFeatures', () => {
+  it('maps enabled agent feature flags to booleans', async () => {
+    const { result } = renderHook(() => useBuilderAgentFeatures(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.browser).toBe(true));
+
+    expect(result.current).toEqual({
+      tools: true,
+      memory: true,
+      workflows: true,
+      agents: true,
+      avatarUpload: true,
+      skills: true,
+      model: true,
+      favorites: true,
+      browser: true,
+    });
+  });
+
+  it('defaults every feature to false when settings or agent features are missing', async () => {
+    server.use(
+      http.get('http://localhost/api/builder/settings', () => HttpResponse.json({ enabled: true, features: {} })),
+    );
+
+    const { result } = renderHook(() => useBuilderAgentFeatures(), { wrapper: createWrapper() });
+
+    expect(result.current).toEqual({
+      tools: false,
+      memory: false,
+      workflows: false,
+      agents: false,
+      avatarUpload: false,
+      skills: false,
+      model: false,
+      favorites: false,
+      browser: false,
+    });
+
+    await waitFor(() => expect(getBuilderSettings).toHaveBeenCalledTimes(1));
+    expect(result.current).toEqual({
+      tools: false,
+      memory: false,
+      workflows: false,
+      agents: false,
+      avatarUpload: false,
+      skills: false,
+      model: false,
+      favorites: false,
+      browser: false,
+    });
+  });
+
+  it('treats non-true feature values as disabled', async () => {
+    server.use(
+      http.get('http://localhost/api/builder/settings', () =>
+        HttpResponse.json({
+          enabled: true,
+          features: {
+            agent: {
+              tools: false,
+              memory: 'yes',
+              workflows: 1,
+              agents: null,
+              avatarUpload: undefined,
+              skills: true,
+              model: false,
+              favorites: true,
+              browser: false,
+            },
+          },
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useBuilderAgentFeatures(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.skills).toBe(true));
+
+    expect(result.current).toEqual({
+      tools: false,
+      memory: false,
+      workflows: false,
+      agents: false,
+      avatarUpload: false,
+      skills: true,
+      model: false,
+      favorites: true,
+      browser: false,
+    });
+  });
+});

--- a/packages/playground/src/domains/agent-builder/hooks/use-builder-agent-features.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-builder-agent-features.ts
@@ -1,0 +1,18 @@
+import { useBuilderSettings } from '../hooks/use-builder-settings';
+
+export const useBuilderAgentFeatures = () => {
+  const { data } = useBuilderSettings();
+  const features = data?.features?.agent;
+
+  return {
+    tools: features?.tools === true,
+    memory: features?.memory === true,
+    workflows: features?.workflows === true,
+    agents: features?.agents === true,
+    avatarUpload: features?.avatarUpload === true,
+    skills: features?.skills === true,
+    model: features?.model === true,
+    favorites: features?.favorites === true,
+    browser: features?.browser === true,
+  };
+};

--- a/packages/playground/src/domains/agent-builder/hooks/use-builder-settings.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-builder-settings.ts
@@ -1,0 +1,89 @@
+import type { BuilderModelPolicy } from '@mastra/client-js';
+import { useMastraClient } from '@mastra/react';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+interface UseBuilderSettingsOptions {
+  enabled?: boolean;
+}
+
+/**
+ * Fetches agent builder settings from the server.
+ * Returns feature flags and configuration set by admin.
+ */
+export const useBuilderSettings = (options?: UseBuilderSettingsOptions) => {
+  const client = useMastraClient();
+
+  return useQuery({
+    queryKey: ['builder-settings'],
+    queryFn: () => client.getBuilderSettings(),
+    enabled: options?.enabled ?? true,
+  });
+};
+
+/**
+ * Returns whether the agent builder is enabled.
+ * Handles loading and error states gracefully.
+ */
+export const useIsBuilderEnabled = () => {
+  const { data, isLoading, error } = useBuilderSettings();
+
+  return {
+    isEnabled: data?.enabled === true,
+    isLoading,
+    error,
+  };
+};
+
+const INACTIVE_POLICY: BuilderModelPolicy = { active: false };
+
+/**
+ * Returns the server-derived `BuilderModelPolicy`.
+ *
+ * Thin selector — the server is the single owner of policy derivation. Callers
+ * that need to know whether the model picker is visible, what's allowed, or
+ * what the admin's default is should consume this hook directly.
+ *
+ * Defaults to `{ active: false }` while loading or when the server didn't
+ * include a `modelPolicy` field (older servers / OSS builds), so consumers
+ * can rely on `policy.active === false` as the "no admin policy" guard.
+ */
+export const useBuilderModelPolicy = (): BuilderModelPolicy => {
+  const { data } = useBuilderSettings();
+  return data?.modelPolicy ?? INACTIVE_POLICY;
+};
+
+export interface BuilderPickerVisibility {
+  /** `null` ⇒ unrestricted; `Set` ⇒ explicit allowlist (may be empty). */
+  visibleTools: Set<string> | null;
+  /** `null` ⇒ unrestricted; `Set` ⇒ explicit allowlist (may be empty). */
+  visibleAgents: Set<string> | null;
+  /** `null` ⇒ unrestricted; `Set` ⇒ explicit allowlist (may be empty). */
+  visibleWorkflows: Set<string> | null;
+}
+
+const UNRESTRICTED_PICKER: BuilderPickerVisibility = {
+  visibleTools: null,
+  visibleAgents: null,
+  visibleWorkflows: null,
+};
+
+/**
+ * Returns the server-resolved picker visibility for tools / agents / workflows.
+ *
+ * Defaults to fully unrestricted when the server didn't include a `picker`
+ * field (older servers, builder disabled). When restricted for a kind, the
+ * corresponding `visible*` Set holds the allowed IDs in admin-provided order.
+ */
+export const useBuilderPickerVisibility = (): BuilderPickerVisibility => {
+  const { data } = useBuilderSettings();
+  const picker = data?.picker;
+  return useMemo<BuilderPickerVisibility>(() => {
+    if (!picker) return UNRESTRICTED_PICKER;
+    return {
+      visibleTools: picker.visibleTools === null ? null : new Set(picker.visibleTools),
+      visibleAgents: picker.visibleAgents === null ? null : new Set(picker.visibleAgents),
+      visibleWorkflows: picker.visibleWorkflows === null ? null : new Set(picker.visibleWorkflows),
+    };
+  }, [picker]);
+};

--- a/packages/playground/src/domains/agent-builder/schemas.ts
+++ b/packages/playground/src/domains/agent-builder/schemas.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+/**
+ * Static model selection captured by the form. Mirrors `StorageModelConfig`'s
+ * core fields (`{ provider, name }`) — the form does not own conditional models;
+ * those are loaded as a read-only banner via `stored-agent-to-form-values`.
+ */
+export const AgentBuilderModelSchema = z.object({
+  provider: z.string().min(1),
+  name: z.string().min(1),
+});
+
+export const AgentBuilderEditFormSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  instructions: z.string(),
+  tools: z.record(z.string(), z.boolean()).optional(),
+  agents: z.record(z.string(), z.boolean()).optional(),
+  workflows: z.record(z.string(), z.boolean()).optional(),
+  skills: z.record(z.string(), z.boolean()).optional(),
+  workspaceId: z.string().optional(),
+  visibility: z.enum(['private', 'public']).default('private').optional(),
+  browserEnabled: z.boolean().default(false).optional(),
+  /**
+   * Selected static model. Optional — the create path's decision matrix decides
+   * whether this is required at submit time based on the admin's model policy.
+   */
+  model: AgentBuilderModelSchema.optional(),
+  avatarUrl: z.string().optional(),
+});
+
+export type AgentBuilderModel = z.infer<typeof AgentBuilderModelSchema>;
+export type AgentBuilderEditFormValues = z.infer<typeof AgentBuilderEditFormSchema>;

--- a/packages/playground/src/domains/agent-builder/services/__tests__/build-available-tool-records.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/build-available-tool-records.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { buildAvailableToolRecords } from '../build-available-tool-records';
+
+describe('buildAvailableToolRecords', () => {
+  it('extracts tool descriptions into the tools record', () => {
+    const result = buildAvailableToolRecords(
+      {
+        'tool-a': { description: 'Tool A description' },
+        'tool-b': { description: undefined },
+      },
+      {},
+    );
+
+    expect(result.tools).toEqual({
+      'tool-a': { description: 'Tool A description' },
+      'tool-b': { description: undefined },
+    });
+  });
+
+  it('builds agents records and falls back to id when name is missing', () => {
+    const result = buildAvailableToolRecords(
+      {},
+      {
+        'agent-x': { name: 'Agent X', description: 'desc' },
+        'agent-y': {},
+      },
+    );
+
+    expect(result.agents).toEqual({
+      'agent-x': { id: 'agent-x', name: 'Agent X', description: 'desc' },
+      'agent-y': { id: 'agent-y', name: 'agent-y', description: undefined },
+    });
+  });
+
+  it('excludes the agent matching excludeAgentId from the agents record', () => {
+    const result = buildAvailableToolRecords(
+      {},
+      {
+        'agent-self': { name: 'Self' },
+        'agent-other': { name: 'Other' },
+      },
+      {},
+      'agent-self',
+    );
+
+    expect(result.agents).toEqual({
+      'agent-other': { id: 'agent-other', name: 'Other', description: undefined },
+    });
+  });
+
+  it('builds workflows record and falls back to id when name is missing', () => {
+    const result = buildAvailableToolRecords(
+      {},
+      {},
+      {
+        'wf-1': { name: 'Workflow One', description: 'workflow desc' },
+        'wf-2': {},
+      },
+    );
+
+    expect(result.workflows).toEqual({
+      'wf-1': { id: 'wf-1', name: 'Workflow One', description: 'workflow desc' },
+      'wf-2': { id: 'wf-2', name: 'wf-2', description: undefined },
+    });
+  });
+
+  it('returns tools, agents, and workflows when all three are populated', () => {
+    const result = buildAvailableToolRecords(
+      { 'tool-a': { description: 'Tool A' } },
+      { 'agent-x': { name: 'Agent X' } },
+      { 'wf-1': { name: 'Workflow One' } },
+    );
+
+    expect(result.tools).toEqual({ 'tool-a': { description: 'Tool A' } });
+    expect(result.agents).toEqual({ 'agent-x': { id: 'agent-x', name: 'Agent X', description: undefined } });
+    expect(result.workflows).toEqual({ 'wf-1': { id: 'wf-1', name: 'Workflow One', description: undefined } });
+  });
+
+  it('defaults workflows to an empty record when omitted', () => {
+    const result = buildAvailableToolRecords({}, {});
+
+    expect(result.workflows).toEqual({});
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/__tests__/build-form-snapshot.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/build-form-snapshot.test.ts
@@ -1,0 +1,265 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import { describe, expect, it } from 'vitest';
+
+import type { useBuilderAgentFeatures } from '../../hooks/use-builder-agent-features';
+import type { AgentBuilderEditFormValues } from '../../schemas';
+import type { AgentTool } from '../../types/agent-tool';
+import { buildFormSnapshotInstructions } from '../build-form-snapshot';
+import type { AvailableWorkspaceLike, BuildFormSnapshotOptions } from '../build-form-snapshot';
+import type { ModelInfo } from '@/domains/llm';
+
+type Features = ReturnType<typeof useBuilderAgentFeatures>;
+
+const allOff: Features = {
+  tools: false,
+  memory: false,
+  workflows: false,
+  agents: false,
+  avatarUpload: false,
+  skills: false,
+  model: false,
+  favorites: false,
+  browser: false,
+};
+const allOn: Features = {
+  tools: true,
+  memory: true,
+  workflows: true,
+  agents: true,
+  avatarUpload: true,
+  skills: true,
+  model: true,
+  favorites: true,
+  browser: true,
+};
+
+const baseValues: AgentBuilderEditFormValues = {
+  name: '',
+  description: '',
+  instructions: '',
+  tools: {},
+  agents: {},
+  workflows: {},
+  skills: {},
+};
+
+const buildOptions = (overrides: Partial<BuildFormSnapshotOptions> = {}): BuildFormSnapshotOptions => ({
+  availableAgentTools: [] as AgentTool[],
+  availableSkills: [] as StoredSkillResponse[],
+  availableWorkspaces: [] as AvailableWorkspaceLike[],
+  availableModels: [] as ModelInfo[],
+  features: allOff,
+  ...overrides,
+});
+
+describe('buildFormSnapshotInstructions', () => {
+  it('renders empty/not-set placeholders for an empty form', () => {
+    const result = buildFormSnapshotInstructions(baseValues, buildOptions());
+
+    expect(result).toContain('- Name: (empty)');
+    expect(result).toContain('- Description: (empty)');
+    expect(result).toContain('- Instructions: (empty)');
+    expect(result).toContain('- Workspace: (not set)');
+    expect(result).toContain('- Visibility: private');
+  });
+
+  it('omits feature-gated sections when disabled', () => {
+    const result = buildFormSnapshotInstructions(baseValues, buildOptions({ features: allOff }));
+
+    expect(result).not.toContain('- Model:');
+    expect(result).not.toContain('- Tools');
+    expect(result).not.toContain('- Skills');
+    expect(result).not.toContain('- Browser enabled:');
+  });
+
+  it('shows feature-gated sections when enabled', () => {
+    const result = buildFormSnapshotInstructions(baseValues, buildOptions({ features: allOn }));
+
+    expect(result).toContain('- Model: (not set)');
+    expect(result).toContain('- Tools: (none selected)');
+    expect(result).toContain('- Skills: (none selected)');
+    expect(result).toContain('- Browser enabled: false');
+  });
+
+  it('resolves selected tool ids to display names and drops unknown ids', () => {
+    const tools: AgentTool[] = [
+      { id: 'web-search', name: 'Web Search', isChecked: false, type: 'tool' },
+      { id: 'http-fetch', name: 'HTTP Fetch', isChecked: false, type: 'tool' },
+      { id: 'agent-x', name: 'Agent X', isChecked: false, type: 'agent' },
+    ];
+
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      name: 'Bot',
+      instructions: 'Help users',
+      tools: { 'web-search': true, 'unknown-tool': true },
+      agents: { 'agent-x': true },
+    };
+
+    const result = buildFormSnapshotInstructions(values, buildOptions({ features: allOn, availableAgentTools: tools }));
+
+    expect(result).toContain('- Tools (2):');
+    expect(result).toContain('"Web Search" (web-search)');
+    expect(result).toContain('"Agent X" (agent-x)');
+    expect(result).not.toContain('unknown-tool');
+    expect(result).not.toContain('"HTTP Fetch"');
+  });
+
+  it('resolves selected skill ids to display names', () => {
+    const skills: StoredSkillResponse[] = [
+      {
+        id: 'skill_42',
+        name: 'Triage',
+        instructions: '...',
+        status: 'ready',
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+      },
+      {
+        id: 'skill_99',
+        name: 'Other',
+        instructions: '...',
+        status: 'ready',
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+      },
+    ];
+
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      skills: { skill_42: true, missing: true },
+    };
+
+    const result = buildFormSnapshotInstructions(values, buildOptions({ features: allOn, availableSkills: skills }));
+
+    expect(result).toContain('- Skills (1): "Triage" (skill_42)');
+    expect(result).not.toContain('skill_99');
+    expect(result).not.toContain('missing');
+  });
+
+  it('truncates long instructions and appends [truncated]', () => {
+    const longInstructions = 'a'.repeat(2000);
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      instructions: longInstructions,
+    };
+
+    const result = buildFormSnapshotInstructions(values, buildOptions());
+
+    expect(result).toContain('[truncated]');
+    expect(result).not.toContain('a'.repeat(2000));
+    expect(result).toContain('a'.repeat(1500));
+  });
+
+  it('renders model as provider/name when set and feature is enabled', () => {
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      model: { provider: 'openai', name: 'gpt-4o-mini' },
+    };
+    const models: ModelInfo[] = [{ provider: 'openai', providerName: 'OpenAI', model: 'gpt-4o-mini' }];
+
+    const result = buildFormSnapshotInstructions(values, buildOptions({ features: allOn, availableModels: models }));
+
+    expect(result).toContain('- Model: openai/gpt-4o-mini');
+    expect(result).not.toContain('not in available models list');
+  });
+
+  it('marks the model with a note when the selection is not in the catalog', () => {
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      model: { provider: 'anthropic', name: 'claude-opus-4-7' },
+    };
+
+    const result = buildFormSnapshotInstructions(values, buildOptions({ features: allOn, availableModels: [] }));
+
+    expect(result).toContain('- Model: anthropic/claude-opus-4-7 (not in available models list)');
+  });
+
+  it('drops the model section entirely when the model feature is off', () => {
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      model: { provider: 'openai', name: 'gpt-4o-mini' },
+    };
+
+    const result = buildFormSnapshotInstructions(values, buildOptions({ features: allOff }));
+
+    expect(result).not.toContain('- Model:');
+  });
+
+  it('renders workspace by name when known', () => {
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      workspaceId: 'ws_123',
+    };
+    const workspaces = [{ id: 'ws_123', name: 'Acme Workspace' }];
+
+    const result = buildFormSnapshotInstructions(values, buildOptions({ availableWorkspaces: workspaces }));
+
+    expect(result).toContain('- Workspace: "Acme Workspace" (id: ws_123)');
+  });
+
+  it('renders quoted name and description when set', () => {
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      name: 'Customer Support Bot',
+      description: 'Helps users reset passwords',
+    };
+
+    const result = buildFormSnapshotInstructions(values, buildOptions());
+
+    expect(result).toContain('- Name: "Customer Support Bot"');
+    expect(result).toContain('- Description: "Helps users reset passwords"');
+  });
+
+  it('renders "(none selected)" when the tools record is undefined', () => {
+    const values = {
+      ...baseValues,
+      tools: undefined,
+      agents: undefined,
+      workflows: undefined,
+    } as unknown as AgentBuilderEditFormValues;
+
+    const result = buildFormSnapshotInstructions(values, buildOptions({ features: allOn }));
+
+    expect(result).toContain('- Tools: (none selected)');
+  });
+
+  it('falls back to "(unknown)" when the workspaceId has no match in availableWorkspaces', () => {
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      workspaceId: 'ws_unknown',
+    };
+
+    const result = buildFormSnapshotInstructions(values, buildOptions({ availableWorkspaces: [] }));
+
+    expect(result).toContain('- Workspace: "(unknown)" (id: ws_unknown)');
+  });
+
+  it('ignores tool ids that are mapped to false in the selection record', () => {
+    const tools: AgentTool[] = [
+      { id: 'web-search', name: 'Web Search', isChecked: false, type: 'tool' },
+      { id: 'http-fetch', name: 'HTTP Fetch', isChecked: false, type: 'tool' },
+    ];
+
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      tools: { 'web-search': true, 'http-fetch': false },
+    };
+
+    const result = buildFormSnapshotInstructions(values, buildOptions({ features: allOn, availableAgentTools: tools }));
+
+    expect(result).toContain('- Tools (1): "Web Search" (web-search)');
+    expect(result).not.toContain('http-fetch');
+  });
+
+  it('renders browser enabled: true when feature is on and browserEnabled is true', () => {
+    const values: AgentBuilderEditFormValues = {
+      ...baseValues,
+      browserEnabled: true,
+    };
+
+    const result = buildFormSnapshotInstructions(values, buildOptions({ features: allOn }));
+
+    expect(result).toContain('- Browser enabled: true');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/__tests__/build-tool-description.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/build-tool-description.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentTool } from '../../types/agent-tool';
+import { buildAgentBuilderToolDescription } from '../build-tool-description';
+
+const allOff = {
+  tools: false,
+  skills: false,
+  memory: false,
+  workflows: false,
+  agents: false,
+  avatarUpload: false,
+  model: false,
+  favorites: false,
+  browser: false,
+};
+
+describe('buildAgentBuilderToolDescription', () => {
+  it('lists name, description, instructions, and workspaceId by default', () => {
+    const description = buildAgentBuilderToolDescription(allOff, [], []);
+
+    expect(description).toContain('name');
+    expect(description).toContain('description');
+    expect(description).toContain('instructions');
+    expect(description).toContain('workspaceId');
+    expect(description).not.toContain('Available tools');
+    expect(description).not.toContain('Available workspaces');
+  });
+
+  it('mentions tools and lists available tools when tools feature is on', () => {
+    const tools: AgentTool[] = [
+      { id: 'web-search', name: 'Web Search', description: 'Search the web', isChecked: false, type: 'tool' },
+      { id: 'http-fetch', name: 'HTTP Fetch', isChecked: false, type: 'tool' },
+    ];
+    const description = buildAgentBuilderToolDescription({ ...allOff, tools: true }, tools, []);
+
+    expect(description).toContain('tools');
+    expect(description).toContain('web-search');
+    expect(description).toContain('Search the web');
+    expect(description).toContain('http-fetch');
+  });
+
+  it('mentions skills and lists available skills when skills feature is on and skills are available', () => {
+    const skills = [
+      {
+        id: 'researcher',
+        status: 'published',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        name: 'researcher',
+        description: 'Research things',
+        instructions: 'inst',
+      },
+      {
+        id: 'writer',
+        status: 'published',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        name: 'writer',
+        instructions: 'inst',
+      },
+    ] as never;
+    const description = buildAgentBuilderToolDescription({ ...allOff, skills: true }, [], [], skills);
+
+    expect(description).toContain('skills');
+    expect(description).toContain('Available skills');
+    expect(description).toContain('researcher');
+    expect(description).toContain('Research things');
+    expect(description).toContain('writer');
+  });
+
+  it('mentions createSkillTool when skills feature is on', () => {
+    const description = buildAgentBuilderToolDescription({ ...allOff, skills: true }, [], []);
+    expect(description).toContain('createSkillTool');
+  });
+
+  it('does not mention createSkillTool when skills feature is off', () => {
+    const description = buildAgentBuilderToolDescription(allOff, [], []);
+    expect(description).not.toContain('createSkillTool');
+  });
+
+  it('does not mention skills when feature is off even if skills are provided', () => {
+    const skills = [
+      {
+        id: 'researcher',
+        status: 'published',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        name: 'researcher',
+        instructions: 'inst',
+      },
+    ] as never;
+    const description = buildAgentBuilderToolDescription(allOff, [], [], skills);
+
+    expect(description).not.toContain('Available skills');
+  });
+
+  it('lists available workspaces when present', () => {
+    const description = buildAgentBuilderToolDescription(
+      allOff,
+      [],
+      [
+        { id: 'ws-1', name: 'Primary' },
+        { id: 'ws-2', name: 'Secondary' },
+      ],
+    );
+
+    expect(description).toContain('ws-1');
+    expect(description).toContain('Primary');
+    expect(description).toContain('ws-2');
+    expect(description).toContain('Secondary');
+  });
+
+  it('lists browserEnabled when browser feature is on', () => {
+    const description = buildAgentBuilderToolDescription({ ...allOff, browser: true }, [], []);
+    expect(description).toContain('browserEnabled');
+  });
+
+  it('does not list browserEnabled when browser feature is off', () => {
+    const description = buildAgentBuilderToolDescription(allOff, [], []);
+    expect(description).not.toContain('browserEnabled');
+  });
+
+  it('mentions model and lists available provider/model pairs when models are available', () => {
+    const description = buildAgentBuilderToolDescription(
+      { ...allOff, model: true },
+      [],
+      [],
+      [],
+      [
+        { provider: 'openai', providerName: 'OpenAI', model: 'gpt-4o' },
+        { provider: 'anthropic', providerName: 'Anthropic', model: 'claude-opus-4-7' },
+      ],
+    );
+
+    expect(description).toContain('model');
+    expect(description).toContain('Available models');
+    expect(description).toContain('provider: openai (OpenAI), name: gpt-4o');
+    expect(description).toContain('provider: anthropic (Anthropic), name: claude-opus-4-7');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/__tests__/build-tool-schema.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/build-tool-schema.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentTool } from '../../types/agent-tool';
+import { buildAgentBuilderToolSchema } from '../build-tool-schema';
+
+const allOff = {
+  tools: false,
+  memory: false,
+  workflows: false,
+  agents: false,
+  avatarUpload: false,
+  skills: false,
+  model: false,
+  favorites: false,
+  browser: false,
+};
+const allOn = { ...allOff, tools: true };
+
+describe('buildAgentBuilderToolSchema', () => {
+  it('exposes name and instructions as required and omits tools when its flag is off', () => {
+    const schema = buildAgentBuilderToolSchema(allOff, [], []);
+    const shape = schema.shape;
+
+    expect(shape.name).toBeDefined();
+    expect(shape.instructions).toBeDefined();
+    expect(shape.tools).toBeUndefined();
+  });
+
+  it('adds tools shape entry when the flag is on', () => {
+    const schema = buildAgentBuilderToolSchema(allOn, [], []);
+    const shape = schema.shape;
+
+    expect(shape.tools).toBeDefined();
+  });
+
+  it('constrains tool ids to the provided ids when available', () => {
+    const tools: AgentTool[] = [{ id: 'web-search', name: 'Web Search', isChecked: false, type: 'tool' }];
+    const schema = buildAgentBuilderToolSchema({ ...allOff, tools: true }, tools, []);
+
+    expect(
+      schema.safeParse({
+        name: 'N',
+        instructions: 'I',
+        tools: [{ id: 'web-search', name: 'Web Search' }],
+      }).success,
+    ).toBe(true);
+
+    expect(
+      schema.safeParse({
+        name: 'N',
+        instructions: 'I',
+        tools: [{ id: 'unknown', name: 'Unknown' }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('exposes the skills field only when feature is on and there is at least one skill', () => {
+    const skill = {
+      id: 'skill-a',
+      status: 'published',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      name: 'skill-a',
+      instructions: 'inst',
+    } as never;
+
+    const offShape = buildAgentBuilderToolSchema(allOff, [], [], [skill]).shape;
+    expect(offShape.skills).toBeUndefined();
+
+    const onNoSkills = buildAgentBuilderToolSchema({ ...allOff, skills: true }, [], [], []).shape;
+    expect(onNoSkills.skills).toBeUndefined();
+
+    const schema = buildAgentBuilderToolSchema({ ...allOff, skills: true }, [], [], [skill]);
+    expect(schema.shape.skills).toBeDefined();
+
+    expect(
+      schema.safeParse({
+        name: 'N',
+        instructions: 'I',
+        skills: [{ id: 'skill-a', name: 'Skill A' }],
+      }).success,
+    ).toBe(true);
+
+    expect(
+      schema.safeParse({
+        name: 'N',
+        instructions: 'I',
+        skills: [{ id: 'unknown', name: 'Unknown' }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('always exposes an optional workspaceId and constrains it when workspaces are provided', () => {
+    const schema = buildAgentBuilderToolSchema(allOff, [], [{ id: 'ws-1', name: 'Primary' }]);
+    expect(schema.shape.workspaceId).toBeDefined();
+
+    expect(schema.safeParse({ name: 'N', instructions: 'I', workspaceId: 'ws-1' }).success).toBe(true);
+    expect(schema.safeParse({ name: 'N', instructions: 'I', workspaceId: 'unknown' }).success).toBe(false);
+    expect(schema.safeParse({ name: 'N', instructions: 'I' }).success).toBe(true);
+  });
+
+  it('exposes model only when available models exist and constrains exact provider/model pairs', () => {
+    const emptySchema = buildAgentBuilderToolSchema(allOff, [], []);
+    expect(emptySchema.shape.model).toBeUndefined();
+
+    const schema = buildAgentBuilderToolSchema(
+      { ...allOff, model: true },
+      [],
+      [],
+      [],
+      [
+        { provider: 'openai', providerName: 'OpenAI', model: 'gpt-4o' },
+        { provider: 'anthropic', providerName: 'Anthropic', model: 'claude-opus-4-7' },
+      ],
+    );
+
+    expect(schema.shape.model).toBeDefined();
+    expect(
+      schema.safeParse({ name: 'N', instructions: 'I', model: { provider: 'openai', name: 'gpt-4o' } }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({ name: 'N', instructions: 'I', model: { provider: 'openai', name: 'claude-opus-4-7' } })
+        .success,
+    ).toBe(false);
+    expect(
+      schema.safeParse({ name: 'N', instructions: 'I', model: { provider: 'openai', name: 'unknown' } }).success,
+    ).toBe(false);
+  });
+
+  it('uses a single object schema for model when exactly one model is available', () => {
+    const schema = buildAgentBuilderToolSchema(
+      { ...allOff, model: true },
+      [],
+      [],
+      [],
+      [{ provider: 'openai', providerName: 'OpenAI', model: 'gpt-4o' }],
+    );
+
+    expect(schema.shape.model).toBeDefined();
+    expect(
+      schema.safeParse({ name: 'N', instructions: 'I', model: { provider: 'openai', name: 'gpt-4o' } }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({ name: 'N', instructions: 'I', model: { provider: 'openai', name: 'other' } }).success,
+    ).toBe(false);
+  });
+
+  it('exposes browserEnabled only when the browser feature is on', () => {
+    const offShape = buildAgentBuilderToolSchema(allOff, [], []).shape;
+    expect(offShape.browserEnabled).toBeUndefined();
+
+    const schema = buildAgentBuilderToolSchema({ ...allOff, browser: true }, [], []);
+    expect(schema.shape.browserEnabled).toBeDefined();
+
+    expect(schema.safeParse({ name: 'N', instructions: 'I', browserEnabled: true }).success).toBe(true);
+    expect(schema.safeParse({ name: 'N', instructions: 'I', browserEnabled: false }).success).toBe(true);
+    expect(schema.safeParse({ name: 'N', instructions: 'I' }).success).toBe(true);
+    expect(schema.safeParse({ name: 'N', instructions: 'I', browserEnabled: 'yes' }).success).toBe(false);
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/__tests__/downscale-avatar.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/downscale-avatar.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { downscaleImageToDataUrl, estimateDataUrlBytes } from '../downscale-avatar';
+
+describe('estimateDataUrlBytes', () => {
+  it('returns 0 for a string without a comma', () => {
+    expect(estimateDataUrlBytes('no-comma')).toBe(0);
+  });
+
+  it('estimates the correct byte length for a small base64 payload', () => {
+    // 4 base64 chars = 3 bytes
+    const dataUrl = 'data:image/png;base64,AAAA';
+    expect(estimateDataUrlBytes(dataUrl)).toBe(3);
+  });
+
+  it('accounts for base64 padding (=)', () => {
+    // "AA==" → 1 byte (4 chars, 2 padding)
+    const dataUrl = 'data:image/png;base64,AA==';
+    expect(estimateDataUrlBytes(dataUrl)).toBe(1);
+
+    // "AAA=" → 2 bytes (4 chars, 1 padding)
+    const dataUrl2 = 'data:image/png;base64,AAA=';
+    expect(estimateDataUrlBytes(dataUrl2)).toBe(2);
+  });
+
+  it('estimates correctly for a larger payload', () => {
+    // 100 bytes → ceil(100/3)*4 = 136 base64 chars with padding
+    const buf = Buffer.alloc(100, 0x42);
+    const b64 = buf.toString('base64');
+    const dataUrl = `data:image/png;base64,${b64}`;
+    expect(estimateDataUrlBytes(dataUrl)).toBe(100);
+  });
+
+  it('estimates correctly for a 512KB payload', () => {
+    const size = 512 * 1024;
+    const buf = Buffer.alloc(size, 0);
+    const b64 = buf.toString('base64');
+    const dataUrl = `data:image/png;base64,${b64}`;
+    expect(estimateDataUrlBytes(dataUrl)).toBe(size);
+  });
+});
+
+describe('downscaleImageToDataUrl', () => {
+  // A tiny base64 payload that decodes to a known, small byte size.
+  // 'AAAA' = 4 base64 chars = 3 bytes when decoded.
+  const TINY_DATA_URL = 'data:image/png;base64,AAAA';
+
+  const originalCreateImageBitmap: typeof globalThis.createImageBitmap | undefined = globalThis.createImageBitmap;
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+
+  let bitmap: { width: number; height: number; close: ReturnType<typeof vi.fn> };
+  let drawImage: ReturnType<typeof vi.fn>;
+  let toDataURL: ReturnType<typeof vi.fn>;
+  let getContext: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    bitmap = { width: 1024, height: 1024, close: vi.fn() };
+    drawImage = vi.fn();
+    toDataURL = vi.fn(() => TINY_DATA_URL);
+    getContext = vi.fn(() => ({ drawImage }) as unknown as CanvasRenderingContext2D);
+
+    Object.defineProperty(globalThis, 'createImageBitmap', {
+      value: vi.fn(async () => bitmap),
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      value: getContext,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, 'toDataURL', {
+      value: toDataURL,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalCreateImageBitmap === undefined) {
+      delete (globalThis as { createImageBitmap?: unknown }).createImageBitmap;
+    } else {
+      Object.defineProperty(globalThis, 'createImageBitmap', {
+        value: originalCreateImageBitmap,
+        configurable: true,
+        writable: true,
+      });
+    }
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      value: originalGetContext,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, 'toDataURL', {
+      value: originalToDataURL,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('returns image/png contentType for a PNG file', async () => {
+    const file = new File(['stub'], 'a.png', { type: 'image/png' });
+
+    const result = await downscaleImageToDataUrl(file);
+
+    expect(result.contentType).toBe('image/png');
+    expect(result.dataUrl).toBe(TINY_DATA_URL);
+    expect(toDataURL).toHaveBeenCalledWith('image/png', expect.any(Number));
+  });
+
+  it('returns image/jpeg contentType for non-PNG sources', async () => {
+    const file = new File(['stub'], 'a.jpg', { type: 'image/jpeg' });
+
+    const result = await downscaleImageToDataUrl(file);
+
+    expect(result.contentType).toBe('image/jpeg');
+    expect(toDataURL).toHaveBeenCalledWith('image/jpeg', expect.any(Number));
+  });
+
+  it('center-crops a taller-than-wide source into a square region', async () => {
+    bitmap.width = 200;
+    bitmap.height = 600;
+    const file = new File(['stub'], 'a.png', { type: 'image/png' });
+
+    await downscaleImageToDataUrl(file);
+
+    // side = min(200, 600) = 200; sx = 0; sy = (600 - 200) / 2 = 200
+    expect(drawImage).toHaveBeenCalledWith(bitmap, 0, 200, 200, 200, 0, 0, 256, 256);
+  });
+
+  it('throws when canvas 2D context is unavailable', async () => {
+    getContext.mockReturnValueOnce(null);
+    const file = new File(['stub'], 'a.png', { type: 'image/png' });
+
+    await expect(downscaleImageToDataUrl(file)).rejects.toThrow('Canvas 2D context is not available');
+  });
+
+  it('throws when the encoded result exceeds 512 KB', async () => {
+    // Build a base64 payload that decodes to > 512KB.
+    const oversizedBytes = 512 * 1024 + 1;
+    const oversizedB64 = Buffer.alloc(oversizedBytes, 0).toString('base64');
+    toDataURL.mockReturnValueOnce(`data:image/png;base64,${oversizedB64}`);
+    const file = new File(['stub'], 'a.png', { type: 'image/png' });
+
+    await expect(downscaleImageToDataUrl(file)).rejects.toThrow(/too large after downscaling/);
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/__tests__/extract-workspace-id.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/extract-workspace-id.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { extractWorkspaceId } from '../extract-workspace-id';
+
+describe('extractWorkspaceId', () => {
+  it('returns undefined for an undefined workspace', () => {
+    expect(extractWorkspaceId(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when workspace is not an "id" type', () => {
+    expect(extractWorkspaceId({ type: 'inline', config: {} } as never)).toBeUndefined();
+  });
+
+  it('returns the workspaceId when type is "id" and workspaceId is a string', () => {
+    expect(extractWorkspaceId({ type: 'id', workspaceId: 'ws-123' } as never)).toBe('ws-123');
+  });
+
+  it('returns undefined when type is "id" but workspaceId is not a string', () => {
+    expect(extractWorkspaceId({ type: 'id', workspaceId: 42 } as never)).toBeUndefined();
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/__tests__/form-values-to-save-params.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/form-values-to-save-params.test.ts
@@ -1,0 +1,223 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import { describe, expect, it } from 'vitest';
+import type { AgentTool } from '../../types/agent-tool';
+import { formValuesToSaveParams } from '../form-values-to-save-params';
+
+const buildSkill = (id: string, description?: string): StoredSkillResponse => ({
+  id,
+  status: 'published',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  name: id,
+  description,
+  instructions: 'inst',
+});
+
+const baseValues = {
+  name: 'My agent',
+  description: '',
+  instructions: 'Do things',
+  tools: {},
+  agents: {},
+  workflows: {},
+};
+
+describe('formValuesToSaveParams', () => {
+  it('builds a tool entry with description when the available tool has one', () => {
+    const availableAgentTools: AgentTool[] = [
+      { id: 'tool-a', name: 'tool-a', description: 'Tool A desc', isChecked: true, type: 'tool' },
+    ];
+
+    const result = formValuesToSaveParams({ ...baseValues, tools: { 'tool-a': true } }, availableAgentTools);
+
+    expect(result.tools).toEqual({ 'tool-a': { description: 'Tool A desc' } });
+  });
+
+  it('builds a tool entry with an empty record when the available tool has no description', () => {
+    const availableAgentTools: AgentTool[] = [{ id: 'tool-a', name: 'tool-a', isChecked: true, type: 'tool' }];
+
+    const result = formValuesToSaveParams({ ...baseValues, tools: { 'tool-a': true } }, availableAgentTools);
+
+    expect(result.tools).toEqual({ 'tool-a': {} });
+  });
+
+  it('omits disabled tools from the resulting record', () => {
+    const availableAgentTools: AgentTool[] = [
+      { id: 'tool-a', name: 'tool-a', isChecked: true, type: 'tool' },
+      { id: 'tool-b', name: 'tool-b', isChecked: false, type: 'tool' },
+    ];
+
+    const result = formValuesToSaveParams(
+      { ...baseValues, tools: { 'tool-a': true, 'tool-b': false } },
+      availableAgentTools,
+    );
+
+    expect(result.tools).toEqual({ 'tool-a': {} });
+  });
+
+  it('routes agent ids the same way and uses agent descriptions', () => {
+    const availableAgentTools: AgentTool[] = [
+      { id: 'agent-x', name: 'Agent X', description: 'Agent X desc', isChecked: true, type: 'agent' },
+    ];
+
+    const result = formValuesToSaveParams({ ...baseValues, agents: { 'agent-x': true } }, availableAgentTools);
+
+    expect(result.agents).toEqual({ 'agent-x': { description: 'Agent X desc' } });
+  });
+
+  it('returns empty records for tools/agents/workflows when their resolved record is empty', () => {
+    const result = formValuesToSaveParams(baseValues, []);
+
+    expect(result.tools).toEqual({});
+    expect(result.agents).toEqual({});
+    expect(result.workflows).toEqual({});
+  });
+
+  it('returns an empty tools record when a previously-selected tool is toggled off', () => {
+    const availableAgentTools: AgentTool[] = [
+      { id: 'tool-a', name: 'Tool A', description: 'Tool A desc', isChecked: false, type: 'tool' },
+    ];
+
+    const result = formValuesToSaveParams({ ...baseValues, tools: { 'tool-a': false } }, availableAgentTools);
+
+    expect(result.tools).toEqual({});
+  });
+
+  it('builds a workflow entry with description when the available workflow has one', () => {
+    const availableAgentTools: AgentTool[] = [
+      { id: 'wf-1', name: 'Workflow One', description: 'Workflow desc', isChecked: true, type: 'workflow' },
+    ];
+
+    const result = formValuesToSaveParams({ ...baseValues, workflows: { 'wf-1': true } }, availableAgentTools);
+
+    expect(result.workflows).toEqual({ 'wf-1': { description: 'Workflow desc' } });
+  });
+
+  it('builds a workflow entry with an empty record when the available workflow has no description', () => {
+    const availableAgentTools: AgentTool[] = [{ id: 'wf-1', name: 'Workflow One', isChecked: true, type: 'workflow' }];
+
+    const result = formValuesToSaveParams({ ...baseValues, workflows: { 'wf-1': true } }, availableAgentTools);
+
+    expect(result.workflows).toEqual({ 'wf-1': {} });
+  });
+
+  it('omits disabled workflows from the resulting record', () => {
+    const availableAgentTools: AgentTool[] = [
+      { id: 'wf-1', name: 'Workflow One', isChecked: true, type: 'workflow' },
+      { id: 'wf-2', name: 'Workflow Two', isChecked: false, type: 'workflow' },
+    ];
+
+    const result = formValuesToSaveParams(
+      { ...baseValues, workflows: { 'wf-1': true, 'wf-2': false } },
+      availableAgentTools,
+    );
+
+    expect(result.workflows).toEqual({ 'wf-1': {} });
+  });
+
+  it('returns undefined workspace when workspaceId is missing or empty', () => {
+    expect(formValuesToSaveParams({ ...baseValues, workspaceId: undefined }, []).workspace).toBeUndefined();
+    expect(formValuesToSaveParams({ ...baseValues, workspaceId: '' }, []).workspace).toBeUndefined();
+  });
+
+  it('returns an "id" workspace ref when workspaceId is set', () => {
+    const result = formValuesToSaveParams({ ...baseValues, workspaceId: 'ws-1' }, []);
+
+    expect(result.workspace).toEqual({ type: 'id', workspaceId: 'ws-1' });
+  });
+
+  it('returns undefined description when the input is empty or whitespace only', () => {
+    expect(formValuesToSaveParams({ ...baseValues, description: '' }, []).description).toBeUndefined();
+    expect(formValuesToSaveParams({ ...baseValues, description: '   ' }, []).description).toBeUndefined();
+  });
+
+  it('trims and returns description when the input has content', () => {
+    const result = formValuesToSaveParams({ ...baseValues, description: '  Hello  ' }, []);
+
+    expect(result.description).toBe('Hello');
+  });
+
+  it('builds a skill entry with description when the available skill has one', () => {
+    const availableSkills = [buildSkill('skill-a', 'Skill A desc')];
+
+    const result = formValuesToSaveParams({ ...baseValues, skills: { 'skill-a': true } }, [], availableSkills);
+
+    expect(result.skills).toEqual({ 'skill-a': { description: 'Skill A desc' } });
+  });
+
+  it('builds a skill entry with an empty record when the available skill has no description', () => {
+    const availableSkills = [buildSkill('skill-a')];
+
+    const result = formValuesToSaveParams({ ...baseValues, skills: { 'skill-a': true } }, [], availableSkills);
+
+    expect(result.skills).toEqual({ 'skill-a': {} });
+  });
+
+  it('returns an empty skills record when nothing is selected', () => {
+    const result = formValuesToSaveParams(baseValues, [], [buildSkill('skill-a', 'Skill A desc')]);
+
+    expect(result.skills).toEqual({});
+  });
+
+  it('omits disabled skills from the resulting record', () => {
+    const availableSkills = [buildSkill('skill-a'), buildSkill('skill-b')];
+
+    const result = formValuesToSaveParams(
+      { ...baseValues, skills: { 'skill-a': true, 'skill-b': false } },
+      [],
+      availableSkills,
+    );
+
+    expect(result.skills).toEqual({ 'skill-a': {} });
+  });
+
+  it('returns metadata with avatarUrl when values.avatarUrl is set', () => {
+    const result = formValuesToSaveParams({ ...baseValues, avatarUrl: 'https://cdn.example/a.png' }, []);
+
+    expect(result.metadata).toEqual({ avatarUrl: 'https://cdn.example/a.png' });
+  });
+
+  it('returns undefined metadata when avatarUrl is missing', () => {
+    const result = formValuesToSaveParams(baseValues, []);
+
+    expect(result.metadata).toBeUndefined();
+  });
+
+  it('returns browser=true when browserEnabled is true', () => {
+    const result = formValuesToSaveParams({ ...baseValues, browserEnabled: true }, []);
+
+    expect(result.browser).toBe(true);
+  });
+
+  it('returns browser=false when browserEnabled is false', () => {
+    const result = formValuesToSaveParams({ ...baseValues, browserEnabled: false }, []);
+
+    expect(result.browser).toBe(false);
+  });
+
+  it('returns browser=false when browserEnabled is undefined', () => {
+    const result = formValuesToSaveParams(baseValues, []);
+
+    expect(result.browser).toBe(false);
+  });
+
+  it('passes visibility through unchanged for private, public, and undefined', () => {
+    expect(formValuesToSaveParams({ ...baseValues, visibility: 'private' }, []).visibility).toBe('private');
+    expect(formValuesToSaveParams({ ...baseValues, visibility: 'public' }, []).visibility).toBe('public');
+    expect(formValuesToSaveParams(baseValues, []).visibility).toBeUndefined();
+  });
+
+  it('passes model through unchanged when set and undefined when unset', () => {
+    const result = formValuesToSaveParams({ ...baseValues, model: { provider: 'openai', name: 'gpt-4o' } }, []);
+
+    expect(result.model).toEqual({ provider: 'openai', name: 'gpt-4o' });
+    expect(formValuesToSaveParams(baseValues, []).model).toBeUndefined();
+  });
+
+  it('passes name and instructions through unchanged', () => {
+    const result = formValuesToSaveParams({ ...baseValues, name: 'My agent', instructions: 'Do things' }, []);
+
+    expect(result.name).toBe('My agent');
+    expect(result.instructions).toBe('Do things');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/__tests__/route-tool-input.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/route-tool-input.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentTool } from '../../types/agent-tool';
+import { routeToolInputToFormKeys } from '../route-tool-input';
+
+describe('routeToolInputToFormKeys', () => {
+  it('routes tool ids to tools and agent ids to agents based on the available type map', () => {
+    const available: AgentTool[] = [
+      { id: 'tool-a', name: 'tool-a', isChecked: false, type: 'tool' },
+      { id: 'agent-x', name: 'Agent X', isChecked: false, type: 'agent' },
+    ];
+
+    const result = routeToolInputToFormKeys(available, [
+      { id: 'tool-a', name: 'Tool A' },
+      { id: 'agent-x', name: 'Agent X' },
+    ]);
+
+    expect(result.tools).toEqual({ 'tool-a': true });
+    expect(result.agents).toEqual({ 'agent-x': true });
+    expect(result.workflows).toEqual({});
+  });
+
+  it('routes workflow ids into the workflows bucket', () => {
+    const available: AgentTool[] = [{ id: 'wf-1', name: 'Workflow', isChecked: false, type: 'workflow' }];
+
+    const result = routeToolInputToFormKeys(available, [{ id: 'wf-1', name: 'Workflow' }]);
+
+    expect(result.workflows).toEqual({ 'wf-1': true });
+    expect(result.tools).toEqual({});
+    expect(result.agents).toEqual({});
+  });
+
+  it('routes mixed input across tools, agents, and workflows correctly', () => {
+    const available: AgentTool[] = [
+      { id: 'tool-a', name: 'tool-a', isChecked: false, type: 'tool' },
+      { id: 'agent-x', name: 'Agent X', isChecked: false, type: 'agent' },
+      { id: 'wf-1', name: 'Workflow One', isChecked: false, type: 'workflow' },
+    ];
+
+    const result = routeToolInputToFormKeys(available, [
+      { id: 'tool-a', name: 'Tool A' },
+      { id: 'agent-x', name: 'Agent X' },
+      { id: 'wf-1', name: 'Workflow One' },
+    ]);
+
+    expect(result.tools).toEqual({ 'tool-a': true });
+    expect(result.agents).toEqual({ 'agent-x': true });
+    expect(result.workflows).toEqual({ 'wf-1': true });
+  });
+
+  it('returns empty records when no entries are provided', () => {
+    const result = routeToolInputToFormKeys([], []);
+    expect(result.tools).toEqual({});
+    expect(result.agents).toEqual({});
+    expect(result.workflows).toEqual({});
+  });
+
+  it('drops ids that are not present in the available list (e.g. when a feature is gated off)', () => {
+    const result = routeToolInputToFormKeys([], [{ id: 'unknown', name: 'Unknown' }]);
+    expect(result.tools).toEqual({});
+    expect(result.agents).toEqual({});
+    expect(result.workflows).toEqual({});
+  });
+
+  it('drops agent/workflow ids when the available list only exposes tools (gated features)', () => {
+    const available: AgentTool[] = [{ id: 'tool-a', name: 'tool-a', isChecked: false, type: 'tool' }];
+
+    const result = routeToolInputToFormKeys(available, [
+      { id: 'tool-a', name: 'Tool A' },
+      { id: 'agent-x', name: 'Agent X' },
+      { id: 'wf-1', name: 'Workflow' },
+    ]);
+
+    expect(result.tools).toEqual({ 'tool-a': true });
+    expect(result.agents).toEqual({});
+    expect(result.workflows).toEqual({});
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/__tests__/stored-agent-to-agent-config.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/stored-agent-to-agent-config.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { storedAgentToAgentConfig } from '../stored-agent-to-agent-config';
+
+describe('storedAgentToAgentConfig', () => {
+  it('uses the fallback id when storedAgent is null or undefined', () => {
+    expect(storedAgentToAgentConfig(null, 'fallback-id')).toEqual({
+      id: 'fallback-id',
+      name: '',
+      description: '',
+      systemPrompt: '',
+      authorId: undefined,
+      visibility: 'private',
+      avatarUrl: undefined,
+    });
+    expect(storedAgentToAgentConfig(undefined, 'fallback-id')).toEqual({
+      id: 'fallback-id',
+      name: '',
+      description: '',
+      systemPrompt: '',
+      authorId: undefined,
+      visibility: 'private',
+      avatarUrl: undefined,
+    });
+  });
+
+  it('uses storedAgent.id when present and copies over name/description/instructions', () => {
+    const result = storedAgentToAgentConfig(
+      {
+        id: 'stored-id',
+        name: 'Researcher',
+        description: 'Helps with research',
+        instructions: 'Be helpful',
+      } as never,
+      'fallback-id',
+    );
+
+    expect(result).toEqual({
+      id: 'stored-id',
+      name: 'Researcher',
+      description: 'Helps with research',
+      systemPrompt: 'Be helpful',
+      authorId: undefined,
+      visibility: 'private',
+      avatarUrl: undefined,
+    });
+  });
+
+  it('falls back to empty string when instructions is not a string', () => {
+    const result = storedAgentToAgentConfig(
+      { id: 'a', name: 'N', instructions: { type: 'rule' } } as never,
+      'fallback-id',
+    );
+
+    expect(result.systemPrompt).toBe('');
+  });
+
+  it('extracts avatarUrl from metadata when present', () => {
+    const result = storedAgentToAgentConfig(
+      { id: 'a', name: 'N', metadata: { avatarUrl: 'https://cdn.example/a.png' } } as never,
+      'fallback-id',
+    );
+
+    expect(result.avatarUrl).toBe('https://cdn.example/a.png');
+  });
+
+  it('leaves avatarUrl undefined when metadata is present but lacks avatarUrl', () => {
+    const result = storedAgentToAgentConfig(
+      { id: 'a', name: 'N', metadata: { other: 'value' } } as never,
+      'fallback-id',
+    );
+
+    expect(result.avatarUrl).toBeUndefined();
+  });
+
+  it('preserves visibility=public when set', () => {
+    const result = storedAgentToAgentConfig({ id: 'a', name: 'N', visibility: 'public' } as never, 'fallback-id');
+
+    expect(result.visibility).toBe('public');
+  });
+
+  it('preserves authorId when set to a string', () => {
+    const result = storedAgentToAgentConfig({ id: 'a', name: 'N', authorId: 'user-1' } as never, 'fallback-id');
+
+    expect(result.authorId).toBe('user-1');
+  });
+
+  it('preserves authorId when set to null', () => {
+    const result = storedAgentToAgentConfig({ id: 'a', name: 'N', authorId: null } as never, 'fallback-id');
+
+    expect(result.authorId).toBeNull();
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/__tests__/stored-agent-to-form-values.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/stored-agent-to-form-values.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import { extractStaticModel, isConditionalStoredModel, storedAgentToFormValues } from '../stored-agent-to-form-values';
+
+describe('storedAgentToFormValues', () => {
+  it('returns empty defaults when storedAgent is null or undefined', () => {
+    const fromNull = storedAgentToFormValues(null);
+    const fromUndefined = storedAgentToFormValues(undefined);
+
+    const expected = {
+      name: '',
+      description: '',
+      instructions: '',
+      tools: {},
+      agents: {},
+      workflows: {},
+      skills: {},
+      workspaceId: undefined,
+      visibility: undefined,
+      avatarUrl: undefined,
+      browserEnabled: false,
+      model: undefined,
+    };
+
+    expect(fromNull).toEqual(expected);
+    expect(fromUndefined).toEqual(expected);
+  });
+
+  it('maps every stored agent field into the form value shape', () => {
+    const result = storedAgentToFormValues({
+      id: 'agent-1',
+      name: 'Researcher',
+      description: 'Helps with research',
+      instructions: 'Be helpful',
+      tools: { 'tool-a': {}, 'tool-b': {} },
+      agents: { 'agent-x': {} },
+      workflows: { 'wf-1': {} },
+      workspace: { type: 'id', workspaceId: 'ws-1' },
+    } as never);
+
+    expect(result).toEqual({
+      name: 'Researcher',
+      description: 'Helps with research',
+      instructions: 'Be helpful',
+      tools: { 'tool-a': true, 'tool-b': true },
+      agents: { 'agent-x': true },
+      workflows: { 'wf-1': true },
+      skills: {},
+      workspaceId: 'ws-1',
+      visibility: undefined,
+      avatarUrl: undefined,
+      browserEnabled: false,
+      model: undefined,
+    });
+  });
+
+  it('hydrates skills from a flat record', () => {
+    const result = storedAgentToFormValues({
+      id: 'agent-1',
+      name: 'A',
+      skills: { s1: { description: 'desc' }, s2: {} },
+    } as never);
+
+    expect(result.skills).toEqual({ s1: true, s2: true });
+  });
+
+  it('merges skills across ConditionalField variants', () => {
+    const result = storedAgentToFormValues({
+      id: 'agent-1',
+      name: 'A',
+      skills: [
+        { when: { type: 'always' }, value: { s1: { description: 'one' } } },
+        { when: { type: 'always' }, value: { s2: {} } },
+      ],
+    } as never);
+
+    expect(result.skills).toEqual({ s1: true, s2: true });
+  });
+
+  it('falls back to empty string when instructions is not a string', () => {
+    const result = storedAgentToFormValues({
+      id: 'agent-1',
+      name: 'A',
+      instructions: { type: 'rule' },
+    } as never);
+
+    expect(result.instructions).toBe('');
+  });
+
+  it('hydrates a static model into the form value', () => {
+    const result = storedAgentToFormValues({
+      id: 'agent-1',
+      name: 'A',
+      model: { provider: 'openai', name: 'gpt-4o' },
+    } as never);
+
+    expect(result.model).toEqual({ provider: 'openai', name: 'gpt-4o' });
+  });
+
+  it('leaves model undefined for conditional stored models', () => {
+    const result = storedAgentToFormValues({
+      id: 'agent-1',
+      name: 'A',
+      model: [{ when: { type: 'always' }, value: { provider: 'openai', name: 'gpt-4o' } }],
+    } as never);
+
+    expect(result.model).toBeUndefined();
+  });
+
+  it('propagates metadata.avatarUrl into the form value', () => {
+    const result = storedAgentToFormValues({
+      id: 'agent-1',
+      name: 'A',
+      metadata: { avatarUrl: 'https://cdn.example/a.png' },
+    } as never);
+
+    expect(result.avatarUrl).toBe('https://cdn.example/a.png');
+  });
+
+  it('leaves avatarUrl undefined when metadata exists without the key', () => {
+    const result = storedAgentToFormValues({
+      id: 'agent-1',
+      name: 'A',
+      metadata: { other: 'value' },
+    } as never);
+
+    expect(result.avatarUrl).toBeUndefined();
+  });
+
+  it('propagates visibility and browserEnabled=true when browser is non-null', () => {
+    const result = storedAgentToFormValues({
+      id: 'agent-1',
+      name: 'A',
+      visibility: 'public',
+      browser: { enabled: true },
+    } as never);
+
+    expect(result.visibility).toBe('public');
+    expect(result.browserEnabled).toBe(true);
+  });
+});
+
+describe('extractStaticModel', () => {
+  it('returns undefined for undefined input', () => {
+    expect(extractStaticModel(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for a conditional (array) input', () => {
+    expect(
+      extractStaticModel([{ when: { type: 'always' }, value: { provider: 'openai', name: 'gpt-4o' } }] as never),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when provider is missing or empty', () => {
+    expect(extractStaticModel({ name: 'gpt-4o' } as never)).toBeUndefined();
+    expect(extractStaticModel({ provider: '', name: 'gpt-4o' } as never)).toBeUndefined();
+    expect(extractStaticModel({ provider: 42, name: 'gpt-4o' } as never)).toBeUndefined();
+  });
+
+  it('returns undefined when name is missing or empty', () => {
+    expect(extractStaticModel({ provider: 'openai' } as never)).toBeUndefined();
+    expect(extractStaticModel({ provider: 'openai', name: '' } as never)).toBeUndefined();
+    expect(extractStaticModel({ provider: 'openai', name: 42 } as never)).toBeUndefined();
+  });
+
+  it('returns the static model when both provider and name are valid strings', () => {
+    expect(extractStaticModel({ provider: 'openai', name: 'gpt-4o' } as never)).toEqual({
+      provider: 'openai',
+      name: 'gpt-4o',
+    });
+  });
+});
+
+describe('isConditionalStoredModel', () => {
+  it('returns true for array input', () => {
+    expect(isConditionalStoredModel([] as never)).toBe(true);
+  });
+
+  it('returns false for object input', () => {
+    expect(isConditionalStoredModel({ provider: 'openai', name: 'gpt-4o' } as never)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isConditionalStoredModel(undefined)).toBe(false);
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/__tests__/to-providers.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/to-providers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { ListProvider } from '../to-providers';
+import { toProviders } from '../to-providers';
+
+const baseProvider: ListProvider = {
+  id: 'openai',
+  name: 'openai',
+  label: 'OpenAI',
+  description: 'OpenAI provider',
+  models: ['gpt-4o', 'gpt-4o-mini'],
+} as never;
+
+describe('toProviders', () => {
+  it('maps the source provider fields onto the target Provider shape', () => {
+    const [result] = toProviders([baseProvider]);
+
+    expect(result.id).toBe('openai');
+    expect(result.name).toBe('openai');
+    expect((result as unknown as { label: string }).label).toBe('OpenAI');
+    expect((result as unknown as { description: string }).description).toBe('OpenAI provider');
+    expect(result.models).toEqual(['gpt-4o', 'gpt-4o-mini']);
+  });
+
+  it('sets envVar to an empty string and connected to false', () => {
+    const [result] = toProviders([baseProvider]);
+
+    expect(result.envVar).toBe('');
+    expect(result.connected).toBe(false);
+  });
+
+  it('defaults models to an empty array when missing', () => {
+    const [result] = toProviders([{ ...baseProvider, models: undefined as never }]);
+
+    expect(result.models).toEqual([]);
+  });
+
+  it('returns an empty array when given no providers', () => {
+    expect(toProviders([])).toEqual([]);
+  });
+
+  it('preserves the order of input providers', () => {
+    const result = toProviders([
+      { ...baseProvider, id: 'a', name: 'a' },
+      { ...baseProvider, id: 'b', name: 'b' },
+      { ...baseProvider, id: 'c', name: 'c' },
+    ]);
+
+    expect(result.map(p => p.id)).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/packages/playground/src/domains/agent-builder/services/build-available-tool-records.ts
+++ b/packages/playground/src/domains/agent-builder/services/build-available-tool-records.ts
@@ -1,0 +1,47 @@
+import type { AvailableAgentsRecord, AvailableToolsRecord, AvailableWorkflowsRecord } from '../types/agent-tool';
+
+interface BuildAvailableToolRecordsResult {
+  tools: AvailableToolsRecord;
+  agents: AvailableAgentsRecord;
+  workflows: AvailableWorkflowsRecord;
+}
+
+export function buildAvailableToolRecords(
+  toolsData: Record<string, unknown>,
+  agentsData: Record<string, unknown>,
+  workflowsData: Record<string, unknown> = {},
+  excludeAgentId?: string,
+): BuildAvailableToolRecordsResult {
+  const tools: AvailableToolsRecord = Object.fromEntries(
+    Object.entries(toolsData).map(([toolId, tool]) => [
+      toolId,
+      { description: (tool as { description?: string }).description },
+    ]),
+  );
+
+  const agents: AvailableAgentsRecord = Object.fromEntries(
+    Object.entries(agentsData)
+      .filter(([agentId]) => agentId !== excludeAgentId)
+      .map(([agentId, agent]) => [
+        agentId,
+        {
+          id: agentId,
+          name: (agent as { name?: string }).name ?? agentId,
+          description: (agent as { description?: string }).description,
+        },
+      ]),
+  );
+
+  const workflows: AvailableWorkflowsRecord = Object.fromEntries(
+    Object.entries(workflowsData).map(([workflowId, workflow]) => [
+      workflowId,
+      {
+        id: workflowId,
+        name: (workflow as { name?: string }).name ?? workflowId,
+        description: (workflow as { description?: string }).description,
+      },
+    ]),
+  );
+
+  return { tools, agents, workflows };
+}

--- a/packages/playground/src/domains/agent-builder/services/build-form-snapshot.ts
+++ b/packages/playground/src/domains/agent-builder/services/build-form-snapshot.ts
@@ -1,0 +1,121 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+
+import type { useBuilderAgentFeatures } from '../hooks/use-builder-agent-features';
+import type { AgentBuilderEditFormValues } from '../schemas';
+import type { AgentTool } from '../types/agent-tool';
+import type { ModelInfo } from '@/domains/llm';
+
+export interface AvailableWorkspaceLike {
+  id: string;
+  name: string;
+}
+
+export interface BuildFormSnapshotOptions {
+  availableAgentTools: AgentTool[];
+  availableSkills: StoredSkillResponse[];
+  availableWorkspaces: AvailableWorkspaceLike[];
+  availableModels: ModelInfo[];
+  features: ReturnType<typeof useBuilderAgentFeatures>;
+}
+
+const INSTRUCTIONS_MAX_CHARS = 1500;
+const EMPTY_TEXT = '(empty)';
+const NOT_SET_TEXT = '(not set)';
+
+const truncate = (value: string, max: number): string => {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}… [truncated]`;
+};
+
+const renderQuoted = (value: string | undefined): string => {
+  if (!value || value.length === 0) return EMPTY_TEXT;
+  return `"${value}"`;
+};
+
+const renderInstructions = (value: string | undefined): string => {
+  if (!value || value.length === 0) return EMPTY_TEXT;
+  const truncated = truncate(value, INSTRUCTIONS_MAX_CHARS);
+  return `"""\n${truncated}\n"""`;
+};
+
+const collectSelectedIds = (record: Record<string, boolean | undefined> | undefined): string[] => {
+  if (!record) return [];
+  const ids: string[] = [];
+  for (const [id, selected] of Object.entries(record)) {
+    if (selected) ids.push(id);
+  }
+  return ids;
+};
+
+const renderToolEntry = (tool: AgentTool): string => `"${tool.name}" (${tool.id})`;
+
+const renderSkillEntry = (skill: StoredSkillResponse): string => `"${skill.name}" (${skill.id})`;
+
+export function buildFormSnapshotInstructions(
+  values: AgentBuilderEditFormValues,
+  options: BuildFormSnapshotOptions,
+): string {
+  const { availableAgentTools, availableSkills, availableWorkspaces, availableModels, features } = options;
+
+  const lines: string[] = [];
+  lines.push('## Current agent configuration (read-only context)');
+  lines.push('');
+  lines.push(
+    "The user's form currently has these values. Use them to ground your suggestions: validate, challenge, or refine them rather than asking the user to repeat them.",
+  );
+  lines.push('');
+
+  lines.push(`- Name: ${renderQuoted(values.name)}`);
+  lines.push(`- Description: ${renderQuoted(values.description)}`);
+  lines.push(`- Instructions: ${renderInstructions(values.instructions)}`);
+
+  if (features.model) {
+    if (values.model && values.model.provider && values.model.name) {
+      const known = availableModels.find(m => m.provider === values.model!.provider && m.model === values.model!.name);
+      const label = `${values.model.provider}/${values.model.name}`;
+      lines.push(`- Model: ${known ? label : `${label} (not in available models list)`}`);
+    } else {
+      lines.push(`- Model: ${NOT_SET_TEXT}`);
+    }
+  }
+
+  if (values.workspaceId && values.workspaceId.length > 0) {
+    const workspace = availableWorkspaces.find(w => w.id === values.workspaceId);
+    const name = workspace?.name ?? '(unknown)';
+    lines.push(`- Workspace: "${name}" (id: ${values.workspaceId})`);
+  } else {
+    lines.push(`- Workspace: ${NOT_SET_TEXT}`);
+  }
+
+  lines.push(`- Visibility: ${values.visibility ?? 'private'}`);
+
+  if (features.browser) {
+    lines.push(`- Browser enabled: ${values.browserEnabled === true ? 'true' : 'false'}`);
+  }
+
+  if (features.tools) {
+    const selectedToolIds = new Set([
+      ...collectSelectedIds(values.tools),
+      ...collectSelectedIds(values.agents),
+      ...collectSelectedIds(values.workflows),
+    ]);
+    const selected = availableAgentTools.filter(t => selectedToolIds.has(t.id));
+    if (selected.length === 0) {
+      lines.push('- Tools: (none selected)');
+    } else {
+      lines.push(`- Tools (${selected.length}): ${selected.map(renderToolEntry).join(', ')}`);
+    }
+  }
+
+  if (features.skills) {
+    const selectedSkillIds = new Set(collectSelectedIds(values.skills));
+    const selected = availableSkills.filter(s => selectedSkillIds.has(s.id));
+    if (selected.length === 0) {
+      lines.push('- Skills: (none selected)');
+    } else {
+      lines.push(`- Skills (${selected.length}): ${selected.map(renderSkillEntry).join(', ')}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/packages/playground/src/domains/agent-builder/services/build-tool-description.ts
+++ b/packages/playground/src/domains/agent-builder/services/build-tool-description.ts
@@ -1,0 +1,69 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import type { ModelInfo } from '../../llm/hooks/use-filtered-models';
+import type { useBuilderAgentFeatures } from '../hooks/use-builder-agent-features';
+import type { AgentTool } from '../types/agent-tool';
+
+interface AvailableWorkspace {
+  id: string;
+  name: string;
+}
+
+type Features = ReturnType<typeof useBuilderAgentFeatures>;
+
+export function buildAgentBuilderToolDescription(
+  features: Features,
+  availableAgentTools: AgentTool[],
+  availableWorkspaces: AvailableWorkspace[],
+  availableSkills: StoredSkillResponse[] = [],
+  availableModels: ModelInfo[] = [],
+): string {
+  const skillsAvailable = features.skills && availableSkills.length > 0;
+  const modelsAvailable = features.model && availableModels.length > 0;
+
+  const descriptionParts = ['name', 'description', 'instructions'];
+  if (features.tools) descriptionParts.push('tools');
+  if (skillsAvailable) descriptionParts.push('skills');
+  if (modelsAvailable) descriptionParts.push('model');
+  if (features.browser) descriptionParts.push('browserEnabled');
+  descriptionParts.push('workspaceId');
+
+  const availableToolsBlock =
+    features.tools && availableAgentTools.length > 0
+      ? `\n\nAvailable tools (use these ids in the "tools" field):\n${availableAgentTools
+          .map(t => `- ${t.id}${t.description ? `: ${t.description}` : ''}`)
+          .join('\n')}`
+      : '';
+
+  const availableSkillsBlock = skillsAvailable
+    ? `\n\nAvailable skills (use these ids in the "skills" field):\n${availableSkills
+        .map(s => `- ${s.id}${s.description ? `: ${s.description}` : ''}`)
+        .join('\n')}`
+    : '';
+
+  const availableWorkspacesBlock =
+    availableWorkspaces.length > 0
+      ? `\n\nAvailable workspaces (use these ids in the "workspaceId" field):\n${availableWorkspaces
+          .map(w => `- ${w.id}: ${w.name}`)
+          .join('\n')}`
+      : '';
+
+  const availableModelsBlock = modelsAvailable
+    ? `\n\nAvailable models (use these exact provider/name pairs in the "model" field):\n${availableModels
+        .map(model => `- provider: ${model.provider} (${model.providerName}), name: ${model.model}`)
+        .join('\n')}`
+    : '';
+
+  const toolsGuidance = features.tools
+    ? ' When enabling tools, each entry in `tools` MUST include both `id` (from the available tools list) and `name` (a concise Title Case display label, e.g. "Web Search"). The `name` is shown to the user in chat.'
+    : '';
+
+  const skillsGuidance = skillsAvailable
+    ? ' When enabling skills, each entry in `skills` MUST include both `id` (from the available skills list) and `name` (a concise Title Case display label). The `name` is shown to the user in chat.'
+    : '';
+
+  const createSkillGuidance = features.skills
+    ? ' If the user asks to create a NEW skill (one that does not already exist), call the separate `createSkillTool` tool with `name`, `description`, `instructions`, optional `workspaceId`, and optional `visibility`. The new skill will be auto-attached to the agent. Use this `agentBuilderTool` `skills` field only to attach skills that already exist.'
+    : '';
+
+  return `Modify the agent configuration that the user is building. Supported fields: ${descriptionParts.join(', ')}.${toolsGuidance}${skillsGuidance}${createSkillGuidance}${availableToolsBlock}${availableSkillsBlock}${availableWorkspacesBlock}${availableModelsBlock}`;
+}

--- a/packages/playground/src/domains/agent-builder/services/build-tool-schema.ts
+++ b/packages/playground/src/domains/agent-builder/services/build-tool-schema.ts
@@ -1,0 +1,116 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import { z } from 'zod-v4';
+import type { ModelInfo } from '../../llm/hooks/use-filtered-models';
+import type { useBuilderAgentFeatures } from '../hooks/use-builder-agent-features';
+import type { AgentTool } from '../types/agent-tool';
+
+interface AvailableWorkspace {
+  id: string;
+  name: string;
+}
+
+type Features = ReturnType<typeof useBuilderAgentFeatures>;
+
+export function buildAgentBuilderToolSchema(
+  features: Features,
+  availableAgentTools: AgentTool[],
+  availableWorkspaces: AvailableWorkspace[],
+  availableSkills: StoredSkillResponse[] = [],
+  availableModels: ModelInfo[] = [],
+): z.ZodObject<Record<string, z.ZodType>> {
+  const toolIds = availableAgentTools.map(t => t.id);
+  const workspaceIds = availableWorkspaces.map(w => w.id);
+  const skillIds = availableSkills.map(s => s.id);
+
+  const shape: Record<string, z.ZodType> = {
+    name: z.string(),
+    description: z
+      .string()
+      .optional()
+      .describe(
+        'A short, human-readable summary of what this agent does. Shown to users when browsing agents. Keep it concise (one sentence).',
+      ),
+    instructions: z.string(),
+  };
+
+  if (features.tools) {
+    const toolIdSchema = toolIds.length > 0 ? z.enum(toolIds as [string, ...string[]]) : z.string();
+    shape.tools = z
+      .array(
+        z.object({
+          id: toolIdSchema.describe(
+            'The tool id. Only use ids from the available tools list in this tool description.',
+          ),
+          name: z
+            .string()
+            .min(1)
+            .describe(
+              'A short, human-readable display name for this tool in Title Case (max ~3 words), derived from the tool\'s description. Example: "Web Search", "Weather Lookup". Shown to the user in chat.',
+            ),
+        }),
+      )
+      .describe(
+        "Tools to enable on the agent. Each entry must include both the tool `id` (from the available tools list) and a concise human-readable `name` derived from that tool's description.",
+      );
+  }
+
+  if (features.skills && skillIds.length > 0) {
+    const skillIdSchema = z.enum(skillIds as [string, ...string[]]);
+    shape.skills = z
+      .array(
+        z.object({
+          id: skillIdSchema.describe(
+            'The skill id. Only use ids from the available skills list in this tool description.',
+          ),
+          name: z
+            .string()
+            .min(1)
+            .describe(
+              'A short, human-readable Title Case display label for this skill (max ~3 words). Shown to the user in chat.',
+            ),
+        }),
+      )
+      .describe(
+        'Skills to enable on the agent. Each entry must include both the skill `id` (from the available skills list) and a concise human-readable `name`.',
+      );
+  }
+
+  if (features.model && availableModels.length > 0) {
+    const modelSchemas = availableModels.map(model =>
+      z.object({
+        provider: z.literal(model.provider).describe('The provider id from the available models list.'),
+        name: z.literal(model.model).describe('The model name from the available models list.'),
+      }),
+    );
+    const modelSchema =
+      modelSchemas.length === 1
+        ? modelSchemas[0]
+        : z.union(
+            modelSchemas as [
+              z.ZodObject<{ provider: z.ZodLiteral<string>; name: z.ZodLiteral<string> }>,
+              z.ZodObject<{ provider: z.ZodLiteral<string>; name: z.ZodLiteral<string> }>,
+              ...z.ZodObject<{ provider: z.ZodLiteral<string>; name: z.ZodLiteral<string> }>[],
+            ],
+          );
+
+    shape.model = modelSchema
+      .optional()
+      .describe('Model to use for the agent. Only use a provider/name pair from the available models list.');
+  }
+
+  if (features.browser) {
+    shape.browserEnabled = z
+      .boolean()
+      .optional()
+      .describe('Whether to enable browser access for this agent. Set to true to let the agent browse the web.');
+  }
+
+  const workspaceIdSchema = workspaceIds.length > 0 ? z.enum(workspaceIds as [string, ...string[]]) : z.string();
+  shape.workspaceId = workspaceIdSchema
+    .optional()
+    .describe(
+      'Id of the workspace to attach to the agent. Only use ids from the available workspaces list in this tool description.',
+    );
+
+  return z.object(shape);
+}

--- a/packages/playground/src/domains/agent-builder/services/downscale-avatar.ts
+++ b/packages/playground/src/domains/agent-builder/services/downscale-avatar.ts
@@ -1,0 +1,64 @@
+/** Target pixel size for avatar images (square). */
+const AVATAR_SIZE = 256;
+
+/** Maximum decoded byte size for the final avatar. */
+const AVATAR_MAX_BYTES = 512 * 1024;
+
+/** JPEG quality for non-PNG sources. */
+const JPEG_QUALITY = 0.85;
+
+export interface DownscaledAvatar {
+  /** Data URL ready to store in metadata.avatarUrl */
+  dataUrl: string;
+  /** MIME content type used for encoding */
+  contentType: 'image/png' | 'image/jpeg';
+}
+
+/**
+ * Estimate the decoded byte length of a base64 data URL.
+ * Does not allocate a full buffer — uses the 3/4 ratio.
+ */
+export function estimateDataUrlBytes(dataUrl: string): number {
+  const commaIdx = dataUrl.indexOf(',');
+  if (commaIdx < 0) return 0;
+  const base64 = dataUrl.slice(commaIdx + 1);
+  const padding = (base64.match(/=+$/) ?? [''])[0]!.length;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
+
+/**
+ * Downscales an image file to a 256×256 center-cropped square and returns it
+ * as a data URL. Preserves PNG for PNG sources; everything else becomes JPEG.
+ *
+ * Throws if the result exceeds 512 KB after encoding (unlikely at 256×256, but
+ * guards against pathological inputs).
+ */
+export async function downscaleImageToDataUrl(file: File): Promise<DownscaledAvatar> {
+  const bitmap = await createImageBitmap(file);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = AVATAR_SIZE;
+  canvas.height = AVATAR_SIZE;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context is not available');
+
+  // Center-crop to a square region from the source
+  const side = Math.min(bitmap.width, bitmap.height);
+  const sx = (bitmap.width - side) / 2;
+  const sy = (bitmap.height - side) / 2;
+  ctx.drawImage(bitmap, sx, sy, side, side, 0, 0, AVATAR_SIZE, AVATAR_SIZE);
+
+  const contentType: 'image/png' | 'image/jpeg' = file.type === 'image/png' ? 'image/png' : 'image/jpeg';
+  const dataUrl = canvas.toDataURL(contentType, JPEG_QUALITY);
+
+  // Validate size
+  const decodedSize = estimateDataUrlBytes(dataUrl);
+  if (decodedSize > AVATAR_MAX_BYTES) {
+    throw new Error(
+      `Avatar is too large after downscaling (${Math.round(decodedSize / 1024)} KB). Try a smaller image.`,
+    );
+  }
+
+  return { dataUrl, contentType };
+}

--- a/packages/playground/src/domains/agent-builder/services/extract-workspace-id.ts
+++ b/packages/playground/src/domains/agent-builder/services/extract-workspace-id.ts
@@ -1,0 +1,14 @@
+import type { StoredAgent } from '@/domains/agents/hooks/use-stored-agents';
+
+export function extractWorkspaceId(workspace: StoredAgent['workspace']): string | undefined {
+  if (
+    workspace &&
+    typeof workspace === 'object' &&
+    'type' in workspace &&
+    (workspace as { type: string }).type === 'id'
+  ) {
+    const id = (workspace as { workspaceId?: unknown }).workspaceId;
+    return typeof id === 'string' ? id : undefined;
+  }
+  return undefined;
+}

--- a/packages/playground/src/domains/agent-builder/services/form-values-to-save-params.ts
+++ b/packages/playground/src/domains/agent-builder/services/form-values-to-save-params.ts
@@ -1,0 +1,98 @@
+import type {
+  StoredAgentSkillConfig,
+  StoredAgentToolConfig,
+  StoredSkillResponse,
+  StoredWorkspaceRef,
+} from '@mastra/client-js';
+import type { AgentBuilderEditFormValues, AgentBuilderModel } from '../schemas';
+import type { AgentTool } from '../types/agent-tool';
+
+export interface SaveParams {
+  name: string;
+  description: string | undefined;
+  instructions: string;
+  tools: Record<string, StoredAgentToolConfig>;
+  agents: Record<string, StoredAgentToolConfig>;
+  workflows: Record<string, StoredAgentToolConfig>;
+  skills: Record<string, StoredAgentSkillConfig>;
+  workspace: StoredWorkspaceRef | undefined;
+  /** `true` = enable browser (server applies default config); `false` = disable browser */
+  browser: boolean;
+  visibility: 'private' | 'public' | undefined;
+  /**
+   * Static model selection from the form. Conditional models are owned by code;
+   * the form never round-trips them, so this is always either `undefined` or
+   * a `{ provider, name }` pair.
+   */
+  model: AgentBuilderModel | undefined;
+  metadata: Record<string, unknown> | undefined;
+}
+
+function buildEnabledRecord(
+  selectedById: Record<string, boolean> | undefined,
+  descriptionById: Map<string, string | undefined>,
+): Record<string, StoredAgentToolConfig> {
+  return Object.fromEntries(
+    Object.entries(selectedById ?? {})
+      .filter(([, enabled]) => enabled)
+      .map(([id]) => {
+        const description = descriptionById.get(id);
+        return [id, description ? { description } : {}];
+      }),
+  );
+}
+
+export function formValuesToSaveParams(
+  values: AgentBuilderEditFormValues,
+  availableAgentTools: AgentTool[],
+  availableSkills: StoredSkillResponse[] = [],
+): SaveParams {
+  const toolDescriptionById = new Map<string, string | undefined>();
+  const agentDescriptionById = new Map<string, string | undefined>();
+  const workflowDescriptionById = new Map<string, string | undefined>();
+  for (const item of availableAgentTools) {
+    if (item.type === 'tool') {
+      toolDescriptionById.set(item.id, item.description);
+    } else if (item.type === 'agent') {
+      agentDescriptionById.set(item.id, item.description);
+    } else {
+      workflowDescriptionById.set(item.id, item.description);
+    }
+  }
+
+  const skillDescriptionById = new Map<string, string | undefined>();
+  for (const skill of availableSkills) {
+    skillDescriptionById.set(skill.id, skill.description);
+  }
+
+  const tools = buildEnabledRecord(values.tools, toolDescriptionById);
+  const agents = buildEnabledRecord(values.agents, agentDescriptionById);
+  const workflows = buildEnabledRecord(values.workflows, workflowDescriptionById);
+  const skills = buildEnabledRecord(values.skills, skillDescriptionById);
+
+  const workspace: StoredWorkspaceRef | undefined =
+    typeof values.workspaceId === 'string' && values.workspaceId.length > 0
+      ? { type: 'id', workspaceId: values.workspaceId }
+      : undefined;
+
+  const description = values.description?.trim() ? values.description.trim() : undefined;
+
+  const metadata: Record<string, unknown> | undefined = values.avatarUrl ? { avatarUrl: values.avatarUrl } : undefined;
+
+  const browser = values.browserEnabled === true;
+
+  return {
+    name: values.name,
+    description,
+    instructions: values.instructions,
+    tools,
+    agents,
+    workflows,
+    skills: skills as Record<string, StoredAgentSkillConfig>,
+    workspace,
+    browser,
+    visibility: values.visibility,
+    model: values.model,
+    metadata,
+  };
+}

--- a/packages/playground/src/domains/agent-builder/services/route-tool-input.ts
+++ b/packages/playground/src/domains/agent-builder/services/route-tool-input.ts
@@ -1,0 +1,35 @@
+import type { AgentTool } from '../types/agent-tool';
+
+export interface ToolInputEntry {
+  id: string;
+  name: string;
+}
+
+export interface RoutedToolInput {
+  tools: Record<string, true>;
+  agents: Record<string, true>;
+  workflows: Record<string, true>;
+}
+
+export function routeToolInputToFormKeys(
+  availableAgentTools: AgentTool[],
+  inputTools: ToolInputEntry[],
+): RoutedToolInput {
+  const typeById = new Map(availableAgentTools.map(item => [item.id, item.type] as const));
+  const tools: Record<string, true> = {};
+  const agents: Record<string, true> = {};
+  const workflows: Record<string, true> = {};
+
+  for (const entry of inputTools) {
+    const type = typeById.get(entry.id);
+    if (type === 'agent') {
+      agents[entry.id] = true;
+    } else if (type === 'workflow') {
+      workflows[entry.id] = true;
+    } else if (type === 'tool') {
+      tools[entry.id] = true;
+    }
+  }
+
+  return { tools, agents, workflows };
+}

--- a/packages/playground/src/domains/agent-builder/services/stored-agent-to-agent-config.ts
+++ b/packages/playground/src/domains/agent-builder/services/stored-agent-to-agent-config.ts
@@ -1,0 +1,29 @@
+import type { StoredAgent } from '@/domains/agents/hooks/use-stored-agents';
+
+export interface AgentConfig {
+  id: string;
+  name: string;
+  description?: string;
+  avatarUrl?: string;
+  systemPrompt: string;
+  visibility?: 'private' | 'public';
+  authorId?: string | null;
+  browserEnabled?: boolean;
+}
+
+export function storedAgentToAgentConfig(storedAgent: StoredAgent | null | undefined, fallbackId: string): AgentConfig {
+  const avatarUrl =
+    storedAgent?.metadata && typeof storedAgent.metadata === 'object' && 'avatarUrl' in storedAgent.metadata
+      ? (storedAgent.metadata.avatarUrl as string | undefined)
+      : undefined;
+
+  return {
+    id: storedAgent?.id ?? fallbackId,
+    name: storedAgent?.name ?? '',
+    description: storedAgent?.description ?? '',
+    avatarUrl,
+    systemPrompt: typeof storedAgent?.instructions === 'string' ? storedAgent.instructions : '',
+    visibility: storedAgent?.visibility ?? 'private',
+    authorId: storedAgent?.authorId,
+  };
+}

--- a/packages/playground/src/domains/agent-builder/services/stored-agent-to-form-values.ts
+++ b/packages/playground/src/domains/agent-builder/services/stored-agent-to-form-values.ts
@@ -1,0 +1,64 @@
+import type { AgentBuilderEditFormValues, AgentBuilderModel } from '../schemas';
+import { extractWorkspaceId } from './extract-workspace-id';
+import type { StoredAgent } from '@/domains/agents/hooks/use-stored-agents';
+
+function flattenAgentSkills(skills: StoredAgent['skills'] | undefined): Record<string, unknown> {
+  if (!skills) return {};
+  if (Array.isArray(skills)) {
+    const merged: Record<string, unknown> = {};
+    for (const variant of skills) {
+      Object.assign(merged, variant.value);
+    }
+    return merged;
+  }
+  return skills as Record<string, unknown>;
+}
+
+/**
+ * Pull the static `{ provider, name }` model out of a stored agent, if present.
+ *
+ * `StorageConditionalField<T>` is `T | StorageConditionalVariant<T>[]`, so:
+ * - object with `provider` + `name` (strings)            → static model, surface in the form.
+ * - array (conditional model) or anything unrecognized   → return `undefined`; the form
+ *   doesn't own conditional models. The UI renders a read-only banner instead.
+ */
+export function extractStaticModel(model: StoredAgent['model'] | undefined): AgentBuilderModel | undefined {
+  if (!model || Array.isArray(model)) return undefined;
+  const provider = (model as { provider?: unknown }).provider;
+  const name = (model as { name?: unknown }).name;
+  if (typeof provider === 'string' && provider.length > 0 && typeof name === 'string' && name.length > 0) {
+    return { provider, name };
+  }
+  return undefined;
+}
+
+/**
+ * `true` when the stored agent's model is configured conditionally (in code).
+ * The form shows a read-only banner for these — v1 does not support editing
+ * conditional models in the playground UI.
+ */
+export function isConditionalStoredModel(model: StoredAgent['model'] | undefined): boolean {
+  return Array.isArray(model);
+}
+
+export function storedAgentToFormValues(storedAgent: StoredAgent | null | undefined): AgentBuilderEditFormValues {
+  const avatarUrl =
+    storedAgent?.metadata && typeof storedAgent.metadata === 'object' && 'avatarUrl' in storedAgent.metadata
+      ? (storedAgent.metadata.avatarUrl as string | undefined)
+      : undefined;
+
+  return {
+    name: storedAgent?.name ?? '',
+    description: storedAgent?.description ?? '',
+    instructions: typeof storedAgent?.instructions === 'string' ? storedAgent.instructions : '',
+    tools: Object.fromEntries(Object.keys(storedAgent?.tools ?? {}).map(k => [k, true])),
+    agents: Object.fromEntries(Object.keys(storedAgent?.agents ?? {}).map(k => [k, true])),
+    workflows: Object.fromEntries(Object.keys(storedAgent?.workflows ?? {}).map(k => [k, true])),
+    skills: Object.fromEntries(Object.keys(flattenAgentSkills(storedAgent?.skills)).map(k => [k, true])),
+    workspaceId: extractWorkspaceId(storedAgent?.workspace),
+    browserEnabled: storedAgent?.browser != null,
+    visibility: storedAgent?.visibility,
+    avatarUrl,
+    model: extractStaticModel(storedAgent?.model),
+  };
+}

--- a/packages/playground/src/domains/agent-builder/services/to-providers.ts
+++ b/packages/playground/src/domains/agent-builder/services/to-providers.ts
@@ -1,0 +1,19 @@
+import type { ListAgentsModelProvidersResponse, Provider } from '@mastra/client-js';
+
+export type ListProvider = ListAgentsModelProvidersResponse['providers'][number] & {
+  models: string[];
+};
+
+export function toProviders(providers: ListProvider[]): Provider[] {
+  return providers.map(provider => {
+    return {
+      id: provider.id,
+      name: provider.name,
+      label: provider.label,
+      description: provider.description,
+      envVar: '',
+      connected: false,
+      models: provider.models || [],
+    };
+  });
+}

--- a/packages/playground/src/domains/agent-builder/services/tool-constants.ts
+++ b/packages/playground/src/domains/agent-builder/services/tool-constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Tool-name constants for the atomic per-field agent-builder client tools.
+ *
+ * Each constant is the wire name the server emits in `dynamic-tool` /
+ * `tool-<name>` parts, and is used by the chat message renderer to dispatch
+ * the right ToolCard component.
+ */
+export const SET_AGENT_NAME_TOOL_NAME = 'set-agent-name';
+export const SET_AGENT_DESCRIPTION_TOOL_NAME = 'set-agent-description';
+export const SET_AGENT_INSTRUCTIONS_TOOL_NAME = 'set-agent-instructions';
+export const SET_AGENT_MODEL_TOOL_NAME = 'set-agent-model';
+export const SET_AGENT_TOOLS_TOOL_NAME = 'set-agent-tools';
+export const SET_AGENT_SKILLS_TOOL_NAME = 'set-agent-skills';
+export const SET_AGENT_WORKSPACE_ID_TOOL_NAME = 'set-agent-workspace-id';
+export const SET_AGENT_BROWSER_ENABLED_TOOL_NAME = 'set-agent-browser-enabled';

--- a/packages/playground/src/domains/agent-builder/types/__tests__/agent-tool.test.ts
+++ b/packages/playground/src/domains/agent-builder/types/__tests__/agent-tool.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildAgentTools, splitAgentTools } from '../agent-tool';
+
+describe('buildAgentTools', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('merges tools and agents into a single AgentTool array', () => {
+    const result = buildAgentTools({
+      tools: { 'tool-a': { description: 'Tool A' } },
+      agents: { 'agent-x': { name: 'Agent X', description: 'Useful agent' } },
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.find(r => r.id === 'tool-a')).toMatchObject({
+      id: 'tool-a',
+      name: 'tool-a',
+      description: 'Tool A',
+      type: 'tool',
+      isChecked: false,
+    });
+    expect(result.find(r => r.id === 'agent-x')).toMatchObject({
+      id: 'agent-x',
+      name: 'Agent X',
+      description: 'Useful agent',
+      type: 'agent',
+      isChecked: false,
+    });
+  });
+
+  it('merges workflows into the AgentTool array with type "workflow"', () => {
+    const result = buildAgentTools({
+      tools: {},
+      agents: {},
+      workflows: { 'wf-1': { name: 'Workflow One', description: 'Does workflow things' } },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'wf-1',
+      name: 'Workflow One',
+      description: 'Does workflow things',
+      type: 'workflow',
+      isChecked: false,
+    });
+  });
+
+  it('derives isChecked from the selected maps', () => {
+    const result = buildAgentTools({
+      tools: { 'tool-a': {} },
+      agents: { 'agent-x': { name: 'Agent X' } },
+      workflows: { 'wf-1': { name: 'Workflow' } },
+      selected: {
+        tools: { 'tool-a': true },
+        agents: { 'agent-x': true },
+        workflows: { 'wf-1': true },
+      },
+    });
+
+    expect(result.find(r => r.id === 'tool-a')?.isChecked).toBe(true);
+    expect(result.find(r => r.id === 'agent-x')?.isChecked).toBe(true);
+    expect(result.find(r => r.id === 'wf-1')?.isChecked).toBe(true);
+  });
+
+  it('treats falsy/missing entries in selected maps as unchecked', () => {
+    const result = buildAgentTools({
+      tools: { 'tool-a': {} },
+      agents: { 'agent-x': { name: 'Agent X' } },
+      workflows: { 'wf-1': { name: 'Workflow' } },
+      selected: {
+        tools: { 'tool-a': false },
+        agents: {},
+        workflows: { 'wf-1': false },
+      },
+    });
+
+    expect(result.find(r => r.id === 'tool-a')?.isChecked).toBe(false);
+    expect(result.find(r => r.id === 'agent-x')?.isChecked).toBe(false);
+    expect(result.find(r => r.id === 'wf-1')?.isChecked).toBe(false);
+  });
+
+  it('warns and lets the agent win when an id collides between tool and agent', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = buildAgentTools({
+      tools: { collide: { description: 'tool description' } },
+      agents: { collide: { name: 'Collide Agent', description: 'agent description' } },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'collide',
+      name: 'Collide Agent',
+      description: 'agent description',
+      type: 'agent',
+    });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('lets the agent win and warns when an id collides between agent and workflow', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = buildAgentTools({
+      tools: {},
+      agents: { collide: { name: 'Collide Agent', description: 'agent description' } },
+      workflows: { collide: { name: 'Collide Workflow', description: 'workflow description' } },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'collide',
+      type: 'agent',
+    });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('lets the workflow win over a tool with the same id and warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = buildAgentTools({
+      tools: { collide: { description: 'tool description' } },
+      agents: {},
+      workflows: { collide: { name: 'Collide Workflow', description: 'workflow description' } },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'collide',
+      name: 'Collide Workflow',
+      type: 'workflow',
+    });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('splitAgentTools', () => {
+  it('routes checked items to tools, agents, or workflows based on type', () => {
+    const result = splitAgentTools([
+      { id: 'tool-a', name: 'tool-a', isChecked: true, type: 'tool' },
+      { id: 'tool-b', name: 'tool-b', isChecked: false, type: 'tool' },
+      { id: 'agent-x', name: 'Agent X', isChecked: true, type: 'agent' },
+      { id: 'agent-y', name: 'Agent Y', isChecked: false, type: 'agent' },
+      { id: 'wf-1', name: 'Workflow', isChecked: true, type: 'workflow' },
+      { id: 'wf-2', name: 'Workflow 2', isChecked: false, type: 'workflow' },
+    ]);
+
+    expect(result).toEqual({
+      tools: { 'tool-a': true },
+      agents: { 'agent-x': true },
+      workflows: { 'wf-1': true },
+    });
+  });
+
+  it('round-trips with buildAgentTools', () => {
+    const items = buildAgentTools({
+      tools: { 'tool-a': {} },
+      agents: { 'agent-x': { name: 'Agent X' } },
+      workflows: { 'wf-1': { name: 'Workflow' } },
+      selected: {
+        tools: { 'tool-a': true },
+        agents: { 'agent-x': true },
+        workflows: { 'wf-1': true },
+      },
+    });
+
+    expect(splitAgentTools(items)).toEqual({
+      tools: { 'tool-a': true },
+      agents: { 'agent-x': true },
+      workflows: { 'wf-1': true },
+    });
+  });
+});

--- a/packages/playground/src/domains/agent-builder/types/agent-tool.ts
+++ b/packages/playground/src/domains/agent-builder/types/agent-tool.ts
@@ -1,0 +1,113 @@
+export type AgentToolType = 'tool' | 'agent' | 'workflow';
+
+export interface AgentTool {
+  id: string;
+  name: string;
+  description?: string;
+  isChecked: boolean;
+  type: AgentToolType;
+}
+
+export interface AvailableToolsRecord {
+  [id: string]: { description?: string };
+}
+
+export interface AvailableAgentsRecord {
+  [id: string]: { id?: string; name?: string; description?: string };
+}
+
+export interface AvailableWorkflowsRecord {
+  [id: string]: { id?: string; name?: string; description?: string };
+}
+
+export interface SelectedMaps {
+  tools?: Record<string, boolean | undefined>;
+  agents?: Record<string, boolean | undefined>;
+  workflows?: Record<string, boolean | undefined>;
+}
+
+export interface BuildAgentToolsArgs {
+  tools: AvailableToolsRecord;
+  agents: AvailableAgentsRecord;
+  workflows?: AvailableWorkflowsRecord;
+  selected?: SelectedMaps;
+}
+
+export const buildAgentTools = ({ tools, agents, workflows = {}, selected }: BuildAgentToolsArgs): AgentTool[] => {
+  const selectedTools = selected?.tools ?? {};
+  const selectedAgents = selected?.agents ?? {};
+  const selectedWorkflows = selected?.workflows ?? {};
+
+  const result: AgentTool[] = [];
+  const seen = new Set<string>();
+
+  for (const [id, agent] of Object.entries(agents)) {
+    seen.add(id);
+    result.push({
+      id,
+      name: agent?.name ?? id,
+      description: agent?.description,
+      isChecked: Boolean(selectedAgents[id]),
+      type: 'agent',
+    });
+  }
+
+  for (const [id, workflow] of Object.entries(workflows)) {
+    if (seen.has(id)) {
+      console.warn(
+        `[buildAgentTools] id collision for "${id}": agent and workflow share the same id; agent takes precedence.`,
+      );
+      continue;
+    }
+    seen.add(id);
+    result.push({
+      id,
+      name: workflow?.name ?? id,
+      description: workflow?.description,
+      isChecked: Boolean(selectedWorkflows[id]),
+      type: 'workflow',
+    });
+  }
+
+  for (const [id, tool] of Object.entries(tools)) {
+    if (seen.has(id)) {
+      console.warn(
+        `[buildAgentTools] id collision for "${id}": agent or workflow and tool share the same id; agent/workflow takes precedence.`,
+      );
+      continue;
+    }
+    seen.add(id);
+    result.push({
+      id,
+      name: id,
+      description: tool?.description,
+      isChecked: Boolean(selectedTools[id]),
+      type: 'tool',
+    });
+  }
+
+  return result;
+};
+
+export interface SplitAgentToolsResult {
+  tools: Record<string, true>;
+  agents: Record<string, true>;
+  workflows: Record<string, true>;
+}
+
+export const splitAgentTools = (items: AgentTool[]): SplitAgentToolsResult => {
+  const tools: Record<string, true> = {};
+  const agents: Record<string, true> = {};
+  const workflows: Record<string, true> = {};
+  for (const item of items) {
+    if (!item.isChecked) continue;
+    if (item.type === 'agent') {
+      agents[item.id] = true;
+    } else if (item.type === 'workflow') {
+      workflows[item.id] = true;
+    } else {
+      tools[item.id] = true;
+    }
+  }
+  return { tools, agents, workflows };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4320,6 +4320,9 @@ importers:
       zod:
         specifier: ^3.25.0
         version: 3.25.76
+      zod-v4:
+        specifier: npm:zod@^4.3.6
+        version: zod@4.4.3
       zustand:
         specifier: ^5.0.12
         version: 5.0.13(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
@@ -4366,6 +4369,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
         version: 0.5.2(eslint@10.3.0(jiti@2.6.1))
+      msw:
+        specifier: ^2.6.0
+        version: 2.14.6(@types/node@22.19.15)(typescript@6.0.3)
       react-grab:
         specifier: ^0.1.32
         version: 0.1.33(react@19.2.6)
@@ -27602,10 +27608,6 @@ packages:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
 
-  tough-cookie@6.0.0:
-    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
-    engines: {node: '>=16'}
-
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -47015,7 +47017,7 @@ snapshots:
   fetch-cookie@3.2.0:
     dependencies:
       set-cookie-parser: 2.7.2
-      tough-cookie: 6.0.0
+      tough-cookie: 6.0.1
 
   fetch-h2@3.0.2:
     dependencies:
@@ -53497,7 +53499,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -54730,10 +54732,6 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
-
-  tough-cookie@6.0.0:
-    dependencies:
-      tldts: 7.0.19
 
   tough-cookie@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

This PR adds the Agent Builder domain helpers under `packages/playground/src/domains/agent-builder` with full colocated test coverage.

Included areas:

- Agent Builder schemas and types
- Agent Builder service helpers
- Agent Builder React Query hooks
- Vitest coverage for services
- Vitest + MSW coverage for hooks

## Coverage

The targeted Agent Builder services and hooks suite passes with 100% coverage:

```txt
Test Files  12 passed (12)
Tests       129 passed (129)

Statements  100%
Branches    100%
Functions   100%
Lines       100%
```

Command used:

```bash
cd packages/playground
npx vitest run src/domains/agent-builder/services src/domains/agent-builder/hooks \
  --coverage \
  --coverage.provider=v8 \
  --coverage.include='src/domains/agent-builder/services/**' \
  --coverage.include='src/domains/agent-builder/hooks/**' \
  --coverage.exclude='**/__tests__/**' \
  --coverage.exclude='**/tool-constants.ts' \
  --coverage.reporter=text
```

## Typecheck

I also ran:

```bash
pnpm --filter ./packages/playground typecheck
```

That command currently fails on pre-existing Playground type errors outside `src/domains/agent-builder`. I also checked for hook-specific type errors with:

```bash
pnpm typecheck 2>&1 | grep -E "agent-builder/hooks"
```

That produced no output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->