### PR TITLE
fix(core): guard against undefined toolInvocation on tool-invocation parts

### DIFF
--- a/.changeset/seven-experts-own.md
+++ b/.changeset/seven-experts-own.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed crash in CacheKeyGenerator.fromAIV4Part when a tool-invocation part has undefined toolInvocation. This can happen when observational memory seals a partially-streamed assistant message. Also guarded MessageMerger against the same condition.

--- a/packages/core/src/agent/message-list/cache/CacheKeyGenerator-tool-invocation-guard.test.ts
+++ b/packages/core/src/agent/message-list/cache/CacheKeyGenerator-tool-invocation-guard.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { CacheKeyGenerator } from './CacheKeyGenerator';
+
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/16756
+ *
+ * When Observational Memory's UPSERT collision produces a tool-invocation part
+ * with `toolInvocation === undefined`, CacheKeyGenerator.fromAIV4Part crashes:
+ *
+ *   TypeError: Cannot read properties of undefined (reading 'toolCallId')
+ *
+ * The cache key generator must handle malformed parts gracefully instead of
+ * crashing the entire message loading pipeline.
+ */
+describe('CacheKeyGenerator tool-invocation null guard (#16756)', () => {
+  it('fromAIV4Part should not crash when toolInvocation is undefined', () => {
+    const brokenPart = {
+      type: 'tool-invocation' as const,
+      toolInvocation: undefined,
+    };
+
+    expect(() => CacheKeyGenerator.fromAIV4Part(brokenPart as any)).not.toThrow();
+  });
+
+  it('fromAIV4Part should return a stable key for a broken tool-invocation part', () => {
+    const brokenPart = {
+      type: 'tool-invocation' as const,
+      toolInvocation: undefined,
+    };
+
+    const key1 = CacheKeyGenerator.fromAIV4Part(brokenPart as any);
+    const key2 = CacheKeyGenerator.fromAIV4Part(brokenPart as any);
+
+    expect(key1).toBe(key2);
+  });
+
+  it('fromAIV4Parts should not crash when a tool-invocation part has undefined toolInvocation', () => {
+    const parts = [
+      { type: 'text' as const, text: 'hello' },
+      { type: 'tool-invocation' as const, toolInvocation: undefined },
+    ];
+
+    expect(() => CacheKeyGenerator.fromAIV4Parts(parts as any)).not.toThrow();
+  });
+
+  it('fromDBParts should not crash when a tool-invocation part has undefined toolInvocation', () => {
+    const parts = [
+      { type: 'text' as const, text: 'hello' },
+      { type: 'tool-invocation' as const, toolInvocation: undefined },
+    ];
+
+    expect(() => CacheKeyGenerator.fromDBParts(parts as any)).not.toThrow();
+  });
+
+  it('fromAIV4Part should still work correctly with valid tool-invocation parts', () => {
+    const validPart = {
+      type: 'tool-invocation' as const,
+      toolInvocation: {
+        toolCallId: 'call_123',
+        state: 'result',
+        toolName: 'myTool',
+        args: {},
+        result: 'done',
+      },
+    };
+
+    const key = CacheKeyGenerator.fromAIV4Part(validPart as any);
+    expect(key).toContain('call_123');
+    expect(key).toContain('result');
+  });
+});

--- a/packages/core/src/agent/message-list/cache/CacheKeyGenerator.ts
+++ b/packages/core/src/agent/message-list/cache/CacheKeyGenerator.ts
@@ -55,6 +55,7 @@ export class CacheKeyGenerator {
       cacheKey = appendResponseProviderItemKeys(cacheKey, (part as any).providerMetadata);
     }
     if (part.type === 'tool-invocation') {
+      if (!part.toolInvocation) return cacheKey;
       cacheKey += part.toolInvocation.toolCallId;
       cacheKey += part.toolInvocation.state;
     }

--- a/packages/core/src/agent/message-list/merge/MessageMerger.ts
+++ b/packages/core/src/agent/message-list/merge/MessageMerger.ts
@@ -111,9 +111,10 @@ export class MessageMerger {
     for (const [index, part] of incomingMessage.content.parts.entries()) {
       // If the incoming part is a tool-invocation result, find the corresponding call in the latest message
       if (part.type === 'tool-invocation') {
+        if (!part.toolInvocation) continue;
         const existingCallPart = [...latestMessage.content.parts]
           .reverse()
-          .find(p => p.type === 'tool-invocation' && p.toolInvocation.toolCallId === part.toolInvocation.toolCallId);
+          .find(p => p.type === 'tool-invocation' && p.toolInvocation?.toolCallId === part.toolInvocation.toolCallId);
 
         const existingCallToolInvocation = !!existingCallPart && existingCallPart.type === 'tool-invocation';
 


### PR DESCRIPTION
## Summary

When observational memory seals assistant messages at multi-step tool-call boundaries, it can capture a snapshot of a `tool-invocation` part before the AI SDK has populated the `toolInvocation` property. The part has `type: 'tool-invocation'` but no `toolInvocation` object yet — the SDK populates it progressively through states (`partial-call` → `call` → `result`).

This partial part gets persisted to storage via the upsert path (`persistMessages`). When the message is later loaded back via `memory.getContext()` and added to the message list, the equality check in `shouldReplaceMessage` calls `CacheKeyGenerator.fromAIV4Part`, which crashes accessing `part.toolInvocation.toolCallId` on `undefined`.

## Changes

**`CacheKeyGenerator.ts`** — Added a null guard in `fromAIV4Part` to return an empty cache key contribution when `toolInvocation` is undefined, rather than crashing.

**`MessageMerger.ts`** — Added a null guard for incoming parts with missing `toolInvocation` (skip with `continue`) and optional chaining on existing parts searched during merge (`p.toolInvocation?.toolCallId`).

**`CacheKeyGenerator-tool-invocation-guard.test.ts`** — 5 new unit tests covering `fromAIV4Part`, `fromAIV4Parts`, and `fromDBParts` with both missing and present `toolInvocation`.

## Test Plan

- New unit tests verify the fix directly (5 tests, all passing)
- Full message-list test suite passes (33 files, 425 tests, 0 failures)
- Typecheck clean (`tsc --noEmit`)

Fixes #16756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->