### PR TITLE
docs(evals): guide and example for evals with memory-enabled agents

### DIFF
--- a/docs/src/content/en/docs/evals/evals-with-memory.mdx
+++ b/docs/src/content/en/docs/evals/evals-with-memory.mdx
@@ -1,0 +1,158 @@
+---
+title: "Evals with memory | Evals"
+description: "Run scorers against memory-enabled agents — including observational memory in thread scope — using runEvals and dataset experiments."
+packages:
+  - "@mastra/core"
+  - "@mastra/memory"
+---
+
+# Evals with memory
+
+Agents that use memory in `thread` scope — including observational memory — require a thread ID at run time. When an eval invokes the agent without one, you'll see:
+
+```
+ObservationalMemory (scope: 'thread') requires a threadId, but none was found in RequestContext or MessageList.
+```
+
+This page covers the three working patterns for running Mastra evals against memory-enabled agents, what each path supports, and which one to pick. A complete runnable repro for all three approaches lives in [`examples/evals-with-memory`](https://github.com/mastra-ai/mastra/tree/main/examples/evals-with-memory).
+
+## When to use which approach
+
+| Goal | Approach |
+| - | - |
+| One shared conversation across every item | [`runEvals` with global `targetOptions.memory`](#shared-thread-with-runevals) |
+| One independent thread per item, simple CI loop | [`runEvals` per item](#per-item-threads-with-runevals) |
+| Per-item threads driven by a stored `Dataset` | [`dataset.startExperiment` with an inline task](#dataset-experiments-with-an-inline-task) |
+
+Pre-seeding `RequestContext` with `MastraMemory` is **not** a supported way to drive memory into an agent. Thread resolution reads `args.memory.thread` — `RequestContext.MastraMemory` is populated by `prepare-memory-step` after the agent has already resolved its thread.
+
+## Shared thread with `runEvals`
+
+`runEvals` accepts `targetOptions`, which is forwarded to `agent.generate()`. Passing `memory: { thread, resource }` runs every data item against the same thread — useful for testing recall across a multi-turn conversation.
+
+```typescript title="src/mastra/agents/support-agent.test.ts"
+import { runEvals } from '@mastra/core/evals'
+import { supportAgent } from './support-agent'
+import { recallScorer } from '../scorers/recall-scorer'
+
+const memory = await supportAgent.getMemory()
+await memory!.createThread({ threadId: 'eval-thread', resourceId: 'ci-user' })
+
+const result = await runEvals({
+  target: supportAgent,
+  scorers: [recallScorer],
+  targetOptions: {
+    memory: { thread: 'eval-thread', resource: 'ci-user' },
+  },
+  data: [
+    { input: 'My order number is 12345' },
+    { input: 'What is my order number?', groundTruth: '12345' },
+  ],
+})
+```
+
+`targetOptions` is **global per call**. There is no per-item override on `RunEvalsDataItem` today.
+
+## Per-item threads with `runEvals`
+
+When each data item needs its own thread (the common CI shape), call `runEvals` once per item with a unique `targetOptions.memory` and aggregate the scores yourself.
+
+```typescript title="src/mastra/agents/support-agent.test.ts"
+import { randomUUID } from 'node:crypto'
+import { runEvals } from '@mastra/core/evals'
+import { supportAgent } from './support-agent'
+import { recallScorer } from '../scorers/recall-scorer'
+
+const memory = await supportAgent.getMemory()
+const resourceId = 'ci-user'
+
+const items = [
+  { input: 'Cats are mammals', groundTruth: 'mammals' },
+  { input: 'Dogs are mammals too', groundTruth: 'mammals' },
+]
+
+// `runEvals` returns `{ scores: Record<string, number>; summary: { totalItems } }`.
+const scores: number[] = []
+for (const item of items) {
+  const threadId = `eval-${randomUUID()}`
+  await memory!.createThread({ threadId, resourceId, title: item.input })
+
+  const result = await runEvals({
+    target: supportAgent,
+    scorers: [recallScorer],
+    targetOptions: { memory: { thread: threadId, resource: resourceId } },
+    data: [item],
+  })
+
+  scores.push(result.scores[recallScorer.id])
+}
+
+const average = scores.reduce((a, b) => a + b, 0) / scores.length
+```
+
+:::note
+Create the thread before running the eval. Observational memory in `thread` scope reads from a record that must already exist.
+:::
+
+## Dataset experiments with an inline task
+
+`dataset.startExperiment({ target: agent })` does **not** forward a `memory` option to the agent — only `requestContext`. To run a stored dataset against a memory-enabled agent, use an inline `task` function and stash `{ threadId, resourceId }` in each item's `metadata`. The scorer pipeline still runs as normal.
+
+```typescript title="src/mastra/evals/dataset-experiment.ts"
+import { randomUUID } from 'node:crypto'
+import { mastra } from '../index'
+import { supportAgent } from '../agents/support-agent'
+import { recallScorer } from '../scorers/recall-scorer'
+
+const memory = await supportAgent.getMemory()
+const resourceId = 'ci-user'
+
+const items = [
+  { input: 'Cats are mammals', groundTruth: 'mammals', thread: `ds-${randomUUID()}` },
+  { input: 'Dogs are mammals too', groundTruth: 'mammals', thread: `ds-${randomUUID()}` },
+]
+
+for (const it of items) {
+  await memory!.createThread({ threadId: it.thread, resourceId, title: it.input })
+}
+
+const dataset = await mastra.datasets.create({
+  name: 'support-recall',
+  description: 'Per-item memory via inline task + item metadata',
+})
+
+await dataset.addItems({
+  items: items.map(it => ({
+    input: it.input,
+    groundTruth: it.groundTruth,
+    metadata: { threadId: it.thread, resourceId },
+  })),
+})
+
+const summary = await dataset.startExperiment({
+  scorers: [recallScorer],
+  task: async ({ input, metadata }) => {
+    const { threadId, resourceId: rid } = (metadata ?? {}) as {
+      threadId: string
+      resourceId: string
+    }
+    const result = await supportAgent.generate(input as string, {
+      memory: { thread: threadId, resource: rid },
+    })
+    return result.text
+  },
+})
+```
+
+The inline `task` receives the item's `metadata`, so each row can drive its own thread without changing the agent or any scorer.
+
+:::note
+Visit [runEvals reference](/reference/evals/run-evals) and [Dataset reference](/reference/datasets/dataset) for full configuration.
+:::
+
+## Related
+
+- [Running scorers in CI](/docs/evals/running-in-ci)
+- [Running experiments](/docs/evals/datasets/running-experiments)
+- [Observational memory](/docs/memory/observational-memory)
+- [runEvals API reference](/reference/evals/run-evals)

--- a/docs/src/content/en/docs/evals/running-in-ci.mdx
+++ b/docs/src/content/en/docs/evals/running-in-ci.mdx
@@ -128,4 +128,5 @@ describe('Weather Agent Tests', () => {
 
 - Learn about [creating custom scorers](/docs/evals/custom-scorers)
 - Explore [built-in scorers](/docs/evals/built-in-scorers)
+- Run scorers against [memory-enabled agents](/docs/evals/evals-with-memory)
 - Read the [runEvals API reference](/reference/evals/run-evals)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -710,6 +710,11 @@ const sidebars = {
           label: 'Running in CI',
         },
         {
+          type: 'doc',
+          id: 'evals/evals-with-memory',
+          label: 'Evals with Memory',
+        },
+        {
           type: 'category',
           label: 'Datasets',
           items: [

--- a/examples/evals-with-memory/.gitignore
+++ b/examples/evals-with-memory/.gitignore
@@ -1,0 +1,3 @@
+.env
+node_modules
+.mastra

--- a/examples/evals-with-memory/README.md
+++ b/examples/evals-with-memory/README.md
@@ -1,0 +1,125 @@
+# Evals With Memory
+
+Three concrete, working ways to run **Mastra evals** against an agent that
+has **memory** turned on — including observational-memory in `thread` scope
+(the configuration that triggers `ObservationalMemory (scope: 'thread')
+requires a threadId, but none was found in RequestContext or MessageList.`).
+
+Everything in this example uses Mastra evals primitives (`runEvals`,
+`createScorer`, `Dataset.startExperiment`). No custom evaluation harness.
+
+The agent in every script uses `@mastra/memory` + `@mastra/libsql` for
+storage and observational memory in `thread` scope. Each script writes to a
+fresh temp DB and cleans up after itself. A deterministic mock model is used
+so no API key is required and runs are reproducible in CI.
+
+## Run
+
+```bash
+pnpm install --ignore-workspace
+pnpm ex:all
+```
+
+## The three approaches
+
+### 1. `runEvals` with global `targetOptions.memory`
+Script: `src/runeval-global.ts`
+
+Simplest. Pass `targetOptions: { memory: { thread, resource } }` once and
+every data item runs against that thread. Use when you want a single
+multi-turn conversation across items (e.g. testing recall over a chat).
+
+```ts
+await runEvals({
+  target: agent,
+  scorers: [scorer],
+  targetOptions: { memory: { thread: 'eval-thread', resource: 'ci-user' } },
+  data: [...]
+});
+```
+
+Verified: all items land in one thread, scorer runs cleanly, no
+`threadId required` errors.
+
+### 2. `runEvals` once per item (per-item threads)
+Script: `src/runeval-per-item.ts`
+
+`runEvals` does **not** support per-item agent options today. Pre-seeding
+`RequestContext.MastraMemory` on each data item does NOT drive thread
+resolution — only `args.memory.thread` does (`resolveThreadIdFromArgs`
+in `packages/core/src/agent/utils.ts`).
+
+The supported CI shape is therefore: loop, calling `runEvals` once per item
+with its own `targetOptions.memory`, then aggregate scores yourself.
+
+```ts
+for (const it of items) {
+  const result = await runEvals({
+    target: agent,
+    scorers: [scorer],
+    targetOptions: { memory: { thread: it.thread, resource: 'ci-user' } },
+    data: [{ input: it.input, groundTruth: it.groundTruth }],
+  });
+}
+```
+
+### 3. `dataset.startExperiment` with inline task
+Script: `src/dataset.ts`
+
+The dataset / experiment runner (`runExperiment` under the hood) does
+**not** pass any `memory` option to `agent.generate()` — only
+`requestContext`. So the registry-based `target: agent` path can't drive
+memory either.
+
+Workaround that stays inside Mastra primitives: use an **inline `task`**
+function, stash the per-item `{ threadId, resourceId }` in the dataset
+item's `metadata`, and call `agent.generate(input, { memory: {...} })`
+yourself. The scorer still runs through the dataset/experiment pipeline.
+
+```ts
+await dataset.addItems({
+  items: items.map(it => ({
+    input: it.input,
+    groundTruth: it.groundTruth,
+    metadata: { threadId: it.thread, resourceId },
+  })),
+});
+await dataset.startExperiment({
+  scorers: [scorer],
+  task: async ({ input, metadata }) => {
+    const { threadId, resourceId } = metadata as any;
+    const r = await agent.generate(input, {
+      memory: { thread: threadId, resource: resourceId },
+    });
+    return r.text;
+  },
+});
+```
+
+## Notes / gotchas
+
+- **Thread scope requires the thread to exist before observational memory
+  reads it.** Each example pre-creates threads with
+  `memory.createThread(...)`.
+- `runEvals.targetOptions` is **global per call**. There's no per-item
+  override there today.
+- Pre-setting `RequestContext.MastraMemory` (the trick used inside
+  workflow-tool isolation and processor tests) does **not** by itself give
+  the agent a thread — it's an internal contract populated by
+  `prepare-memory-step` after a thread is resolved.
+- `Dataset.startExperiment({ target: agent })` does not forward memory.
+  Use the inline `task` workaround above, or call `runEvals` and skip the
+  dataset entirely.
+- The scorers in these examples are registered on the `Mastra` instance
+  (`scorers: { contains }`) so persistence doesn't log
+  `MASTRA_GET_SCORER_BY_ID_NOT_FOUND` warnings.
+
+## Gaps worth filing
+
+- `ExperimentConfig` / `StartExperimentConfig` should accept a
+  `targetOptions` field that mirrors `runEvals.targetOptions`, so dataset
+  users can pass `{ memory: { thread, resource } }` without dropping to an
+  inline task.
+- `runEvals` could accept per-item `targetOptions` (or a `memory` field on
+  `RunEvalsDataItem`) so per-item threads don't require a manual loop +
+  aggregation.

--- a/examples/evals-with-memory/package.json
+++ b/examples/evals-with-memory/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "examples-evals-with-memory",
+  "type": "module",
+  "private": true,
+  "description": "Three ways to run Mastra evals against memory-enabled agents",
+  "version": "0.0.1",
+  "scripts": {
+    "ex:runeval-global": "npx tsx src/runeval-global.ts",
+    "ex:runeval-per-item": "npx tsx src/runeval-per-item.ts",
+    "ex:dataset": "npx tsx src/dataset.ts",
+    "ex:all": "pnpm ex:runeval-global && pnpm ex:runeval-per-item && pnpm ex:dataset",
+    "clean": "rm -rf .mastra"
+  },
+  "dependencies": {
+    "@mastra/core": "latest",
+    "@mastra/evals": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/memory": "latest",
+    "ai": "^4.3.19",
+    "typescript": "^5.9.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "@mastra/core": "link:../../packages/core",
+      "@mastra/evals": "link:../../packages/evals",
+      "@mastra/libsql": "link:../../stores/libsql",
+      "@mastra/memory": "link:../../packages/memory"
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "tsx": "^4.19.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2.0",
+  "packageManager": "pnpm@10.29.3+sha512.498e1fb4cca5aa06c1dcf2611e6fafc50972ffe7189998c409e90de74566444298ffe43e6cd2acdc775ba1aa7cc5e092a8b7054c811ba8c5770f84693d33d2dc"
+}

--- a/examples/evals-with-memory/pnpm-lock.yaml
+++ b/examples/evals-with-memory/pnpm-lock.yaml
@@ -1,0 +1,529 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  '@mastra/core': link:../../packages/core
+  '@mastra/evals': link:../../packages/evals
+  '@mastra/libsql': link:../../stores/libsql
+  '@mastra/memory': link:../../packages/memory
+
+importers:
+
+  .:
+    dependencies:
+      '@mastra/core':
+        specifier: link:../../packages/core
+        version: link:../../packages/core
+      '@mastra/evals':
+        specifier: link:../../packages/evals
+        version: link:../../packages/evals
+      '@mastra/libsql':
+        specifier: link:../../stores/libsql
+        version: link:../../stores/libsql
+      '@mastra/memory':
+        specifier: link:../../packages/memory
+        version: link:../../packages/memory
+      ai:
+        specifier: ^4.3.19
+        version: 4.3.19(react@19.2.6)(zod@3.25.76)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+    devDependencies:
+      '@types/node':
+        specifier: ^20.12.7
+        version: 20.19.41
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.2
+
+packages:
+
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@1.2.12':
+    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/ui-utils@1.2.11':
+    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@types/diff-match-patch@1.0.36':
+    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
+
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  ai@4.3.19:
+    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  jsondiffpatch@0.6.0:
+    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
+  tsx@4.22.2:
+    resolution: {integrity: sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.12
+      secure-json-parse: 2.7.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@1.2.12(react@19.2.6)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      react: 19.2.6
+      swr: 2.4.1(react@19.2.6)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@types/diff-match-patch@1.0.36': {}
+
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
+
+  ai@4.3.19(react@19.2.6)(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/react': 1.2.12(react@19.2.6)(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 3.25.76
+    optionalDependencies:
+      react: 19.2.6
+
+  chalk@5.6.2: {}
+
+  dequal@2.0.3: {}
+
+  diff-match-patch@1.0.5: {}
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  json-schema@0.4.0: {}
+
+  jsondiffpatch@0.6.0:
+    dependencies:
+      '@types/diff-match-patch': 1.0.36
+      chalk: 5.6.2
+      diff-match-patch: 1.0.5
+
+  nanoid@3.3.12: {}
+
+  react@19.2.6: {}
+
+  secure-json-parse@2.7.0: {}
+
+  swr@2.4.1(react@19.2.6):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
+
+  throttleit@2.1.0: {}
+
+  tsx@4.22.2:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}

--- a/examples/evals-with-memory/src/dataset.ts
+++ b/examples/evals-with-memory/src/dataset.ts
@@ -17,52 +17,63 @@ import { buildAgent, containsScorer } from './shared.ts';
 
 async function main() {
   const { mastra, agent, cleanup } = buildAgent({ observationalMemory: true });
-  const memory = await agent.getMemory();
-  const resourceId = 'ci-user';
+  try {
+    const memory = await agent.getMemory();
+    if (!memory) {
+      throw new Error('Memory not available — ensure observationalMemory is enabled');
+    }
+    const resourceId = 'ci-user';
 
-  const items = [
-    { input: 'Cats are mammals', groundTruth: 'mammals', thread: `ds-${randomUUID()}` },
-    { input: 'Dogs are mammals too', groundTruth: 'mammals', thread: `ds-${randomUUID()}` },
-  ];
-  for (const it of items) {
-    await memory!.createThread({ threadId: it.thread, resourceId, title: it.input });
+    const items = [
+      { input: 'Cats are mammals', groundTruth: 'mammals', thread: `ds-${randomUUID()}` },
+      { input: 'Dogs are mammals too', groundTruth: 'mammals', thread: `ds-${randomUUID()}` },
+    ];
+    for (const it of items) {
+      await memory.createThread({ threadId: it.thread, resourceId, title: it.input });
+    }
+
+    const dataset = await mastra.datasets.create({
+      name: 'evals-with-memory-ds',
+      description: 'Per-item memory via inline task + item metadata',
+    });
+
+    await dataset.addItems({
+      items: items.map(it => ({
+        input: it.input,
+        groundTruth: it.groundTruth,
+        metadata: { threadId: it.thread, resourceId },
+      })),
+    });
+
+    const summary = await dataset.startExperiment({
+      scorers: [containsScorer],
+      task: async ({ input, metadata }) => {
+        const { threadId, resourceId: rid } = (metadata ?? {}) as {
+          threadId?: unknown;
+          resourceId?: unknown;
+        };
+        if (typeof input !== 'string' || !input) {
+          throw new Error(`Expected non-empty string input, got ${typeof input}`);
+        }
+        if (typeof threadId !== 'string' || typeof rid !== 'string') {
+          throw new Error('Item metadata is missing string threadId/resourceId');
+        }
+        const result = await agent.generate(input, {
+          memory: { thread: threadId, resource: rid },
+        });
+        return result.text;
+      },
+    });
+
+    console.log('[dataset] result:', JSON.stringify(summary, null, 2));
+
+    for (const it of items) {
+      const { messages } = await memory.recall({ threadId: it.thread, resourceId });
+      console.log(`[dataset] thread ${it.thread}: ${messages.length} messages`);
+    }
+  } finally {
+    cleanup();
   }
-
-  const dataset = await mastra.datasets.create({
-    name: 'evals-with-memory-ds',
-    description: 'Per-item memory via inline task + item metadata',
-  });
-
-  await dataset.addItems({
-    items: items.map(it => ({
-      input: it.input,
-      groundTruth: it.groundTruth,
-      metadata: { threadId: it.thread, resourceId },
-    })),
-  });
-
-  const summary = await dataset.startExperiment({
-    scorers: [containsScorer],
-    task: async ({ input, metadata }) => {
-      const { threadId, resourceId: rid } = (metadata ?? {}) as {
-        threadId: string;
-        resourceId: string;
-      };
-      const result = await agent.generate(input as string, {
-        memory: { thread: threadId, resource: rid },
-      });
-      return result.text;
-    },
-  });
-
-  console.log('[dataset] result:', JSON.stringify(summary, null, 2));
-
-  for (const it of items) {
-    const { messages } = await memory!.recall({ threadId: it.thread, resourceId });
-    console.log(`[dataset] thread ${it.thread}: ${messages.length} messages`);
-  }
-
-  cleanup();
 }
 
 main().catch(err => {

--- a/examples/evals-with-memory/src/dataset.ts
+++ b/examples/evals-with-memory/src/dataset.ts
@@ -1,0 +1,71 @@
+/**
+ * Approach 3: dataset.startExperiment with per-item memory via inline task
+ *
+ * The dataset / experiment runner does NOT pass memory options to the agent.
+ * Only `requestContext` is plumbed per item, and pre-seeding
+ * `RequestContext.MastraMemory` does not drive the agent's thread resolution
+ * (only `args.memory.thread` does).
+ *
+ * The supported way to run memory-enabled agents from a dataset today is to
+ * skip the `target: agent` registry path and use an inline `task` instead.
+ * The inline task receives per-item `metadata`, so we stash `{ threadId,
+ * resourceId }` there at insert time and invoke `agent.generate(input, {
+ * memory: { thread, resource } })` ourselves.
+ */
+import { randomUUID } from 'node:crypto';
+import { buildAgent, containsScorer } from './shared.ts';
+
+async function main() {
+  const { mastra, agent, cleanup } = buildAgent({ observationalMemory: true });
+  const memory = await agent.getMemory();
+  const resourceId = 'ci-user';
+
+  const items = [
+    { input: 'Cats are mammals', groundTruth: 'mammals', thread: `ds-${randomUUID()}` },
+    { input: 'Dogs are mammals too', groundTruth: 'mammals', thread: `ds-${randomUUID()}` },
+  ];
+  for (const it of items) {
+    await memory!.createThread({ threadId: it.thread, resourceId, title: it.input });
+  }
+
+  const dataset = await mastra.datasets.create({
+    name: 'evals-with-memory-ds',
+    description: 'Per-item memory via inline task + item metadata',
+  });
+
+  await dataset.addItems({
+    items: items.map(it => ({
+      input: it.input,
+      groundTruth: it.groundTruth,
+      metadata: { threadId: it.thread, resourceId },
+    })),
+  });
+
+  const summary = await dataset.startExperiment({
+    scorers: [containsScorer],
+    task: async ({ input, metadata }) => {
+      const { threadId, resourceId: rid } = (metadata ?? {}) as {
+        threadId: string;
+        resourceId: string;
+      };
+      const result = await agent.generate(input as string, {
+        memory: { thread: threadId, resource: rid },
+      });
+      return result.text;
+    },
+  });
+
+  console.log('[dataset] result:', JSON.stringify(summary, null, 2));
+
+  for (const it of items) {
+    const { messages } = await memory!.recall({ threadId: it.thread, resourceId });
+    console.log(`[dataset] thread ${it.thread}: ${messages.length} messages`);
+  }
+
+  cleanup();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/evals-with-memory/src/runeval-global.ts
+++ b/examples/evals-with-memory/src/runeval-global.ts
@@ -1,0 +1,46 @@
+/**
+ * Approach 1: runEvals + global targetOptions.memory
+ *
+ * Pro: simplest. The same thread/resource for every eval item.
+ * Con: all items share state — turn N can see turn N-1. Use only when you
+ *      actually want a single multi-turn conversation across items.
+ */
+import { randomUUID } from 'node:crypto';
+import { runEvals } from '@mastra/core/evals';
+import { buildAgent, containsScorer } from './shared.ts';
+
+async function main() {
+  const { agent, cleanup } = buildAgent({ observationalMemory: true });
+  const threadId = `eval-global-${randomUUID()}`;
+  const resourceId = 'ci-user';
+
+  // Pre-create the thread so observational-memory thread scope doesn't bail.
+  const memory = await agent.getMemory();
+  await memory!.createThread({ threadId, resourceId, title: 'eval-global' });
+
+  const result = await runEvals({
+    target: agent,
+    scorers: [containsScorer],
+    targetOptions: {
+      memory: { thread: threadId, resource: resourceId },
+    },
+    data: [
+      { input: 'My name is Ada', groundTruth: 'Ada' },
+      { input: 'What did I just say my name was?', groundTruth: 'Ada' },
+      { input: 'I work on numerical analysis', groundTruth: 'numerical' },
+    ],
+  });
+
+  console.log('[runeval-global] result:', JSON.stringify(result, null, 2));
+
+  // Verify memory was actually written.
+  const { messages } = await memory!.recall({ threadId, resourceId });
+  console.log(`[runeval-global] stored ${messages.length} messages in thread`);
+
+  cleanup();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/evals-with-memory/src/runeval-per-item.ts
+++ b/examples/evals-with-memory/src/runeval-per-item.ts
@@ -1,0 +1,64 @@
+/**
+ * Approach 2: per-item threads with `runEvals` — looped invocation
+ *
+ * `runEvals` accepts `targetOptions.memory` GLOBALLY (one thread for the
+ * whole batch). It does NOT support per-item agent options today, and
+ * pre-seeding `RequestContext.MastraMemory` does not drive the agent's
+ * thread resolution (only `args.memory.thread` does).
+ *
+ * The pragmatic CI shape is therefore: call `runEvals` once per item (or
+ * per group) with its own `targetOptions.memory`. Aggregate scores yourself.
+ * This is what existing prebuilt scorers do for stateful agents in CI.
+ */
+import { randomUUID } from 'node:crypto';
+import { runEvals } from '@mastra/core/evals';
+import { buildAgent, containsScorer } from './shared.ts';
+
+async function main() {
+  const { agent, cleanup } = buildAgent({ observationalMemory: true });
+  const memory = await agent.getMemory();
+  const resourceId = 'ci-user';
+
+  const items = [
+    { input: 'Tell me about quicksort', groundTruth: 'quicksort' },
+    { input: 'Tell me about heapsort', groundTruth: 'heapsort' },
+    { input: 'Tell me about mergesort', groundTruth: 'mergesort' },
+  ];
+
+  const perItem: Array<{ thread: string; result: any }> = [];
+  for (const it of items) {
+    const thread = `t-${randomUUID()}`;
+    await memory!.createThread({ threadId: thread, resourceId, title: it.input });
+    const result = await runEvals({
+      target: agent,
+      scorers: [containsScorer],
+      targetOptions: { memory: { thread, resource: resourceId } },
+      data: [{ input: it.input, groundTruth: it.groundTruth }],
+    });
+    perItem.push({ thread, result });
+  }
+
+  // Aggregate: simple mean per scorer
+  const scoreSums: Record<string, number> = {};
+  for (const { result } of perItem) {
+    for (const [name, score] of Object.entries<number>(result.scores)) {
+      scoreSums[name] = (scoreSums[name] ?? 0) + score;
+    }
+  }
+  const aggregate = Object.fromEntries(
+    Object.entries(scoreSums).map(([n, s]) => [n, s / perItem.length]),
+  );
+
+  console.log('[runeval-per-item] aggregate scores:', aggregate);
+  for (const { thread } of perItem) {
+    const { messages } = await memory!.recall({ threadId: thread, resourceId });
+    console.log(`[runeval-per-item] thread ${thread}: ${messages.length} messages`);
+  }
+
+  cleanup();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/evals-with-memory/src/runeval-per-item.ts
+++ b/examples/evals-with-memory/src/runeval-per-item.ts
@@ -16,46 +16,51 @@ import { buildAgent, containsScorer } from './shared.ts';
 
 async function main() {
   const { agent, cleanup } = buildAgent({ observationalMemory: true });
-  const memory = await agent.getMemory();
-  const resourceId = 'ci-user';
-
-  const items = [
-    { input: 'Tell me about quicksort', groundTruth: 'quicksort' },
-    { input: 'Tell me about heapsort', groundTruth: 'heapsort' },
-    { input: 'Tell me about mergesort', groundTruth: 'mergesort' },
-  ];
-
-  const perItem: Array<{ thread: string; result: any }> = [];
-  for (const it of items) {
-    const thread = `t-${randomUUID()}`;
-    await memory!.createThread({ threadId: thread, resourceId, title: it.input });
-    const result = await runEvals({
-      target: agent,
-      scorers: [containsScorer],
-      targetOptions: { memory: { thread, resource: resourceId } },
-      data: [{ input: it.input, groundTruth: it.groundTruth }],
-    });
-    perItem.push({ thread, result });
-  }
-
-  // Aggregate: simple mean per scorer
-  const scoreSums: Record<string, number> = {};
-  for (const { result } of perItem) {
-    for (const [name, score] of Object.entries<number>(result.scores)) {
-      scoreSums[name] = (scoreSums[name] ?? 0) + score;
+  try {
+    const memory = await agent.getMemory();
+    if (!memory) {
+      throw new Error('Memory not available — ensure observationalMemory is enabled');
     }
-  }
-  const aggregate = Object.fromEntries(
-    Object.entries(scoreSums).map(([n, s]) => [n, s / perItem.length]),
-  );
+    const resourceId = 'ci-user';
 
-  console.log('[runeval-per-item] aggregate scores:', aggregate);
-  for (const { thread } of perItem) {
-    const { messages } = await memory!.recall({ threadId: thread, resourceId });
-    console.log(`[runeval-per-item] thread ${thread}: ${messages.length} messages`);
-  }
+    const items = [
+      { input: 'Tell me about quicksort', groundTruth: 'quicksort' },
+      { input: 'Tell me about heapsort', groundTruth: 'heapsort' },
+      { input: 'Tell me about mergesort', groundTruth: 'mergesort' },
+    ];
 
-  cleanup();
+    const perItem: Array<{ thread: string; result: any }> = [];
+    for (const it of items) {
+      const thread = `t-${randomUUID()}`;
+      await memory.createThread({ threadId: thread, resourceId, title: it.input });
+      const result = await runEvals({
+        target: agent,
+        scorers: [containsScorer],
+        targetOptions: { memory: { thread, resource: resourceId } },
+        data: [{ input: it.input, groundTruth: it.groundTruth }],
+      });
+      perItem.push({ thread, result });
+    }
+
+    // Aggregate: simple mean per scorer
+    const scoreSums: Record<string, number> = {};
+    for (const { result } of perItem) {
+      for (const [name, score] of Object.entries<number>(result.scores)) {
+        scoreSums[name] = (scoreSums[name] ?? 0) + score;
+      }
+    }
+    const aggregate = Object.fromEntries(
+      Object.entries(scoreSums).map(([n, s]) => [n, s / perItem.length]),
+    );
+
+    console.log('[runeval-per-item] aggregate scores:', aggregate);
+    for (const { thread } of perItem) {
+      const { messages } = await memory.recall({ threadId: thread, resourceId });
+      console.log(`[runeval-per-item] thread ${thread}: ${messages.length} messages`);
+    }
+  } finally {
+    cleanup();
+  }
 }
 
 main().catch(err => {

--- a/examples/evals-with-memory/src/shared.ts
+++ b/examples/evals-with-memory/src/shared.ts
@@ -99,7 +99,7 @@ export type AgentBundle = {
  * triggered the original "threadId is required" complaint.
  */
 export function buildAgent(opts: { observationalMemory?: boolean } = {}): AgentBundle {
-  const { dir, url, cleanup } = makeTmpDb('evals-with-memory');
+  const { url, cleanup } = makeTmpDb('evals-with-memory');
   const storage = new LibSQLStore({ id: `evals-with-memory-${Date.now()}`, url });
 
   const memory = new Memory({
@@ -149,7 +149,6 @@ export function buildAgent(opts: { observationalMemory?: boolean } = {}): AgentB
       } catch {
         void 0;
       }
-      void dir;
     },
   };
 }

--- a/examples/evals-with-memory/src/shared.ts
+++ b/examples/evals-with-memory/src/shared.ts
@@ -1,0 +1,155 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Agent } from '@mastra/core/agent';
+import { createScorer } from '@mastra/core/evals';
+import { Mastra } from '@mastra/core/mastra';
+import { LibSQLStore } from '@mastra/libsql';
+import { Memory } from '@mastra/memory';
+
+/**
+ * Deterministic v2 mock model — no network/API key required.
+ * Echoes whatever the agent last received as `user` content.
+ */
+export function createEchoModel() {
+  return {
+    specificationVersion: 'v2' as const,
+    provider: 'mock',
+    modelId: 'mock-echo',
+    doGenerate: async ({ prompt }: any) => {
+      const lastUser = [...prompt].reverse().find((m: any) => m.role === 'user');
+      const text =
+        typeof lastUser?.content === 'string'
+          ? lastUser.content
+          : (lastUser?.content?.find?.((p: any) => p.type === 'text')?.text ?? 'hello');
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+        content: [{ type: 'text' as const, text: `echo:${text}` }],
+        warnings: [],
+      };
+    },
+    doStream: async ({ prompt }: any) => {
+      const lastUser = [...prompt].reverse().find((m: any) => m.role === 'user');
+      const text =
+        typeof lastUser?.content === 'string'
+          ? lastUser.content
+          : (lastUser?.content?.find?.((p: any) => p.type === 'text')?.text ?? 'hello');
+      const delta = `echo:${text}`;
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({
+              type: 'response-metadata',
+              id: 'r1',
+              modelId: 'mock-echo',
+              timestamp: new Date(0),
+            });
+            controller.enqueue({ type: 'text-start', id: 't1' });
+            controller.enqueue({ type: 'text-delta', id: 't1', delta });
+            controller.enqueue({ type: 'text-end', id: 't1' });
+            controller.enqueue({
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+            });
+            controller.close();
+          },
+        }),
+      };
+    },
+  };
+}
+
+/** Simple scorer: did the assistant output mention the substring in groundTruth? */
+export const containsScorer = createScorer({
+  id: 'contains',
+  name: 'contains',
+  description: 'Returns 1 if assistant output contains groundTruth substring, else 0',
+}).generateScore(({ run }: any) => {
+  const out = JSON.stringify(run?.output ?? '');
+  const expected = String(run?.groundTruth ?? '');
+  return out.includes(expected) ? 1 : 0;
+});
+
+export function makeTmpDb(prefix: string) {
+  const dir = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  const url = `file:${join(dir, 'eval.db')}`;
+  return {
+    dir,
+    url,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+export type AgentBundle = {
+  mastra: Mastra;
+  agent: Agent;
+  storage: LibSQLStore;
+  cleanup: () => void;
+};
+
+/**
+ * Build a Mastra app with a single agent backed by Memory + LibSQL storage.
+ * Observational memory is enabled in thread scope — the configuration that
+ * triggered the original "threadId is required" complaint.
+ */
+export function buildAgent(opts: { observationalMemory?: boolean } = {}): AgentBundle {
+  const { dir, url, cleanup } = makeTmpDb('evals-with-memory');
+  const storage = new LibSQLStore({ id: `evals-with-memory-${Date.now()}`, url });
+
+  const memory = new Memory({
+    storage,
+    options: {
+      lastMessages: 10,
+      workingMemory: { enabled: false },
+      ...(opts.observationalMemory
+        ? {
+            observationalMemory: {
+              enabled: true,
+              scope: 'thread',
+              observation: {
+                model: createEchoModel() as any,
+                messageTokens: 200,
+                bufferTokens: false,
+              },
+            },
+          }
+        : {}),
+    },
+  });
+
+  const agent = new Agent({
+    id: 'echo-agent',
+    name: 'echo-agent',
+    instructions: 'Echo the user input.',
+    model: createEchoModel() as any,
+    memory,
+  });
+
+  const mastra = new Mastra({
+    storage,
+    agents: { 'echo-agent': agent },
+    scorers: { contains: containsScorer as any },
+  });
+  // Touch the agent through Mastra so memory inherits storage as expected.
+  void mastra.getAgent('echo-agent');
+
+  return {
+    mastra,
+    agent,
+    storage,
+    cleanup: () => {
+      try {
+        cleanup();
+      } catch {
+        void 0;
+      }
+      void dir;
+    },
+  };
+}

--- a/examples/evals-with-memory/tsconfig.json
+++ b/examples/evals-with-memory/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds a docs page and a runnable example showing how to run Mastra evals against agents that use memory in thread scope (including observational memory). Without one of these patterns the agent throws `ObservationalMemory (scope: 'thread') requires a threadId, but none was found in RequestContext or MessageList.`

Three working patterns are covered:

Shared thread for every item via `runEvals` global `targetOptions.memory`:

```ts
await runEvals({
  target: supportAgent,
  scorers: [recallScorer],
  targetOptions: { memory: { thread: 'eval-thread', resource: 'ci-user' } },
  data: [...],
});
```

Per-item threads by calling `runEvals` once per item:

```ts
for (const item of items) {
  const threadId = `eval-${randomUUID()}`;
  await memory.createThread({ threadId, resourceId, title: item.input });
  await runEvals({
    target: supportAgent,
    scorers: [recallScorer],
    targetOptions: { memory: { thread: threadId, resource: resourceId } },
    data: [item],
  });
}
```

Dataset experiments with an inline task that pulls the thread id from item metadata:

```ts
await dataset.startExperiment({
  scorers: [recallScorer],
  task: async ({ input, metadata }) => {
    const { threadId, resourceId } = metadata as { threadId: string; resourceId: string };
    return (await supportAgent.generate(input as string, {
      memory: { thread: threadId, resource: resourceId },
    })).text;
  },
});
```

The page also notes a common trap: pre-seeding `RequestContext.MastraMemory` does not drive thread resolution — that field is populated by `prepare-memory-step` after the agent has already resolved its thread.

The full runnable repro for all three approaches lives in `examples/evals-with-memory/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a simple how-to guide plus runnable examples showing three safe ways to run Mastra evals when agents use conversation memory so evals don't fail and you can verify memory behavior.

## Changes

### Documentation

- New doc: docs/src/content/en/docs/evals/evals-with-memory.mdx (+158 lines)
  - Explains that thread-scoped memory must be resolved at runtime via args.memory.thread (pre-seeding RequestContext.MastraMemory does not drive thread resolution).
  - Documents three working patterns to avoid "ObservationalMemory (scope: 'thread') requires a threadId" errors:
    1. Shared thread for all items via runEvals with targetOptions.memory.
    2. Per-item threads by calling runEvals once per item with a pre-created threadId.
    3. Dataset experiments using dataset.startExperiment with an inline task that reads per-item metadata (threadId/resourceId) and calls agent.generate({ memory: { thread, resource } }).
  - Notes the common trap that RequestContext.MastraMemory is populated after agent thread resolution and thus doesn't help.

- Updated docs/src/content/en/docs/evals/running-in-ci.mdx (+1 line)
  - Adds a "Next steps" link to the new memory-enabled agents doc.

- Added docs sidebar entry: docs/src/content/en/docs/sidebars.js (+5 lines)
  - Adds "Evals with Memory" under Evals so the new page appears in the sidebar.

### Examples: examples/evals-with-memory/

A runnable example project demonstrating the three patterns and helpers.

- package.json (+38 lines)
  - ESM example package with scripts to run demos, workspace overrides for `@mastra/`*, dependencies, and devDependencies.

- README.md (+125 lines)
  - Describes the three patterns, setup notes (pre-create threads), limitations (runEvals.targetOptions is global; RequestContext caveat), scorer behavior, and suggested API gaps to file.

- .gitignore (+3 lines)
  - Ignores .env, node_modules, and .mastra.

- tsconfig.json (+17 lines)
  - Strict TypeScript config for the example.

Code examples and helpers (medium review effort):
- src/shared.ts (+154 lines)
  - Deterministic "echo" mock model (doGenerate/doStream), containsScorer, makeTmpDb helper, and buildAgent() that wires LibSQLStore + Memory + Agent with optional observational (thread-scoped) memory. Exports AgentBundle and a cleanup wrapper that suppresses cleanup errors.

- src/runeval-global.ts (+46 lines)
  - Demonstrates the shared-thread pattern: pre-create a thread/resource, run runEvals with targetOptions.memory globally, verify memory writes, then cleanup.

- src/runeval-per-item.ts (+69 lines)
  - Demonstrates per-item isolation by creating a unique thread per input, calling runEvals once per item with that thread, aggregating scorer outputs, and verifying stored messages per thread.

- src/dataset.ts (+82 lines)
  - Demonstrates dataset experiment pattern: create per-item threads at insert time, store threadId/resourceId in item metadata, run dataset.startExperiment with an inline task that reads metadata and calls agent.generate with per-item memory; logs experiment summary and message counts.

### Other notes / fixes

- Documentation-only changes; no public API or exported code modifications in the main library.
- Small robustness fixes in examples: input/metadata validation, ensuring temp DB cleanup, null-checks around agent.getMemory(), and minor typechecker fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->