### PR TITLE
fix(e2e-tests/monorepo): use default import for date-fns endOfDay

### DIFF
--- a/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/lodash.ts
+++ b/e2e-tests/monorepo/template/apps/custom/src/mastra/tools/lodash.ts
@@ -2,7 +2,7 @@ import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
 import get from 'lodash/fp/get';
 import { get as getFp } from 'lodash/fp';
-import { endOfDay } from 'date-fns/endOfDay';
+import endOfDay from 'date-fns/endOfDay';
 
 export const lodashTool = createTool({
   id: 'lodash',


### PR DESCRIPTION
## Summary

The e2e monorepo fixture currently imports `date-fns/endOfDay` as a **named** import, but the fixture pins `date-fns: 2.30.0` whose ESM modules only have `export default`. The Mastra bundler resolves the subpath to `date-fns/esm/endOfDay/index.js` (which is default-only), so the runtime named import fails:

```
SyntaxError: The requested module 'date-fns/esm/endOfDay/index.js'
does not provide an export named 'endOfDay'
```

This blocks `monorepo.test.ts > pnpm monorepo > build / dev / start` on every PR. Main is currently red on this.

This PR changes the fixture import to the default form to match the pinned 2.30.0.

```diff
-import { endOfDay } from 'date-fns/endOfDay';
+import endOfDay from 'date-fns/endOfDay';
```

## How we got here — timeline

| When | Commit | Change | Result |
|---|---|---|---|
| May 19 13:17 | [`f5fb539`](https://github.com/mastra-ai/mastra/commit/f5fb539022) #16757 (Ward) | Pinned `date-fns: ^4.1.0 → 2.30.0` | At this point `lodash.ts` had `import endOfDay` (default). Combo worked → **E2E green** |
| May 19 16:09 | [`720a61d`](https://github.com/mastra-ai/mastra/commit/720a61dbb4) #16736 (Mohamed) — `feat(convex): add server cache` | Bundled an unrelated one-line change flipping the fixture import to **named** `{ endOfDay }` | Combo (named import + 2.30.0 default-only) → **E2E red ever since** |

`git blame` confirms the breaking change came in with #16736:

```
720a61dbb4e (Mohamed BEN HAMDOUNE 2026-05-19 16:09:08)
  import { endOfDay } from 'date-fns/endOfDay';
```

#16736 was scoped to convex server cache work; the lodash fixture edit appears unintentional.

## Why default (not bump to v4)

Ward's pin to 2.30.0 in #16757 was deliberate (a prior attempt to pin v4 — `81bb6277` — was reverted). Fixing the import side to match keeps the test exercising 2.x compatibility, which is what the pin intends.

## Test plan

- [ ] CI `E2E Tests / E2E monorepo (ubuntu-latest)` passes — same job that's been red since #16736