### PR TITLE
fix(datadog): drop empty user messages from LLM spans

### DIFF
--- a/.changeset/gold-crews-deny.md
+++ b/.changeset/gold-crews-deny.md
@@ -1,0 +1,5 @@
+---
+'@mastra/datadog': patch
+---
+
+Fixed Datadog LLM span input formatting to remove empty user messages.

--- a/observability/datadog/src/bridge.test.ts
+++ b/observability/datadog/src/bridge.test.ts
@@ -490,6 +490,40 @@ describe('DatadogBridge', () => {
       expect(mockTrace).not.toHaveBeenCalled();
     });
 
+    it('drops empty user messages from MODEL_INFERENCE input annotations', async () => {
+      const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
+      const spanResult = bridge.createSpan(
+        createMockSpanOptions({
+          type: SpanType.MODEL_INFERENCE as SpanTypeGeneric,
+        }),
+      )!;
+      const apmSpan = capturedApmSpans[0];
+
+      const span = createMockSpan({
+        id: spanResult.spanId,
+        traceId: spanResult.traceId,
+        type: SpanType.MODEL_INFERENCE,
+        input: [
+          { role: 'user', content: '' },
+          { role: 'system', content: 'You are helpful' },
+          { role: 'user', content: 'Hello' },
+          { role: 'user', content: '   ' },
+        ],
+      });
+
+      await bridge.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        apmSpan,
+        expect.objectContaining({
+          inputData: [
+            { role: 'system', content: 'You are helpful' },
+            { role: 'user', content: 'Hello' },
+          ],
+        }),
+      );
+    });
+
     it('annotates and finishes event spans on span_started', async () => {
       const bridge = new DatadogBridge({ mlApp: 'test', agentless: false });
       const spanResult = bridge.createSpan(createMockSpanOptions())!;

--- a/observability/datadog/src/tracing.test.ts
+++ b/observability/datadog/src/tracing.test.ts
@@ -1140,6 +1140,31 @@ describe('DatadogExporter', () => {
       );
     });
 
+    it('drops empty user messages from MODEL_INFERENCE input annotations', async () => {
+      const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
+      const span = createMockSpan({
+        type: SpanType.MODEL_INFERENCE,
+        input: [
+          { role: 'user', content: '' },
+          { role: 'system', content: 'You are helpful' },
+          { role: 'user', content: 'Hello' },
+          { role: 'user', content: '   ' },
+        ],
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(TracingEventType.SPAN_ENDED, span));
+
+      expect(mockAnnotate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          inputData: [
+            { role: 'system', content: 'You are helpful' },
+            { role: 'user', content: 'Hello' },
+          ],
+        }),
+      );
+    });
+
     it('inherits modelName/modelProvider from parent MODEL_GENERATION onto MODEL_INFERENCE descendants', async () => {
       const exporter = new DatadogExporter({ mlApp: 'test', apiKey: 'test-key' });
       const generation = createMockSpan({

--- a/observability/datadog/src/utils.test.ts
+++ b/observability/datadog/src/utils.test.ts
@@ -179,6 +179,31 @@ describe('formatInput', () => {
       expect(result).toEqual(messages);
     });
 
+    it('drops empty user messages from message arrays', () => {
+      const result = formatInput(
+        [
+          { role: 'system', content: 'You are helpful' },
+          { role: 'user', content: '' },
+          { role: 'user', content: '   ' },
+          { role: 'assistant', content: 'What do you need?' },
+          { role: 'user', content: 'Hello' },
+        ],
+        SpanType.MODEL_GENERATION,
+      );
+
+      expect(result).toEqual([
+        { role: 'system', content: 'You are helpful' },
+        { role: 'assistant', content: 'What do you need?' },
+        { role: 'user', content: 'Hello' },
+      ]);
+    });
+
+    it('drops blank string input instead of creating an empty user message', () => {
+      const result = formatInput('   ', SpanType.MODEL_GENERATION);
+
+      expect(result).toEqual([]);
+    });
+
     it('stringifies object input as user message', () => {
       const result = formatInput({ query: 'search term', filters: { date: '2024' } }, SpanType.MODEL_GENERATION);
       expect(result).toEqual([{ role: 'user', content: '{"query":"search term","filters":{"date":"2024"}}' }]);
@@ -217,6 +242,22 @@ describe('formatInput', () => {
       };
       const result = formatInput(input, SpanType.MODEL_STEP);
       expect(result).toEqual([{ role: 'user', content: 'Hi' }]);
+    });
+
+    it('cleans unwrapped message arrays for MODEL_INFERENCE spans', () => {
+      const input = {
+        messages: [
+          { role: 'user', content: '' },
+          { role: 'system', content: 'You are helpful' },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+      const result = formatInput(input, SpanType.MODEL_INFERENCE);
+
+      expect(result).toEqual([
+        { role: 'system', content: 'You are helpful' },
+        { role: 'user', content: 'Hi' },
+      ]);
     });
 
     it('unwraps Gemini { contents } request body shape', () => {
@@ -313,6 +354,11 @@ describe('formatOutput', () => {
     it('uses object payload when text is empty and an object result is present', () => {
       const result = formatOutput({ text: '', object: { ok: true } }, SpanType.MODEL_GENERATION);
       expect(result).toEqual([{ role: 'assistant', content: '{"ok":true}' }]);
+    });
+
+    it('formats MODEL_INFERENCE output as assistant messages', () => {
+      const result = formatOutput('Hi there!', SpanType.MODEL_INFERENCE);
+      expect(result).toEqual([{ role: 'assistant', content: 'Hi there!' }]);
     });
   });
 

--- a/observability/datadog/src/utils.test.ts
+++ b/observability/datadog/src/utils.test.ts
@@ -161,6 +161,10 @@ describe('safeStringify', () => {
     expect(safeStringify('hello')).toBe('"hello"');
     expect(safeStringify(123)).toBe('123');
   });
+
+  it('returns an empty string for undefined values', () => {
+    expect(safeStringify(undefined)).toBe('');
+  });
 });
 
 describe('formatInput', () => {
@@ -200,6 +204,12 @@ describe('formatInput', () => {
 
     it('drops blank string input instead of creating an empty user message', () => {
       const result = formatInput('   ', SpanType.MODEL_GENERATION);
+
+      expect(result).toEqual([]);
+    });
+
+    it('drops undefined input instead of throwing during empty message filtering', () => {
+      const result = formatInput(undefined, SpanType.MODEL_GENERATION);
 
       expect(result).toEqual([]);
     });

--- a/observability/datadog/src/utils.ts
+++ b/observability/datadog/src/utils.ts
@@ -129,7 +129,7 @@ export function toDate(value: Date | string | number): Date {
  */
 export function safeStringify(data: unknown): string {
   try {
-    return JSON.stringify(data);
+    return JSON.stringify(data) ?? '';
   } catch {
     if (typeof data === 'object' && data !== null) {
       return `[Non-serializable ${data.constructor?.name || 'Object'}]`;
@@ -158,6 +158,10 @@ function isGeminiContentArray(data: any): data is Array<{ role: string; parts: a
   return Array.isArray(data) && data.every(m => m?.role && Array.isArray(m?.parts));
 }
 
+function toMessageContent(content: any): string {
+  return typeof content === 'string' ? content : safeStringify(content);
+}
+
 /**
  * Maps a {role, content}[] message array into the Datadog message shape,
  * stringifying any non-string content (e.g. multimodal part arrays).
@@ -166,7 +170,7 @@ function toDatadogMessages(messages: Array<{ role: string; content: any }>): Arr
   return messages
     .map(m => ({
       role: m.role,
-      content: typeof m.content === 'string' ? m.content : safeStringify(m.content),
+      content: toMessageContent(m.content),
     }))
     .filter(m => !(m.role === 'user' && m.content.trim().length === 0));
 }

--- a/observability/datadog/src/utils.ts
+++ b/observability/datadog/src/utils.ts
@@ -145,6 +145,12 @@ function isMessageArray(data: any): data is Array<{ role: string; content: any }
   return Array.isArray(data) && data.every(m => m?.role && m?.content !== undefined);
 }
 
+function isModelDataSpan(spanType: SpanType): boolean {
+  return (
+    spanType === SpanType.MODEL_GENERATION || spanType === SpanType.MODEL_STEP || spanType === SpanType.MODEL_INFERENCE
+  );
+}
+
 /**
  * Checks if data is in Gemini content array format ({role, parts}[]).
  */
@@ -157,10 +163,12 @@ function isGeminiContentArray(data: any): data is Array<{ role: string; parts: a
  * stringifying any non-string content (e.g. multimodal part arrays).
  */
 function toDatadogMessages(messages: Array<{ role: string; content: any }>): Array<{ role: string; content: string }> {
-  return messages.map(m => ({
-    role: m.role,
-    content: typeof m.content === 'string' ? m.content : safeStringify(m.content),
-  }));
+  return messages
+    .map(m => ({
+      role: m.role,
+      content: typeof m.content === 'string' ? m.content : safeStringify(m.content),
+    }))
+    .filter(m => !(m.role === 'user' && m.content.trim().length === 0));
 }
 
 /**
@@ -182,18 +190,18 @@ function geminiContentToMessage(item: { role: string; parts: any[] }): { role: s
 
 /**
  * Formats input data for Datadog annotations.
- * LLM spans use message array format; others use raw or stringified data.
+ * Model spans use message array format; others use raw or stringified data.
  */
 export function formatInput(input: any, spanType: SpanType): any {
-  // LLM spans expect {role, content}[] format
-  if (spanType === SpanType.MODEL_GENERATION || spanType === SpanType.MODEL_STEP) {
+  // Model spans expect {role, content}[] format
+  if (isModelDataSpan(spanType)) {
     // Already in message format
     if (isMessageArray(input)) {
       return toDatadogMessages(input);
     }
     // Gemini format: {role, parts} → normalize to {role, content}
     if (isGeminiContentArray(input)) {
-      return input.map(geminiContentToMessage);
+      return toDatadogMessages(input.map(geminiContentToMessage));
     }
     // Mastra wraps MODEL_GENERATION input as { messages, schema? } and Gemini
     // request bodies use { contents }. Unwrap so we don't bury the message array
@@ -203,32 +211,32 @@ export function formatInput(input: any, spanType: SpanType): any {
         return toDatadogMessages((input as any).messages);
       }
       if (isGeminiContentArray((input as any).messages)) {
-        return (input as any).messages.map(geminiContentToMessage);
+        return toDatadogMessages((input as any).messages.map(geminiContentToMessage));
       }
       if (isGeminiContentArray((input as any).contents)) {
-        return (input as any).contents.map(geminiContentToMessage);
+        return toDatadogMessages((input as any).contents.map(geminiContentToMessage));
       }
     }
     // String input becomes user message
     if (typeof input === 'string') {
-      return [{ role: 'user', content: input }];
+      return toDatadogMessages([{ role: 'user', content: input }]);
     }
     // Object input gets stringified as user message
-    return [{ role: 'user', content: safeStringify(input) }];
+    return toDatadogMessages([{ role: 'user', content: safeStringify(input) }]);
   }
 
-  // Non-LLM spans: pass through strings/arrays, stringify objects
+  // Non-model spans: pass through strings/arrays, stringify objects
   if (typeof input === 'string' || Array.isArray(input)) return input;
   return safeStringify(input);
 }
 
 /**
  * Formats output data for Datadog annotations.
- * LLM spans use message array format; others use raw or stringified data.
+ * Model spans use message array format; others use raw or stringified data.
  */
 export function formatOutput(output: any, spanType: SpanType): any {
-  // LLM spans expect {role, content}[] format
-  if (spanType === SpanType.MODEL_GENERATION || spanType === SpanType.MODEL_STEP) {
+  // Model spans expect {role, content}[] format
+  if (isModelDataSpan(spanType)) {
     // Already in message format
     if (isMessageArray(output)) {
       return toDatadogMessages(output);
@@ -256,7 +264,7 @@ export function formatOutput(output: any, spanType: SpanType): any {
     return [{ role: 'assistant', content: safeStringify(output) }];
   }
 
-  // Non-LLM spans: pass through strings, stringify objects
+  // Non-model spans: pass through strings, stringify objects
   if (typeof output === 'string') return output;
   return safeStringify(output);
 }


### PR DESCRIPTION
## Description

This fixes Datadog model span formatting so empty `user` messages are removed before `inputData` is annotated. It applies the shared model-message formatter to `MODEL_INFERENCE` spans too, so both `DatadogExporter` and `DatadogBridge` send clean LLM input/output data. Added regression tests for the formatter, exporter, and bridge paths. Verified with Datadog package tests, build, and lint.

## Related Issue(s)

Related to internal Issue #4 — empty user messages in LLM span input.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR cleans up Datadog traces by removing blank user messages from AI model span inputs so we don't record empty chat lines. That keeps span annotations concise and avoids noisy/empty entries in Datadog.

## Overview

Filters empty or whitespace-only user messages from LLM span input formatting and applies that normalization to MODEL_INFERENCE spans in addition to MODEL_GENERATION and MODEL_STEP. Ensures both DatadogExporter and DatadogBridge annotate spans with cleaned input/output data. Includes tests and a changeset documenting the patch.

## Changes

- observability/datadog/src/utils.ts
  - Added isModelDataSpan(spanType) to treat MODEL_INFERENCE as a model-data span.
  - Introduced toMessageContent helper and strengthened safeStringify fallback.
  - Implemented toDatadogMessages(...) to stringify message contents and filter out user messages whose trimmed content is empty.
  - Updated formatInput() and formatOutput() to use isModelDataSpan and toDatadogMessages for consistent normalization across MODEL_GENERATION, MODEL_STEP, and MODEL_INFERENCE, including unwrapping Mastra/Gemini input shapes and normalizing Gemini parts.
  - Ensured string/object inputs are converted to user messages and then filtered so blank or undefined values yield an empty array rather than an empty user message.

- Tests
  - observability/datadog/src/utils.test.ts
    - Added tests verifying safeStringify(undefined) -> '', formatInput behavior for MODEL_GENERATION and MODEL_INFERENCE: removal of empty/whitespace user messages, dropping blank/undefined inputs, Gemini normalization, and output formatting for MODEL_INFERENCE.
  - observability/datadog/src/tracing.test.ts
    - Added DatadogExporter test asserting MODEL_INFERENCE input annotations omit empty/whitespace-only user messages and pass only non-empty system/user messages to dd-trace annotate.
  - observability/datadog/src/bridge.test.ts
    - Added DatadogBridge test asserting exportTracingEvent drops empty/whitespace user messages from MODEL_INFERENCE span input annotations and uses annotate rather than creating synthetic traces.

- .changeset/gold-crews-deny.md
  - Patch changeset documenting the fix for `@mastra/datadog`.

## Miscellaneous

- A small guard/robustness improvement was added around the empty-message filtering logic to avoid creating empty user messages from blank or undefined inputs.
- No public API signatures were changed; changes are internal behavior and tests only.

## Impact

DatadogExporter and DatadogBridge now consistently remove empty user messages before annotating model spans (including MODEL_INFERENCE), producing cleaner, more meaningful LLM span input/output annotations in Datadog traces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->