### PR TITLE
fix(core): delegate MastraCompositeStore.init() to default and editor parents

### DIFF
--- a/.changeset/gentle-garlics-clean.md
+++ b/.changeset/gentle-garlics-clean.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `MastraCompositeStore.init()` silently skipping the parent store's init when constructed with `default` or `editor`. The composite extracted the inner domain instances and initialized them in parallel, never invoking the parent's `init()` — bypassing any connection setup, migrations, DDL ordering, and coalescing of concurrent callers that the adapter relies on.
+
+The loudest symptom was on `LibSQLStore` backed by a local file: skipping its `init()` meant pragmas like `busy_timeout` and `journal_mode=WAL` were never applied, so parallel `CREATE TABLE IF NOT EXISTS` statements raced on the same SQLite file, returned `SQLITE_BUSY`, and left tables like `mastra_schedules` partially created — which the scheduler then tripped over with `no such table`. Other adapters were quietly affected the same way whenever their `init()` did meaningful work.
+
+`MastraCompositeStore.init()` now delegates to the parent `default` and `editor` stores first, then only initializes domains that aren't already covered by a parent. Subclasses that override `init()` (including `LibSQLStore` itself) are unaffected.
+
+Fixes #16782.

--- a/.changeset/gentle-garlics-clean.md
+++ b/.changeset/gentle-garlics-clean.md
@@ -2,10 +2,10 @@
 '@mastra/core': patch
 ---
 
-Fixed `MastraCompositeStore.init()` silently skipping the parent store's init when constructed with `default` or `editor`. The composite extracted the inner domain instances and initialized them in parallel, never invoking the parent's `init()` — bypassing any connection setup, migrations, DDL ordering, and coalescing of concurrent callers that the adapter relies on.
+Fixed a startup bug in `MastraCompositeStore.init()` when using `default` or `editor`.
 
-The loudest symptom was on `LibSQLStore` backed by a local file: skipping its `init()` meant pragmas like `busy_timeout` and `journal_mode=WAL` were never applied, so parallel `CREATE TABLE IF NOT EXISTS` statements raced on the same SQLite file, returned `SQLITE_BUSY`, and left tables like `mastra_schedules` partially created — which the scheduler then tripped over with `no such table`. Other adapters were quietly affected the same way whenever their `init()` did meaningful work.
+Before this fix, the composite initialized inner domains directly and could skip parent store initialization. That could skip adapter setup steps and cause missing-table errors during startup (most visibly with `LibSQLStore` on a local file).
 
-`MastraCompositeStore.init()` now delegates to the parent `default` and `editor` stores first, then only initializes domains that aren't already covered by a parent. Subclasses that override `init()` (including `LibSQLStore` itself) are unaffected.
+Now, `MastraCompositeStore.init()` runs parent `default` and `editor` initialization first, then initializes only domains not already covered by those parents. This preserves adapter-specific initialization behavior and prevents startup races.
 
 Fixes #16782.

--- a/packages/core/src/storage/base.test.ts
+++ b/packages/core/src/storage/base.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MastraCompositeStore } from './base';
+import { InMemoryStore } from './mock';
+
+/**
+ * Regression for https://github.com/mastra-ai/mastra/issues/16782
+ *
+ * When a user passes `default: someStore` to MastraCompositeStore, the outer
+ * composite extracts the inner domain instances at construction time (via the
+ * `resolve()` helper) and exposes them directly as `this.stores`. The outer
+ * composite's `init()` then iterates those domains and calls each domain's
+ * `init()` in parallel — but it never calls `default.init()`.
+ *
+ * That's wrong for every adapter: a store's own `init()` is where it owns
+ * connection setup, migrations, DDL ordering, and coalescing of concurrent
+ * callers. Bypassing it silently skips that work.
+ *
+ * The loud failure happens with LibSQLStore on a local file: the parent
+ * `init()` is where pragmas (`busy_timeout`, WAL) get applied and where local
+ * DBs init their domains sequentially. Skipping it makes 17 parallel
+ * `CREATE TABLE IF NOT EXISTS` statements race on the same SQLite file, hit
+ * SQLITE_BUSY, and leave tables uncreated — which the scheduler then trips
+ * over with `no such table: mastra_schedules`.
+ */
+describe('MastraCompositeStore — default delegation (issue #16782)', () => {
+  it('delegates init() to the underlying `default` store', async () => {
+    // The inner store stands in for any real adapter that does work in its
+    // own init() (setup, migrations, sequencing). The composite must call
+    // that init(), not iterate the inner domains itself.
+    const inner = new InMemoryStore({ id: 'inner' });
+    const innerInitSpy = vi.spyOn(inner, 'init');
+
+    const composite = new MastraCompositeStore({
+      id: 'outer',
+      default: inner,
+    });
+
+    await composite.init();
+
+    expect(innerInitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates init() to the underlying `editor` store', async () => {
+    const inner = new InMemoryStore({ id: 'editor-inner' });
+    const innerInitSpy = vi.spyOn(inner, 'init');
+
+    const composite = new MastraCompositeStore({
+      id: 'outer-editor',
+      editor: inner,
+    });
+
+    await composite.init();
+
+    expect(innerInitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates to both default and editor when both are provided', async () => {
+    const defaultStore = new InMemoryStore({ id: 'default-inner' });
+    const editorStore = new InMemoryStore({ id: 'editor-inner' });
+    const defaultInitSpy = vi.spyOn(defaultStore, 'init');
+    const editorInitSpy = vi.spyOn(editorStore, 'init');
+
+    const composite = new MastraCompositeStore({
+      id: 'outer-both',
+      default: defaultStore,
+      editor: editorStore,
+    });
+
+    await composite.init();
+
+    expect(defaultInitSpy).toHaveBeenCalledTimes(1);
+    expect(editorInitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats the inner store's init() as authoritative (failure surfaces)", async () => {
+    // If the composite bypasses the inner's init(), a thrown error from the
+    // inner's init() would never surface. We must see it.
+    const inner = new InMemoryStore({ id: 'failing-inner' });
+    const failure = new Error('inner init failed');
+    vi.spyOn(inner, 'init').mockRejectedValueOnce(failure);
+
+    const composite = new MastraCompositeStore({
+      id: 'outer-failing',
+      default: inner,
+    });
+
+    await expect(composite.init()).rejects.toThrow('inner init failed');
+  });
+});

--- a/packages/core/src/storage/base.test.ts
+++ b/packages/core/src/storage/base.test.ts
@@ -72,6 +72,23 @@ describe('MastraCompositeStore — default delegation (issue #16782)', () => {
     expect(editorInitSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('only init()s a shared parent once when used as both default and editor', async () => {
+    // Defensive: if the same instance is passed as both `default` and
+    // `editor`, dedupe by identity so we don't double-init it.
+    const shared = new InMemoryStore({ id: 'shared-inner' });
+    const sharedInitSpy = vi.spyOn(shared, 'init');
+
+    const composite = new MastraCompositeStore({
+      id: 'outer-shared',
+      default: shared,
+      editor: shared,
+    });
+
+    await composite.init();
+
+    expect(sharedInitSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("treats the inner store's init() as authoritative (failure surfaces)", async () => {
     // If the composite bypasses the inner's init(), a thrown error from the
     // inner's init() would never surface. We must see it.

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -364,11 +364,12 @@ export class MastraCompositeStore extends MastraBase {
 
   async #runInit(): Promise<boolean> {
     // 1. Delegate to parent stores. Each parent owns its own init contract
-    //    (setup, migrations, sequencing, coalescing).
-    const parentTasks: Promise<void>[] = [];
-    if (this.parentDefault) parentTasks.push(this.parentDefault.init());
-    if (this.parentEditor) parentTasks.push(this.parentEditor.init());
-    await Promise.all(parentTasks);
+    //    (setup, migrations, sequencing, coalescing). Dedupe by identity so
+    //    a store passed as both `default` and `editor` only gets init()'d once.
+    const uniqueParents = new Set<MastraCompositeStore>();
+    if (this.parentDefault) uniqueParents.add(this.parentDefault);
+    if (this.parentEditor) uniqueParents.add(this.parentEditor);
+    await Promise.all([...uniqueParents].map(parent => parent.init()));
 
     // 2. Build a set of domain instances the parents already initialized so
     //    we don't init them a second time below.

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -237,6 +237,16 @@ export class MastraCompositeStore extends MastraBase {
    */
   disableInit: boolean = false;
 
+  /**
+   * Retained references to the parent stores supplied via composition. `init()`
+   * delegates to these so the parent's own `init()` logic (pragmas, ordered
+   * DDL, init coalescing, etc.) runs instead of being bypassed by the
+   * composite iterating the inner domains in parallel — which was the cause
+   * of the SQLITE_BUSY / "no such table" races reported in issue #16782.
+   */
+  protected parentDefault?: MastraCompositeStore;
+  protected parentEditor?: MastraCompositeStore;
+
   constructor(config: MastraCompositeStoreConfig) {
     const name = config.name ?? 'MastraCompositeStore';
 
@@ -257,6 +267,11 @@ export class MastraCompositeStore extends MastraBase {
       const defaultStores = config.default?.stores;
       const editorStores = config.editor?.stores;
       const domainOverrides = config.domains ?? {};
+
+      // Retain the parent store refs so init() can delegate to their own
+      // init() — see field doc above and init() below.
+      this.parentDefault = config.default;
+      this.parentEditor = config.editor;
 
       // Validate that at least one storage source is provided
       const hasDefaultDomains = defaultStores && Object.values(defaultStores).some(v => v !== undefined);
@@ -323,7 +338,19 @@ export class MastraCompositeStore extends MastraBase {
 
   /**
    * Initialize all domain stores.
-   * This creates necessary tables, indexes, and performs any required migrations.
+   *
+   * When a parent store was supplied via `default` or `editor`, delegate to
+   * its own `init()` first. Each adapter owns its `init()` contract — it may
+   * apply connection-level setup, run migrations, enforce DDL ordering, or
+   * coalesce concurrent callers. Calling each domain's `init()` directly
+   * against the parent's shared client would bypass all of that and can
+   * corrupt or partially create schema (see issue #16782 for the SQLite
+   * symptom).
+   *
+   * Any remaining domains that did NOT come from a parent (e.g. supplied via
+   * the explicit `domains` override pointing at a different store) are then
+   * initialized individually — but only the ones the parents didn't already
+   * cover, so we never double-init the same domain instance.
    */
   async init(): Promise<void> {
     // to prevent race conditions, await any current init
@@ -331,83 +358,63 @@ export class MastraCompositeStore extends MastraBase {
       return;
     }
 
-    // Initialize all domain stores
-    const initTasks: Promise<void>[] = [];
-
-    if (this.stores?.memory) {
-      initTasks.push(this.stores.memory.init());
-    }
-
-    if (this.stores?.workflows) {
-      initTasks.push(this.stores.workflows.init());
-    }
-
-    if (this.stores?.scores) {
-      initTasks.push(this.stores.scores.init());
-    }
-
-    if (this.stores?.observability) {
-      initTasks.push(this.stores.observability.init());
-    }
-
-    if (this.stores?.agents) {
-      initTasks.push(this.stores.agents.init());
-    }
-
-    if (this.stores?.datasets) {
-      initTasks.push(this.stores.datasets.init());
-    }
-
-    if (this.stores?.experiments) {
-      initTasks.push(this.stores.experiments.init());
-    }
-
-    if (this.stores?.promptBlocks) {
-      initTasks.push(this.stores.promptBlocks.init());
-    }
-
-    if (this.stores?.scorerDefinitions) {
-      initTasks.push(this.stores.scorerDefinitions.init());
-    }
-
-    if (this.stores?.mcpClients) {
-      initTasks.push(this.stores.mcpClients.init());
-    }
-
-    if (this.stores?.mcpServers) {
-      initTasks.push(this.stores.mcpServers.init());
-    }
-
-    if (this.stores?.workspaces) {
-      initTasks.push(this.stores.workspaces.init());
-    }
-
-    if (this.stores?.skills) {
-      initTasks.push(this.stores.skills.init());
-    }
-
-    if (this.stores?.favorites) {
-      initTasks.push(this.stores.favorites.init());
-    }
-
-    if (this.stores?.blobs) {
-      initTasks.push(this.stores.blobs.init());
-    }
-
-    if (this.stores?.backgroundTasks) {
-      initTasks.push(this.stores.backgroundTasks.init());
-    }
-
-    if (this.stores?.schedules) {
-      initTasks.push(this.stores.schedules.init());
-    }
-
-    if (this.stores?.channels) {
-      initTasks.push(this.stores.channels.init());
-    }
-
-    this.hasInitialized = Promise.all(initTasks).then(() => true);
+    this.hasInitialized = this.#runInit();
     await this.hasInitialized;
+  }
+
+  async #runInit(): Promise<boolean> {
+    // 1. Delegate to parent stores. Each parent owns its own init contract
+    //    (setup, migrations, sequencing, coalescing).
+    const parentTasks: Promise<void>[] = [];
+    if (this.parentDefault) parentTasks.push(this.parentDefault.init());
+    if (this.parentEditor) parentTasks.push(this.parentEditor.init());
+    await Promise.all(parentTasks);
+
+    // 2. Build a set of domain instances the parents already initialized so
+    //    we don't init them a second time below.
+    const alreadyInitialized = new Set<unknown>();
+    const addParentDomains = (parent?: MastraCompositeStore) => {
+      if (!parent?.stores) return;
+      for (const domain of Object.values(parent.stores)) {
+        if (domain) alreadyInitialized.add(domain);
+      }
+    };
+    addParentDomains(this.parentDefault);
+    addParentDomains(this.parentEditor);
+
+    // 3. Init any remaining domains (typically those provided via the
+    //    explicit `domains` override pointing at a different store, or those
+    //    set directly by a subclass).
+    const initTasks: Promise<void>[] = [];
+    const maybeInit = (domain: { init(): Promise<void> } | undefined) => {
+      if (!domain || alreadyInitialized.has(domain)) return;
+      initTasks.push(domain.init());
+      alreadyInitialized.add(domain);
+    };
+
+    if (this.stores) {
+      maybeInit(this.stores.memory);
+      maybeInit(this.stores.workflows);
+      maybeInit(this.stores.scores);
+      maybeInit(this.stores.observability);
+      maybeInit(this.stores.agents);
+      maybeInit(this.stores.datasets);
+      maybeInit(this.stores.experiments);
+      maybeInit(this.stores.promptBlocks);
+      maybeInit(this.stores.scorerDefinitions);
+      maybeInit(this.stores.mcpClients);
+      maybeInit(this.stores.mcpServers);
+      maybeInit(this.stores.workspaces);
+      maybeInit(this.stores.skills);
+      maybeInit(this.stores.favorites);
+      maybeInit(this.stores.blobs);
+      maybeInit(this.stores.backgroundTasks);
+      maybeInit(this.stores.schedules);
+      maybeInit(this.stores.channels);
+    }
+
+    await Promise.all(initTasks);
+    return true;
   }
 }
 


### PR DESCRIPTION
Fixes #16782.

When you give `MastraCompositeStore` a `default` (or `editor`) store, it pulls out the inner domain instances and initializes them in parallel — but never actually calls the parent's own `init()`. So any connection setup, migrations, DDL ordering, or coalescing the parent adapter does is silently skipped.

The loudest version of this is `LibSQLStore` on a local file: its `init()` is where pragmas like `busy_timeout` and `journal_mode=WAL` get applied and where domains init sequentially. Without it, the 17 parallel `CREATE TABLE IF NOT EXISTS` statements race on the same SQLite file, hit `SQLITE_BUSY`, and leave tables like `mastra_schedules` partially created — then the scheduler trips with `no such table`. Other adapters were quietly broken in the same way whenever their `init()` did real work.

Before:

```ts
async init(): Promise<void> {
  // domains init in parallel; default.init() / editor.init() never run
  await Promise.all(Object.values(this.stores).map(d => d?.init()));
}
```

After:

```ts
async init(): Promise<void> {
  // parents own their init contract — call it first
  await Promise.all([this.parentDefault?.init(), this.parentEditor?.init()]);
  // then only init domains not already covered by a parent
  await Promise.all(orphanDomains.map(d => d.init()));
}
```

Subclasses that override `init()` (including `LibSQLStore` itself) aren't affected.

Test plan: new `packages/core/src/storage/base.test.ts` covers default delegation, editor delegation, both-at-once, and parent-init-failure propagation. Existing storage + scheduler-integration + evented-workflow tests all pass; `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

The PR makes sure the main supervisor (parent store) sets up the database first so the workers (domain stores) don't try to create the same tables at once and break things. This prevents races that caused missing-table errors.

---

## Problem

MastraCompositeStore.init() used to initialize each domain store directly and in parallel, but when parent stores (default or editor) were supplied it did not call their init(). That skipped parent-level setup (connection setup, pragmas, migrations, DDL ordering, and init coalescing). On LibSQL local files this led to pragmas not being applied and parallel CREATE TABLE statements racing (SQLITE_BUSY), leaving tables partially created and causing runtime "no such table" errors (e.g., mastra_schedules).

---

## Solution

- MastraCompositeStore now stores references to the provided parent default and editor stores and delegates initialization to them first.
- init() calls parentDefault?.init() and parentEditor?.init() before initializing domains.
- After parent init, only orphan domain instances (not already covered by a parent) are initialized.
- Identical parent instances passed to multiple slots are deduped (initialized exactly once).
- Existing init guards and subclass overrides (e.g., LibSQLStore) remain unaffected; failures from parent init propagate through composite.init().

---

## Changes

1. .changeset/gentle-garlics-clean.md — changelog entry describing the fix.
2. packages/core/src/storage/base.ts — MastraCompositeStore:
   - added protected parentDefault? and parentEditor? fields,
   - refactored init to delegate to parents first, dedupe shared parent instances, and only init remaining domain stores.
3. packages/core/src/storage/base.test.ts — new Vitest regression tests:
   - verifies delegation to default and editor parents,
   - verifies shared-parent dedupe (initialized once),
   - verifies parent-init failure propagates through composite.init().

---

## Impact

- Fixes scheduler/startup races where WorkflowScheduler could see uninitialized domain tables.
- Prevents parallel per-domain CREATE TABLE races on the same SQLite file and associated SQLITE_BUSY / missing-table errors.
- Preserves adapter-specific init behavior and sequential/coalescing semantics for parent stores.
- Existing storage, scheduler-integration, and evented-workflow tests pass; TypeScript compiles clean.

--- 
Fixes `#16782`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->