### PR TITLE
fix(clickhouse): dedupe v-next observability discovery values

### DIFF
--- a/.changeset/shaky-needles-dance.md
+++ b/.changeset/shaky-needles-dance.md
@@ -2,4 +2,4 @@
 '@mastra/clickhouse': patch
 ---
 
-Fixed duplicate discovery values returned from the ClickHouse v-next observability discovery endpoints (tags, services, environments, entities, metric names, metric labels). Each refresh of the underlying refreshable materialized views was appending a fresh copy of every distinct value because the target tables used plain MergeTree; values are now collapsed via ReplacingMergeTree and existing deployments are migrated automatically on next startup.
+Fixed duplicate entries in the ClickHouse v-next observability discovery endpoints — tags, services, environments, entities, metric names, and metric labels now return each value once. Existing deployments are reconciled automatically on next startup; no manual migration required.

--- a/.changeset/shaky-needles-dance.md
+++ b/.changeset/shaky-needles-dance.md
@@ -1,0 +1,5 @@
+---
+'@mastra/clickhouse': patch
+---
+
+Fixed duplicate discovery values returned from the ClickHouse v-next observability discovery endpoints (tags, services, environments, entities, metric names, metric labels). Each refresh of the underlying refreshable materialized views was appending a fresh copy of every distinct value because the target tables used plain MergeTree; values are now collapsed via ReplacingMergeTree and existing deployments are migrated automatically on next startup.

--- a/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
@@ -900,13 +900,18 @@ FROM (
 // discovery_values — refreshable helper
 // ---------------------------------------------------------------------------
 
+// ReplacingMergeTree with ORDER BY covering every column: the refreshable MV
+// below writes via `REFRESH EVERY ... TO <pre-created table>`, which in
+// ClickHouse appends a fresh copy of its result set on each refresh. Pairing
+// the helper table with ReplacingMergeTree lets background merges collapse
+// the identical rows so on-disk size tracks actual cardinality.
 export const DISCOVERY_VALUES_DDL = `
 CREATE TABLE IF NOT EXISTS ${TABLE_DISCOVERY_VALUES} (
   kind               LowCardinality(String),
   key1               String,
   value              String
 )
-ENGINE = MergeTree
+ENGINE = ReplacingMergeTree
 ORDER BY (kind, key1, value)
 `;
 
@@ -914,6 +919,7 @@ ORDER BY (kind, key1, value)
 // discovery_pairs — refreshable helper
 // ---------------------------------------------------------------------------
 
+// ReplacingMergeTree for the same reason as DISCOVERY_VALUES_DDL above.
 export const DISCOVERY_PAIRS_DDL = `
 CREATE TABLE IF NOT EXISTS ${TABLE_DISCOVERY_PAIRS} (
   kind               LowCardinality(String),
@@ -921,7 +927,7 @@ CREATE TABLE IF NOT EXISTS ${TABLE_DISCOVERY_PAIRS} (
   key2               String,
   value              String
 )
-ENGINE = MergeTree
+ENGINE = ReplacingMergeTree
 ORDER BY (kind, key1, key2, value)
 `;
 

--- a/stores/clickhouse/src/storage/domains/observability/v-next/discovery.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/discovery.ts
@@ -7,6 +7,12 @@
  * Per design: discovery methods return empty results until the
  * helper tables have been initialized and refreshed successfully.
  * They do NOT fall back to base-table scans.
+ *
+ * Queries use `SELECT DISTINCT` even though the helper tables are
+ * ReplacingMergeTree — dedup happens during background merges, so a row
+ * can briefly appear more than once between refresh cycles. DISTINCT over
+ * the ORDER BY columns is effectively free at this cardinality and keeps
+ * results unique regardless of merge timing.
  */
 
 import type { ClickHouseClient } from '@clickhouse/client';
@@ -50,7 +56,7 @@ export async function getEntityTypes(
 ): Promise<GetEntityTypesResponse> {
   const rows = await queryJson<{ value: string }>(
     client,
-    `SELECT value FROM ${TABLE_DISCOVERY_VALUES} WHERE kind = 'entityType' ORDER BY value`,
+    `SELECT DISTINCT value FROM ${TABLE_DISCOVERY_VALUES} WHERE kind = 'entityType' ORDER BY value`,
   );
 
   const validTypes = new Set(Object.values(EntityType));
@@ -77,7 +83,7 @@ export async function getEntityNames(
 
   const rows = await queryJson<{ value: string }>(
     client,
-    `SELECT value FROM ${TABLE_DISCOVERY_PAIRS} WHERE ${conditions.join(' AND ')} ORDER BY value`,
+    `SELECT DISTINCT value FROM ${TABLE_DISCOVERY_PAIRS} WHERE ${conditions.join(' AND ')} ORDER BY value`,
     params,
   );
   return { names: rows.map(r => r.value) };
@@ -91,7 +97,7 @@ export async function getServiceNames(
 ): Promise<GetServiceNamesResponse> {
   const rows = await queryJson<{ value: string }>(
     client,
-    `SELECT value FROM ${TABLE_DISCOVERY_VALUES} WHERE kind = 'serviceName' ORDER BY value`,
+    `SELECT DISTINCT value FROM ${TABLE_DISCOVERY_VALUES} WHERE kind = 'serviceName' ORDER BY value`,
   );
   return { serviceNames: rows.map(r => r.value) };
 }
@@ -102,7 +108,7 @@ export async function getEnvironments(
 ): Promise<GetEnvironmentsResponse> {
   const rows = await queryJson<{ value: string }>(
     client,
-    `SELECT value FROM ${TABLE_DISCOVERY_VALUES} WHERE kind = 'environment' ORDER BY value`,
+    `SELECT DISTINCT value FROM ${TABLE_DISCOVERY_VALUES} WHERE kind = 'environment' ORDER BY value`,
   );
   return { environments: rows.map(r => r.value) };
 }
@@ -120,7 +126,7 @@ export async function getTags(client: ClickHouseClient, args: GetTagsArgs): Prom
 
   const rows = await queryJson<{ value: string }>(
     client,
-    `SELECT value FROM ${TABLE_DISCOVERY_VALUES} WHERE ${conditions.join(' AND ')} ORDER BY value`,
+    `SELECT DISTINCT value FROM ${TABLE_DISCOVERY_VALUES} WHERE ${conditions.join(' AND ')} ORDER BY value`,
     params,
   );
   return { tags: rows.map(r => r.value) };

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -26,6 +26,7 @@ import {
   TABLE_DISCOVERY_PAIRS,
   TABLE_DISCOVERY_VALUES,
 } from './ddl';
+import { isReplacingMergeTreeEngine } from './migration';
 import { ObservabilityStorageClickhouseVNext } from '.';
 
 vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
@@ -3083,7 +3084,18 @@ describe('ObservabilityStorageClickhouseVNext', () => {
               format: 'JSONEachRow',
             })
           ).json()) as Array<{ name: string; engine: string }>;
-          expect(after.map(r => r.engine)).toEqual(['ReplacingMergeTree', 'ReplacingMergeTree']);
+          // Use the same predicate that reconcileDiscoveryTables() uses to
+          // decide whether a table is already migrated, so this assertion
+          // passes on ClickHouse Cloud / replicated clusters where the
+          // engine is transparently rewritten to SharedReplacingMergeTree
+          // or ReplicatedReplacingMergeTree.
+          expect(after.map(r => r.name)).toEqual([TABLE_DISCOVERY_PAIRS, TABLE_DISCOVERY_VALUES]);
+          for (const row of after) {
+            expect(
+              isReplacingMergeTreeEngine(row.engine),
+              `expected ${row.name} engine to satisfy isReplacingMergeTreeEngine but got '${row.engine}'`,
+            ).toBe(true);
+          }
 
           const mvs = (await (
             await scopedClient.query({

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -2927,12 +2927,14 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       // Trigger discovery refresh so helper tables are populated.
       // In production, discovery MVs refresh automatically on a schedule.
       // In tests, we trigger an immediate refresh after inserting data.
-      // Refresh twice: the MV writes via `REFRESH ... TO <pre-created table>`
-      // which uses APPEND semantics, so each refresh re-inserts every distinct
-      // value. Running it twice exercises the duplicate-rows path that reads
-      // must deduplicate.
       await triggerDiscoveryRefresh();
-      await triggerDiscoveryRefresh();
+
+      // Inject duplicate rows directly into the helper tables to model the
+      // intermediate state between an MV refresh and a `ReplacingMergeTree`
+      // background merge. The discovery read paths must dedupe these rows
+      // before returning them to callers — that's what the assertions below
+      // verify.
+      await injectDuplicateDiscoveryRows();
     });
 
     it('getMetricNames returns distinct names', async () => {
@@ -3040,6 +3042,18 @@ describe('ObservabilityStorageClickhouseVNext', () => {
           query: `CREATE TABLE ${TABLE_DISCOVERY_PAIRS} (kind LowCardinality(String), key1 String, key2 String, value String) ENGINE = MergeTree ORDER BY (kind, key1, key2, value)`,
         });
 
+        // Seed refreshable MVs pointing at the legacy helper tables. This
+        // mirrors a real upgrade and proves the reconcile path drops the
+        // pre-existing MVs before recreating the tables — otherwise
+        // ClickHouse would refuse to drop a table that an MV still depends
+        // on, and the recreate would also fail with "view already exists".
+        await scopedClient.command({
+          query: `CREATE MATERIALIZED VIEW ${MV_DISCOVERY_VALUES} REFRESH EVERY 1 MINUTE TO ${TABLE_DISCOVERY_VALUES} AS SELECT CAST('' AS LowCardinality(String)) AS kind, '' AS key1, '' AS value WHERE 0`,
+        });
+        await scopedClient.command({
+          query: `CREATE MATERIALIZED VIEW ${MV_DISCOVERY_PAIRS} REFRESH EVERY 5 MINUTE TO ${TABLE_DISCOVERY_PAIRS} AS SELECT CAST('' AS LowCardinality(String)) AS kind, '' AS key1, '' AS key2, '' AS value WHERE 0`,
+        });
+
         const before = (await (
           await scopedClient.query({
             query: `SELECT name, engine FROM system.tables WHERE database = currentDatabase() AND name IN ({tables:Array(String)}) ORDER BY name`,
@@ -3048,6 +3062,15 @@ describe('ObservabilityStorageClickhouseVNext', () => {
           })
         ).json()) as Array<{ name: string; engine: string }>;
         expect(before.map(r => r.engine)).toEqual(['MergeTree', 'MergeTree']);
+
+        const beforeMvs = (await (
+          await scopedClient.query({
+            query: `SELECT name FROM system.tables WHERE database = currentDatabase() AND name IN ({mvs:Array(String)}) ORDER BY name`,
+            query_params: { mvs: [MV_DISCOVERY_VALUES, MV_DISCOVERY_PAIRS] },
+            format: 'JSONEachRow',
+          })
+        ).json()) as Array<{ name: string }>;
+        expect(beforeMvs.map(r => r.name).sort()).toEqual([MV_DISCOVERY_PAIRS, MV_DISCOVERY_VALUES].sort());
 
         const migratedStorage = new ObservabilityStorageClickhouseVNext({ client: scopedClient });
         try {
@@ -5402,6 +5425,56 @@ async function triggerDiscoveryRefresh(): Promise<void> {
     await client.command({ query: `SYSTEM WAIT VIEW ${MV_DISCOVERY_VALUES}` });
     await client.command({ query: `SYSTEM REFRESH VIEW ${MV_DISCOVERY_PAIRS}` });
     await client.command({ query: `SYSTEM WAIT VIEW ${MV_DISCOVERY_PAIRS}` });
+  } finally {
+    await client.close();
+  }
+}
+
+/**
+ * Inserts a second copy of every row already in the discovery helper tables.
+ * This models the window between a refreshable MV firing and
+ * `ReplacingMergeTree` collapsing the duplicate parts: identical rows live
+ * in separate parts and a plain `SELECT` returns them all. The discovery
+ * read paths must compensate with their own `SELECT DISTINCT`.
+ *
+ * Also asserts the duplicates are present so a regression in the seeding
+ * step shows up here instead of as a confusing "tests passed for the
+ * wrong reason" later on.
+ */
+async function injectDuplicateDiscoveryRows(): Promise<void> {
+  const { createClient } = await import('@clickhouse/client');
+  const { TABLE_DISCOVERY_VALUES, TABLE_DISCOVERY_PAIRS } = await import('./ddl');
+
+  const client = createClient({
+    url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+    username: process.env.CLICKHOUSE_USERNAME || 'default',
+    password: process.env.CLICKHOUSE_PASSWORD || 'password',
+  });
+
+  try {
+    const tables: Array<{ table: string; keys: string }> = [
+      { table: TABLE_DISCOVERY_VALUES, keys: 'kind, key1, value' },
+      { table: TABLE_DISCOVERY_PAIRS, keys: 'kind, key1, key2, value' },
+    ];
+    for (const { table, keys } of tables) {
+      await client.command({ query: `INSERT INTO ${table} SELECT * FROM ${table}` });
+      const partsResult = await client.query({
+        query: `SELECT sum(rows) AS rowsInParts FROM system.parts WHERE database = currentDatabase() AND table = '${table}' AND active`,
+        format: 'JSONEachRow',
+      });
+      const rowsInParts = Number(((await partsResult.json()) as Array<{ rowsInParts: string }>)[0]?.rowsInParts ?? 0);
+      const distinctResult = await client.query({
+        query: `SELECT countDistinct(${keys}) AS distinctRows FROM ${table}`,
+        format: 'JSONEachRow',
+      });
+      const distinctRows = Number(
+        ((await distinctResult.json()) as Array<{ distinctRows: string }>)[0]?.distinctRows ?? 0,
+      );
+      expect(
+        rowsInParts,
+        `expected duplicates in ${table} but got rowsInParts=${rowsInParts}, distinctRows=${distinctRows}`,
+      ).toBeGreaterThan(distinctRows);
+    }
   } finally {
     await client.close();
   }

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -20,7 +20,11 @@ import {
   buildAllTableDDL,
   buildRetentionDDL,
   buildRetentionEntries,
+  MV_DISCOVERY_PAIRS,
+  MV_DISCOVERY_VALUES,
   parseTtlExpression,
+  TABLE_DISCOVERY_PAIRS,
+  TABLE_DISCOVERY_VALUES,
 } from './ddl';
 import { ObservabilityStorageClickhouseVNext } from '.';
 
@@ -2923,6 +2927,11 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       // Trigger discovery refresh so helper tables are populated.
       // In production, discovery MVs refresh automatically on a schedule.
       // In tests, we trigger an immediate refresh after inserting data.
+      // Refresh twice: the MV writes via `REFRESH ... TO <pre-created table>`
+      // which uses APPEND semantics, so each refresh re-inserts every distinct
+      // value. Running it twice exercises the duplicate-rows path that reads
+      // must deduplicate.
+      await triggerDiscoveryRefresh();
       await triggerDiscoveryRefresh();
     });
 
@@ -2930,18 +2939,21 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       const result = await storage.getMetricNames({});
       expect(result.names).toContain('mastra_agent_duration_ms');
       expect(result.names).toContain('mastra_tool_calls_started');
+      expect(result.names).toEqual([...new Set(result.names)]);
     });
 
     it('getMetricNames filters by prefix', async () => {
       const result = await storage.getMetricNames({ prefix: 'mastra_agent' });
       expect(result.names).toContain('mastra_agent_duration_ms');
       expect(result.names).not.toContain('mastra_tool_calls_started');
+      expect(result.names).toEqual([...new Set(result.names)]);
     });
 
     it('getMetricLabelKeys returns label keys', async () => {
       const result = await storage.getMetricLabelKeys({ metricName: 'mastra_agent_duration_ms' });
       expect(result.keys).toContain('agent');
       expect(result.keys).toContain('status');
+      expect(result.keys).toEqual([...new Set(result.keys)]);
     });
 
     it('getMetricLabelValues returns values for a label key', async () => {
@@ -2950,6 +2962,7 @@ describe('ObservabilityStorageClickhouseVNext', () => {
         labelKey: 'status',
       });
       expect(result.values).toContain('ok');
+      expect(result.values).toEqual([...new Set(result.values)]);
     });
 
     it('getEntityTypes returns distinct entity types', async () => {
@@ -2957,17 +2970,21 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       expect(result.entityTypes).toContain('agent');
       expect(result.entityTypes).toContain('tool');
       expect(result.entityTypes).toContain('input_processor');
+      expect(result.entityTypes).toEqual([...new Set(result.entityTypes)]);
     });
 
     it('getEntityNames returns entity names', async () => {
       const result = await storage.getEntityNames({ entityType: EntityType.AGENT });
       expect(result.names).toContain('weatherAgent');
+      expect(result.names).toEqual([...new Set(result.names)]);
 
       const toolNames = await storage.getEntityNames({ entityType: EntityType.TOOL });
       expect(toolNames.names).toContain('metricTool');
+      expect(toolNames.names).toEqual([...new Set(toolNames.names)]);
 
       const processorNames = await storage.getEntityNames({ entityType: EntityType.INPUT_PROCESSOR });
       expect(processorNames.names).toContain('logProcessor');
+      expect(processorNames.names).toEqual([...new Set(processorNames.names)]);
     });
 
     it('getServiceNames returns service names', async () => {
@@ -2975,6 +2992,7 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       expect(result.serviceNames).toContain('my-service');
       expect(result.serviceNames).toContain('metric-service');
       expect(result.serviceNames).toContain('log-service');
+      expect(result.serviceNames).toEqual([...new Set(result.serviceNames)]);
     });
 
     it('getEnvironments returns environments', async () => {
@@ -2982,6 +3000,7 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       expect(result.environments).toContain('production');
       expect(result.environments).toContain('metric-env');
       expect(result.environments).toContain('log-env');
+      expect(result.environments).toEqual([...new Set(result.environments)]);
     });
 
     it('getTags returns distinct tags', async () => {
@@ -2990,6 +3009,75 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       expect(result.tags).toContain('experiment');
       expect(result.tags).toContain('metric-tag');
       expect(result.tags).toContain('log-tag');
+      expect(result.tags).toEqual([...new Set(result.tags)]);
+    });
+
+    it('init() reconciles pre-existing MergeTree discovery tables to ReplacingMergeTree', async () => {
+      // Simulates an upgrade from an older deployment that created the
+      // discovery helper tables as MergeTree. init() should drop the MV
+      // and table, then recreate both with the current ReplacingMergeTree
+      // engine — preserving the discovery refresh behavior end-to-end.
+      const adminClient = createClient({
+        url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+        username: process.env.CLICKHOUSE_USERNAME || 'default',
+        password: process.env.CLICKHOUSE_PASSWORD || 'password',
+      });
+      const database = `mig_discovery_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+      await adminClient.command({ query: `CREATE DATABASE ${database}` });
+
+      const scopedClient = createClient({
+        url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+        username: process.env.CLICKHOUSE_USERNAME || 'default',
+        password: process.env.CLICKHOUSE_PASSWORD || 'password',
+        database,
+      });
+
+      try {
+        await scopedClient.command({
+          query: `CREATE TABLE ${TABLE_DISCOVERY_VALUES} (kind LowCardinality(String), key1 String, value String) ENGINE = MergeTree ORDER BY (kind, key1, value)`,
+        });
+        await scopedClient.command({
+          query: `CREATE TABLE ${TABLE_DISCOVERY_PAIRS} (kind LowCardinality(String), key1 String, key2 String, value String) ENGINE = MergeTree ORDER BY (kind, key1, key2, value)`,
+        });
+
+        const before = (await (
+          await scopedClient.query({
+            query: `SELECT name, engine FROM system.tables WHERE database = currentDatabase() AND name IN ({tables:Array(String)}) ORDER BY name`,
+            query_params: { tables: [TABLE_DISCOVERY_VALUES, TABLE_DISCOVERY_PAIRS] },
+            format: 'JSONEachRow',
+          })
+        ).json()) as Array<{ name: string; engine: string }>;
+        expect(before.map(r => r.engine)).toEqual(['MergeTree', 'MergeTree']);
+
+        const migratedStorage = new ObservabilityStorageClickhouseVNext({ client: scopedClient });
+        try {
+          await migratedStorage.init();
+
+          const after = (await (
+            await scopedClient.query({
+              query: `SELECT name, engine FROM system.tables WHERE database = currentDatabase() AND name IN ({tables:Array(String)}) ORDER BY name`,
+              query_params: { tables: [TABLE_DISCOVERY_VALUES, TABLE_DISCOVERY_PAIRS] },
+              format: 'JSONEachRow',
+            })
+          ).json()) as Array<{ name: string; engine: string }>;
+          expect(after.map(r => r.engine)).toEqual(['ReplacingMergeTree', 'ReplacingMergeTree']);
+
+          const mvs = (await (
+            await scopedClient.query({
+              query: `SELECT name FROM system.tables WHERE database = currentDatabase() AND name IN ({mvs:Array(String)}) ORDER BY name`,
+              query_params: { mvs: [MV_DISCOVERY_VALUES, MV_DISCOVERY_PAIRS] },
+              format: 'JSONEachRow',
+            })
+          ).json()) as Array<{ name: string }>;
+          expect(mvs.map(r => r.name).sort()).toEqual([MV_DISCOVERY_PAIRS, MV_DISCOVERY_VALUES].sort());
+        } finally {
+          await migratedStorage.dangerouslyClearAll();
+        }
+      } finally {
+        await scopedClient.close();
+        await adminClient.command({ query: `DROP DATABASE IF EXISTS ${database} SYNC` });
+        await adminClient.close();
+      }
     });
   });
 

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -5457,23 +5457,33 @@ async function injectDuplicateDiscoveryRows(): Promise<void> {
       { table: TABLE_DISCOVERY_PAIRS, keys: 'kind, key1, key2, value' },
     ];
     for (const { table, keys } of tables) {
-      await client.command({ query: `INSERT INTO ${table} SELECT * FROM ${table}` });
-      const partsResult = await client.query({
-        query: `SELECT sum(rows) AS rowsInParts FROM system.parts WHERE database = currentDatabase() AND table = '${table}' AND active`,
-        format: 'JSONEachRow',
-      });
-      const rowsInParts = Number(((await partsResult.json()) as Array<{ rowsInParts: string }>)[0]?.rowsInParts ?? 0);
-      const distinctResult = await client.query({
-        query: `SELECT countDistinct(${keys}) AS distinctRows FROM ${table}`,
-        format: 'JSONEachRow',
-      });
-      const distinctRows = Number(
-        ((await distinctResult.json()) as Array<{ distinctRows: string }>)[0]?.distinctRows ?? 0,
-      );
-      expect(
-        rowsInParts,
-        `expected duplicates in ${table} but got rowsInParts=${rowsInParts}, distinctRows=${distinctRows}`,
-      ).toBeGreaterThan(distinctRows);
+      // Pause background merges around the duplicate-seed + check so a fast
+      // server can't collapse the inserted parts before the assertion runs.
+      // Without this, the test would intermittently observe rowsInParts ==
+      // distinctRows on hot servers and fail for reasons unrelated to the
+      // read-side DISTINCT behavior we're trying to exercise.
+      await client.command({ query: `SYSTEM STOP MERGES ${table}` });
+      try {
+        await client.command({ query: `INSERT INTO ${table} SELECT * FROM ${table}` });
+        const partsResult = await client.query({
+          query: `SELECT sum(rows) AS rowsInParts FROM system.parts WHERE database = currentDatabase() AND table = '${table}' AND active`,
+          format: 'JSONEachRow',
+        });
+        const rowsInParts = Number(((await partsResult.json()) as Array<{ rowsInParts: string }>)[0]?.rowsInParts ?? 0);
+        const distinctResult = await client.query({
+          query: `SELECT countDistinct(${keys}) AS distinctRows FROM ${table}`,
+          format: 'JSONEachRow',
+        });
+        const distinctRows = Number(
+          ((await distinctResult.json()) as Array<{ distinctRows: string }>)[0]?.distinctRows ?? 0,
+        );
+        expect(
+          rowsInParts,
+          `expected duplicates in ${table} but got rowsInParts=${rowsInParts}, distinctRows=${distinctRows}`,
+        ).toBeGreaterThan(distinctRows);
+      } finally {
+        await client.command({ query: `SYSTEM START MERGES ${table}` });
+      }
     }
   } finally {
     await client.close();

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
@@ -118,7 +118,7 @@ import * as discoveryOps from './discovery';
 import * as feedbackOps from './feedback';
 import * as logsOps from './logs';
 import * as metricsOps from './metrics';
-import { checkSignalTablesMigrationStatus, migrateSignalTables } from './migration';
+import { checkSignalTablesMigrationStatus, isReplacingMergeTreeEngine, migrateSignalTables } from './migration';
 import type { ClickHouseDeltaCursorStrategy } from './polling';
 import { deltaPollingSupported } from './polling';
 import * as scoresOps from './scores';
@@ -247,8 +247,6 @@ async function filterAppliedRetention(
  * will still run and leave any existing tables untouched.
  */
 async function reconcileDiscoveryTables(client: ClickHouseClient): Promise<void> {
-  const EXPECTED_ENGINE = 'ReplacingMergeTree';
-
   let engines: Map<string, string>;
   try {
     const result = await client.query({
@@ -267,9 +265,13 @@ async function reconcileDiscoveryTables(client: ClickHouseClient): Promise<void>
     { table: TABLE_DISCOVERY_PAIRS, mv: MV_DISCOVERY_PAIRS },
   ];
 
+  // ClickHouse Cloud rewrites `ReplacingMergeTree` to `SharedReplacingMergeTree`
+  // and self-managed replicated clusters rewrite it to `ReplicatedReplacingMergeTree`.
+  // `isReplacingMergeTreeEngine` accepts all three so we don't churn the helper
+  // tables on every init for those deployments.
   for (const { table, mv } of targets) {
     const engine = engines.get(table);
-    if (!engine || engine === EXPECTED_ENGINE) continue;
+    if (!engine || isReplacingMergeTreeEngine(engine)) continue;
     await client.command({ query: `DROP VIEW IF EXISTS ${mv}` });
     await client.command({ query: `DROP TABLE IF EXISTS ${table}` });
   }

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
@@ -100,6 +100,8 @@ import {
   DELTA_MV_NAMES,
   MV_DISCOVERY_VALUES,
   MV_DISCOVERY_PAIRS,
+  TABLE_DISCOVERY_VALUES,
+  TABLE_DISCOVERY_PAIRS,
   buildRetentionEntries,
   parseTtlExpression,
 } from './ddl';
@@ -228,6 +230,49 @@ async function filterAppliedRetention(
     if (!current) return true;
     return current.column !== e.column || current.days !== e.days;
   });
+}
+
+/**
+ * Reconciles the discovery helper tables with the engine declared in the
+ * current DDL. Skips tables that are already on the expected engine or that
+ * don't exist yet; in those cases the regular `CREATE TABLE IF NOT EXISTS`
+ * in init() handles them.
+ *
+ * When an engine mismatch is found, the refreshable MV is dropped first so
+ * it can't write into the table mid-drop, then the table itself is dropped.
+ * Init's subsequent `CREATE TABLE IF NOT EXISTS` and discovery MV bootstrap
+ * recreate both with the current definitions.
+ *
+ * Silently returns if `system.tables` can't be queried — the rest of init
+ * will still run and leave any existing tables untouched.
+ */
+async function reconcileDiscoveryTables(client: ClickHouseClient): Promise<void> {
+  const EXPECTED_ENGINE = 'ReplacingMergeTree';
+
+  let engines: Map<string, string>;
+  try {
+    const result = await client.query({
+      query: `SELECT name, engine FROM system.tables WHERE database = currentDatabase() AND name IN ({tables:Array(String)})`,
+      query_params: { tables: [TABLE_DISCOVERY_VALUES, TABLE_DISCOVERY_PAIRS] },
+      format: 'JSONEachRow',
+    });
+    const rows = (await result.json()) as Array<{ name: string; engine: string }>;
+    engines = new Map(rows.map(r => [r.name, r.engine]));
+  } catch {
+    return;
+  }
+
+  const targets: Array<{ table: string; mv: string }> = [
+    { table: TABLE_DISCOVERY_VALUES, mv: MV_DISCOVERY_VALUES },
+    { table: TABLE_DISCOVERY_PAIRS, mv: MV_DISCOVERY_PAIRS },
+  ];
+
+  for (const { table, mv } of targets) {
+    const engine = engines.get(table);
+    if (!engine || engine === EXPECTED_ENGINE) continue;
+    await client.command({ query: `DROP VIEW IF EXISTS ${mv}` });
+    await client.command({ query: `DROP TABLE IF EXISTS ${table}` });
+  }
 }
 
 async function queryNamesByTable(
@@ -374,6 +419,12 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
       } else {
         this.#deltaCursorStrategy = await detectDeltaCursorStrategy(this.#client, undefined, existingStrategy);
       }
+
+      // Align the discovery helper tables with the current DDL. The discovery
+      // tables are fully derived from the base signal tables and get
+      // repopulated by the refreshable MV at the end of init(), so it is safe
+      // to recreate them in place when the engine doesn't match.
+      await reconcileDiscoveryTables(this.#client);
 
       // Core tables + incremental MVs (must succeed)
       const coreDdl =

--- a/stores/clickhouse/src/storage/domains/observability/v-next/metrics.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/metrics.ts
@@ -706,6 +706,9 @@ export async function getMetricPercentiles(
 // ============================================================================
 // Discovery / Metadata — reads from helper tables, not source tables.
 // Per design: returns empty results until helper tables have been refreshed.
+// Queries use SELECT DISTINCT to stay correct between ReplacingMergeTree
+// background merges, where the same value may briefly appear more than once
+// after a refresh cycle.
 // ============================================================================
 
 export async function getMetricNames(
@@ -725,7 +728,7 @@ export async function getMetricNames(
 
   const rows = await queryJson<{ value: string }>(
     client,
-    `SELECT value FROM ${TABLE_DISCOVERY_VALUES} WHERE ${conditions.join(' AND ')} ORDER BY value ${limitClause}`,
+    `SELECT DISTINCT value FROM ${TABLE_DISCOVERY_VALUES} WHERE ${conditions.join(' AND ')} ORDER BY value ${limitClause}`,
     params,
   );
 
@@ -738,7 +741,7 @@ export async function getMetricLabelKeys(
 ): Promise<GetMetricLabelKeysResponse> {
   const rows = await queryJson<{ value: string }>(
     client,
-    `SELECT value FROM ${TABLE_DISCOVERY_VALUES} WHERE kind = 'metricLabelKey' AND key1 = {metricName:String} ORDER BY value`,
+    `SELECT DISTINCT value FROM ${TABLE_DISCOVERY_VALUES} WHERE kind = 'metricLabelKey' AND key1 = {metricName:String} ORDER BY value`,
     { metricName: args.metricName },
   );
   return { keys: rows.map(r => r.value) };
@@ -764,7 +767,7 @@ export async function getMetricLabelValues(
 
   const rows = await queryJson<{ value: string }>(
     client,
-    `SELECT value FROM ${TABLE_DISCOVERY_PAIRS} WHERE ${conditions.join(' AND ')} ORDER BY value ${limitClause}`,
+    `SELECT DISTINCT value FROM ${TABLE_DISCOVERY_PAIRS} WHERE ${conditions.join(' AND ')} ORDER BY value ${limitClause}`,
     params,
   );
 


### PR DESCRIPTION
## Summary

The ClickHouse v-next observability discovery endpoints (tags, services, environments, entities, metric names, metric labels) were returning each distinct value multiple times. The refreshable materialized views that populate the `mastra_discovery_values` and `mastra_discovery_pairs` helper tables use `REFRESH EVERY ... TO <pre-created table>`, which in ClickHouse appends a fresh copy of its result set on every refresh. Because the helper tables were plain `MergeTree`, each refresh cycle layered on another full copy of every distinct value — so by the time a user hit `GET /observability/discovery/tags` they saw every tag once per refresh cycle that had run.

This PR switches the helper tables to `ReplacingMergeTree` with `ORDER BY` covering every column so background merges collapse the byte-identical duplicate rows, reconciles existing deployments on startup by dropping and recreating any helper tables still on `MergeTree`, and keeps `SELECT DISTINCT` on the read side so results stay correct between refreshes and merges.

Closes #16747

## What changed

- `ddl.ts` — `DISCOVERY_VALUES_DDL` and `DISCOVERY_PAIRS_DDL` now use `ReplacingMergeTree`.
- `index.ts` — New `reconcileDiscoveryTables()` helper runs early in `init()`. It introspects `system.tables`; when a helper table is found on the old engine it drops the refreshable MV first (so it cannot write into the table mid-drop) then drops the table. The existing `CREATE TABLE IF NOT EXISTS` and discovery MV bootstrap then recreate both with the current definitions. No-op when the table is already on the expected engine or doesn't exist yet.
- `discovery.ts` / `metrics.ts` — All discovery read queries use `SELECT DISTINCT`. `ReplacingMergeTree` only dedupes during background merges, so a row can briefly appear more than once between refresh cycles; `DISTINCT` over the `ORDER BY` columns is effectively free at this cardinality and keeps results stable regardless of merge timing.

## Testing

- Added an automated integration test `init() reconciles pre-existing MergeTree discovery tables to ReplacingMergeTree` that creates an isolated database, manually provisions the helper tables as `MergeTree` to simulate a pre-fix deployment, runs `init()`, and asserts the tables are now `ReplacingMergeTree` and that both refreshable MVs were recreated.
- The 9 existing `discovery` integration tests were tightened to assert uniqueness (`expect(result).toEqual([...new Set(result)])`) rather than just presence. A second discovery refresh was added to the test setup so duplicates would accumulate without the fix — verifying the test would actually catch the regression.
- Verified the test suite fails as expected when `SELECT DISTINCT` is reverted, then passes again once restored.
- Manually validated the migration path end-to-end against a ClickHouse 26.2 instance: provisioned the helper tables as `MergeTree`, ran `init()`, confirmed `system.tables` reported `ReplacingMergeTree` for both, and confirmed discovery reads still returned unique values after the refresh.
- Full v-next test suite (170 tests) passing locally; lint and typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The observability filters were showing the same values multiple times. This PR makes the DB helper tables automatically collapse duplicate rows, adds a startup step to upgrade old helper tables if present, and ensures queries only return unique values so the UI shows each value once.

---

## Problem

Discovery endpoints (tags, services, environments, entities, metric names, metric labels) could return duplicate values because refreshable materialized views wrote into helper tables backed by MergeTree and duplicates could appear between MV refresh and background consolidation (issue `#16747`).

## Solution

1. Schema (DDL)
- Changed discovery helper tables (`DISCOVERY_VALUES_DDL`, `DISCOVERY_PAIRS_DDL`) from MergeTree to ReplacingMergeTree and added ORDER BY covering all logical columns so background merges collapse byte-identical duplicates.

2. Runtime reconciliation
- Added reconcileDiscoveryTables(client), invoked early in init(), which inspects system.tables and:
  - Uses the existing isReplacingMergeTreeEngine() helper to accept Shared/Replicated/*ReplacingMergeTree variants as already migrated,
  - If a helper table uses a legacy engine, drops dependent refreshable MV(s) first, drops the table, and lets subsequent CREATE TABLE IF NOT EXISTS + MV bootstrap recreate them with ReplacingMergeTree.
- Silently no-ops if tables are absent or already correct.

3. Read-side stability
- Discovery and metrics read queries updated to use SELECT DISTINCT for returned value fields (getEntityTypes, getEntityNames, getServiceNames, getEnvironments, getTags, metric names/label keys/values) so results remain unique between MV refresh and ReplacingMergeTree background merges.

## Notable implementation & test details

- reconcileDiscoveryTables reuses isReplacingMergeTreeEngine() to correctly recognize Shared/Replicated ReplacingMergeTree variants and avoid unnecessary drops.
- Tests were strengthened to model the real intermediate window: after MV refresh the suite injects duplicate rows (INSERT INTO t SELECT * FROM t) to ensure duplicates exist on disk before ReplacingMergeTree merges, and assertions require unique outputs (via new Set). Reverting the DISTINCT in reads causes tests to fail as expected.
- The migration/reconcile test pre-creates helper tables with MergeTree and refreshable MVs pointing at them so the MV-drop branch is exercised end-to-end.
- Verified locally against ClickHouse 26.2.x; full v-next test suite passes; lint and typecheck are clean.

## Files changed (high level)

- .changeset/shaky-needles-dance.md — changelog entry
- stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts — helper tables changed to ReplacingMergeTree with full ORDER BY
- stores/clickhouse/src/storage/domains/observability/v-next/index.ts — added reconcileDiscoveryTables() and wired into init(), imported isReplacingMergeTreeEngine
- stores/clickhouse/src/storage/domains/observability/v-next/discovery.ts & metrics.ts — queries updated to SELECT DISTINCT
- stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts & migration.test.ts — integration & migration tests strengthened to seed duplicates and validate reconciliation

## Tests & verification

- New integration test verifies pre-existing MergeTree helper tables + refreshable MVs are reconciled to ReplacingMergeTree and MVs recreated.
- Discovery tests seed duplicate rows and assert uniqueness; they fail if DISTINCT is removed.
- Verified locally against ClickHouse 26.2.x; v-next test suite, lint, and typecheck pass.

Closes issue `#16747`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->