### PR TITLE
fix(core): allow void in tool execute return type for suspend()

### DIFF
--- a/.changeset/funky-llamas-unite.md
+++ b/.changeset/funky-llamas-unite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed type error when a tool calls `suspend(...)` inside `execute` while also declaring an `outputSchema`. The `execute` return type now allows `void` in addition to the declared output shape, so the idiomatic `return await suspend(...)` pattern type-checks correctly.

--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -105,6 +105,12 @@ A tool can also pause _during_ its `execute` function by calling `suspend()`. Th
 
 The stream emits a `tool-call-suspended` chunk with a custom payload defined by the tool's `suspendSchema`. You resume by calling `resumeStream()` with data matching the tool's `resumeSchema`.
 
+:::note
+
+`suspend()` does not throw — return immediately after calling it (e.g. `return await suspend({ ... })`). Code after `await suspend(...)` still runs before the tool pauses.
+
+:::
+
 ## Tool approval with `generate()`
 
 Tool approval also works with `generate()` for non-streaming use cases. When a tool requires approval, `generate()` returns immediately with `finishReason: 'suspended'`, a `suspendPayload` containing the tool call details (`toolCallId`, `toolName`, `args`), and a `runId`:

--- a/packages/core/src/tools/hitl.md
+++ b/packages/core/src/tools/hitl.md
@@ -78,6 +78,8 @@ const findUserTool = createTool({
 
 In this case, by calling the `suspend()` function, the tool call will be suspended and the agent will wait for the tool to be resumed.
 
+`suspend()` resolves with `void` and does not throw — your `execute` must return after calling it (idiomatically `return await suspend({ ... })`) so the framework can pause the tool. The `execute` return type allows `void` alongside the `outputSchema` shape for this reason; when a suspension is recorded, output validation is skipped.
+
 You can resume with the `.resumeStreamVNext()` method. You pass `resumeData` to continue execution from the point of suspension. This `resumeData` will be available in the tool execution context, and if specified in the tool options, should match the schema of the `resumeSchema`.
 
 ```typescript

--- a/packages/core/src/tools/suspend-execute-return-types.test-d.ts
+++ b/packages/core/src/tools/suspend-execute-return-types.test-d.ts
@@ -1,0 +1,78 @@
+import { describe, it } from 'vitest';
+import { z } from 'zod';
+import { createTool } from './tool';
+
+// Regression tests for the createTool execute return type when a tool calls
+// `suspend(...)`. The runtime contract is cooperative: calling `suspend`
+// records the suspend payload and the execute function is expected to return
+// (typically with `return await suspend(...)`), at which point the framework
+// skips output validation. The type of `execute` therefore must allow `void`
+// as a return alongside the declared output schema shape.
+
+describe('createTool execute return type with suspend', () => {
+  it('accepts `return await suspend(...)` when an outputSchema is declared', () => {
+    createTool({
+      id: 'get-weather',
+      description: 'Get current weather for a location',
+      inputSchema: z.object({ location: z.string() }),
+      outputSchema: z.object({
+        temperature: z.number(),
+        conditions: z.string(),
+        location: z.string(),
+      }),
+      resumeSchema: z.object({ approved: z.boolean() }),
+      suspendSchema: z.object({ reason: z.string() }),
+      execute: async (inputData, context) => {
+        const { resumeData: { approved } = {}, suspend } = context?.agent ?? {};
+        if (!approved) {
+          return suspend?.({ reason: 'Approval required.' });
+        }
+        return { temperature: 70, conditions: 'clear', location: inputData.location };
+      },
+    });
+  });
+
+  it('accepts the docs idiom (workflow.suspend) when an outputSchema is declared', () => {
+    createTool({
+      id: 'find-user',
+      description: 'docs example with outputSchema added',
+      inputSchema: z.object({ name: z.string() }),
+      outputSchema: z.object({ name: z.string(), email: z.string() }),
+      suspendSchema: z.object({ message: z.string() }),
+      resumeSchema: z.object({ name: z.string() }),
+      execute: async (_inputData, { workflow }) => {
+        if (!workflow?.resumeData) {
+          return await workflow!.suspend({ message: 'Please provide the name of the user' });
+        }
+        return { name: workflow.resumeData.name, email: 'test@test.com' };
+      },
+    });
+  });
+
+  it('still rejects a clearly wrong return shape', () => {
+    createTool({
+      id: 'wrong-shape',
+      description: 'returning a mismatched shape should still error',
+      inputSchema: z.object({ location: z.string() }),
+      outputSchema: z.object({ temperature: z.number() }),
+      // @ts-expect-error returning a string is not assignable to { temperature: number } | void
+      execute: async () => 'not the right shape',
+    });
+  });
+
+  it('still accepts the docs example pattern with no outputSchema', () => {
+    createTool({
+      id: 'find-user-no-output',
+      description: 'docs example as-is',
+      inputSchema: z.object({ name: z.string() }),
+      suspendSchema: z.object({ message: z.string() }),
+      resumeSchema: z.object({ name: z.string() }),
+      execute: async (_inputData, { workflow }) => {
+        if (!workflow?.resumeData) {
+          return await workflow!.suspend({ message: 'Please provide the name of the user' });
+        }
+        return { name: workflow.resumeData.name, email: 'test@test.com' };
+      },
+    });
+  });
+});

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -468,11 +468,15 @@ export interface ToolAction<
   // Execute signature with unified context type
   // First parameter: raw input data (validated against inputSchema)
   // Second parameter: unified execution context with all metadata
-  // Returns: The expected output OR a validation error if input validation fails
+  // Returns: The expected output, a validation error, or void when the tool
+  // suspends via `context.agent?.suspend?.(...)` / `context.workflow?.suspend?.(...)`.
+  // When `suspend` has been called, the tool runtime skips output validation
+  // (see `Tool.execute` in tool.ts), so returning `undefined` after `suspend`
+  // is the supported idiom (e.g. `return await suspend(...)`).
   // Note: When no outputSchema is provided, returns any to allow property access
   // Note: For outputSchema, we use the input type because Zod transforms are applied during validation
   // Note: { error?: never } enables inline type narrowing with 'error' in result checks
-  execute?: (inputData: TSchemaIn, context: TContext) => Promise<TSchemaOut | ValidationError>;
+  execute?: (inputData: TSchemaIn, context: TContext) => Promise<TSchemaOut | ValidationError | void>;
   mastra?: Mastra;
   /**
    * Whether the tool requires explicit user approval before execution.


### PR DESCRIPTION
Calling `suspend()` inside a tool's `execute` while also declaring an `outputSchema` failed to type-check, because `suspend()` resolves to `void` but the return type only allowed the output shape or a `ValidationError`. The runtime already handles this case (it skips output validation when a suspension is recorded), so the fix is just widening the type.

```ts
const tool = createTool({
  inputSchema: z.object({ location: z.string() }),
  outputSchema: z.object({ temperature: z.number() }),
  suspendSchema: z.object({ reason: z.string() }),
  resumeSchema: z.object({ approved: z.boolean() }),
  execute: async (input, { agent }) => {
    if (!agent?.resumeData?.approved) {
      return await agent?.suspend({ reason: 'needs approval' }); // ← was a type error
    }
    return { temperature: 70 };
  },
});
```

Also added a `.test-d.ts` regression test and a short note in the agent approval docs and internal `hitl.md` clarifying that `suspend()` is cooperative — you must return after calling it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you use the `suspend()` function inside a tool's `execute` method (like asking for human approval), TypeScript was complaining that the return type didn't match what the function declared. This PR fixes that by saying "it's okay for `execute` to return nothing (void) when you use `suspend()`" since the framework already knows how to handle that case properly.

---

## Changes

### Type System Update
- Updated the `ToolAction.execute` return type to include `void` alongside the existing `TSchemaOut` and `ValidationError` types
- Changed from: `Promise<TSchemaOut | ValidationError>`
- Changed to: `Promise<TSchemaOut | ValidationError | void>`
- This allows developers to idiomatically write `return await suspend(...)` inside `execute` without TypeScript errors

### Documentation Updates
- **Agent Approval Docs**: Added a clarification note that `suspend()` does not throw and execution must return immediately after calling it, since code after `await suspend(...)` continues to run before the tool pauses
- **HITL Documentation** (`packages/core/src/tools/hitl.md`): Added clarification that `suspend()` resolves to `void`, does not throw, and that the `execute` function must return immediately after calling `suspend()` so the framework can pause execution; also notes that output validation is skipped during recorded suspension

### Testing
- Added new regression test file (`suspend-execute-return-types.test-d.ts`) with TypeScript type tests verifying:
  - `execute` accepts the `return suspend?.(...)` pattern with an `outputSchema` declared
  - `return await workflow.suspend(...)` pattern is accepted
  - Invalid return values (e.g., strings) are properly rejected
  - The documented idiom works when no `outputSchema` is provided

### Metadata
- Added Changesets entry (`@mastra/core` patch) documenting the type fix

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->