### PR TITLE
fix(duckdb): checkpoint WAL after schema init to prevent corruption on dev server restart

### DIFF
--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -128,7 +128,8 @@ describe('ObservabilityStorageDuckDB', () => {
 
     expect(db.executeBatch).toHaveBeenCalledTimes(1);
     expect(db.executeBatch).toHaveBeenCalledWith([...ALL_DDL, ...ALL_MIGRATIONS]);
-    expect(db.execute).not.toHaveBeenCalled();
+    expect(db.execute).toHaveBeenCalledTimes(1);
+    expect(db.execute).toHaveBeenCalledWith('CHECKPOINT');
   });
 
   // ==========================================================================

--- a/stores/duckdb/src/storage/domains/observability/index.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.ts
@@ -148,6 +148,11 @@ export class ObservabilityStorageDuckDB extends ObservabilityStorage {
     }
 
     await this.db.executeBatch([...ALL_DDL, ...ALL_MIGRATIONS]);
+
+    // Flush the WAL to the main database file so that incomplete WAL entries
+    // from schema migrations (especially ALTER COLUMN SET DEFAULT nextval(...))
+    // don't cause corruption on abrupt process termination (e.g. dev server restart).
+    await this.db.execute('CHECKPOINT');
   }
 
   /**
@@ -173,6 +178,9 @@ export class ObservabilityStorageDuckDB extends ObservabilityStorage {
     }
 
     await migrateSignalTables(this.db, this.logger);
+
+    // Flush the WAL after heavy schema migration to avoid corrupt WAL replay on abrupt shutdown.
+    await this.db.execute('CHECKPOINT');
 
     return {
       success: true,


### PR DESCRIPTION
## Problem

On the alpha branch, restarting the dev server after initial setup causes a DuckDB WAL corruption error:

```
INTERNAL Error: Failure while replaying WAL file "mastra.duckdb.wal":
Unhandled exception: Calling DatabaseManager::GetDefaultDatabase with no default database set
```

This does **not** occur on @latest — it's a regression introduced by the delta polling feature (PR #16632).

## Root Cause

The new delta polling migrations add `ALTER COLUMN SET DEFAULT nextval('..._cursor_id_seq')` statements to all observability tables. When the dev server is killed (abrupt process termination), these statements remain in the WAL. On the next startup, DuckDB's WAL replayer tries to resolve `nextval()` sequence references before the catalog is fully initialized, causing the `GetDefaultDatabase` error.

The `executeBatch()` method runs all 50+ DDL and migration statements without transaction wrapping and without flushing the WAL afterward, leaving the database vulnerable to corruption on any non-graceful shutdown.

## Fix

Add an explicit `CHECKPOINT` call after `executeBatch()` in both `init()` and `migrateSpans()`. This flushes the WAL to the main database file immediately after schema changes, ensuring no incomplete operations survive a process kill.

## Changes

- `stores/duckdb/src/storage/domains/observability/index.ts` — Added `CHECKPOINT` after `executeBatch()` in `init()` and after `migrateSignalTables()` in `migrateSpans()`
- `stores/duckdb/src/storage/domains/observability/index.test.ts` — Updated init test to expect the new `CHECKPOINT` call

## Test Plan

- [x] Migration tests pass (`migration.test.ts` — 5/5)
- [x] Init schema test updated and passes
- [x] Existing observability tests unaffected (9 pre-existing delta polling test failures are unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the database is first set up, a lot of changes are made all at once. If the server crashes before those changes are properly saved to disk, the database gets confused and crashes next time you start it. This PR makes sure the database saves its work right after making big schema changes, so sudden shutdowns don't corrupt anything.

## Problem

The dev server crashes with a DuckDB WAL (Write-Ahead Log) corruption error when restarted after initial setup: "Failure while replaying WAL file... Calling DatabaseManager::GetDefaultDatabase with no default database set". This regression was introduced by the delta polling feature, which adds ALTER COLUMN SET DEFAULT statements to observability tables. If the server is killed before the WAL is flushed, these statements remain incomplete in the WAL and cause failures when the WAL is replayed on restart.

## Root Cause

The `executeBatch()` method runs 50+ DDL/migration statements without transaction wrapping and without flushing the WAL. This leaves incomplete schema changes in the WAL that can cause failures on non-graceful shutdown.

## Solution

Added explicit `CHECKPOINT` calls to flush the WAL to the main database file immediately after schema changes:
- Added `CHECKPOINT` after `executeBatch()` in `init()`
- Added `CHECKPOINT` after `migrateSignalTables()` in `migrateSpans()`

These changes ensure the WAL is synced to disk before continuing, preventing corruption if the server crashes during or immediately after initialization.

## Changes

**stores/duckdb/src/storage/domains/observability/index.ts**
- Added explicit DuckDB `CHECKPOINT` calls with comments explaining the intent to prevent WAL replay corruption on abrupt shutdowns

**stores/duckdb/src/storage/domains/observability/index.test.ts**
- Updated the initialization/batching test to assert the new `CHECKPOINT` call after `executeBatch()`

## Testing

- Migration tests pass (5/5)
- Init schema test updated and passes
- Existing observability tests unaffected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->