### PR TITLE
fix(duckdb): avoid cursor defaults that break WAL replay

### DIFF
--- a/.changeset/fluffy-melons-divide.md
+++ b/.changeset/fluffy-melons-divide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/duckdb': patch
+---
+
+Fixed DuckDB observability storage so dev server restarts no longer fail when replaying cursor migrations.

--- a/stores/duckdb/src/storage/domains/observability/ddl.ts
+++ b/stores/duckdb/src/storage/domains/observability/ddl.ts
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS span_events (
   -- Event metadata
   eventType VARCHAR NOT NULL,
   timestamp TIMESTAMP NOT NULL,
-  cursorId BIGINT DEFAULT nextval('span_events_cursor_id_seq'),
+  cursorId BIGINT,
 
   -- IDs
   traceId VARCHAR NOT NULL,
@@ -86,7 +86,7 @@ export const METRIC_EVENTS_DDL = `
 CREATE TABLE IF NOT EXISTS metric_events (
   -- Event metadata
   timestamp TIMESTAMP NOT NULL,
-  cursorId BIGINT DEFAULT nextval('metric_events_cursor_id_seq'),
+  cursorId BIGINT,
 
   -- IDs
   metricId VARCHAR NOT NULL PRIMARY KEY,
@@ -141,7 +141,7 @@ export const LOG_EVENTS_DDL = `
 CREATE TABLE IF NOT EXISTS log_events (
   -- Event metadata
   timestamp TIMESTAMP NOT NULL,
-  cursorId BIGINT DEFAULT nextval('log_events_cursor_id_seq'),
+  cursorId BIGINT,
 
   -- IDs
   logId VARCHAR NOT NULL PRIMARY KEY,
@@ -191,7 +191,7 @@ export const SCORE_EVENTS_DDL = `
 CREATE TABLE IF NOT EXISTS score_events (
   -- Event metadata
   timestamp TIMESTAMP NOT NULL,
-  cursorId BIGINT DEFAULT nextval('score_events_cursor_id_seq'),
+  cursorId BIGINT,
 
   -- IDs
   scoreId VARCHAR NOT NULL PRIMARY KEY,
@@ -245,7 +245,7 @@ export const FEEDBACK_EVENTS_DDL = `
 CREATE TABLE IF NOT EXISTS feedback_events (
   -- Event metadata
   timestamp TIMESTAMP NOT NULL,
-  cursorId BIGINT DEFAULT nextval('feedback_events_cursor_id_seq'),
+  cursorId BIGINT,
 
   -- IDs
   feedbackId VARCHAR NOT NULL PRIMARY KEY,
@@ -317,15 +317,13 @@ export const ALL_MIGRATIONS = [
   `CREATE SEQUENCE IF NOT EXISTS score_events_cursor_id_seq START 1`,
   `CREATE SEQUENCE IF NOT EXISTS feedback_events_cursor_id_seq START 1`,
 
-  // Span events. Existing rows intentionally keep NULL cursorId values; delta
-  // polling only applies to rows written after this migration path is in place.
+  // Existing rows intentionally keep NULL cursorId values; delta polling only
+  // applies to rows written by insert paths that explicitly call nextval().
   `ALTER TABLE span_events ADD COLUMN IF NOT EXISTS cursorId BIGINT`,
-  `ALTER TABLE span_events ALTER COLUMN cursorId SET DEFAULT nextval('span_events_cursor_id_seq')`,
   `ALTER TABLE span_events ADD COLUMN IF NOT EXISTS entityVersionId VARCHAR`,
 
   // Metrics. Legacy rows remain page-visible but are not part of delta polling.
   `ALTER TABLE metric_events ADD COLUMN IF NOT EXISTS cursorId BIGINT`,
-  `ALTER TABLE metric_events ALTER COLUMN cursorId SET DEFAULT nextval('metric_events_cursor_id_seq')`,
   `ALTER TABLE metric_events ADD COLUMN IF NOT EXISTS entityVersionId VARCHAR`,
   `ALTER TABLE metric_events ADD COLUMN IF NOT EXISTS parentEntityVersionId VARCHAR`,
   `ALTER TABLE metric_events ADD COLUMN IF NOT EXISTS rootEntityVersionId VARCHAR`,
@@ -352,7 +350,6 @@ export const ALL_MIGRATIONS = [
 
   // Logs. Legacy rows remain page-visible but are not part of delta polling.
   `ALTER TABLE log_events ADD COLUMN IF NOT EXISTS cursorId BIGINT`,
-  `ALTER TABLE log_events ALTER COLUMN cursorId SET DEFAULT nextval('log_events_cursor_id_seq')`,
   `ALTER TABLE log_events ADD COLUMN IF NOT EXISTS entityVersionId VARCHAR`,
   `ALTER TABLE log_events ADD COLUMN IF NOT EXISTS parentEntityVersionId VARCHAR`,
   `ALTER TABLE log_events ADD COLUMN IF NOT EXISTS rootEntityVersionId VARCHAR`,
@@ -379,7 +376,6 @@ export const ALL_MIGRATIONS = [
 
   // Scores. Legacy rows remain page-visible but are not part of delta polling.
   `ALTER TABLE score_events ADD COLUMN IF NOT EXISTS cursorId BIGINT`,
-  `ALTER TABLE score_events ALTER COLUMN cursorId SET DEFAULT nextval('score_events_cursor_id_seq')`,
   `ALTER TABLE score_events ADD COLUMN IF NOT EXISTS entityVersionId VARCHAR`,
   `ALTER TABLE score_events ADD COLUMN IF NOT EXISTS parentEntityVersionId VARCHAR`,
   `ALTER TABLE score_events ADD COLUMN IF NOT EXISTS rootEntityVersionId VARCHAR`,
@@ -410,7 +406,6 @@ export const ALL_MIGRATIONS = [
 
   // Feedback. Legacy rows remain page-visible but are not part of delta polling.
   `ALTER TABLE feedback_events ADD COLUMN IF NOT EXISTS cursorId BIGINT`,
-  `ALTER TABLE feedback_events ALTER COLUMN cursorId SET DEFAULT nextval('feedback_events_cursor_id_seq')`,
   `ALTER TABLE feedback_events ADD COLUMN IF NOT EXISTS entityVersionId VARCHAR`,
   `ALTER TABLE feedback_events ADD COLUMN IF NOT EXISTS parentEntityVersionId VARCHAR`,
   `ALTER TABLE feedback_events ADD COLUMN IF NOT EXISTS rootEntityVersionId VARCHAR`,

--- a/stores/duckdb/src/storage/domains/observability/ddl.ts
+++ b/stores/duckdb/src/storage/domains/observability/ddl.ts
@@ -319,6 +319,10 @@ export const ALL_MIGRATIONS = [
 
   // Existing rows intentionally keep NULL cursorId values; delta polling only
   // applies to rows written by insert paths that explicitly call nextval().
+  // Databases upgraded from a prior version may still carry a
+  // `DEFAULT nextval(...)` on cursorId, which breaks DuckDB WAL replay; that
+  // remediation lives in `dropLegacyCursorIdDefaults` and only runs when the
+  // bad default is detected in information_schema.
   `ALTER TABLE span_events ADD COLUMN IF NOT EXISTS cursorId BIGINT`,
   `ALTER TABLE span_events ADD COLUMN IF NOT EXISTS entityVersionId VARCHAR`,
 

--- a/stores/duckdb/src/storage/domains/observability/feedback.ts
+++ b/stores/duckdb/src/storage/domains/observability/feedback.ts
@@ -251,7 +251,7 @@ export async function createFeedback(db: DuckDBConnection, args: CreateFeedbackA
   const feedbackUserId = f.feedbackUserId ?? f.userId ?? null;
   await db.execute(
     `INSERT INTO feedback_events (
-      feedbackId, timestamp, traceId, spanId, experimentId,
+      feedbackId, timestamp, cursorId, traceId, spanId, experimentId,
       entityType, entityId, entityName, entityVersionId, parentEntityVersionId, parentEntityType, parentEntityId, parentEntityName, rootEntityVersionId, rootEntityType, rootEntityId, rootEntityName,
       userId, organizationId, resourceId, runId, sessionId, threadId, requestId, environment, executionSource, serviceName,
       feedbackUserId, sourceId, feedbackSource, feedbackType, value, comment, tags, metadata, scope
@@ -259,6 +259,7 @@ export async function createFeedback(db: DuckDBConnection, args: CreateFeedbackA
      VALUES (${[
        v(f.feedbackId),
        v(f.timestamp),
+       "nextval('feedback_events_cursor_id_seq')",
        v(f.traceId),
        v(f.spanId ?? null),
        v(f.experimentId ?? null),
@@ -309,6 +310,7 @@ export async function batchCreateFeedback(db: DuckDBConnection, args: BatchCreat
     return `(${[
       v(legacyFeedback.feedbackId),
       v(legacyFeedback.timestamp),
+      "nextval('feedback_events_cursor_id_seq')",
       v(legacyFeedback.traceId),
       v(legacyFeedback.spanId ?? null),
       v(legacyFeedback.experimentId ?? null),
@@ -348,7 +350,7 @@ export async function batchCreateFeedback(db: DuckDBConnection, args: BatchCreat
 
   await db.execute(
     `INSERT INTO feedback_events (
-      feedbackId, timestamp, traceId, spanId, experimentId,
+      feedbackId, timestamp, cursorId, traceId, spanId, experimentId,
       entityType, entityId, entityName, entityVersionId, parentEntityVersionId, parentEntityType, parentEntityId, parentEntityName, rootEntityVersionId, rootEntityType, rootEntityId, rootEntityName,
       userId, organizationId, resourceId, runId, sessionId, threadId, requestId, environment, executionSource, serviceName,
       feedbackUserId, sourceId, feedbackSource, feedbackType, value, comment, tags, metadata, scope

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -141,6 +141,56 @@ describe('ObservabilityStorageDuckDB', () => {
     expect(schemaStatements).not.toContain('ALTER COLUMN cursorId SET DEFAULT');
   });
 
+  it('drops the legacy cursorId default left behind by older migrations on init', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-duckdb-cursor-default-'));
+    const dbPath = join(dir, 'observability.duckdb');
+    const observabilityTables = ['span_events', 'metric_events', 'log_events', 'score_events', 'feedback_events'];
+    let db: DuckDBConnection | undefined;
+
+    try {
+      db = new DuckDBConnection({ path: dbPath });
+      const storage = new ConcreteObservabilityStorageDuckDB({ db });
+      await storage.init();
+
+      // Reintroduce the broken catalog default that the prior migration would
+      // have applied, to simulate a database upgraded from that version.
+      for (const table of observabilityTables) {
+        await db.execute(
+          `ALTER TABLE ${table} ALTER COLUMN cursorId SET DEFAULT nextval('${table}_cursor_id_seq')`,
+        );
+      }
+
+      await storage.init();
+
+      const rows = await db.query<{ table_name: string; column_default: string | null }>(
+        `SELECT table_name, column_default FROM information_schema.columns
+         WHERE column_name = 'cursorId' AND table_name IN (${observabilityTables.map(t => `'${t}'`).join(', ')})`,
+      );
+
+      expect(rows).toHaveLength(observabilityTables.length);
+      for (const row of rows) {
+        expect(row.column_default).toBeNull();
+      }
+    } finally {
+      await db?.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips the cursorId DROP DEFAULT when the column has no default', async () => {
+    const db = {
+      query: vi.fn().mockResolvedValue([]),
+      execute: vi.fn(),
+      executeBatch: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DuckDBConnection;
+    const storage = new ConcreteObservabilityStorageDuckDB({ db });
+
+    await storage.init();
+
+    expect(db.executeBatch).toHaveBeenCalledTimes(1);
+    expect(db.executeBatch).toHaveBeenCalledWith([...ALL_DDL, ...ALL_MIGRATIONS]);
+  });
+
   it('reopens a file database after cursor sequence migrations and explicit cursor writes', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'mastra-duckdb-observability-'));
     const dbPath = join(dir, 'observability.duckdb');

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -155,9 +155,7 @@ describe('ObservabilityStorageDuckDB', () => {
       // Reintroduce the broken catalog default that the prior migration would
       // have applied, to simulate a database upgraded from that version.
       for (const table of observabilityTables) {
-        await db.execute(
-          `ALTER TABLE ${table} ALTER COLUMN cursorId SET DEFAULT nextval('${table}_cursor_id_seq')`,
-        );
+        await db.execute(`ALTER TABLE ${table} ALTER COLUMN cursorId SET DEFAULT nextval('${table}_cursor_id_seq')`);
       }
 
       await storage.init();

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -1,7 +1,10 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { coreFeatures } from '@mastra/core/features';
 import { EntityType, SpanType } from '@mastra/core/observability';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { DuckDBConnection } from '../../db/index';
+import { DuckDBConnection } from '../../db/index';
 import { DuckDBStore } from '../../index';
 import { ALL_DDL, ALL_MIGRATIONS } from './ddl';
 import type { ObservabilityStorageDuckDB } from './index';
@@ -129,6 +132,41 @@ describe('ObservabilityStorageDuckDB', () => {
     expect(db.executeBatch).toHaveBeenCalledTimes(1);
     expect(db.executeBatch).toHaveBeenCalledWith([...ALL_DDL, ...ALL_MIGRATIONS]);
     expect(db.execute).not.toHaveBeenCalled();
+  });
+
+  it('keeps cursor ids out of DuckDB column defaults', () => {
+    const schemaStatements = [...ALL_DDL, ...ALL_MIGRATIONS].join('\n');
+
+    expect(schemaStatements).not.toContain('cursorId BIGINT DEFAULT');
+    expect(schemaStatements).not.toContain('ALTER COLUMN cursorId SET DEFAULT');
+  });
+
+  it('reopens a file database after cursor sequence migrations and explicit cursor writes', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-duckdb-observability-'));
+    const dbPath = join(dir, 'observability.duckdb');
+    let db: DuckDBConnection | undefined;
+
+    try {
+      db = new DuckDBConnection({ path: dbPath });
+      await db.executeBatch([...ALL_DDL, ...ALL_MIGRATIONS]);
+      await db.execute(`
+        INSERT INTO span_events (eventType, timestamp, cursorId, traceId, spanId, name, spanType, isEvent)
+        VALUES ('span.started', '2026-05-19T00:00:00.000Z'::TIMESTAMP, nextval('span_events_cursor_id_seq'), 'trace-reopen', 'span-reopen', 'root', 'agent_run', false)
+      `);
+      await db.close();
+      db = undefined;
+
+      db = new DuckDBConnection({ path: dbPath });
+      await db.executeBatch([...ALL_DDL, ...ALL_MIGRATIONS]);
+      const rows = await db.query<{ count: number }>(
+        `SELECT COUNT(*) AS count FROM span_events WHERE traceId = 'trace-reopen'`,
+      );
+
+      expect(rows).toEqual([{ count: 1 }]);
+    } finally {
+      await db?.close();
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   // ==========================================================================

--- a/stores/duckdb/src/storage/domains/observability/index.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.ts
@@ -81,7 +81,7 @@ import * as discoveryOps from './discovery';
 import * as feedbackOps from './feedback';
 import * as logOps from './logs';
 import * as metricOps from './metrics';
-import { checkSignalTablesMigrationStatus, migrateSignalTables } from './migration';
+import { checkSignalTablesMigrationStatus, dropLegacyCursorIdDefaults, migrateSignalTables } from './migration';
 import { deltaPollingFeatureEnabled } from './polling';
 import * as scoreOps from './scores';
 import * as tracingOps from './tracing';
@@ -148,6 +148,7 @@ export class ObservabilityStorageDuckDB extends ObservabilityStorage {
     }
 
     await this.db.executeBatch([...ALL_DDL, ...ALL_MIGRATIONS]);
+    await dropLegacyCursorIdDefaults(this.db);
   }
 
   /**

--- a/stores/duckdb/src/storage/domains/observability/logs.ts
+++ b/stores/duckdb/src/storage/domains/observability/logs.ts
@@ -14,6 +14,7 @@ import {
 const COLUMNS = [
   'logId',
   'timestamp',
+  'cursorId',
   'level',
   'message',
   'data',
@@ -95,6 +96,7 @@ export async function batchCreateLogs(db: DuckDBConnection, args: BatchCreateLog
     return `(${[
       v(log.logId),
       v(log.timestamp),
+      "nextval('log_events_cursor_id_seq')",
       v(log.level),
       v(log.message),
       jsonV(log.data),

--- a/stores/duckdb/src/storage/domains/observability/metrics.ts
+++ b/stores/duckdb/src/storage/domains/observability/metrics.ts
@@ -104,6 +104,7 @@ function buildMetricNameFilter(name: string | string[]): { clause: string; param
 const METRIC_COLUMNS = [
   'metricId',
   'timestamp',
+  'cursorId',
   'name',
   'value',
   'traceId',
@@ -287,6 +288,7 @@ export async function batchCreateMetrics(db: DuckDBConnection, args: BatchCreate
     return `(${[
       v(m.metricId),
       v(m.timestamp),
+      "nextval('metric_events_cursor_id_seq')",
       v(m.name),
       v(m.value),
       v(m.traceId ?? null),

--- a/stores/duckdb/src/storage/domains/observability/migration.ts
+++ b/stores/duckdb/src/storage/domains/observability/migration.ts
@@ -32,6 +32,40 @@ export interface SignalMigrationStatus {
   tables: SignalMigrationStatusTable[];
 }
 
+const CURSOR_ID_TABLES = [
+  'span_events',
+  'metric_events',
+  'log_events',
+  'score_events',
+  'feedback_events',
+] as const;
+
+/**
+ * Drop any leftover `DEFAULT nextval(...)` on observability `cursorId` columns.
+ *
+ * A previous version of the migration set this default via
+ * `ALTER COLUMN cursorId SET DEFAULT nextval(...)`. DuckDB WAL replay cannot
+ * bind that function expression before the default database is attached, so
+ * affected databases fail to reopen. Insert paths now write cursor IDs
+ * explicitly, so the catalog default is unnecessary and should be removed.
+ *
+ * We query `information_schema` first and only emit the `ALTER` for tables that
+ * actually carry the bad default; this avoids writing redundant SetDefault
+ * entries to the WAL on every startup for healthy databases.
+ */
+export async function dropLegacyCursorIdDefaults(db: DuckDBConnection): Promise<void> {
+  const rows = await db.query<{ table_name: string }>(
+    `SELECT table_name FROM information_schema.columns
+     WHERE column_name = 'cursorId'
+       AND column_default IS NOT NULL
+       AND table_name IN (${CURSOR_ID_TABLES.map(t => `'${t}'`).join(', ')})`,
+  );
+
+  if (rows.length === 0) return;
+
+  await db.executeBatch(rows.map(row => `ALTER TABLE ${row.table_name} ALTER COLUMN cursorId DROP DEFAULT`));
+}
+
 const SIGNAL_MIGRATIONS: SignalMigration[] = [
   {
     table: 'metric_events',

--- a/stores/duckdb/src/storage/domains/observability/migration.ts
+++ b/stores/duckdb/src/storage/domains/observability/migration.ts
@@ -32,13 +32,7 @@ export interface SignalMigrationStatus {
   tables: SignalMigrationStatusTable[];
 }
 
-const CURSOR_ID_TABLES = [
-  'span_events',
-  'metric_events',
-  'log_events',
-  'score_events',
-  'feedback_events',
-] as const;
+const CURSOR_ID_TABLES = ['span_events', 'metric_events', 'log_events', 'score_events', 'feedback_events'] as const;
 
 /**
  * Drop any leftover `DEFAULT nextval(...)` on observability `cursorId` columns.

--- a/stores/duckdb/src/storage/domains/observability/scores.ts
+++ b/stores/duckdb/src/storage/domains/observability/scores.ts
@@ -241,7 +241,7 @@ export async function createScore(db: DuckDBConnection, args: CreateScoreArgs): 
   const scoreSource = s.scoreSource ?? s.source ?? null;
   await db.execute(
     `INSERT INTO score_events (
-      scoreId, timestamp, traceId, spanId, experimentId, scoreTraceId,
+      scoreId, timestamp, cursorId, traceId, spanId, experimentId, scoreTraceId,
       entityType, entityId, entityName, entityVersionId, parentEntityVersionId, parentEntityType, parentEntityId, parentEntityName, rootEntityVersionId, rootEntityType, rootEntityId, rootEntityName,
       userId, organizationId, resourceId, runId, sessionId, threadId, requestId, environment, executionSource, serviceName,
       scorerId, scorerVersion, scoreSource, score, reason, tags, metadata, scope
@@ -249,6 +249,7 @@ export async function createScore(db: DuckDBConnection, args: CreateScoreArgs): 
      VALUES (${[
        v(s.scoreId),
        v(s.timestamp),
+       "nextval('score_events_cursor_id_seq')",
        v(s.traceId),
        v(s.spanId ?? null),
        v(s.experimentId ?? null),
@@ -298,6 +299,7 @@ export async function batchCreateScores(db: DuckDBConnection, args: BatchCreateS
     return `(${[
       v(legacyScore.scoreId),
       v(legacyScore.timestamp),
+      "nextval('score_events_cursor_id_seq')",
       v(legacyScore.traceId),
       v(legacyScore.spanId ?? null),
       v(legacyScore.experimentId ?? null),
@@ -337,7 +339,7 @@ export async function batchCreateScores(db: DuckDBConnection, args: BatchCreateS
 
   await db.execute(
     `INSERT INTO score_events (
-      scoreId, timestamp, traceId, spanId, experimentId, scoreTraceId,
+      scoreId, timestamp, cursorId, traceId, spanId, experimentId, scoreTraceId,
       entityType, entityId, entityName, entityVersionId, parentEntityVersionId, parentEntityType, parentEntityId, parentEntityName, rootEntityVersionId, rootEntityType, rootEntityId, rootEntityName,
       userId, organizationId, resourceId, runId, sessionId, threadId, requestId, environment, executionSource, serviceName,
       scorerId, scorerVersion, scoreSource, score, reason, tags, metadata, scope

--- a/stores/duckdb/src/storage/domains/observability/tracing.ts
+++ b/stores/duckdb/src/storage/domains/observability/tracing.ts
@@ -32,6 +32,7 @@ import { assertDeltaPollingEnabled, deltaPollingFeatureEnabled, encodeDeltaCurso
 const COLUMNS = [
   'eventType',
   'timestamp',
+  'cursorId',
   'traceId',
   'spanId',
   'parentSpanId',
@@ -401,6 +402,7 @@ function toValuesTuple(row: SpanEventRow): string {
   return [
     v(row.eventType),
     v(row.timestamp),
+    "nextval('span_events_cursor_id_seq')",
     v(row.traceId),
     v(row.spanId),
     v(row.parentSpanId),


### PR DESCRIPTION
## Summary
- remove DuckDB sequence-backed defaults from observability cursor columns and migrations
- write sequence cursor IDs explicitly in span, log, metric, score, and feedback insert paths
- add regression coverage that ensures cursor schema avoids defaults and a file-backed DuckDB database reopens after cursor migrations and cursor writes
- add a patch changeset for @mastra/duckdb

## Why
The delta polling migration introduced ALTER COLUMN cursorId SET DEFAULT nextval(...) for DuckDB observability tables. We reproduced that DuckDB can fail WAL replay after dev server hot reload with this catalog default. This keeps the delta polling behavior for new rows without relying on fragile column defaults.

## Test plan
- pnpm --filter @mastra/duckdb test -- src/storage/domains/observability/index.test.ts --bail 1 --reporter=dot
- pnpm --filter @mastra/duckdb typecheck
- pnpm --filter @mastra/duckdb lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

DuckDB could crash after dev-server restarts because it relied on automatic cursor ID defaults in the DB. This PR removes those fragile defaults and makes the app explicitly generate and write cursor IDs on insert so databases reopen and WAL replay no longer fail.

---

## Overview

Removes DuckDB sequence-backed DEFAULTs from observability cursorId columns, updates all observability write paths to explicitly generate and write cursor IDs using the corresponding sequences, adds a migration helper to drop legacy cursor defaults, and adds regression tests (including a file-backed reopen test). Also adds a patch changeset for `@mastra/duckdb`.

## Changes

- DDL & migrations (stores/duckdb/src/storage/domains/observability/ddl.ts)
  - cursorId columns defined as nullable BIGINT with no DEFAULT nextval(...).
  - ALL_MIGRATIONS no longer sets column defaults; additive migrations add cursorId as BIGINT only.
  - Comments note that upgraded rows may have NULL cursorId and delta polling relies on explicit nextval() on writes.

- Explicit cursor generation on insert paths
  - tracing.ts (span events): include cursorId in COLUMNS and inject nextval('span_events_cursor_id_seq') for inserted rows.
  - logs.ts (log events): add cursorId to COLUMNS and batch inserts use nextval('log_events_cursor_id_seq').
  - metrics.ts (metric events): include cursorId and use nextval('metric_events_cursor_id_seq') in batch inserts.
  - scores.ts (score events): populate cursorId via nextval('score_events_cursor_id_seq') for single and batch inserts.
  - feedback.ts (feedback events): populate cursorId via nextval('feedback_events_cursor_id_seq') for single and batch inserts.

- Migration helper & init changes
  - Added dropLegacyCursorIdDefaults(db) (migration.ts) that queries information_schema.columns and DROP DEFAULT for cursorId only when present.
  - ObservabilityStorageDuckDB.init() calls dropLegacyCursorIdDefaults(db) after applying DDL + migrations.

- Tests & regression coverage (index.test.ts)
  - Test that combined DDL + migrations SQL contains no cursorId DEFAULT clauses.
  - Simulate legacy DB defaults via ALTER TABLE ... SET DEFAULT nextval(...) and assert init() removes them for observability tables.
  - Assert init() skips drop when no defaults exist by verifying expected executeBatch usage.
  - Integration: file-backed DuckDB DDL/migrations → insert rows using explicit nextval(...) cursor writes → close & reopen DB, asserting rows persist and reopen succeeds.

- Changeset
  - .changeset/fluffy-melons-divide.md: patch bump for `@mastra/duckdb` documenting the fix.

## Reasoning & Impact

- Reason: DuckDB catalog defaults (ALTER COLUMN ... SET DEFAULT nextval(...)) can cause WAL replay failures during dev hot reloads. Relying on them is fragile.
- Impact: Prevents dev-server WAL replay crashes, preserves delta-polling behavior by ensuring new rows receive monotonically increasing cursor IDs via explicit nextval() calls, and provides a migration path to remove legacy defaults.

## Tests / Validation

- New tests in stores/duckdb/src/storage/domains/observability/index.test.ts cover schema defaults removal, init behavior, and file-backed reopen after explicit cursor writes.
- Recommended local checks included in PR: pnpm --filter `@mastra/duckdb` test ...; pnpm --filter `@mastra/duckdb` typecheck; pnpm --filter `@mastra/duckdb` lint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->