### PR TITLE
fix(mastracode): polish quiet mode follow-ups

### DIFF
--- a/examples/evals-with-memory/README.md
+++ b/examples/evals-with-memory/README.md
@@ -23,6 +23,7 @@ pnpm ex:all
 ## The three approaches
 
 ### 1. `runEvals` with global `targetOptions.memory`
+
 Script: `src/runeval-global.ts`
 
 Simplest. Pass `targetOptions: { memory: { thread, resource } }` once and
@@ -42,6 +43,7 @@ Verified: all items land in one thread, scorer runs cleanly, no
 `threadId required` errors.
 
 ### 2. `runEvals` once per item (per-item threads)
+
 Script: `src/runeval-per-item.ts`
 
 `runEvals` does **not** support per-item agent options today. Pre-seeding
@@ -64,6 +66,7 @@ for (const it of items) {
 ```
 
 ### 3. `dataset.startExperiment` with inline task
+
 Script: `src/dataset.ts`
 
 The dataset / experiment runner (`runExperiment` under the hood) does

--- a/examples/evals-with-memory/src/runeval-per-item.ts
+++ b/examples/evals-with-memory/src/runeval-per-item.ts
@@ -49,9 +49,7 @@ async function main() {
         scoreSums[name] = (scoreSums[name] ?? 0) + score;
       }
     }
-    const aggregate = Object.fromEntries(
-      Object.entries(scoreSums).map(([n, s]) => [n, s / perItem.length]),
-    );
+    const aggregate = Object.fromEntries(Object.entries(scoreSums).map(([n, s]) => [n, s / perItem.length]));
 
     console.log('[runeval-per-item] aggregate scores:', aggregate);
     for (const { thread } of perItem) {

--- a/mastracode/src/tui/__tests__/render-messages.test.ts
+++ b/mastracode/src/tui/__tests__/render-messages.test.ts
@@ -343,6 +343,7 @@ describe('renderExistingMessages subagents', () => {
       ],
     };
     const state = createState();
+    state.quietMode = true;
     state.harness = {
       listMessages: vi.fn().mockResolvedValue([message]),
       getDisplayState: () => ({ isRunning: false }),
@@ -358,5 +359,6 @@ describe('renderExistingMessages subagents', () => {
       .join('\n')
       .replace(/\x1b\[[0-9;]*m/g, '');
     expect(rendered).toContain('subagent fork openai/gpt-5.5');
+    expect(rendered).toContain('summary text');
   });
 });

--- a/mastracode/src/tui/commands/mode.ts
+++ b/mastracode/src/tui/commands/mode.ts
@@ -1,4 +1,13 @@
+import type { IToolExecutionComponent } from '../components/tool-execution-interface.js';
 import type { SlashCommandContext } from './types.js';
+
+function applyCurrentModeColorToRenderedTools(ctx: SlashCommandContext): void {
+  const modeColor = ctx.harness.getCurrentMode?.()?.color;
+  for (const tool of ctx.state.allToolComponents as IToolExecutionComponent[]) {
+    tool.setCompactToolModeColor?.(modeColor);
+  }
+  ctx.state.ui.requestRender();
+}
 
 export async function handleModeCommand(ctx: SlashCommandContext, args: string[]): Promise<void> {
   const modes = ctx.harness.listModes();
@@ -9,6 +18,7 @@ export async function handleModeCommand(ctx: SlashCommandContext, args: string[]
   if (args[0]) {
     try {
       await ctx.harness.switchMode({ modeId: args[0] });
+      applyCurrentModeColorToRenderedTools(ctx);
     } catch (err) {
       ctx.showError(`Failed to switch mode: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/mastracode/src/tui/commands/settings.ts
+++ b/mastracode/src/tui/commands/settings.ts
@@ -7,12 +7,17 @@ import { showModalOverlay } from '../overlay.js';
 import { handleApiKeysCommand } from './api-keys.js';
 import type { SlashCommandContext } from './types.js';
 
+function getCurrentModeColor(ctx: SlashCommandContext): string | undefined {
+  return ctx.state.harness.getCurrentMode?.()?.color;
+}
+
 function applyQuietModeToRenderedTools(ctx: SlashCommandContext, enabled: boolean, previewLineLimit: number): void {
   const tools = ctx.state.allToolComponents.filter(
     (tool): tool is IToolExecutionComponent => typeof tool.setQuietModeDisplay === 'function',
   );
 
   tools.forEach(tool => {
+    tool.setCompactToolModeColor?.(getCurrentModeColor(ctx));
     tool.setQuietModeDisplay?.(enabled ? 'quiet' : 'normal');
     tool.setQuietPreviewLineLimit?.(previewLineLimit);
   });

--- a/mastracode/src/tui/components/__tests__/chat-boundary-spacer.test.ts
+++ b/mastracode/src/tui/components/__tests__/chat-boundary-spacer.test.ts
@@ -49,16 +49,16 @@ describe('ChatBoundarySpacer', () => {
     insertChatComponentWithBoundarySpacing(container, quietTool('view'));
     insertChatComponentWithBoundarySpacing(container, assistant());
 
-    expect(container.render(100).filter(line => line === '')).toHaveLength(3);
+    expect(container.render(100).filter(line => line === '')).toHaveLength(1);
   });
 
-  it('does not space singleton tool changes across empty streaming message placeholders', () => {
+  it('spaces unrelated singleton tool changes across empty streaming message placeholders', () => {
     const container = new Container();
     insertChatComponentWithBoundarySpacing(container, quietTool('view'));
     insertChatComponentWithBoundarySpacing(container, new AssistantMessageComponent());
     insertChatComponentWithBoundarySpacing(container, quietTool('string_replace_lsp'));
 
-    expect(container.render(100).filter(line => line === '')).toHaveLength(0);
+    expect(container.render(100).filter(line => line === '')).toHaveLength(1);
   });
 
   it('renders no blank line between adjacent quiet compact tools with the same tool name', () => {
@@ -66,14 +66,14 @@ describe('ChatBoundarySpacer', () => {
     expect(lines).not.toContain('');
   });
 
-  it('renders no blank line between adjacent singleton quiet compact tools with different tool names', () => {
+  it('renders one blank line between unrelated sibling quiet compact tools', () => {
     const lines = renderSequence([
       quietTool('view'),
       quietTool('string_replace_lsp'),
       quietTool('view'),
       quietTool('string_replace_lsp'),
     ]);
-    expect(lines.filter(line => line === '')).toHaveLength(0);
+    expect(lines.filter(line => line === '')).toHaveLength(3);
   });
 
   it('renders blank lines around repeated quiet compact tool runs', () => {
@@ -85,7 +85,7 @@ describe('ChatBoundarySpacer', () => {
       quietTool('view'),
       quietTool('string_replace_lsp'),
     ]);
-    expect(lines.filter(line => line === '')).toHaveLength(2);
+    expect(lines.filter(line => line === '')).toHaveLength(3);
   });
 
   it('keeps the visible grouped tool label orange unless a continuation fails', () => {
@@ -141,7 +141,7 @@ describe('ChatBoundarySpacer', () => {
     ]);
 
     expect(lines).not.toContain('');
-    expect(stripAnsi(lines[0]!)).toContain('view  mastracode/src/tui/components/tool-execution-enhanced.ts:301-384');
+    expect(stripAnsi(lines[0]!)).toContain('▐view▌mastracode/src/tui/components/tool-execution-enhanced.ts:301-384');
     expect(stripAnsi(lines[1]!)).not.toContain('view');
     expect(stripAnsi(lines[1]!)).toContain('/tui/chat-boundary-reconciliation.ts:1-45');
     expect(stripAnsi(lines[2]!)).toContain('/tui/chat-boundary-reconciliation.ts:50-59');
@@ -157,14 +157,14 @@ describe('ChatBoundarySpacer', () => {
     expect(lines.filter(line => line === '')).toHaveLength(1);
   });
 
-  it('renders extra blank lines between a same-tool quiet run and assistant text', () => {
+  it('renders one blank line between a same-tool quiet run and assistant text', () => {
     const lines = renderSequence([quietTool('view'), quietTool('view'), assistant()]);
-    expect(lines.filter(line => line === '')).toHaveLength(3);
+    expect(lines.filter(line => line === '')).toHaveLength(1);
   });
 
-  it('renders extra blank lines between assistant text and a quiet tool', () => {
+  it('renders one blank line between assistant text and a quiet tool', () => {
     const lines = renderSequence([assistant(), quietTool('view')]);
-    expect(lines.filter(line => line === '')).toHaveLength(3);
+    expect(lines.filter(line => line === '')).toHaveLength(1);
   });
 
   it('renders one blank line between user message and assistant text', () => {

--- a/mastracode/src/tui/components/__tests__/chat-boundary-spacer.test.ts
+++ b/mastracode/src/tui/components/__tests__/chat-boundary-spacer.test.ts
@@ -49,7 +49,7 @@ describe('ChatBoundarySpacer', () => {
     insertChatComponentWithBoundarySpacing(container, quietTool('view'));
     insertChatComponentWithBoundarySpacing(container, assistant());
 
-    expect(container.render(100).filter(line => line === '')).toHaveLength(1);
+    expect(container.render(100).filter(line => line === '')).toHaveLength(3);
   });
 
   it('does not space singleton tool changes across empty streaming message placeholders', () => {
@@ -158,9 +158,14 @@ describe('ChatBoundarySpacer', () => {
     expect(lines.filter(line => line === '')).toHaveLength(1);
   });
 
-  it('renders one blank line between a same-tool quiet run and assistant text', () => {
+  it('renders extra blank lines between a same-tool quiet run and assistant text', () => {
     const lines = renderSequence([quietTool('view'), quietTool('view'), assistant()]);
-    expect(lines.filter(line => line === '')).toHaveLength(1);
+    expect(lines.filter(line => line === '')).toHaveLength(3);
+  });
+
+  it('renders extra blank lines between assistant text and a quiet tool', () => {
+    const lines = renderSequence([assistant(), quietTool('view')]);
+    expect(lines.filter(line => line === '')).toHaveLength(3);
   });
 
   it('renders one blank line between user message and assistant text', () => {

--- a/mastracode/src/tui/components/__tests__/chat-boundary-spacer.test.ts
+++ b/mastracode/src/tui/components/__tests__/chat-boundary-spacer.test.ts
@@ -105,11 +105,10 @@ describe('ChatBoundarySpacer', () => {
     );
 
     let lines = renderSequence([first, second]);
-    expect(lines[0]).toContain('\u001b[93mview');
+    expect(lines[0]).toContain('view');
 
     second.updateResult({ content: [{ type: 'text', text: 'failed' }], isError: true });
     lines = renderSequence([first, second]);
-    expect(lines[0]).toContain('\u001b[91m');
     expect(lines[0]).toContain('view');
   });
 
@@ -142,7 +141,7 @@ describe('ChatBoundarySpacer', () => {
     ]);
 
     expect(lines).not.toContain('');
-    expect(stripAnsi(lines[0]!)).toContain('view mastracode/src/tui/components/tool-execution-enhanced.ts:301-384');
+    expect(stripAnsi(lines[0]!)).toContain('view  mastracode/src/tui/components/tool-execution-enhanced.ts:301-384');
     expect(stripAnsi(lines[1]!)).not.toContain('view');
     expect(stripAnsi(lines[1]!)).toContain('/tui/chat-boundary-reconciliation.ts:1-45');
     expect(stripAnsi(lines[2]!)).toContain('/tui/chat-boundary-reconciliation.ts:50-59');

--- a/mastracode/src/tui/components/__tests__/idle-counter.test.ts
+++ b/mastracode/src/tui/components/__tests__/idle-counter.test.ts
@@ -14,13 +14,13 @@ describe('formatIdleDuration', () => {
 });
 
 describe('IdleCounterComponent', () => {
-  it('stays hidden until one minute idle, then renders like a temporal-gap marker', () => {
+  it('reserves one stable line until one minute idle, then renders like a temporal-gap marker', () => {
     const component = new IdleCounterComponent();
 
-    expect(component.render(80)).toEqual([]);
+    expect(component.render(80)).toEqual(['']);
 
     component.setIdleStartedAt(0, 59_999);
-    expect(component.render(80)).toEqual([]);
+    expect(component.render(80)).toEqual(['']);
 
     component.update(60_000);
     expect(component.render(80).join('\n')).toContain('1 minute idle');
@@ -30,6 +30,6 @@ describe('IdleCounterComponent', () => {
     expect(component.render(80).join('\n')).toContain('1 hour 36 minutes idle');
 
     component.setIdleStartedAt(undefined);
-    expect(component.render(80)).toEqual([]);
+    expect(component.render(80)).toEqual(['']);
   });
 });

--- a/mastracode/src/tui/components/__tests__/subagent-execution.test.ts
+++ b/mastracode/src/tui/components/__tests__/subagent-execution.test.ts
@@ -194,6 +194,24 @@ describe('SubagentExecutionComponent', () => {
       expect(lines.some(l => l.includes('╰──'))).toBe(true);
     });
 
+    it('can stay expanded on completion and show the final result', () => {
+      const comp = new SubagentExecutionComponent('explore', 'List files', mockTui, 'openai/gpt-5.5', {
+        expandOnComplete: true,
+      });
+      comp.addToolStart('find_files', { path: '/tmp/quiet-tool-demo' });
+      comp.addToolEnd('find_files', 'browser-demo.html', false);
+
+      comp.finish(false, 10, 'nested\nbrowser-demo.html');
+
+      const lines = nonEmpty(renderPlain(comp));
+      expect(lines.some(l => l.includes('╭──'))).toBe(true);
+      expect(lines.some(l => l.includes('List files'))).toBe(true);
+      expect(lines.some(l => l.includes('find_files'))).toBe(true);
+      expect(lines.some(l => l.includes('nested'))).toBe(true);
+      expect(lines.some(l => l.includes('browser-demo.html'))).toBe(true);
+      expect(lines.some(l => l.includes('subagent explore openai/gpt-5.5'))).toBe(true);
+    });
+
     it('toggleExpanded works correctly after completion', () => {
       const comp = new SubagentExecutionComponent('explore', 'Find usages', mockTui, undefined, {
         collapseOnComplete: true,

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -223,7 +223,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
 
     const rendered = component.render(100).join('\n');
     const output = stripAnsi(rendered);
-    expect(output).toContain('list  src (5 results)');
+    expect(output).toContain('▐list▌src (5 results)');
     expect(output).not.toContain('│ .');
     expect(rendered).toContain(theme.fg('toolOutput', 'src/a.ts'));
     expect(rendered).toContain(theme.fg('toolOutput', 'src/b.ts'));
@@ -255,7 +255,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     });
 
     const output = stripAnsi(component.render(100).join('\n'));
-    expect(output).toContain('web  "muted cli-highlight theme"');
+    expect(output).toContain('▐web▌"muted cli-highlight theme"');
     expect(output).toContain('│ cli-highlight README');
     expect(output).toContain('│ https://github.com/felixfbecker/cli-highlight');
     expect(output).not.toContain('highlight.js Themes');
@@ -269,7 +269,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       { quietDisplayMode: 'quiet', collapsedByDefault: true },
       ui,
     );
-    expect(active.render(100).join('\n')).toContain('\u001b[30m\u001b[1m view ');
+    expect(stripAnsi(active.render(100).join('\n'))).toContain('▐view▌src/example.ts');
 
     const complete = new ToolExecutionComponentEnhanced(
       'view',
@@ -278,7 +278,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       ui,
     );
     complete.updateResult({ content: [{ type: 'text', text: 'done' }], isError: false });
-    expect(complete.render(100).join('\n')).toContain('\u001b[30m\u001b[1m view ');
+    expect(stripAnsi(complete.render(100).join('\n'))).toContain('▐view▌src/example.ts');
   });
 
   it('renders quiet non-shell tool validation errors with actionable details', () => {
@@ -426,7 +426,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
 
     const lines = component.render(100).map(stripAnsi);
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('write  /tmp/example.ts');
+    expect(lines[0]).toContain('▐write▌/tmp/example.ts');
     expect(lines.join('\n')).not.toContain('first line');
     expect(component.hasQuietStreamingPreview()).toBe(false);
   });
@@ -511,6 +511,22 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(lines[0]).not.toContain('●─');
   });
 
+  it('does not use orange dot continuation markers when preview lines are disabled', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'write_file',
+      { path: '/tmp/a.ts', content: 'const first = 1;' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true, quietPreviewLineLimit: 0 },
+      ui,
+    );
+
+    component.setCompactToolContinuation(true, '/tmp/previous.ts');
+    component.setCompactToolHasFollowingContinuation(true);
+    const lines = component.render(100).map(stripAnsi);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('├─');
+    expect(lines[0]).not.toContain('●─');
+  });
+
   it('uses an open continuation header when the continuation has preview lines', () => {
     const component = new ToolExecutionComponentEnhanced(
       'write_file',
@@ -522,9 +538,10 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     component.setCompactToolHasFollowingContinuation(true);
     component.updateResult({ content: [{ type: 'text', text: 'done' }], isError: false });
     const lines = component.render(100).map(stripAnsi);
-    expect(lines).toHaveLength(3);
+    expect(lines).toHaveLength(4);
     expect(lines[1]).toContain('│ const first = 1;');
     expect(lines[2]).toContain('│ const second = 2;');
+    expect(lines[3]).toContain('│');
     expect(lines.join('\n')).not.toContain('╰─');
   });
 

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -28,8 +28,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     const output = component.render(100).join('\n');
     const visible = stripAnsi(output);
     expect(output).toContain('view');
-    expect(output).toContain(theme.fg('text', 'src/example.ts'));
-    expect(output).toContain(theme.fg('dim', ':10-14'));
+    expect(visible).toContain('src/example.ts:10-14');
     expect(output).not.toContain('path=');
     expect(output).not.toContain('✓');
     expect(output).not.toContain('╭──');
@@ -224,8 +223,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
 
     const rendered = component.render(100).join('\n');
     const output = stripAnsi(rendered);
-    expect(output).toContain('list src (5 results)');
-    expect(rendered).toContain(theme.fg('text', 'src (5 results)'));
+    expect(output).toContain('list  src (5 results)');
     expect(output).not.toContain('│ .');
     expect(rendered).toContain(theme.fg('toolOutput', 'src/a.ts'));
     expect(rendered).toContain(theme.fg('toolOutput', 'src/b.ts'));
@@ -257,7 +255,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     });
 
     const output = stripAnsi(component.render(100).join('\n'));
-    expect(output).toContain('web "muted cli-highlight theme"');
+    expect(output).toContain('web  "muted cli-highlight theme"');
     expect(output).toContain('│ cli-highlight README');
     expect(output).toContain('│ https://github.com/felixfbecker/cli-highlight');
     expect(output).not.toContain('highlight.js Themes');
@@ -271,7 +269,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       { quietDisplayMode: 'quiet', collapsedByDefault: true },
       ui,
     );
-    expect(active.render(100).join('\n')).toContain(`\u001b[93mview`);
+    expect(active.render(100).join('\n')).toContain('\u001b[30m\u001b[1m view ');
 
     const complete = new ToolExecutionComponentEnhanced(
       'view',
@@ -280,7 +278,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       ui,
     );
     complete.updateResult({ content: [{ type: 'text', text: 'done' }], isError: false });
-    expect(complete.render(100).join('\n')).toContain(`\u001b[93mview`);
+    expect(complete.render(100).join('\n')).toContain('\u001b[30m\u001b[1m view ');
   });
 
   it('renders quiet non-shell tool validation errors with actionable details', () => {
@@ -335,11 +333,11 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     });
 
     const output = component.render(100).join('\n');
+    const visible = stripAnsi(output);
     expect(output).toContain('edit');
-    expect(output).toContain('src/example.ts');
-    expect(output).toContain(theme.fg('dim', ':42-44'));
-    expect(stripAnsi(output)).toContain('new');
-    expect(stripAnsi(output)).not.toContain('old →');
+    expect(visible).toContain('src/example.ts:42-44');
+    expect(visible).toContain('new');
+    expect(visible).not.toContain('old →');
     expect(output).not.toContain('old_string=');
     expect(output.split('\n')).toHaveLength(3);
   });
@@ -428,7 +426,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
 
     const lines = component.render(100).map(stripAnsi);
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('write /tmp/example.ts');
+    expect(lines[0]).toContain('write  /tmp/example.ts');
     expect(lines.join('\n')).not.toContain('first line');
     expect(component.hasQuietStreamingPreview()).toBe(false);
   });
@@ -491,7 +489,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     second.setCompactToolContinuation(true, '/tmp/a.ts');
     const lines = second.render(100);
     expect(lines).toHaveLength(4);
-    expect(stripAnsi(lines[0]!)).toContain('├─');
+    expect(stripAnsi(lines[0]!)).toContain('●─');
     expect(stripAnsi(lines[1]!)).toContain('const second = 2;');
     expect(stripAnsi(lines[2]!)).toContain('const third = 3;');
     expect(stripAnsi(lines[3]!)).toContain('╰──');
@@ -510,7 +508,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     const lines = component.render(100).map(stripAnsi);
     expect(lines).toHaveLength(1);
     expect(lines[0]).toContain('╰─');
-    expect(lines[0]).not.toContain('├─');
+    expect(lines[0]).not.toContain('●─');
   });
 
   it('uses an open continuation header when the continuation has preview lines', () => {
@@ -550,7 +548,6 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     lines = component.render(100);
     expect(lines).toHaveLength(3);
     expect(lines[0]).toContain('src/**/*.ts');
-    expect(lines[0]).toContain(theme.fg('text', 'src/**/*.ts'));
     expect(lines[0]).not.toContain('foo');
     expect(lines[1]).toContain('│');
     expect(lines[1]).toContain(theme.fg('toolOutput', 'foo'));

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -317,11 +317,10 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     });
 
     const output = stripAnsi(component.render(100).join('\n'));
-    expect(output).toContain('Tool validation failed: ask_user');
-    expect(output).toContain('Parameter: question');
-    expect(output).toContain('Required parameter is missing');
-    expect(output).toContain('Make sure to provide a "question" parameter');
-    expect(output).not.toMatch(/^ask_user .*✗$/m);
+    expect(output).toContain('ask_user');
+    expect(output).toContain('✗');
+    expect(output).toContain('Validation error: missing required parameter "question"');
+    expect(output).not.toContain('╭──');
   });
 
   it('renders quiet non-shell tool errors through detailed renderers', () => {
@@ -335,10 +334,11 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     component.updateResult({ content: [{ type: 'text', text: 'The specified text was not found.' }], isError: false });
 
     const output = stripAnsi(component.render(100).join('\n'));
-    expect(output).toContain('╭──');
-    expect(output).toContain('edit src/example.ts');
+    expect(output).toContain('edit');
+    expect(output).toContain('src/example.ts');
     expect(output).toContain('✗');
-    expect(output).not.toMatch(/^edit .*✗$/m);
+    expect(output).toContain('The specified text was not found.');
+    expect(output).not.toContain('╭──');
   });
 
   it('renders quiet edit tools with line ranges from the tool result', () => {
@@ -618,7 +618,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(output.split('\n')).toHaveLength(1);
   });
 
-  it('limits quiet shell output to nine content lines', () => {
+  it('limits quiet shell output to fifteen content lines', () => {
     const component = new ToolExecutionComponentEnhanced(
       'execute_command',
       { command: 'printf lines' },
@@ -628,7 +628,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
 
     component.updateResult(
       {
-        content: [{ type: 'text', text: Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n') }],
+        content: [{ type: 'text', text: Array.from({ length: 16 }, (_, i) => `line ${i + 1}`).join('\n') }],
         isError: false,
       },
       false,
@@ -638,9 +638,9 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     const lines = output.split('\n');
     expect(output).toContain(theme.fg('success', ' ✓'));
     expect(output).toContain('line 2');
-    expect(output).toContain('line 10');
+    expect(output).toContain('line 16');
     expect(lines.some(line => line.includes('line 1 ') || line.includes('line 1│'))).toBe(false);
-    expect(lines.filter(line => line.includes('line '))).toHaveLength(9);
+    expect(lines.filter(line => line.includes('line '))).toHaveLength(15);
   });
 
   it('keeps quiet detail lines visible after completion', () => {
@@ -669,8 +669,11 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     );
 
     const output = component.render(100).join('\n');
+    const visible = stripAnsi(output);
     expect(output).toContain('\u001b[93m$');
     expect(output).not.toContain('⟶');
+    expect(visible).not.toContain('├');
+    expect(visible.split('\n')).toHaveLength(3);
   });
 
   it('wraps long quiet shell commands in the footer instead of truncating them', () => {
@@ -689,6 +692,225 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(footerLines.length).toBeGreaterThan(1);
     expect(footerLines[0]).toContain('│ $ pnpm');
     expect(footerLines[1]).toMatch(/^│   \S/);
+  });
+
+  it('shows same-file continuation paths while edit args are still streaming', () => {
+    const first = new ToolExecutionComponentEnhanced(
+      'string_replace_lsp',
+      { path: 'packages/app/src/example.ts', old_string: 'a', new_string: 'b' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    first.updateResult({ content: [{ type: 'text', text: 'Edited packages/app/src/example.ts (lines 4-4)' }], isError: false }, false);
+
+    const second = new ToolExecutionComponentEnhanced(
+      'string_replace_lsp',
+      { path: 'packages/app/src/example.ts', old_string: 'b', new_string: 'c' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    second.setCompactToolContinuation(true, 'packages/app/src/example.ts:4-4');
+
+    const visible = stripAnsi(second.render(100).join('\n'));
+    expect(visible).toContain('src/example.ts');
+    expect(visible).toMatch(/●─+ \/src\/example\.ts/);
+    expect(visible).not.toMatch(/^\s*[●├─ ]+$/m);
+
+    second.updateResult({ content: [{ type: 'text', text: 'Replaced 1 occurrence in packages/app/src/example.ts (lines 8-8)' }], isError: false }, false);
+    second.setCompactToolContinuation(true, 'packages/app/src/example.ts:4-4');
+    const completedVisible = stripAnsi(second.render(100).join('\n'));
+    expect(completedVisible).toContain('src/example.ts:8-8');
+    expect(completedVisible).toMatch(/●─+ \/src\/example\.ts:8-8/);
+  });
+
+  it('keeps same-file continuation connector geometry when both edits have line ranges', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'string_replace_lsp',
+      { path: '/tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts', new_string: 'const suffix = true;' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    component.updateResult({ content: [{ type: 'text', text: 'Replaced 1 occurrence in /tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts (lines 38-43)' }], isError: false }, false);
+    component.setCompactToolContinuation(
+      true,
+      '/tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts:26-29',
+    );
+
+    const visible = stripAnsi(component.render(220).join('\n'));
+    expect(visible).toContain('/components/payment-metho');
+    expect(visible).toMatch(/●─+ \/components\/payment-metho/);
+  });
+
+  it('renders standalone incomplete continuations with a tool label instead of a blank call', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'string_replace_lsp',
+      {},
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    component.setCompactToolContinuation(true);
+
+    const visible = stripAnsi(component.render(100).join('\n'));
+    expect(visible).toContain('edit');
+    expect(visible.trim()).not.toBe('');
+  });
+
+  it('renders grouped empty continuations as a dot instead of flashing the tool label', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'string_replace_lsp',
+      {},
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    component.setCompactToolContinuation(true, '/tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts:26-29');
+
+    const firstLine = stripAnsi(component.render(120)[0] ?? '');
+    expect(firstLine).toContain('●─');
+    expect(firstLine).not.toContain('edit');
+  });
+
+  it('does not render connector-only continuation headers when summaries fully overlap', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'string_replace_lsp',
+      { path: 'mastracode/src/tui/handlers/tool.ts', new_string: 'reconcileToolBoundaries(ctx);' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    component.setCompactToolContinuation(true, 'mastracode/src/tui/handlers/tool.ts');
+
+    const lines = stripAnsi(component.render(120).join('\n')).split('\n');
+    expect(lines[0]).toContain('/handlers/tool.ts');
+    expect(lines[0]).not.toMatch(/^\s*[●╰├─ ]+▌?\s*$/);
+  });
+
+  it('renders quiet non-shell failures in compact style with error detail', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'string_replace_lsp',
+      { path: 'src/example.ts', old_string: 'missing', new_string: 'replacement' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    component.updateResult({ content: [{ type: 'text', text: 'Error: missing replacement' }], isError: true }, false);
+
+    const output = component.render(100).join('\n');
+    const visible = stripAnsi(output);
+    expect(visible).toContain('edit');
+    expect(visible).toContain('src/example.ts');
+    expect(visible).toContain('✗');
+    expect(visible).toContain('Error: missing replacement');
+    expect(visible).not.toContain('╭──');
+  });
+
+  it('renders browser tools without duplicating args as preview lines', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'browser_goto',
+      { url: 'https://example.com' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    component.updateResult({ content: [{ type: 'text', text: 'navigated' }], isError: false }, false);
+
+    const visible = stripAnsi(component.render(100).join('\n'));
+    expect(visible).toContain('browser_goto');
+    expect(visible).toContain('https://example.com');
+    expect(visible.split('https://example.com')).toHaveLength(2);
+    expect(visible).not.toContain('url=');
+  });
+
+  it('unwraps browser evaluate and snapshot results instead of showing success JSON', () => {
+    const evaluate = new ToolExecutionComponentEnhanced(
+      'browser_evaluate',
+      { script: 'document.title' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    evaluate.updateResult(
+      { content: [{ type: 'text', text: '{"success":true,"result":{"title":"","url":"about:blank"}}' }], isError: false },
+      false,
+    );
+
+    const snapshot = new ToolExecutionComponentEnhanced(
+      'browser_snapshot',
+      { interactiveOnly: false, maxDepth: 3 },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    snapshot.updateResult({ content: [{ type: 'text', text: '{"success":true,"snapshot":"- button Demo"}' }], isError: false }, false);
+
+    const output = stripAnsi(`${evaluate.render(120).join('\n')}\n${snapshot.render(120).join('\n')}`);
+    expect(output).toContain('title: ""');
+    expect(output).toContain('url: about:blank');
+    expect(output).toContain('- button Demo');
+    expect(output).not.toContain('"success"');
+    expect(output).not.toContain('{');
+  });
+
+  it('renders process file stat and generic result previews', () => {
+    const processOutput = new ToolExecutionComponentEnhanced(
+      'get_process_output',
+      { pid: '1234' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    processOutput.updateResult({ content: [{ type: 'text', text: 'quiet-process-demo-1\nquiet-process-demo-2' }], isError: false }, false);
+
+    const stat = new ToolExecutionComponentEnhanced(
+      'file_stat',
+      { path: 'src/example.ts' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    stat.updateResult({ content: [{ type: 'text', text: 'src/example.ts Type: file Size: 123 bytes Modified: today' }], isError: false }, false);
+
+    const generic = new ToolExecutionComponentEnhanced(
+      'custom_tool',
+      { file: 'src/example.ts', line: 1 },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    generic.updateResult({ content: [{ type: 'text', text: '{"action":"exit","count":2}' }], isError: false }, false);
+
+    const visible = stripAnsi(`${processOutput.render(120).join('\n')}\n${stat.render(120).join('\n')}\n${generic.render(120).join('\n')}`);
+    expect(visible).toContain('process');
+    expect(visible).toContain('1234');
+    expect(visible).toContain('quiet-process-demo-1');
+    expect(visible).toContain('stat');
+    expect(visible).toContain('Type: file Size: 123 bytes Modified: today');
+    expect(visible).toContain('custom_tool');
+    expect(visible).toContain('action: exit');
+    expect(visible).toContain('count: 2');
+  });
+
+  it('uses the active continuation dot while a continuation is still streaming', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'write_file',
+      { path: 'src/example.ts' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    component.setCompactToolContinuation(true, 'src/other.ts');
+
+    const visible = stripAnsi(component.render(120).join('\n'));
+    expect(visible).toContain('●─');
+    expect(visible).not.toContain('╰─');
+  });
+
+  it('renders deliberate browser skill workspace and process summaries', () => {
+    const cases: Array<[string, Record<string, unknown>, string[]]> = [
+      ['browser_type', { ref: 'e12', text: 'hello' }, ['browser_type', 'e12', '"hello"']],
+      ['skill_read', { skillName: 'mastra-docs', path: 'references/style.md' }, ['skill_read', 'mastra-docs references/style.md']],
+      ['file_stat', { path: 'src/example.ts' }, ['stat', 'src/example.ts']],
+      ['get_process_output', { pid: '1234' }, ['process', '1234']],
+      ['ast_smart_edit', { path: 'src/example.ts', transform: 'rename' }, ['ast_edit', 'src/example.ts']],
+    ];
+
+    for (const [toolName, args, expectedParts] of cases) {
+      const component = new ToolExecutionComponentEnhanced(toolName, args, { quietDisplayMode: 'quiet', collapsedByDefault: true }, ui);
+      const visible = stripAnsi(component.render(120).join('\n'));
+      for (const expected of expectedParts) expect(visible).toContain(expected);
+      expect(visible).not.toContain('path=');
+      expect(visible).not.toContain('pid=');
+    }
   });
 });
 

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -28,7 +28,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     const output = component.render(100).join('\n');
     const visible = stripAnsi(output);
     expect(output).toContain('view');
-    expect(output).toContain('src/example.ts');
+    expect(output).toContain(theme.fg('text', 'src/example.ts'));
     expect(output).toContain(theme.fg('dim', ':10-14'));
     expect(output).not.toContain('path=');
     expect(output).not.toContain('✓');
@@ -39,7 +39,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(output.split('\n')).toHaveLength(4);
   });
 
-  it('wraps quiet view previews before applying ANSI syntax highlighting', () => {
+  it('highlights quiet view previews before truncating displayed lines', () => {
     const component = new ToolExecutionComponentEnhanced(
       'view',
       { path: 'src/example.ts', offset: 1, limit: 1, showLineNumbers: true },
@@ -54,8 +54,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     });
 
     const output = component.render(120).join('\n');
-    const withoutCompleteAnsiSequences = output.replace(/\u001b\[[0-9;]*m/g, '');
-    expect(withoutCompleteAnsiSequences).not.toContain('\u001b');
+    expect(stripAnsi(output)).not.toContain('\u001b');
     expect(stripAnsi(output)).toContain('│ const value =');
   });
 
@@ -223,13 +222,46 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       isError: false,
     });
 
-    const output = stripAnsi(component.render(100).join('\n'));
+    const rendered = component.render(100).join('\n');
+    const output = stripAnsi(rendered);
     expect(output).toContain('list src (5 results)');
+    expect(rendered).toContain(theme.fg('text', 'src (5 results)'));
     expect(output).not.toContain('│ .');
-    expect(output).toContain('│ src/a.ts');
-    expect(output).toContain('│ src/b.ts');
+    expect(rendered).toContain(theme.fg('toolOutput', 'src/a.ts'));
+    expect(rendered).toContain(theme.fg('toolOutput', 'src/b.ts'));
     expect(output).not.toContain('src/c.ts');
     expect(output).toContain('╰──');
+  });
+
+  it('renders quiet web search with query summary and compact result preview', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'web_search',
+      { query: 'muted cli-highlight theme' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    component.updateResult({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            sources: [
+              { title: 'cli-highlight README', url: 'https://github.com/felixfbecker/cli-highlight' },
+              { title: 'highlight.js Themes', url: 'https://highlightjs.org' },
+            ],
+          }),
+        },
+      ],
+      isError: false,
+    });
+
+    const output = stripAnsi(component.render(100).join('\n'));
+    expect(output).toContain('web "muted cli-highlight theme"');
+    expect(output).toContain('│ cli-highlight README');
+    expect(output).toContain('│ https://github.com/felixfbecker/cli-highlight');
+    expect(output).not.toContain('highlight.js Themes');
+    expect(output).not.toContain('sources');
   });
 
   it('colors quiet compact tool labels by status', () => {
@@ -511,16 +543,17 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(lines[0]).toContain('grep');
     expect(lines[0]).not.toContain('foo');
     expect(lines[1]).toContain('│');
-    expect(lines[1]).toContain('foo');
+    expect(lines[1]).toContain(theme.fg('toolOutput', 'foo'));
     expect(stripAnsi(lines[2]!)).toContain('╰──');
 
     component.updateArgs({ pattern: 'foo', path: 'src/**/*.ts' });
     lines = component.render(100);
     expect(lines).toHaveLength(3);
     expect(lines[0]).toContain('src/**/*.ts');
+    expect(lines[0]).toContain(theme.fg('text', 'src/**/*.ts'));
     expect(lines[0]).not.toContain('foo');
     expect(lines[1]).toContain('│');
-    expect(lines[1]).toContain('foo');
+    expect(lines[1]).toContain(theme.fg('toolOutput', 'foo'));
     expect(lines[1]).not.toContain('src/**/*.ts');
     expect(stripAnsi(lines[2]!)).toContain('╰──');
 
@@ -549,7 +582,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(output.split('\n')).toHaveLength(1);
   });
 
-  it('limits quiet shell output to eight content lines', () => {
+  it('limits quiet shell output to nine content lines', () => {
     const component = new ToolExecutionComponentEnhanced(
       'execute_command',
       { command: 'printf lines' },
@@ -566,10 +599,12 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     );
 
     const output = component.render(100).join('\n');
-    expect(output).toContain('line 3');
+    const lines = output.split('\n');
+    expect(output).toContain(theme.fg('success', ' ✓'));
+    expect(output).toContain('line 2');
     expect(output).toContain('line 10');
-    expect(output).not.toContain('line 2');
-    expect(output.split('\n').filter(line => line.includes('│'))).toHaveLength(8);
+    expect(lines.some(line => line.includes('line 1 ') || line.includes('line 1│'))).toBe(false);
+    expect(lines.filter(line => line.includes('line '))).toHaveLength(9);
   });
 
   it('keeps quiet detail lines visible after completion', () => {
@@ -600,6 +635,24 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     const output = component.render(100).join('\n');
     expect(output).toContain('\u001b[93m$');
     expect(output).not.toContain('⟶');
+  });
+
+  it('wraps long quiet shell commands in the footer instead of truncating them', () => {
+    const command = 'pnpm --filter mastracode exec vitest run src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot';
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    const output = stripAnsi(component.render(60).join('\n'));
+    const footerLines = output.split('\n').filter(line => line.startsWith('│') && line.trim() !== '│');
+    expect(output).not.toContain('…');
+    expect(output).toContain('--reporter=dot');
+    expect(footerLines.length).toBeGreaterThan(1);
+    expect(footerLines[0]).toContain('│ $ pnpm');
+    expect(footerLines[1]).toMatch(/^│   \S/);
   });
 });
 

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -728,7 +728,8 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
   });
 
   it('wraps long quiet shell commands in the footer instead of truncating them', () => {
-    const command = 'pnpm --filter mastracode exec vitest run src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot';
+    const command =
+      'pnpm --filter mastracode exec vitest run src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot';
     const component = new ToolExecutionComponentEnhanced(
       'execute_command',
       { command },
@@ -747,7 +748,8 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
   });
 
   it('keeps base shell command color on wrapped continuation lines', () => {
-    const command = 'pnpm --filter mastracode exec vitest run src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot && pnpm --filter mastracode lint && pnpm --filter mastracode check';
+    const command =
+      'pnpm --filter mastracode exec vitest run src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot && pnpm --filter mastracode lint && pnpm --filter mastracode check';
     const component = new ToolExecutionComponentEnhanced(
       'execute_command',
       { command },
@@ -767,7 +769,10 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       { quietDisplayMode: 'quiet', collapsedByDefault: true },
       ui,
     );
-    first.updateResult({ content: [{ type: 'text', text: 'Edited packages/app/src/example.ts (lines 4-4)' }], isError: false }, false);
+    first.updateResult(
+      { content: [{ type: 'text', text: 'Edited packages/app/src/example.ts (lines 4-4)' }], isError: false },
+      false,
+    );
 
     const second = new ToolExecutionComponentEnhanced(
       'string_replace_lsp',
@@ -782,7 +787,13 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(visible).toMatch(/●─+ \/src\/example\.ts/);
     expect(visible).not.toMatch(/^\s*[●├─ ]+$/m);
 
-    second.updateResult({ content: [{ type: 'text', text: 'Replaced 1 occurrence in packages/app/src/example.ts (lines 8-8)' }], isError: false }, false);
+    second.updateResult(
+      {
+        content: [{ type: 'text', text: 'Replaced 1 occurrence in packages/app/src/example.ts (lines 8-8)' }],
+        isError: false,
+      },
+      false,
+    );
     second.setCompactToolContinuation(true, 'packages/app/src/example.ts:4-4');
     const completedVisible = stripAnsi(second.render(100).join('\n'));
     expect(completedVisible).toContain('src/example.ts:8-8');
@@ -792,11 +803,25 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
   it('keeps same-file continuation connector geometry when both edits have line ranges', () => {
     const component = new ToolExecutionComponentEnhanced(
       'string_replace_lsp',
-      { path: '/tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts', new_string: 'const suffix = true;' },
+      {
+        path: '/tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts',
+        new_string: 'const suffix = true;',
+      },
       { quietDisplayMode: 'quiet', collapsedByDefault: true },
       ui,
     );
-    component.updateResult({ content: [{ type: 'text', text: 'Replaced 1 occurrence in /tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts (lines 38-43)' }], isError: false }, false);
+    component.updateResult(
+      {
+        content: [
+          {
+            type: 'text',
+            text: 'Replaced 1 occurrence in /tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts (lines 38-43)',
+          },
+        ],
+        isError: false,
+      },
+      false,
+    );
     component.setCompactToolContinuation(
       true,
       '/tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts:26-29',
@@ -828,7 +853,10 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       { quietDisplayMode: 'quiet', collapsedByDefault: true },
       ui,
     );
-    component.setCompactToolContinuation(true, '/tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts:26-29');
+    component.setCompactToolContinuation(
+      true,
+      '/tmp/project/apps/web/src/features/checkout/components/payment-method-selector.ts:26-29',
+    );
 
     const firstLine = stripAnsi(component.render(120)[0] ?? '');
     expect(firstLine).toContain('●─');
@@ -891,7 +919,10 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       ui,
     );
     evaluate.updateResult(
-      { content: [{ type: 'text', text: '{"success":true,"result":{"title":"","url":"about:blank"}}' }], isError: false },
+      {
+        content: [{ type: 'text', text: '{"success":true,"result":{"title":"","url":"about:blank"}}' }],
+        isError: false,
+      },
       false,
     );
 
@@ -901,7 +932,10 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       { quietDisplayMode: 'quiet', collapsedByDefault: true },
       ui,
     );
-    snapshot.updateResult({ content: [{ type: 'text', text: '{"success":true,"snapshot":"- button Demo"}' }], isError: false }, false);
+    snapshot.updateResult(
+      { content: [{ type: 'text', text: '{"success":true,"snapshot":"- button Demo"}' }], isError: false },
+      false,
+    );
 
     const output = stripAnsi(`${evaluate.render(120).join('\n')}\n${snapshot.render(120).join('\n')}`);
     expect(output).toContain('title: ""');
@@ -918,7 +952,10 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       { quietDisplayMode: 'quiet', collapsedByDefault: true },
       ui,
     );
-    processOutput.updateResult({ content: [{ type: 'text', text: 'quiet-process-demo-1\nquiet-process-demo-2' }], isError: false }, false);
+    processOutput.updateResult(
+      { content: [{ type: 'text', text: 'quiet-process-demo-1\nquiet-process-demo-2' }], isError: false },
+      false,
+    );
 
     const stat = new ToolExecutionComponentEnhanced(
       'file_stat',
@@ -926,7 +963,13 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       { quietDisplayMode: 'quiet', collapsedByDefault: true },
       ui,
     );
-    stat.updateResult({ content: [{ type: 'text', text: 'src/example.ts Type: file Size: 123 bytes Modified: today' }], isError: false }, false);
+    stat.updateResult(
+      {
+        content: [{ type: 'text', text: 'src/example.ts Type: file Size: 123 bytes Modified: today' }],
+        isError: false,
+      },
+      false,
+    );
 
     const generic = new ToolExecutionComponentEnhanced(
       'custom_tool',
@@ -936,7 +979,9 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     );
     generic.updateResult({ content: [{ type: 'text', text: '{"action":"exit","count":2}' }], isError: false }, false);
 
-    const visible = stripAnsi(`${processOutput.render(120).join('\n')}\n${stat.render(120).join('\n')}\n${generic.render(120).join('\n')}`);
+    const visible = stripAnsi(
+      `${processOutput.render(120).join('\n')}\n${stat.render(120).join('\n')}\n${generic.render(120).join('\n')}`,
+    );
     expect(visible).toContain('process');
     expect(visible).toContain('1234');
     expect(visible).toContain('quiet-process-demo-1');
@@ -964,14 +1009,23 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
   it('renders deliberate browser skill workspace and process summaries', () => {
     const cases: Array<[string, Record<string, unknown>, string[]]> = [
       ['browser_type', { ref: 'e12', text: 'hello' }, ['browser_type', 'e12', '"hello"']],
-      ['skill_read', { skillName: 'mastra-docs', path: 'references/style.md' }, ['skill_read', 'mastra-docs references/style.md']],
+      [
+        'skill_read',
+        { skillName: 'mastra-docs', path: 'references/style.md' },
+        ['skill_read', 'mastra-docs references/style.md'],
+      ],
       ['file_stat', { path: 'src/example.ts' }, ['stat', 'src/example.ts']],
       ['get_process_output', { pid: '1234' }, ['process', '1234']],
       ['ast_smart_edit', { path: 'src/example.ts', transform: 'rename' }, ['ast_edit', 'src/example.ts']],
     ];
 
     for (const [toolName, args, expectedParts] of cases) {
-      const component = new ToolExecutionComponentEnhanced(toolName, args, { quietDisplayMode: 'quiet', collapsedByDefault: true }, ui);
+      const component = new ToolExecutionComponentEnhanced(
+        toolName,
+        args,
+        { quietDisplayMode: 'quiet', collapsedByDefault: true },
+        ui,
+      );
       const visible = stripAnsi(component.render(120).join('\n'));
       for (const expected of expectedParts) expect(visible).toContain(expected);
       expect(visible).not.toContain('path=');

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -708,6 +708,25 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(output).toContain(chalk.white("'done'"));
   });
 
+  it('keeps quoted shell strings highlighted after wrapping', () => {
+    const command = `echo "${'quoted '.repeat(40)}if then fi"`;
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    const output = component.render(80).join('\n');
+    const footerLines = stripAnsi(output)
+      .split('\n')
+      .filter(line => line.startsWith('│') && line.trim() !== '│');
+    expect(footerLines.length).toBeGreaterThan(1);
+    expect(stripAnsi(output)).toContain('then fi"');
+    expect(output).toContain(chalk.white('then fi"'));
+    expect(output).not.toContain(chalk.blue('then'));
+  });
+
   it('wraps long quiet shell commands in the footer instead of truncating them', () => {
     const command = 'pnpm --filter mastracode exec vitest run src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot';
     const component = new ToolExecutionComponentEnhanced(

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -676,6 +676,22 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(visible.split('\n')).toHaveLength(3);
   });
 
+  it('syntax highlights quiet shell command footers as bash', () => {
+    const command = 'if [ -f package.json ]; then echo "ok"; fi';
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    const output = component.render(100).join('\n');
+    expect(stripAnsi(output)).toContain(`$ ${command}`);
+    expect(output).toContain(chalk.blue('if'));
+    expect(output).toContain(chalk.cyan('echo'));
+    expect(output).toContain(chalk.hex('#f6c177')('-f'));
+  });
+
   it('wraps long quiet shell commands in the footer instead of truncating them', () => {
     const command = 'pnpm --filter mastracode exec vitest run src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot';
     const component = new ToolExecutionComponentEnhanced(
@@ -689,9 +705,24 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     const footerLines = output.split('\n').filter(line => line.startsWith('│') && line.trim() !== '│');
     expect(output).not.toContain('…');
     expect(output).toContain('--reporter=dot');
+    expect(component.render(60).join('\n')).toContain(chalk.hex('#f6c177')('--reporter=dot'));
     expect(footerLines.length).toBeGreaterThan(1);
     expect(footerLines[0]).toContain('│ $ pnpm');
     expect(footerLines[1]).toMatch(/^│   \S/);
+  });
+
+  it('keeps base shell command color on wrapped continuation lines', () => {
+    const command = 'pnpm --filter mastracode exec vitest run src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot && pnpm --filter mastracode lint && pnpm --filter mastracode check';
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    const output = component.render(120).join('\n');
+    const wrappedLine = output.split('\n').find(line => stripAnsi(line).includes('lint && pnpm --filter'));
+    expect(wrappedLine).toContain(theme.fg('toolArgs', 'lint'));
   });
 
   it('shows same-file continuation paths while edit args are still streaming', () => {

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -688,8 +688,8 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     const output = component.render(100).join('\n');
     expect(stripAnsi(output)).toContain(`$ ${command}`);
     expect(output).toContain(chalk.blue('if'));
-    expect(output).toContain(chalk.hex('#93c5fd')('echo'));
-    expect(output).toContain(chalk.hex('#f6c177')('-f'));
+    expect(output).toContain(theme.fg('toolArgs', 'echo'));
+    expect(output).toContain(theme.fg('toolArgs', '-f'));
   });
 
   it('keeps shell keywords inside quoted strings highlighted as strings', () => {
@@ -721,7 +721,7 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     const footerLines = output.split('\n').filter(line => line.startsWith('│') && line.trim() !== '│');
     expect(output).not.toContain('…');
     expect(output).toContain('--reporter=dot');
-    expect(component.render(60).join('\n')).toContain(chalk.hex('#f6c177')('--reporter=dot'));
+    expect(component.render(60).join('\n')).toContain(theme.fg('toolArgs', '--reporter=dot'));
     expect(footerLines.length).toBeGreaterThan(1);
     expect(footerLines[0]).toContain('│ $ pnpm');
     expect(footerLines[1]).toMatch(/^│   \S/);

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -1,5 +1,6 @@
+import chalk from 'chalk';
 import { describe, it, expect } from 'vitest';
-import { theme } from '../../theme.js';
+import { theme, tintHex } from '../../theme.js';
 import { ToolExecutionComponentEnhanced, parseErrorFromContent } from '../tool-execution-enhanced.js';
 
 const ui = { requestRender() {} } as any;
@@ -279,6 +280,27 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     );
     complete.updateResult({ content: [{ type: 'text', text: 'done' }], isError: false });
     expect(stripAnsi(complete.render(100).join('\n'))).toContain('▐view▌src/example.ts');
+  });
+
+  it('uses the active mode color for quiet compact tool badges', () => {
+    const modeColor = '#3366cc';
+    const component = new ToolExecutionComponentEnhanced(
+      'view',
+      { path: 'src/example.ts' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true, compactToolModeColor: modeColor },
+      ui,
+    );
+
+    component.updateResult({
+      content: [{ type: 'text', text: '     1→const value = true;' }],
+      isError: false,
+    });
+
+    const output = component.render(100).join('\n');
+    expect(output).toContain(chalk.hex(modeColor)('▐'));
+    expect(output).toContain(chalk.bgHex(modeColor).hex('#000000').bold('view'));
+    expect(output).toContain(chalk.bgHex('#0f0f0f').hex(modeColor)('src/example.ts'));
+    expect(output).toContain(chalk.hex(tintHex(modeColor, 0.35))('│'));
   });
 
   it('renders quiet non-shell tool validation errors with actionable details', () => {

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -727,6 +727,21 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(output).not.toContain(chalk.blue('then'));
   });
 
+  it('preserves standalone ampersands in quiet shell command footers', () => {
+    const command = 'sleep 1 & wait && echo ok 2>&1';
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    const output = component.render(100).join('\n');
+    expect(stripAnsi(output)).toContain(command);
+    expect(output).toContain(theme.fg('muted', '&'));
+    expect(output).toContain(theme.fg('muted', '>'));
+  });
+
   it('wraps long quiet shell commands in the footer instead of truncating them', () => {
     const command =
       'pnpm --filter mastracode exec vitest run src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot';

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -688,8 +688,24 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     const output = component.render(100).join('\n');
     expect(stripAnsi(output)).toContain(`$ ${command}`);
     expect(output).toContain(chalk.blue('if'));
-    expect(output).toContain(chalk.cyan('echo'));
+    expect(output).toContain(chalk.hex('#93c5fd')('echo'));
     expect(output).toContain(chalk.hex('#f6c177')('-f'));
+  });
+
+  it('keeps shell keywords inside quoted strings highlighted as strings', () => {
+    const command = 'echo "if then fi" && printf \'done\'';
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    const output = component.render(100).join('\n');
+    expect(stripAnsi(output)).toContain(command);
+    expect(output).toContain(chalk.white('"if then fi"'));
+    expect(output).not.toContain(chalk.blue('then'));
+    expect(output).toContain(chalk.white("'done'"));
   });
 
   it('wraps long quiet shell commands in the footer instead of truncating them', () => {

--- a/mastracode/src/tui/components/chat-spacing.ts
+++ b/mastracode/src/tui/components/chat-spacing.ts
@@ -28,8 +28,8 @@ export function getChatSpacingKind(component: Component | undefined): ChatSpacin
 export function getSpacingBetweenComponents(
   prev: Component | undefined,
   next: Component | undefined,
-  prevPrev?: Component | undefined,
-  nextNext?: Component | undefined,
+  _prevPrev?: Component | undefined,
+  _nextNext?: Component | undefined,
 ): number {
   const prevKind = getChatSpacingKind(prev);
   const nextKind = getChatSpacingKind(next);
@@ -38,12 +38,7 @@ export function getSpacingBetweenComponents(
     const prevKey = getCompactToolGroupKey(prev);
     const nextKey = getCompactToolGroupKey(next);
     if (prevKey && nextKey && prevKey === nextKey) return 0;
-
-    if (hasQuietStreamingPreview(prev) || hasQuietStreamingPreview(next)) return 1;
-
-    const prevIsRunEnd = !!prevKey && prevKey === getCompactToolGroupKey(prevPrev);
-    const nextIsRunStart = !!nextKey && nextKey === getCompactToolGroupKey(nextNext);
-    return prevIsRunEnd || nextIsRunStart ? 1 : 0;
+    return 1;
   }
   if (hasQuietStreamingPreview(prev) || hasQuietStreamingPreview(next)) return 1;
   return getSpacingBetween(prevKind, nextKind);
@@ -60,8 +55,8 @@ function hasQuietStreamingPreview(component: Component | undefined): boolean {
 export function getSpacingBetween(prev: ChatSpacingKind | undefined, next: ChatSpacingKind | undefined): number {
   if (!prev || !next) return 0;
   if (prev === 'quiet-compact-tool' && next === 'quiet-compact-tool') return 0;
-  if (isToolSpacingKind(prev) && next === 'assistant-message') return 3;
-  if (prev === 'assistant-message' && isToolSpacingKind(next)) return 3;
+  if (isToolSpacingKind(prev) && next === 'assistant-message') return 1;
+  if (prev === 'assistant-message' && isToolSpacingKind(next)) return 1;
   return 1;
 }
 

--- a/mastracode/src/tui/components/chat-spacing.ts
+++ b/mastracode/src/tui/components/chat-spacing.ts
@@ -60,5 +60,11 @@ function hasQuietStreamingPreview(component: Component | undefined): boolean {
 export function getSpacingBetween(prev: ChatSpacingKind | undefined, next: ChatSpacingKind | undefined): number {
   if (!prev || !next) return 0;
   if (prev === 'quiet-compact-tool' && next === 'quiet-compact-tool') return 0;
+  if (isToolSpacingKind(prev) && next === 'assistant-message') return 3;
+  if (prev === 'assistant-message' && isToolSpacingKind(next)) return 3;
   return 1;
+}
+
+function isToolSpacingKind(kind: ChatSpacingKind | undefined): boolean {
+  return kind === 'quiet-compact-tool' || kind === 'quiet-shell-tool' || kind === 'normal-tool';
 }

--- a/mastracode/src/tui/components/idle-counter.ts
+++ b/mastracode/src/tui/components/idle-counter.ts
@@ -42,11 +42,8 @@ export class IdleCounterComponent extends Container {
   }
 
   render(width: number): string[] {
-    if (this.idleStartedAt === undefined || this.textChild.render(width).join('').length === 0) {
-      return [];
-    }
-
-    return super.render(width);
+    const rendered = super.render(width);
+    return rendered.length > 0 ? rendered : [''];
   }
 }
 

--- a/mastracode/src/tui/components/subagent-execution.ts
+++ b/mastracode/src/tui/components/subagent-execution.ts
@@ -12,6 +12,7 @@ import { Container, Spacer, Text } from '@mariozechner/pi-tui';
 import type { TUI } from '@mariozechner/pi-tui';
 import { safeStringify } from '@mastra/core/utils';
 import { BOX_INDENT, getTermWidth, theme } from '../theme.js';
+import type { ChatSpacingKind } from './chat-spacing.js';
 import type { IToolExecutionComponent } from './tool-execution-interface.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -38,6 +39,8 @@ export interface SubagentExecutionOptions {
   collapseOnComplete?: boolean;
   /** True when this subagent is running on a forked copy of the parent thread. */
   forked?: boolean;
+  /** When true, show full completed content including the final result. Default false. */
+  expandOnComplete?: boolean;
 }
 
 export class SubagentExecutionComponent extends Container implements IToolExecutionComponent {
@@ -55,6 +58,7 @@ export class SubagentExecutionComponent extends Container implements IToolExecut
   private finalResult?: string;
   private expanded = false;
   private collapseOnComplete: boolean;
+  private expandOnComplete: boolean;
   private forked: boolean;
 
   constructor(agentType: string, task: string, ui: TUI, modelId?: string, options?: SubagentExecutionOptions) {
@@ -64,6 +68,7 @@ export class SubagentExecutionComponent extends Container implements IToolExecut
     this.modelId = modelId;
     this.ui = ui;
     this.collapseOnComplete = options?.collapseOnComplete ?? false;
+    this.expandOnComplete = options?.expandOnComplete ?? false;
     this.forked = options?.forked ?? false;
 
     this.rebuild();
@@ -93,7 +98,9 @@ export class SubagentExecutionComponent extends Container implements IToolExecut
     this.isError = isError;
     this.durationMs = durationMs;
     this.finalResult = result;
-    if (this.collapseOnComplete) {
+    if (this.expandOnComplete) {
+      this.expanded = true;
+    } else if (this.collapseOnComplete) {
       this.expanded = false;
     }
     this.rebuild();
@@ -112,6 +119,10 @@ export class SubagentExecutionComponent extends Container implements IToolExecut
   // IToolExecutionComponent interface methods
   updateArgs(_args: unknown): void {}
   updateResult(_result: unknown, _isPartial: boolean): void {}
+
+  getChatSpacingKind(): ChatSpacingKind {
+    return 'normal-tool';
+  }
 
   // ── Rendering ──────────────────────────────────────────────────────────
 
@@ -134,7 +145,8 @@ export class SubagentExecutionComponent extends Container implements IToolExecut
     const durationStr = this.done ? theme.fg('muted', ` ${formatDuration(this.durationMs)}`) : '';
     const footerText = `${theme.bold(theme.fg('toolTitle', 'subagent'))} ${typeLabel}${modelLabel}${durationStr}${statusIcon}`;
 
-    // When collapse-on-complete is enabled, render only the single-line footer summary
+    // When collapse-on-complete is enabled, render only the single-line footer summary.
+    // Quiet mode does not enable this for subagents; it is kept for explicit callers/tests.
     if (this.collapseOnComplete && this.done && !this.expanded) {
       this.addChild(new Text(`${border('╰──')} ${footerText}`, BOX_INDENT, 0));
       this.invalidate();

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -509,8 +509,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private tokenizeQuietShellCommand(command: string): Array<{ text: string; color: (value: string) => string }> {
-    const tokens =
-      command.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\s+|&&|\|\||[|;&()<>]|[^\s|;&()<>]+/g) ?? [''];
+    const tokens = command.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\s+|&&|\|\||[|;&()<>]|[^\s|;&()<>]+/g) ?? [''];
 
     return tokens.map(token => {
       if (/^\s+$/.test(token)) return { text: token, color: (value: string) => value };

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -122,6 +122,14 @@ function isWebSearchTool(name: string): boolean {
   return name === 'web_search' || /^web_search_\d+$/.test(name);
 }
 
+function isBrowserTool(name: string): boolean {
+  return name.startsWith('browser_');
+}
+
+function isSkillTool(name: string): boolean {
+  return name === 'skill' || name === 'skill_search' || name === 'skill_read';
+}
+
 /**
  * Extract the actual content from tool result text.
  */
@@ -340,10 +348,10 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private limitQuietShellLines(lines: string[]): string[] {
-    if (this.quietDisplayMode !== 'quiet' || lines.length <= 9) {
+    if (this.quietDisplayMode !== 'quiet' || lines.length <= 15) {
       return lines;
     }
-    return lines.slice(-9);
+    return lines.slice(-15);
   }
 
   /**
@@ -357,11 +365,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     this.updateBgColor();
     this.contentBox.clear();
 
-    if (
-      this.quietDisplayMode === 'quiet' &&
-      this.toolName !== MC_TOOLS.EXECUTE_COMMAND &&
-      !(this.result && !this.isPartial && this.isErrorResult())
-    ) {
+    if (this.quietDisplayMode === 'quiet' && this.toolName !== MC_TOOLS.EXECUTE_COMMAND) {
       this.renderCompactTool();
       return;
     }
@@ -516,11 +520,15 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const toolLabel = this.getCompactToolLabel();
     const toolLabelColor = this.getCompactToolLabelColor();
     const summary = this.compactToolContinuation ? this.getCompactContinuationSummary() : this.getCompactToolSummary();
+    const detailLines = this.getQuietPreviewLines(getTermWidth() - BOX_INDENT * 2 - 2);
     const firstLine = this.compactToolContinuation
-      ? `${this.getCompactContinuationIndent()}${this.formatCompactContinuationLine(summary)}${status}`
+      ? summary
+        ? `${this.getCompactContinuationIndent()}${this.formatCompactContinuationLine(summary)}${status}`
+        : this.compactToolPreviousSummary
+          ? `${this.getCompactContinuationIndent()}${this.formatEmptyCompactContinuationLine()}${status}`
+          : `${this.getCompactContinuationIndent()}${this.formatCompactToolHeader(toolLabel, toolLabelColor, '')}${status}`
       : `${this.formatCompactToolHeader(toolLabel, toolLabelColor, summary)}${status}`;
 
-    const detailLines = this.getQuietPreviewLines(getTermWidth() - BOX_INDENT * 2 - 2);
     if (detailLines.length === 0) return [firstLine];
     const previewLines = this.shouldCloseQuietPreview() ? [...detailLines, this.getQuietPreviewCapLine()] : detailLines;
     if (this.compactToolHasFollowingContinuation) previewLines.push(this.getQuietPreviewSpacerLine());
@@ -588,7 +596,12 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private getQuietActivePreview(): string {
+    if (this.isErrorResult()) return this.formatQuietErrorPreview();
     if (isWebSearchTool(this.toolName)) return this.formatQuietWebSearchPreview();
+    if (isBrowserTool(this.toolName)) return this.formatQuietBrowserPreview();
+    if (isSkillTool(this.toolName)) return this.formatQuietSkillPreview();
+    if (this.toolName === MC_TOOLS.GET_PROCESS_OUTPUT) return this.formatQuietProcessOutputPreview();
+    if (this.toolName === MC_TOOLS.FILE_STAT) return this.formatQuietFileStatPreview();
 
     switch (this.toolName) {
       case MC_TOOLS.VIEW:
@@ -605,12 +618,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         return this.formatSearchDetail();
       case MC_TOOLS.LSP_INSPECT:
         return this.getFirstLineArg('match', 80);
-      default: {
-        const preview =
-          this.formatArgsPreview(1, 120).join(' ').replace(/\s+/g, ' ').trim() ||
-          this.stripAnsi(this.formatArgsSummary()).trim();
-        return preview === this.getCompactToolSummary() ? '' : preview;
-      }
+      default:
+        return this.formatQuietGenericResultPreview();
     }
   }
 
@@ -619,6 +628,17 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       this.getMultilinePreview('new_str', Number.POSITIVE_INFINITY, false) ||
       this.getMultilinePreview('new_string', Number.POSITIVE_INFINITY, false)
     );
+  }
+
+  private formatQuietErrorPreview(): string {
+    const outputLines = this.stripAnsi(this.getFormattedOutput())
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean);
+    if (outputLines.some(line => line.startsWith('Validation error:') || line.startsWith('Parameter:'))) {
+      return outputLines.join(' — ');
+    }
+    return outputLines.slice(0, 2).join('\n');
   }
 
   private formatQuietViewPreview(): string {
@@ -646,6 +666,111 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     if (!this.result) return '';
 
     return this.stripAnsi(this.formatWebSearchResults())
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .slice(0, 2)
+      .join('\n');
+  }
+
+  private formatQuietBrowserPreview(): string {
+    if (!this.result || !['browser_snapshot', 'browser_evaluate'].includes(this.toolName)) return '';
+    const output = this.unwrapBrowserToolOutput(this.getFormattedOutput());
+    return this.stripAnsi(output)
+      .split('\n')
+      .map(line => line.trimEnd())
+      .filter(Boolean)
+      .slice(0, 2)
+      .join('\n');
+  }
+
+  private unwrapBrowserToolOutput(output: string): string {
+    try {
+      const parsed = JSON.parse(output) as unknown;
+      if (typeof parsed !== 'object' || parsed === null) return output;
+      const record = parsed as Record<string, unknown>;
+      if (this.toolName === 'browser_evaluate' && record.result !== undefined) {
+        return this.formatBrowserEvaluateResult(record.result);
+      }
+      if (this.toolName === 'browser_snapshot' && typeof record.snapshot === 'string') return record.snapshot;
+      if (typeof record.error === 'string') return record.error;
+      return '';
+    } catch {
+      return output;
+    }
+  }
+
+  private formatBrowserEvaluateResult(result: unknown): string {
+    if (typeof result === 'string') return result;
+    if (typeof result !== 'object' || result === null) return String(result);
+    if (Array.isArray(result)) return `[${result.length} items]`;
+
+    return Object.entries(result as Record<string, unknown>)
+      .slice(0, 3)
+      .map(([key, value]) => `${key}: ${this.formatCompactBrowserValue(value)}`)
+      .join('\n');
+  }
+
+  private formatCompactBrowserValue(value: unknown): string {
+    if (typeof value === 'string') return value === '' ? '""' : value;
+    if (value === undefined) return 'undefined';
+    if (value === null) return 'null';
+    if (Array.isArray(value)) return `[${value.length} items]`;
+    if (typeof value === 'object') return '{…}';
+    return String(value);
+  }
+
+  private formatQuietProcessOutputPreview(): string {
+    if (!this.result) return '';
+    return this.stripAnsi(this.getFormattedOutput())
+      .split('\n')
+      .map(line => line.trimEnd())
+      .filter(Boolean)
+      .slice(0, 3)
+      .join('\n');
+  }
+
+  private formatQuietFileStatPreview(): string {
+    if (!this.result) return '';
+    const output = this.stripAnsi(this.getFormattedOutput()).trim();
+    return output.replace(/^\S+\s+/, '').replace(/\s+/g, ' ');
+  }
+
+  private formatQuietGenericResultPreview(): string {
+    if (!this.result || this.isPartial) return '';
+    const output = this.stripAnsi(this.getFormattedOutput()).trim();
+    if (!output) return '';
+
+    const compactJson = this.formatCompactJsonResult(output);
+    const preview = compactJson || output;
+    const argsSummary = this.stripAnsi(this.formatArgsSummary()).trim();
+    if (argsSummary && preview === argsSummary) return '';
+
+    return preview
+      .split('\n')
+      .map(line => line.trimEnd())
+      .filter(Boolean)
+      .slice(0, 2)
+      .join('\n');
+  }
+
+  private formatCompactJsonResult(output: string): string {
+    try {
+      const parsed = JSON.parse(output) as unknown;
+      if (typeof parsed !== 'object' || parsed === null) return String(parsed);
+      if (Array.isArray(parsed)) return `[${parsed.length} items]`;
+      return Object.entries(parsed as Record<string, unknown>)
+        .slice(0, 3)
+        .map(([key, value]) => `${key}: ${this.formatCompactBrowserValue(value)}`)
+        .join('\n');
+    } catch {
+      return '';
+    }
+  }
+
+  private formatQuietSkillPreview(): string {
+    if (!this.result || this.toolName !== 'skill_search') return '';
+    return this.stripAnsi(this.getFormattedOutput())
       .split('\n')
       .map(line => line.trim())
       .filter(Boolean)
@@ -685,6 +810,13 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     return '  ';
   }
 
+  private formatEmptyCompactContinuationLine(): string {
+    const railColor = this.getQuietToolRailColor();
+    const isStreamingContinuation = !this.isComplete() && this.quietPreviewLineLimit > 0;
+    if (isStreamingContinuation) return `${chalk.hex(this.getCompactToolAccentColor(this.getCompactToolLabelColor()))('●')}${chalk.hex(railColor)('─')}`;
+    return chalk.hex(railColor)(this.compactToolHasFollowingContinuation ? '├─' : '╰─');
+  }
+
   private formatCompactContinuationLine(summary: string): string {
     const lineMatch = summary.match(/^─+/);
     const linePrefix = lineMatch?.[0] ?? '';
@@ -696,8 +828,9 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const argsBg = this.getCompactToolArgsBg(toolLabelColor);
     const argsColor = this.getCompactToolArgsColor(toolLabelColor);
     const railColor = this.getQuietToolRailColor();
-    const branch = hasFollowing
-      ? `${hasPreview ? chalk.hex(color)('●') : chalk.hex(railColor)('├')}${chalk.hex(railColor)(`─${separator}${linePrefix}`)}`
+    const isStreamingContinuation = this.compactToolContinuation && !this.isComplete() && this.quietPreviewLineLimit > 0;
+    const branch = hasFollowing || isStreamingContinuation
+      ? `${hasPreview || isStreamingContinuation ? chalk.hex(color)('●') : chalk.hex(railColor)('├')}${chalk.hex(railColor)(`─${separator}${linePrefix}`)}`
       : chalk.hex(railColor)(`╰─${separator}${linePrefix}`);
     const continuationSummary = ` ${summary.slice(linePrefix.length)}`;
     const trail = continuationSummary ? chalk.hex(argsBg)('▌') : '';
@@ -716,12 +849,27 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   private getCompactContinuationSummary(): string {
     const summary = this.getCompactToolSummary();
     const previousSummary = this.compactToolPreviousSummary;
+    if (!summary) return '';
     if (!previousSummary) return this.isComplete() ? summary : '';
+
+    if (previousSummary.startsWith(`${summary}:`)) {
+      const dirnameStart = this.getImmediateDirnameStart(summary);
+      if (dirnameStart !== undefined) {
+        return `${this.formatSharedPrefixPlaceholder(summary, dirnameStart)}${summary.slice(dirnameStart)}`;
+      }
+    }
 
     const sharedPrefixLength = this.getSharedPrefixLength(previousSummary, summary);
     if (sharedPrefixLength === 0) return summary;
 
-    return `${this.formatSharedPrefixPlaceholder(summary, sharedPrefixLength)}${summary.slice(sharedPrefixLength)}`;
+    const visibleRemainder = summary.slice(sharedPrefixLength);
+    if (!visibleRemainder && this.hasCompletePathSegment(summary)) {
+      const dirnameStart = this.getImmediateDirnameStart(summary);
+      if (dirnameStart !== undefined) {
+        return `${this.formatSharedPrefixPlaceholder(summary, dirnameStart)}${summary.slice(dirnameStart)}`;
+      }
+    }
+    return `${this.formatSharedPrefixPlaceholder(summary, sharedPrefixLength)}${visibleRemainder}`;
   }
 
   private getImmediateDirnameStart(summary: string): number | undefined {
@@ -731,6 +879,13 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     if (filenameSlashIndex < 0) return undefined;
     const dirnameSlashIndex = path.lastIndexOf('/', filenameSlashIndex - 1);
     return dirnameSlashIndex >= 0 ? dirnameSlashIndex : filenameSlashIndex;
+  }
+
+  private hasCompletePathSegment(summary: string): boolean {
+    const pathEnd = summary.indexOf(':');
+    const path = pathEnd >= 0 ? summary.slice(0, pathEnd) : summary;
+    const lastSegment = path.slice(path.lastIndexOf('/') + 1);
+    return lastSegment.length > 0 && (pathEnd >= 0 || lastSegment.includes('.'));
   }
 
   private formatSharedPrefixPlaceholder(summary: string, sharedPrefixLength: number): string {
@@ -774,6 +929,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
 
   private getCompactToolSummary(): string {
     if (isWebSearchTool(this.toolName)) return this.formatWebSearchSummary();
+    if (isBrowserTool(this.toolName)) return this.formatBrowserSummary();
+    if (isSkillTool(this.toolName)) return this.formatSkillSummary();
 
     switch (this.toolName) {
       case MC_TOOLS.VIEW:
@@ -788,6 +945,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       case MC_TOOLS.FILE_STAT:
       case MC_TOOLS.MKDIR:
         return this.getFirstStringArg('path');
+      case MC_TOOLS.AST_SMART_EDIT:
+        return this.getFirstStringArg('path') || this.getFirstStringArg('targetName');
       case MC_TOOLS.SEARCH_CONTENT:
         return this.formatSearchSummary();
       case MC_TOOLS.LSP_INSPECT:
@@ -797,8 +956,10 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         return this.getFirstStringArg('pid');
       case 'skill':
         return this.getFirstStringArg('name');
+      case 'subagent':
+        return this.formatSubagentSummary();
       default:
-        return this.formatArgsSummary().trim();
+        return this.formatPlainArgsSummary().trim();
     }
   }
 
@@ -816,6 +977,18 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         return 'list';
       case MC_TOOLS.SEARCH_CONTENT:
         return 'grep';
+      case MC_TOOLS.DELETE_FILE:
+        return 'delete';
+      case MC_TOOLS.FILE_STAT:
+        return 'stat';
+      case MC_TOOLS.MKDIR:
+        return 'mkdir';
+      case MC_TOOLS.GET_PROCESS_OUTPUT:
+        return 'process';
+      case MC_TOOLS.KILL_PROCESS:
+        return 'kill';
+      case MC_TOOLS.AST_SMART_EDIT:
+        return 'ast_edit';
       default:
         return this.toolName;
     }
@@ -864,6 +1037,69 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const action = argsObj?.action as Record<string, unknown> | undefined;
     const query = argsObj?.query ? String(argsObj.query) : action?.query ? String(action.query) : '';
     return query ? `"${query}"` : '';
+  }
+
+  private formatBrowserSummary(): string {
+    const argsObj = this.args as Record<string, unknown> | undefined;
+    const first = (...keys: string[]) => keys.map(key => argsObj?.[key]).find(value => value !== undefined && value !== null);
+    const quote = (value: unknown) => (typeof value === 'string' ? `"${value}"` : String(value));
+
+    switch (this.toolName) {
+      case 'browser_goto':
+        return this.getFirstStringArg('url');
+      case 'browser_snapshot': {
+        const interactiveOnly = first('interactiveOnly');
+        const maxDepth = first('maxDepth');
+        return [interactiveOnly !== undefined ? `interactive=${interactiveOnly}` : '', maxDepth !== undefined ? `depth=${maxDepth}` : '']
+          .filter(Boolean)
+          .join(' ');
+      }
+      case 'browser_click':
+        return [this.getFirstStringArg('ref'), first('button') ? `button=${first('button')}` : '', first('clickCount') ? `x${first('clickCount')}` : '']
+          .filter(Boolean)
+          .join(' ');
+      case 'browser_type':
+        return [this.getFirstStringArg('ref'), this.getFirstStringArg('text') ? quote(this.getFirstStringArg('text')) : '']
+          .filter(Boolean)
+          .join(' ');
+      case 'browser_press':
+        return this.getFirstStringArg('key');
+      case 'browser_select':
+        return [this.getFirstStringArg('ref'), first('value', 'label', 'index') !== undefined ? quote(first('value', 'label', 'index')) : '']
+          .filter(Boolean)
+          .join(' ');
+      case 'browser_scroll':
+        return [this.getFirstStringArg('direction'), first('amount') !== undefined ? `${first('amount')}px` : '', this.getFirstStringArg('ref')]
+          .filter(Boolean)
+          .join(' ');
+      case 'browser_wait':
+        return [this.getFirstStringArg('ref'), this.getFirstStringArg('state')].filter(Boolean).join(' ');
+      case 'browser_tabs':
+        return [this.getFirstStringArg('action'), this.getFirstStringArg('url')].filter(Boolean).join(' ');
+      case 'browser_evaluate':
+        return this.getFirstLineArg('script', 80);
+      default:
+        return this.formatPlainArgsSummary().trim();
+    }
+  }
+
+  private formatSubagentSummary(): string {
+    const agentType = this.getFirstStringArg('agentType');
+    const task = this.getFirstLineArg('task', 80);
+    return [agentType, task].filter(Boolean).join(' ');
+  }
+
+  private formatSkillSummary(): string {
+    switch (this.toolName) {
+      case 'skill':
+        return this.getFirstStringArg('name');
+      case 'skill_search':
+        return this.getFirstStringArg('query');
+      case 'skill_read':
+        return [this.getFirstStringArg('skillName'), this.getFirstStringArg('path')].filter(Boolean).join(' ');
+      default:
+        return '';
+    }
   }
 
   private formatSearchDetail(): string {
@@ -1052,14 +1288,14 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         return lines.length ? lines : [''];
       };
 
-      this.contentBox.addChild(new Text(`${border('╭')}${border(horizontal)}${border('╮')}`, 0, 0));
-
       const displayOutput = outputLines.map(line => renderLine(line)).join('\n');
-      if (displayOutput.trim()) {
-        this.contentBox.addChild(new Text(displayOutput, 0, 0));
-      }
+      const hasOutput = displayOutput.trim() !== '';
 
-      this.contentBox.addChild(new Text(`${border('├')}${border(horizontal)}${border('┤')}`, 0, 0));
+      this.contentBox.addChild(new Text(`${border('╭')}${border(horizontal)}${border('╮')}`, 0, 0));
+      if (hasOutput) {
+        this.contentBox.addChild(new Text(displayOutput, 0, 0));
+        this.contentBox.addChild(new Text(`${border('├')}${border(horizontal)}${border('┤')}`, 0, 0));
+      }
       const footerWrapWidth = Math.max(1, contentWidth - 2);
       const footerLines = wrapFooter(command, footerWrapWidth);
       const footerSuffixWidth = this.stripAnsi(footerSuffix).length;
@@ -2133,6 +2369,10 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       lines.push(line);
     }
     return lines;
+  }
+
+  private formatPlainArgsSummary(): string {
+    return this.stripAnsi(this.formatArgsSummary());
   }
 
   /**

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -74,7 +74,22 @@ const QUIET_CODE_HIGHLIGHT_THEME: HighlightTheme = {
   name: chalk.hex('#c4b5fd'),
 };
 
-const SHELL_CONTROL_WORDS = new Set(['if', 'then', 'else', 'elif', 'fi', 'for', 'while', 'until', 'do', 'done', 'case', 'esac', 'in', 'function']);
+const SHELL_CONTROL_WORDS = new Set([
+  'if',
+  'then',
+  'else',
+  'elif',
+  'fi',
+  'for',
+  'while',
+  'until',
+  'do',
+  'done',
+  'case',
+  'esac',
+  'in',
+  'function',
+]);
 
 export interface ToolExecutionOptions {
   showImages?: boolean;
@@ -882,7 +897,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   private formatEmptyCompactContinuationLine(): string {
     const railColor = this.getQuietToolRailColor();
     const isStreamingContinuation = !this.isComplete() && this.quietPreviewLineLimit > 0;
-    if (isStreamingContinuation) return `${chalk.hex(this.getCompactToolAccentColor(this.getCompactToolLabelColor()))('●')}${chalk.hex(railColor)('─')}`;
+    if (isStreamingContinuation)
+      return `${chalk.hex(this.getCompactToolAccentColor(this.getCompactToolLabelColor()))('●')}${chalk.hex(railColor)('─')}`;
     return chalk.hex(railColor)(this.compactToolHasFollowingContinuation ? '├─' : '╰─');
   }
 
@@ -897,10 +913,12 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const argsBg = this.getCompactToolArgsBg(toolLabelColor);
     const argsColor = this.getCompactToolArgsColor(toolLabelColor);
     const railColor = this.getQuietToolRailColor();
-    const isStreamingContinuation = this.compactToolContinuation && !this.isComplete() && this.quietPreviewLineLimit > 0;
-    const branch = hasFollowing || isStreamingContinuation
-      ? `${hasPreview || isStreamingContinuation ? chalk.hex(color)('●') : chalk.hex(railColor)('├')}${chalk.hex(railColor)(`─${separator}${linePrefix}`)}`
-      : chalk.hex(railColor)(`╰─${separator}${linePrefix}`);
+    const isStreamingContinuation =
+      this.compactToolContinuation && !this.isComplete() && this.quietPreviewLineLimit > 0;
+    const branch =
+      hasFollowing || isStreamingContinuation
+        ? `${hasPreview || isStreamingContinuation ? chalk.hex(color)('●') : chalk.hex(railColor)('├')}${chalk.hex(railColor)(`─${separator}${linePrefix}`)}`
+        : chalk.hex(railColor)(`╰─${separator}${linePrefix}`);
     const continuationSummary = ` ${summary.slice(linePrefix.length)}`;
     const trail = continuationSummary ? chalk.hex(argsBg)('▌') : '';
     return `${branch}${this.formatCompactSummaryBadge(continuationSummary, argsBg, argsColor)}${trail}`;
@@ -1110,7 +1128,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
 
   private formatBrowserSummary(): string {
     const argsObj = this.args as Record<string, unknown> | undefined;
-    const first = (...keys: string[]) => keys.map(key => argsObj?.[key]).find(value => value !== undefined && value !== null);
+    const first = (...keys: string[]) =>
+      keys.map(key => argsObj?.[key]).find(value => value !== undefined && value !== null);
     const quote = (value: unknown) => (typeof value === 'string' ? `"${value}"` : String(value));
 
     switch (this.toolName) {
@@ -1119,26 +1138,43 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       case 'browser_snapshot': {
         const interactiveOnly = first('interactiveOnly');
         const maxDepth = first('maxDepth');
-        return [interactiveOnly !== undefined ? `interactive=${interactiveOnly}` : '', maxDepth !== undefined ? `depth=${maxDepth}` : '']
+        return [
+          interactiveOnly !== undefined ? `interactive=${interactiveOnly}` : '',
+          maxDepth !== undefined ? `depth=${maxDepth}` : '',
+        ]
           .filter(Boolean)
           .join(' ');
       }
       case 'browser_click':
-        return [this.getFirstStringArg('ref'), first('button') ? `button=${first('button')}` : '', first('clickCount') ? `x${first('clickCount')}` : '']
+        return [
+          this.getFirstStringArg('ref'),
+          first('button') ? `button=${first('button')}` : '',
+          first('clickCount') ? `x${first('clickCount')}` : '',
+        ]
           .filter(Boolean)
           .join(' ');
       case 'browser_type':
-        return [this.getFirstStringArg('ref'), this.getFirstStringArg('text') ? quote(this.getFirstStringArg('text')) : '']
+        return [
+          this.getFirstStringArg('ref'),
+          this.getFirstStringArg('text') ? quote(this.getFirstStringArg('text')) : '',
+        ]
           .filter(Boolean)
           .join(' ');
       case 'browser_press':
         return this.getFirstStringArg('key');
       case 'browser_select':
-        return [this.getFirstStringArg('ref'), first('value', 'label', 'index') !== undefined ? quote(first('value', 'label', 'index')) : '']
+        return [
+          this.getFirstStringArg('ref'),
+          first('value', 'label', 'index') !== undefined ? quote(first('value', 'label', 'index')) : '',
+        ]
           .filter(Boolean)
           .join(' ');
       case 'browser_scroll':
-        return [this.getFirstStringArg('direction'), first('amount') !== undefined ? `${first('amount')}px` : '', this.getFirstStringArg('ref')]
+        return [
+          this.getFirstStringArg('direction'),
+          first('amount') !== undefined ? `${first('amount')}px` : '',
+          this.getFirstStringArg('ref'),
+        ]
           .filter(Boolean)
           .join(' ');
       case 'browser_wait':
@@ -1346,11 +1382,23 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         const isLast = index === footerLines.length - 1;
         const suffixFits = isLast && this.stripAnsi(footerLine).length + footerSuffixWidth <= footerWrapWidth;
         const suffix = suffixFits ? footerSuffix : '';
-        this.contentBox.addChild(new Text(renderLine(`${prefix}${footerLine}${suffix}`, value => value), 0, 0));
+        this.contentBox.addChild(
+          new Text(
+            renderLine(`${prefix}${footerLine}${suffix}`, value => value),
+            0,
+            0,
+          ),
+        );
       });
       const lastFooterLine = footerLines[footerLines.length - 1] ?? '';
       if (this.stripAnsi(lastFooterLine).length + footerSuffixWidth > footerWrapWidth) {
-        this.contentBox.addChild(new Text(renderLine(`  ${footerSuffix}`, value => value), 0, 0));
+        this.contentBox.addChild(
+          new Text(
+            renderLine(`  ${footerSuffix}`, value => value),
+            0,
+            0,
+          ),
+        );
       }
       this.contentBox.addChild(new Text(`${border('╰')}${border(horizontal)}${border('╯')}`, 0, 0));
     };

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -509,14 +509,15 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private tokenizeQuietShellCommand(command: string): Array<{ text: string; color: (value: string) => string }> {
-    const tokens = command.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\s+|&&|\|\||[|;()<>]|[^\s|;&()<>]+/g) ?? [''];
+    const tokens =
+      command.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\s+|&&|\|\||[|;&()<>]|[^\s|;&()<>]+/g) ?? [''];
 
     return tokens.map(token => {
       if (/^\s+$/.test(token)) return { text: token, color: (value: string) => value };
       if ((token.startsWith('"') && token.endsWith('"')) || (token.startsWith("'") && token.endsWith("'"))) {
         return { text: token, color: chalk.white };
       }
-      if (token === '&&' || token === '||' || token === '|' || token === ';') {
+      if (token === '&&' || token === '||' || token === '|' || token === ';' || token === '&') {
         return { text: token, color: (value: string) => theme.fg('muted', value) };
       }
       if (token === '(' || token === ')' || token === '<' || token === '>') {

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -45,6 +45,26 @@ const CODE_HIGHLIGHT_THEME: HighlightTheme = {
   name: chalk.hex('#c084fc'),
 };
 
+const QUIET_CODE_HIGHLIGHT_THEME: HighlightTheme = {
+  default: chalk.hex('#b4b4bd'),
+  keyword: chalk.hex('#c4b5fd'),
+  built_in: chalk.hex('#93c5fd'),
+  type: chalk.hex('#93c5fd'),
+  literal: chalk.hex('#fca5a5'),
+  number: chalk.hex('#fbbf24'),
+  string: chalk.hex('#9ecfa9'),
+  regexp: chalk.hex('#fca5a5'),
+  title: chalk.hex('#93c5fd'),
+  function: chalk.hex('#7dd3fc'),
+  params: chalk.hex('#b4b4bd'),
+  comment: chalk.hex('#71717a'),
+  meta: chalk.hex('#71717a'),
+  attr: chalk.hex('#fbbf24'),
+  variable: chalk.hex('#d4d4d8'),
+  tag: chalk.hex('#c4b5fd'),
+  name: chalk.hex('#c4b5fd'),
+};
+
 export interface ToolExecutionOptions {
   showImages?: boolean;
   autoCollapse?: boolean;
@@ -301,10 +321,10 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private limitQuietShellLines(lines: string[]): string[] {
-    if (this.quietDisplayMode !== 'quiet' || lines.length <= 8) {
+    if (this.quietDisplayMode !== 'quiet' || lines.length <= 9) {
       return lines;
     }
-    return lines.slice(-8);
+    return lines.slice(-9);
   }
 
   /**
@@ -383,6 +403,10 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const preview = this.getQuietActivePreview();
     if (!preview) return [];
 
+    if (this.isQuietCodePreviewTool()) {
+      return this.getQuietCodePreviewLines(preview, maxLineWidth);
+    }
+
     const firstLineWidth = Math.max(10, maxLineWidth - 4);
     const continuationWidth = Math.max(10, maxLineWidth - 4);
     const wrapped = this.wrapPreviewLines(preview, firstLineWidth, continuationWidth).slice(
@@ -390,13 +414,29 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     );
 
     return wrapped.map(line => {
-      const linePrefix = `  ${theme.bold(theme.fg('toolBorderSuccess', '│'))} `;
+      const linePrefix = `  ${theme.fg('toolBorderSuccess', '│')} `;
       return truncateAnsi(`${linePrefix}${this.formatQuietActivePreview(line)}`, maxLineWidth);
     });
   }
 
+  private getQuietCodePreviewLines(preview: string, maxLineWidth: number): string[] {
+    const linePrefix = `  ${theme.fg('toolBorderSuccess', '│')} `;
+    return this.highlightQuietCodePreview(preview)
+      .split('\n')
+      .slice(-this.quietPreviewLineLimit)
+      .map(line => truncateAnsi(`${linePrefix}${line}`, maxLineWidth));
+  }
+
+  private isQuietCodePreviewTool(): boolean {
+    return (
+      this.toolName === MC_TOOLS.VIEW ||
+      this.toolName === MC_TOOLS.WRITE_FILE ||
+      this.toolName === MC_TOOLS.STRING_REPLACE_LSP
+    );
+  }
+
   private getQuietPreviewCapLine(): string {
-    return `  ${theme.bold(theme.fg('toolBorderSuccess', '╰──'))}`;
+    return `  ${theme.fg('toolBorderSuccess', '╰──')}`;
   }
 
   private shouldCloseQuietPreview(): boolean {
@@ -404,16 +444,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private formatQuietActivePreview(preview: string): string {
-    if (
-      this.toolName === MC_TOOLS.VIEW ||
-      this.toolName === MC_TOOLS.WRITE_FILE ||
-      this.toolName === MC_TOOLS.STRING_REPLACE_LSP
-    ) {
-      return this.highlightQuietCodePreview(preview);
-    }
-
     if (this.toolName === MC_TOOLS.FIND_FILES || this.toolName === MC_TOOLS.SEARCH_CONTENT) {
-      return theme.fg('toolArgs', preview);
+      return theme.fg('toolOutput', preview);
     }
 
     return theme.fg('text', preview);
@@ -425,7 +457,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       return highlight(preview, {
         language: getLanguageFromPath(path),
         ignoreIllegals: true,
-        theme: CODE_HIGHLIGHT_THEME,
+        theme: QUIET_CODE_HIGHLIGHT_THEME,
       });
     } catch {
       return theme.fg('toolArgs', preview);
@@ -500,6 +532,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private getQuietActivePreview(): string {
+    if (isWebSearchTool(this.toolName)) return this.formatQuietWebSearchPreview();
+
     switch (this.toolName) {
       case MC_TOOLS.VIEW:
         return this.formatQuietViewPreview();
@@ -552,6 +586,17 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     return entries.slice(0, 2).join('\n');
   }
 
+  private formatQuietWebSearchPreview(): string {
+    if (!this.result) return '';
+
+    return this.stripAnsi(this.formatWebSearchResults())
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .slice(0, 2)
+      .join('\n');
+  }
+
   private getListResultEntries(): string[] {
     return this.getFormattedOutput()
       .split('\n')
@@ -590,7 +635,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const separator = linePrefix ? '' : ' ';
     const connector = this.compactToolHasFollowingContinuation || this.hasQuietStreamingPreview() ? '├' : '╰';
     const branch = `${connector}─${separator}${linePrefix}`;
-    return `${theme.bold(theme.fg('toolBorderSuccess', branch))}${this.formatCompactSummaryText(summary.slice(linePrefix.length))}`;
+    return `${theme.fg('toolBorderSuccess', branch)}${this.formatCompactSummaryText(summary.slice(linePrefix.length))}`;
   }
 
   private formatCompactSummaryText(summary: string): string {
@@ -661,6 +706,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private getCompactToolSummary(): string {
+    if (isWebSearchTool(this.toolName)) return this.formatWebSearchSummary();
+
     switch (this.toolName) {
       case MC_TOOLS.VIEW:
         return this.formatPathWithRange();
@@ -689,6 +736,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private getCompactToolLabel(): string {
+    if (isWebSearchTool(this.toolName)) return 'web';
+
     switch (this.toolName) {
       case MC_TOOLS.EXECUTE_COMMAND:
         return '$';
@@ -741,6 +790,13 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
 
   private formatSearchSummary(): string {
     return this.getFirstStringArg('path');
+  }
+
+  private formatWebSearchSummary(): string {
+    const argsObj = this.args as Record<string, unknown> | undefined;
+    const action = argsObj?.action as Record<string, unknown> | undefined;
+    const query = argsObj?.query ? String(argsObj.query) : action?.query ? String(action.query) : '';
+    return query ? `"${query}"` : '';
   }
 
   private formatSearchDetail(): string {
@@ -889,28 +945,69 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const cwdSuffix = cwd ? theme.fg('muted', ` in ${cwd}`) : '';
     const timeSuffix = this.isPartial ? timeoutSuffix : this.getDurationSuffix();
 
-    // Helper to render shell command with bordered box
+    // Helper to render shell command with terminal-like bordered box
     const renderBorderedShell = (status: string, outputLines: string[]) => {
       const border = (char: string) => theme.bold(theme.fg('toolBorderSuccess', char));
-      const footerText = `${theme.bold(theme.fg('toolTitle', '$'))} ${theme.fg('toolArgs', command)}${cwdSuffix}${timeSuffix}${status}`;
-
-      // Top border
-      this.contentBox.addChild(new Text(border('╭──'), 0, 0));
-
-      // Output lines with left border, truncated to prevent soft wrap
+      const footerPrompt = `${theme.bold(theme.fg('toolTitle', '$'))} `;
+      const footerSuffix = `${cwdSuffix}${timeSuffix}${status}`;
       const termWidth = getTermWidth();
-      const maxLineWidth = termWidth - 4 - BOX_INDENT * 2; // Account for border "│ " (2) + buffer (2)
-      const borderedLines = outputLines.map(line => {
-        const truncated = truncateAnsi(line, maxLineWidth);
-        return border('│') + ' ' + theme.fg('toolOutput', truncated);
-      });
-      const displayOutput = borderedLines.join('\n');
+      const contentWidth = Math.max(20, termWidth - BOX_INDENT * 2 - 4); // Account for "│ " + " │"
+      const horizontal = '─'.repeat(contentWidth + 2);
+      const renderLine = (line: string, color: (value: string) => string = value => theme.fg('toolOutput', value)) => {
+        const truncated = truncateAnsi(line, contentWidth);
+        const padding = ' '.repeat(Math.max(0, contentWidth - this.stripAnsi(truncated).length));
+        return `${border('│')} ${color(truncated)}${padding} ${border('│')}`;
+      };
+      const wrapFooter = (text: string, width: number): string[] => {
+        const words = text.split(/\s+/).filter(Boolean);
+        const lines: string[] = [];
+        let current = '';
+        for (const word of words) {
+          let remaining = word;
+          while (remaining.length > width) {
+            if (current) {
+              lines.push(current);
+              current = '';
+            }
+            lines.push(remaining.slice(0, width));
+            remaining = remaining.slice(width);
+          }
+          if (!current) {
+            current = remaining;
+          } else if (current.length + 1 + remaining.length <= width) {
+            current += ` ${remaining}`;
+          } else {
+            lines.push(current);
+            current = remaining;
+          }
+        }
+        if (current) lines.push(current);
+        return lines.length ? lines : [''];
+      };
+
+      this.contentBox.addChild(new Text(`${border('╭')}${border(horizontal)}${border('╮')}`, 0, 0));
+
+      const displayOutput = outputLines.map(line => renderLine(line)).join('\n');
       if (displayOutput.trim()) {
         this.contentBox.addChild(new Text(displayOutput, 0, 0));
       }
 
-      // Bottom border with command info
-      this.contentBox.addChild(new Text(`${border('╰──')} ${footerText}`, 0, 0));
+      this.contentBox.addChild(new Text(`${border('├')}${border(horizontal)}${border('┤')}`, 0, 0));
+      const footerWrapWidth = Math.max(1, contentWidth - 2);
+      const footerLines = wrapFooter(command, footerWrapWidth);
+      const footerSuffixWidth = this.stripAnsi(footerSuffix).length;
+      footerLines.forEach((footerLine, index) => {
+        const prefix = index === 0 ? footerPrompt : '  ';
+        const isLast = index === footerLines.length - 1;
+        const suffixFits = isLast && footerLine.length + footerSuffixWidth <= footerWrapWidth;
+        const suffix = suffixFits ? footerSuffix : '';
+        this.contentBox.addChild(new Text(renderLine(`${prefix}${theme.fg('toolArgs', footerLine)}${suffix}`, value => value), 0, 0));
+      });
+      const lastFooterLine = footerLines[footerLines.length - 1] ?? '';
+      if (lastFooterLine.length + footerSuffixWidth > footerWrapWidth) {
+        this.contentBox.addChild(new Text(renderLine(`  ${footerSuffix}`, value => value), 0, 0));
+      }
+      this.contentBox.addChild(new Text(`${border('╰')}${border(horizontal)}${border('╯')}`, 0, 0));
     };
 
     if (!this.result || this.isPartial) {

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -45,7 +45,9 @@ const CODE_HIGHLIGHT_THEME: HighlightTheme = {
   name: chalk.hex('#c084fc'),
 };
 
-const COMPACT_TOOL_ARGS_BG = '#111827';
+const COMPACT_TOOL_COLOR = mastra.orange;
+const COMPACT_TOOL_ARGS_BG = '#0f0f0f';
+const QUIET_TOOL_RAIL = '#5f4530';
 
 const QUIET_CODE_HIGHLIGHT_THEME: HighlightTheme = {
   default: chalk.hex('#b4b4bd'),
@@ -416,13 +418,13 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     );
 
     return wrapped.map(line => {
-      const linePrefix = `  ${theme.fg('toolBorderSuccess', '│')} `;
+      const linePrefix = `  ${chalk.hex(QUIET_TOOL_RAIL)('│')} `;
       return truncateAnsi(`${linePrefix}${this.formatQuietActivePreview(line)}`, maxLineWidth);
     });
   }
 
   private getQuietCodePreviewLines(preview: string, maxLineWidth: number): string[] {
-    const linePrefix = `  ${theme.fg('toolBorderSuccess', '│')} `;
+    const linePrefix = `  ${chalk.hex(QUIET_TOOL_RAIL)('│')} `;
     return this.highlightQuietCodePreview(preview)
       .split('\n')
       .slice(-this.quietPreviewLineLimit)
@@ -438,7 +440,11 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private getQuietPreviewCapLine(): string {
-    return `  ${theme.fg('toolBorderSuccess', '╰──')}`;
+    return `  ${chalk.hex(QUIET_TOOL_RAIL)('╰──')}`;
+  }
+
+  private getQuietPreviewSpacerLine(): string {
+    return `  ${chalk.hex(QUIET_TOOL_RAIL)('│')}`;
   }
 
   private shouldCloseQuietPreview(): boolean {
@@ -501,8 +507,9 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
 
     const detailLines = this.getQuietPreviewLines(getTermWidth() - BOX_INDENT * 2 - 2);
     if (detailLines.length === 0) return [firstLine];
-    if (!this.shouldCloseQuietPreview()) return [firstLine, ...detailLines];
-    return [firstLine, ...detailLines, this.getQuietPreviewCapLine()];
+    const previewLines = this.shouldCloseQuietPreview() ? [...detailLines, this.getQuietPreviewCapLine()] : detailLines;
+    if (this.compactToolHasFollowingContinuation) previewLines.push(this.getQuietPreviewSpacerLine());
+    return [firstLine, ...previewLines];
   }
 
   private getCompactStatusIndicator(): string {
@@ -510,9 +517,11 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private formatCompactToolHeader(toolLabel: string, toolLabelColor: CompactToolLabelColor, summary: string): string {
-    const color = this.isErrorResult() ? mastra.red : toolLabelColor === 'error' ? mastra.red : mastra.orange;
-    const label = chalk.bgHex(color).hex('#000000').bold(` ${toolLabel} `);
-    const args = summary ? this.formatCompactSummaryBadge(` ${summary}`) : '';
+    const color = this.isErrorResult() ? mastra.red : toolLabelColor === 'error' ? mastra.red : COMPACT_TOOL_COLOR;
+    const leftHalf = chalk.hex(color)('▐');
+    const rightHalf = summary ? chalk.hex(color).bgHex(COMPACT_TOOL_ARGS_BG)('▌') : chalk.hex(color)('▌');
+    const label = `${leftHalf}${chalk.bgHex(color).hex('#000000').bold(toolLabel)}${rightHalf}`;
+    const args = summary ? this.formatCompactSummaryBadge(summary) : '';
     const trail = summary ? chalk.hex(COMPACT_TOOL_ARGS_BG)('▌') : '';
     return `${label}${args}${trail}`;
   }
@@ -644,10 +653,11 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const linePrefix = lineMatch?.[0] ?? '';
     const separator = linePrefix ? '' : ' ';
     const hasFollowing = this.compactToolHasFollowingContinuation || this.hasQuietStreamingPreview();
+    const hasPreview = this.hasQuietStreamingPreview();
     const branch = hasFollowing
-      ? `${chalk.hex(mastra.orange)('●')}${theme.fg('toolBorderSuccess', `─${separator}${linePrefix}`)}`
-      : theme.fg('toolBorderSuccess', `╰─${separator}${linePrefix}`);
-    const continuationSummary = summary.slice(linePrefix.length);
+      ? `${hasPreview ? chalk.hex(mastra.orange)('●') : chalk.hex(QUIET_TOOL_RAIL)('├')}${chalk.hex(QUIET_TOOL_RAIL)(`─${separator}${linePrefix}`)}`
+      : chalk.hex(QUIET_TOOL_RAIL)(`╰─${separator}${linePrefix}`);
+    const continuationSummary = ` ${summary.slice(linePrefix.length)}`;
     const trail = continuationSummary ? chalk.hex(COMPACT_TOOL_ARGS_BG)('▌') : '';
     return `${branch}${this.formatCompactSummaryBadge(continuationSummary)}${trail}`;
   }

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -74,6 +74,9 @@ const QUIET_CODE_HIGHLIGHT_THEME: HighlightTheme = {
   name: chalk.hex('#c4b5fd'),
 };
 
+const SHELL_CONTROL_WORDS = new Set(['if', 'then', 'else', 'elif', 'fi', 'for', 'while', 'until', 'do', 'done', 'case', 'esac', 'in', 'function']);
+const SHELL_BUILTINS = new Set(['cd', 'echo', 'export', 'source', 'alias', 'unalias', 'set', 'unset', 'test', '[', 'printf']);
+
 export interface ToolExecutionOptions {
   showImages?: boolean;
   autoCollapse?: boolean;
@@ -489,6 +492,67 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     } catch {
       return theme.fg('toolArgs', preview);
     }
+  }
+
+  private highlightQuietShellCommandLine(line: string): string {
+    const tokens = line.match(/\s+|&&|\|\||[|;()<>]|[^\s|;&()<>]+/g) ?? [''];
+    let expectsCommand = true;
+
+    return tokens
+      .map(token => {
+        if (/^\s+$/.test(token)) return token;
+        if (token === '&&' || token === '||' || token === '|' || token === ';') {
+          expectsCommand = true;
+          return theme.fg('muted', token);
+        }
+        if (token === '(' || token === ')' || token === '<' || token === '>') {
+          return theme.fg('muted', token);
+        }
+        if (SHELL_CONTROL_WORDS.has(token)) {
+          expectsCommand = token === 'then' || token === 'do' || token === 'else';
+          return chalk.blue(token);
+        }
+        if (/^--?[A-Za-z0-9][\w-]*(?:=.*)?$/.test(token)) {
+          expectsCommand = false;
+          return chalk.hex('#f6c177')(token);
+        }
+        if (expectsCommand || SHELL_BUILTINS.has(token)) {
+          expectsCommand = false;
+          return chalk.cyan(token);
+        }
+        expectsCommand = false;
+        return theme.fg('toolArgs', token);
+      })
+      .join('');
+  }
+
+  private wrapQuietShellCommand(command: string, width: number): string[] {
+    const words = command.match(/\S+/g) ?? [''];
+    const lines: string[] = [];
+    let current = '';
+
+    for (const word of words) {
+      let remaining = word;
+      while (remaining.length > width) {
+        if (current) {
+          lines.push(current);
+          current = '';
+        }
+        lines.push(remaining.slice(0, width));
+        remaining = remaining.slice(width);
+      }
+      if (!current) {
+        current = remaining;
+      } else if (current.length + 1 + remaining.length <= width) {
+        current += ` ${remaining}`;
+      } else {
+        lines.push(current);
+        current = remaining;
+      }
+    }
+
+    if (current) lines.push(current);
+    return lines.length ? lines : [''];
   }
 
   private wrapPreviewLines(preview: string, firstLineWidth: number, continuationWidth: number): string[] {
@@ -1261,33 +1325,6 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         const padding = ' '.repeat(Math.max(0, contentWidth - this.stripAnsi(truncated).length));
         return `${border('│')} ${color(truncated)}${padding} ${border('│')}`;
       };
-      const wrapFooter = (text: string, width: number): string[] => {
-        const words = text.split(/\s+/).filter(Boolean);
-        const lines: string[] = [];
-        let current = '';
-        for (const word of words) {
-          let remaining = word;
-          while (remaining.length > width) {
-            if (current) {
-              lines.push(current);
-              current = '';
-            }
-            lines.push(remaining.slice(0, width));
-            remaining = remaining.slice(width);
-          }
-          if (!current) {
-            current = remaining;
-          } else if (current.length + 1 + remaining.length <= width) {
-            current += ` ${remaining}`;
-          } else {
-            lines.push(current);
-            current = remaining;
-          }
-        }
-        if (current) lines.push(current);
-        return lines.length ? lines : [''];
-      };
-
       const displayOutput = outputLines.map(line => renderLine(line)).join('\n');
       const hasOutput = displayOutput.trim() !== '';
 
@@ -1297,17 +1334,18 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         this.contentBox.addChild(new Text(`${border('├')}${border(horizontal)}${border('┤')}`, 0, 0));
       }
       const footerWrapWidth = Math.max(1, contentWidth - 2);
-      const footerLines = wrapFooter(command, footerWrapWidth);
+      const footerLines = this.wrapQuietShellCommand(command, footerWrapWidth);
       const footerSuffixWidth = this.stripAnsi(footerSuffix).length;
       footerLines.forEach((footerLine, index) => {
         const prefix = index === 0 ? footerPrompt : '  ';
         const isLast = index === footerLines.length - 1;
-        const suffixFits = isLast && footerLine.length + footerSuffixWidth <= footerWrapWidth;
+        const suffixFits = isLast && this.stripAnsi(footerLine).length + footerSuffixWidth <= footerWrapWidth;
         const suffix = suffixFits ? footerSuffix : '';
-        this.contentBox.addChild(new Text(renderLine(`${prefix}${theme.fg('toolArgs', footerLine)}${suffix}`, value => value), 0, 0));
+        const highlightedFooterLine = this.highlightQuietShellCommandLine(footerLine);
+        this.contentBox.addChild(new Text(renderLine(`${prefix}${highlightedFooterLine}${suffix}`, value => value), 0, 0));
       });
       const lastFooterLine = footerLines[footerLines.length - 1] ?? '';
-      if (lastFooterLine.length + footerSuffixWidth > footerWrapWidth) {
+      if (this.stripAnsi(lastFooterLine).length + footerSuffixWidth > footerWrapWidth) {
         this.contentBox.addChild(new Text(renderLine(`  ${footerSuffix}`, value => value), 0, 0));
       }
       this.contentBox.addChild(new Text(`${border('╰')}${border(horizontal)}${border('╯')}`, 0, 0));

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -75,7 +75,6 @@ const QUIET_CODE_HIGHLIGHT_THEME: HighlightTheme = {
 };
 
 const SHELL_CONTROL_WORDS = new Set(['if', 'then', 'else', 'elif', 'fi', 'for', 'while', 'until', 'do', 'done', 'case', 'esac', 'in', 'function']);
-const SHELL_BUILTINS = new Set(['cd', 'echo', 'export', 'source', 'alias', 'unalias', 'set', 'unset', 'test', '[', 'printf']);
 
 export interface ToolExecutionOptions {
   showImages?: boolean;
@@ -494,64 +493,66 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     }
   }
 
-  private highlightQuietShellCommandLine(line: string): string {
-    const tokens = line.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\s+|&&|\|\||[|;()<>]|[^\s|;&()<>]+/g) ?? [''];
-    let expectsCommand = true;
+  private tokenizeQuietShellCommand(command: string): Array<{ text: string; color: (value: string) => string }> {
+    const tokens = command.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\s+|&&|\|\||[|;()<>]|[^\s|;&()<>]+/g) ?? [''];
 
-    return tokens
-      .map(token => {
-        if (/^\s+$/.test(token)) return token;
-        if ((token.startsWith('"') && token.endsWith('"')) || (token.startsWith("'") && token.endsWith("'"))) {
-          expectsCommand = false;
-          return chalk.white(token);
-        }
-        if (token === '&&' || token === '||' || token === '|' || token === ';') {
-          expectsCommand = true;
-          return theme.fg('muted', token);
-        }
-        if (token === '(' || token === ')' || token === '<' || token === '>') {
-          return theme.fg('muted', token);
-        }
-        if (SHELL_CONTROL_WORDS.has(token)) {
-          expectsCommand = token === 'then' || token === 'do' || token === 'else';
-          return chalk.blue(token);
-        }
-        if (/^--?[A-Za-z0-9][\w-]*(?:=.*)?$/.test(token)) {
-          expectsCommand = false;
-          return theme.fg('toolArgs', token);
-        }
-        if (expectsCommand || SHELL_BUILTINS.has(token)) {
-          expectsCommand = false;
-          return theme.fg('toolArgs', token);
-        }
-        expectsCommand = false;
-        return theme.fg('toolArgs', token);
-      })
-      .join('');
+    return tokens.map(token => {
+      if (/^\s+$/.test(token)) return { text: token, color: (value: string) => value };
+      if ((token.startsWith('"') && token.endsWith('"')) || (token.startsWith("'") && token.endsWith("'"))) {
+        return { text: token, color: chalk.white };
+      }
+      if (token === '&&' || token === '||' || token === '|' || token === ';') {
+        return { text: token, color: (value: string) => theme.fg('muted', value) };
+      }
+      if (token === '(' || token === ')' || token === '<' || token === '>') {
+        return { text: token, color: (value: string) => theme.fg('muted', value) };
+      }
+      if (SHELL_CONTROL_WORDS.has(token)) {
+        return { text: token, color: chalk.blue };
+      }
+      return { text: token, color: (value: string) => theme.fg('toolArgs', value) };
+    });
   }
 
   private wrapQuietShellCommand(command: string, width: number): string[] {
-    const words = command.match(/\S+/g) ?? [''];
     const lines: string[] = [];
     let current = '';
+    let currentWidth = 0;
 
-    for (const word of words) {
-      let remaining = word;
-      while (remaining.length > width) {
-        if (current) {
-          lines.push(current);
-          current = '';
+    const pushCurrent = () => {
+      lines.push(current);
+      current = '';
+      currentWidth = 0;
+    };
+
+    for (const token of this.tokenizeQuietShellCommand(command)) {
+      let remaining = token.text;
+
+      while (remaining.length > 0) {
+        if (currentWidth === 0 && /^\s+$/.test(remaining)) break;
+
+        const available = width - currentWidth;
+        if (available <= 0) {
+          pushCurrent();
+          continue;
         }
-        lines.push(remaining.slice(0, width));
-        remaining = remaining.slice(width);
-      }
-      if (!current) {
-        current = remaining;
-      } else if (current.length + 1 + remaining.length <= width) {
-        current += ` ${remaining}`;
-      } else {
-        lines.push(current);
-        current = remaining;
+
+        if (remaining.length <= available) {
+          current += token.color(remaining);
+          currentWidth += remaining.length;
+          break;
+        }
+
+        if (currentWidth > 0 && !/^\s+$/.test(remaining)) {
+          pushCurrent();
+          continue;
+        }
+
+        const chunk = remaining.slice(0, available);
+        current += token.color(chunk);
+        currentWidth += chunk.length;
+        remaining = remaining.slice(available);
+        pushCurrent();
       }
     }
 
@@ -1345,8 +1346,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         const isLast = index === footerLines.length - 1;
         const suffixFits = isLast && this.stripAnsi(footerLine).length + footerSuffixWidth <= footerWrapWidth;
         const suffix = suffixFits ? footerSuffix : '';
-        const highlightedFooterLine = this.highlightQuietShellCommandLine(footerLine);
-        this.contentBox.addChild(new Text(renderLine(`${prefix}${highlightedFooterLine}${suffix}`, value => value), 0, 0));
+        this.contentBox.addChild(new Text(renderLine(`${prefix}${footerLine}${suffix}`, value => value), 0, 0));
       });
       const lastFooterLine = footerLines[footerLines.length - 1] ?? '';
       if (this.stripAnsi(lastFooterLine).length + footerSuffixWidth > footerWrapWidth) {

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -45,6 +45,8 @@ const CODE_HIGHLIGHT_THEME: HighlightTheme = {
   name: chalk.hex('#c084fc'),
 };
 
+const COMPACT_TOOL_ARGS_BG = '#111827';
+
 const QUIET_CODE_HIGHLIGHT_THEME: HighlightTheme = {
   default: chalk.hex('#b4b4bd'),
   keyword: chalk.hex('#c4b5fd'),
@@ -495,7 +497,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const summary = this.compactToolContinuation ? this.getCompactContinuationSummary() : this.getCompactToolSummary();
     const firstLine = this.compactToolContinuation
       ? `${this.getCompactContinuationIndent()}${this.formatCompactContinuationLine(summary)}${status}`
-      : `${theme.bold(theme.fg(toolLabelColor, toolLabel))}${summary ? ` ${this.formatCompactSummaryText(summary)}` : ''}${status}`;
+      : `${this.formatCompactToolHeader(toolLabel, toolLabelColor, summary)}${status}`;
 
     const detailLines = this.getQuietPreviewLines(getTermWidth() - BOX_INDENT * 2 - 2);
     if (detailLines.length === 0) return [firstLine];
@@ -505,6 +507,14 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
 
   private getCompactStatusIndicator(): string {
     return this.isErrorResult() ? theme.fg('error', ' ✗') : '';
+  }
+
+  private formatCompactToolHeader(toolLabel: string, toolLabelColor: CompactToolLabelColor, summary: string): string {
+    const color = this.isErrorResult() ? mastra.red : toolLabelColor === 'error' ? mastra.red : mastra.orange;
+    const label = chalk.bgHex(color).hex('#000000').bold(` ${toolLabel} `);
+    const args = summary ? this.formatCompactSummaryBadge(` ${summary}`) : '';
+    const trail = summary ? chalk.hex(COMPACT_TOOL_ARGS_BG)('▌') : '';
+    return `${label}${args}${trail}`;
   }
 
   getCompactToolLabelColor(): CompactToolLabelColor {
@@ -633,17 +643,21 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const lineMatch = summary.match(/^─+/);
     const linePrefix = lineMatch?.[0] ?? '';
     const separator = linePrefix ? '' : ' ';
-    const connector = this.compactToolHasFollowingContinuation || this.hasQuietStreamingPreview() ? '├' : '╰';
-    const branch = `${connector}─${separator}${linePrefix}`;
-    return `${theme.fg('toolBorderSuccess', branch)}${this.formatCompactSummaryText(summary.slice(linePrefix.length))}`;
+    const hasFollowing = this.compactToolHasFollowingContinuation || this.hasQuietStreamingPreview();
+    const branch = hasFollowing
+      ? `${chalk.hex(mastra.orange)('●')}${theme.fg('toolBorderSuccess', `─${separator}${linePrefix}`)}`
+      : theme.fg('toolBorderSuccess', `╰─${separator}${linePrefix}`);
+    const continuationSummary = summary.slice(linePrefix.length);
+    const trail = continuationSummary ? chalk.hex(COMPACT_TOOL_ARGS_BG)('▌') : '';
+    return `${branch}${this.formatCompactSummaryBadge(continuationSummary)}${trail}`;
   }
 
-  private formatCompactSummaryText(summary: string): string {
+  private formatCompactSummaryBadge(summary: string): string {
     const rangeMatch = summary.match(/(:\d+(?:-\d+)?)$/);
-    if (!rangeMatch?.[1]) return theme.fg('text', summary);
+    if (!rangeMatch?.[1]) return chalk.bgHex(COMPACT_TOOL_ARGS_BG)(theme.fg('text', summary));
 
     const rangeStart = summary.length - rangeMatch[1].length;
-    return `${theme.fg('text', summary.slice(0, rangeStart))}${theme.fg('dim', rangeMatch[1])}`;
+    return `${chalk.bgHex(COMPACT_TOOL_ARGS_BG)(theme.fg('text', summary.slice(0, rangeStart)))}${chalk.bgHex(COMPACT_TOOL_ARGS_BG)(theme.fg('dim', rangeMatch[1]))}`;
   }
 
   private getCompactContinuationSummary(): string {

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -518,11 +518,11 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         }
         if (/^--?[A-Za-z0-9][\w-]*(?:=.*)?$/.test(token)) {
           expectsCommand = false;
-          return chalk.hex('#f6c177')(token);
+          return theme.fg('toolArgs', token);
         }
         if (expectsCommand || SHELL_BUILTINS.has(token)) {
           expectsCommand = false;
-          return chalk.hex('#93c5fd')(token);
+          return theme.fg('toolArgs', token);
         }
         expectsCommand = false;
         return theme.fg('toolArgs', token);

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -495,12 +495,16 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private highlightQuietShellCommandLine(line: string): string {
-    const tokens = line.match(/\s+|&&|\|\||[|;()<>]|[^\s|;&()<>]+/g) ?? [''];
+    const tokens = line.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\s+|&&|\|\||[|;()<>]|[^\s|;&()<>]+/g) ?? [''];
     let expectsCommand = true;
 
     return tokens
       .map(token => {
         if (/^\s+$/.test(token)) return token;
+        if ((token.startsWith('"') && token.endsWith('"')) || (token.startsWith("'") && token.endsWith("'"))) {
+          expectsCommand = false;
+          return chalk.white(token);
+        }
         if (token === '&&' || token === '||' || token === '|' || token === ';') {
           expectsCommand = true;
           return theme.fg('muted', token);
@@ -518,7 +522,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         }
         if (expectsCommand || SHELL_BUILTINS.has(token)) {
           expectsCommand = false;
-          return chalk.cyan(token);
+          return chalk.hex('#93c5fd')(token);
         }
         expectsCommand = false;
         return theme.fg('toolArgs', token);

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -11,7 +11,7 @@ import chalk from 'chalk';
 import { highlight } from 'cli-highlight';
 import type { Theme as HighlightTheme } from 'cli-highlight';
 import { MC_TOOLS } from '../../tool-names.js';
-import { BOX_INDENT, getTermWidth, theme, mastra } from '../theme.js';
+import { BOX_INDENT, getTermWidth, theme, mastra, tintHex } from '../theme.js';
 import { truncateAnsi } from './ansi.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
 import { ErrorDisplayComponent } from './error-display.js';
@@ -47,7 +47,12 @@ const CODE_HIGHLIGHT_THEME: HighlightTheme = {
 
 const COMPACT_TOOL_COLOR = mastra.orange;
 const COMPACT_TOOL_ARGS_BG = '#0f0f0f';
-const QUIET_TOOL_RAIL = '#5f4530';
+const QUIET_TOOL_RAIL = tintHex(COMPACT_TOOL_COLOR, 0.35);
+
+function normalizeHexColor(color: string | undefined): string | undefined {
+  if (!color || !/^#[0-9a-f]{6}$/i.test(color)) return undefined;
+  return color;
+}
 
 const QUIET_CODE_HIGHLIGHT_THEME: HighlightTheme = {
   default: chalk.hex('#b4b4bd'),
@@ -75,6 +80,7 @@ export interface ToolExecutionOptions {
   collapsedByDefault?: boolean;
   quietDisplayMode?: QuietToolDisplayMode;
   quietPreviewLineLimit?: number;
+  compactToolModeColor?: string;
 }
 /**
  * Convert absolute path to tilde notation if it's in home directory
@@ -174,6 +180,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   private compactToolHasFollowingContinuation = false;
   private compactToolPreviousSummary: string | undefined;
   private compactToolGroupLabelColor: CompactToolLabelColor | undefined;
+  private compactToolModeColor: string | undefined;
 
   constructor(toolName: string, args: unknown, options: ToolExecutionOptions = {}, ui: TUI) {
     super();
@@ -188,6 +195,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     this.expanded = !this.options.collapsedByDefault;
     this.quietDisplayMode = this.options.quietDisplayMode ?? 'normal';
     this.quietPreviewLineLimit = this.options.quietPreviewLineLimit ?? 2;
+    this.compactToolModeColor = normalizeHexColor(this.options.compactToolModeColor);
 
     // Content box - left indent for chat history alignment, no background
     this.contentBox = new Box(BOX_INDENT, 0, (text: string) => text);
@@ -244,6 +252,13 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const normalizedLimit = Number.isFinite(limit) ? limit : 2;
     this.quietPreviewLineLimit = Math.min(8, Math.max(0, Math.floor(normalizedLimit)));
     this.rebuild();
+  }
+
+  setCompactToolModeColor(color: string | undefined): void {
+    const nextColor = normalizeHexColor(color);
+    if (this.compactToolModeColor === nextColor) return;
+    this.compactToolModeColor = nextColor;
+    if (this.quietDisplayMode === 'quiet') this.rebuild();
   }
 
   getChatSpacingKind(): ChatSpacingKind {
@@ -418,13 +433,13 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     );
 
     return wrapped.map(line => {
-      const linePrefix = `  ${chalk.hex(QUIET_TOOL_RAIL)('│')} `;
+      const linePrefix = `  ${chalk.hex(this.getQuietToolRailColor())('│')} `;
       return truncateAnsi(`${linePrefix}${this.formatQuietActivePreview(line)}`, maxLineWidth);
     });
   }
 
   private getQuietCodePreviewLines(preview: string, maxLineWidth: number): string[] {
-    const linePrefix = `  ${chalk.hex(QUIET_TOOL_RAIL)('│')} `;
+    const linePrefix = `  ${chalk.hex(this.getQuietToolRailColor())('│')} `;
     return this.highlightQuietCodePreview(preview)
       .split('\n')
       .slice(-this.quietPreviewLineLimit)
@@ -440,11 +455,11 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private getQuietPreviewCapLine(): string {
-    return `  ${chalk.hex(QUIET_TOOL_RAIL)('╰──')}`;
+    return `  ${chalk.hex(this.getQuietToolRailColor())('╰──')}`;
   }
 
   private getQuietPreviewSpacerLine(): string {
-    return `  ${chalk.hex(QUIET_TOOL_RAIL)('│')}`;
+    return `  ${chalk.hex(this.getQuietToolRailColor())('│')}`;
   }
 
   private shouldCloseQuietPreview(): boolean {
@@ -517,13 +532,35 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private formatCompactToolHeader(toolLabel: string, toolLabelColor: CompactToolLabelColor, summary: string): string {
-    const color = this.isErrorResult() ? mastra.red : toolLabelColor === 'error' ? mastra.red : COMPACT_TOOL_COLOR;
+    const color = this.getCompactToolAccentColor(toolLabelColor);
+    const argsBg = this.getCompactToolArgsBg(toolLabelColor);
+    const argsColor = this.getCompactToolArgsColor(toolLabelColor);
     const leftHalf = chalk.hex(color)('▐');
-    const rightHalf = summary ? chalk.hex(color).bgHex(COMPACT_TOOL_ARGS_BG)('▌') : chalk.hex(color)('▌');
+    const rightHalf = summary ? chalk.hex(color).bgHex(argsBg)('▌') : chalk.hex(color)('▌');
     const label = `${leftHalf}${chalk.bgHex(color).hex('#000000').bold(toolLabel)}${rightHalf}`;
-    const args = summary ? this.formatCompactSummaryBadge(summary) : '';
-    const trail = summary ? chalk.hex(COMPACT_TOOL_ARGS_BG)('▌') : '';
+    const args = summary ? this.formatCompactSummaryBadge(summary, argsBg, argsColor) : '';
+    const trail = summary ? chalk.hex(argsBg)('▌') : '';
     return `${label}${args}${trail}`;
+  }
+
+  private getCompactToolAccentColor(toolLabelColor: CompactToolLabelColor): string {
+    if (this.isErrorResult() || toolLabelColor === 'error') return mastra.red;
+    return this.compactToolModeColor ?? COMPACT_TOOL_COLOR;
+  }
+
+  private getCompactToolArgsBg(toolLabelColor: CompactToolLabelColor): string {
+    if (this.isErrorResult() || toolLabelColor === 'error') return tintHex(mastra.red, 0.15);
+    return COMPACT_TOOL_ARGS_BG;
+  }
+
+  private getCompactToolArgsColor(toolLabelColor: CompactToolLabelColor): string | undefined {
+    if (this.isErrorResult() || toolLabelColor === 'error') return undefined;
+    return this.compactToolModeColor ?? COMPACT_TOOL_COLOR;
+  }
+
+  private getQuietToolRailColor(): string {
+    if (this.isErrorResult()) return tintHex(mastra.red, 0.35);
+    return this.compactToolModeColor ? tintHex(this.compactToolModeColor, 0.35) : QUIET_TOOL_RAIL;
   }
 
   getCompactToolLabelColor(): CompactToolLabelColor {
@@ -654,20 +691,26 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const separator = linePrefix ? '' : ' ';
     const hasFollowing = this.compactToolHasFollowingContinuation || this.hasQuietStreamingPreview();
     const hasPreview = this.hasQuietStreamingPreview();
+    const toolLabelColor = this.getCompactToolLabelColor();
+    const color = this.getCompactToolAccentColor(toolLabelColor);
+    const argsBg = this.getCompactToolArgsBg(toolLabelColor);
+    const argsColor = this.getCompactToolArgsColor(toolLabelColor);
+    const railColor = this.getQuietToolRailColor();
     const branch = hasFollowing
-      ? `${hasPreview ? chalk.hex(mastra.orange)('●') : chalk.hex(QUIET_TOOL_RAIL)('├')}${chalk.hex(QUIET_TOOL_RAIL)(`─${separator}${linePrefix}`)}`
-      : chalk.hex(QUIET_TOOL_RAIL)(`╰─${separator}${linePrefix}`);
+      ? `${hasPreview ? chalk.hex(color)('●') : chalk.hex(railColor)('├')}${chalk.hex(railColor)(`─${separator}${linePrefix}`)}`
+      : chalk.hex(railColor)(`╰─${separator}${linePrefix}`);
     const continuationSummary = ` ${summary.slice(linePrefix.length)}`;
-    const trail = continuationSummary ? chalk.hex(COMPACT_TOOL_ARGS_BG)('▌') : '';
-    return `${branch}${this.formatCompactSummaryBadge(continuationSummary)}${trail}`;
+    const trail = continuationSummary ? chalk.hex(argsBg)('▌') : '';
+    return `${branch}${this.formatCompactSummaryBadge(continuationSummary, argsBg, argsColor)}${trail}`;
   }
 
-  private formatCompactSummaryBadge(summary: string): string {
+  private formatCompactSummaryBadge(summary: string, argsBg: string, argsColor?: string): string {
+    const styleText = (text: string) => (argsColor ? chalk.hex(argsColor)(text) : theme.fg('text', text));
     const rangeMatch = summary.match(/(:\d+(?:-\d+)?)$/);
-    if (!rangeMatch?.[1]) return chalk.bgHex(COMPACT_TOOL_ARGS_BG)(theme.fg('text', summary));
+    if (!rangeMatch?.[1]) return chalk.bgHex(argsBg)(styleText(summary));
 
     const rangeStart = summary.length - rangeMatch[1].length;
-    return `${chalk.bgHex(COMPACT_TOOL_ARGS_BG)(theme.fg('text', summary.slice(0, rangeStart)))}${chalk.bgHex(COMPACT_TOOL_ARGS_BG)(theme.fg('dim', rangeMatch[1]))}`;
+    return `${chalk.bgHex(argsBg)(styleText(summary.slice(0, rangeStart)))}${chalk.bgHex(argsBg)(theme.fg('dim', rangeMatch[1]))}`;
   }
 
   private getCompactContinuationSummary(): string {

--- a/mastracode/src/tui/components/tool-execution-interface.ts
+++ b/mastracode/src/tui/components/tool-execution-interface.ts
@@ -24,6 +24,7 @@ export interface IToolExecutionComponent {
   setExpanded(expanded: boolean): void;
   setQuietModeDisplay?(mode: QuietToolDisplayMode): void;
   setQuietPreviewLineLimit?(limit: number): void;
+  setCompactToolModeColor?(color: string | undefined): void;
   getChatSpacingKind?(): ChatSpacingKind | undefined;
   getCompactToolGroupKey?(): string | undefined;
   getCompactToolGroupSummary?(): string | undefined;

--- a/mastracode/src/tui/handlers/message.ts
+++ b/mastracode/src/tui/handlers/message.ts
@@ -17,6 +17,10 @@ import { getMarkdownTheme } from '../theme.js';
 
 import type { EventHandlerContext } from './types.js';
 
+function getCurrentModeColor(ctx: EventHandlerContext): string | undefined {
+  return ctx.state.harness.getCurrentMode?.()?.color;
+}
+
 /**
  * Get content parts after the last tool_call/tool_result in the message.
  * These are the parts that should be rendered in the current streaming component.
@@ -244,6 +248,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
         );
         component.setExpanded(state.toolOutputExpanded);
         if (state.quietMode) {
+          component.setCompactToolModeColor(getCurrentModeColor(ctx));
           component.setQuietModeDisplay('quiet');
           component.setQuietPreviewLineLimit(state.quietModeMaxToolPreviewLines);
         }

--- a/mastracode/src/tui/handlers/message.ts
+++ b/mastracode/src/tui/handlers/message.ts
@@ -255,6 +255,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
         ctx.addChildBeforeFollowUps(component);
         state.pendingTools.set(content.id, component);
         state.allToolComponents.push(component);
+        reconcileChatBoundarySpacers(state.chatContainer);
 
         state.streamingComponent = new AssistantMessageComponent(
           undefined,

--- a/mastracode/src/tui/handlers/subagent.ts
+++ b/mastracode/src/tui/handlers/subagent.ts
@@ -2,6 +2,7 @@
  * Event handlers for subagent delegation events:
  * subagent_start, subagent_tool_start, subagent_tool_end, subagent_end.
  */
+import { insertChatComponentWithBoundarySpacing } from '../chat-boundary-reconciliation.js';
 import { SubagentExecutionComponent } from '../components/subagent-execution.js';
 
 import type { EventHandlerContext } from './types.js';
@@ -16,7 +17,8 @@ export function handleSubagentStart(
 ): void {
   const { state } = ctx;
   const component = new SubagentExecutionComponent(agentType, task, state.ui, modelId, {
-    collapseOnComplete: state.quietMode,
+    collapseOnComplete: false,
+    expandOnComplete: state.quietMode,
     forked,
   });
   state.pendingSubagents.set(toolCallId, component);
@@ -27,13 +29,12 @@ export function handleSubagentStart(
   if (state.streamingComponent) {
     const idx = state.chatContainer.children.indexOf(state.streamingComponent as any);
     if (idx >= 0) {
-      (state.chatContainer.children as unknown[]).splice(idx, 0, component);
-      state.chatContainer.invalidate();
+      insertChatComponentWithBoundarySpacing(state.chatContainer, component, idx);
     } else {
-      state.chatContainer.addChild(component);
+      insertChatComponentWithBoundarySpacing(state.chatContainer, component);
     }
   } else {
-    state.chatContainer.addChild(component);
+    insertChatComponentWithBoundarySpacing(state.chatContainer, component);
   }
 
   state.ui.requestRender();

--- a/mastracode/src/tui/handlers/tool.test.ts
+++ b/mastracode/src/tui/handlers/tool.test.ts
@@ -111,7 +111,7 @@ describe('task tool rendering', () => {
 
     const output = stripAnsi(ctx.state.chatContainer.render(100).join('\n'));
     expect(output).toContain('The specified text was not found.');
-    expect(output).toContain('╰── edit ... ✗');
+    expect(output).toContain('▐edit▌ ✗');
   });
 
   it('regroups quiet tools as streamed args arrive', () => {
@@ -131,7 +131,7 @@ describe('task tool rendering', () => {
     const output = stripAnsi(ctx.state.chatContainer.render(120).join('\n'));
     expect(output).toContain('view');
     expect(output).toContain('src/example.ts:80-169');
-    expect(output).toContain('╰─────/example.ts:1-25');
+    expect(output).toContain('●───── /example.ts:1-25▌');
   });
 
   it('streams submit_plan args into a plan box instead of rendering a generic tool', () => {

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -24,6 +24,10 @@ import { getMarkdownTheme } from '../theme.js';
 
 import type { EventHandlerContext } from './types.js';
 
+function getCurrentModeColor(ctx: EventHandlerContext): string | undefined {
+  return ctx.state.harness.getCurrentMode?.()?.color;
+}
+
 export function isTaskMutationTool(toolName: string): boolean {
   return toolName === 'task_write' || toolName === 'task_update' || toolName === 'task_complete';
 }
@@ -31,6 +35,7 @@ export function isTaskMutationTool(toolName: string): boolean {
 function applyQuietDisplayForNewTool(ctx: EventHandlerContext, component: ToolExecutionComponentEnhanced): void {
   if (!ctx.state.quietMode) return;
 
+  component.setCompactToolModeColor(getCurrentModeColor(ctx));
   component.setQuietModeDisplay('quiet');
   component.setQuietPreviewLineLimit(ctx.state.quietModeMaxToolPreviewLines);
 }

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -230,6 +230,7 @@ export function handleToolStart(ctx: EventHandlerContext, toolCallId: string, to
     ctx.addChildBeforeFollowUps(component);
     state.pendingTools.set(toolCallId, component);
     state.allToolComponents.push(component);
+    reconcileToolBoundaries(ctx);
 
     // Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
     state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
@@ -345,6 +346,7 @@ export function handleToolInputStart(ctx: EventHandlerContext, toolCallId: strin
     ctx.addChildBeforeFollowUps(component);
     state.pendingTools.set(toolCallId, component);
     state.allToolComponents.push(component);
+    reconcileToolBoundaries(ctx);
 
     // Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
     state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -1297,7 +1297,9 @@ export class MastraTUI {
     const tools = this.state.allToolComponents.filter(
       (tool): tool is IToolExecutionComponent => typeof tool.setQuietModeDisplay === 'function',
     );
+    const modeColor = this.state.harness.getCurrentMode?.()?.color;
     for (const tool of tools) {
+      tool.setCompactToolModeColor?.(modeColor);
       tool.setQuietModeDisplay?.(enabled ? 'quiet' : 'normal');
       tool.setQuietPreviewLineLimit?.(previewLineLimit);
     }

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -1297,7 +1297,7 @@ export class MastraTUI {
     const tools = this.state.allToolComponents.filter(
       (tool): tool is IToolExecutionComponent => typeof tool.setQuietModeDisplay === 'function',
     );
-    const modeColor = this.state.harness.getCurrentMode?.()?.color;
+    const modeColor = this.state.harness?.getCurrentMode?.()?.color;
     for (const tool of tools) {
       tool.setCompactToolModeColor?.(modeColor);
       tool.setQuietModeDisplay?.(enabled ? 'quiet' : 'normal');

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -591,7 +591,7 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
               subArgs?.task ?? '',
               state.ui,
               modelId,
-              { collapseOnComplete: state.quietMode, forked: subArgs?.forked },
+              { collapseOnComplete: false, expandOnComplete: state.quietMode, forked: subArgs?.forked },
             );
             // Populate tool calls from metadata
             if (meta?.toolCalls) {
@@ -602,7 +602,7 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
             }
             // Mark as finished with result
             subComponent.finish(isErr ?? false, durationMs, resultText);
-            state.chatContainer.addChild(subComponent);
+            insertChatComponentWithBoundarySpacing(state.chatContainer, subComponent);
             state.allToolComponents.push(subComponent as any);
             continue;
           }

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -31,6 +31,10 @@ import { BOX_INDENT, getMarkdownTheme, theme, mastra } from './theme.js';
 // Re-export so existing consumers can still import from here
 export { formatToolResult };
 
+function getCurrentModeColor(state: TUIState): string | undefined {
+  return state.harness.getCurrentMode?.()?.color;
+}
+
 // =============================================================================
 // renderCompletedTasksInline / renderClearedTasksInline
 // =============================================================================
@@ -711,6 +715,7 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
 
           if (!replacedWithInline) {
             if (state.quietMode) {
+              toolComponent.setCompactToolModeColor(getCurrentModeColor(state));
               toolComponent.setQuietModeDisplay('quiet');
               toolComponent.setQuietPreviewLineLimit(state.quietModeMaxToolPreviewLines);
             }


### PR DESCRIPTION
Had local changes and commits when https://github.com/mastra-ai/mastra/pull/16771 was merged! just styling tweaks and bug fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR polishes the TUI "quiet mode": compact tool outputs render more consistently and follow the active UI color, shell footers and tokenization behave better (ampersands preserved), spacing/layout jumps are reduced, and tests were updated to match the rebased behavior.

## Summary

Follow-up refinements to quiet-mode rendering and adjacent TUI behavior after rebasing onto main. Key focuses are propagating the current mode color to compact tool displays, expanding and standardizing quiet-mode previews across many tool types (notably shell, code-like, browser/process outputs), simplifying spacing logic to avoid layout jumps, improving subagent insertion/expansion behavior, and addressing tokenizer/footer issues for shell output. Tests and formatting/lint fixes were applied.

### Key Changes

- Mode-color propagation
  - Added optional IToolExecutionComponent.setCompactToolModeColor(color?: string) and ToolExecutionOptions.compactToolModeColor.
  - New helpers (getCurrentModeColor / applyCurrentModeColorToRenderedTools / applyQuietModePreference) call setCompactToolModeColor across commands, handlers, mastra-tui, and render paths so compact tool displays follow the active mode color.

- Quiet-mode rendering & previews
  - Expanded quiet preview formatters and compact-summary routing for many tools (web search, browser_*, skill*, process/file_stat, code-like tools, condensed validation/error previews).
  - Shell: increased quiet preview tail limit to 15 lines, refactored footer wrapping and tokenization (preserves standalone ampersands so background commands and stderr redirects render correctly), and improved wrapping/highlighting across wrapped lines.
  - Compact rendering: tighter integration of quiet preview detail lines, refined continuation/badge/range rendering, shared-prefix grouping, and improved path/label detection.

- Subagent insertion & expansion
  - SubagentExecutionOptions gained expandOnComplete?: boolean; finish() respects expandOnComplete (auto-expands when enabled).
  - Subagents are inserted using insertChatComponentWithBoundarySpacing to preserve spacing; collapseOnComplete is kept false and expansion is driven by quietMode where appropriate.

- Spacing and component stability
  - chat-spacing.getSpacingBetweenComponents signature adjusted (prevPrev/nextNext params now unused) and logic simplified: quiet-compact-tool groups return 0 spacing only when group keys match, otherwise 1.
  - reconcileToolBoundaries called after creating new tool components; tool insertion now reconciles boundary spacers to avoid layout jumps.
  - IdleCounterComponent.render() simplified to always return at least [''] to avoid empty-array-driven layout instability.

- Handlers/commands updates
  - Applied getCurrentModeColor and mode-color application in commands/mode, commands/settings, handlers (message, tool, subagent), render-messages, and mastra-tui so existing rendered tool components receive updated compact mode colors on mode switches and when quiet preferences change.

- Tests & formatting
  - Large test updates across src/tui to match rebased quiet-mode semantics (render-messages, chat-boundary-spacer, idle-counter, subagent-execution, tool-execution-enhanced, and handler tests).
  - Commit also includes lint/format fixes applied after quiet shell footer updates.

### Files of note

- Core rendering & behavior: src/tui/components/tool-execution-enhanced.ts, src/tui/components/tool-execution-interface.ts, src/tui/components/chat-spacing.ts, src/tui/components/subagent-execution.ts, src/tui/components/idle-counter.ts.
- Integrations & handlers: src/tui/handlers/{message,tool,subagent}.ts, src/tui/commands/{mode,settings}.ts, src/tui/mastra-tui.ts, src/tui/render-messages.ts.
- Tests: many updated under src/tui/components/__tests__ and handlers to reflect new quiet-mode semantics.
- Commits: included a fix to preserve ampersands in quiet shell footers and a chore commit to fix lint/formatting.

### Risk & Review Notes

- The new interface method is optional (non-breaking) but is now invoked broadly—verify that tool components that should accept the compact mode color implement or safely ignore setCompactToolModeColor.
- tool-execution-enhanced contains substantial behavior changes (ANSI/color handling, shell footer wrapping/tokenization, compact continuation rules); prioritize reviewing ANSI/color correctness, shell footer wrapping/highlighting across wrapped lines (including ampersand handling), spacing invariants around streaming vs completed components, and boundary insertion/reconciliation logic.
- Tests are extensive; confirm changes reflect intended rendering semantics rather than accidental formatting-only differences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->