### PR TITLE
feat(core): add harness v1 subpath scaffold

### DIFF
--- a/.changeset/tough-clubs-mate.md
+++ b/.changeset/tough-clubs-mate.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': minor
+---
+
+Preview: `@mastra/core/harness/v1` can now be imported for early migration work. It exposes the new `Harness` and `Session` entry points that will host the v1 Harness + Session split as the implementation lands.
+
+```ts
+import { Harness, Session } from '@mastra/core/harness/v1';
+```
+
+This v1 entry point is not production-ready yet; continue using `@mastra/core/harness` for stable Harness behavior until the follow-up migration PRs land.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -251,6 +251,16 @@
         "default": "./dist/harness/index.cjs"
       }
     },
+    "./harness/v1": {
+      "import": {
+        "types": "./dist/harness/v1/index.d.ts",
+        "default": "./dist/harness/v1/index.js"
+      },
+      "require": {
+        "types": "./dist/harness/v1/index.d.ts",
+        "default": "./dist/harness/v1/index.cjs"
+      }
+    },
     "./hooks": {
       "import": {
         "types": "./dist/hooks/index.d.ts",

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -1,0 +1,3 @@
+export class Harness {
+  constructor(readonly config: Record<string, unknown> = {}) {}
+}

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Harness v1 public entry point.
+ *
+ * This subpath is introduced separately from the runtime implementation so the
+ * migration stack can land reviewable foundations before the Harness + Session
+ * behavior is extracted from the fork.
+ */
+
+export { Harness } from './harness';
+export { Session } from './session';
+
+export type {
+  HarnessMessage,
+  HarnessMessageContent,
+  HarnessMode,
+  HarnessThread,
+  ToolCategory,
+  ToolsetInput,
+  Workspace,
+  WorkspaceConfig,
+} from './shared';

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1,0 +1,3 @@
+export class Session {
+  constructor(readonly id: string) {}
+}

--- a/packages/core/src/harness/v1/shared.ts
+++ b/packages/core/src/harness/v1/shared.ts
@@ -1,0 +1,7 @@
+import type { HarnessMode as LegacyHarnessMode } from '../types';
+
+export type { ToolsInput as ToolsetInput } from '../../agent/types';
+export type { Workspace, WorkspaceConfig } from '../../workspace';
+export type { HarnessMessage, HarnessMessageContent, HarnessThread, ToolCategory } from '../types';
+
+export type HarnessMode<TState = unknown> = LegacyHarnessMode<TState>;

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
     'src/evals/scoreTraces/index.ts',
     'src/agent/message-list/index.ts',
     'src/agent/durable/index.ts',
+    'src/harness/v1/index.ts',
     'src/auth/ee/index.ts',
     'src/agent-builder/ee/index.ts',
     'src/storage/domains/agents/index.ts',


### PR DESCRIPTION
## Description

Adds the first @mastra/core/harness/v1 package entry point for the Harness v1 migration stack.

This PR intentionally includes only the import/build scaffold: package exports, tsup entry, minimal Harness and Session exports, and stable shared type re-exports from existing canonical core modules. Runtime behavior remains in follow-up PRs where the audited fork implementation is extracted in reviewable slices.

Source evidence: this matches the package export/build-entry shape from the fork source branch, with implementation intentionally deferred from backup/harness-v1-fork-source.

## Related issue(s)

Refs #16816
Stacked on #16817

## Type of change

- [x] New feature
- [x] Code refactoring

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Verification

- pnpm build:core
- pnpm --filter ./packages/core check
- pnpm --filter ./packages/core lint
- pnpm prettier --check packages/core/package.json packages/core/tsup.config.ts packages/core/src/harness/v1 .changeset/tough-clubs-mate.md
- ESM import smoke from packages/core: import('@mastra/core/harness/v1')
- CJS import smoke from packages/core: require('@mastra/core/harness/v1')
- codex review --base chore/harness-legacy-rename