### PR TITLE
chore(playground-ui): upgrade @base-ui/react to 1.5

### DIFF
--- a/.changeset/metal-boats-walk.md
+++ b/.changeset/metal-boats-walk.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Upgraded the `@base-ui/react` dependency to 1.5.

--- a/.changeset/metal-boats-walk.md
+++ b/.changeset/metal-boats-walk.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Upgraded the `@base-ui/react` dependency to 1.5.
+Upgraded `@base-ui/react` to 1.5, making popups noticeably faster — components built on Base UI such as `Tooltip`, `Popover`, `DropdownMenu` and `ContextMenu` now open and close more quickly.

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -59,7 +59,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@assistant-ui/react-ui": "^0.2.1",
-    "@base-ui/react": "^1.3.0",
+    "@base-ui/react": "^1.5.0",
     "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4412,8 +4412,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1(@assistant-ui/react-markdown@0.12.11(@assistant-ui/react@0.14.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@assistant-ui/react@0.14.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
       '@base-ui/react':
-        specifier: ^1.3.0
-        version: 1.4.1(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^1.5.0
+        version: 1.5.0(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@codemirror/autocomplete':
         specifier: ^6.20.1
         version: 6.20.1
@@ -9712,8 +9712,8 @@ packages:
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
-  '@base-ui/react@1.4.1':
-    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+  '@base-ui/react@1.5.0':
+    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -9729,8 +9729,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.2.8':
-    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -31992,10 +31992,10 @@ snapshots:
 
   '@balena/dockerignore@1.0.2': {}
 
-  '@base-ui/react@1.4.1(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@base-ui/react@1.5.0(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@base-ui/utils': 0.2.9(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@floating-ui/utils': 0.2.11
       react: 19.2.6
@@ -32005,7 +32005,7 @@ snapshots:
       '@types/react': 19.2.14
       date-fns: 4.1.0
 
-  '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@base-ui/utils@0.2.9(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11


### PR DESCRIPTION
## Summary

- Bumps `@base-ui/react` from `^1.3.0` to `^1.5.0` in `@mastra/playground-ui`.
- Pure dependency upgrade — no API or component changes.

## Note

Draft until the `pnpm-lock.yaml` update lands. `@base-ui/react@1.5.0` was published <24h ago and is currently blocked by the repo's `minimumReleaseAge` gate (1 day). The lockfile commit will be pushed once the gate passes (~1h after opening), at which point this can be marked ready.

## Test plan

- [ ] `pnpm install --filter @mastra/playground-ui` updates lockfile cleanly
- [ ] `pnpm build` on `@mastra/playground-ui` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR upgrades a UI helper library (Base UI) used by the playground from version 1.3 to 1.5 so popup components open/close faster; it's a safe dependency bump with no API changes.

## Overview

- Bumps `@base-ui/react` from ^1.3.0 to ^1.5.0 in packages/playground-ui.
- Adds a changeset to publish a patch release for `@mastra/playground-ui` documenting the upgrade and popup performance improvements.
- No exported/public API changes.

## Changes

- packages/playground-ui/package.json: dependency updated to "`@base-ui/react`": "^1.5.0"
- .changeset/metal-boats-walk.md: notes patch release and improved popup open/close performance

## Status Notes

- PR is currently draft. `@base-ui/react`@1.5.0 was published <24h ago and the repo enforces a minimumReleaseAge gate (1 day). The pnpm lockfile update has not been committed yet; it will be added once the gate passes (≈1 hour after opening), at which point the PR can be marked ready.

## Testing

- Expected checklist:
  - pnpm install --filter `@mastra/playground-ui` updates lockfile cleanly (lockfile commit pending gate)
  - pnpm build on `@mastra/playground-ui` — should pass (no source changes)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->