### PR TITLE
feat(playground-ui): condensed DataList primitives + Dataset Items list refactor

### DIFF
--- a/.changeset/data-list-selection-row-primitives.md
+++ b/.changeset/data-list-selection-row-primitives.md
@@ -1,0 +1,40 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added `DataList` primitives and props for building selection-aware, condensed list rows that match the Traces/Logs visual style.
+
+**New cells** on `DataList`:
+
+- `IdCell` — compact mono cell that truncates long IDs to 8 chars.
+- `MonoCell` — compact mono + truncate text cell (for input previews, JSON summaries, etc.).
+- `DateCell` — compact date cell rendering "Today" or "MMM dd".
+- `TimeCell` — compact mono time cell rendering `HH:mm:ss.SSS` with the millisecond portion tinted.
+- `SelectCell` — labelled checkbox cell with a shift-key range-select handler.
+- `TopSelectCell` — header version with `indeterminate` support for "select all".
+- `TopCells` — non-interactive header sibling of `RowButton`, for hosting top cells beside a leading select cell.
+
+**New props** on `DataList.RowButton` and `DataList.RowLink`:
+
+- `flushLeft` — drops the default left margin when wrapped beside a leading cell.
+- `colStart` — places the row starting at a column line (e.g. `colStart={2}` to leave column 1 for a leading cell).
+- `featured` — applies the highlighted background to mark the active row.
+
+**New props** on existing wrappers:
+
+- `as` on `DataList.Cell` and `DataList.TopCell` — render the cell as any HTML element (e.g. `<label>` so the whole cell is clickable).
+- `hasLeadingCell` on `DataList.Top` — drops default gap and left padding so a leading cell sits flush, mirroring how `Row` + `RowButton` compose.
+
+**Example** — selection row with a checkbox in column 1 and an interactive button spanning the rest:
+
+```tsx
+<DataList.Row>
+  <DataList.SelectCell checked={isSelected} onToggle={shiftKey => toggle(id, shiftKey)} />
+  <DataList.RowButton flushLeft colStart={2} featured={isFeatured} onClick={onRowClick}>
+    <DataList.IdCell id={item.id} />
+    <DataList.MonoCell>{item.input}</DataList.MonoCell>
+  </DataList.RowButton>
+</DataList.Row>
+```
+
+Internally the Traces and Logs list views now use the shared primitives — no behavior change for those consumers.

--- a/.changeset/dataset-items-list-condensed.md
+++ b/.changeset/dataset-items-list-condensed.md
@@ -2,4 +2,4 @@
 '@internal/playground': patch
 ---
 
-Refactored the Dataset Items list to use the condensed `DataList` primitives, so it matches the Traces and Logs visual style. Rows are tighter, the ID column uses a shared truncated mono cell, and selection mode now renders a flush checkbox cell beside the row button without misalignment.
+Improved the Dataset Items list to use the condensed `DataList` primitives, so it matches the Traces and Logs visual style. Rows are tighter, the ID column uses a shared truncated mono cell, and selection mode now renders a flush checkbox cell beside the row button without misalignment.

--- a/.changeset/dataset-items-list-condensed.md
+++ b/.changeset/dataset-items-list-condensed.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Refactored the Dataset Items list to use the condensed `DataList` primitives, so it matches the Traces and Logs visual style. Rows are tighter, the ID column uses a shared truncated mono cell, and selection mode now renders a flush checkbox cell beside the row button without misalignment.

--- a/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
+++ b/packages/playground-ui/src/domains/logs/components/logs-list-view.tsx
@@ -2,7 +2,6 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { useEffect, useRef } from 'react';
 import type { LogRecord } from '../types';
 import { LogsDataList, LogsDataListSkeleton } from '@/ds/components/LogsDataList';
-import { cn } from '@/lib/utils';
 
 // Fixed widths on non-flex columns prevent track shifts as the virtualizer swaps rows in/out.
 const COLUMNS = '6rem 9rem 5rem 10rem minmax(8rem,1fr) minmax(8rem,1fr)';
@@ -109,7 +108,7 @@ export function LogsListView({
                 ref={virtualizer.measureElement}
                 data-index={vi.index}
                 onClick={() => onLogClick(log)}
-                className={cn(isFeatured && 'bg-surface4')}
+                featured={isFeatured}
               >
                 <LogsDataList.DateCell timestamp={log.timestamp} />
                 <LogsDataList.TimeCell timestamp={log.timestamp} />

--- a/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
+++ b/packages/playground-ui/src/domains/traces/components/traces-list-view.tsx
@@ -150,7 +150,8 @@ export function TracesListView({
                 ref={virtualizer.measureElement}
                 data-index={vi.index}
                 onClick={() => onTraceClick(trace)}
-                className={cn(isFeatured && 'bg-surface4', isRecentlyAdded && 'animate-row-highlight')}
+                featured={isFeatured}
+                className={cn(isRecentlyAdded && 'animate-row-highlight')}
               >
                 <TracesDataList.DateCell timestamp={displayDate} />
                 <TracesDataList.TimeCell timestamp={displayDate} />

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list-cells.tsx
@@ -1,82 +1,10 @@
-import { format, isToday } from 'date-fns';
 import { CornerDownRightIcon, ListTreeIcon } from 'lucide-react';
-import { DataListCell } from '../data-list-cells';
+import { DataListCell, DataListMonoCell } from '../data-list-cells';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { WorkflowIcon } from '@/ds/icons/WorkflowIcon';
 import { Colors } from '@/ds/tokens/colors';
 import { cn } from '@/lib/utils';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function toDate(value: Date | string): Date | null {
-  const date = value instanceof Date ? value : new Date(value);
-  return isNaN(date.getTime()) ? null : date;
-}
-
-function getShortId(id: string | undefined): string {
-  if (!id) return '';
-  return id.length > 8 ? id.slice(0, 8) : id;
-}
-
-// ---------------------------------------------------------------------------
-// IdCell
-// ---------------------------------------------------------------------------
-
-export interface TracesDataListIdCellProps {
-  traceId: string;
-}
-
-export function TracesDataListIdCell({ traceId }: TracesDataListIdCellProps) {
-  return (
-    <DataListCell height="compact" className="text-ui-smd font-mono text-neutral3">
-      {getShortId(traceId)}
-    </DataListCell>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// DateCell
-// ---------------------------------------------------------------------------
-
-export interface TracesDataListDateCellProps {
-  timestamp: Date | string;
-}
-
-export function TracesDataListDateCell({ timestamp }: TracesDataListDateCellProps) {
-  const date = toDate(timestamp);
-  return (
-    <DataListCell height="compact" className="text-ui-smd text-neutral2">
-      {date ? (isToday(date) ? 'Today' : format(date, 'MMM dd')) : '-'}
-    </DataListCell>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// TimeCell
-// ---------------------------------------------------------------------------
-
-export interface TracesDataListTimeCellProps {
-  timestamp: Date | string;
-}
-
-export function TracesDataListTimeCell({ timestamp }: TracesDataListTimeCellProps) {
-  const date = toDate(timestamp);
-  return (
-    <DataListCell height="compact" className="text-ui-smd font-mono text-neutral3 flex">
-      {date ? (
-        <>
-          {format(date, 'HH:mm:ss')}
-          <span className="text-neutral2">.{String(date.getMilliseconds()).padStart(3, '0')}</span>
-        </>
-      ) : (
-        '-'
-      )}
-    </DataListCell>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // NameCell
@@ -124,11 +52,7 @@ export interface TracesDataListInputCellProps {
 }
 
 export function TracesDataListInputCell({ input }: TracesDataListInputCellProps) {
-  return (
-    <DataListCell height="compact" className="min-w-0">
-      <span className="block text-neutral3 text-ui-smd font-mono truncate">{input || '-'}</span>
-    </DataListCell>
-  );
+  return <DataListMonoCell>{input || '-'}</DataListMonoCell>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/TracesDataList/traces-data-list.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps } from 'react';
+import { DataListDateCell, DataListIdCell, DataListTimeCell } from '../data-list-cells';
 import { DataListNextPageLoading } from '../data-list-next-page-loading';
 import { DataListNoMatch } from '../data-list-no-match';
 import { DataListRoot } from '../data-list-root';
@@ -9,9 +10,6 @@ import { DataListSubHeading } from '../data-list-subheading';
 import { DataListTop } from '../data-list-top';
 import { DataListTopCell, DataListTopCellWithTooltip } from '../data-list-top-cell';
 import {
-  TracesDataListIdCell,
-  TracesDataListDateCell,
-  TracesDataListTimeCell,
   TracesDataListNameCell,
   TracesDataListInputCell,
   TracesDataListEntityCell,
@@ -31,9 +29,9 @@ export const TracesDataList = Object.assign(TracesDataListRoot, {
   Subheader: DataListSubheader,
   SubHeading: DataListSubHeading,
   Spacer: DataListSpacer,
-  IdCell: TracesDataListIdCell,
-  DateCell: TracesDataListDateCell,
-  TimeCell: TracesDataListTimeCell,
+  IdCell: DataListIdCell,
+  DateCell: DataListDateCell,
+  TimeCell: DataListTimeCell,
   NameCell: TracesDataListNameCell,
   InputCell: TracesDataListInputCell,
   EntityCell: TracesDataListEntityCell,

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -1,23 +1,33 @@
-import type { ReactNode } from 'react';
+import { format, isToday } from 'date-fns';
+import type { ComponentPropsWithoutRef, ElementType, MouseEvent, ReactNode } from 'react';
+import { Checkbox } from '@/ds/components/Checkbox';
 import { cn } from '@/lib/utils';
 
 export type DataListCellProps = {
   children: ReactNode;
   className?: string;
   height?: 'default' | 'compact';
-};
+  /**
+   * HTML element rendered for the cell. Defaults to `span`. Use `'label'` when
+   * the cell wraps a labelable control (e.g. a Checkbox), so the whole cell
+   * area acts as the click/hover target.
+   */
+  as?: ElementType;
+} & Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className'>;
 
-export function DataListCell({ children, className, height = 'default' }: DataListCellProps) {
+export function DataListCell({ children, className, height = 'default', as, ...rest }: DataListCellProps) {
+  const Component = as || 'span';
   return (
-    <span
+    <Component
       className={cn(
         'relative grid items-center text-ui-md whitespace-nowrap text-neutral3',
         height === 'compact' ? 'py-2' : 'py-4',
         className,
       )}
+      {...rest}
     >
       {children}
-    </span>
+    </Component>
   );
 }
 
@@ -37,6 +47,113 @@ export function DataListDescriptionCell({ children, className }: DataListCellPro
   return (
     <DataListCell className={cn('text-neutral2', className)}>
       <span className="truncate">{children}</span>
+    </DataListCell>
+  );
+}
+
+function getShortId(id: string | undefined): string {
+  if (!id) return '';
+  return id.length > 8 ? id.slice(0, 8) : id;
+}
+
+export interface DataListIdCellProps {
+  id: string;
+}
+
+export function DataListIdCell({ id }: DataListIdCellProps) {
+  return (
+    <DataListCell height="compact" className="text-ui-smd font-mono text-neutral3">
+      {getShortId(id)}
+    </DataListCell>
+  );
+}
+
+export interface DataListSelectCellProps {
+  checked: boolean;
+  /**
+   * Called when the checkbox is clicked. Receives the click event's `shiftKey`
+   * so callers can implement range-select. The event's propagation is stopped
+   * before `onToggle` runs, so the host row's `onClick` doesn't fire.
+   */
+  onToggle: (shiftKey: boolean) => void;
+  'aria-label'?: string;
+}
+
+export function DataListSelectCell({ checked, onToggle, ...rest }: DataListSelectCellProps) {
+  return (
+    <DataListCell
+      as="label"
+      height="compact"
+      className="cursor-pointer justify-items-center rounded-lg transition-colors duration-200 hover:bg-surface4 px-4"
+      onClick={e => e.stopPropagation()}
+    >
+      <Checkbox
+        checked={checked}
+        onCheckedChange={() => {}} // no-op: selection handled by onClick to capture shiftKey
+        onClick={(e: MouseEvent<HTMLButtonElement>) => {
+          e.stopPropagation();
+          onToggle(e.shiftKey);
+        }}
+        aria-label={rest['aria-label']}
+      />
+    </DataListCell>
+  );
+}
+
+export interface DataListMonoCellProps {
+  children: ReactNode;
+  /** Override classes on the inner span (e.g. swap the default `text-neutral3` tone). */
+  className?: string;
+}
+
+/**
+ * Compact mono-typography cell with truncation. Shared by any column that
+ * shows code-like text (input previews, JSON summaries, identifiers, etc.).
+ */
+export function DataListMonoCell({ children, className }: DataListMonoCellProps) {
+  return (
+    <DataListCell height="compact" className="min-w-0">
+      <span className={cn('block text-ui-smd font-mono text-neutral3 truncate', className)}>{children}</span>
+    </DataListCell>
+  );
+}
+
+function toDate(value: Date | string): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+  return isNaN(date.getTime()) ? null : date;
+}
+
+export interface DataListDateCellProps {
+  timestamp: Date | string;
+}
+
+/** Compact date cell — `Today` or `MMM dd` (e.g. `May 19`). */
+export function DataListDateCell({ timestamp }: DataListDateCellProps) {
+  const date = toDate(timestamp);
+  return (
+    <DataListCell height="compact" className="text-ui-smd text-neutral2">
+      {date ? (isToday(date) ? 'Today' : format(date, 'MMM dd')) : '-'}
+    </DataListCell>
+  );
+}
+
+export interface DataListTimeCellProps {
+  timestamp: Date | string;
+}
+
+/** Compact monospace time cell — `HH:mm:ss.SSS` with the millisecond portion tinted. */
+export function DataListTimeCell({ timestamp }: DataListTimeCellProps) {
+  const date = toDate(timestamp);
+  return (
+    <DataListCell height="compact" className="text-ui-smd font-mono text-neutral3 flex">
+      {date ? (
+        <>
+          {format(date, 'HH:mm:ss')}
+          <span className="text-neutral2">.{String(date.getMilliseconds()).padStart(3, '0')}</span>
+        </>
+      ) : (
+        '-'
+      )}
     </DataListCell>
   );
 }

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
@@ -1,18 +1,25 @@
 import { forwardRef } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
 import { dataListRowStyles } from './shared';
+import type { DataListRowSharedProps } from './shared';
 import { cn } from '@/lib/utils';
 
-export type DataListRowButtonProps = ComponentPropsWithoutRef<'button'>;
+export type DataListRowButtonProps = ComponentPropsWithoutRef<'button'> & DataListRowSharedProps;
 
 /**
  * Forwarded ref + spread props so virtualizers (`useVirtualizer.measureElement`)
  * can attach a ref and `data-index` to each rendered row.
  */
 export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButtonProps>(
-  ({ children, className, type = 'button', ...rest }, ref) => {
+  ({ children, className, type = 'button', flushLeft, colStart, featured, style, ...rest }, ref) => {
     return (
-      <button ref={ref} type={type} className={cn(...dataListRowStyles, 'text-left', className)} {...rest}>
+      <button
+        ref={ref}
+        type={type}
+        className={cn(...dataListRowStyles, 'text-left', flushLeft && 'ml-0!', featured && 'bg-surface4', className)}
+        style={colStart ? { ...style, gridColumn: `${colStart} / -1` } : style}
+        {...rest}
+      >
         {children}
       </button>
     );

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
@@ -1,18 +1,33 @@
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { dataListRowStyles } from './shared';
+import type { DataListRowSharedProps } from './shared';
 import type { LinkComponent } from '@/ds/types/link-component';
 import { cn } from '@/lib/utils';
 
-export type DataListRowLinkProps = {
+export type DataListRowLinkProps = DataListRowSharedProps & {
   children: ReactNode;
   to: string;
   className?: string;
+  style?: CSSProperties;
   LinkComponent: LinkComponent;
 };
 
-export function DataListRowLink({ children, to, className, LinkComponent: Link }: DataListRowLinkProps) {
+export function DataListRowLink({
+  children,
+  to,
+  className,
+  style,
+  LinkComponent: Link,
+  flushLeft,
+  colStart,
+  featured,
+}: DataListRowLinkProps) {
   return (
-    <Link href={to} className={cn(...dataListRowStyles, className)}>
+    <Link
+      href={to}
+      className={cn(...dataListRowStyles, flushLeft && 'ml-0!', featured && 'bg-surface4', className)}
+      style={colStart ? { ...style, gridColumn: `${colStart} / -1` } : style}
+    >
       {children}
     </Link>
   );

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row.tsx
@@ -1,17 +1,18 @@
 import { forwardRef } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
-import { dataListRowStyles } from './shared';
 import { cn } from '@/lib/utils';
 
 export type DataListRowProps = ComponentPropsWithoutRef<'div'>;
 
 /**
- * Forwarded ref + spread props so virtualizers (`useVirtualizer.measureElement`)
- * can attach a ref and `data-index` to each rendered row.
+ * Non-interactive grid wrapper. Used to host a leading cell (e.g. a selection
+ * checkbox) alongside a `DataList.RowButton` so hover/focus/click only apply to
+ * the button portion. For standalone interactive rows, use `DataList.RowButton`
+ * directly without this wrapper.
  */
 export const DataListRow = forwardRef<HTMLDivElement, DataListRowProps>(({ children, className, ...rest }, ref) => {
   return (
-    <div ref={ref} className={cn(...dataListRowStyles, className)} {...rest}>
+    <div ref={ref} className={cn('grid grid-cols-subgrid gap-0 col-span-full ml-1', className)} {...rest}>
       {children}
     </div>
   );

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cell.tsx
@@ -1,26 +1,36 @@
-import type { ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
 import { forwardRef } from 'react';
+import { Checkbox } from '@/ds/components/Checkbox';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/ds/components/Tooltip';
 import { cn } from '@/lib/utils';
 
 export type DataListTopCellProps = {
   children: ReactNode;
   className?: string;
-};
+  /**
+   * HTML element rendered for the top cell. Defaults to `span`. Use `'label'`
+   * when the cell wraps a labelable control (e.g. a select-all Checkbox).
+   */
+  as?: ElementType;
+} & Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className' | 'ref'>;
 
-export const DataListTopCell = forwardRef<HTMLSpanElement, DataListTopCellProps>(({ children, className }, ref) => {
-  return (
-    <span
-      ref={ref}
-      className={cn(
-        'h-8 py-1 flex items-center uppercase whitespace-nowrap text-neutral2 tracking-widest text-ui-xs',
-        className,
-      )}
-    >
-      {children}
-    </span>
-  );
-});
+export const DataListTopCell = forwardRef<HTMLSpanElement, DataListTopCellProps>(
+  ({ children, className, as, ...rest }, ref) => {
+    const Component = as || 'span';
+    return (
+      <Component
+        ref={ref}
+        className={cn(
+          'h-8 py-1 flex items-center uppercase whitespace-nowrap text-neutral2 tracking-widest text-ui-xs',
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  },
+);
 
 export type DataListTopCellWithTooltipProps = {
   children: ReactNode;
@@ -85,5 +95,25 @@ export function DataListTopCellSmart({
 
   return (
     <DataListTopCell className={cn('flex [&_svg]:w-[1.3em] [&_svg]:h-[1.3em]', className)}>{content}</DataListTopCell>
+  );
+}
+
+export interface DataListTopSelectCellProps {
+  /** Pass `'indeterminate'` when some — but not all — rows are selected. */
+  checked: boolean | 'indeterminate';
+  /** Toggles the global selection. Typically clears when fully selected, otherwise selects all. */
+  onToggle: () => void;
+  'aria-label'?: string;
+}
+
+export function DataListTopSelectCell({ checked, onToggle, ...rest }: DataListTopSelectCellProps) {
+  return (
+    <DataListTopCell
+      as="label"
+      className="cursor-pointer justify-center rounded-lg transition-colors duration-200 hover:bg-surface4 px-4"
+      onClick={e => e.stopPropagation()}
+    >
+      <Checkbox checked={checked} onCheckedChange={() => onToggle()} aria-label={rest['aria-label']} />
+    </DataListTopCell>
   );
 }

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cells.tsx
@@ -28,7 +28,7 @@ export const DataListTopCells = forwardRef<HTMLDivElement, DataListTopCellsProps
     return (
       <div
         ref={ref}
-        className={cn('grid grid-cols-subgrid gap-10 col-span-full px-5', flushLeft && 'pl-0!', className)}
+        className={cn('grid grid-cols-subgrid gap-8 col-span-full px-5', flushLeft && 'pl-0!', className)}
         style={colStart ? { ...style, gridColumn: `${colStart} / -1` } : style}
         {...rest}
       >

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top-cells.tsx
@@ -1,0 +1,41 @@
+import { forwardRef } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export type DataListTopCellsProps = ComponentPropsWithoutRef<'div'> & {
+  /**
+   * Drop the group's default left margin. Use when this sits as the second
+   * child of a gap-0 `DataList.Top`, beside a `DataList.TopSelectCell` that
+   * owns the leading column.
+   */
+  flushLeft?: boolean;
+  /**
+   * Place the group starting at this column line, spanning through to the
+   * last column. Defaults to the full grid (`col-span-full`). Use when this
+   * sits beside a leading cell that owns column 1.
+   */
+  colStart?: number;
+};
+
+/**
+ * Non-interactive header equivalent of `DataList.RowButton`. Groups a set of
+ * `DataList.TopCell`s with the same horizontal layout (gap, mx, px) as
+ * `RowButton`, so columns inside a wrapped `Top` line up cell-for-cell with the
+ * columns inside a wrapped `Row`.
+ */
+export const DataListTopCells = forwardRef<HTMLDivElement, DataListTopCellsProps>(
+  ({ children, className, flushLeft, colStart, style, ...rest }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn('grid grid-cols-subgrid gap-10 col-span-full px-5', flushLeft && 'pl-0!', className)}
+        style={colStart ? { ...style, gridColumn: `${colStart} / -1` } : style}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+DataListTopCells.displayName = 'DataListTopCells';

--- a/packages/playground-ui/src/ds/components/DataList/data-list-top.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-top.tsx
@@ -4,13 +4,21 @@ import { cn } from '@/lib/utils';
 export type DataListTopProps = {
   children: ReactNode;
   className?: string;
+  /**
+   * Switch to a "leading cell" layout: drops the default gap between children
+   * and the default left padding, so a leading cell (e.g. `TopSelectCell`)
+   * sits flush against the grid edge and an inner `TopCells` group owns the
+   * remaining column spacing. Mirrors how `Row` + `RowButton` compose.
+   */
+  hasLeadingCell?: boolean;
 };
 
-export function DataListTop({ children, className }: DataListTopProps) {
+export function DataListTop({ children, className, hasLeadingCell }: DataListTopProps) {
   return (
     <div
       className={cn(
-        'grid grid-cols-subgrid gap-6 lg:gap-8 xl:gap-10 2xl:gap-12 3xl:gap-14 col-span-full border-b border-border1 px-4 bg-surface2 sticky top-0 z-10',
+        'mx-1 grid grid-cols-subgrid gap-8 col-span-full border-b border-border1 px-5 bg-surface2 sticky top-0 z-10',
+        hasLeadingCell && 'gap-0 pl-0!',
         className,
       )}
     >

--- a/packages/playground-ui/src/ds/components/DataList/data-list.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list.tsx
@@ -1,4 +1,14 @@
-import { DataListCell, DataListTextCell, DataListNameCell, DataListDescriptionCell } from './data-list-cells';
+import {
+  DataListCell,
+  DataListTextCell,
+  DataListNameCell,
+  DataListDescriptionCell,
+  DataListIdCell,
+  DataListSelectCell,
+  DataListMonoCell,
+  DataListDateCell,
+  DataListTimeCell,
+} from './data-list-cells';
 import { DataListNextPageLoading } from './data-list-next-page-loading';
 import { DataListNoMatch } from './data-list-no-match';
 import { DataListPagination } from './data-list-pagination';
@@ -10,10 +20,17 @@ import { DataListSpacer } from './data-list-spacer';
 import { DataListSubheader } from './data-list-subheader';
 import { DataListSubHeading } from './data-list-subheading';
 import { DataListTop } from './data-list-top';
-import { DataListTopCell, DataListTopCellWithTooltip, DataListTopCellSmart } from './data-list-top-cell';
+import {
+  DataListTopCell,
+  DataListTopCellWithTooltip,
+  DataListTopCellSmart,
+  DataListTopSelectCell,
+} from './data-list-top-cell';
+import { DataListTopCells } from './data-list-top-cells';
 
 export const DataList = Object.assign(DataListRoot, {
   Top: DataListTop,
+  TopCells: DataListTopCells,
   TopCell: DataListTopCell,
   TopCellWithTooltip: DataListTopCellWithTooltip,
   TopCellSmart: DataListTopCellSmart,
@@ -24,6 +41,12 @@ export const DataList = Object.assign(DataListRoot, {
   TextCell: DataListTextCell,
   NameCell: DataListNameCell,
   DescriptionCell: DataListDescriptionCell,
+  IdCell: DataListIdCell,
+  MonoCell: DataListMonoCell,
+  DateCell: DataListDateCell,
+  TimeCell: DataListTimeCell,
+  SelectCell: DataListSelectCell,
+  TopSelectCell: DataListTopSelectCell,
   NoMatch: DataListNoMatch,
   Subheader: DataListSubheader,
   SubHeading: DataListSubHeading,

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -1,5 +1,5 @@
 export const dataListRowStyles = [
-  'mx-1 data-list-row grid grid-cols-subgrid gap-10 col-span-full px-5 outline-none cursor-pointer border-y border-b-border1 border-t-transparent',
+  'mx-1 data-list-row grid grid-cols-subgrid gap-8 col-span-full px-5 outline-none cursor-pointer border-y border-b-border1 border-t-transparent',
   'hover:bg-surface4 hover:border-transparent focus-visible:bg-surface4 focus-visible:border-transparent focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent1',
   '[.data-list-row:hover+&]:border-t-transparent [.data-list-row:focus-visible+&]:border-t-transparent',
   '[.data-list-subheader+&]:border-t-transparent',
@@ -7,3 +7,27 @@ export const dataListRowStyles = [
   '[&:not(:has(~.data-list-row))]:border-b-transparent',
   'transition-colors duration-200 rounded-lg',
 ] as const;
+
+/**
+ * Layout/state modifiers shared by interactive row primitives
+ * (`DataList.RowButton`, `DataList.RowLink`).
+ */
+export type DataListRowSharedProps = {
+  /**
+   * Drop the row's default left margin. Use when the row is wrapped in a
+   * `DataList.Row` that owns the leading inset (e.g. for selection rows where
+   * the checkbox cell sits on the left).
+   */
+  flushLeft?: boolean;
+  /**
+   * Place the row starting at this column line, spanning through to the last
+   * column. Defaults to the full grid (`col-span-full`). Use when the row
+   * sits beside a leading cell that owns column 1.
+   */
+  colStart?: number;
+  /**
+   * Apply the highlighted background. Use to mark the row that is currently
+   * featured (e.g. the row whose detail is open in a side panel).
+   */
+  featured?: boolean;
+};

--- a/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list-cells.tsx
@@ -1,19 +1,9 @@
-import { format, isToday } from 'date-fns';
-import { DataListCell } from '../DataList/data-list-cells';
+import { DataListCell, DataListMonoCell } from '../DataList/data-list-cells';
 type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { ToolsIcon } from '@/ds/icons/ToolsIcon';
 import { WorkflowIcon } from '@/ds/icons/WorkflowIcon';
 import { cn } from '@/lib/utils';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function toDate(value: Date | string): Date | null {
-  const date = value instanceof Date ? value : new Date(value);
-  return isNaN(date.getTime()) ? null : date;
-}
 
 const LEVEL_CONFIG: Record<LogLevel, { label: string; color: string }> = {
   debug: { label: 'DEBUG', color: '#71717a' },
@@ -39,47 +29,6 @@ export function LogsDataListLevelCell({ level }: LogsDataListLevelCellProps) {
       <span className="uppercase text-ui-sm font-semibold" style={{ color: config.color }}>
         {config.label}
       </span>
-    </DataListCell>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// DateCell
-// ---------------------------------------------------------------------------
-
-export interface LogsDataListDateCellProps {
-  timestamp: Date | string;
-}
-
-export function LogsDataListDateCell({ timestamp }: LogsDataListDateCellProps) {
-  const date = toDate(timestamp);
-  return (
-    <DataListCell height="compact" className="text-ui-smd text-neutral2">
-      {date ? (isToday(date) ? 'Today' : format(date, 'MMM dd')) : '-'}
-    </DataListCell>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// TimeCell
-// ---------------------------------------------------------------------------
-
-export interface LogsDataListTimeCellProps {
-  timestamp: Date | string;
-}
-
-export function LogsDataListTimeCell({ timestamp }: LogsDataListTimeCellProps) {
-  const date = toDate(timestamp);
-  return (
-    <DataListCell height="compact" className="text-ui-smd font-mono text-neutral3 flex">
-      {date ? (
-        <>
-          {format(date, 'HH:mm:ss')}
-          <span className="text-neutral2">.{String(date.getMilliseconds()).padStart(3, '0')}</span>
-        </>
-      ) : (
-        '-'
-      )}
     </DataListCell>
   );
 }
@@ -158,9 +107,5 @@ export function LogsDataListDataCell({ data }: LogsDataListDataCellProps) {
     })
     .join(', ');
 
-  return (
-    <DataListCell height="compact" className="min-w-0">
-      <span className="block text-neutral3 text-ui-smd font-mono truncate">{summary}</span>
-    </DataListCell>
-  );
+  return <DataListMonoCell>{summary}</DataListMonoCell>;
 }

--- a/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list.tsx
+++ b/packages/playground-ui/src/ds/components/LogsDataList/logs-data-list.tsx
@@ -1,3 +1,4 @@
+import { DataListDateCell, DataListTimeCell } from '../DataList/data-list-cells';
 import { DataListNextPageLoading } from '../DataList/data-list-next-page-loading';
 import { DataListNoMatch } from '../DataList/data-list-no-match';
 import { DataListRoot } from '../DataList/data-list-root';
@@ -9,8 +10,6 @@ import { DataListTop } from '../DataList/data-list-top';
 import { DataListTopCell, DataListTopCellWithTooltip, DataListTopCellSmart } from '../DataList/data-list-top-cell';
 import {
   LogsDataListLevelCell,
-  LogsDataListDateCell,
-  LogsDataListTimeCell,
   LogsDataListEntityCell,
   LogsDataListMessageCell,
   LogsDataListDataCell,
@@ -26,8 +25,8 @@ export const LogsDataList = Object.assign(DataListRoot, {
   RowLink: DataListRowLink,
   Spacer: DataListSpacer,
   NoMatch: DataListNoMatch,
-  DateCell: LogsDataListDateCell,
-  TimeCell: LogsDataListTimeCell,
+  DateCell: DataListDateCell,
+  TimeCell: DataListTimeCell,
   LevelCell: LogsDataListLevelCell,
   EntityCell: LogsDataListEntityCell,
   MessageCell: LogsDataListMessageCell,

--- a/packages/playground/e2e/tests/__utils__/index.ts
+++ b/packages/playground/e2e/tests/__utils__/index.ts
@@ -7,4 +7,5 @@
 export * from './auth';
 export * from './reset-storage';
 export * from './seed-datasets';
+export * from './seed-dataset-items';
 export * from './select-fixture';

--- a/packages/playground/e2e/tests/__utils__/seed-dataset-items.ts
+++ b/packages/playground/e2e/tests/__utils__/seed-dataset-items.ts
@@ -1,0 +1,52 @@
+const PORT = process.env.E2E_PORT || '4111';
+const BASE_URL = `http://localhost:${PORT}`;
+
+export interface SeededDataset {
+  id: string;
+  name: string;
+  itemIds: string[];
+}
+
+/**
+ * Creates a dataset with items via the Studio API.
+ * Returns dataset ID, name, and item IDs.
+ */
+export const seedDatasetWithItems = async (
+  itemCount: number,
+  datasetName = 'E2E Items Dataset',
+): Promise<SeededDataset> => {
+  const datasetRes = await fetch(`${BASE_URL}/api/datasets`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: datasetName }),
+  });
+
+  if (!datasetRes.ok) {
+    throw new Error(`Failed to create dataset: ${datasetRes.status} ${datasetRes.statusText}`);
+  }
+
+  const dataset = (await datasetRes.json()) as { id: string };
+
+  const items = Array.from({ length: itemCount }, (_, i) => ({
+    input: `Test input ${i + 1}`,
+    groundTruth: `Expected output ${i + 1}`,
+  }));
+
+  const itemsRes = await fetch(`${BASE_URL}/api/datasets/${dataset.id}/items/batch`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ items }),
+  });
+
+  if (!itemsRes.ok) {
+    throw new Error(`Failed to add items: ${itemsRes.status} ${itemsRes.statusText}`);
+  }
+
+  const itemsData = (await itemsRes.json()) as { items: { id: string }[] };
+
+  return {
+    id: dataset.id,
+    name: datasetName,
+    itemIds: itemsData.items.map(i => i.id),
+  };
+};

--- a/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
+++ b/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
 import { resetStorage, seedDatasetWithItems } from '../__utils__';
 
-const BASE_URL = 'http://localhost:4111';
+const PORT = process.env.E2E_PORT || '4111';
+const BASE_URL = `http://localhost:${PORT}`;
 
 test.afterEach(async () => {
   await resetStorage();
@@ -86,6 +87,9 @@ test.describe('Dataset Items List - Behavior Tests', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ name: 'Empty E2E Dataset' }),
     });
+    if (!datasetRes.ok) {
+      throw new Error(`Failed to create empty dataset: ${datasetRes.status} ${datasetRes.statusText}`);
+    }
     const dataset = (await datasetRes.json()) as { id: string };
 
     await page.goto(`/datasets/${dataset.id}`);

--- a/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
+++ b/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test';
+import { resetStorage, seedDatasetWithItems } from '../__utils__';
+
+const BASE_URL = 'http://localhost:4111';
+
+test.afterEach(async () => {
+  await resetStorage();
+});
+
+/**
+ * FEATURE: Dataset items list
+ * USER STORY: As a user, I want to view and manage items in a dataset so I can prepare data for experiments.
+ * BEHAVIOR UNDER TEST: Items list displays data, supports selection, and enables bulk operations.
+ */
+
+test.describe('Dataset Items List - Behavior Tests', () => {
+  test('clicking an item row opens the detail panel showing item metadata', async ({ page }) => {
+    const { id: datasetId } = await seedDatasetWithItems(3);
+
+    await page.goto(`/datasets/${datasetId}`);
+    await expect(page.getByText('Test input 1')).toBeVisible();
+
+    await page.getByRole('button', { name: /Test input 1/ }).click();
+
+    await expect(page.getByText(/Created May/).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('selecting Delete Items from menu enables selection mode with checkboxes', async ({ page }) => {
+    const { id: datasetId } = await seedDatasetWithItems(3);
+
+    await page.goto(`/datasets/${datasetId}`);
+    await expect(page.getByText('Test input 1')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Actions menu', exact: true }).click();
+    await page.getByRole('menuitem', { name: /Delete Items/i }).click();
+
+    await expect(page.getByRole('checkbox').first()).toBeVisible();
+
+    const checkbox1 = page.getByRole('checkbox').first();
+    await checkbox1.click();
+
+    await expect(page.getByText(/selected/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /Delete Items/i })).toBeEnabled();
+  });
+
+  test('bulk delete removes selected items from the list', async ({ page }) => {
+    const { id: datasetId } = await seedDatasetWithItems(3);
+
+    await page.goto(`/datasets/${datasetId}`);
+
+    await expect(page.getByText('Test input 1')).toBeVisible();
+    await expect(page.getByText('Test input 2')).toBeVisible();
+    await expect(page.getByText('Test input 3')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Actions menu', exact: true }).click();
+    await page.getByRole('menuitem', { name: /Delete Items/i }).click();
+
+    const selectAllCheckbox = page.getByRole('checkbox', { name: /Select all/i });
+    await selectAllCheckbox.click();
+
+    await page.getByRole('button', { name: /Delete Items/i }).click();
+
+    const confirmButton = page.getByRole('button', { name: /^Delete$/i });
+    await confirmButton.click();
+
+    await expect(page.getByText('No items yet')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('search filters items by input content', async ({ page }) => {
+    const { id: datasetId } = await seedDatasetWithItems(5);
+
+    await page.goto(`/datasets/${datasetId}`);
+    await expect(page.getByText('Test input 1')).toBeVisible();
+    await expect(page.getByText('Test input 5')).toBeVisible();
+
+    await page.getByPlaceholder(/Search/i).fill('input 3');
+
+    await expect(page.getByText('Test input 3')).toBeVisible();
+    await expect(page.getByText('Test input 1')).not.toBeVisible();
+    await expect(page.getByText('Test input 5')).not.toBeVisible();
+  });
+
+  test('empty dataset shows empty state with add item actions', async ({ page }) => {
+    const datasetRes = await fetch(`${BASE_URL}/api/datasets`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Empty E2E Dataset' }),
+    });
+    const dataset = (await datasetRes.json()) as { id: string };
+
+    await page.goto(`/datasets/${dataset.id}`);
+
+    await expect(page.getByText('No items yet')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Add Single Item/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Import CSV/i })).toBeVisible();
+  });
+
+  test('select all checkbox selects all visible items in selection mode', async ({ page }) => {
+    const { id: datasetId } = await seedDatasetWithItems(3);
+
+    await page.goto(`/datasets/${datasetId}`);
+    await expect(page.getByText('Test input 1')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Actions menu', exact: true }).click();
+    await page.getByRole('menuitem', { name: /Delete Items/i }).click();
+
+    const selectAllCheckbox = page.getByRole('checkbox', { name: /Select all/i });
+    await selectAllCheckbox.click();
+
+    await expect(page.getByText('items selected')).toBeVisible();
+  });
+
+  test('cancel button clears selection and exits selection mode', async ({ page }) => {
+    const { id: datasetId } = await seedDatasetWithItems(3);
+
+    await page.goto(`/datasets/${datasetId}`);
+    await expect(page.getByText('Test input 1')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Actions menu', exact: true }).click();
+    await page.getByRole('menuitem', { name: /Delete Items/i }).click();
+
+    const checkbox = page.getByRole('checkbox').nth(1);
+    await checkbox.click();
+    await expect(page.getByText(/selected/i)).toBeVisible();
+
+    await page.getByRole('button', { name: /Cancel/i }).click();
+
+    await expect(page.getByText(/selected/i)).not.toBeVisible();
+    await expect(page.getByRole('checkbox')).toHaveCount(0);
+  });
+});

--- a/packages/playground/src/domains/datasets/components/items/dataset-items-list.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items-list.tsx
@@ -1,5 +1,5 @@
 import type { DatasetItem } from '@mastra/client-js';
-import { Button, ButtonsGroup, Checkbox, EmptyState, EntityList, Spinner, Txt } from '@mastra/playground-ui';
+import { Button, ButtonsGroup, DataList, EmptyState } from '@mastra/playground-ui';
 import { format, isThisYear, isToday } from 'date-fns';
 import { Plus, Upload, FileJson } from 'lucide-react';
 
@@ -99,103 +99,89 @@ export function DatasetItemsList({
     onToggleSelection(id, shiftKey, allIds);
   };
 
-  const gridColumns = [isSelectionActive ? '2rem' : '', ...columns.map(c => c.size)].filter(Boolean).join(' ');
+  const gridColumns = [isSelectionActive ? 'auto' : '', ...columns.map(c => c.size)].filter(Boolean).join(' ');
 
   return (
-    <>
-      <EntityList columns={gridColumns}>
-        <EntityList.Top>
-          {isSelectionActive && !maxSelection && (
-            <EntityList.TopCell>
-              <Checkbox
-                checked={isIndeterminate ? 'indeterminate' : isAllSelected}
-                onCheckedChange={handleSelectAllToggle}
-                aria-label="Select all items"
-              />
-            </EntityList.TopCell>
-          )}
-          {isSelectionActive && maxSelection && <EntityList.TopCell>&nbsp;</EntityList.TopCell>}
-          {columns.map(col => (
-            <EntityList.TopCell key={col.name}>{col.label || col.name}</EntityList.TopCell>
-          ))}
-        </EntityList.Top>
-
-        {items.length === 0 && searchQuery ? (
-          <EntityList.NoMatch message="No items match your search" />
-        ) : (
-          <EntityList.Rows>
-            {items.map(item => {
-              const createdAtDate = new Date(item.createdAt);
-              const isSelected = featuredItemId === item.id;
-
-              return (
-                <EntityList.Row
-                  key={item.id}
-                  onClick={() => onItemClick?.(item.id)}
-                  selected={isSelected || selectedIds.has(item.id)}
-                >
-                  {isSelectionActive && (
-                    <EntityList.Cell>
-                      <Checkbox
-                        checked={selectedIds.has(item.id)}
-                        onCheckedChange={() => {}} // no-op: selection handled by onClick for shift-key multi-select
-                        onClick={e => {
-                          e.stopPropagation();
-                          handleToggleSelection(item.id, e.shiftKey, allIds);
-                        }}
-                        aria-label={`Select item ${item.id}`}
-                      />
-                    </EntityList.Cell>
-                  )}
-                  <EntityList.TextCell>
-                    <span className="truncate block font-mono">{item.id}</span>
-                  </EntityList.TextCell>
-                  <EntityList.TextCell>
-                    <span className="truncate block font-mono">{truncateValue(item.input, 60)}</span>
-                  </EntityList.TextCell>
-                  {columns.some(col => col.name === 'groundTruth') && (
-                    <EntityList.TextCell>
-                      <span className="truncate block font-mono">
-                        {item.groundTruth ? truncateValue(item.groundTruth, 40) : '-'}
-                      </span>
-                    </EntityList.TextCell>
-                  )}
-                  {columns.some(col => col.name === 'trajectory') && (
-                    <EntityList.TextCell>
-                      {item.expectedTrajectory ? (
-                        <span className="text-xs">
-                          {Array.isArray((item.expectedTrajectory as Record<string, unknown>)?.steps)
-                            ? `${((item.expectedTrajectory as Record<string, unknown>).steps as unknown[]).length} steps`
-                            : 'Yes'}
-                        </span>
-                      ) : (
-                        <span className="text-neutral4">—</span>
-                      )}
-                    </EntityList.TextCell>
-                  )}
-                  <EntityList.TextCell>
-                    <span className="truncate block text-neutral2">{formatDate(createdAtDate)}</span>
-                  </EntityList.TextCell>
-                </EntityList.Row>
-              );
-            })}
-
-            <div ref={setEndOfListElement} className="h-1 col-span-full">
-              {isFetchingNextPage && (
-                <div className="flex justify-center py-4">
-                  <Spinner />
-                </div>
-              )}
-            </div>
-          </EntityList.Rows>
+    <DataList columns={gridColumns}>
+      <DataList.Top hasLeadingCell={isSelectionActive}>
+        {isSelectionActive && !maxSelection && (
+          <DataList.TopSelectCell
+            checked={isIndeterminate ? 'indeterminate' : isAllSelected}
+            onToggle={handleSelectAllToggle}
+            aria-label="Select all items"
+          />
         )}
-      </EntityList>
-      {!hasNextPage && items.length > 0 && (
-        <Txt variant="ui-xs" className="text-icon3 text-center">
-          All items loaded
-        </Txt>
+        {isSelectionActive && maxSelection && <DataList.TopCell>&nbsp;</DataList.TopCell>}
+        {isSelectionActive ? (
+          <DataList.TopCells colStart={2}>
+            {columns.map(col => (
+              <DataList.TopCell key={col.name}>{col.label || col.name}</DataList.TopCell>
+            ))}
+          </DataList.TopCells>
+        ) : (
+          columns.map(col => <DataList.TopCell key={col.name}>{col.label || col.name}</DataList.TopCell>)
+        )}
+      </DataList.Top>
+
+      {items.length === 0 && searchQuery ? (
+        <DataList.NoMatch message="No items match your search" />
+      ) : (
+        <>
+          {items.map(item => {
+            const createdAtDate = new Date(item.createdAt);
+            const isFeatured = featuredItemId === item.id;
+
+            const rowCells = (
+              <>
+                <DataList.IdCell id={item.id} />
+                <DataList.MonoCell>{truncateValue(item.input, 60)}</DataList.MonoCell>
+                <DataList.MonoCell>{item.groundTruth ? truncateValue(item.groundTruth, 40) : '-'}</DataList.MonoCell>
+                <DataList.Cell height="compact" className="min-w-0">
+                  {item.expectedTrajectory ? (
+                    <span className="text-ui-smd text-neutral3">
+                      {Array.isArray((item.expectedTrajectory as Record<string, unknown>)?.steps)
+                        ? `${((item.expectedTrajectory as Record<string, unknown>).steps as unknown[]).length} steps`
+                        : 'Yes'}
+                    </span>
+                  ) : (
+                    <span className="text-neutral4">—</span>
+                  )}
+                </DataList.Cell>
+                <DataList.Cell height="compact" className="min-w-0">
+                  <span className="block text-ui-smd text-neutral2 truncate">{formatDate(createdAtDate)}</span>
+                </DataList.Cell>
+              </>
+            );
+
+            if (!isSelectionActive) {
+              return (
+                <DataList.RowButton key={item.id} featured={isFeatured} onClick={() => onItemClick?.(item.id)}>
+                  {rowCells}
+                </DataList.RowButton>
+              );
+            }
+
+            return (
+              <DataList.Row key={item.id}>
+                <DataList.SelectCell
+                  checked={selectedIds.has(item.id)}
+                  onToggle={shiftKey => handleToggleSelection(item.id, shiftKey, allIds)}
+                  aria-label={`Select item ${item.id}`}
+                />
+                <DataList.RowButton flushLeft colStart={2} featured={isFeatured} onClick={() => onItemClick?.(item.id)}>
+                  {rowCells}
+                </DataList.RowButton>
+              </DataList.Row>
+            );
+          })}
+          <DataList.NextPageLoading
+            isLoading={isFetchingNextPage}
+            hasMore={hasNextPage}
+            setEndOfListElement={setEndOfListElement}
+          />
+        </>
       )}
-    </>
+    </DataList>
   );
 }
 

--- a/packages/playground/src/domains/datasets/components/items/dataset-items.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items.tsx
@@ -158,10 +158,10 @@ export function DatasetItems({
   const isSelectionActive = selectionMode !== 'idle';
 
   const itemsListColumns = [
-    { name: 'id', label: 'ID', size: '5rem' },
-    { name: 'input', label: 'Input', size: '1fr' },
-    ...(!featuredItem ? [{ name: 'groundTruth', label: 'Ground Truth', size: '1fr' }] : []),
-    ...(!featuredItem ? [{ name: 'trajectory', label: 'Trajectory', size: '6rem' }] : []),
+    { name: 'id', label: 'ID', size: '7rem' },
+    { name: 'input', label: 'Input', size: 'minmax(10rem,1fr)' },
+    { name: 'groundTruth', label: 'Ground Truth', size: 'minmax(10rem,1fr)' },
+    { name: 'trajectory', label: 'Trajectory', size: '8rem' },
     { name: 'date', label: 'Created', size: '10rem' },
   ];
 


### PR DESCRIPTION
## Summary

- Adds new `DataList` primitives — `IdCell`, `MonoCell`, `DateCell`, `TimeCell`, `SelectCell`, `TopSelectCell`, `TopCells` — and three shared modifier props on the row primitives: `flushLeft`, `colStart`, `featured`.
- Adds an `as` prop on `DataList.Cell` and `DataList.TopCell` (lets a cell render as `<label>` so the whole cell area becomes the click/hover target) and `hasLeadingCell` on `DataList.Top` (drops gap + left padding so a leading select cell sits flush).
- Refactors the Dataset Items list to the condensed style: same row primitives Traces and Logs use, with a proper selection-mode layout — checkbox cell in column 1 vertically aligned with the header's select-all cell, and the row button in cols 2..-1.
- Dedups DateCell/TimeCell/MonoCell content between TracesDataList and LogsDataList (they were byte-identical), and switches Traces and Logs list views to the new `featured` prop instead of inline `bg-surface4` className recipes.

## Test plan

- [ ] Open `/datasets/<id>` (Dataset Items page) — row density and alignment should match the Traces/Logs list visual style.
- [ ] Enter selection mode (any action that flips `selectionMode`) and verify:
  - [ ] Header checkbox aligns vertically with row checkboxes.
  - [ ] Clicking anywhere in a checkbox cell toggles selection (label hit area).
  - [ ] Shift-click on a row checkbox extends the range.
  - [ ] Header's select-all toggle works with `indeterminate` state.
- [ ] Open an item to feature it — only the featured row should have the highlighted background; checkbox-only-selected rows should not.
- [ ] Open `/observability` (Traces) and `/logs` — featured row still highlights; no visual regressions.
- [ ] Horizontal-scroll the Dataset Items list at narrow widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR introduces a compact set of reusable list building blocks so multiple list views (Datasets, Traces, Logs) look and behave the same: tighter rows, aligned checkboxes/selection, and shared small cell components to remove duplicated code.

---

## Overview

Adds condensed DataList primitives (small typed cells and header helpers), shared row layout props, polymorphic cell/header components, and refactors Dataset Items, Traces, and Logs list views to use these primitives. Outcome: consistent condensed layout, correct selection-mode alignment/behavior, centralized featured highlighting, and deduplicated date/time/mono cell logic.

## Key Additions

- New compact cell components and header helpers
  - DataList.IdCell — truncated identifier (first 8 chars)
  - DataList.MonoCell — monospaced truncated text
  - DataList.DateCell — renders "Today", formatted date (MMM dd), or "-"
  - DataList.TimeCell — renders HH:mm:ss + padded ms or "-"
  - DataList.SelectCell — row checkbox cell with shift-click support
  - DataList.TopSelectCell — header checkbox (select-all / indeterminate)
  - DataList.TopCells — header grid container aligned with row columns

- Shared row modifiers (DataListRowSharedProps)
  - flushLeft — remove left padding for leading cells (e.g., checkboxes)
  - colStart — start column index for a RowButton to span from
  - featured — centralized featured/highlight styling

- Polymorphic / interaction improvements
  - DataList.Cell and DataList.TopCell accept as?: ElementType and forward element props (can render as label for larger hit targets)
  - DataList.Top gains hasLeadingCell?: boolean to remove gap/left padding when a leading cell exists
  - New DataList.TopCells component to align header columns with row columns

## Refactors / Behavioral Changes

- Dataset Items List
  - Migrated from EntityList → DataList using condensed primitives and grid columns.
  - Selection UI: checkbox is a DataList.SelectCell in column 1 (aligned to header select-all); row button spans columns 2..-1 and receives featured state.
  - Loading/pagination uses DataList.NextPageLoading; empty/search states moved into DataList; previous “All items loaded” footer removed.

- Traces & Logs
  - Replaced file-local ID/date/time cell implementations with the shared DataList.IdCell / DateCell / TimeCell (removed local date-fns usage).
  - Mono/date/time cell rendering deduplicated across TracesDataList and LogsDataList.
  - Featured/highlight behavior moved to the featured prop (removed ad-hoc bg-surface4 classNames).

## API / Export Changes (public surface)

- DataList now exposes: IdCell, MonoCell, DateCell, TimeCell, SelectCell, TopSelectCell, TopCells.
- DataListCell/DataListTopCell typings extended to support as?: ElementType and forward additional element props.
- DataListRowButton / DataListRowLink props extended with DataListRowSharedProps (flushLeft, colStart, featured).
- DataList.Top adds hasLeadingCell?: boolean.
- New exported type: DataListRowSharedProps and new component DataListTopCells.
- Trace/log-specific local cell components were removed from their local modules — update direct imports to the shared DataList cells if present.

## Layout / Visual Tweaks

- Condensed spacing: row gap tightened (gap-10 → gap-8).
- Selection-mode layout aligns row checkbox with header checkbox and makes row label/hit area larger.
- Featured highlighting centralized via featured prop for consistent behavior.
- Horizontal-scroll / narrow-width behavior preserved; tests added to cover regressions.

## Tests / QA

- New Playwright E2E tests for Dataset Items List covering: row open/detail panel, entering/exiting selection mode, select-all/indeterminate, shift-range selection, bulk delete, search/empty states, and canceling selection mode.
- New e2e helper to seed datasets with items; E2E tests read E2E_PORT (fallback 4111) and surface seed POST failures.

## Notes for reviewers / impact

- Intended as an internal refactor: consumer-visible list behavior should remain stable but public typings/exports for DataList were expanded — check for any direct imports of removed trace/log-specific cells and update them to the shared DataList cells.
- Pay special attention to files adding new components/typing (data-list-cells, data-list-top-cell/top-cells, data-list-row-button/link, shared types) and dataset-items list wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->