### PR TITLE
feat(playground-ui): migrate Dialog to Base UI

### DIFF
--- a/.changeset/tricky-turtles-march.md
+++ b/.changeset/tricky-turtles-march.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Migrated the `Dialog` component from Radix UI to Base UI. The public API is unchanged — `asChild` on `DialogTrigger` and `DialogClose` is preserved through a render-prop shim, and open/close animations are kept intact.
+Moved the `Dialog` component to Base UI. The public API is unchanged — `asChild` on `DialogTrigger` and `DialogClose` still works the same way, and open/close animations behave as before.

--- a/.changeset/tricky-turtles-march.md
+++ b/.changeset/tricky-turtles-march.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Migrated the `Dialog` component from Radix UI to Base UI. The public API is unchanged — `asChild` on `DialogTrigger` and `DialogClose` is preserved through a render-prop shim, and open/close animations are kept intact.

--- a/packages/playground-ui/src/ds/components/Command/command.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.tsx
@@ -18,7 +18,8 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-type CommandDialogProps = React.ComponentPropsWithoutRef<typeof Dialog> & {
+type CommandDialogProps = Omit<React.ComponentPropsWithoutRef<typeof Dialog>, 'children'> & {
+  children?: React.ReactNode;
   title?: string;
   description?: string;
 };

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.css
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.css
@@ -46,18 +46,25 @@
   }
 }
 
-.dialog-overlay-anim[data-state='open'] {
+/* Open/close state attributes: Radix (`data-state`) for AlertDialog, Base UI
+ * (`data-open` / `data-closed`) for Dialog. Both share these animation classes. */
+
+.dialog-overlay-anim[data-state='open'],
+.dialog-overlay-anim[data-open] {
   animation: dialog-overlay-in 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.dialog-overlay-anim[data-state='closed'] {
+.dialog-overlay-anim[data-state='closed'],
+.dialog-overlay-anim[data-closed] {
   animation: dialog-overlay-out 240ms cubic-bezier(0.32, 0, 0.67, 0);
 }
 
-.dialog-content-anim[data-state='open'] {
+.dialog-content-anim[data-state='open'],
+.dialog-content-anim[data-open] {
   animation: dialog-content-in 680ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.dialog-content-anim[data-state='closed'] {
+.dialog-content-anim[data-state='closed'],
+.dialog-content-anim[data-closed] {
   animation: dialog-content-out 180ms cubic-bezier(0.5, 0, 0.75, 0);
 }

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.test.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog';
+import { Button } from '@/ds/components/Button';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Dialog', () => {
+  it('mounts every dialog part inside an open dialog without throwing', () => {
+    expect(() =>
+      render(
+        <Dialog defaultOpen>
+          <DialogTrigger>Open</DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Title</DialogTitle>
+              <DialogDescription>Description</DialogDescription>
+            </DialogHeader>
+            <DialogBody>Body content</DialogBody>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline">Cancel</Button>
+              </DialogClose>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByRole('heading', { name: 'Title' })).toBeDefined();
+    expect(screen.getByText('Body content')).toBeDefined();
+  });
+
+  it('renders an asChild Trigger as the child element without nesting buttons', () => {
+    render(
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button>Open dialog</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogTitle>Title</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open dialog' });
+    expect(trigger.querySelector('button')).toBeNull();
+  });
+
+  it('opens the dialog when the trigger is clicked', () => {
+    render(
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button>Open dialog</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogTitle>Revealed title</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.queryByText('Revealed title')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+    expect(screen.getByText('Revealed title')).toBeDefined();
+  });
+
+  it('fires onOpenChange when the built-in close button is clicked', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Dialog defaultOpen onOpenChange={onOpenChange}>
+        <DialogContent>
+          <DialogTitle>Title</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false, expect.anything());
+  });
+
+  it('fires onOpenChange when an asChild DialogClose is clicked', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Dialog defaultOpen onOpenChange={onOpenChange}>
+        <DialogContent>
+          <DialogTitle>Title</DialogTitle>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false, expect.anything());
+  });
+});

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -32,17 +32,15 @@ type DialogCloseProps = DialogPrimitive.Close.Props & {
   asChild?: boolean;
 };
 
-const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
-  ({ asChild, children, ...props }, ref) => {
-    const renderProps = asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {};
+const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(({ asChild, children, ...props }, ref) => {
+  const renderProps = asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {};
 
-    return (
-      <DialogPrimitive.Close ref={ref} {...renderProps} {...props}>
-        {asChild ? undefined : children}
-      </DialogPrimitive.Close>
-    );
-  },
-);
+  return (
+    <DialogPrimitive.Close ref={ref} {...renderProps} {...props}>
+      {asChild ? undefined : children}
+    </DialogPrimitive.Close>
+  );
+});
 DialogClose.displayName = 'DialogClose';
 
 type DialogOverlayProps = Omit<DialogPrimitive.Backdrop.Props, 'className'> & {
@@ -62,35 +60,33 @@ type DialogContentProps = Omit<DialogPrimitive.Popup.Props, 'className'> & {
   className?: string;
 };
 
-const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
-  ({ className, children, ...props }, ref) => (
-    <DialogPortal>
-      <DialogOverlay />
-      <DialogPrimitive.Popup
-        ref={ref}
-        data-slot="dialog-content"
-        className={cn(
-          'dialog-content-anim',
-          'fixed left-[50%] top-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%]',
-          'w-full max-w-[calc(100%-2rem)] sm:max-w-lg',
-          'rounded-xl border border-border1/40 bg-surface2/96 backdrop-blur-md shadow-dialog',
-          'focus-visible:outline-hidden',
-          className,
-        )}
-        {...props}
-      >
-        {children}
-        <DialogPrimitive.Close
-          render={
-            <Button variant="ghost" size="sm" className="absolute top-3 right-3" aria-label="Close">
-              <X />
-            </Button>
-          }
-        />
-      </DialogPrimitive.Popup>
-    </DialogPortal>
-  ),
-);
+const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Popup
+      ref={ref}
+      data-slot="dialog-content"
+      className={cn(
+        'dialog-content-anim',
+        'fixed left-[50%] top-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%]',
+        'w-full max-w-[calc(100%-2rem)] sm:max-w-lg',
+        'rounded-xl border border-border1/40 bg-surface2/96 backdrop-blur-md shadow-dialog',
+        'focus-visible:outline-hidden',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close
+        render={
+          <Button variant="ghost" size="sm" className="absolute top-3 right-3" aria-label="Close">
+            <X />
+          </Button>
+        }
+      />
+    </DialogPrimitive.Popup>
+  </DialogPortal>
+));
 DialogContent.displayName = 'DialogContent';
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -1,4 +1,4 @@
-import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { X } from 'lucide-react';
 import * as React from 'react';
 
@@ -9,51 +9,89 @@ import './dialog.css';
 
 const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = DialogPrimitive.Trigger;
+type DialogTriggerProps = DialogPrimitive.Trigger.Props & {
+  asChild?: boolean;
+};
+
+const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
+  ({ asChild, children, ...props }, ref) => {
+    const renderProps = asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {};
+
+    return (
+      <DialogPrimitive.Trigger ref={ref} {...renderProps} {...props}>
+        {asChild ? undefined : children}
+      </DialogPrimitive.Trigger>
+    );
+  },
+);
+DialogTrigger.displayName = 'DialogTrigger';
 
 const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close;
+type DialogCloseProps = DialogPrimitive.Close.Props & {
+  asChild?: boolean;
+};
 
-const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
+const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
+  ({ asChild, children, ...props }, ref) => {
+    const renderProps = asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {};
+
+    return (
+      <DialogPrimitive.Close ref={ref} {...renderProps} {...props}>
+        {asChild ? undefined : children}
+      </DialogPrimitive.Close>
+    );
+  },
+);
+DialogClose.displayName = 'DialogClose';
+
+type DialogOverlayProps = Omit<DialogPrimitive.Backdrop.Props, 'className'> & {
+  className?: string;
+};
+
+const DialogOverlay = React.forwardRef<HTMLDivElement, DialogOverlayProps>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Backdrop
     ref={ref}
     className={cn('dialog-overlay-anim fixed inset-0 z-50 bg-overlay backdrop-blur-xs', className)}
     {...props}
   />
 ));
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+DialogOverlay.displayName = 'DialogOverlay';
 
-const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'dialog-content-anim',
-        'fixed left-[50%] top-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%]',
-        'w-full max-w-[calc(100%-2rem)] sm:max-w-lg',
-        'rounded-xl border border-border1/40 bg-surface2/96 backdrop-blur-md shadow-dialog',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close asChild>
-        <Button variant="ghost" size="sm" className="absolute top-3 right-3" aria-label="Close">
-          <X />
-        </Button>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
-DialogContent.displayName = DialogPrimitive.Content.displayName;
+type DialogContentProps = Omit<DialogPrimitive.Popup.Props, 'className'> & {
+  className?: string;
+};
+
+const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
+  ({ className, children, ...props }, ref) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        ref={ref}
+        data-slot="dialog-content"
+        className={cn(
+          'dialog-content-anim',
+          'fixed left-[50%] top-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%]',
+          'w-full max-w-[calc(100%-2rem)] sm:max-w-lg',
+          'rounded-xl border border-border1/40 bg-surface2/96 backdrop-blur-md shadow-dialog',
+          'focus-visible:outline-hidden',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close
+          render={
+            <Button variant="ghost" size="sm" className="absolute top-3 right-3" aria-label="Close">
+              <X />
+            </Button>
+          }
+        />
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  ),
+);
+DialogContent.displayName = 'DialogContent';
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={cn('flex flex-col gap-0.5 px-4 py-3 text-left', className)} {...props} />
@@ -70,21 +108,25 @@ const DialogBody = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement
 );
 DialogBody.displayName = 'DialogBody';
 
-const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
+type DialogTitleProps = Omit<DialogPrimitive.Title.Props, 'className'> & {
+  className?: string;
+};
+
+const DialogTitle = React.forwardRef<HTMLHeadingElement, DialogTitleProps>(({ className, ...props }, ref) => (
   <DialogPrimitive.Title ref={ref} className={cn('text-ui-md font-medium', className)} {...props} />
 ));
-DialogTitle.displayName = DialogPrimitive.Title.displayName;
+DialogTitle.displayName = 'DialogTitle';
 
-const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description ref={ref} className={cn('sr-only', className)} {...props} />
-));
-DialogDescription.displayName = DialogPrimitive.Description.displayName;
+type DialogDescriptionProps = Omit<DialogPrimitive.Description.Props, 'className'> & {
+  className?: string;
+};
+
+const DialogDescription = React.forwardRef<HTMLParagraphElement, DialogDescriptionProps>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Description ref={ref} className={cn('sr-only', className)} {...props} />
+  ),
+);
+DialogDescription.displayName = 'DialogDescription';
 
 export {
   Dialog,


### PR DESCRIPTION
## Summary

- Migrates the `Dialog` design system component from `@radix-ui/react-dialog` to `@base-ui/react/dialog`.
- **Public API unchanged.** `asChild` on `DialogTrigger` and `DialogClose` is preserved through a render-prop shim (same pattern as the `Popover`/`DropdownMenu` migrations). All exports kept: `Dialog`, `DialogTrigger`, `DialogClose`, `DialogPortal`, `DialogOverlay`, `DialogContent`, `DialogHeader`, `DialogFooter`, `DialogBody`, `DialogTitle`, `DialogDescription`.
- Part mapping: Radix `Overlay` → Base UI `Backdrop`, `Content` → `Portal` + `Popup`.
- `dialog.css` now matches both `data-open`/`data-closed` (Base UI) and `data-state` (Radix) so the shared stylesheet keeps animating `AlertDialog`, which is still on Radix.
- `CommandDialog` props narrow `children` to `ReactNode` — Base UI's `Dialog.Root` widens `children` with a payload render-function overload that `cmdk` can't accept.
- Adds `dialog.test.tsx` smoke tests: mounts every part in an open dialog, verifies the `asChild` shim, trigger open, and `onOpenChange` on both the built-in close button and an `asChild` `DialogClose`.

## Test plan

- [x] `pnpm exec tsc --noEmit` on `@mastra/playground-ui` — exit 0
- [x] `pnpm exec tsc --noEmit` on `@mastra/playground` (consumer, ~30 dialog files) — exit 0
- [x] `pnpm build` on `@mastra/playground-ui` — OK
- [x] `pnpm test` on `@mastra/playground-ui` — 200/200 (5 new)
- [x] `eslint` on `Dialog` + `Command` — clean
- [ ] Manual visual check of open/close animations in Studio (not run — dev server lives on the main checkout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR swaps the Dialog component's underlying library from Radix UI to Base UI while keeping the same public API and behavior — like replacing an engine but leaving the steering and controls unchanged.

---

## Overview

Migrates the Dialog design-system component from `@radix-ui/react-dialog` to `@base-ui/react/dialog` while preserving public exports, asChild behavior, and the visual open/close animations so consumers are unaffected.

## Changes

### Core Migration
- Replaced Radix Dialog primitives with Base UI primitives (imported from `@base-ui/react/dialog`).
- Kept public exports: Dialog, DialogTrigger, DialogClose, DialogPortal, DialogOverlay, DialogContent, DialogHeader, DialogFooter, DialogBody, DialogTitle, DialogDescription.
- Mapped Radix concepts to Base UI equivalents: Radix Overlay → Base UI Backdrop; Radix Content → Base UI Portal + Popup.

### asChild Shim & Component Wrappers
- DialogTrigger and DialogClose implemented as explicit React.forwardRef wrappers that preserve asChild by passing Base UI's render-prop when children is a valid element (same shim pattern used for Popover/DropdownMenu).
- DialogOverlay and DialogContent are forwardRef wrappers around Base UI Backdrop/Popup with local prop typings and className handling.
- DialogContent includes the built-in close button using the primitive Close's render prop (Button with X icon).

### Styling
- dialog.css updated so overlay/content animations respond to both Radix data-state (open/closed) and Base UI data-open/data-closed attributes; existing keyframes and animation timings retained so AlertDialog (still on Radix) and the new Dialog share animations.

### Props & Typing
- CommandDialog props narrowed: children is now React.ReactNode (Omit of Dialog props with children reintroduced) to avoid Base UI Dialog.Root's render-function overload conflicting with cmdk.

### Tests
- Added dialog.test.tsx (Vitest + React Testing Library) covering:
  - Mounting every dialog part inside an open dialog.
  - DialogTrigger asChild renders child without nested button.
  - Clicking trigger opens dialog.
  - onOpenChange called with false when closing via built-in close button and via an asChild DialogClose.
- 5 new tests added; test suite passes locally.

## Validation
- Type-check: pnpm exec tsc --noEmit for `@mastra/playground-ui` and `@mastra/playground` — passed.
- Build: `@mastra/playground-ui` builds successfully.
- Tests: all tests passing (includes the 5 new tests).
- ESLint: Dialog and Command files lint-clean.
- Manual visual check of open/close animations: not run.

## Notes for reviewers
- Focus review on dialog.tsx wrapper implementations (asChild render-prop shims), dialog.css selector additions, and the CommandDialog props change that tightens children to ReactNode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->