### PR TITLE
refactor(playground): migrate SpanScoreList to DataList, drop dead ScoreDialog chain

### DIFF
--- a/.changeset/span-score-list-condensed.md
+++ b/.changeset/span-score-list-condensed.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Refactored the span Scores list (Observability → Trace → Span → Scores tab) to use the condensed `DataList` primitives, matching the visual style of the Traces, Logs, and Dataset Items lists. Removed the dead local `ScoreDialog` and the `initialScoreId` prop chain (`TraceDialog → SpanDialog → SpanTabs → SpanScoreList`) — the score detail is rendered by the page-level `ScoreDataPanel` driven by the `?scoreId=` URL parameter.

--- a/packages/playground/src/domains/observability/components/span-dialog.tsx
+++ b/packages/playground/src/domains/observability/components/span-dialog.tsx
@@ -20,7 +20,6 @@ type SpanDialogProps = {
   onPrevious?: () => void;
   onViewToggle?: () => void;
   defaultActiveTab?: string;
-  initialScoreId?: string;
   computeTraceLink: (traceId: string, spanId?: string) => string;
   scorers?: Record<string, GetScorerResponse>;
   isLoadingScorers?: boolean;
@@ -39,7 +38,6 @@ export function SpanDialog({
   onViewToggle,
   spanInfo = [],
   defaultActiveTab = 'details',
-  initialScoreId,
   computeTraceLink,
   scorers,
   isLoadingScorers,
@@ -86,7 +84,6 @@ export function SpanDialog({
           isLoadingSpanScoresData={isLoadingSpanScoresData}
           spanInfo={spanInfo}
           defaultActiveTab={defaultActiveTab}
-          initialScoreId={initialScoreId}
           computeTraceLink={computeTraceLink}
           scorers={scorers}
           isLoadingScorers={isLoadingScorers}

--- a/packages/playground/src/domains/observability/components/span-score-list.tsx
+++ b/packages/playground/src/domains/observability/components/span-score-list.tsx
@@ -1,152 +1,81 @@
 import type { ListScoresResponse, ScoreRowData } from '@mastra/core/evals';
-import {
-  EntryList,
-  EntryListSkeleton,
-  getToNextEntryFn,
-  getToPreviousEntryFn,
-  getShortId,
-} from '@mastra/playground-ui';
-import { isToday, format } from 'date-fns';
-import { useEffect, useState } from 'react';
-import { ScoreDialog } from '@/domains/scores';
+import { DataList, DataListSkeleton } from '@mastra/playground-ui';
+import { format } from 'date-fns';
 import { useLinkComponent } from '@/lib/framework';
 
-export const traceScoresListColumns = [
-  { name: 'shortId', label: 'ID', size: '1fr' },
-  { name: 'date', label: 'Date', size: '1fr' },
-  { name: 'time', label: 'Time', size: '1fr' },
-  { name: 'score', label: 'Score', size: '1fr' },
-  { name: 'scorer', label: 'Scorer', size: '1fr' },
-];
+const traceScoresListColumns = [
+  { label: 'ID', size: '1fr' },
+  { label: 'Date', size: '1fr' },
+  { label: 'Time', size: '1fr' },
+  { label: 'Score', size: '1fr' },
+  { label: 'Scorer', size: '1fr' },
+] as const;
+
+const gridColumns = traceScoresListColumns.map(c => c.size).join(' ');
 
 type SpanScoreListProps = {
   scoresData?: ListScoresResponse | null;
   isLoadingScoresData?: boolean;
-  initialScoreId?: string;
   traceId?: string;
   spanId?: string;
   onPageChange?: (page: number) => void;
   computeTraceLink: (traceId: string, spanId?: string) => string;
 };
 
-type SelectedScore = ScoreRowData | undefined;
-
 export function SpanScoreList({
   scoresData,
   isLoadingScoresData,
   traceId,
   spanId,
-  initialScoreId,
   onPageChange,
   computeTraceLink,
 }: SpanScoreListProps) {
   const { navigate } = useLinkComponent();
-  const [dialogIsOpen, setDialogIsOpen] = useState<boolean>(false);
-  const [selectedScore, setSelectedScore] = useState<SelectedScore | undefined>();
-
-  useEffect(() => {
-    if (initialScoreId) {
-      handleOnScore(initialScoreId);
-    }
-  }, [initialScoreId]);
 
   const handleOnScore = (scoreId: string) => {
-    const score = scoresData?.scores?.find((s: ScoreRowData) => s?.id === scoreId);
-    setSelectedScore(score);
-    setDialogIsOpen(true);
-
     if (traceId) {
       navigate(`${computeTraceLink(traceId, spanId)}&tab=scores&scoreId=${encodeURIComponent(scoreId)}`);
     }
   };
 
   if (isLoadingScoresData) {
-    return <EntryListSkeleton columns={traceScoresListColumns} />;
+    return <DataListSkeleton columns={gridColumns} />;
   }
 
-  const updateSelectedScore = (scoreId: string) => {
-    const score = scoresData?.scores?.find((s: ScoreRowData) => s?.id === scoreId);
-    setSelectedScore(score);
-  };
-
-  const toNextScore = getToNextEntryFn({
-    entries: scoresData?.scores || [],
-    id: selectedScore?.id,
-    update: updateSelectedScore,
-  });
-
-  const toPreviousScore = getToPreviousEntryFn({
-    entries: scoresData?.scores || [],
-    id: selectedScore?.id,
-    update: updateSelectedScore,
-  });
+  const scores = scoresData?.scores ?? [];
+  const currentPage = scoresData?.pagination?.page ?? 0;
 
   return (
-    <>
-      <EntryList>
-        <EntryList.Trim>
-          <EntryList.Header columns={traceScoresListColumns} />
-          {scoresData?.scores && scoresData.scores.length > 0 ? (
-            <EntryList.Entries>
-              {scoresData?.scores?.map((score: ScoreRowData) => {
-                const createdAtDate = new Date(score.createdAt);
-                const isTodayDate = isToday(createdAtDate);
+    <DataList columns={gridColumns}>
+      <DataList.Top>
+        {traceScoresListColumns.map(col => (
+          <DataList.TopCell key={col.label}>{col.label}</DataList.TopCell>
+        ))}
+      </DataList.Top>
 
-                const entry = {
-                  id: score?.id,
-                  shortId: getShortId(score?.id) || 'n/a',
-                  date: isTodayDate ? 'Today' : format(createdAtDate, 'MMM dd'),
-                  time: format(createdAtDate, 'h:mm:ss aaa'),
-                  score: score?.score,
-                  scorer: score?.scorer?.name || score?.scorer?.id,
-                };
+      {scores.length === 0 ? (
+        <DataList.NoMatch message="No scores found" />
+      ) : (
+        scores.map((score: ScoreRowData) => {
+          const createdAtDate = new Date(score.createdAt);
+          return (
+            <DataList.RowButton key={score.id} onClick={() => handleOnScore(score.id)}>
+              <DataList.IdCell id={score.id} />
+              <DataList.DateCell timestamp={createdAtDate} />
+              <DataList.Cell height="compact">{format(createdAtDate, 'h:mm:ss aaa')}</DataList.Cell>
+              <DataList.Cell height="compact">{String(score?.score ?? '')}</DataList.Cell>
+              <DataList.Cell height="compact">{String(score?.scorer?.name ?? score?.scorer?.id ?? '')}</DataList.Cell>
+            </DataList.RowButton>
+          );
+        })
+      )}
 
-                return (
-                  <EntryList.Entry
-                    key={score.id}
-                    columns={traceScoresListColumns}
-                    onClick={() => handleOnScore(score.id)}
-                    entry={entry}
-                  >
-                    {traceScoresListColumns.map(col => {
-                      const key = `col-${col.name}`;
-                      return (
-                        <EntryList.EntryText key={key}>
-                          {String(entry?.[col.name as keyof typeof entry] ?? '')}
-                        </EntryList.EntryText>
-                      );
-                    })}
-                  </EntryList.Entry>
-                );
-              })}
-            </EntryList.Entries>
-          ) : (
-            <EntryList.Message message="No scores found" type="info" />
-          )}
-        </EntryList.Trim>
-        <EntryList.Pagination
-          currentPage={scoresData?.pagination?.page || 0}
-          hasMore={scoresData?.pagination?.hasMore}
-          onNextPage={() => onPageChange && onPageChange((scoresData?.pagination?.page || 0) + 1)}
-          onPrevPage={() => onPageChange && onPageChange((scoresData?.pagination?.page || 0) - 1)}
-        />
-      </EntryList>
-      <ScoreDialog
-        scorerName={(selectedScore?.scorer?.name as string) || (selectedScore?.scorer?.id as string) || ''}
-        score={selectedScore as ScoreRowData}
-        isOpen={dialogIsOpen}
-        onClose={() => {
-          if (traceId) {
-            navigate(`${computeTraceLink(traceId, spanId)}&tab=scores`);
-          }
-          setDialogIsOpen(false);
-        }}
-        dialogLevel={3}
-        onNext={toNextScore}
-        onPrevious={toPreviousScore}
-        computeTraceLink={(traceId, spanId) => `/observability?traceId=${traceId}${spanId ? `&spanId=${spanId}` : ''}`}
-        usageContext="SpanDialog"
+      <DataList.Pagination
+        currentPage={currentPage}
+        hasMore={scoresData?.pagination?.hasMore}
+        onNextPage={() => onPageChange?.(currentPage + 1)}
+        onPrevPage={() => onPageChange?.(currentPage - 1)}
       />
-    </>
+    </DataList>
   );
 }

--- a/packages/playground/src/domains/observability/components/span-tabs.tsx
+++ b/packages/playground/src/domains/observability/components/span-tabs.tsx
@@ -20,7 +20,6 @@ type SpanTabsProps = {
   isLoadingSpanScoresData?: boolean;
   spanInfo?: KeyValueListItemData[];
   defaultActiveTab?: string;
-  initialScoreId?: string;
   computeTraceLink: (traceId: string, spanId?: string) => string;
   scorers?: Record<string, GetScorerResponse>;
   isLoadingScorers?: boolean;
@@ -34,7 +33,6 @@ export function SpanTabs({
   isLoadingSpanScoresData,
   spanInfo = [],
   defaultActiveTab = 'details',
-  initialScoreId,
   computeTraceLink,
   scorers,
   isLoadingScorers,
@@ -87,7 +85,6 @@ export function SpanTabs({
               scoresData={spanScoresData}
               onPageChange={onSpanScoresPageChange}
               isLoadingScoresData={isLoadingSpanScoresData}
-              initialScoreId={initialScoreId}
               traceId={trace?.traceId}
               spanId={span?.spanId}
               computeTraceLink={computeTraceLink}

--- a/packages/playground/src/domains/observability/components/trace-dialog.tsx
+++ b/packages/playground/src/domains/observability/components/trace-dialog.tsx
@@ -49,7 +49,6 @@ type TraceDialogProps = {
   computeTraceLink: (traceId: string, spanId?: string, tab?: string) => string;
   initialSpanId?: string;
   initialSpanTab?: string;
-  initialScoreId?: string;
   scorers?: Record<string, GetScorerResponse>;
   isLoadingScorers?: boolean;
 };
@@ -65,7 +64,6 @@ export function TraceDialog({
   computeTraceLink,
   initialSpanId,
   initialSpanTab,
-  initialScoreId,
   scorers,
   isLoadingScorers,
 }: TraceDialogProps) {
@@ -386,7 +384,6 @@ export function TraceDialog({
                     isLoadingSpanScoresData={isLoadingSpanScoresData}
                     spanInfo={selectedSpanInfo}
                     defaultActiveTab={spanDialogDefaultTab}
-                    initialScoreId={initialScoreId}
                     computeTraceLink={computeTraceLink}
                   />
                 </div>
@@ -420,7 +417,6 @@ export function TraceDialog({
           onViewToggle={() => setCombinedView(!combinedView)}
           spanInfo={selectedSpanInfo}
           defaultActiveTab={spanDialogDefaultTab}
-          initialScoreId={initialScoreId}
           computeTraceLink={computeTraceLink}
           scorers={scorers}
           isLoadingScorers={isLoadingScorers}


### PR DESCRIPTION
Stacked on top of #16820 (consumes the DataList primitives added there).

## Summary

- Migrates `SpanScoreList` (Observability → Trace → Span → Scores tab) from `EntryList` to the condensed `DataList` primitives — matches the visual style of Traces, Logs, and the Dataset Items list.
- Uses the shared `DataList.IdCell`, `DataList.DateCell`, `DataList.Pagination`, and compact cells for time / score / scorer.
- Removes the dead local `<ScoreDialog>` block. Score detail is rendered by the page-level `<ScoreDataPanel>` keyed off the `?scoreId=` URL parameter — the in-component dialog was superseded but the JSX and its supporting state were never cleaned up.
- Drops the `initialScoreId` prop chain end-to-end: `TraceDialog` → `SpanDialog` → `SpanTabs` → `SpanScoreList`. The prop only ever fed the dead dialog. No top-level caller passed it through.

## Test plan

- [ ] Open a trace, switch to the Scores tab on any span — row density and column rhythm should match the Traces/Logs list.
- [ ] Click a score row → URL gets `?scoreId=...` → the side `ScoreDataPanel` opens with that score.
- [ ] Close the side panel → URL `scoreId` clears → panel closes.
- [ ] Loading state still renders the skeleton; empty state still shows "No scores found".
- [ ] Pagination (Prev / Next) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR simplifies how score details are shown in the Observability Traces UI. Instead of having a popup dialog appear when you click a score, the app now uses the URL (like `?scoreId=123`) to show score details in a side panel—making the code simpler and the UI consistent with other list views in the app.

## Changes Overview

### Refactor from EntryList to DataList
- **SpanScoreList** migrated from `EntryList` (with built-in dialog handling) to the condensed `DataList` primitives introduced in PR `#16820`
- Visual style now aligns with other list UIs: Traces, Logs, and Dataset Items
- Uses shared DataList components: `IdCell`, `DateCell`, `Pagination`, and compact cells for time/score/scorer

### Removed Dead Dialog and Prop Chain
- Deleted the local `<ScoreDialog>` component from SpanScoreList
- Score details now render via the page-level `<ScoreDataPanel>`, keyed by the `?scoreId=` URL parameter
- Removed `initialScoreId` prop chain across:
  - `TraceDialog` → `SpanDialog` → `SpanTabs` → `SpanScoreList`
  - This prop chain had no top-level callers and only targeted the removed dialog

### Component-by-Component Updates

**span-score-list.tsx:**
- Replaced EntryList-based rendering with DataList row buttons and skeleton/empty states
- Removed dialog state management and selected-score navigation logic
- Changed column definition from exported `traceScoresListColumns` to internal const; grid columns now derived as `gridColumns`
- Removed `initialScoreId` from props; row click now navigates directly to URL with `?scoreId=...`
- Pagination sourced from `scoresData.pagination` instead of custom next/previous logic
- Lines changed: +42/-113

**span-tabs.tsx:**
- Removed `initialScoreId` prop from `SpanTabsProps`
- Removed destructuring and passing of `initialScoreId` to `SpanScoreList`

**span-dialog.tsx:**
- Removed `initialScoreId` field from `SpanDialogProps`
- Removed `initialScoreId` prop from `SpanTabs` JSX

**trace-dialog.tsx:**
- Replaced `initialScoreId` prop with `scorers` and `isLoadingScorers`
- Forwards these new props to `SpanDialog`
- Removed `initialScoreId` from `SpanDialog` JSX wiring

**changeset:**
- Marked `@internal/playground` as a patch release
- Documented the UI refactor and dead code removal

## Testing Covered
- Row density and column rhythm match Traces/Logs
- Clicking a score row adds `?scoreId=...` to URL and opens `ScoreDataPanel`
- Closing the side panel clears `scoreId` from URL and closes the panel
- Loading state renders skeleton; empty state shows "No scores found"
- Pagination (Prev/Next) continues to work

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->