### PR TITLE
feat(playground-ui): migrate AlertDialog to Base UI

### DIFF
--- a/.changeset/giant-carrots-exist.md
+++ b/.changeset/giant-carrots-exist.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Moved the `AlertDialog` component to Base UI. The public API is unchanged — `asChild` on `AlertDialog.Trigger` still works, and `AlertDialog.Action` and `AlertDialog.Cancel` behave as before.

--- a/.changeset/giant-carrots-exist.md
+++ b/.changeset/giant-carrots-exist.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Moved the `AlertDialog` component to Base UI. The public API is unchanged — `asChild` on `AlertDialog.Trigger` still works, and `AlertDialog.Action` and `AlertDialog.Cancel` behave as before.
+`AlertDialog`'s API and behavior are unchanged — `asChild` on `AlertDialog.Trigger`, and `AlertDialog.Action` and `AlertDialog.Cancel`, all work exactly as before. (Internally it now builds on Base UI primitives.)

--- a/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.test.tsx
+++ b/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AlertDialog } from './alert-dialog';
+import { Button } from '@/ds/components/Button';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AlertDialog', () => {
+  it('mounts every part inside an open alert dialog without throwing', () => {
+    expect(() =>
+      render(
+        <AlertDialog open>
+          <AlertDialog.Trigger>Open</AlertDialog.Trigger>
+          <AlertDialog.Content>
+            <AlertDialog.Header>
+              <AlertDialog.Title>Title</AlertDialog.Title>
+              <AlertDialog.Description>Description</AlertDialog.Description>
+            </AlertDialog.Header>
+            <AlertDialog.Body>Body content</AlertDialog.Body>
+            <AlertDialog.Footer>
+              <AlertDialog.Action>Confirm</AlertDialog.Action>
+              <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+            </AlertDialog.Footer>
+          </AlertDialog.Content>
+        </AlertDialog>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByRole('heading', { name: 'Title' })).toBeDefined();
+    expect(screen.getByText('Body content')).toBeDefined();
+  });
+
+  it('renders an asChild Trigger as the child element without nesting buttons', () => {
+    render(
+      <AlertDialog>
+        <AlertDialog.Trigger asChild>
+          <Button>Open alert</Button>
+        </AlertDialog.Trigger>
+        <AlertDialog.Content>
+          <AlertDialog.Title>Title</AlertDialog.Title>
+        </AlertDialog.Content>
+      </AlertDialog>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open alert' });
+    expect(trigger.querySelector('button')).toBeNull();
+  });
+
+  it('opens the alert dialog when the trigger is clicked', () => {
+    render(
+      <AlertDialog>
+        <AlertDialog.Trigger asChild>
+          <Button>Open alert</Button>
+        </AlertDialog.Trigger>
+        <AlertDialog.Content>
+          <AlertDialog.Title>Revealed title</AlertDialog.Title>
+        </AlertDialog.Content>
+      </AlertDialog>,
+    );
+
+    expect(screen.queryByText('Revealed title')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Open alert' }));
+    expect(screen.getByText('Revealed title')).toBeDefined();
+  });
+
+  it('closes via Action and runs its onClick handler', () => {
+    const onOpenChange = vi.fn();
+    const onAction = vi.fn();
+    render(
+      <AlertDialog open onOpenChange={onOpenChange}>
+        <AlertDialog.Content>
+          <AlertDialog.Title>Title</AlertDialog.Title>
+          <AlertDialog.Footer>
+            <AlertDialog.Action onClick={onAction}>Confirm</AlertDialog.Action>
+          </AlertDialog.Footer>
+        </AlertDialog.Content>
+      </AlertDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false, expect.anything());
+  });
+
+  it('closes via Cancel', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <AlertDialog open onOpenChange={onOpenChange}>
+        <AlertDialog.Content>
+          <AlertDialog.Title>Title</AlertDialog.Title>
+          <AlertDialog.Footer>
+            <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+          </AlertDialog.Footer>
+        </AlertDialog.Content>
+      </AlertDialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false, expect.anything());
+  });
+});

--- a/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.tsx
+++ b/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.tsx
@@ -1,4 +1,4 @@
-import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+import { AlertDialog as AlertDialogPrimitive } from '@base-ui/react/alert-dialog';
 import * as React from 'react';
 
 import { buttonVariants } from '@/ds/components/Button/Button';
@@ -7,10 +7,6 @@ import { cn } from '@/lib/utils';
 import '@/ds/components/Dialog/dialog.css';
 
 const AlertDialogRoot = AlertDialogPrimitive.Root;
-
-const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
-
-const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
 function AlertDialog({
   open,
@@ -28,26 +24,48 @@ function AlertDialog({
   );
 }
 
-const AlertDialogOverlay = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Overlay
+type AlertDialogTriggerProps = AlertDialogPrimitive.Trigger.Props & {
+  asChild?: boolean;
+};
+
+const AlertDialogTrigger = React.forwardRef<HTMLButtonElement, AlertDialogTriggerProps>(
+  ({ asChild, children, ...props }, ref) => {
+    const renderProps = asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {};
+
+    return (
+      <AlertDialogPrimitive.Trigger ref={ref} {...renderProps} {...props}>
+        {asChild ? undefined : children}
+      </AlertDialogPrimitive.Trigger>
+    );
+  },
+);
+AlertDialogTrigger.displayName = 'AlertDialogTrigger';
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+type AlertDialogOverlayProps = Omit<AlertDialogPrimitive.Backdrop.Props, 'className'> & {
+  className?: string;
+};
+
+const AlertDialogOverlay = React.forwardRef<HTMLDivElement, AlertDialogOverlayProps>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Backdrop
     ref={ref}
     className={cn('dialog-overlay-anim fixed inset-0 z-50 bg-overlay backdrop-blur-xs', className)}
     {...props}
   />
 ));
-AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+AlertDialogOverlay.displayName = 'AlertDialogOverlay';
 
-const AlertDialogContent = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
+type AlertDialogContentProps = Omit<AlertDialogPrimitive.Popup.Props, 'className'> & {
+  className?: string;
+};
+
+const AlertDialogContent = React.forwardRef<HTMLDivElement, AlertDialogContentProps>(({ className, ...props }, ref) => (
   <AlertDialogPortal>
     <AlertDialogOverlay />
-    <AlertDialogPrimitive.Content
+    <AlertDialogPrimitive.Popup
       ref={ref}
+      data-slot="alert-dialog-content"
       className={cn(
         'dialog-content-anim',
         'fixed left-[50%] top-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%]',
@@ -59,7 +77,7 @@ const AlertDialogContent = React.forwardRef<
     />
   </AlertDialogPortal>
 ));
-AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+AlertDialogContent.displayName = 'AlertDialogContent';
 
 const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={cn('flex flex-col gap-0.5 px-4 py-3 text-left', className)} {...props} />
@@ -76,45 +94,51 @@ const AlertDialogBody = ({ className, ...props }: React.HTMLAttributes<HTMLDivEl
 );
 AlertDialogBody.displayName = 'AlertDialogBody';
 
-const AlertDialogTitle = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
->(({ className, ...props }, ref) => (
+type AlertDialogTitleProps = Omit<AlertDialogPrimitive.Title.Props, 'className'> & {
+  className?: string;
+};
+
+const AlertDialogTitle = React.forwardRef<HTMLHeadingElement, AlertDialogTitleProps>(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title ref={ref} className={cn('text-ui-md font-medium', className)} {...props} />
 ));
-AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+AlertDialogTitle.displayName = 'AlertDialogTitle';
 
-const AlertDialogDescription = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Description ref={ref} className={cn('text-ui-sm text-neutral3', className)} {...props} />
-));
-AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+type AlertDialogDescriptionProps = Omit<AlertDialogPrimitive.Description.Props, 'className'> & {
+  className?: string;
+};
 
-const AlertDialogAction = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Action>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Action
-    ref={ref}
-    className={cn(buttonVariants({ variant: 'primary', size: 'default' }), className)}
-    {...props}
-  />
-));
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+const AlertDialogDescription = React.forwardRef<HTMLParagraphElement, AlertDialogDescriptionProps>(
+  ({ className, ...props }, ref) => (
+    <AlertDialogPrimitive.Description ref={ref} className={cn('text-ui-sm text-neutral3', className)} {...props} />
+  ),
+);
+AlertDialogDescription.displayName = 'AlertDialogDescription';
 
-const AlertDialogCancel = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Cancel
-    ref={ref}
-    className={cn(buttonVariants({ variant: 'default', size: 'default' }), className)}
-    {...props}
-  />
-));
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+type AlertDialogActionProps = Omit<AlertDialogPrimitive.Close.Props, 'className'> & {
+  className?: string;
+};
+
+const AlertDialogAction = React.forwardRef<HTMLButtonElement, AlertDialogActionProps>(
+  ({ className, ...props }, ref) => (
+    <AlertDialogPrimitive.Close
+      ref={ref}
+      className={cn(buttonVariants({ variant: 'primary', size: 'default' }), className)}
+      {...props}
+    />
+  ),
+);
+AlertDialogAction.displayName = 'AlertDialogAction';
+
+const AlertDialogCancel = React.forwardRef<HTMLButtonElement, AlertDialogActionProps>(
+  ({ className, ...props }, ref) => (
+    <AlertDialogPrimitive.Close
+      ref={ref}
+      className={cn(buttonVariants({ variant: 'default', size: 'default' }), className)}
+      {...props}
+    />
+  ),
+);
+AlertDialogCancel.displayName = 'AlertDialogCancel';
 
 AlertDialog.Trigger = AlertDialogTrigger;
 AlertDialog.Portal = AlertDialogPortal;


### PR DESCRIPTION
## Summary

- Migrates the `AlertDialog` design system component from `@radix-ui/react-alert-dialog` to `@base-ui/react/alert-dialog`.
- **Public API unchanged.** `asChild` on `AlertDialog.Trigger` is preserved through a render-prop shim. `AlertDialog.Action` and `AlertDialog.Cancel` map to Base UI's `Close` part, keeping their styling and close-on-click behavior.
- Part mapping: Radix `Overlay` → Base UI `Backdrop`, `Content` → `Portal` + `Popup`, `Action`/`Cancel` → `Close`.
- Adds `alert-dialog.test.tsx` smoke tests: mounts every part open, verifies the `asChild` shim, trigger open, and `onOpenChange` via `Action` (plus its `onClick`) and `Cancel`.

## Stacked PR

> Based on `feat/dialog-base-ui` (#16821), not `main`. `AlertDialog` shares `dialog.css` with `Dialog`; the Dialog PR adds the `data-open`/`data-closed` selectors that Base UI relies on. Review/merge #16821 first — GitHub will retarget this PR to `main` automatically once it lands.

## Test plan

- [x] `pnpm exec tsc --noEmit` on `@mastra/playground-ui` — exit 0
- [x] `pnpm exec tsc --noEmit` on `@mastra/playground` — exit 0
- [x] `pnpm build` on `@mastra/playground-ui` — OK
- [x] `pnpm test` on `@mastra/playground-ui` — 205/205 (5 new)
- [x] `eslint` + `prettier` on `AlertDialog` — clean
- [ ] Manual visual check of open/close animations in Studio (not run — dev server lives on the main checkout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR replaces the underlying dialog implementation for AlertDialog from Radix UI to Base UI so internals use a different library, but from a developer/user perspective the dialog works the same as before.

---

## Summary

**Migration of AlertDialog component from Radix UI to Base UI**

This PR migrates the `AlertDialog` component in `@mastra/playground-ui` from `@radix-ui/react-alert-dialog` to `@base-ui/react/alert-dialog`. The external API remains backward compatible.

### Key Changes

- Replaces Radix primitives with Base UI equivalents:
  - Radix Overlay → Base UI Backdrop
  - Radix Content → Base UI Portal + Popup
  - Radix Action/Cancel → Base UI Close (preserving close-on-click)
- AlertDialogTrigger: now a React.forwardRef wrapper that implements an asChild render-prop shim to preserve previous asChild behavior (avoids extra DOM nesting).
- AlertDialogOverlay / AlertDialogContent: refactored to use Base UI primitives and updated prop typings; `AlertDialogContent.displayName` set explicitly to 'AlertDialogContent'.
- AlertDialogTitle / AlertDialogDescription: prop typings refactored to use Omit<...Props, 'className'> for consistency.
- AlertDialogAction / AlertDialogCancel: now wrap Base UI Close primitive and preserve Action onClick behavior while ensuring onOpenChange is called when closing.

### Tests

- Adds alert-dialog.test.tsx (Vitest + React Testing Library) that:
  - Mounts all parts open without errors
  - Verifies asChild shim avoids nested button
  - Opens the dialog via the trigger
  - Confirms onOpenChange(true/false) behavior and that Action’s onClick is invoked when Action closes the dialog

### Styling & Stacking

- Reuses `dialog.css` and relies on data-open/data-closed selectors introduced in the companion Dialog Base UI migration (PR `#16821`). Review/merge `#16821` first.
- Manual visual check of animations was not performed.

### Status

- Type-checks and builds pass for `@mastra/playground-ui` and `@mastra/playground`.
- Local build/tests for `@mastra/playground-ui` passed (205/205 tests; 5 new).
- ESLint and Prettier clean for AlertDialog.

### Breaking Changes

- None. Public API behavior is preserved (including Trigger.asChild and close behavior of Action/Cancel).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->