### PR TITLE
feat(playground-ui): migrate Collapsible to Base UI

### DIFF
--- a/.changeset/hip-toes-grab.md
+++ b/.changeset/hip-toes-grab.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Moved the `Collapsible` component to Base UI, with a smoother height-based expand and collapse animation. The public API is unchanged — `asChild` on `CollapsibleTrigger` still works.

--- a/packages/playground-ui/src/ds/components/Collapsible/collapsible.test.tsx
+++ b/packages/playground-ui/src/ds/components/Collapsible/collapsible.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './collapsible';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Collapsible', () => {
+  it('mounts trigger and content in an open collapsible without throwing', () => {
+    expect(() =>
+      render(
+        <Collapsible defaultOpen>
+          <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+          <CollapsibleContent>Panel content</CollapsibleContent>
+        </Collapsible>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByText('Panel content')).toBeDefined();
+  });
+
+  it('renders an asChild Trigger as the child element without nesting buttons', () => {
+    render(
+      <Collapsible>
+        <CollapsibleTrigger asChild>
+          <button type="button">Toggle panel</button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>Panel content</CollapsibleContent>
+      </Collapsible>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Toggle panel' });
+    expect(trigger.querySelector('button')).toBeNull();
+  });
+
+  it('toggles the panel when the trigger is clicked', () => {
+    render(
+      <Collapsible>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent>Panel content</CollapsibleContent>
+      </Collapsible>,
+    );
+
+    expect(screen.queryByText('Panel content')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+    expect(screen.getByText('Panel content')).toBeDefined();
+  });
+});

--- a/packages/playground-ui/src/ds/components/Collapsible/collapsible.tsx
+++ b/packages/playground-ui/src/ds/components/Collapsible/collapsible.tsx
@@ -43,6 +43,9 @@ type CollapsibleContentProps = Omit<CollapsiblePrimitive.Panel.Props, 'className
 
 const CollapsibleContent = React.forwardRef<HTMLDivElement, CollapsibleContentProps>(
   ({ className, children, ...props }, ref) => (
+    // Base UI animates the panel's `height` between 0 and `--collapsible-panel-height`.
+    // Padding/margin/borders must live on an inner wrapper — if applied to the panel
+    // itself they keep it from collapsing to 0, which makes the animation jump.
     <CollapsiblePrimitive.Panel
       ref={ref}
       data-slot="collapsible-content"
@@ -50,11 +53,10 @@ const CollapsibleContent = React.forwardRef<HTMLDivElement, CollapsibleContentPr
         'overflow-hidden',
         'h-[var(--collapsible-panel-height)] transition-[height] duration-normal ease-out-custom',
         'data-[starting-style]:h-0 data-[ending-style]:h-0',
-        className,
       )}
       {...props}
     >
-      {children}
+      <div className={className}>{children}</div>
     </CollapsiblePrimitive.Panel>
   ),
 );

--- a/packages/playground-ui/src/ds/components/Collapsible/collapsible.tsx
+++ b/packages/playground-ui/src/ds/components/Collapsible/collapsible.tsx
@@ -1,50 +1,63 @@
-import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
+import { Collapsible as CollapsiblePrimitive } from '@base-ui/react/collapsible';
 import React from 'react';
 import { transitions, focusRing } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
 const Collapsible = CollapsiblePrimitive.Root;
 
-const CollapsibleTrigger = React.forwardRef<
-  React.ElementRef<typeof CollapsiblePrimitive.CollapsibleTrigger>,
-  CollapsiblePrimitive.CollapsibleTriggerProps
->(({ className, children, ...props }, ref) => (
-  <CollapsiblePrimitive.CollapsibleTrigger
-    ref={ref}
-    className={cn(
-      '-outline-offset-2',
-      transitions.colors,
-      focusRing.visible,
-      'hover:text-neutral5',
-      '[&>svg]:transition-transform [&>svg]:duration-normal [&>svg]:ease-out-custom',
-      '[&[data-state=open]>svg]:rotate-90',
-      className,
-    )}
-    {...props}
-  >
-    {children}
-  </CollapsiblePrimitive.CollapsibleTrigger>
-));
-CollapsibleTrigger.displayName = CollapsiblePrimitive.CollapsibleTrigger.displayName;
+type CollapsibleTriggerProps = Omit<CollapsiblePrimitive.Trigger.Props, 'className'> & {
+  className?: string;
+  asChild?: boolean;
+};
 
-const CollapsibleContent = React.forwardRef<
-  React.ElementRef<typeof CollapsiblePrimitive.CollapsibleContent>,
-  CollapsiblePrimitive.CollapsibleContentProps
->(({ className, children, ...props }, ref) => (
-  <CollapsiblePrimitive.CollapsibleContent
-    ref={ref}
-    className={cn(
-      'overflow-hidden',
-      'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1',
-      'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1',
-      'duration-normal ease-out-custom',
-      className,
-    )}
-    {...props}
-  >
-    {children}
-  </CollapsiblePrimitive.CollapsibleContent>
-));
-CollapsibleContent.displayName = CollapsiblePrimitive.CollapsibleContent.displayName;
+const CollapsibleTrigger = React.forwardRef<HTMLButtonElement, CollapsibleTriggerProps>(
+  ({ className, asChild, children, ...props }, ref) => {
+    const renderProps = asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {};
+
+    return (
+      <CollapsiblePrimitive.Trigger
+        ref={ref}
+        data-slot="collapsible-trigger"
+        className={cn(
+          '-outline-offset-2',
+          transitions.colors,
+          focusRing.visible,
+          'hover:text-neutral5',
+          '[&>svg]:transition-transform [&>svg]:duration-normal [&>svg]:ease-out-custom',
+          '[&[data-panel-open]>svg]:rotate-90',
+          className,
+        )}
+        {...renderProps}
+        {...props}
+      >
+        {asChild ? undefined : children}
+      </CollapsiblePrimitive.Trigger>
+    );
+  },
+);
+CollapsibleTrigger.displayName = 'CollapsibleTrigger';
+
+type CollapsibleContentProps = Omit<CollapsiblePrimitive.Panel.Props, 'className'> & {
+  className?: string;
+};
+
+const CollapsibleContent = React.forwardRef<HTMLDivElement, CollapsibleContentProps>(
+  ({ className, children, ...props }, ref) => (
+    <CollapsiblePrimitive.Panel
+      ref={ref}
+      data-slot="collapsible-content"
+      className={cn(
+        'overflow-hidden',
+        'h-[var(--collapsible-panel-height)] transition-[height] duration-normal ease-out-custom',
+        'data-[starting-style]:h-0 data-[ending-style]:h-0',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </CollapsiblePrimitive.Panel>
+  ),
+);
+CollapsibleContent.displayName = 'CollapsibleContent';
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent };


### PR DESCRIPTION
## Summary

- Migrates the `Collapsible` design system component from `@radix-ui/react-collapsible` to `@base-ui/react/collapsible`.
- **Public API unchanged.** `asChild` on `CollapsibleTrigger` is preserved through a render-prop shim. `Collapsible` and `CollapsibleContent` keep the same props.
- Part mapping: Radix `Root`/`Trigger`/`Content` → Base UI `Root`/`Trigger`/`Panel`.
- **Smoother animation.** `CollapsibleContent` now animates with Base UI's height-based transition (`--collapsible-panel-height`) instead of the previous fade + slide, so the panel expands and collapses by actual height.
- Chevron rotation moves from Radix's `data-state=open` to Base UI's `data-panel-open` on the trigger.
- Adds `collapsible.test.tsx` smoke tests: mounts trigger + content open, verifies the `asChild` shim, and trigger toggle.

## Test plan

- [x] `pnpm exec tsc --noEmit` on `@mastra/playground-ui` — exit 0
- [x] `pnpm exec tsc --noEmit` on `@mastra/playground` — exit 0
- [x] `pnpm build` on `@mastra/playground-ui` — OK
- [x] `pnpm test` on `@mastra/playground-ui` — 198/198 (3 new)
- [x] `eslint` + `prettier` on `Collapsible` — clean
- [ ] Manual visual check of the height animation in Studio (not run — dev server lives on the main checkout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR replaces the underlying library for the Collapsible component (Radix → Base UI) while keeping the developer-facing API the same. The panel now expands/collapses by actual height for a smoother animation instead of the previous fade+slide.

## Changes

### Component Implementation (`collapsible.tsx`)
- Reimplemented Collapsible using `@base-ui/react/collapsible` (Root → Root, Trigger → Trigger, Content → Panel).
- Preserved public API: `Collapsible`, `CollapsibleTrigger`, `CollapsibleContent` props unchanged and `asChild` support preserved via a render-prop shim on `CollapsibleTrigger`.
- Animation: replaced Radix fade+slide with Base UI height-based transition using CSS variable `--collapsible-panel-height` and explicit starting/ending height rules (`h-0`) for smooth expand/collapse.
- Layout fix: introduced an inner wrapper inside the Panel so consumer padding/margin/border do not break the height animation (prevents jump-to-0 issues).
- Chevron rotation/triggers updated to use Base UI’s `data-panel-open` on the trigger (replaces Radix `data-state=open`).
- Updated component display names and forwardRef signatures to match Base UI element types.

### Tests (`collapsible.test.tsx`)
- Added three smoke tests:
  - mounting an open Collapsible renders trigger + content,
  - `asChild` renders a provided button element directly (no nested buttons),
  - clicking the trigger toggles content visibility.
- Test run: `@mastra/playground-ui` tests pass (198/198, includes 3 new tests).

## Public API
- No breaking changes: props and `asChild` behavior remain compatible with prior Radix-based implementation.

## Validation
- Type checks and builds for `@mastra/playground-ui` and `@mastra/playground` complete per checklist.
- ESLint and Prettier clean for Collapsible.
- Manual visual check in Studio not performed in this branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->