### PR TITLE
feat(core): add Harness v1 storage domain

### DIFF
--- a/.changeset/brave-bobcats-dress.md
+++ b/.changeset/brave-bobcats-dress.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': minor
+---
+
+Added the Harness v1 storage contract for session records, leases, and attachments. Storage adapters can now provide durable session state for the new Harness and Session APIs.
+
+```ts
+import { Harness } from '@mastra/core/harness/v1';
+import type { HarnessStorage } from '@mastra/core/storage/domains/harness';
+
+const myHarnessStorage: HarnessStorage = createHarnessStorage();
+
+const harness = new Harness({
+  agents,
+  modes,
+  sessions: { storage: myHarnessStorage },
+});
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -732,6 +732,16 @@
         "default": "./dist/storage/domains/favorites/index.cjs"
       }
     },
+    "./storage/domains/harness": {
+      "import": {
+        "types": "./dist/storage/domains/harness/index.d.ts",
+        "default": "./dist/storage/domains/harness/index.js"
+      },
+      "require": {
+        "types": "./dist/storage/domains/harness/index.d.ts",
+        "default": "./dist/storage/domains/harness/index.cjs"
+      }
+    },
     "./storage/domains/workspaces": {
       "import": {
         "types": "./dist/storage/domains/workspaces/index.d.ts",

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -3,8 +3,25 @@ import type { z } from 'zod';
 import type { AgentExecutionOptionsBase } from '../../agent/agent.types';
 import type { CreatedAgentSignal } from '../../agent/signals';
 import type { ToolsInput } from '../../agent/types';
+import type { GoalState, PendingResume, PermissionRules, SessionGrants } from '../../storage/domains/harness';
 import type { MastraModelOutput, FullOutput } from '../../stream/base/output';
-import type { HarnessMode, ToolCategory } from './shared';
+import type { HarnessMode } from './shared';
+
+export type {
+  AttachmentRecord,
+  GoalJudgeDecision,
+  GoalState,
+  LoadedAttachment,
+  PendingResume,
+  PermissionRules,
+  PersistedAttachment,
+  QueuedItem,
+  SessionGrants,
+  SessionRecord,
+  SessionSummary,
+  SessionWorkspaceState,
+  TokenUsage,
+} from '../../storage/domains/harness';
 
 export type PermissionPolicy = 'allow' | 'ask' | 'deny';
 
@@ -40,17 +57,6 @@ export interface HarnessLease {
   acquiredAt: number;
   expiresAt: number;
   renewCount?: number;
-}
-
-export interface PersistedAttachment {
-  id: string;
-  resourceId: string;
-  filename: string;
-  contentType: string;
-  size?: number;
-  url?: string;
-  metadata?: Record<string, unknown>;
-  createdAt: Date;
 }
 
 export interface AttachmentRef {
@@ -97,8 +103,6 @@ export interface PendingPlanApproval extends PendingBase {
   transitionModeId?: string;
 }
 
-export type PendingResume = PendingApproval | PendingToolSuspension | PendingQuestion | PendingPlanApproval;
-
 export interface PendingReceipt {
   id: string;
   sessionId: string;
@@ -108,80 +112,12 @@ export interface PendingReceipt {
   createdAt: number;
 }
 
-export interface QueuedItem {
-  id: string;
-  content: string;
-  attachments?: AttachmentRef[];
-  model?: string;
-  mode?: string;
-  yolo?: boolean;
-  createdAt: number;
-  startedAt?: number;
-  runId?: string;
-}
-
-export interface SessionGrants {
-  categories?: Partial<Record<ToolCategory, boolean>>;
-  tools?: Record<string, boolean>;
-}
-
-export interface PermissionRules {
-  categories?: Partial<Record<ToolCategory, PermissionPolicy>>;
-  tools?: Record<string, PermissionPolicy>;
-}
-
-export interface GoalState {
-  id: string;
-  objective: string;
-  status: 'active' | 'paused' | 'done' | 'cleared';
-  judgeModel?: string;
-  maxTurns: number;
-  turnsUsed: number;
-  createdAt: number;
-  updatedAt: number;
-  doneReason?: string;
-  pausedReason?: 'requested' | 'budget_exhausted' | 'judge_failed';
-}
-
-export type GoalJudgeDecision =
-  | { type: 'done'; reason: string }
-  | { type: 'continue'; reason?: string; reminder?: string }
-  | { type: 'waiting'; reason?: string };
-
 export interface WorkspaceSessionBinding {
   providerId: string;
   workspaceId?: string;
   status: 'initializing' | 'ready' | 'destroying' | 'destroyed' | 'lost' | 'error';
   state?: unknown;
   metadata?: Record<string, unknown>;
-}
-
-export interface SessionRecord<TState = unknown> {
-  id: string;
-  resourceId: string;
-  threadId: string;
-  parentSessionId?: string;
-  ownsThread?: boolean;
-  origin?: 'top-level' | 'subagent-tool';
-  lifecycleState: SessionLifecycleState;
-  modeId: string;
-  modelId: string;
-  state: TState;
-  subagentDepth: number;
-  pendingResume?: PendingResume | null;
-  pendingQueue: QueuedItem[];
-  grants?: SessionGrants;
-  permissionRules?: PermissionRules;
-  goal?: GoalState | null;
-  workspace?: WorkspaceSessionBinding;
-  attachments?: PersistedAttachment[];
-  subagentModels?: Record<string, string | null>;
-  lease?: HarnessLease | null;
-  metadata?: Record<string, unknown>;
-  createdAt: Date;
-  updatedAt: Date;
-  closedAt?: Date;
-  version: number;
 }
 
 export interface HarnessRunOperationalState {

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -19,6 +19,7 @@ import type {
   BackgroundTasksStorage,
   SchedulesStorage,
   ChannelsStorage,
+  HarnessStorage,
 } from './domains';
 
 /** Map of all storage domain interfaces available in a composite store. */
@@ -27,6 +28,7 @@ export type StorageDomains = {
   scores?: ScoresStorage;
   memory?: MemoryStorage;
   channels?: ChannelsStorage;
+  harness?: HarnessStorage;
   observability?: ObservabilityStorage;
   agents?: AgentsStorage;
   datasets?: DatasetsStorage;
@@ -313,6 +315,7 @@ export class MastraCompositeStore extends MastraBase {
         backgroundTasks: resolve('backgroundTasks'),
         schedules: resolve('schedules'),
         channels: resolve('channels'),
+        harness: resolve('harness'),
       } as StorageDomains;
     }
     // Otherwise, subclasses set stores themselves
@@ -412,6 +415,7 @@ export class MastraCompositeStore extends MastraBase {
       maybeInit(this.stores.backgroundTasks);
       maybeInit(this.stores.schedules);
       maybeInit(this.stores.channels);
+      maybeInit(this.stores.harness);
     }
 
     await Promise.all(initTasks);

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -1,0 +1,167 @@
+import { StorageDomain } from '../base';
+import type {
+  AcquireSessionLeaseInput,
+  AttachmentRecord,
+  ListSessionsInput,
+  LoadedAttachment,
+  ReleaseSessionLeaseInput,
+  RenewSessionLeaseInput,
+  SaveAttachmentInput,
+  SaveSessionOptions,
+  SaveSessionResult,
+  SessionLeaseResult,
+  SessionRecord,
+  SessionSummary,
+} from './types';
+
+/**
+ * Thrown by `saveSession` when `ifVersion` does not match the record's
+ * current `version`. The caller should rehydrate and retry once.
+ */
+export class HarnessStorageVersionConflictError extends Error {
+  readonly name = 'HarnessStorageVersionConflictError';
+  readonly code = 'harness.storage.version_conflict' as const;
+
+  constructor(
+    public readonly sessionId: string,
+    public readonly expectedVersion: number,
+    public readonly actualVersion: number,
+  ) {
+    super(`Session "${sessionId}" version conflict: expected ${expectedVersion}, found ${actualVersion}`);
+  }
+}
+
+/**
+ * Thrown by lease operations and `saveSession` when another owner currently
+ * holds the lease.
+ */
+export class HarnessStorageLeaseConflictError extends Error {
+  readonly name = 'HarnessStorageLeaseConflictError';
+  readonly code = 'harness.storage.lease_conflict' as const;
+
+  constructor(
+    public readonly sessionId: string,
+    public readonly heldBy: string,
+    public readonly expiresAt: number,
+  ) {
+    super(`Session "${sessionId}" lease held by "${heldBy}" until ${new Date(expiresAt).toISOString()}`);
+  }
+}
+
+/**
+ * Thrown by lease operations when the targeted session record does not exist.
+ */
+export class HarnessStorageSessionNotFoundError extends Error {
+  readonly name = 'HarnessStorageSessionNotFoundError';
+  readonly code = 'harness.storage.session_not_found' as const;
+
+  constructor(public readonly sessionId: string) {
+    super(`Session "${sessionId}" not found in harness storage`);
+  }
+}
+
+/**
+ * Storage domain for the v1 Harness.
+ *
+ * Owns three resources:
+ *
+ *   1. Session records - durable session state persisted under an
+ *      optimistic-CAS contract.
+ *   2. Session leases - per-session ownership tokens that gate writes across
+ *      multiple Harness instances pointing at the same store.
+ *   3. Attachment metadata and bytes - an index from `attachmentId` to the
+ *      stored attachment payload.
+ *
+ * Threads and messages are NOT in this domain - they live under
+ * `MemoryStorage`. The harness layer composes the two.
+ */
+export abstract class HarnessStorage extends StorageDomain {
+  constructor() {
+    super({
+      component: 'STORAGE',
+      name: 'HARNESS',
+    });
+  }
+
+  /**
+   * Direct ID lookup. Returns the record regardless of `closedAt`.
+   */
+  abstract loadSession(opts: { sessionId: string }): Promise<SessionRecord | null>;
+
+  /**
+   * Lookup by (thread, resource). Returns only active records
+   * (`closedAt === undefined`). If multiple active records match,
+   * implementations return the most recent by `lastActivityAt`.
+   */
+  abstract loadSessionByThread(opts: { threadId: string; resourceId: string }): Promise<SessionRecord | null>;
+
+  /**
+   * List session summaries for a resource. Closed records are excluded by
+   * default; pass `includeClosed: true` to surface them.
+   */
+  abstract listSessions(opts: ListSessionsInput): Promise<SessionSummary[]>;
+
+  /**
+   * Optimistic-CAS write of a session record.
+   *
+   * Throws `HarnessStorageVersionConflictError` on version mismatch.
+   * Throws `HarnessStorageLeaseConflictError` when `ownerId` does not match
+   * the row's current lease holder and the lease has not expired.
+   */
+  abstract saveSession(record: SessionRecord, opts: SaveSessionOptions): Promise<SaveSessionResult>;
+
+  /**
+   * Hard-delete of a single session record. No-op when the record does not
+   * exist. Implementations should also delete attachments owned by the
+   * session.
+   */
+  abstract deleteSession(opts: { sessionId: string }): Promise<void>;
+
+  /**
+   * Acquire the write lease for a session.
+   */
+  abstract acquireSessionLease(opts: AcquireSessionLeaseInput): Promise<SessionLeaseResult>;
+
+  /**
+   * Renew an existing lease.
+   */
+  abstract renewSessionLease(opts: RenewSessionLeaseInput): Promise<SessionLeaseResult>;
+
+  /**
+   * Release the lease. No-op when `opts.ownerId` does not match the current
+   * owner.
+   */
+  abstract releaseSessionLease(opts: ReleaseSessionLeaseInput): Promise<void>;
+
+  /**
+   * Persist an attachment's bytes and index row.
+   */
+  abstract saveAttachment(opts: SaveAttachmentInput): Promise<void>;
+
+  /**
+   * Load an attachment by (sessionId, attachmentId). Returns null when the row
+   * is missing.
+   */
+  abstract loadAttachment(opts: { sessionId: string; attachmentId: string }): Promise<LoadedAttachment | null>;
+
+  /**
+   * Delete a single attachment. No-op when the row is missing.
+   */
+  abstract deleteAttachment(opts: { sessionId: string; attachmentId: string }): Promise<void>;
+
+  /**
+   * Delete all attachments owned by a session.
+   */
+  abstract deleteAttachmentsForSession(opts: { sessionId: string }): Promise<void>;
+
+  /**
+   * Look up the index row only, without bytes.
+   */
+  abstract getAttachmentRecord(opts: { sessionId: string; attachmentId: string }): Promise<AttachmentRecord | null>;
+
+  /**
+   * Drop all session records, leases, and attachments held by this domain.
+   * Intended for tests only.
+   */
+  abstract dangerouslyClearAll(): Promise<void>;
+}

--- a/packages/core/src/storage/domains/harness/index.ts
+++ b/packages/core/src/storage/domains/harness/index.ts
@@ -1,0 +1,3 @@
+export * from './base';
+export * from './types';
+export * from './inmemory';

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InMemoryDB } from '../inmemory-db';
+import {
+  HarnessStorageLeaseConflictError,
+  HarnessStorageSessionNotFoundError,
+  HarnessStorageVersionConflictError,
+} from './base';
+import { InMemoryHarness } from './inmemory';
+import type { SessionRecord } from './types';
+
+function makeSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: 'session-1',
+    resourceId: 'resource-1',
+    threadId: 'thread-1',
+    origin: 'top-level',
+    subagentDepth: 0,
+    ownsThread: true,
+    modeId: 'default',
+    modelId: 'openai:gpt-4o-mini',
+    subagentModelOverrides: {},
+    permissionRules: { categories: {}, tools: {} },
+    sessionGrants: { categories: [], tools: [] },
+    tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    pendingQueue: [],
+    state: {},
+    createdAt: 1_000,
+    lastActivityAt: 1_000,
+    version: 0,
+    ...overrides,
+  };
+}
+
+describe('InMemoryHarness', () => {
+  let db: InMemoryDB;
+  let storage: InMemoryHarness;
+
+  beforeEach(() => {
+    db = new InMemoryDB();
+    storage = new InMemoryHarness({ db });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('saves and loads a session with optimistic version increments', async () => {
+    const record = makeSession();
+
+    await expect(storage.saveSession(record, { ownerId: 'owner-1', ifVersion: 0 })).resolves.toEqual({ version: 1 });
+
+    expect(await storage.loadSession({ sessionId: 'session-1' })).toEqual({ ...record, version: 1 });
+
+    await expect(
+      storage.saveSession({ ...record, state: { step: 2 }, version: 1 }, { ownerId: 'owner-1', ifVersion: 1 }),
+    ).resolves.toEqual({ version: 2 });
+
+    expect(await storage.loadSession({ sessionId: 'session-1' })).toMatchObject({
+      id: 'session-1',
+      state: { step: 2 },
+      version: 2,
+    });
+  });
+
+  it('rejects stale save versions', async () => {
+    const record = makeSession();
+    await storage.saveSession(record, { ownerId: 'owner-1', ifVersion: 0 });
+
+    await expect(
+      storage.saveSession({ ...record, version: 1 }, { ownerId: 'owner-1', ifVersion: 0 }),
+    ).rejects.toBeInstanceOf(HarnessStorageVersionConflictError);
+
+    await expect(
+      storage.saveSession(makeSession({ id: 'new-session' }), { ownerId: 'owner-1', ifVersion: 2 }),
+    ).rejects.toBeInstanceOf(HarnessStorageVersionConflictError);
+  });
+
+  it('enforces active leases on save', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+
+    const record = makeSession();
+    await storage.saveSession(record, { ownerId: 'owner-1', ifVersion: 0 });
+    await storage.acquireSessionLease({ sessionId: 'session-1', ownerId: 'owner-1', ttlMs: 1_000 });
+
+    await expect(
+      storage.saveSession({ ...record, version: 1 }, { ownerId: 'owner-2', ifVersion: 1 }),
+    ).rejects.toBeInstanceOf(HarnessStorageLeaseConflictError);
+
+    vi.setSystemTime(11_001);
+
+    await expect(
+      storage.saveSession(
+        { ...record, state: { afterExpiry: true }, version: 1 },
+        { ownerId: 'owner-2', ifVersion: 1 },
+      ),
+    ).resolves.toEqual({ version: 2 });
+  });
+
+  it('acquires, renews, and releases session leases', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(20_000);
+
+    await storage.saveSession(makeSession(), { ownerId: 'owner-1', ifVersion: 0 });
+
+    await expect(
+      storage.acquireSessionLease({ sessionId: 'missing', ownerId: 'owner-1', ttlMs: 100 }),
+    ).rejects.toBeInstanceOf(HarnessStorageSessionNotFoundError);
+
+    await expect(
+      storage.acquireSessionLease({ sessionId: 'session-1', ownerId: 'owner-1', ttlMs: 100 }),
+    ).resolves.toEqual({
+      version: 1,
+      expiresAt: 20_100,
+    });
+
+    await expect(
+      storage.acquireSessionLease({ sessionId: 'session-1', ownerId: 'owner-2', ttlMs: 100 }),
+    ).rejects.toBeInstanceOf(HarnessStorageLeaseConflictError);
+
+    vi.setSystemTime(20_050);
+    await expect(
+      storage.renewSessionLease({ sessionId: 'session-1', ownerId: 'owner-1', ttlMs: 200 }),
+    ).resolves.toEqual({
+      version: 1,
+      expiresAt: 20_250,
+    });
+
+    await storage.releaseSessionLease({ sessionId: 'session-1', ownerId: 'owner-2' });
+    expect(await storage.loadSession({ sessionId: 'session-1' })).toMatchObject({
+      ownerId: 'owner-1',
+      leaseExpiresAt: 20_250,
+    });
+
+    await storage.releaseSessionLease({ sessionId: 'session-1', ownerId: 'owner-1' });
+    expect(await storage.loadSession({ sessionId: 'session-1' })).toMatchObject({
+      ownerId: undefined,
+      leaseExpiresAt: undefined,
+    });
+  });
+
+  it('rejects renew after the lease expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(30_000);
+
+    await storage.saveSession(makeSession(), { ownerId: 'owner-1', ifVersion: 0 });
+    await storage.acquireSessionLease({ sessionId: 'session-1', ownerId: 'owner-1', ttlMs: 100 });
+
+    vi.setSystemTime(30_101);
+
+    await expect(
+      storage.renewSessionLease({ sessionId: 'session-1', ownerId: 'owner-1', ttlMs: 100 }),
+    ).rejects.toBeInstanceOf(HarnessStorageLeaseConflictError);
+  });
+
+  it('loads the most recent active session for a thread and resource', async () => {
+    await storage.saveSession(makeSession({ id: 'old-active', lastActivityAt: 1_000 }), {
+      ownerId: 'owner-1',
+      ifVersion: 0,
+    });
+    await storage.saveSession(makeSession({ id: 'new-active', lastActivityAt: 2_000 }), {
+      ownerId: 'owner-1',
+      ifVersion: 0,
+    });
+    await storage.saveSession(makeSession({ id: 'closed', lastActivityAt: 3_000, closedAt: 3_000 }), {
+      ownerId: 'owner-1',
+      ifVersion: 0,
+    });
+    await storage.saveSession(makeSession({ id: 'other-resource', resourceId: 'resource-2', lastActivityAt: 4_000 }), {
+      ownerId: 'owner-1',
+      ifVersion: 0,
+    });
+
+    expect(await storage.loadSessionByThread({ threadId: 'thread-1', resourceId: 'resource-1' })).toMatchObject({
+      id: 'new-active',
+    });
+  });
+
+  it('lists sessions by resource, parent, closed state, and activity order', async () => {
+    await storage.saveSession(makeSession({ id: 'parent', lastActivityAt: 1_000 }), {
+      ownerId: 'owner-1',
+      ifVersion: 0,
+    });
+    await storage.saveSession(makeSession({ id: 'child-1', parentSessionId: 'parent', lastActivityAt: 3_000 }), {
+      ownerId: 'owner-1',
+      ifVersion: 0,
+    });
+    await storage.saveSession(
+      makeSession({ id: 'child-2', parentSessionId: 'parent', lastActivityAt: 2_000, closedAt: 2_500 }),
+      {
+        ownerId: 'owner-1',
+        ifVersion: 0,
+      },
+    );
+    await storage.saveSession(makeSession({ id: 'other-resource', resourceId: 'resource-2', lastActivityAt: 4_000 }), {
+      ownerId: 'owner-1',
+      ifVersion: 0,
+    });
+
+    await expect(storage.listSessions({ resourceId: 'resource-1' })).resolves.toEqual([
+      expect.objectContaining({ id: 'child-1' }),
+      expect.objectContaining({ id: 'parent' }),
+    ]);
+
+    await expect(
+      storage.listSessions({ resourceId: 'resource-1', parentSessionId: 'parent', includeClosed: true }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'child-1' }), expect.objectContaining({ id: 'child-2' })]);
+  });
+
+  it('stores attachment metadata and copied bytes', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    await storage.saveAttachment({
+      sessionId: 'session-1',
+      attachmentId: 'attachment-1',
+      name: 'file.txt',
+      mimeType: 'text/plain',
+      data,
+    });
+    data[0] = 9;
+
+    const loaded = await storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'attachment-1' });
+    expect(loaded).toEqual({
+      name: 'file.txt',
+      mimeType: 'text/plain',
+      data: new Uint8Array([1, 2, 3]),
+    });
+
+    loaded!.data[1] = 9;
+    await expect(
+      storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toMatchObject({
+      data: new Uint8Array([1, 2, 3]),
+    });
+
+    await expect(
+      storage.getAttachmentRecord({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        attachmentId: 'attachment-1',
+        sessionId: 'session-1',
+        name: 'file.txt',
+        mimeType: 'text/plain',
+        sizeBytes: 3,
+      }),
+    );
+  });
+
+  it('deletes single attachments, session attachments, and attachments on session delete', async () => {
+    await storage.saveSession(makeSession(), { ownerId: 'owner-1', ifVersion: 0 });
+    await storage.saveAttachment({
+      sessionId: 'session-1',
+      attachmentId: 'a',
+      name: 'a.txt',
+      mimeType: 'text/plain',
+      data: new Uint8Array([1]),
+    });
+    await storage.saveAttachment({
+      sessionId: 'session-1',
+      attachmentId: 'b',
+      name: 'b.txt',
+      mimeType: 'text/plain',
+      data: new Uint8Array([2]),
+    });
+
+    await storage.deleteAttachment({ sessionId: 'session-1', attachmentId: 'a' });
+    await expect(storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'a' })).resolves.toBeNull();
+    await expect(storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'b' })).resolves.not.toBeNull();
+
+    await storage.deleteSession({ sessionId: 'session-1' });
+    await expect(storage.loadSession({ sessionId: 'session-1' })).resolves.toBeNull();
+    await expect(storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'b' })).resolves.toBeNull();
+  });
+
+  it('clears all harness records from the shared in-memory database', async () => {
+    await storage.saveSession(makeSession(), { ownerId: 'owner-1', ifVersion: 0 });
+    await storage.saveAttachment({
+      sessionId: 'session-1',
+      attachmentId: 'attachment-1',
+      name: 'file.txt',
+      mimeType: 'text/plain',
+      data: new Uint8Array([1]),
+    });
+
+    await storage.dangerouslyClearAll();
+
+    expect(db.harnessSessions.size).toBe(0);
+    expect(db.harnessAttachmentRecords.size).toBe(0);
+    expect(db.harnessAttachmentBytes.size).toBe(0);
+  });
+});

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -1,0 +1,249 @@
+import type { InMemoryDB } from '../inmemory-db';
+import {
+  HarnessStorage,
+  HarnessStorageLeaseConflictError,
+  HarnessStorageSessionNotFoundError,
+  HarnessStorageVersionConflictError,
+} from './base';
+import type {
+  AcquireSessionLeaseInput,
+  AttachmentRecord,
+  ListSessionsInput,
+  LoadedAttachment,
+  ReleaseSessionLeaseInput,
+  RenewSessionLeaseInput,
+  SaveAttachmentInput,
+  SaveSessionOptions,
+  SaveSessionResult,
+  SessionLeaseResult,
+  SessionRecord,
+  SessionSummary,
+} from './types';
+
+/**
+ * In-memory `HarnessStorage` adapter - backs onto the shared `InMemoryDB`
+ * Maps so it composes naturally with the other in-memory domains.
+ *
+ * Records are stored by reference; reads return the live row, callers should
+ * treat returned `SessionRecord`s as read-only and pass a fresh object to
+ * `saveSession` for updates. This matches the pattern used by `InMemoryMemory`.
+ */
+export class InMemoryHarness extends HarnessStorage {
+  private db: InMemoryDB;
+
+  constructor({ db }: { db: InMemoryDB }) {
+    super();
+    this.db = db;
+  }
+
+  async loadSession({ sessionId }: { sessionId: string }): Promise<SessionRecord | null> {
+    return this.db.harnessSessions.get(sessionId) ?? null;
+  }
+
+  async loadSessionByThread({
+    threadId,
+    resourceId,
+  }: {
+    threadId: string;
+    resourceId: string;
+  }): Promise<SessionRecord | null> {
+    let candidate: SessionRecord | null = null;
+    for (const record of this.db.harnessSessions.values()) {
+      if (record.threadId !== threadId || record.resourceId !== resourceId) continue;
+      if (record.closedAt !== undefined) continue;
+      if (candidate === null || record.lastActivityAt > candidate.lastActivityAt) {
+        candidate = record;
+      }
+    }
+    return candidate;
+  }
+
+  async listSessions({
+    resourceId,
+    includeClosed = false,
+    parentSessionId,
+  }: ListSessionsInput): Promise<SessionSummary[]> {
+    const matched: SessionRecord[] = [];
+    for (const record of this.db.harnessSessions.values()) {
+      if (record.resourceId !== resourceId) continue;
+      if (!includeClosed && record.closedAt !== undefined) continue;
+      if (parentSessionId !== undefined && record.parentSessionId !== parentSessionId) continue;
+      matched.push(record);
+    }
+    matched.sort((a, b) => b.lastActivityAt - a.lastActivityAt);
+    return matched.map(toSummary);
+  }
+
+  async saveSession(record: SessionRecord, opts: SaveSessionOptions): Promise<SaveSessionResult> {
+    const existing = this.db.harnessSessions.get(record.id);
+
+    if (existing) {
+      assertLeaseHolder(existing, opts.ownerId);
+
+      if (existing.version !== opts.ifVersion) {
+        throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, existing.version);
+      }
+    } else if (opts.ifVersion !== 0) {
+      throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, 0);
+    }
+
+    const nextVersion = opts.ifVersion + 1;
+    const stored: SessionRecord = {
+      ...record,
+      version: nextVersion,
+      // Preserve current lease metadata - `saveSession` does not mutate it.
+      ownerId: existing?.ownerId,
+      leaseExpiresAt: existing?.leaseExpiresAt,
+    };
+
+    this.db.harnessSessions.set(record.id, stored);
+    return { version: nextVersion };
+  }
+
+  async deleteSession({ sessionId }: { sessionId: string }): Promise<void> {
+    this.db.harnessSessions.delete(sessionId);
+    await this.deleteAttachmentsForSession({ sessionId });
+  }
+
+  async acquireSessionLease({ sessionId, ownerId, ttlMs }: AcquireSessionLeaseInput): Promise<SessionLeaseResult> {
+    const existing = this.db.harnessSessions.get(sessionId);
+    if (!existing) throw new HarnessStorageSessionNotFoundError(sessionId);
+
+    const now = Date.now();
+    const heldBy = existing.ownerId;
+    const heldUntil = existing.leaseExpiresAt;
+    const leaseHeld = heldBy !== undefined && heldUntil !== undefined && heldUntil > now;
+
+    if (leaseHeld && heldBy !== ownerId) {
+      throw new HarnessStorageLeaseConflictError(sessionId, heldBy, heldUntil);
+    }
+
+    const expiresAt = now + ttlMs;
+    const updated: SessionRecord = {
+      ...existing,
+      ownerId,
+      leaseExpiresAt: expiresAt,
+    };
+    this.db.harnessSessions.set(sessionId, updated);
+    return { version: existing.version, expiresAt };
+  }
+
+  async renewSessionLease({ sessionId, ownerId, ttlMs }: RenewSessionLeaseInput): Promise<SessionLeaseResult> {
+    const existing = this.db.harnessSessions.get(sessionId);
+    if (!existing) throw new HarnessStorageSessionNotFoundError(sessionId);
+
+    const now = Date.now();
+    const leaseValid =
+      existing.ownerId === ownerId && existing.leaseExpiresAt !== undefined && existing.leaseExpiresAt > now;
+
+    if (!leaseValid) {
+      throw new HarnessStorageLeaseConflictError(
+        sessionId,
+        existing.ownerId ?? '<unowned>',
+        existing.leaseExpiresAt ?? 0,
+      );
+    }
+
+    const expiresAt = now + ttlMs;
+    const updated: SessionRecord = { ...existing, leaseExpiresAt: expiresAt };
+    this.db.harnessSessions.set(sessionId, updated);
+    return { version: existing.version, expiresAt };
+  }
+
+  async releaseSessionLease({ sessionId, ownerId }: ReleaseSessionLeaseInput): Promise<void> {
+    const existing = this.db.harnessSessions.get(sessionId);
+    if (!existing) throw new HarnessStorageSessionNotFoundError(sessionId);
+
+    if (existing.ownerId !== ownerId) return;
+
+    const updated: SessionRecord = { ...existing, ownerId: undefined, leaseExpiresAt: undefined };
+    this.db.harnessSessions.set(sessionId, updated);
+  }
+
+  async saveAttachment({ sessionId, attachmentId, name, mimeType, data }: SaveAttachmentInput): Promise<void> {
+    const key = attachmentKey(sessionId, attachmentId);
+    const record: AttachmentRecord = {
+      attachmentId,
+      sessionId,
+      name,
+      mimeType,
+      sizeBytes: data.byteLength,
+      createdAt: Date.now(),
+    };
+    this.db.harnessAttachmentRecords.set(key, record);
+    // Copy the bytes so callers can reuse their buffer.
+    this.db.harnessAttachmentBytes.set(key, new Uint8Array(data));
+  }
+
+  async loadAttachment({
+    sessionId,
+    attachmentId,
+  }: {
+    sessionId: string;
+    attachmentId: string;
+  }): Promise<LoadedAttachment | null> {
+    const key = attachmentKey(sessionId, attachmentId);
+    const record = this.db.harnessAttachmentRecords.get(key);
+    const bytes = this.db.harnessAttachmentBytes.get(key);
+    if (!record || !bytes) return null;
+    return { name: record.name, mimeType: record.mimeType, data: new Uint8Array(bytes) };
+  }
+
+  async deleteAttachment({ sessionId, attachmentId }: { sessionId: string; attachmentId: string }): Promise<void> {
+    const key = attachmentKey(sessionId, attachmentId);
+    this.db.harnessAttachmentRecords.delete(key);
+    this.db.harnessAttachmentBytes.delete(key);
+  }
+
+  async deleteAttachmentsForSession({ sessionId }: { sessionId: string }): Promise<void> {
+    const prefix = `${sessionId}\u0000`;
+    for (const key of this.db.harnessAttachmentRecords.keys()) {
+      if (key.startsWith(prefix)) {
+        this.db.harnessAttachmentRecords.delete(key);
+        this.db.harnessAttachmentBytes.delete(key);
+      }
+    }
+  }
+
+  async getAttachmentRecord({
+    sessionId,
+    attachmentId,
+  }: {
+    sessionId: string;
+    attachmentId: string;
+  }): Promise<AttachmentRecord | null> {
+    return this.db.harnessAttachmentRecords.get(attachmentKey(sessionId, attachmentId)) ?? null;
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    this.db.harnessSessions.clear();
+    this.db.harnessAttachmentRecords.clear();
+    this.db.harnessAttachmentBytes.clear();
+  }
+}
+
+function attachmentKey(sessionId: string, attachmentId: string): string {
+  return `${sessionId}\u0000${attachmentId}`;
+}
+
+function assertLeaseHolder(existing: SessionRecord, ownerId: string): void {
+  if (existing.ownerId === undefined) return;
+  const now = Date.now();
+  if (existing.leaseExpiresAt !== undefined && existing.leaseExpiresAt <= now) return;
+  if (existing.ownerId === ownerId) return;
+  throw new HarnessStorageLeaseConflictError(existing.id, existing.ownerId, existing.leaseExpiresAt ?? 0);
+}
+
+function toSummary(record: SessionRecord): SessionSummary {
+  return {
+    id: record.id,
+    resourceId: record.resourceId,
+    threadId: record.threadId,
+    parentSessionId: record.parentSessionId,
+    origin: record.origin,
+    modeId: record.modeId,
+    modelId: record.modelId,
+    lastActivityAt: record.lastActivityAt,
+    closedAt: record.closedAt,
+  };
+}

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -1,0 +1,295 @@
+/**
+ * Harness storage domain - durable session state for `@mastra/core/harness/v1`.
+ *
+ * The shapes here are JSON-serializable by contract. No `Date`, no
+ * `Map`/`Set`, no functions. Time fields are epoch milliseconds.
+ *
+ * Threads and messages are NOT in this domain - they live under
+ * `MemoryStorage`. The harness layer composes the two.
+ */
+
+/**
+ * Per-session permission rules. Plain JSON - no closures.
+ *
+ * `categories` holds per-category defaults; `tools` holds per-tool overrides
+ * and wins over the category default.
+ */
+export interface PermissionRules {
+  categories: Record<string, 'allow' | 'deny' | 'ask'>;
+  tools: Record<string, 'allow' | 'deny' | 'ask'>;
+}
+
+/**
+ * Session-scoped permission grants. Cleared when the session ends.
+ */
+export interface SessionGrants {
+  categories: string[];
+  tools: string[];
+}
+
+/**
+ * Aggregate token usage counters carried on the session record.
+ */
+export interface TokenUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+/**
+ * A persisted attachment reference on a queued or pending message.
+ *
+ * `kind: 'ref'` points at a row in the harness attachment index.
+ * `kind: 'url'` is a remote URL fetched at message-build time.
+ */
+export type PersistedAttachment =
+  | { kind: 'ref'; name: string; mimeType: string; attachmentId: string }
+  | { kind: 'url'; name: string; mimeType: string; url: string };
+
+/**
+ * A single item enqueued via `session.queue(...)`.
+ *
+ * `addTools` is intentionally not present: tool implementations are closures
+ * and cannot be serialized, so `queue(...)` rejects them at admission rather
+ * than dropping them silently after the fact.
+ */
+export interface QueuedItem {
+  id: string;
+  enqueuedAt: number;
+  content: string;
+  attachments: PersistedAttachment[];
+  model?: string;
+  mode?: string;
+  yolo?: boolean;
+  /**
+   * Origin of this queued item. `'user'` (default) for items enqueued by
+   * `session.queue(...)`, `'goal'` for harness-enqueued goal continuations.
+   */
+  source?: 'user' | 'goal';
+  /** Set when `source === 'goal'`. Identifies which goal produced the item. */
+  goalId?: string;
+}
+
+/**
+ * Outstanding agent suspension. At most one per session - the agent layer can
+ * only be in one of {approval, suspension, question, plan} at a time, so the
+ * four spec'd shapes collapse into a single tagged record.
+ */
+export interface PendingResume {
+  kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+  runId: string;
+  toolCallId: string;
+  /** Populated for tool-approval / tool-suspension; omitted otherwise. */
+  toolName?: string;
+  source: 'parent' | 'subagent';
+  subagentToolCallId?: string;
+  requestedAt: number;
+  /**
+   * Idempotency marker. Set by the resume helper before calling
+   * `agent.resumeStream(...)` and observed on replay so a crash between
+   * "wrote resumedAt" and "cleared pendingResume" does not double-resume.
+   */
+  resumedAt?: number;
+  /**
+   * Kind-specific UX surface - opaque to the harness, rendered by the UI.
+   * Populated at suspend-capture time from the agent's `suspendPayload`.
+   */
+  payload?: {
+    toolCategory?: string;
+    input?: unknown;
+    suspendData?: unknown;
+    question?: string;
+    options?: { label: string; description?: string }[];
+    selectionMode?: 'single_select' | 'multi_select';
+    title?: string;
+    plan?: string;
+  };
+  /**
+   * Plan-approval only. Frozen at registration from the submitting mode's
+   * transitions. A mode switch while the plan is pending does not retarget
+   * the approval.
+   */
+  transitionModeId?: string;
+  /** Plan-approval only. Idempotency markers for the mode-flip side effect. */
+  approvedTransitionModeId?: string;
+  modeTransitionAppliedAt?: number;
+}
+
+/**
+ * Verdict returned by the goal judge model after evaluating an assistant turn
+ * against the current goal objective.
+ */
+export interface GoalJudgeDecision {
+  decision: 'done' | 'continue' | 'waiting';
+  reason: string;
+  judgedAt: number;
+}
+
+/**
+ * Active goal state. Set via `session.setGoal(...)`, evaluated by the judge
+ * model after each assistant turn.
+ */
+export interface GoalState {
+  id: string;
+  objective: string;
+  status: 'active' | 'paused' | 'done';
+  turnsUsed: number;
+  maxTurns: number;
+  judgeModelId: string;
+  createdAt: number;
+  /** Most recent judge verdict, persisted so subscribers can read it. */
+  lastDecision?: GoalJudgeDecision;
+}
+
+/**
+ * Per-session workspace state, only populated under a resumable per-session
+ * workspace provider.
+ */
+export interface SessionWorkspaceState {
+  providerId: string;
+  state: unknown;
+}
+
+/**
+ * Durable session state. Loaded on hydration, flushed under the session's
+ * write lease.
+ */
+export interface SessionRecord {
+  id: string;
+  resourceId: string;
+  threadId: string;
+  parentSessionId?: string;
+  /**
+   * `'subagent-tool'` opts the record into the auto-close-on-subagent-end rule.
+   * `'top-level'` covers regular user sessions and programmatic child sessions.
+   */
+  origin: 'top-level' | 'subagent-tool';
+  /**
+   * Depth of this session in the subagent tree. `0` for top-level sessions;
+   * `parent.subagentDepth + 1` for sessions spawned via `spawn_subagent`.
+   */
+  subagentDepth?: number;
+  /**
+   * True when the session was created with `threadId: { fresh: true }` and
+   * therefore owns the underlying thread under `MemoryStorage`.
+   */
+  ownsThread: boolean;
+  modeId: string;
+  modelId: string;
+  subagentModelOverrides: Record<string, string>;
+  permissionRules: PermissionRules;
+  sessionGrants: SessionGrants;
+  tokenUsage: TokenUsage;
+  pendingQueue: QueuedItem[];
+  pendingResume?: PendingResume;
+  observationalMemory?: {
+    observerModelId?: string;
+    reflectorModelId?: string;
+  };
+  goal?: GoalState;
+  workspace?: SessionWorkspaceState;
+  state: unknown;
+  createdAt: number;
+  lastActivityAt: number;
+  closedAt?: number;
+  /** Monotonically incremented on every successful saveSession. */
+  version: number;
+  /** Owner Harness instance id, or undefined when no live Session holds the lease. */
+  ownerId?: string;
+  /** Epoch ms - when the current lease TTLs out. */
+  leaseExpiresAt?: number;
+}
+
+/**
+ * Lightweight projection of `SessionRecord`, used by `listSessions(...)`.
+ */
+export interface SessionSummary {
+  id: string;
+  resourceId: string;
+  threadId: string;
+  parentSessionId?: string;
+  origin: 'top-level' | 'subagent-tool';
+  modeId: string;
+  modelId: string;
+  lastActivityAt: number;
+  closedAt?: number;
+}
+
+/**
+ * Metadata index row for a persisted file attachment.
+ */
+export interface AttachmentRecord {
+  /** Stable identifier referenced by `PersistedAttachment.attachmentId`. */
+  attachmentId: string;
+  /** Owning session - bytes are deleted with the session. */
+  sessionId: string;
+  /** Original filename (display only). */
+  name: string;
+  /** MIME type, validated at upload. */
+  mimeType: string;
+  /** Size of the underlying bytes. */
+  sizeBytes: number;
+  /** Epoch ms. */
+  createdAt: number;
+}
+
+export interface ListSessionsInput {
+  resourceId: string;
+  /** When true, includes records with `closedAt` set. */
+  includeClosed?: boolean;
+  /** Filter to direct children of this parent. */
+  parentSessionId?: string;
+}
+
+export interface SaveSessionOptions {
+  /** The Harness instance currently holding the lease. */
+  ownerId: string;
+  /**
+   * Optimistic concurrency token. Must match the record's current `version`.
+   * Use `0` for first insert.
+   */
+  ifVersion: number;
+}
+
+export interface SaveSessionResult {
+  /** New version after the write - `ifVersion + 1`. */
+  version: number;
+}
+
+export interface AcquireSessionLeaseInput {
+  sessionId: string;
+  ownerId: string;
+  ttlMs: number;
+}
+
+export interface RenewSessionLeaseInput {
+  sessionId: string;
+  ownerId: string;
+  ttlMs: number;
+}
+
+export interface ReleaseSessionLeaseInput {
+  sessionId: string;
+  ownerId: string;
+}
+
+export interface SessionLeaseResult {
+  /** Record version observed at lease time - caller passes this to `saveSession`. */
+  version: number;
+  /** Epoch ms when the lease expires if not renewed. */
+  expiresAt: number;
+}
+
+export interface SaveAttachmentInput {
+  sessionId: string;
+  attachmentId: string;
+  name: string;
+  mimeType: string;
+  data: Uint8Array;
+}
+
+export interface LoadedAttachment {
+  name: string;
+  mimeType: string;
+  data: Uint8Array;
+}

--- a/packages/core/src/storage/domains/index.ts
+++ b/packages/core/src/storage/domains/index.ts
@@ -2,6 +2,7 @@ export * from './base';
 export * from './versioned';
 export * from './agents';
 export * from './channels';
+export * from './harness';
 export * from './prompt-blocks';
 export * from './scorer-definitions';
 export * from './mcp-clients';

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -21,6 +21,7 @@ import type {
   ExperimentResult,
 } from '../types';
 import type { AgentVersion } from './agents';
+import type { AttachmentRecord, SessionRecord } from './harness';
 import type { MCPClientVersion } from './mcp-clients';
 import type { MCPServerVersion } from './mcp-servers';
 import type { TraceEntry } from './observability';
@@ -99,6 +100,11 @@ export class InMemoryDB {
   readonly schedules = new Map<string, Schedule>();
   readonly scheduleTriggers: ScheduleTrigger[] = [];
 
+  // Harness domain
+  readonly harnessSessions = new Map<string, SessionRecord>();
+  readonly harnessAttachmentRecords = new Map<string, AttachmentRecord>();
+  readonly harnessAttachmentBytes = new Map<string, Uint8Array>();
+
   /**
    * Clears all data from all collections.
    * Useful for testing.
@@ -145,5 +151,8 @@ export class InMemoryDB {
     this.backgroundTasks.clear();
     this.schedules.clear();
     this.scheduleTriggers.length = 0;
+    this.harnessSessions.clear();
+    this.harnessAttachmentRecords.clear();
+    this.harnessAttachmentBytes.clear();
   }
 }

--- a/packages/core/src/storage/mock.test.ts
+++ b/packages/core/src/storage/mock.test.ts
@@ -4,7 +4,50 @@ import { MessageList } from '../agent';
 import type { MastraMessageV1, StorageThreadType } from '../memory/types';
 import { deepMerge } from '../utils';
 import type { MemoryStorage } from './domains';
+import { InMemoryHarness } from './domains/harness/inmemory';
 import { InMemoryStore } from './mock';
+
+describe('InMemoryStore - Harness domain', () => {
+  it('exposes the Harness v1 storage domain through getStore', async () => {
+    const store = new InMemoryStore();
+
+    const harness = await store.getStore('harness');
+
+    expect(harness).toBeInstanceOf(InMemoryHarness);
+  });
+
+  it('clears harness records with the shared in-memory database', async () => {
+    const store = new InMemoryStore();
+    const harness = await store.getStore('harness');
+
+    await harness!.saveSession(
+      {
+        id: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        origin: 'top-level',
+        subagentDepth: 0,
+        ownsThread: true,
+        modeId: 'default',
+        modelId: 'openai:gpt-4o-mini',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [],
+        state: {},
+        createdAt: 1_000,
+        lastActivityAt: 1_000,
+        version: 0,
+      },
+      { ownerId: 'owner-1', ifVersion: 0 },
+    );
+
+    store.clear();
+
+    await expect(harness!.loadSession({ sessionId: 'session-1' })).resolves.toBeNull();
+  });
+});
 
 describe('InMemoryStore - Thread Sorting', () => {
   let store: InMemoryStore;

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -7,6 +7,7 @@ import { InMemoryChannelsStorage } from './domains/channels/inmemory';
 import { DatasetsInMemory } from './domains/datasets/inmemory';
 import { ExperimentsInMemory } from './domains/experiments/inmemory';
 import { InMemoryFavoritesStorage } from './domains/favorites/inmemory';
+import { InMemoryHarness } from './domains/harness/inmemory';
 import { InMemoryDB } from './domains/inmemory-db';
 import { InMemoryMCPClientsStorage } from './domains/mcp-clients/inmemory';
 import { InMemoryMCPServersStorage } from './domains/mcp-servers/inmemory';
@@ -76,6 +77,7 @@ export class InMemoryStore extends MastraCompositeStore {
       blobs: new InMemoryBlobStore(),
       backgroundTasks: new BackgroundTasksInMemory({ db: this.#db }),
       schedules: new InMemorySchedulesStorage({ db: this.#db }),
+      harness: new InMemoryHarness({ db: this.#db }),
     };
   }
 

--- a/packages/core/storage/domains/harness.d.ts
+++ b/packages/core/storage/domains/harness.d.ts
@@ -1,0 +1,1 @@
+export * from './../../dist/storage/domains/harness';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -75,6 +75,7 @@ export default defineConfig({
     'src/storage/domains/skills/index.ts',
     'src/storage/domains/favorites/index.ts',
     'src/storage/domains/workspaces/index.ts',
+    'src/storage/domains/harness/index.ts',
   ],
   format: ['esm', 'cjs'],
   clean: true,


### PR DESCRIPTION
## Description

Adds the Harness v1 storage domain for durable session records, session leases, and attachment metadata/bytes. The in-memory adapter is backed by the shared InMemoryDB and is exposed through the standard InMemoryStore path, so `getStore("harness")` works for local development and tests.

This keeps thread and message logs in MemoryStorage; the harness domain stores the per-session runtime state that composes with those existing memory records.

## Related issue(s)

Fixes #16826

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Validation

- `pnpm --filter @mastra/core test:unit src/storage/domains/harness src/storage/mock.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check packages/core/src/storage/domains/harness packages/core/src/storage/domains/inmemory-db.ts packages/core/src/storage/domains/index.ts packages/core/src/storage/base.ts packages/core/src/storage/mock.ts packages/core/src/storage/mock.test.ts packages/core/src/harness/v1/types.ts packages/core/package.json packages/core/tsup.config.ts packages/core/storage/domains/harness.d.ts .changeset/brave-bobcats-dress.md`
- `pnpm build:core`
- ESM and CJS import smoke for `@mastra/core/storage/domains/harness` and `new InMemoryStore().getStore("harness")`