### PR TITLE
fix(playground): use Base UI submenu in filter menus

### DIFF
--- a/.changeset/cute-buckets-prove.md
+++ b/.changeset/cute-buckets-prove.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed a crash in filter menus with nested submenus (such as the Filter on the Agent review page) that showed "`MenuPortal` must be used within `Menu`". The submenu content now uses the design system's `DropdownMenu.SubContent` instead of the underlying library's portal directly.

--- a/packages/playground-ui/src/ds/components/DataFilter/select-data-filter.tsx
+++ b/packages/playground-ui/src/ds/components/DataFilter/select-data-filter.tsx
@@ -1,6 +1,5 @@
-import { Portal as DropdownMenuPortal, SubContent as DropdownMenuSubContent } from '@radix-ui/react-dropdown-menu';
 import { FilterIcon, SearchIcon, XIcon } from 'lucide-react';
-import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useState, useMemo, useCallback } from 'react';
 
 import { Button } from '@/ds/components/Button/Button';
@@ -59,23 +58,6 @@ export type SelectDataFilterProps = {
 // ---------------------------------------------------------------------------
 
 const SUBMENU_SEARCH_THRESHOLD = 6;
-
-const subContentClass = cn(
-  'bg-surface5 backdrop-blur-xl z-50 min-w-[8rem] overflow-auto rounded-lg p-2 shadow-md',
-  'data-[state=open]:animate-in data-[state=closed]:animate-out',
-  'data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0',
-  'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-);
-
-function PortalSubContent({ className, children, ...props }: ComponentPropsWithoutRef<typeof DropdownMenuSubContent>) {
-  return (
-    <DropdownMenuPortal>
-      <DropdownMenuSubContent className={cn(subContentClass, className)} {...props}>
-        {children}
-      </DropdownMenuSubContent>
-    </DropdownMenuPortal>
-  );
-}
 
 function SubMenuSearch({
   value,
@@ -205,7 +187,7 @@ export function SelectDataFilter({
           <span className={cn('truncate')}>{cat.label}</span>
           {selectedCount > 0 && <span className={cn('ml-auto text-ui-sm text-accent1')}>{selectedCount}</span>}
         </DropdownMenu.SubTrigger>
-        <PortalSubContent className={cn('max-h-[20rem]')}>
+        <DropdownMenu.SubContent className={cn('max-h-[20rem]')}>
           {cat.values.length >= searchThreshold && (
             <SubMenuSearch value={subSearch} onChange={setSubSearch} label={`Search ${cat.label.toLowerCase()}`} />
           )}
@@ -233,7 +215,7 @@ export function SelectDataFilter({
                 </DropdownMenu.CheckboxItem>
               ))
           )}
-        </PortalSubContent>
+        </DropdownMenu.SubContent>
       </DropdownMenu.Sub>
     );
   };
@@ -293,9 +275,9 @@ export function SelectDataFilter({
           return (
             <DropdownMenu.Sub key={group.key}>
               <DropdownMenu.SubTrigger>{group.label}</DropdownMenu.SubTrigger>
-              <PortalSubContent className={cn('max-h-[20rem]')}>
+              <DropdownMenu.SubContent className={cn('max-h-[20rem]')}>
                 {group.items.map(cat => renderCategory(cat))}
-              </PortalSubContent>
+              </DropdownMenu.SubContent>
             </DropdownMenu.Sub>
           );
         })}

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
@@ -21,7 +21,6 @@ import {
   cn,
 } from '@mastra/playground-ui';
 import { useMastraClient } from '@mastra/react';
-import { Portal as DropdownMenuPortal, SubContent as DropdownMenuSubContent } from '@radix-ui/react-dropdown-menu';
 import {
   CheckCircle,
   ChevronDown,
@@ -33,7 +32,6 @@ import {
   Trash2,
   XIcon,
 } from 'lucide-react';
-import type { ComponentPropsWithoutRef } from 'react';
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
 import { usePlaygroundModel } from '../../context/playground-model-context';
 import { useReviewQueue } from '../../context/review-queue-context';
@@ -54,23 +52,6 @@ function truncateInput(value: unknown, max: number): string {
   } catch {
     return String(value);
   }
-}
-
-const subContentClass = cn(
-  'bg-surface5 backdrop-blur-xl z-50 min-w-32 overflow-auto rounded-lg p-2 shadow-md',
-  'data-[state=open]:animate-in data-[state=closed]:animate-out',
-  'data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0',
-  'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-);
-
-function PortalSubContent({ className, children, ...props }: ComponentPropsWithoutRef<typeof DropdownMenuSubContent>) {
-  return (
-    <DropdownMenuPortal>
-      <DropdownMenuSubContent className={cn(subContentClass, className)} {...props}>
-        {children}
-      </DropdownMenuSubContent>
-    </DropdownMenuPortal>
-  );
 }
 
 interface AgentPlaygroundReviewProps {
@@ -565,7 +546,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                       Status
                       {showCompleted && <span className={cn('ml-auto text-ui-sm text-accent1')}>1</span>}
                     </DropdownMenu.SubTrigger>
-                    <PortalSubContent>
+                    <DropdownMenu.SubContent>
                       <DropdownMenu.CheckboxItem
                         checked={!showCompleted}
                         onCheckedChange={() => {
@@ -586,7 +567,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                       >
                         Completed
                       </DropdownMenu.CheckboxItem>
-                    </PortalSubContent>
+                    </DropdownMenu.SubContent>
                   </DropdownMenu.Sub>
 
                   {/* Tags */}
@@ -595,7 +576,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                       Tags
                       {activeTagFilter && <span className={cn('ml-auto text-ui-sm text-accent1')}>1</span>}
                     </DropdownMenu.SubTrigger>
-                    <PortalSubContent>
+                    <DropdownMenu.SubContent>
                       <DropdownMenu.CheckboxItem
                         checked={!activeTagFilter}
                         onCheckedChange={() => setActiveTagFilter(null)}
@@ -624,7 +605,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                           {tag}
                         </DropdownMenu.CheckboxItem>
                       ))}
-                    </PortalSubContent>
+                    </DropdownMenu.SubContent>
                   </DropdownMenu.Sub>
 
                   {activeFilterCount > 0 && (

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -20,7 +20,6 @@ import {
   DialogTitle,
 } from '@mastra/playground-ui';
 import { useMastraClient } from '@mastra/react';
-import { Portal as DropdownMenuPortal, SubContent as DropdownMenuSubContent } from '@radix-ui/react-dropdown-menu';
 import {
   CheckCircle,
   ChevronDown,
@@ -33,7 +32,6 @@ import {
   XIcon,
 } from 'lucide-react';
 import { useState, useMemo, useCallback, useEffect } from 'react';
-import type { ComponentPropsWithoutRef } from 'react';
 import { useDatasetReviewItems, useDatasetCompletedItems } from '../hooks/use-dataset-review-items';
 import { ProposalTag } from './proposal-tag';
 import type { ReviewItem } from './review-item-card';
@@ -51,23 +49,6 @@ function truncateInput(value: unknown, max: number): string {
   } catch {
     return String(value);
   }
-}
-
-const subContentClass = cn(
-  'bg-surface5 backdrop-blur-xl z-50 min-w-32 overflow-auto rounded-lg p-2 shadow-md',
-  'data-[state=open]:animate-in data-[state=closed]:animate-out',
-  'data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0',
-  'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-);
-
-function PortalSubContent({ className, children, ...props }: ComponentPropsWithoutRef<typeof DropdownMenuSubContent>) {
-  return (
-    <DropdownMenuPortal>
-      <DropdownMenuSubContent className={cn(subContentClass, className)} {...props}>
-        {children}
-      </DropdownMenuSubContent>
-    </DropdownMenuPortal>
-  );
 }
 
 export interface DatasetReviewProps {
@@ -102,14 +83,14 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
 
   // Items in local state — null means "not hydrated yet", [] means "user cleared all"
   const [localItems, setLocalItems] = useState<ReviewItem[] | null>(null);
-  const items = localItems ?? reviewItems ?? [];
+  const items = useMemo(() => localItems ?? reviewItems ?? [], [localItems, reviewItems]);
 
   // Sync server data to local on initial load
   useEffect(() => {
     if (reviewItems && localItems === null) {
       setLocalItems(reviewItems);
     }
-  }, [reviewItems]);
+  }, [reviewItems, localItems]);
 
   // Tag vocabulary from dataset + existing item tags
   const datasetTagVocabulary = useMemo(() => {
@@ -584,7 +565,7 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
                       Status
                       {showCompleted && <span className={cn('ml-auto text-ui-sm text-accent1')}>1</span>}
                     </DropdownMenu.SubTrigger>
-                    <PortalSubContent>
+                    <DropdownMenu.SubContent>
                       <DropdownMenu.CheckboxItem
                         checked={!showCompleted}
                         onCheckedChange={() => {
@@ -605,7 +586,7 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
                       >
                         Completed
                       </DropdownMenu.CheckboxItem>
-                    </PortalSubContent>
+                    </DropdownMenu.SubContent>
                   </DropdownMenu.Sub>
 
                   {/* Tags */}
@@ -614,7 +595,7 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
                       Tags
                       {activeTagFilter && <span className={cn('ml-auto text-ui-sm text-accent1')}>1</span>}
                     </DropdownMenu.SubTrigger>
-                    <PortalSubContent>
+                    <DropdownMenu.SubContent>
                       <DropdownMenu.CheckboxItem
                         checked={!activeTagFilter}
                         onCheckedChange={() => setActiveTagFilter(null)}
@@ -644,7 +625,7 @@ export function DatasetReview({ datasetId }: DatasetReviewProps) {
                           {tag}
                         </DropdownMenu.CheckboxItem>
                       ))}
-                    </PortalSubContent>
+                    </DropdownMenu.SubContent>
                   </DropdownMenu.Sub>
 
                   {/* Clear all */}


### PR DESCRIPTION
## Summary

The Filter menu on the Agent **Review** page (and Dataset Review) crashed with `\`MenuPortal\` must be used within \`Menu\``.

**Root cause:** the recent migration of `DropdownMenu` to Base UI (#16791). Three files still imported `Portal`/`SubContent` directly from `@radix-ui/react-dropdown-menu` and rendered them inside the now Base-UI `DropdownMenu`. The Radix `Portal` looks up the Radix `Menu` context, which no longer exists → crash.

**Fix:** replace the local `PortalSubContent` helper with the design system's `DropdownMenu.SubContent` (already Base UI `Portal` + `Positioner` + `Popup`).

Files:
- `packages/playground-ui/.../DataFilter/select-data-filter.tsx`
- `packages/playground/.../agent-playground/agent-playground-review.tsx`
- `packages/playground/.../review/components/dataset-review.tsx`

Also memoized a pre-existing non-memoized `items` value in `dataset-review.tsx` to satisfy the lint gate (behavior unchanged).

**Scope check:** grepped the whole repo — no remaining direct imports of `@radix-ui/react-dropdown-menu` / `react-popover` / `react-context-menu`, no use of the removed Popover `onOpenAutoFocus`/`onCloseAutoFocus` props, and every `DropdownMenu.Sub*` usage sits inside a valid `DropdownMenu` root. These three files were the only source of this error class.

## Test plan

- [ ] Agents -> an agent -> **Review** tab -> **Filter** -> hover **Status** / **Tags** submenus — opens without crashing
- [ ] Datasets -> a dataset -> **Review** -> **Filter** -> hover **Status** / **Tags** submenus
- [ ] Verify menu items (checkboxes, radio, clear-all) still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Filter menus were breaking on the Agent and Dataset review pages with an error about "MenuPortal must be used within Menu." This happened because the code was trying to use old dropdown menu components (from Radix UI) with a new dropdown menu system (Base UI), which don't work together. The fix was simple: replace those old components with the correct new versions from the design system.

---

## Problem

Filter menus on the Agent Review and Dataset Review pages were crashing with the error "MenuPortal must be used within Menu" after `DropdownMenu` was migrated from Radix UI to Base UI.

## Root Cause

Three files were still importing `Portal`/`SubContent` directly from `@radix-ui/react-dropdown-menu` and rendering them inside the Base UI `DropdownMenu`. The Radix `Portal` component depended on Radix `Menu` context, which no longer exists after the migration.

## Solution

Replaced the custom `PortalSubContent` helper component with the design system's `DropdownMenu.SubContent` component (which properly composes Base UI `Portal` + `Positioner` + `Popup`).

## Changes Made

**Modified files:**
- `packages/playground-ui/src/ds/components/DataFilter/select-data-filter.tsx` — Removed custom `PortalSubContent` wrapper; submenu content now uses `DropdownMenu.SubContent`
- `packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx` — Replaced Radix-based `PortalSubContent` with `DropdownMenu.SubContent` in Status and Tags nested dropdowns
- `packages/playground/src/domains/review/components/dataset-review.tsx` — Removed custom Radix Portal-based helper; switched submenu content to use `DropdownMenu.SubContent`; memoized `items` value to satisfy linting requirements

**Added:**
- `packages/playground-ui/.changeset/cute-buckets-prove.md` — Changeset documenting the patch fix

## Validation

Repository-wide grep confirms no remaining direct imports of deprecated Radix UI dropdown menu components; all `DropdownMenu.Sub*` usage is within valid `DropdownMenu` roots. The three modified files were the only sources of this error class.

## Testing

- Agent Review page: open an agent → Review → Filter → hover Status/Tags submenus (should open without crashing)
- Dataset Review page: open a dataset → Review → Filter → hover Status/Tags submenus (should open without crashing)
- Menu items (checkboxes, radio, clear-all) continue to function correctly

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->