### PR TITLE
refactor(playground): migrate SpanFeedbackList to DataList

### DIFF
--- a/.changeset/span-feedback-list-condensed.md
+++ b/.changeset/span-feedback-list-condensed.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Refactored the span Feedback list (Observability → Trace → Span → Feedback tab) to use the condensed `DataList` primitives, matching the visual style of the Traces, Logs, Scores, and Dataset Items lists. The Feedback detail dialog is unchanged — only the list rendering moved off `EntryList`.

--- a/.changeset/span-feedback-list-condensed.md
+++ b/.changeset/span-feedback-list-condensed.md
@@ -2,4 +2,4 @@
 '@internal/playground': patch
 ---
 
-Refactored the span Feedback list (Observability → Trace → Span → Feedback tab) to use the condensed `DataList` primitives, matching the visual style of the Traces, Logs, Scores, and Dataset Items lists. The Feedback detail dialog is unchanged — only the list rendering moved off `EntryList`.
+Improved the Span Feedback list (Observability → Trace → Span → Feedback tab) with a condensed layout that matches the Traces, Logs, Scores, and Dataset Items lists. The Feedback detail dialog is unchanged.

--- a/packages/playground/src/domains/traces/components/span-feedback-list.tsx
+++ b/packages/playground/src/domains/traces/components/span-feedback-list.tsx
@@ -1,16 +1,18 @@
 import type { FeedbackRecord, ListFeedbackResponse } from '@mastra/core/storage';
-import { EntryList, EntryListSkeleton } from '@mastra/playground-ui';
-import { isToday, format } from 'date-fns';
+import { DataList, DataListSkeleton } from '@mastra/playground-ui';
+import { format } from 'date-fns';
 import { useState } from 'react';
 import { FeedbackDialog } from './feedback-dialog';
 
 const feedbackListColumns = [
-  { name: 'source', label: 'Source', size: '1fr' },
-  { name: 'date', label: 'Date', size: '0.8fr' },
-  { name: 'time', label: 'Time', size: '0.8fr' },
-  { name: 'value', label: 'Value', size: '0.6fr' },
-  { name: 'comment', label: 'Comment', size: '2fr' },
-];
+  { label: 'Source', size: '1fr' },
+  { label: 'Date', size: '0.8fr' },
+  { label: 'Time', size: '0.8fr' },
+  { label: 'Value', size: '0.6fr' },
+  { label: 'Comment', size: '2fr' },
+] as const;
+
+const gridColumns = feedbackListColumns.map(c => c.size).join(' ');
 
 type SpanFeedbackListProps = {
   feedbackData?: ListFeedbackResponse | null;
@@ -42,76 +44,61 @@ export function SpanFeedbackList({ feedbackData, isLoadingFeedbackData, onPageCh
   const [dialogIsOpen, setDialogIsOpen] = useState(false);
   const [selectedFeedback, setSelectedFeedback] = useState<FeedbackRecord | undefined>();
 
+  if (isLoadingFeedbackData) {
+    return <DataListSkeleton columns={gridColumns} />;
+  }
+
   const feedbackItems = feedbackData?.feedback ?? [];
+  const currentPage = feedbackData?.pagination?.page ?? 0;
 
   const handleOnFeedback = (index: number) => {
     setSelectedFeedback(feedbackItems[index]);
     setDialogIsOpen(true);
   };
 
-  if (isLoadingFeedbackData) {
-    return <EntryListSkeleton columns={feedbackListColumns} />;
-  }
-
   const selectedIndex = selectedFeedback ? feedbackItems.indexOf(selectedFeedback) : -1;
-
   const toNext =
     selectedIndex >= 0 && selectedIndex < feedbackItems.length - 1
       ? () => setSelectedFeedback(feedbackItems[selectedIndex + 1])
       : undefined;
-
   const toPrevious = selectedIndex > 0 ? () => setSelectedFeedback(feedbackItems[selectedIndex - 1]) : undefined;
 
   return (
     <>
-      <EntryList>
-        <EntryList.Trim>
-          <EntryList.Header columns={feedbackListColumns} />
-          {feedbackItems.length > 0 ? (
-            <EntryList.Entries>
-              {feedbackItems.map((fb, index) => {
-                const ts = new Date(fb.timestamp);
-                const isTodayDate = isToday(ts);
+      <DataList columns={gridColumns}>
+        <DataList.Top>
+          {feedbackListColumns.map(col => (
+            <DataList.TopCell key={col.label}>{col.label}</DataList.TopCell>
+          ))}
+        </DataList.Top>
 
-                const entry = {
-                  id: `${fb.traceId}-${index}`,
-                  source: fb.feedbackUserId || fb.feedbackSource || 'unknown',
-                  date: isTodayDate ? 'Today' : format(ts, 'MMM dd'),
-                  time: format(ts, 'h:mm:ss aaa'),
-                  value: formatValue(fb),
-                  comment: formatComment(fb),
-                };
+        {feedbackItems.length === 0 ? (
+          <DataList.NoMatch message="No feedback found" />
+        ) : (
+          feedbackItems.map((fb, index) => {
+            const ts = new Date(fb.timestamp);
+            const source = fb.feedbackUserId || fb.feedbackSource || 'unknown';
+            return (
+              <DataList.RowButton key={`${fb.traceId}-${index}`} onClick={() => handleOnFeedback(index)}>
+                <DataList.Cell height="compact">{source}</DataList.Cell>
+                <DataList.DateCell timestamp={ts} />
+                <DataList.Cell height="compact">{format(ts, 'h:mm:ss aaa')}</DataList.Cell>
+                <DataList.Cell height="compact">{formatValue(fb)}</DataList.Cell>
+                <DataList.Cell height="compact">{formatComment(fb)}</DataList.Cell>
+              </DataList.RowButton>
+            );
+          })
+        )}
 
-                return (
-                  <EntryList.Entry
-                    key={entry.id}
-                    columns={feedbackListColumns}
-                    onClick={() => handleOnFeedback(index)}
-                    entry={entry}
-                  >
-                    {feedbackListColumns.map(col => (
-                      <EntryList.EntryText key={`col-${col.name}`}>
-                        {String(entry[col.name as keyof typeof entry] ?? '')}
-                      </EntryList.EntryText>
-                    ))}
-                  </EntryList.Entry>
-                );
-              })}
-            </EntryList.Entries>
-          ) : (
-            <EntryList.Message message="No feedback found" type="info" />
-          )}
-        </EntryList.Trim>
-        <EntryList.Pagination
-          currentPage={feedbackData?.pagination?.page || 0}
+        <DataList.Pagination
+          currentPage={currentPage}
           hasMore={feedbackData?.pagination?.hasMore}
-          onNextPage={() => onPageChange?.((feedbackData?.pagination?.page || 0) + 1)}
+          onNextPage={() => onPageChange?.(currentPage + 1)}
           onPrevPage={() => {
-            const currentPage = feedbackData?.pagination?.page || 0;
             if (currentPage > 0) onPageChange?.(currentPage - 1);
           }}
         />
-      </EntryList>
+      </DataList>
       <FeedbackDialog
         feedback={selectedFeedback}
         isOpen={dialogIsOpen}


### PR DESCRIPTION
Stacked on top of #16823 (which is stacked on #16820 — consumes the DataList primitives added there).

## Summary

- Migrates `SpanFeedbackList` (Observability → Trace → Span → Feedback tab) from `EntryList` to the condensed `DataList` primitives.
- Uses `DataList.DateCell` for the Date column and compact `DataList.Cell`s for Source, Time, Value, Comment.
- Keeps `FeedbackDialog` and the prev/next navigation — only the list rendering moved.

## Test plan

- [ ] Open a trace → switch to the Feedback tab on any span — row density and column rhythm should match the Traces/Logs/Scores lists.
- [ ] Click a row → `FeedbackDialog` opens with that feedback record.
- [ ] Use the Prev / Next buttons in the dialog — they walk through `feedbackData.feedback` in order.
- [ ] Loading state still shows the skeleton; empty state still shows "No feedback found".
- [ ] Pagination (Prev / Next) at the bottom still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR makes the Feedback list on a trace look the same as other compact lists in the app so it’s easier to scan, while keeping the feedback dialog and navigation working the same as before.

## Overview

Refactors the SpanFeedbackList component to render using the condensed DataList primitives (DataList, DataListSkeleton, DateCell, NoMatch, Pagination, RowButton, Cell) from `@mastra/playground-ui` instead of the previous EntryList implementation. Visual row density, column rhythm, and behavior are aligned with other Observability lists (Traces, Logs, Scores, Dataset Items). FeedbackDialog, prev/next navigation inside the dialog, and pagination behavior remain unchanged.

## Changes

- Changeset
  - .changeset/span-feedback-list-condensed.md: Added a patch-level entry describing the UI refinement with consumer-facing wording ("Improved the Span Feedback list...").

- Component refactor (packages/playground/src/domains/traces/components/span-feedback-list.tsx)
  - Replaced EntryList/EntryListSkeleton with DataList/DataListSkeleton.
  - Defined columns as label/size tuples and derived gridColumns from those sizes.
  - Uses DataList.DateCell for date rendering (removed custom isToday logic) and DataList.Cell (compact height) for other columns.
  - Value and comment formatting moved into small helpers (formatValue, formatComment) and rendered in compact cells.
  - Empty state uses DataList.NoMatch with message "No feedback found".
  - Loading state renders DataListSkeleton with derived grid columns.
  - Pagination wired to a single currentPage value; onNextPage/onPrevPage call onPageChange with page arithmetic.
  - Row rendering uses DataList.RowButton and opens FeedbackDialog on click; FeedbackDialog receives onNext/onPrevious callbacks derived from the selected item index.

## Impact
- No public API or exported entity changes.
- Visual/UX: list density and column rhythm now match other condensed lists in the Observability area.
- Behavior: feedback dialog navigation, loading state, empty state, and pagination continue to work as before.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->