### PR TITLE
fix(mastracode): improve tui render scheduling

### DIFF
--- a/.changeset/many-onions-show.md
+++ b/.changeset/many-onions-show.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved MastraCode rendering responsiveness during large streamed tool previews by upgrading the terminal UI renderer.

--- a/mastracode/package.json
+++ b/mastracode/package.json
@@ -61,7 +61,7 @@
     "@ai-sdk/openai": "^3.0.63",
     "@ai-sdk/openai-compatible": "^2.0.47",
     "@ast-grep/napi": "^0.42.0",
-    "@mariozechner/pi-tui": "^0.60.0",
+    "@mariozechner/pi-tui": "^0.73.1",
     "@mastra/agent-browser": "workspace:*",
     "@mastra/core": "workspace:*",
     "@mastra/duckdb": "workspace:*",

--- a/mastracode/src/tui/components/__tests__/ask-question-inline-multiline.test.ts
+++ b/mastracode/src/tui/components/__tests__/ask-question-inline-multiline.test.ts
@@ -52,7 +52,7 @@ vi.mock('@mariozechner/pi-tui', async importOriginal => {
     Text: StubText,
     Spacer: StubSpacer,
     SelectList: StubSelectList,
-    getEditorKeybindings: () => ({ matches: () => false }),
+    getKeybindings: () => ({ matches: () => false }),
     matchesKey: (_data: string, _key: string) => false,
   };
 });

--- a/mastracode/src/tui/components/__tests__/thread-selector.test.ts
+++ b/mastracode/src/tui/components/__tests__/thread-selector.test.ts
@@ -66,12 +66,12 @@ vi.mock('@mariozechner/pi-tui', () => {
     Text,
     fuzzyFilter: (threads: HarnessThread[], query: string, getText: (thread: HarnessThread) => string) =>
       threads.filter(thread => getText(thread).toLowerCase().includes(query.toLowerCase())),
-    getEditorKeybindings: () => ({
+    getKeybindings: () => ({
       matches: (keyData: string, action: string) => {
-        if (action === 'selectUp') return keyData === 'UP';
-        if (action === 'selectDown') return keyData === 'DOWN';
-        if (action === 'selectConfirm') return keyData === '\r';
-        if (action === 'selectCancel') return keyData === 'ESC';
+        if (action === 'tui.select.up') return keyData === 'UP';
+        if (action === 'tui.select.down') return keyData === 'DOWN';
+        if (action === 'tui.select.confirm') return keyData === '\r';
+        if (action === 'tui.select.cancel') return keyData === 'ESC';
         return false;
       },
     }),

--- a/mastracode/src/tui/components/api-key-dialog.ts
+++ b/mastracode/src/tui/components/api-key-dialog.ts
@@ -4,7 +4,7 @@
  * Allows entering a key or cancelling to proceed without one.
  */
 
-import { Box, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, getKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable } from '@mariozechner/pi-tui';
 import { theme } from '../theme.js';
 import { MaskedInput } from './masked-input.js';
@@ -69,8 +69,8 @@ export class ApiKeyDialogComponent extends Box implements Focusable {
   }
 
   handleInput(data: string): void {
-    const kb = getEditorKeybindings();
-    if (kb.matches(data, 'selectCancel')) {
+    const kb = getKeybindings();
+    if (kb.matches(data, 'tui.select.cancel')) {
       this.onCancel();
       return;
     }

--- a/mastracode/src/tui/components/ask-question-dialog.ts
+++ b/mastracode/src/tui/components/ask-question-dialog.ts
@@ -4,7 +4,7 @@
  * Used by the ask_user tool to collect structured answers from the user.
  */
 
-import { Box, getEditorKeybindings, Input, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, getKeybindings, Input, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, Component, TUI } from '@mariozechner/pi-tui';
 import { theme, getSelectListTheme, getEditorTheme } from '../theme.js';
 import { MultilineInput } from './multiline-input.js';
@@ -184,8 +184,8 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
     if (this.selectList) {
       this.selectList.handleInput(data);
     } else if (this.input) {
-      const kb = getEditorKeybindings();
-      if (kb.matches(data, 'selectCancel')) {
+      const kb = getKeybindings();
+      if (kb.matches(data, 'tui.select.cancel')) {
         this.onCancel();
         return;
       }

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -14,7 +14,7 @@
 
 import {
   Container,
-  getEditorKeybindings,
+  getKeybindings,
   Input,
   SelectList,
   Spacer,
@@ -473,7 +473,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
           this.handleAnswer(trimmed);
         }
       };
-      (this.input as any).keybindings = getEditorKeybindings();
+      (this.input as any).keybindings = getKeybindings();
     }
 
     // Carry focus over so callers (constructor, activate, switchToCustomInput)
@@ -511,8 +511,8 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     if (this.selectList) {
       this.selectList.handleInput(data);
     } else if (this.input) {
-      const kb = getEditorKeybindings();
-      if (kb.matches(data, 'selectCancel')) {
+      const kb = getKeybindings();
+      if (kb.matches(data, 'tui.select.cancel')) {
         this.handleCancel();
         return;
       }

--- a/mastracode/src/tui/components/goal-cycles-dialog.ts
+++ b/mastracode/src/tui/components/goal-cycles-dialog.ts
@@ -3,7 +3,7 @@
  * Shows a preconfigured input with the current default value that the user can edit.
  */
 
-import { Box, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, getKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable } from '@mariozechner/pi-tui';
 
 import { theme } from '../theme.js';
@@ -55,8 +55,8 @@ export class GoalCyclesDialogComponent extends Box implements Focusable {
   }
 
   handleInput(data: string): void {
-    const kb = getEditorKeybindings();
-    if (kb.matches(data, 'selectCancel')) {
+    const kb = getKeybindings();
+    if (kb.matches(data, 'tui.select.cancel')) {
       this.onCancel();
       return;
     }

--- a/mastracode/src/tui/components/login-dialog.ts
+++ b/mastracode/src/tui/components/login-dialog.ts
@@ -3,7 +3,7 @@
  */
 
 import { exec } from 'node:child_process';
-import { Box, Container, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, getKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import { getOAuthProviders } from '../../auth/index.js';
 import { theme } from '../theme.js';
@@ -131,9 +131,9 @@ export class LoginDialogComponent extends Box implements Focusable {
   }
 
   handleInput(data: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
-    if (kb.matches(data, 'selectCancel')) {
+    if (kb.matches(data, 'tui.select.cancel')) {
       this.cancel();
       return;
     }

--- a/mastracode/src/tui/components/login-mode-selector.ts
+++ b/mastracode/src/tui/components/login-mode-selector.ts
@@ -5,7 +5,7 @@
  * an env var.
  */
 
-import { Box, Container, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, getKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { TUI } from '@mariozechner/pi-tui';
 import type { AuthMode } from '../../auth/types.js';
 import { showModalOverlay } from '../overlay.js';
@@ -61,20 +61,20 @@ export class LoginModeSelectorComponent extends Box {
   }
 
   handleInput(keyData: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
-    if (kb.matches(keyData, 'selectUp')) {
+    if (kb.matches(keyData, 'tui.select.up')) {
       this.selectedIndex = Math.max(0, this.selectedIndex - 1);
       this.updateList();
-    } else if (kb.matches(keyData, 'selectDown')) {
+    } else if (kb.matches(keyData, 'tui.select.down')) {
       this.selectedIndex = Math.min(this.modes.length - 1, this.selectedIndex + 1);
       this.updateList();
-    } else if (kb.matches(keyData, 'selectConfirm')) {
+    } else if (kb.matches(keyData, 'tui.select.confirm')) {
       const selected = this.modes[this.selectedIndex];
       if (selected) {
         this.onSelectCallback(selected.id);
       }
-    } else if (kb.matches(keyData, 'selectCancel')) {
+    } else if (kb.matches(keyData, 'tui.select.cancel')) {
       this.onCancelCallback();
     }
   }

--- a/mastracode/src/tui/components/login-selector.ts
+++ b/mastracode/src/tui/components/login-selector.ts
@@ -2,7 +2,7 @@
  * OAuth provider selector component for /login and /logout commands
  */
 
-import { Box, Container, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, getKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { OAuthProviderInterface } from '../../auth/types.js';
 import { theme } from '../theme.js';
 
@@ -93,27 +93,27 @@ export class LoginSelectorComponent extends Box {
   }
 
   handleInput(keyData: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
     // Up arrow
-    if (kb.matches(keyData, 'selectUp')) {
+    if (kb.matches(keyData, 'tui.select.up')) {
       this.selectedIndex = Math.max(0, this.selectedIndex - 1);
       this.updateList();
     }
     // Down arrow
-    else if (kb.matches(keyData, 'selectDown')) {
+    else if (kb.matches(keyData, 'tui.select.down')) {
       this.selectedIndex = Math.min(this.allProviders.length - 1, this.selectedIndex + 1);
       this.updateList();
     }
     // Enter
-    else if (kb.matches(keyData, 'selectConfirm')) {
+    else if (kb.matches(keyData, 'tui.select.confirm')) {
       const selectedProvider = this.allProviders[this.selectedIndex];
       if (selectedProvider) {
         this.onSelectCallback(selectedProvider.id);
       }
     }
     // Escape or Ctrl+C
-    else if (kb.matches(keyData, 'selectCancel')) {
+    else if (kb.matches(keyData, 'tui.select.cancel')) {
       this.onCancelCallback();
     }
   }

--- a/mastracode/src/tui/components/mcp-selector.ts
+++ b/mastracode/src/tui/components/mcp-selector.ts
@@ -3,7 +3,7 @@
  * Uses pi-tui overlay pattern with navigation.
  */
 
-import { Box, Container, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, getKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import type { McpServerStatus, McpSkippedServer } from '../../mcp/types.js';
@@ -256,11 +256,11 @@ export class McpSelectorComponent extends Box implements Focusable {
   }
 
   handleInput(data: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
     // During reload, only allow closing the selector
     if (this._reloading) {
-      if (kb.matches(data, 'selectCancel')) {
+      if (kb.matches(data, 'tui.select.cancel')) {
         this.onCloseCallback();
       }
       return;
@@ -269,7 +269,7 @@ export class McpSelectorComponent extends Box implements Focusable {
 
     // Detail view (tool list or error) — Esc goes back to server list
     if (this._detailView) {
-      if (kb.matches(data, 'selectCancel')) {
+      if (kb.matches(data, 'tui.select.cancel')) {
         this._detailView = false;
         this.updateList();
       }
@@ -282,19 +282,19 @@ export class McpSelectorComponent extends Box implements Focusable {
     }
 
     // Up arrow
-    if (kb.matches(data, 'selectUp')) {
+    if (kb.matches(data, 'tui.select.up')) {
       if (totalItems === 0) return;
       this.selectedIndex = this.selectedIndex === 0 ? totalItems - 1 : this.selectedIndex - 1;
       this.updateList();
     }
     // Down arrow
-    else if (kb.matches(data, 'selectDown')) {
+    else if (kb.matches(data, 'tui.select.down')) {
       if (totalItems === 0) return;
       this.selectedIndex = this.selectedIndex === totalItems - 1 ? 0 : this.selectedIndex + 1;
       this.updateList();
     }
     // Enter — open sub-menu for the selected server
-    else if (kb.matches(data, 'selectConfirm')) {
+    else if (kb.matches(data, 'tui.select.confirm')) {
       if (this.selectedIndex < this.statuses.length) {
         this.openSubMenu();
       }
@@ -305,7 +305,7 @@ export class McpSelectorComponent extends Box implements Focusable {
       this.doReloadAll();
     }
     // Escape or Ctrl+C
-    else if (kb.matches(data, 'selectCancel')) {
+    else if (kb.matches(data, 'tui.select.cancel')) {
       this.stopPolling();
       this.onCloseCallback();
     }
@@ -328,25 +328,25 @@ export class McpSelectorComponent extends Box implements Focusable {
     this.updateList();
   }
 
-  private handleSubMenuInput(data: string, kb: ReturnType<typeof getEditorKeybindings>): void {
+  private handleSubMenuInput(data: string, kb: ReturnType<typeof getKeybindings>): void {
     // Up arrow
-    if (kb.matches(data, 'selectUp')) {
+    if (kb.matches(data, 'tui.select.up')) {
       this.subMenuIndex = this.subMenuIndex === 0 ? this.subMenuActions.length - 1 : this.subMenuIndex - 1;
       this.updateList();
     }
     // Down arrow
-    else if (kb.matches(data, 'selectDown')) {
+    else if (kb.matches(data, 'tui.select.down')) {
       this.subMenuIndex = this.subMenuIndex === this.subMenuActions.length - 1 ? 0 : this.subMenuIndex + 1;
       this.updateList();
     }
     // Enter — execute action
-    else if (kb.matches(data, 'selectConfirm')) {
+    else if (kb.matches(data, 'tui.select.confirm')) {
       const action = this.subMenuActions[this.subMenuIndex];
       if (!action || action.key === 'none') return;
       this.executeAction(action.key);
     }
     // Escape — close sub-menu
-    else if (kb.matches(data, 'selectCancel')) {
+    else if (kb.matches(data, 'tui.select.cancel')) {
       this.subMenuOpen = false;
       this.updateList();
     }

--- a/mastracode/src/tui/components/model-selector.ts
+++ b/mastracode/src/tui/components/model-selector.ts
@@ -3,7 +3,7 @@
  * Uses pi-tui overlay pattern with search and fuzzy filtering.
  */
 
-import { Box, Container, fuzzyFilter, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, fuzzyFilter, getKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import { theme } from '../theme.js';
@@ -261,26 +261,26 @@ export class ModelSelectorComponent extends Box implements Focusable {
   }
 
   handleInput(keyData: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
     const totalItems = this.filteredModels.length + (this.hasCustomItem ? 1 : 0);
 
     // Up arrow
-    if (kb.matches(keyData, 'selectUp')) {
+    if (kb.matches(keyData, 'tui.select.up')) {
       if (totalItems === 0) return;
       this.selectedIndex = this.selectedIndex === 0 ? totalItems - 1 : this.selectedIndex - 1;
       this.updateList();
       this.tui.requestRender();
     }
     // Down arrow
-    else if (kb.matches(keyData, 'selectDown')) {
+    else if (kb.matches(keyData, 'tui.select.down')) {
       if (totalItems === 0) return;
       this.selectedIndex = this.selectedIndex === totalItems - 1 ? 0 : this.selectedIndex + 1;
       this.updateList();
       this.tui.requestRender();
     }
     // Enter
-    else if (kb.matches(keyData, 'selectConfirm')) {
+    else if (kb.matches(keyData, 'tui.select.confirm')) {
       if (this.hasCustomItem && this.selectedIndex === 0) {
         const query = this.searchInput.getValue().trim();
         if (query) this.handleSelect(this.makeCustomModelItem(query));
@@ -291,7 +291,7 @@ export class ModelSelectorComponent extends Box implements Focusable {
       }
     }
     // Escape or Ctrl+C
-    else if (kb.matches(keyData, 'selectCancel')) {
+    else if (kb.matches(keyData, 'tui.select.cancel')) {
       this.onCancelCallback();
     }
     // Pass everything else to search input

--- a/mastracode/src/tui/components/plan-approval-inline.ts
+++ b/mastracode/src/tui/components/plan-approval-inline.ts
@@ -7,7 +7,7 @@
 import {
   Box,
   Container,
-  getEditorKeybindings,
+  getKeybindings,
   Input,
   Markdown,
   SelectList,
@@ -279,8 +279,8 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     if (this.resolved) return;
 
     if (this.mode === 'feedback' && this.feedbackInput) {
-      const kb = getEditorKeybindings();
-      if (kb.matches(data, 'selectCancel')) {
+      const kb = getKeybindings();
+      if (kb.matches(data, 'tui.select.cancel')) {
         this.handleReject();
         return;
       }

--- a/mastracode/src/tui/components/thread-selector.ts
+++ b/mastracode/src/tui/components/thread-selector.ts
@@ -3,7 +3,7 @@
  * Uses pi-tui overlay pattern with search and navigation.
  */
 
-import { Box, Container, fuzzyFilter, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, fuzzyFilter, getKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import type { HarnessThread } from '@mastra/core/harness';
 import { theme } from '../theme.js';
@@ -329,26 +329,26 @@ export class ThreadSelectorComponent extends Box implements Focusable {
   }
 
   handleInput(keyData: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
-    if (kb.matches(keyData, 'selectUp')) {
+    if (kb.matches(keyData, 'tui.select.up')) {
       if (this.filteredThreads.length === 0) return;
       this.selectedIndex = this.selectedIndex === 0 ? this.filteredThreads.length - 1 : this.selectedIndex - 1;
       this.updateList();
       this.tui.requestRender();
       this.scheduleMessagePreviewLoad({ delayMs: INTERACTION_PREVIEW_LOAD_DELAY_MS });
-    } else if (kb.matches(keyData, 'selectDown')) {
+    } else if (kb.matches(keyData, 'tui.select.down')) {
       if (this.filteredThreads.length === 0) return;
       this.selectedIndex = this.selectedIndex === this.filteredThreads.length - 1 ? 0 : this.selectedIndex + 1;
       this.updateList();
       this.tui.requestRender();
       this.scheduleMessagePreviewLoad({ delayMs: INTERACTION_PREVIEW_LOAD_DELAY_MS });
-    } else if (kb.matches(keyData, 'selectConfirm')) {
+    } else if (kb.matches(keyData, 'tui.select.confirm')) {
       const selected = this.filteredThreads[this.selectedIndex];
       if (selected) {
         this.onSelectCallback(selected);
       }
-    } else if (kb.matches(keyData, 'selectCancel')) {
+    } else if (kb.matches(keyData, 'tui.select.cancel')) {
       this.onCancelCallback();
     } else if (keyData === 'c' && this.onCloneCallback && !this.searchInput.getValue()) {
       const selected = this.filteredThreads[this.selectedIndex];

--- a/mastracode/src/tui/components/tool-approval-dialog.ts
+++ b/mastracode/src/tui/components/tool-approval-dialog.ts
@@ -8,7 +8,7 @@
  *   a       — always allow this category for the session
  *   Y       — switch to YOLO mode (approve all)
  */
-import { Box, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, getKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable } from '@mariozechner/pi-tui';
 import { safeStringify } from '@mastra/core/utils';
 import chalk from 'chalk';
@@ -132,10 +132,10 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
   }
 
   handleInput(data: string): void {
-    const kb = getEditorKeybindings();
+    const kb = getKeybindings();
 
     // Escape to decline
-    if (kb.matches(data, 'selectCancel')) {
+    if (kb.matches(data, 'tui.select.cancel')) {
       this.onAction({ type: 'decline' });
       return;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1636,8 +1636,8 @@ importers:
         specifier: ^0.42.0
         version: 0.42.2
       '@mariozechner/pi-tui':
-        specifier: ^0.60.0
-        version: 0.60.0
+        specifier: ^0.73.1
+        version: 0.73.1
       '@mastra/agent-browser':
         specifier: workspace:*
         version: link:../browser/agent-browser
@@ -12726,8 +12726,8 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@mariozechner/pi-tui@0.60.0':
-    resolution: {integrity: sha512-ZAK5gxYhGmfJqMjfWcRBjB8glITltDbTrYJXvcDtfengbKTZN0p39p5uO5pvUB8/PiAWKTRS06yaNMhf/LG26g==}
+  '@mariozechner/pi-tui@0.73.1':
+    resolution: {integrity: sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==}
     engines: {node: '>=20.0.0'}
     deprecated: please use @earendil-works/pi-tui instead going forward
 
@@ -35841,7 +35841,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mariozechner/pi-tui@0.60.0':
+  '@mariozechner/pi-tui@0.73.1':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2
@@ -43331,7 +43331,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.6)':
     dependencies:
@@ -43544,7 +43544,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
 
   '@vitest/ui@4.1.5(vitest@4.1.6)':
     dependencies:


### PR DESCRIPTION
Upgrades pi-tui so MastraCode picks up its throttled render scheduler. This keeps the tui from locking up while large tool previews stream in, especially big edit/write previews.

Also updates our keybinding calls for the newer pi-tui API:

```ts
getEditorKeybindings()
```

becomes:

```ts
getKeybindings()
```

and select actions now use the namespaced IDs like `tui.select.up`.

Tested with a large streamed edit, plus:

```bash
pnpm --filter mastracode check
pnpm --filter mastracode lint
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes MastraCode's terminal display faster and more responsive when showing large previews by upgrading a library component. It also updates how keyboard shortcuts work in the interface to match the latest version of that library.

## Overview

This PR upgrades the `@mariozechner/pi-tui` dependency from `^0.60.0` to `^0.73.1` to improve terminal UI rendering responsiveness. The upgrade includes a throttled render scheduler that prevents the TUI from freezing when large tool previews stream in. Additionally, the PR updates all TUI components to use the new keybinding API introduced in the newer version.

## Key Changes

### Dependency Update
- Upgraded `@mariozechner/pi-tui` from `^0.60.0` to `^0.73.1` in `mastracode/package.json`

### Keybinding API Migration
All TUI components have been updated to use the new keybinding API:
- Replaced `getEditorKeybindings()` calls with `getKeybindings()`
- Updated keybinding action identifiers to use the new namespaced format (e.g., `tui.select.up`, `tui.select.down`, `tui.select.confirm`, `tui.select.cancel`)

### Updated Components
The following components were updated to use the new keybinding API:
- `api-key-dialog.ts`
- `ask-question-dialog.ts`
- `ask-question-inline.ts`
- `goal-cycles-dialog.ts`
- `login-dialog.ts`
- `login-mode-selector.ts`
- `login-selector.ts`
- `mcp-selector.ts`
- `model-selector.ts`
- `plan-approval-inline.ts`
- `thread-selector.ts`
- `tool-approval-dialog.ts`

### Test Updates
- Updated vitest mocks in `ask-question-inline-multiline.test.ts` and `thread-selector.test.ts` to use the new `getKeybindings()` API and namespaced action identifiers

### Changeset
Added a changeset entry documenting the improvement to MastraCode rendering responsiveness during large streamed tool previews.

## Testing
Changes were tested with large streamed edits and validated by running:
- `pnpm --filter mastracode check`
- `pnpm --filter mastracode lint`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->