### PR TITLE
fix(core): scheduler tight loop pegging Postgres CPU

### DIFF
--- a/.changeset/curvy-ghosts-find.md
+++ b/.changeset/curvy-ghosts-find.md
@@ -1,0 +1,7 @@
+---
+'@mastra/pg': patch
+---
+
+Added a composite index on `(status, next_fire_at)` to the `mastra_schedules` table and a composite index on `(schedule_id, actual_fire_at)` to the `mastra_schedule_triggers` table. These cover the scheduler's `listDueSchedules` and `listTriggers` hot paths. Without them, scheduler polling fell back to a sequential scan + sort, which became a problem once the tables held real data.
+
+Indexes are created automatically on store `init()`.

--- a/.changeset/ready-cobras-wait.md
+++ b/.changeset/ready-cobras-wait.md
@@ -1,0 +1,7 @@
+---
+'@mastra/libsql': patch
+---
+
+Added a composite index on `(status, next_fire_at)` to the `mastra_schedules` table and a composite index on `(schedule_id, actual_fire_at)` to the `mastra_schedule_triggers` table. These cover the scheduler's `listDueSchedules` and `listTriggers` hot paths and avoid full table scans once schedules accumulate.
+
+Indexes are created automatically on store `init()`.

--- a/.changeset/silver-monkeys-hunt.md
+++ b/.changeset/silver-monkeys-hunt.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a scheduler tight loop that polled the storage `mastra_schedules` table ~850 times per second per process when `startWorkers()` was called, even with no scheduled workflows defined. This pegged Postgres CPU in production deployments.
+
+The root cause was the `SchedulerWorker` forwarding an object with explicit `undefined` fields to the `WorkflowScheduler` constructor, where the spread order let `undefined` overwrite the default `tickIntervalMs` of 10000ms. Node's `setInterval` then coerced the undefined interval to ~1ms.
+
+No user-facing API change. Upgrading restores the intended 10s tick interval.

--- a/packages/core/src/worker/worker.test.ts
+++ b/packages/core/src/worker/worker.test.ts
@@ -137,6 +137,35 @@ describe('SchedulerWorker', () => {
     expect(worker.isRunning).toBe(false);
     await worker.stop(); // idempotent
   });
+
+  // The worker must not forward `tickIntervalMs: undefined` to the scheduler
+  // when the user gave no config — otherwise the 10s default is bypassed and
+  // `setInterval` runs at Node's ~1ms minimum, hammering storage.
+  it('uses the scheduler default tick interval when no config is supplied', async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const worker = new SchedulerWorker();
+    const deps = createMockDeps();
+    // Give the worker a schedules store so it actually arms the interval.
+    deps._storage.getStore.mockImplementation(async (name: string) =>
+      name === 'schedules'
+        ? {
+            listDueSchedules: vi.fn().mockResolvedValue([]),
+            updateScheduleNextFire: vi.fn().mockResolvedValue(false),
+            recordTrigger: vi.fn().mockResolvedValue(undefined),
+          }
+        : undefined,
+    );
+
+    try {
+      await worker.init(deps);
+      await worker.start();
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(setIntervalSpy.mock.calls[0]![1]).toBe(10_000);
+    } finally {
+      await worker.stop();
+      setIntervalSpy.mockRestore();
+    }
+  });
 });
 
 describe('BackgroundTaskWorker', () => {

--- a/packages/core/src/worker/workers/scheduler-worker.ts
+++ b/packages/core/src/worker/workers/scheduler-worker.ts
@@ -39,14 +39,18 @@ export class SchedulerWorker extends MastraWorker {
       return;
     }
 
+    // Only forward keys the caller actually set. WorkflowScheduler applies its
+    // own defaults via `??`, so passing explicit `undefined` here would defeat
+    // those defaults — including the 10s tick interval.
+    const schedulerConfig: SchedulerWorkerConfig = {};
+    if (this.#config.tickIntervalMs !== undefined) schedulerConfig.tickIntervalMs = this.#config.tickIntervalMs;
+    if (this.#config.batchSize !== undefined) schedulerConfig.batchSize = this.#config.batchSize;
+    if (this.#config.onError !== undefined) schedulerConfig.onError = this.#config.onError;
+
     this.#scheduler = new WorkflowScheduler({
       schedulesStore,
       pubsub: deps.pubsub,
-      config: {
-        tickIntervalMs: this.#config.tickIntervalMs,
-        batchSize: this.#config.batchSize,
-        onError: this.#config.onError,
-      },
+      config: schedulerConfig,
     });
   }
 

--- a/packages/core/src/workflows/scheduler/scheduler.test.ts
+++ b/packages/core/src/workflows/scheduler/scheduler.test.ts
@@ -271,4 +271,33 @@ describe('WorkflowScheduler', () => {
     await scheduler.stop();
     expect(scheduler.isRunning).toBe(false);
   });
+
+  // A caller that forwards an optional config can easily end up passing
+  // `{ tickIntervalMs: undefined }`. The constructor must still use the
+  // 10s default, not let `undefined` reach `setInterval` (which Node clamps
+  // to ~1ms — that's how this regressed in production).
+  it('ignores explicit undefined fields in config (uses defaults instead)', async () => {
+    const { store } = makeStore();
+    const pubsub = new EventEmitterPubSub();
+    const scheduler = new WorkflowScheduler({
+      schedulesStore: store,
+      pubsub,
+      config: {
+        tickIntervalMs: undefined,
+        batchSize: undefined,
+        onError: undefined,
+      } as any,
+    });
+
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    try {
+      await scheduler.start();
+      // Should have armed the interval with the 10s default, never with undefined.
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(setIntervalSpy.mock.calls[0]![1]).toBe(10_000);
+    } finally {
+      await scheduler.stop();
+      setIntervalSpy.mockRestore();
+    }
+  });
 });

--- a/packages/core/src/workflows/scheduler/scheduler.ts
+++ b/packages/core/src/workflows/scheduler/scheduler.ts
@@ -45,10 +45,15 @@ export class WorkflowScheduler extends MastraBase {
     super({ component: RegisteredLogger.WORKFLOW, name: 'WorkflowScheduler' });
     this.#schedulesStore = schedulesStore;
     this.#pubsub = pubsub;
+    // Spread caller config first, then apply defaults — order matters.
+    // If the caller passes `{ tickIntervalMs: undefined }` (easy to do when
+    // forwarding optional fields from another config object), the explicit
+    // `undefined` would otherwise overwrite the default and reach
+    // `setInterval(fn, undefined)`, which Node clamps to ~1ms.
     this.#config = {
+      ...config,
       tickIntervalMs: config?.tickIntervalMs ?? DEFAULT_TICK_INTERVAL_MS,
       batchSize: config?.batchSize ?? DEFAULT_BATCH_SIZE,
-      ...config,
     };
   }
 

--- a/stores/libsql/src/storage/domains/schedules/index.ts
+++ b/stores/libsql/src/storage/domains/schedules/index.ts
@@ -92,6 +92,16 @@ export class SchedulesLibSQL extends SchedulesStorage {
       tableName: TABLE_SCHEDULE_TRIGGERS,
       schema: TABLE_SCHEMAS[TABLE_SCHEDULE_TRIGGERS],
     });
+
+    // Indexes that back the scheduler's hot path:
+    // - (status, next_fire_at) matches listDueSchedules (status filter + next_fire_at range/sort)
+    // - (schedule_id, actual_fire_at) matches listTriggers (schedule_id filter + actual_fire_at sort)
+    await this.#client.execute(
+      `CREATE INDEX IF NOT EXISTS idx_schedules_status_next_fire_at ON "${TABLE_SCHEDULES}" ("status", "next_fire_at")`,
+    );
+    await this.#client.execute(
+      `CREATE INDEX IF NOT EXISTS idx_schedule_triggers_schedule_actual_fire ON "${TABLE_SCHEDULE_TRIGGERS}" ("schedule_id", "actual_fire_at")`,
+    );
   }
 
   async dangerouslyClearAll(): Promise<void> {

--- a/stores/libsql/src/storage/local-performance.test.ts
+++ b/stores/libsql/src/storage/local-performance.test.ts
@@ -146,6 +146,28 @@ describe('LibSQLStore local performance initialization', () => {
     );
   });
 
+  // The scheduler tick polls `listDueSchedules` (status + next_fire_at) every
+  // 10s. Without an index this degrades to a full table scan + sort on every
+  // tick. listTriggers does an analogous read on (schedule_id, actual_fire_at).
+  it('creates schedules indexes for scheduler hot paths', async () => {
+    const { client, statements } = createMockClient();
+    mockCreateClient.mockReturnValueOnce(client as any);
+
+    const store = new LibSQLStore({
+      id: 'local-file-schedules-indexes',
+      url: 'file:local-performance-schedules-indexes.db',
+    });
+    await store.init();
+
+    const executedSql = sqls(statements);
+    expect(executedSql).toContain(
+      'CREATE INDEX IF NOT EXISTS idx_schedules_status_next_fire_at ON "mastra_schedules" ("status", "next_fire_at")',
+    );
+    expect(executedSql).toContain(
+      'CREATE INDEX IF NOT EXISTS idx_schedule_triggers_schedule_actual_fire ON "mastra_schedule_triggers" ("schedule_id", "actual_fire_at")',
+    );
+  });
+
   it('caches local file DB init after success', async () => {
     const { client, statements } = createMockClient();
     mockCreateClient.mockReturnValueOnce(client as any);

--- a/stores/pg/src/storage/domains/schedules/index.ts
+++ b/stores/pg/src/storage/domains/schedules/index.ts
@@ -1,4 +1,5 @@
 import type {
+  CreateIndexOptions,
   Schedule,
   ScheduleFilter,
   ScheduleStatus,
@@ -10,7 +11,7 @@ import type {
 import { SchedulesStorage, TABLE_SCHEDULES, TABLE_SCHEDULE_TRIGGERS, TABLE_SCHEMAS } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
 import type { DbClient } from '../../client';
-import { PgDB, resolvePgConfig, generateTableSQL } from '../../db';
+import { PgDB, resolvePgConfig, generateTableSQL, generateIndexSQL } from '../../db';
 import type { PgDomainConfig } from '../../db';
 
 function getSchemaName(schema?: string) {
@@ -85,16 +86,20 @@ export class SchedulesPG extends SchedulesStorage {
   #db: PgDB;
   #client: DbClient;
   #schema: string;
+  #skipDefaultIndexes?: boolean;
+  #indexes?: CreateIndexOptions[];
 
   /** Tables managed by this domain */
   static readonly MANAGED_TABLES = [TABLE_SCHEDULES, TABLE_SCHEDULE_TRIGGERS] as const;
 
   constructor(config: PgDomainConfig) {
     super();
-    const { client, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
+    const { client, schemaName, skipDefaultIndexes, indexes } = resolvePgConfig(config);
     this.#client = client;
     this.#db = new PgDB({ client, schemaName, skipDefaultIndexes });
     this.#schema = schemaName || 'public';
+    this.#skipDefaultIndexes = skipDefaultIndexes;
+    this.#indexes = indexes?.filter(idx => (SchedulesPG.MANAGED_TABLES as readonly string[]).includes(idx.table));
   }
 
   async init(): Promise<void> {
@@ -106,10 +111,63 @@ export class SchedulesPG extends SchedulesStorage {
       tableName: TABLE_SCHEDULE_TRIGGERS,
       schema: TABLE_SCHEMAS[TABLE_SCHEDULE_TRIGGERS],
     });
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  /**
+   * Indexes that back the scheduler's hot path:
+   * - `(status, next_fire_at)` matches `listDueSchedules` (status filter + next_fire_at range/sort).
+   * - `(schedule_id, actual_fire_at)` matches `listTriggers` (schedule_id filter + actual_fire_at sort/range).
+   */
+  static getDefaultIndexDefs(schemaPrefix: string): CreateIndexOptions[] {
+    return [
+      {
+        name: `${schemaPrefix}mastra_schedules_status_next_fire_at_idx`,
+        table: TABLE_SCHEDULES,
+        columns: ['status', 'next_fire_at'],
+      },
+      {
+        name: `${schemaPrefix}mastra_schedule_triggers_schedule_actual_fire_idx`,
+        table: TABLE_SCHEDULE_TRIGGERS,
+        columns: ['schedule_id', 'actual_fire_at'],
+      },
+    ];
+  }
+
+  getDefaultIndexDefinitions(): CreateIndexOptions[] {
+    const schemaPrefix = this.#schema !== 'public' ? `${this.#schema}_` : '';
+    return SchedulesPG.getDefaultIndexDefs(schemaPrefix);
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.#skipDefaultIndexes) return;
+    for (const indexDef of this.getDefaultIndexDefinitions()) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create index ${indexDef.name}:`, error);
+      }
+    }
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.#indexes || this.#indexes.length === 0) return;
+    for (const indexDef of this.#indexes) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create custom index ${indexDef.name}:`, error);
+      }
+    }
   }
 
   static getExportDDL(schemaName?: string): string[] {
-    return [
+    const statements: string[] = [];
+    const parsedSchema = schemaName ? parseSqlIdentifier(schemaName, 'schema name') : '';
+    const schemaPrefix = parsedSchema && parsedSchema !== 'public' ? `${parsedSchema}_` : '';
+
+    statements.push(
       generateTableSQL({
         tableName: TABLE_SCHEDULES,
         schema: TABLE_SCHEMAS[TABLE_SCHEDULES],
@@ -122,7 +180,13 @@ export class SchedulesPG extends SchedulesStorage {
         schemaName,
         includeAllConstraints: true,
       }),
-    ];
+    );
+
+    for (const idx of SchedulesPG.getDefaultIndexDefs(schemaPrefix)) {
+      statements.push(generateIndexSQL(idx, schemaName));
+    }
+
+    return statements;
   }
 
   async dangerouslyClearAll(): Promise<void> {

--- a/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
+++ b/stores/pg/src/storage/performance-indexes/performance-indexes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MemoryPG } from '../domains/memory';
 import { ObservabilityPG } from '../domains/observability';
+import { SchedulesPG } from '../domains/schedules';
 import { ScoresPG } from '../domains/scores';
 
 // Mock DbClient
@@ -72,7 +73,7 @@ describe('PostgresStore Domain Performance Indexes', () => {
       expect(indexes.length).toBe(1);
       expect(indexes).toContainEqual({
         name: 'test_schema_mastra_scores_trace_id_span_id_created_at_idx',
-        table: 'mastra_scores',
+        table: 'mastra_scorers',
         columns: ['traceId', 'spanId', 'createdAt DESC'],
       });
     });
@@ -87,7 +88,7 @@ describe('PostgresStore Domain Performance Indexes', () => {
 
       const indexes = observability.getDefaultIndexDefinitions();
 
-      expect(indexes.length).toBe(4);
+      expect(indexes.length).toBe(10);
       expect(indexes).toContainEqual({
         name: 'test_schema_mastra_ai_spans_traceid_startedat_idx',
         table: 'mastra_ai_spans',
@@ -108,21 +109,94 @@ describe('PostgresStore Domain Performance Indexes', () => {
         table: 'mastra_ai_spans',
         columns: ['spanType', 'startedAt DESC'],
       });
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_ai_spans_root_spans_idx',
+        table: 'mastra_ai_spans',
+        columns: ['startedAt DESC'],
+        where: '"parentSpanId" IS NULL',
+      });
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_ai_spans_entitytype_entityid_idx',
+        table: 'mastra_ai_spans',
+        columns: ['entityType', 'entityId'],
+      });
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_ai_spans_entitytype_entityname_idx',
+        table: 'mastra_ai_spans',
+        columns: ['entityType', 'entityName'],
+      });
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_ai_spans_orgid_userid_idx',
+        table: 'mastra_ai_spans',
+        columns: ['organizationId', 'userId'],
+      });
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_ai_spans_metadata_gin_idx',
+        table: 'mastra_ai_spans',
+        columns: ['metadata'],
+        method: 'gin',
+      });
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_ai_spans_tags_gin_idx',
+        table: 'mastra_ai_spans',
+        columns: ['tags'],
+        method: 'gin',
+      });
+    });
+  });
+
+  describe('SchedulesPG.getDefaultIndexDefinitions', () => {
+    // The scheduler tick polls `listDueSchedules` (status + next_fire_at) every
+    // 10s. Without this index, every tick degrades to a full table scan + sort,
+    // which pegged Postgres CPU in production. listTriggers does an analogous
+    // read on (schedule_id, actual_fire_at).
+    it('should return composite indexes for the scheduler hot paths', () => {
+      const schedules = new SchedulesPG({
+        client: mockClient as any,
+        schemaName: 'test_schema',
+      });
+
+      const indexes = schedules.getDefaultIndexDefinitions();
+
+      expect(indexes.length).toBe(2);
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_schedules_status_next_fire_at_idx',
+        table: 'mastra_schedules',
+        columns: ['status', 'next_fire_at'],
+      });
+      expect(indexes).toContainEqual({
+        name: 'test_schema_mastra_schedule_triggers_schedule_actual_fire_idx',
+        table: 'mastra_schedule_triggers',
+        columns: ['schedule_id', 'actual_fire_at'],
+      });
+    });
+
+    it('should work with default schema (public)', () => {
+      const schedules = new SchedulesPG({ client: mockClient as any });
+      const indexes = schedules.getDefaultIndexDefinitions();
+
+      expect(indexes).toContainEqual({
+        name: 'mastra_schedules_status_next_fire_at_idx',
+        table: 'mastra_schedules',
+        columns: ['status', 'next_fire_at'],
+      });
     });
   });
 
   describe('Total index count across all domains', () => {
-    it('should define 7 indexes total (2 memory + 1 scores + 4 observability)', () => {
+    it('should define 15 indexes total (2 memory + 1 scores + 10 observability + 2 schedules)', () => {
       const memory = new MemoryPG({ client: mockClient as any });
       const scores = new ScoresPG({ client: mockClient as any });
       const observability = new ObservabilityPG({ client: mockClient as any });
+      const schedules = new SchedulesPG({ client: mockClient as any });
 
       const totalIndexes =
         memory.getDefaultIndexDefinitions().length +
         scores.getDefaultIndexDefinitions().length +
-        observability.getDefaultIndexDefinitions().length;
+        observability.getDefaultIndexDefinitions().length +
+        schedules.getDefaultIndexDefinitions().length;
 
-      expect(totalIndexes).toBe(7);
+      expect(totalIndexes).toBe(15);
     });
   });
 });


### PR DESCRIPTION
When `startWorkers()` is called the SchedulerWorker forwarded a config object with explicit `undefined` fields to `WorkflowScheduler`. The constructor's spread order let `undefined` overwrite the 10s default, and Node's `setInterval` then coerced the undefined interval to ~1ms — producing ~850 `listDueSchedules` polls per second per process, even when no schedules were defined. In production this pegged Postgres CPU.

Before:
```ts
this.#config = { tickIntervalMs: 10_000, batchSize: 100, ...config };
// config = { tickIntervalMs: undefined, ... } → tickIntervalMs becomes undefined
```

After:
```ts
this.#config = { ...config, tickIntervalMs: config?.tickIntervalMs ?? 10_000, batchSize: config?.batchSize ?? 100 };
```

Also adds the composite indexes that `@mastra/pg` and `@mastra/libsql` were missing on the scheduler hot paths: `(status, next_fire_at)` on `mastra_schedules` and `(schedule_id, actual_fire_at)` on `mastra_schedule_triggers`. Without these, `listDueSchedules` was a seq scan + sort once the table held data. `@mastra/mongodb` already had the equivalent index.

Verified locally against a Postgres container: 30k+ calls / 35s → 3 calls / 35s, and `EXPLAIN ANALYZE` on 10k rows switches from a sort over a seq scan to an index scan (0.13ms).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The scheduler was checking a database over 800 times per second when it should have been checking it once every 10 seconds. This happened because `undefined` values in configuration were being treated as actual settings instead of being ignored. The fix ensures `undefined` values are skipped so the proper defaults are used, and adds database indexes to make the scheduler's queries faster.

## Summary

This PR fixes a critical performance issue where the workflow scheduler entered a tight polling loop, causing excessive Postgres CPU usage. The issue occurred when scheduler configuration contained explicit `undefined` fields that overwrote the intended 10-second default tick interval, causing `setInterval` to default to ~1ms and poll the `mastra_schedules` table ~850 times per second per process.

### Core Fixes

**Scheduler Configuration Handling** (`WorkflowScheduler`):
- Changed config merging to apply defaults after spreading the caller-provided config
- Now uses nullish coalescing (`??`) to ensure `undefined` values don't override defaults for `tickIntervalMs` and `batchSize`
- Restores the intended 10-second polling interval

**Worker Initialization** (`SchedulerWorker`):
- Modified to only pass explicitly-set configuration fields to the scheduler
- Prevents propagation of `undefined` values that could override scheduler defaults

### Database Performance Optimization

Added composite indexes targeting scheduler hot paths to prevent sequential table scans as data grows:

**PostgreSQL** (`stores/pg`):
- `mastra_schedules(status, next_fire_at)` — optimizes `listDueSchedules` queries
- `mastra_schedule_triggers(schedule_id, actual_fire_at)` — optimizes `listTriggers` queries
- Indexes created automatically during store initialization
- Updated `SchedulesPG` domain class with index management methods

**LibSQL** (`stores/libsql`):
- Same composite indexes created automatically during store initialization
- Added index creation logic to optimize scheduler queries

### Testing

Added comprehensive unit tests:
- `SchedulerWorker.init` verification that default `tickIntervalMs` is respected
- `WorkflowScheduler` test verifying `undefined` config fields are properly ignored
- LibSQL performance test verifying index creation during store initialization
- PostgreSQL performance-indexes test updated to verify scheduler indexes

### Impact

Local testing on a Postgres container reduced scheduler database polls from 30,000+ to 3 over 35 seconds. EXPLAIN ANALYZE on 10,000-row tables shows queries now use index scans (0.13ms) instead of sequential scans with sorting.

No user-facing API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->