### PR TITLE
feat(core): add Harness v1 registry

### DIFF
--- a/.changeset/lucky-flies-fail.md
+++ b/.changeset/lucky-flies-fail.md
@@ -1,0 +1,32 @@
+---
+'@mastra/core': minor
+---
+
+Added the Harness v1 API for durable session resolution, lifecycle management, model discovery, thread utilities, and workspace provider registration.
+
+**Usage**
+
+```ts
+import { Agent } from '@mastra/core/agent';
+import { Harness } from '@mastra/core/harness/v1';
+import { InMemoryStore } from '@mastra/core/storage';
+
+const harness = new Harness({
+  agents: {
+    assistant: new Agent({
+      id: 'assistant',
+      name: 'Assistant',
+      instructions: 'Help the user.',
+      model: 'openai/gpt-4o-mini',
+    }),
+  },
+  modes: [{ id: 'default', agentId: 'assistant' }],
+  defaultModeId: 'default',
+  storage: new InMemoryStore(),
+});
+
+const session = await harness.session({
+  resourceId: 'user-123',
+  threadId: { fresh: true },
+});
+```

--- a/packages/core/src/harness/v1/config.ts
+++ b/packages/core/src/harness/v1/config.ts
@@ -3,11 +3,24 @@ import type { ToolsInput } from '../../agent/types';
 import type { Mastra } from '../../mastra';
 import type { RequestContext } from '../../request-context';
 import type { MastraCompositeStore } from '../../storage/base';
+import type { HarnessStorage } from '../../storage/domains/harness';
 import type { Workspace } from '../../workspace';
 import type { HarnessMode, ToolCategory } from './shared';
-import type { ModelAuthStatus, ModelInfo, PermissionPolicy, SubagentDefinition } from './types';
+import type {
+  CustomModelCatalogProvider,
+  ModelAuthChecker,
+  ModelAuthStatus,
+  ModelInfo,
+  ModelUseCountProvider,
+  ModelUseCountTracker,
+  PermissionPolicy,
+  SubagentDefinition,
+} from './types';
+import type { WorkspaceProvider, WorkspaceProviderContext } from './workspace-provider';
 
-export type HarnessStorageLike = unknown;
+export type { WorkspaceOwnershipKind, WorkspaceProvider, WorkspaceProviderContext } from './workspace-provider';
+
+export type HarnessStorageLike = HarnessStorage;
 
 export type HarnessConfig<TState = unknown> = HarnessConfigCommon<TState> &
   (
@@ -24,6 +37,8 @@ export type HarnessConfig<TState = unknown> = HarnessConfigCommon<TState> &
   );
 
 export interface HarnessConfigCommon<TState = unknown> {
+  id?: string;
+  resourceId?: string;
   modes: Array<HarnessMode<TState>>;
   defaultModeId?: string;
   initialState?: TState | (() => TState | Promise<TState>);
@@ -58,7 +73,9 @@ export interface HarnessConfigCommon<TState = unknown> {
   intervals?: Array<{
     id: string;
     everyMs: number;
+    immediate?: boolean;
     handler: (ctx: { harnessId: string; abortSignal: AbortSignal }) => void | Promise<void>;
+    shutdown?: () => void | Promise<void>;
   }>;
   defaultPermissionPolicy?: PermissionPolicy;
   toolCategoryResolver?: (toolName: string) => ToolCategory | null;
@@ -66,6 +83,10 @@ export interface HarnessConfigCommon<TState = unknown> {
   models?: ModelInfo[];
   resolveModel?: (params: { modeId?: string; agentId?: string; resourceId?: string }) => string | Promise<string>;
   modelAuthStatusResolver?: (modelId: string) => ModelAuthStatus | Promise<ModelAuthStatus>;
+  modelAuthChecker?: ModelAuthChecker;
+  modelUseCountProvider?: ModelUseCountProvider;
+  modelUseCountTracker?: ModelUseCountTracker;
+  customModelCatalogProvider?: CustomModelCatalogProvider;
 }
 
 export type HarnessWorkspaceConfig =
@@ -84,23 +105,6 @@ export type HarnessWorkspaceConfig =
       provider: WorkspaceProvider;
       eager?: boolean;
     };
-
-export interface WorkspaceProviderContext {
-  harnessId: string;
-  sessionId?: string;
-  resourceId?: string;
-  threadId?: string;
-  requestContext: RequestContext;
-}
-
-export interface WorkspaceProvider {
-  id: string;
-  resumable?: boolean;
-  create(ctx: WorkspaceProviderContext): Workspace | Promise<Workspace>;
-  resume?(ctx: WorkspaceProviderContext & { state: unknown }): Workspace | Promise<Workspace>;
-  snapshot?(workspace: Workspace): unknown | Promise<unknown>;
-  destroy?(workspace: Workspace): void | Promise<void>;
-}
 
 export interface HarnessObservationalMemoryConfig {
   enabled?: boolean;

--- a/packages/core/src/harness/v1/events.ts
+++ b/packages/core/src/harness/v1/events.ts
@@ -32,7 +32,7 @@ export interface SessionClosedEvent extends HarnessEventBase {
 
 export interface SessionEvictedEvent extends HarnessEventBase {
   type: 'session_evicted';
-  reason: 'idle' | 'pressure' | 'pinned_timeout' | 'shutdown';
+  reason: 'idle' | 'pressure' | 'pinned_timeout' | 'shutdown' | 'lease_lost';
 }
 
 export interface ModeChangedEvent extends HarnessEventBase {

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -1,0 +1,1007 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Agent } from '../../agent';
+import { MastraCompositeStore } from '../../storage/base';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { InMemoryMemory } from '../../storage/domains/memory/inmemory';
+import type { Workspace } from '../../workspace';
+import type { HarnessConfig } from './config';
+import {
+  HarnessConfigError,
+  HarnessModelNotFoundError,
+  HarnessSessionClosedError,
+  HarnessSessionLockedError,
+  HarnessSessionNotFoundError,
+  HarnessStorageError,
+  HarnessThreadNotFoundError,
+  HarnessWorkspaceProviderMismatchError,
+} from './errors';
+import { Harness } from './harness';
+import { nonDurableProvider } from './workspace-provider';
+
+function makeAgent(name = 'default') {
+  return new Agent({
+    id: name,
+    name,
+    instructions: 'test',
+    model: 'openai/gpt-4o-mini' as any,
+  });
+}
+
+function makeStorage() {
+  return new InMemoryHarness({ db: new InMemoryDB() });
+}
+
+class LeaseStealingStorage extends InMemoryHarness {
+  private stolen = false;
+
+  override async acquireSessionLease(opts: Parameters<InMemoryHarness['acquireSessionLease']>[0]) {
+    if (!this.stolen) {
+      this.stolen = true;
+      await super.acquireSessionLease({ ...opts, ownerId: 'other-owner' });
+    }
+    return super.acquireSessionLease(opts);
+  }
+}
+
+function makeHarness(overrides: Partial<HarnessConfig> = {}) {
+  const storage = overrides.sessions?.storage ?? makeStorage();
+  return new Harness({
+    agents: { default: makeAgent() },
+    modes: [{ id: 'default', agentId: 'default' }],
+    defaultModeId: 'default',
+    sessions: { storage },
+    ...overrides,
+  });
+}
+
+describe('Harness v1 construction', () => {
+  it('accepts a valid config and mints a process owner id', () => {
+    const harness = makeHarness();
+    const other = makeHarness();
+
+    expect(harness.id).toBe(harness.ownerId);
+    expect(harness.ownerId).toMatch(/^harness-/);
+    expect(harness.ownerId).not.toBe(other.ownerId);
+    expect(harness.getMastra()).toBeDefined();
+    expect(harness.listModes()).toHaveLength(1);
+  });
+
+  it('exposes status-quo resource identity helpers', async () => {
+    const harness = makeHarness({ id: 'mastra-code', resourceId: 'project-a' });
+
+    expect(harness.getDefaultResourceId()).toBe('project-a');
+    await harness.threads.create({ resourceId: 'project-b', threadId: 'thread-b' });
+    await harness.threads.create({ resourceId: 'project-a', threadId: 'thread-a' });
+
+    await expect(harness.getKnownResourceIds()).resolves.toEqual(['project-a', 'project-b']);
+  });
+
+  it('validates mode and agent wiring up front', () => {
+    expect(
+      () =>
+        new Harness({
+          agents: { default: makeAgent() },
+          modes: [{ id: 'default', agentId: 'missing' }],
+          defaultModeId: 'default',
+          sessions: { storage: makeStorage() },
+        }),
+    ).toThrow(HarnessConfigError);
+
+    expect(
+      () =>
+        new Harness({
+          agents: { default: makeAgent() },
+          modes: [
+            { id: 'default', agentId: 'default' },
+            { id: 'default', agentId: 'default' },
+          ],
+          defaultModeId: 'default',
+          sessions: { storage: makeStorage() },
+        }),
+    ).toThrow(HarnessConfigError);
+
+    expect(
+      () =>
+        new Harness({
+          agents: { default: makeAgent() },
+          modes: [{ id: 'default', agentId: 'default' }],
+          defaultModeId: 'missing',
+          sessions: { storage: makeStorage() },
+        }),
+    ).toThrow(HarnessConfigError);
+  });
+
+  it('validates mode transitions and tool overlay shape', () => {
+    expect(
+      () =>
+        new Harness({
+          agents: { default: makeAgent() },
+          modes: [{ id: 'default', agentId: 'default', transitionsTo: 'missing' }],
+          defaultModeId: 'default',
+          sessions: { storage: makeStorage() },
+        }),
+    ).toThrow(HarnessConfigError);
+
+    expect(
+      () =>
+        new Harness({
+          agents: { default: makeAgent() },
+          modes: [{ id: 'default', agentId: 'default', tools: {}, additionalTools: {} }],
+          defaultModeId: 'default',
+          sessions: { storage: makeStorage() },
+        }),
+    ).toThrow(HarnessConfigError);
+  });
+
+  it('requires defaultModeId when modes are declared', () => {
+    expect(
+      () =>
+        new Harness({
+          agents: { default: makeAgent() },
+          modes: [{ id: 'default', agentId: 'default' }],
+          sessions: { storage: makeStorage() },
+        }),
+    ).toThrow(HarnessConfigError);
+  });
+});
+
+describe('Harness v1 session resolution', () => {
+  let storage: InMemoryHarness;
+  let harness: Harness;
+
+  beforeEach(() => {
+    storage = makeStorage();
+    harness = makeHarness({ sessions: { storage } });
+  });
+
+  it('creates and reuses a live session for a caller-supplied thread', async () => {
+    const first = await harness.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+    const second = await harness.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+
+    expect(second).toBe(first);
+    expect(first.id).toMatch(/^sess-/);
+    expect(first.threadId).toBe('thread-a');
+    expect(first.resourceId).toBe('resource-a');
+    expect(first.lifecycleState).toBe('live');
+    expect(first.getRecord().ownsThread).toBe(false);
+  });
+
+  it('rejects caller-supplied thread ids already owned by another resource', async () => {
+    await harness.threads.create({ resourceId: 'resource-a', threadId: 'thread-a' });
+
+    await expect(harness.session({ resourceId: 'resource-b', threadId: 'thread-a' })).rejects.toThrow(
+      HarnessConfigError,
+    );
+    await expect(harness.listSessions({ resourceId: 'resource-b' })).resolves.toHaveLength(0);
+  });
+
+  it('coalesces concurrent first resolution for the same caller-supplied thread', async () => {
+    const [first, second] = await Promise.all([
+      harness.session({ threadId: 'thread-a', resourceId: 'resource-a' }),
+      harness.session({ threadId: 'thread-a', resourceId: 'resource-a' }),
+    ]);
+
+    expect(first).toBe(second);
+    await expect(harness.listSessions({ resourceId: 'resource-a' })).resolves.toHaveLength(1);
+  });
+
+  it('hydrates the requested session when multiple sessions share a thread', async () => {
+    const first = await harness.session({ resourceId: 'resource-a', threadId: 'thread-a', sessionId: 'session-a' });
+    await harness.session({ resourceId: 'resource-a', threadId: 'thread-a', sessionId: 'session-b' });
+    await harness.shutdown();
+
+    const nextHarness = makeHarness({ sessions: { storage } });
+    const hydrated = await nextHarness.session({
+      resourceId: 'resource-a',
+      threadId: 'thread-a',
+      sessionId: first.id,
+    });
+
+    expect(hydrated.id).toBe(first.id);
+    expect(hydrated.threadId).toBe('thread-a');
+  });
+
+  it('coalesces concurrent resource-only creation', async () => {
+    const [first, second] = await Promise.all([
+      harness.session({ resourceId: 'resource-a' }),
+      harness.session({ resourceId: 'resource-a' }),
+    ]);
+
+    expect(first).toBe(second);
+    await expect(harness.listSessions({ resourceId: 'resource-a' })).resolves.toHaveLength(1);
+  });
+
+  it('applies configured initial state to each new session', async () => {
+    const initialized = makeHarness({
+      initialState: () => ({ yolo: true, count: 1 }),
+      sessions: { storage },
+    });
+
+    const first = await initialized.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+    const second = await initialized.session({ threadId: 'thread-b', resourceId: 'resource-a' });
+
+    expect(first.getRecord().state).toEqual({ yolo: true, count: 1 });
+    expect(second.getRecord().state).toEqual({ yolo: true, count: 1 });
+    expect(first.getRecord().state).not.toBe(second.getRecord().state);
+  });
+
+  it('uses resolveModel for fresh sessions when no model override is provided', async () => {
+    const resolveModel: NonNullable<HarnessConfig['resolveModel']> = vi.fn(async ({ modeId, agentId, resourceId }) => {
+      expect(modeId).toBe('default');
+      expect(agentId).toBe('default');
+      expect(resourceId).toBe('resource-a');
+      return 'openai/gpt-4o-mini';
+    });
+    const resolved = makeHarness({ resolveModel });
+
+    const session = await resolved.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+
+    expect(resolveModel).toHaveBeenCalledTimes(1);
+    expect(session.modelId).toBe('openai/gpt-4o-mini');
+    expect(session.getRecord().modelId).toBe('openai/gpt-4o-mini');
+  });
+
+  it('mints a fresh thread and owning session when requested', async () => {
+    const first = await harness.session({ threadId: { fresh: true }, resourceId: 'resource-a' });
+    const second = await harness.session({ threadId: { fresh: true }, resourceId: 'resource-a' });
+
+    expect(first.threadId).toMatch(/^thread-/);
+    expect(second.threadId).toMatch(/^thread-/);
+    expect(first.threadId).not.toBe(second.threadId);
+    expect(first.getRecord().ownsThread).toBe(true);
+    await expect(harness.threads.get({ resourceId: 'resource-a', threadId: first.threadId })).resolves.toMatchObject({
+      id: first.threadId,
+      resourceId: 'resource-a',
+    });
+  });
+
+  it('hydrates the newest active session for resource-only resolution', async () => {
+    const session = await harness.session({ resourceId: 'resource-a' });
+    await harness.shutdown();
+
+    const nextHarness = makeHarness({ sessions: { storage } });
+    const hydrated = await nextHarness.session({ resourceId: 'resource-a' });
+
+    expect(hydrated.id).toBe(session.id);
+    expect(hydrated).not.toBe(session);
+  });
+
+  it('re-reads the session after acquiring a hydrate lease', async () => {
+    const session = await harness.session({ resourceId: 'resource-a', threadId: 'thread-a' });
+    await harness.shutdown();
+    const stale = { ...(await storage.loadSession({ sessionId: session.id }))! };
+
+    await storage.saveSession(
+      {
+        ...stale,
+        state: { persistedAfterInitialRead: true },
+      },
+      { ownerId: 'external-owner', ifVersion: stale.version },
+    );
+
+    const originalLoadSessionByThread = storage.loadSessionByThread.bind(storage);
+    vi.spyOn(storage, 'loadSessionByThread')
+      .mockResolvedValueOnce(stale)
+      .mockImplementation(originalLoadSessionByThread);
+
+    const nextHarness = makeHarness({ sessions: { storage } });
+    const hydrated = await nextHarness.session({ resourceId: 'resource-a', threadId: 'thread-a' });
+
+    expect(hydrated.getRecord().state).toEqual({ persistedAfterInitialRead: true });
+  });
+
+  it('coalesces concurrent hydrations for the same durable session', async () => {
+    const session = await harness.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+    await harness.shutdown();
+
+    const nextHarness = makeHarness({ sessions: { storage } });
+    const [first, second] = await Promise.all([
+      nextHarness.session({ sessionId: session.id }),
+      nextHarness.session({ sessionId: session.id }),
+    ]);
+
+    expect(first).toBe(second);
+    expect(nextHarness._internalLiveSessionCount()).toBe(1);
+  });
+
+  it('resolves by session id and enforces resource scoping', async () => {
+    const created = await harness.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+
+    await expect(harness.session({ sessionId: 'missing' })).rejects.toThrow(HarnessSessionNotFoundError);
+    await expect(harness.session({ sessionId: created.id, resourceId: 'resource-b' })).rejects.toThrow(
+      HarnessSessionNotFoundError,
+    );
+    await expect(harness.session({ sessionId: created.id, resourceId: 'resource-a' })).resolves.toBe(created);
+  });
+
+  it('creates a new active session after the previous one closes', async () => {
+    const first = await harness.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+    await first.close();
+
+    await expect(harness.session({ sessionId: first.id })).rejects.toThrow(HarnessSessionClosedError);
+    const second = await harness.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+
+    expect(second.id).not.toBe(first.id);
+    expect(second.threadId).toBe('thread-a');
+  });
+
+  it('surfaces a lock conflict when another harness owns the lease', async () => {
+    const first = await harness.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+    const competingHarness = makeHarness({ sessions: { storage } });
+
+    await expect(competingHarness.session({ sessionId: first.id })).rejects.toThrow(HarnessSessionLockedError);
+  });
+
+  it('renews the live session lease before another harness can take it', async () => {
+    const session = await makeHarness({ sessions: { storage, leaseTtlMs: 25 } }).session({
+      threadId: 'thread-a',
+      resourceId: 'resource-a',
+    });
+    const competingHarness = makeHarness({ sessions: { storage, leaseTtlMs: 25 } });
+
+    await new Promise(resolve => setTimeout(resolve, 80));
+
+    await expect(competingHarness.session({ sessionId: session.id })).rejects.toThrow(HarnessSessionLockedError);
+  });
+
+  it('does not delete a newly inserted session when another owner wins the lease race', async () => {
+    const stealingStorage = new LeaseStealingStorage({ db: new InMemoryDB() });
+    const racingHarness = makeHarness({ sessions: { storage: stealingStorage } });
+
+    await expect(
+      racingHarness.session({ threadId: 'thread-a', resourceId: 'resource-a', sessionId: 'session-a' }),
+    ).rejects.toThrow(HarnessSessionLockedError);
+
+    await expect(stealingStorage.loadSession({ sessionId: 'session-a' })).resolves.toMatchObject({
+      id: 'session-a',
+      ownerId: 'other-owner',
+    });
+  });
+
+  it('keeps a fresh owned thread when another owner wins the session lease race', async () => {
+    const stealingStorage = new LeaseStealingStorage({ db: new InMemoryDB() });
+    const racingHarness = makeHarness({ sessions: { storage: stealingStorage } });
+
+    await expect(
+      racingHarness.session({ threadId: { fresh: true }, resourceId: 'resource-a', sessionId: 'session-a' }),
+    ).rejects.toThrow(HarnessSessionLockedError);
+
+    const threads = await racingHarness.threads.list({ resourceId: 'resource-a', perPage: false });
+    const stored = await stealingStorage.loadSession({ sessionId: 'session-a' });
+
+    expect(threads.threads).toHaveLength(1);
+    expect(stored).toMatchObject({
+      id: 'session-a',
+      ownsThread: true,
+      ownerId: 'other-owner',
+      threadId: threads.threads[0]?.id,
+    });
+  });
+});
+
+describe('Harness v1 lifecycle and discovery', () => {
+  it('lists sessions with closed records excluded by default', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const session = await harness.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+    await session.close();
+
+    await expect(harness.listSessions({ resourceId: 'resource-a' })).resolves.toEqual([]);
+    const withClosed = await harness.listSessions({ resourceId: 'resource-a', includeClosed: true });
+
+    expect(withClosed).toHaveLength(1);
+    expect(withClosed[0]?.id).toBe(session.id);
+    await expect(harness.loadSession({ sessionId: session.id })).resolves.toBeNull();
+    await expect(harness.loadSession({ sessionId: session.id, includeClosed: true })).resolves.toMatchObject({
+      id: session.id,
+      closedAt: expect.any(Number),
+    });
+  });
+
+  it('releases live leases on shutdown without closing records', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const session = await harness.session({ threadId: 'thread-a', resourceId: 'resource-a' });
+
+    await harness.shutdown();
+
+    await expect(harness.session({ resourceId: 'resource-a' })).rejects.toThrow('Harness is shut down');
+    const stored = await storage.loadSession({ sessionId: session.id });
+    expect(stored?.closedAt).toBeUndefined();
+
+    const nextHarness = makeHarness({ sessions: { storage } });
+    await expect(nextHarness.session({ sessionId: session.id })).resolves.toMatchObject({ id: session.id });
+  });
+
+  it('finalizes a parent close when a child close fails', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const parent = await harness.session({ resourceId: 'resource-a', threadId: 'thread-a', sessionId: 'parent' });
+    const child = await harness.session({
+      resourceId: 'resource-a',
+      threadId: 'thread-b',
+      sessionId: 'child',
+      parentSessionId: parent.id,
+    });
+
+    (harness as unknown as { _liveSessions: Map<string, unknown> })._liveSessions.delete(child.id);
+    await storage.releaseSessionLease({ sessionId: child.id, ownerId: harness.ownerId });
+    await storage.acquireSessionLease({ sessionId: child.id, ownerId: 'other-owner', ttlMs: 30_000 });
+
+    await expect(parent.close()).rejects.toThrow(HarnessStorageError);
+    expect(parent.lifecycleState).toBe('closed');
+    await expect(harness.loadSession({ sessionId: parent.id, includeClosed: true })).resolves.toMatchObject({
+      id: parent.id,
+      closedAt: expect.any(Number),
+    });
+    await expect(harness.session({ sessionId: parent.id })).rejects.toThrow(HarnessSessionClosedError);
+  });
+
+  it('destroys shared workspaces on shutdown even when session storage is not configured', async () => {
+    const workspace = {
+      init: vi.fn(async () => undefined),
+      destroy: vi.fn(async () => undefined),
+    } as unknown as Workspace;
+    const harness = new Harness({
+      modes: [],
+      workspace: { kind: 'shared', workspace },
+    });
+
+    await harness.getWorkspace();
+    await harness.shutdown();
+
+    expect(workspace.destroy).toHaveBeenCalledTimes(1);
+    await expect(harness.getWorkspace()).rejects.toThrow('Harness is shut down');
+    expect(workspace.init).toHaveBeenCalledTimes(1);
+    expect(workspace.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys a shared workspace that finishes acquiring during shutdown', async () => {
+    let release!: () => void;
+    const workspace = {
+      init: vi.fn(async () => undefined),
+      destroy: vi.fn(async () => undefined),
+    } as unknown as Workspace;
+    const harness = new Harness({
+      modes: [],
+      workspace: {
+        kind: 'shared',
+        workspace: vi.fn(async () => {
+          await new Promise<void>(resolve => {
+            release = resolve;
+          });
+          return workspace;
+        }),
+      },
+    });
+
+    const acquiring = harness.getWorkspace();
+    await Promise.resolve();
+    const shuttingDown = harness.shutdown();
+    await Promise.resolve();
+    expect(workspace.destroy).not.toHaveBeenCalled();
+
+    release();
+    await expect(acquiring).resolves.toBe(workspace);
+    await shuttingDown;
+
+    expect(workspace.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys a per-resource workspace when initialization fails', async () => {
+    const workspace = {
+      status: 'pending',
+      init: vi.fn(async () => {
+        throw new Error('init failed');
+      }),
+      destroy: vi.fn(async () => undefined),
+    } as unknown as Workspace;
+    const provider = {
+      providerId: 'resource-provider',
+      resumable: false,
+      create: vi.fn(async () => workspace),
+      destroy: vi.fn(async (created: Workspace) => {
+        await created.destroy();
+      }),
+    };
+    const harness = new Harness({
+      modes: [],
+      workspace: { kind: 'per-resource', provider },
+    });
+
+    await expect(harness._workspaceRegistry.acquirePerResource({ resourceId: 'resource-a' })).rejects.toThrow(
+      'init failed',
+    );
+
+    expect(provider.destroy).toHaveBeenCalledWith(workspace, expect.objectContaining({ resourceId: 'resource-a' }));
+    expect(workspace.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys a per-session workspace when initialization fails', async () => {
+    const workspace = {
+      status: 'pending',
+      init: vi.fn(async () => {
+        throw new Error('init failed');
+      }),
+      destroy: vi.fn(async () => undefined),
+    } as unknown as Workspace;
+    const provider = {
+      providerId: 'session-provider',
+      resumable: true,
+      create: vi.fn(async () => workspace),
+      resume: vi.fn(async () => workspace),
+      destroy: vi.fn(async (created: Workspace) => {
+        await created.destroy();
+      }),
+    };
+    const harness = new Harness({
+      modes: [],
+      workspace: { kind: 'per-session', provider },
+    });
+
+    await expect(
+      harness._workspaceRegistry.acquirePerSession({
+        resourceId: 'resource-a',
+        sessionId: 'session-a',
+        onStateUpdate: async () => undefined,
+      }),
+    ).rejects.toThrow('init failed');
+
+    expect(provider.destroy).toHaveBeenCalledWith(
+      workspace,
+      expect.objectContaining({ resourceId: 'resource-a', sessionId: 'session-a' }),
+    );
+    expect(workspace.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('awaits pending per-resource workspace acquisition during shutdown', async () => {
+    let release!: () => void;
+    const workspace = {
+      status: 'ready',
+      init: vi.fn(async () => undefined),
+      destroy: vi.fn(async () => undefined),
+    } as unknown as Workspace;
+    const harness = new Harness({
+      modes: [],
+      workspace: {
+        kind: 'per-resource',
+        provider: nonDurableProvider(async () => {
+          await new Promise<void>(resolve => {
+            release = resolve;
+          });
+          return workspace;
+        }),
+      },
+    });
+
+    const acquiring = harness._workspaceRegistry.acquirePerResource({ resourceId: 'resource-a' });
+    await Promise.resolve();
+    const shuttingDown = harness.shutdown();
+    await Promise.resolve();
+    expect(workspace.destroy).not.toHaveBeenCalled();
+
+    release();
+    await expect(acquiring).resolves.toBe(workspace);
+    await shuttingDown;
+
+    expect(workspace.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('awaits pending per-session workspace acquisition during shutdown', async () => {
+    let release!: () => void;
+    const workspace = {
+      status: 'ready',
+      init: vi.fn(async () => undefined),
+      destroy: vi.fn(async () => undefined),
+    } as unknown as Workspace;
+    const provider = {
+      providerId: 'session-provider',
+      resumable: true,
+      create: vi.fn(async () => {
+        await new Promise<void>(resolve => {
+          release = resolve;
+        });
+        return workspace;
+      }),
+      resume: vi.fn(async () => workspace),
+    };
+    const harness = new Harness({
+      modes: [],
+      workspace: { kind: 'per-session', provider },
+    });
+
+    const acquiring = harness._workspaceRegistry.acquirePerSession({
+      resourceId: 'resource-a',
+      sessionId: 'session-a',
+      onStateUpdate: async () => undefined,
+    });
+    await Promise.resolve();
+    const shuttingDown = harness.shutdown();
+    await Promise.resolve();
+    expect(workspace.destroy).not.toHaveBeenCalled();
+
+    release();
+    await expect(acquiring).resolves.toBe(workspace);
+    await shuttingDown;
+
+    expect(workspace.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not initialize an already ready shared workspace', async () => {
+    const workspace = {
+      status: 'ready',
+      init: vi.fn(async () => undefined),
+      destroy: vi.fn(async () => undefined),
+    } as unknown as Workspace;
+    const harness = new Harness({
+      modes: [],
+      workspace: { kind: 'shared', workspace },
+    });
+
+    await harness.getWorkspace();
+
+    expect(workspace.init).not.toHaveBeenCalled();
+  });
+
+  it('coalesces concurrent per-resource workspace acquisition', async () => {
+    const workspace = {
+      status: 'pending',
+      init: vi.fn(async function (this: { status: string }) {
+        this.status = 'ready';
+      }),
+      destroy: vi.fn(async () => undefined),
+    } as unknown as Workspace;
+    const create = vi.fn(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+      return workspace;
+    });
+    const harness = new Harness({
+      modes: [],
+      workspace: {
+        kind: 'per-resource',
+        provider: nonDurableProvider(create, { providerId: 'test-provider' }),
+      },
+    });
+
+    const [first, second] = await Promise.all([
+      harness._workspaceRegistry.acquirePerResource({ resourceId: 'resource-a' }),
+      harness._workspaceRegistry.acquirePerResource({ resourceId: 'resource-a' }),
+    ]);
+
+    expect(first).toBe(second);
+    expect(create).toHaveBeenCalledTimes(1);
+    await harness._workspaceRegistry.releasePerResource({ resourceId: 'resource-a' });
+    expect(workspace.destroy).not.toHaveBeenCalled();
+    await harness._workspaceRegistry.releasePerResource({ resourceId: 'resource-a' });
+    expect(workspace.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not resume per-session workspace state from a different provider', async () => {
+    const create = vi.fn(async () => ({ status: 'ready', init: vi.fn(), destroy: vi.fn() }) as unknown as Workspace);
+    const resume = vi.fn(async () => ({ status: 'ready', init: vi.fn(), destroy: vi.fn() }) as unknown as Workspace);
+    const harness = new Harness({
+      modes: [],
+      workspace: {
+        kind: 'per-session',
+        provider: {
+          providerId: 'current',
+          resumable: true,
+          create,
+          resume,
+        },
+      },
+    });
+
+    await harness._workspaceRegistry.acquirePerSession({
+      resourceId: 'resource-a',
+      sessionId: 'session-a',
+      storedProviderId: 'previous',
+      storedState: { from: 'previous' },
+      onStateUpdate: async () => undefined,
+    });
+
+    expect(resume).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent per-session workspace acquisition', async () => {
+    const workspace = {
+      status: 'pending',
+      init: vi.fn(async function (this: { status: string }) {
+        this.status = 'ready';
+      }),
+      destroy: vi.fn(async () => undefined),
+    } as unknown as Workspace;
+    const create = vi.fn(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+      return workspace;
+    });
+    const harness = new Harness({
+      modes: [],
+      workspace: {
+        kind: 'per-session',
+        provider: {
+          providerId: 'session-provider',
+          resumable: true,
+          create,
+          resume: async () => workspace,
+        },
+      },
+    });
+
+    const [first, second] = await Promise.all([
+      harness._workspaceRegistry.acquirePerSession({
+        resourceId: 'resource-a',
+        sessionId: 'session-a',
+        onStateUpdate: async () => undefined,
+      }),
+      harness._workspaceRegistry.acquirePerSession({
+        resourceId: 'resource-a',
+        sessionId: 'session-a',
+        onStateUpdate: async () => undefined,
+      }),
+    ]);
+
+    expect(first).toBe(second);
+    expect(create).toHaveBeenCalledTimes(1);
+    await harness._workspaceRegistry.releasePerSession({ sessionId: 'session-a' });
+    expect(workspace.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the session lease when workspace provider mismatch rejects hydration', async () => {
+    const storage = makeStorage();
+    const seedHarness = makeHarness({ sessions: { storage } });
+    const session = await seedHarness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+    await seedHarness.shutdown();
+
+    const stored = await storage.loadSession({ sessionId: session.id });
+    expect(stored).not.toBeNull();
+    await storage.saveSession(
+      { ...stored!, workspace: { providerId: 'previous', state: { branch: 'main' } } },
+      { ownerId: 'seed', ifVersion: stored!.version },
+    );
+
+    const mismatched = makeHarness({
+      sessions: { storage },
+      workspace: {
+        kind: 'per-session',
+        provider: {
+          providerId: 'current',
+          resumable: true,
+          create: async () => ({ status: 'ready', init: vi.fn(), destroy: vi.fn() }) as unknown as Workspace,
+          resume: async () => ({ status: 'ready', init: vi.fn(), destroy: vi.fn() }) as unknown as Workspace,
+        },
+      },
+    });
+    await expect(mismatched.session({ sessionId: session.id })).rejects.toThrow(HarnessWorkspaceProviderMismatchError);
+
+    const matching = makeHarness({
+      sessions: { storage },
+      workspace: {
+        kind: 'per-session',
+        provider: {
+          providerId: 'previous',
+          resumable: true,
+          create: async () => ({ status: 'ready', init: vi.fn(), destroy: vi.fn() }) as unknown as Workspace,
+          resume: async () => ({ status: 'ready', init: vi.fn(), destroy: vi.fn() }) as unknown as Workspace,
+        },
+      },
+    });
+
+    await expect(matching.session({ sessionId: session.id })).resolves.toMatchObject({ id: session.id });
+    const after = await storage.loadSession({ sessionId: session.id });
+    expect(after?.ownerId).toBe(matching.ownerId);
+  });
+
+  it('exposes model catalog and auth status resolution', async () => {
+    const harness = makeHarness({
+      models: [{ id: 'openai/gpt-4o-mini', providerId: 'openai', displayName: 'GPT-4o mini' }],
+      modelAuthStatusResolver: async modelId => (modelId === 'openai/gpt-4o-mini' ? 'authenticated' : 'unknown'),
+    });
+
+    await expect(harness.models.list()).resolves.toHaveLength(1);
+    await expect(harness.models.get('openai/gpt-4o-mini')).resolves.toMatchObject({ providerId: 'openai' });
+    await expect(harness.models.getAuthStatus('openai/gpt-4o-mini')).resolves.toBe('authenticated');
+    await expect(harness.models.getAuthStatus('missing')).rejects.toThrow(HarnessModelNotFoundError);
+  });
+
+  it('exposes legacy-compatible available model discovery hooks', async () => {
+    const harness = makeHarness({
+      models: [{ id: 'local-test/model-a', providerId: 'local-test', displayName: 'Model A' }],
+      modelAuthChecker: provider => (provider === 'local-test' ? true : undefined),
+      modelUseCountProvider: () => ({
+        'local-test/model-a': 2,
+        'custom/model-b': 5,
+      }),
+      customModelCatalogProvider: async () => [
+        {
+          id: 'custom/model-b',
+          provider: 'custom',
+          modelName: 'model-b',
+          hasApiKey: true,
+        },
+      ],
+    });
+
+    const models = await harness.listAvailableModels();
+
+    expect(models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'local-test/model-a',
+          provider: 'local-test',
+          modelName: 'model-a',
+          hasApiKey: true,
+          useCount: 2,
+        }),
+        expect.objectContaining({
+          id: 'custom/model-b',
+          provider: 'custom',
+          modelName: 'model-b',
+          hasApiKey: true,
+          useCount: 5,
+        }),
+      ]),
+    );
+  });
+
+  it('starts and stops process-local interval handlers', async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = vi.fn();
+      const shutdown = vi.fn();
+      const harness = makeHarness({
+        id: 'interval-harness',
+        intervals: [{ id: 'sync', everyMs: 10, handler, shutdown }],
+      });
+
+      await harness.init();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenLastCalledWith(
+        expect.objectContaining({ harnessId: 'interval-harness', abortSignal: expect.any(AbortSignal) }),
+      );
+
+      vi.advanceTimersByTime(25);
+      expect(handler).toHaveBeenCalledTimes(3);
+
+      await harness.stopIntervals();
+      expect(shutdown).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(20);
+      expect(handler).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('Harness v1 threads', () => {
+  it('creates, lists, renames, settings, clones, and deletes resource-scoped threads', async () => {
+    const harness = makeHarness();
+    const created = await harness.threads.create({
+      resourceId: 'resource-a',
+      threadId: 'thread-a',
+      title: 'Initial',
+      metadata: { pinned: true },
+    });
+
+    expect(created).toMatchObject({ id: 'thread-a', resourceId: 'resource-a', title: 'Initial' });
+    await expect(harness.threads.get({ resourceId: 'resource-b', threadId: 'thread-a' })).resolves.toBeNull();
+
+    const listed = await harness.threads.list({ resourceId: 'resource-a', perPage: false });
+    expect(listed.threads).toHaveLength(1);
+    expect(listed.items).toHaveLength(1);
+
+    const renamed = await harness.threads.rename({
+      resourceId: 'resource-a',
+      threadId: 'thread-a',
+      title: 'Renamed',
+      metadata: { color: 'blue' },
+    });
+    expect(renamed.title).toBe('Renamed');
+
+    await harness.threads.setSettings({
+      resourceId: 'resource-a',
+      threadId: 'thread-a',
+      patch: { color: 'green', pinned: undefined },
+    });
+    await expect(
+      harness.threads.getSetting({ resourceId: 'resource-a', threadId: 'thread-a', key: 'color' }),
+    ).resolves.toBe('green');
+
+    const cloned = await harness.threads.clone({
+      resourceId: 'resource-a',
+      threadId: 'thread-a',
+      newThreadId: 'thread-b',
+      title: 'Clone',
+    });
+    expect(cloned).toMatchObject({ id: 'thread-b', title: 'Clone' });
+
+    await expect(harness.threads.getSettings({ resourceId: 'resource-b', threadId: 'thread-a' })).rejects.toThrow(
+      HarnessThreadNotFoundError,
+    );
+
+    await harness.threads.delete({ resourceId: 'resource-a', threadId: 'thread-a' });
+    await expect(harness.threads.get({ resourceId: 'resource-a', threadId: 'thread-a' })).resolves.toBeNull();
+  });
+
+  it('rejects caller-supplied thread id collisions across resources', async () => {
+    const harness = makeHarness();
+    await harness.threads.create({ resourceId: 'resource-a', threadId: 'thread-a' });
+
+    await expect(harness.threads.create({ resourceId: 'resource-b', threadId: 'thread-a' })).rejects.toThrow(
+      HarnessConfigError,
+    );
+    await expect(harness.threads.get({ resourceId: 'resource-a', threadId: 'thread-a' })).resolves.toMatchObject({
+      id: 'thread-a',
+      resourceId: 'resource-a',
+    });
+  });
+
+  it('rejects duplicate thread ids for the same resource', async () => {
+    const harness = makeHarness();
+    await harness.threads.create({
+      resourceId: 'resource-a',
+      threadId: 'thread-a',
+      title: 'Original',
+      metadata: { stable: true },
+    });
+
+    await expect(
+      harness.threads.create({
+        resourceId: 'resource-a',
+        threadId: 'thread-a',
+        title: 'Replacement',
+        metadata: { stable: false },
+      }),
+    ).rejects.toThrow(HarnessConfigError);
+    await expect(harness.threads.get({ resourceId: 'resource-a', threadId: 'thread-a' })).resolves.toMatchObject({
+      title: 'Original',
+      metadata: { stable: true },
+    });
+  });
+
+  it('closes the live session before deleting its thread', async () => {
+    const harness = makeHarness();
+    await harness.threads.create({ resourceId: 'resource-a', threadId: 'thread-a' });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: 'thread-a' });
+
+    await harness.threads.delete({ resourceId: 'resource-a', threadId: 'thread-a' });
+
+    expect(session.lifecycleState).toBe('closed');
+    await expect(harness.session({ sessionId: session.id })).rejects.toThrow(HarnessSessionClosedError);
+  });
+
+  it('closes every active session for a deleted thread', async () => {
+    const harness = makeHarness();
+    await harness.threads.create({ resourceId: 'resource-a', threadId: 'thread-a' });
+    const first = await harness.session({ resourceId: 'resource-a', threadId: 'thread-a', sessionId: 'session-a' });
+    const second = await harness.session({ resourceId: 'resource-a', threadId: 'thread-a', sessionId: 'session-b' });
+
+    await harness.threads.delete({ resourceId: 'resource-a', threadId: 'thread-a' });
+
+    expect(first.lifecycleState).toBe('closed');
+    expect(second.lifecycleState).toBe('closed');
+    await expect(harness.listSessions({ resourceId: 'resource-a' })).resolves.toEqual([]);
+  });
+
+  it('deletes memory threads even when the harness session storage domain is absent', async () => {
+    const db = new InMemoryDB();
+    const storage = new MastraCompositeStore({
+      id: 'memory-only',
+      domains: { memory: new InMemoryMemory({ db }) },
+    });
+    const harness = new Harness({
+      agents: { default: makeAgent() },
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      storage,
+    });
+
+    await harness.threads.create({ resourceId: 'resource-a', threadId: 'thread-a' });
+    await harness.threads.delete({ resourceId: 'resource-a', threadId: 'thread-a' });
+
+    await expect(harness.threads.get({ resourceId: 'resource-a', threadId: 'thread-a' })).resolves.toBeNull();
+  });
+});

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -1,12 +1,1552 @@
+import { randomUUID } from 'node:crypto';
+
+import type { Agent } from '../../agent';
+import { Mastra } from '../../mastra';
+import type {
+  HarnessStorage,
+  PermissionRules,
+  SessionGrants,
+  SessionRecord,
+  SessionSummary,
+  TokenUsage,
+} from '../../storage/domains/harness';
+import {
+  HarnessStorageLeaseConflictError,
+  HarnessStorageSessionNotFoundError,
+  HarnessStorageVersionConflictError,
+} from '../../storage/domains/harness';
+import { InMemoryStore } from '../../storage/mock';
+import type { Workspace } from '../../workspace';
 import type { HarnessConfig } from './config';
+import {
+  HarnessConfigError,
+  HarnessModelNotFoundError,
+  HarnessSessionClosedError,
+  HarnessSessionLockedError,
+  HarnessSessionNotFoundError,
+  HarnessStorageError,
+  HarnessThreadNotFoundError,
+  HarnessWorkspaceProviderMismatchError,
+} from './errors';
+import { EventEmitter } from './events';
+import type { HarnessEvent, HarnessEventListener, HarnessEventUnsubscribe } from './events';
+import { Session } from './session';
+import type { HarnessMode, ToolCategory } from './shared';
+import type {
+  AttachmentDeleteOptions,
+  AttachmentRef,
+  AttachmentUploadOptions,
+  AvailableModel,
+  CustomModelCatalogProvider,
+  ModelAuthChecker,
+  ModelAuthStatus,
+  ModelInfo,
+  ModelUseCountProvider,
+  PermissionPolicy,
+  SessionListOptions,
+  SessionLoadByIdOptions,
+  SessionResolveOptions,
+  ShutdownOptions,
+  SubagentDefinition,
+  ThreadCloneOptions,
+  ThreadCreateOptions,
+  ThreadDeleteOptions,
+  ThreadGetOptions,
+  ThreadGetSettingOptions,
+  ThreadGetSettingsOptions,
+  ThreadListOptions,
+  ThreadListResult,
+  ThreadRecord,
+  ThreadRenameOptions,
+  ThreadSelectOrCreateOptions,
+  ThreadSetSettingsOptions,
+} from './types';
+import { WorkspaceRegistry } from './workspace-registry';
+
+const DEFAULT_LEASE_TTL_MS = 30_000;
+const DEFAULT_MAX_QUEUE_DEPTH = 100;
+const DEFAULT_SUBAGENT_MAX_DEPTH = 1;
+const DEFAULT_GOAL_MAX_TURNS = 50;
+const DEFAULT_PERMISSION_POLICY: PermissionPolicy = 'ask';
+
+type IntervalHandler = NonNullable<HarnessConfig['intervals']>[number];
 
 export class Harness<TState = unknown> {
-  readonly config: HarnessConfig<TState> | Record<string, unknown>;
+  readonly id: string;
+  readonly ownerId: string;
 
-  constructor();
-  constructor(config: HarnessConfig<TState>);
-  constructor(config: Record<string, unknown>);
-  constructor(config: HarnessConfig<TState> | Record<string, unknown> = {}) {
-    this.config = config;
+  private _mastra?: Mastra;
+  private readonly _storageOverride?: HarnessStorage;
+  private readonly _defaultResourceId: string;
+  private readonly _resolveModel?: HarnessConfig<TState>['resolveModel'];
+  private readonly _modesById: Map<string, HarnessMode<TState>>;
+  private readonly _defaultModeId?: string;
+  private readonly _liveSessions = new Map<string, Session>();
+  private readonly _sessionResolutions = new Map<string, Promise<Session>>();
+  private readonly _leaseTtlMs: number;
+  private readonly _maxQueueDepth: number;
+  private readonly _subagentTypes: ReadonlyMap<string, SubagentDefinition>;
+  private readonly _subagentMaxDepth: number;
+  private readonly _goalDefaults: { defaultJudgeModel?: string; defaultMaxTurns: number };
+  private readonly _defaultPermissionPolicy: PermissionPolicy;
+  private readonly _toolCategoryResolver?: (toolName: string) => ToolCategory | null;
+  private readonly _modelCatalog: ReadonlyMap<string, ModelInfo>;
+  private readonly _modelAuthStatusResolver?: (modelId: string) => ModelAuthStatus | Promise<ModelAuthStatus>;
+  private readonly _modelAuthChecker?: ModelAuthChecker;
+  private readonly _modelUseCountProvider?: ModelUseCountProvider;
+  private readonly _customModelCatalogProvider?: CustomModelCatalogProvider;
+  private readonly _initialState?: TState | (() => TState | Promise<TState>);
+  private readonly _configuredIntervals: readonly IntervalHandler[];
+  private readonly _intervals = new Map<
+    string,
+    { timer: ReturnType<typeof setInterval>; abortController: AbortController; shutdown?: () => void | Promise<void> }
+  >();
+  private readonly _emitter = new EventEmitter();
+  private readonly _sessionEventBridges = new Map<string, HarnessEventUnsubscribe>();
+
+  readonly _workspaceRegistry: WorkspaceRegistry;
+  readonly _workspaceKind?: 'shared' | 'per-resource' | 'per-session';
+
+  private _shutdown = false;
+
+  constructor(config: HarnessConfig<TState>) {
+    this.ownerId = `harness-${randomUUID()}`;
+    this.id = config.id ?? this.ownerId;
+    this._defaultResourceId = config.resourceId ?? this.id;
+    this._leaseTtlMs = config.sessions?.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS;
+    this._storageOverride = config.sessions?.storage;
+    this._maxQueueDepth = config.sessions?.maxQueueDepth ?? DEFAULT_MAX_QUEUE_DEPTH;
+    this._initialState = config.initialState;
+    this._configuredIntervals = config.intervals ?? [];
+    this._resolveModel = config.resolveModel;
+
+    if (this._leaseTtlMs < 1) {
+      throw new HarnessConfigError('sessions.leaseTtlMs', 'must be a positive integer');
+    }
+    if (this._maxQueueDepth < 1) {
+      throw new HarnessConfigError('sessions.maxQueueDepth', 'must be a positive integer');
+    }
+
+    const subagentTypes = new Map<string, SubagentDefinition>();
+    if (config.subagents) {
+      for (const [agentType, def] of Object.entries(config.subagents.types ?? {})) {
+        if (typeof def?.agentId !== 'string' || def.agentId.length === 0) {
+          throw new HarnessConfigError(`subagents.types["${agentType}"].agentId`, 'is required');
+        }
+        if (typeof def.description !== 'string' || def.description.length === 0) {
+          throw new HarnessConfigError(`subagents.types["${agentType}"].description`, 'is required');
+        }
+        subagentTypes.set(agentType, def);
+      }
+      this._subagentMaxDepth = config.subagents.maxDepth ?? DEFAULT_SUBAGENT_MAX_DEPTH;
+      if (this._subagentMaxDepth < 1) {
+        throw new HarnessConfigError('subagents.maxDepth', 'must be a positive integer');
+      }
+    } else {
+      this._subagentMaxDepth = DEFAULT_SUBAGENT_MAX_DEPTH;
+    }
+    this._subagentTypes = subagentTypes;
+
+    const goalsCfg = config.goals;
+    if (goalsCfg?.defaultMaxTurns !== undefined && goalsCfg.defaultMaxTurns < 1) {
+      throw new HarnessConfigError('goals.defaultMaxTurns', 'must be a positive integer');
+    }
+    this._goalDefaults = {
+      ...(goalsCfg?.defaultJudgeModel !== undefined ? { defaultJudgeModel: goalsCfg.defaultJudgeModel } : {}),
+      defaultMaxTurns: goalsCfg?.defaultMaxTurns ?? DEFAULT_GOAL_MAX_TURNS,
+    };
+
+    if (
+      config.defaultPermissionPolicy !== undefined &&
+      config.defaultPermissionPolicy !== 'allow' &&
+      config.defaultPermissionPolicy !== 'ask' &&
+      config.defaultPermissionPolicy !== 'deny'
+    ) {
+      throw new HarnessConfigError(
+        'defaultPermissionPolicy',
+        `must be one of 'allow' | 'ask' | 'deny' (received: ${JSON.stringify(config.defaultPermissionPolicy)})`,
+      );
+    }
+    if (config.toolCategoryResolver !== undefined && typeof config.toolCategoryResolver !== 'function') {
+      throw new HarnessConfigError('toolCategoryResolver', 'must be a function');
+    }
+    if (
+      config.toolCategories !== undefined &&
+      (typeof config.toolCategories !== 'object' ||
+        config.toolCategories === null ||
+        Array.isArray(config.toolCategories))
+    ) {
+      throw new HarnessConfigError('toolCategories', 'must be a Record<string, ToolCategory>');
+    }
+    this._defaultPermissionPolicy = config.defaultPermissionPolicy ?? DEFAULT_PERMISSION_POLICY;
+    if (config.toolCategoryResolver) {
+      this._toolCategoryResolver = config.toolCategoryResolver;
+    } else if (config.toolCategories) {
+      const map = config.toolCategories;
+      this._toolCategoryResolver = (name: string) => map[name] ?? null;
+    }
+
+    const catalog = new Map<string, ModelInfo>();
+    if (config.models) {
+      if (!Array.isArray(config.models)) {
+        throw new HarnessConfigError('models', 'must be an array of ModelInfo');
+      }
+      for (const entry of config.models) {
+        if (!entry || typeof entry.id !== 'string' || entry.id.length === 0) {
+          throw new HarnessConfigError('models', 'every entry must have a non-empty string `id`');
+        }
+        if (typeof entry.providerId !== 'string' || entry.providerId.length === 0) {
+          throw new HarnessConfigError('models', `entry "${entry.id}" must have a non-empty string \`providerId\``);
+        }
+        if (catalog.has(entry.id)) {
+          throw new HarnessConfigError('models', `duplicate model id "${entry.id}"`);
+        }
+        catalog.set(entry.id, entry);
+      }
+    }
+    this._modelCatalog = catalog;
+    this._modelAuthStatusResolver = config.modelAuthStatusResolver;
+    this._modelAuthChecker = config.modelAuthChecker;
+    this._modelUseCountProvider = config.modelUseCountProvider;
+    this._customModelCatalogProvider = config.customModelCatalogProvider;
+
+    this._workspaceKind = config.workspace?.kind;
+    this._workspaceRegistry = new WorkspaceRegistry({
+      config: config.workspace,
+      emitter: this._emitter,
+    });
+    if (config.workspace?.kind === 'shared' && config.workspace.eager) {
+      void this._workspaceRegistry.acquireShared().catch(() => undefined);
+    }
+    if (this._workspaceKind !== 'per-session') {
+      for (const [agentType, def] of subagentTypes) {
+        if (def.workspace === 'fresh') {
+          throw new HarnessConfigError(
+            `subagents.types["${agentType}"].workspace`,
+            `"fresh" requires harness workspace kind "per-session" (current: "${this._workspaceKind ?? 'unconfigured'}")`,
+          );
+        }
+      }
+    }
+
+    this._modesById = new Map();
+    for (const mode of config.modes ?? []) {
+      if (this._modesById.has(mode.id)) {
+        throw new HarnessConfigError('modes', `duplicate mode id "${mode.id}"`);
+      }
+      if (mode.tools && mode.additionalTools) {
+        throw new HarnessConfigError(
+          `modes[${mode.id}]`,
+          'cannot set both "tools" and "additionalTools" - choose replace OR augment',
+        );
+      }
+      this._modesById.set(mode.id, mode);
+    }
+    for (const mode of this._modesById.values()) {
+      if (mode.transitionsTo && !this._modesById.has(mode.transitionsTo)) {
+        throw new HarnessConfigError(
+          `modes[${mode.id}].transitionsTo`,
+          `references unknown mode "${mode.transitionsTo}"`,
+        );
+      }
+    }
+    if (config.defaultModeId !== undefined) {
+      if (!this._modesById.has(config.defaultModeId)) {
+        throw new HarnessConfigError('defaultModeId', `references unknown mode "${config.defaultModeId}"`);
+      }
+      this._defaultModeId = config.defaultModeId;
+    } else if (this._modesById.size > 0) {
+      throw new HarnessConfigError('defaultModeId', 'must be set when "modes" is non-empty');
+    }
+
+    if (config.mastra) {
+      this._bindMastra(config.mastra);
+    } else if (config.agents !== undefined || config.storage !== undefined) {
+      const internal = new Mastra({
+        agents: config.agents,
+        storage: config.storage ?? new InMemoryStore(),
+      });
+      this._bindMastra(internal);
+    }
   }
+
+  get mastra(): Mastra {
+    if (!this._mastra) {
+      throw new HarnessConfigError(
+        'mastra',
+        'harness is not yet bound to a Mastra - pass `mastra`/`agents`/`storage` at construction or register it on a parent Mastra',
+      );
+    }
+    return this._mastra;
+  }
+
+  getMastra(): Mastra | undefined {
+    return this._mastra;
+  }
+
+  __registerMastra(mastra: Mastra): void {
+    if (this._mastra && this._mastra !== mastra) {
+      throw new HarnessConfigError('mastra', 'harness is already bound to a different Mastra instance');
+    }
+    if (this._mastra === mastra) return;
+    this._bindMastra(mastra);
+  }
+
+  private _bindMastra(mastra: Mastra): void {
+    for (const mode of this._modesById.values()) {
+      let agent: Agent | undefined;
+      try {
+        agent = mastra.getAgent(mode.agentId as never) as Agent | undefined;
+      } catch {
+        agent = undefined;
+      }
+      if (!agent) {
+        throw new HarnessConfigError(
+          `modes[${mode.id}].agentId`,
+          `references unknown agent "${mode.agentId}" - Mastra has no such agent registered`,
+        );
+      }
+    }
+    for (const [agentType, def] of this._subagentTypes) {
+      let agent: Agent | undefined;
+      try {
+        agent = mastra.getAgent(def.agentId as never) as Agent | undefined;
+      } catch {
+        agent = undefined;
+      }
+      if (!agent) {
+        throw new HarnessConfigError(
+          `subagents.types["${agentType}"].agentId`,
+          `references unknown agent "${def.agentId}" - Mastra has no such agent registered`,
+        );
+      }
+      if (def.modeId !== undefined && !this._modesById.has(def.modeId)) {
+        throw new HarnessConfigError(
+          `subagents.types["${agentType}"].modeId`,
+          `references unknown mode "${def.modeId}"`,
+        );
+      }
+    }
+    this._mastra = mastra;
+  }
+
+  async init(): Promise<void> {
+    if (this._shutdown) {
+      throw new Error('Harness is shut down');
+    }
+    if (this._workspaceKind === 'shared') {
+      await this._workspaceRegistry.acquireShared();
+    }
+    for (const interval of this._configuredIntervals) {
+      this.onInterval(interval);
+    }
+  }
+
+  subscribe(listener: HarnessEventListener): HarnessEventUnsubscribe {
+    return this._emitter.subscribe(listener);
+  }
+
+  onInterval(handler: IntervalHandler): HarnessEventUnsubscribe {
+    if (this._shutdown) {
+      throw new Error('Harness is shut down');
+    }
+    if (!handler || typeof handler.id !== 'string' || handler.id.length === 0) {
+      throw new HarnessConfigError('intervals.id', 'must be a non-empty string');
+    }
+    if (!Number.isFinite(handler.everyMs) || handler.everyMs < 1) {
+      throw new HarnessConfigError(`intervals["${handler.id}"].everyMs`, 'must be a positive number');
+    }
+
+    void this.stopInterval(handler.id);
+    const abortController = new AbortController();
+    const run = async () => {
+      if (abortController.signal.aborted) return;
+      try {
+        await handler.handler({ harnessId: this.id, abortSignal: abortController.signal });
+      } catch (error) {
+        console.error(`[HarnessInterval:${handler.id}] failed:`, error);
+      }
+    };
+
+    if (handler.immediate !== false) {
+      void run();
+    }
+
+    const timer = setInterval(run, handler.everyMs);
+    timer.unref?.();
+    this._intervals.set(handler.id, { timer, abortController, shutdown: handler.shutdown });
+    return () => {
+      void this.stopInterval(handler.id);
+    };
+  }
+
+  async stopInterval(id: string): Promise<void> {
+    const entry = this._intervals.get(id);
+    if (!entry) return;
+    clearInterval(entry.timer);
+    entry.abortController.abort();
+    this._intervals.delete(id);
+    await entry.shutdown?.();
+  }
+
+  async stopIntervals(): Promise<void> {
+    const ids = Array.from(this._intervals.keys());
+    for (const id of ids) {
+      await this.stopInterval(id);
+    }
+  }
+
+  _internalListenerCount(): number {
+    return this._emitter.listenerCount;
+  }
+
+  async getWorkspace(): Promise<Workspace | undefined> {
+    if (this._shutdown) {
+      throw new Error('Harness is shut down');
+    }
+    if (this._workspaceKind !== 'shared') return undefined;
+    return this._workspaceRegistry.acquireShared();
+  }
+
+  async destroyResourceWorkspace(opts: { resourceId: string }): Promise<void> {
+    if (this._workspaceKind !== 'per-resource') {
+      throw new HarnessConfigError(
+        'workspace.kind',
+        `destroyResourceWorkspace requires kind: "per-resource" (current: "${this._workspaceKind ?? 'unconfigured'}")`,
+      );
+    }
+    await this._workspaceRegistry.destroyResourceWorkspace(opts);
+  }
+
+  _emit(event: Parameters<EventEmitter['emit']>[0], overrides?: Parameters<EventEmitter['emit']>[1]): HarnessEvent {
+    return this._emitter.emit(event, overrides);
+  }
+
+  getAgentForMode(modeId: string): Agent {
+    const mode = this._modesById.get(modeId);
+    if (!mode) {
+      throw new HarnessConfigError('modeId', `unknown mode "${modeId}"`);
+    }
+    return this.mastra.getAgent(mode.agentId as never) as Agent;
+  }
+
+  _getSubagentType(agentType: string): SubagentDefinition | undefined {
+    return this._subagentTypes.get(agentType);
+  }
+
+  _listSubagentTypeIds(): string[] {
+    return Array.from(this._subagentTypes.keys());
+  }
+
+  _getSubagentMaxDepth(): number {
+    return this._subagentMaxDepth;
+  }
+
+  _getMode(modeId: string): HarnessMode<TState> {
+    const mode = this._modesById.get(modeId);
+    if (!mode) {
+      throw new HarnessConfigError('modeId', `unknown mode "${modeId}"`);
+    }
+    return mode;
+  }
+
+  getDefaultResourceId(): string {
+    return this._defaultResourceId;
+  }
+
+  async getKnownResourceIds(): Promise<string[]> {
+    const memory = await this._requireMemoryStorage('getKnownResourceIds()');
+    const out = await memory.listThreads({
+      perPage: false,
+      filter: {},
+    });
+    return [...new Set(out.threads.map(thread => thread.resourceId))].sort();
+  }
+
+  listModes(): HarnessMode<TState>[] {
+    return Array.from(this._modesById.values());
+  }
+
+  getMode(modeId: string): HarnessMode<TState> | undefined {
+    return this._modesById.get(modeId);
+  }
+
+  getToolCategory(opts: { toolName: string }): ToolCategory | null {
+    if (!this._toolCategoryResolver) return null;
+    return this._toolCategoryResolver(opts.toolName) ?? null;
+  }
+
+  _getDefaultPermissionPolicy(): PermissionPolicy {
+    return this._defaultPermissionPolicy;
+  }
+
+  async listAvailableModels(): Promise<AvailableModel[]> {
+    try {
+      const { PROVIDER_REGISTRY } = await import('../../llm/model/provider-registry.js');
+      if (!PROVIDER_REGISTRY) return [];
+
+      const registry = PROVIDER_REGISTRY as Record<
+        string,
+        { models?: string[]; name?: string; apiKeyEnvVar?: string | string[] }
+      >;
+      const useCounts = this._modelUseCountProvider?.() ?? {};
+      const modelsById = new Map<string, AvailableModel>();
+
+      const upsertModel = (model: Omit<AvailableModel, 'useCount'>): void => {
+        if (!model.id || !model.provider || !model.modelName) return;
+        modelsById.set(model.id, {
+          ...model,
+          useCount: useCounts[model.id] ?? 0,
+        });
+      };
+
+      for (const provider of Object.keys(registry)) {
+        const providerConfig = registry[provider];
+        const envVars = providerConfig?.apiKeyEnvVar;
+        const apiKeyEnvVar = Array.isArray(envVars) ? envVars[0] : envVars;
+        const hasApiKey = await this._hasProviderAuth(provider, apiKeyEnvVar);
+
+        if (providerConfig?.models && Array.isArray(providerConfig.models)) {
+          for (const modelName of providerConfig.models) {
+            upsertModel({
+              id: `${provider}/${modelName}`,
+              provider,
+              modelName,
+              hasApiKey,
+              apiKeyEnvVar: apiKeyEnvVar || undefined,
+            });
+          }
+        }
+      }
+
+      for (const model of this._modelCatalog.values()) {
+        const { provider, modelName } = splitModelId(model.id, model.providerId);
+        upsertModel({
+          id: model.id,
+          provider,
+          modelName,
+          hasApiKey: await this._hasProviderAuth(provider),
+          apiKeyEnvVar: await this._getProviderApiKeyEnvVar(provider),
+        });
+      }
+
+      if (this._customModelCatalogProvider) {
+        try {
+          const customModels = await Promise.resolve(this._customModelCatalogProvider());
+          for (const model of customModels) {
+            upsertModel(model);
+          }
+        } catch (error) {
+          console.warn('Failed to load custom available models:', error);
+        }
+      }
+
+      return [...modelsById.values()];
+    } catch (error) {
+      console.warn('Failed to load available models:', error);
+      return [];
+    }
+  }
+
+  async session(opts: SessionResolveOptions): Promise<Session> {
+    if (this._shutdown) {
+      throw new Error('Harness is shut down');
+    }
+    const storage = this._requireStorage('session()');
+    const key = this._sessionResolutionKey(opts);
+    if (!key) return this._sessionUncoalesced(storage, opts);
+
+    const existing = this._sessionResolutions.get(key);
+    if (existing) return existing;
+
+    const pending = this._sessionUncoalesced(storage, opts);
+    this._sessionResolutions.set(key, pending);
+    try {
+      return await pending;
+    } finally {
+      this._sessionResolutions.delete(key);
+    }
+  }
+
+  private async _sessionUncoalesced(storage: HarnessStorage, opts: SessionResolveOptions): Promise<Session> {
+    if ('sessionId' in opts && opts.sessionId && !('threadId' in opts && opts.threadId)) {
+      return this._resolveById(storage, opts.sessionId, opts.resourceId);
+    }
+    if ('threadId' in opts && opts.threadId !== undefined) {
+      return this._resolveByThread(storage, opts);
+    }
+    if ('resourceId' in opts && opts.resourceId) {
+      return this._resolveByResource(storage, opts);
+    }
+    throw new HarnessConfigError('session()', 'invalid resolver options');
+  }
+
+  private _sessionResolutionKey(opts: SessionResolveOptions): string | undefined {
+    if ('sessionId' in opts && opts.sessionId) {
+      return `session:${opts.sessionId}:${'resourceId' in opts ? (opts.resourceId ?? '') : ''}`;
+    }
+    if ('threadId' in opts && opts.threadId !== undefined) {
+      if (typeof opts.threadId !== 'string') return undefined;
+      return `thread:${opts.resourceId}:${opts.threadId}`;
+    }
+    if ('resourceId' in opts && opts.resourceId) {
+      return `resource:${opts.resourceId}`;
+    }
+    return undefined;
+  }
+
+  private async _resolveById(storage: HarnessStorage, sessionId: string, resourceId?: string): Promise<Session> {
+    const live = this._liveSessions.get(sessionId);
+    if (live) {
+      if (resourceId !== undefined && live.resourceId !== resourceId) {
+        throw new HarnessSessionNotFoundError(sessionId);
+      }
+      return live;
+    }
+
+    const stored = await storage.loadSession({ sessionId });
+    if (!stored) throw new HarnessSessionNotFoundError(sessionId);
+    if (resourceId !== undefined && stored.resourceId !== resourceId) {
+      throw new HarnessSessionNotFoundError(sessionId);
+    }
+    if (stored.closedAt !== undefined) {
+      throw new HarnessSessionClosedError(sessionId);
+    }
+    return this._hydrate(storage, stored);
+  }
+
+  private async _resolveByThread(
+    storage: HarnessStorage,
+    opts: Extract<SessionResolveOptions, { threadId: unknown }>,
+  ): Promise<Session> {
+    const wantsFreshThread = typeof opts.threadId !== 'string';
+    const resourceId = opts.resourceId;
+
+    if (wantsFreshThread) {
+      return this._createFresh(storage, {
+        resourceId,
+        threadId: this._mintThreadId(),
+        ownsThread: true,
+        sessionId: opts.sessionId,
+        parentSessionId: opts.parentSessionId,
+        origin: opts.origin ?? 'top-level',
+        modeId: opts.modeId,
+        modelId: opts.modelId,
+        subagentDepth: opts.subagentDepth,
+      });
+    }
+
+    const threadId = opts.threadId as string;
+    for (const live of this._liveSessions.values()) {
+      if (live.threadId === threadId && live.resourceId === resourceId) {
+        if (opts.sessionId && live.id !== opts.sessionId) continue;
+        return live;
+      }
+    }
+
+    if (opts.sessionId) {
+      const storedById = await storage.loadSession({ sessionId: opts.sessionId });
+      if (storedById) {
+        if (storedById.resourceId !== resourceId || storedById.threadId !== threadId) {
+          throw new HarnessSessionNotFoundError(opts.sessionId);
+        }
+        if (storedById.closedAt !== undefined) {
+          throw new HarnessSessionClosedError(opts.sessionId);
+        }
+        return this._hydrate(storage, storedById);
+      }
+    }
+
+    const stored = await storage.loadSessionByThread({ threadId, resourceId });
+    if (stored) {
+      if (opts.sessionId && stored.id !== opts.sessionId) {
+        await this._assertThreadIdAvailableForResource({ resourceId, threadId });
+        return this._createFresh(storage, {
+          resourceId,
+          threadId,
+          ownsThread: false,
+          sessionId: opts.sessionId,
+          parentSessionId: opts.parentSessionId,
+          origin: opts.origin ?? 'top-level',
+          modeId: opts.modeId,
+          modelId: opts.modelId,
+          subagentDepth: opts.subagentDepth,
+        });
+      }
+      return this._hydrate(storage, stored);
+    }
+
+    await this._assertThreadIdAvailableForResource({ resourceId, threadId });
+    return this._createFresh(storage, {
+      resourceId,
+      threadId,
+      ownsThread: false,
+      sessionId: opts.sessionId,
+      parentSessionId: opts.parentSessionId,
+      origin: opts.origin ?? 'top-level',
+      modeId: opts.modeId,
+      modelId: opts.modelId,
+      subagentDepth: opts.subagentDepth,
+    });
+  }
+
+  private async _resolveByResource(
+    storage: HarnessStorage,
+    opts: Extract<SessionResolveOptions, { resourceId: string }>,
+  ): Promise<Session> {
+    const resourceId = opts.resourceId;
+    let liveCandidate: Session | undefined;
+    for (const live of this._liveSessions.values()) {
+      if (live.resourceId !== resourceId) continue;
+      if (!liveCandidate || live.lastActivityAt > liveCandidate.lastActivityAt) {
+        liveCandidate = live;
+      }
+    }
+    if (liveCandidate) return liveCandidate;
+
+    const summaries = await storage.listSessions({ resourceId, includeClosed: false });
+    const head = summaries[0];
+    if (head) {
+      const stored = await storage.loadSession({ sessionId: head.id });
+      if (stored && stored.closedAt === undefined) {
+        return this._hydrate(storage, stored);
+      }
+    }
+
+    return this._createFresh(storage, {
+      resourceId,
+      threadId: this._mintThreadId(),
+      ownsThread: true,
+      origin: opts.origin ?? 'top-level',
+      modeId: opts.modeId,
+      modelId: opts.modelId,
+      parentSessionId: opts.parentSessionId,
+      subagentDepth: opts.subagentDepth,
+    });
+  }
+
+  private async _createFresh(
+    storage: HarnessStorage,
+    init: {
+      resourceId: string;
+      threadId: string;
+      ownsThread: boolean;
+      sessionId?: string;
+      parentSessionId?: string;
+      origin: 'top-level' | 'subagent-tool';
+      modeId?: string;
+      modelId?: string;
+      subagentDepth?: number;
+    },
+  ): Promise<Session> {
+    const sessionId = init.sessionId ?? `sess-${randomUUID()}`;
+    const now = Date.now();
+    const modeId = init.modeId ?? this._defaultModeId;
+    const initialState = await this._resolveInitialState();
+    if (modeId === undefined) {
+      throw new HarnessConfigError(
+        'session()',
+        'cannot create a session without a modeId - config has no modes and no override was supplied',
+      );
+    }
+    if (!this._modesById.has(modeId)) {
+      throw new HarnessConfigError('session().modeId', `unknown mode "${modeId}"`);
+    }
+    const modelId = await this._resolveInitialModelId({
+      modelId: init.modelId,
+      modeId,
+      resourceId: init.resourceId,
+    });
+
+    const record: SessionRecord = {
+      id: sessionId,
+      resourceId: init.resourceId,
+      threadId: init.threadId,
+      parentSessionId: init.parentSessionId,
+      origin: init.origin,
+      ownsThread: init.ownsThread,
+      subagentDepth: init.subagentDepth ?? 0,
+      modeId,
+      modelId,
+      subagentModelOverrides: {},
+      permissionRules: emptyPermissionRules(),
+      sessionGrants: emptySessionGrants(),
+      tokenUsage: zeroTokenUsage(),
+      pendingQueue: [],
+      state: initialState,
+      createdAt: now,
+      lastActivityAt: now,
+      version: 0,
+      ownerId: this.ownerId,
+      leaseExpiresAt: now + this._leaseTtlMs,
+    };
+
+    let ownedThreadCreated = false;
+    let saved;
+    try {
+      if (init.ownsThread) {
+        ownedThreadCreated = await this._persistOwnedThread({
+          resourceId: init.resourceId,
+          threadId: init.threadId,
+        });
+      }
+      saved = await storage.saveSession(record, { ownerId: this.ownerId, ifVersion: 0 });
+    } catch (err) {
+      if (ownedThreadCreated) {
+        await this._deleteOwnedThreadBestEffort({ resourceId: init.resourceId, threadId: init.threadId });
+      }
+      if (err instanceof HarnessStorageVersionConflictError) {
+        throw new HarnessSessionLockedError(sessionId, 'unknown', 0);
+      }
+      throw new HarnessStorageError(sessionId, 'flush', err);
+    }
+    record.version = saved.version;
+
+    let lease;
+    try {
+      lease = await this._acquireLease(storage, sessionId);
+    } catch (err) {
+      const rolledBack = await this._deleteUnleasedNewSessionBestEffort(storage, sessionId, saved.version);
+      if (ownedThreadCreated && rolledBack) {
+        await this._deleteOwnedThreadBestEffort({ resourceId: init.resourceId, threadId: init.threadId });
+      }
+      throw err;
+    }
+    record.ownerId = this.ownerId;
+    record.leaseExpiresAt = lease.expiresAt;
+    record.version = lease.version;
+
+    return this._publish(storage, record);
+  }
+
+  private async _hydrate(storage: HarnessStorage, stored: SessionRecord): Promise<Session> {
+    const lease = await this._acquireLease(storage, stored.id);
+    const latest = await storage.loadSession({ sessionId: stored.id });
+    if (!latest) {
+      await storage.releaseSessionLease({ sessionId: stored.id, ownerId: this.ownerId }).catch(() => undefined);
+      throw new HarnessSessionNotFoundError(stored.id);
+    }
+    if (latest.closedAt !== undefined) {
+      await storage.releaseSessionLease({ sessionId: stored.id, ownerId: this.ownerId }).catch(() => undefined);
+      throw new HarnessSessionClosedError(stored.id);
+    }
+    const record: SessionRecord = {
+      ...latest,
+      ownerId: this.ownerId,
+      leaseExpiresAt: lease.expiresAt,
+      version: lease.version,
+    };
+    try {
+      return this._publish(storage, record);
+    } catch (err) {
+      try {
+        await storage.releaseSessionLease({
+          sessionId: stored.id,
+          ownerId: this.ownerId,
+        });
+      } catch {
+        // Lease TTL covers failures; publishing failed before any live Session existed.
+      }
+      throw err;
+    }
+  }
+
+  private _publish(storage: HarnessStorage, record: SessionRecord): Session {
+    const existing = this._liveSessions.get(record.id);
+    if (existing) return existing;
+
+    let workspaceLost = false;
+    if (record.workspace?.providerId && this._workspaceKind === 'per-session') {
+      const configured = this._workspaceRegistry.providerId;
+      if (configured && configured !== record.workspace.providerId) {
+        throw new HarnessWorkspaceProviderMismatchError(record.id, configured, record.workspace.providerId);
+      }
+      if (!this._workspaceRegistry.resumable) {
+        workspaceLost = true;
+      }
+    }
+
+    const session = new Session({
+      harness: this,
+      storage,
+      ownerId: this.ownerId,
+      record,
+      leaseExpiresAt: record.leaseExpiresAt ?? Date.now() + this._leaseTtlMs,
+      leaseTtlMs: this._leaseTtlMs,
+    });
+    if (workspaceLost) session._markWorkspaceLost();
+    this._liveSessions.set(record.id, session);
+
+    const bridge = session.subscribe(event => this._emitter.forward(event));
+    this._sessionEventBridges.set(record.id, bridge);
+    this._emitter.emit(
+      {
+        type: 'session_created',
+        resourceId: record.resourceId,
+        threadId: record.threadId,
+        ...(record.parentSessionId !== undefined && { parentSessionId: record.parentSessionId }),
+        modeId: record.modeId,
+        modelId: record.modelId,
+      },
+      { sessionId: record.id },
+    );
+
+    if ((record.pendingQueue?.length ?? 0) > 0 && record.pendingResume === undefined) {
+      void session._kickQueueDrain();
+    }
+    return session;
+  }
+
+  private async _acquireLease(storage: HarnessStorage, sessionId: string) {
+    try {
+      return await storage.acquireSessionLease({
+        sessionId,
+        ownerId: this.ownerId,
+        ttlMs: this._leaseTtlMs,
+      });
+    } catch (err) {
+      if (err instanceof HarnessStorageLeaseConflictError) {
+        throw new HarnessSessionLockedError(sessionId, err.heldBy, err.expiresAt);
+      }
+      if (err instanceof HarnessStorageSessionNotFoundError) {
+        throw new HarnessSessionNotFoundError(sessionId);
+      }
+      throw new HarnessStorageError(sessionId, 'load', err);
+    }
+  }
+
+  async closeSession(opts: { sessionId: string }): Promise<void> {
+    const storage = this._requireStorage('closeSession()');
+    const live = this._liveSessions.get(opts.sessionId);
+    if (live) {
+      await this._closeSession(live);
+      return;
+    }
+    const stored = await storage.loadSession({ sessionId: opts.sessionId });
+    if (!stored) throw new HarnessSessionNotFoundError(opts.sessionId);
+    if (stored.closedAt !== undefined) return;
+    const session = await this._hydrate(storage, stored);
+    await this._closeSession(session);
+  }
+
+  async _closeSession(session: Session): Promise<void> {
+    if (session.isClosed) return;
+
+    const storage = this._requireStorage('closeSession()');
+    const now = Date.now();
+    const record = session.getRecord();
+    const closed: SessionRecord = {
+      ...record,
+      lastActivityAt: now,
+      closedAt: now,
+    };
+
+    let saved;
+    try {
+      saved = await storage.saveSession(closed, {
+        ownerId: this.ownerId,
+        ifVersion: record.version,
+      });
+    } catch (err) {
+      throw new HarnessStorageError(session.id, 'flush', err);
+    }
+    closed.version = saved.version;
+
+    let childCloseError: unknown;
+    try {
+      const children = await storage.listSessions({
+        resourceId: record.resourceId,
+        includeClosed: false,
+        parentSessionId: record.id,
+      });
+      for (const child of children) {
+        try {
+          await this.closeSession({ sessionId: child.id });
+        } catch (err) {
+          childCloseError ??= err;
+        }
+      }
+    } catch (err) {
+      childCloseError ??= err;
+    }
+
+    try {
+      await storage.releaseSessionLease({
+        sessionId: session.id,
+        ownerId: this.ownerId,
+      });
+    } catch {
+      // The durable closed marker was already written; lease TTL covers failures.
+    }
+
+    try {
+      if (this._workspaceKind === 'per-session') {
+        await this._workspaceRegistry.releasePerSession({ sessionId: session.id });
+      } else if (this._workspaceKind === 'per-resource') {
+        await this._workspaceRegistry.releasePerResource({ resourceId: record.resourceId });
+      }
+    } catch {
+      // Workspace registry errors are surfaced through workspace events.
+    }
+
+    session._markClosed(closed);
+    session._emit({ type: 'session_closed', reason: 'requested' });
+
+    const bridge = this._sessionEventBridges.get(session.id);
+    if (bridge) {
+      bridge();
+      this._sessionEventBridges.delete(session.id);
+    }
+    this._liveSessions.delete(session.id);
+
+    if (childCloseError) {
+      throw new HarnessStorageError(session.id, 'flush', childCloseError);
+    }
+  }
+
+  async listSessions(opts: SessionListOptions & { parentSessionId?: string }): Promise<SessionSummary[]> {
+    const storage = this._requireStorage('listSessions()');
+    return storage.listSessions({
+      resourceId: opts.resourceId,
+      includeClosed: opts.includeClosed,
+      parentSessionId: opts.parentSessionId,
+    });
+  }
+
+  async loadSession(opts: SessionLoadByIdOptions): Promise<SessionRecord | null> {
+    const storage = this._requireStorage('loadSession()');
+    const stored = await storage.loadSession({ sessionId: opts.sessionId });
+    if (!stored) return null;
+    if (stored.closedAt !== undefined && !opts.includeClosed) return null;
+    return stored;
+  }
+
+  async shutdown(_opts?: ShutdownOptions): Promise<void> {
+    if (this._shutdown) return;
+    this._shutdown = true;
+
+    await this.stopIntervals();
+
+    let storage: HarnessStorage | undefined;
+    try {
+      storage = this._requireStorage('shutdown()');
+    } catch {
+      storage = undefined;
+    }
+
+    const sessions = Array.from(this._liveSessions.values());
+    for (const session of sessions) {
+      if (storage) {
+        try {
+          await storage.releaseSessionLease({
+            sessionId: session.id,
+            ownerId: this.ownerId,
+          });
+        } catch {
+          // Leases expire naturally.
+        }
+      }
+
+      await this._evictSession(session, 'shutdown');
+    }
+
+    try {
+      await this._workspaceRegistry.shutdown();
+    } catch {
+      // Workspace registry errors are surfaced through workspace events.
+    }
+  }
+
+  async _evictSession(session: Session, reason: 'idle' | 'pressure' | 'pinned_timeout' | 'shutdown' | 'lease_lost') {
+    if (this._liveSessions.get(session.id) !== session) return;
+
+    try {
+      if (this._workspaceKind === 'per-session') {
+        await this._workspaceRegistry.releasePerSession({ sessionId: session.id });
+      } else if (this._workspaceKind === 'per-resource') {
+        await this._workspaceRegistry.releasePerResource({ resourceId: session.resourceId });
+      }
+    } catch {
+      // Workspace registry errors are surfaced through workspace events.
+    }
+
+    session._emit({ type: 'session_evicted', reason });
+    session._markEvicted();
+
+    const bridge = this._sessionEventBridges.get(session.id);
+    if (bridge) {
+      bridge();
+      this._sessionEventBridges.delete(session.id);
+    }
+    this._liveSessions.delete(session.id);
+  }
+
+  threads = {
+    create: async (opts: ThreadCreateOptions): Promise<ThreadRecord> => {
+      const memory = await this._requireMemoryStorage('threads.create()');
+      const existing = opts.threadId ? await memory.getThreadById({ threadId: opts.threadId }) : null;
+      if (existing) {
+        throw new HarnessConfigError(
+          'threadId',
+          existing.resourceId === opts.resourceId
+            ? 'thread id already exists for this resource'
+            : 'thread id already exists for another resource',
+        );
+      }
+      const now = new Date();
+      const thread = await memory.saveThread({
+        thread: {
+          id: opts.threadId ?? this._mintThreadId(),
+          resourceId: opts.resourceId,
+          title: opts.title,
+          createdAt: now,
+          updatedAt: now,
+          metadata: opts.metadata as Record<string, unknown> | undefined,
+        },
+      });
+      const record = toThreadRecord(thread);
+      this._emitter.emit({
+        type: 'thread_created',
+        threadId: record.id,
+        resourceId: record.resourceId,
+        title: record.title,
+      });
+      return record;
+    },
+
+    list: async (opts: ThreadListOptions): Promise<ThreadListResult> => {
+      const memory = await this._requireMemoryStorage('threads.list()');
+      const out = await memory.listThreads({
+        perPage: opts.perPage ?? 100,
+        page: opts.page ?? 0,
+        orderBy: opts.orderBy ? { field: opts.orderBy.column, direction: opts.orderBy.direction } : undefined,
+        filter: {
+          resourceId: opts.resourceId,
+          metadata: opts.metadata as Record<string, unknown> | undefined,
+        },
+      });
+      return {
+        items: out.threads.map(toThreadRecord),
+        threads: out.threads.map(toThreadRecord),
+        total: out.total,
+        perPage: out.perPage,
+        page: out.page,
+        hasMore: out.hasMore,
+      };
+    },
+
+    get: async (opts: ThreadGetOptions): Promise<ThreadRecord | null> => {
+      const memory = await this._requireMemoryStorage('threads.get()');
+      const thread = await memory.getThreadById({ threadId: opts.threadId });
+      if (!thread || thread.resourceId !== opts.resourceId) return null;
+      return toThreadRecord(thread);
+    },
+
+    rename: async (opts: ThreadRenameOptions): Promise<ThreadRecord> => {
+      const memory = await this._requireMemoryStorage('threads.rename()');
+      const existing = await memory.getThreadById({ threadId: opts.threadId });
+      if (!existing || existing.resourceId !== opts.resourceId) {
+        throw new HarnessThreadNotFoundError(opts.resourceId, opts.threadId);
+      }
+      const previousTitle = existing.title;
+      const merged: Record<string, unknown> = {
+        ...((existing.metadata as Record<string, unknown> | undefined) ?? {}),
+        ...((opts.metadata as Record<string, unknown> | undefined) ?? {}),
+      };
+      const updated = await memory.updateThread({
+        id: opts.threadId,
+        title: opts.title,
+        metadata: merged,
+      });
+      const record = toThreadRecord(updated);
+      this._emitter.emit({
+        type: 'thread_renamed',
+        threadId: record.id,
+        resourceId: record.resourceId,
+        title: opts.title,
+        previousTitle,
+      });
+      return record;
+    },
+
+    clone: async (opts: ThreadCloneOptions): Promise<ThreadRecord> => {
+      const memory = await this._requireMemoryStorage('threads.clone()');
+      const source = await memory.getThreadById({ threadId: opts.threadId });
+      if (!source || source.resourceId !== opts.resourceId) {
+        throw new HarnessThreadNotFoundError(opts.resourceId, opts.threadId);
+      }
+      const cloned = await memory.cloneThread({
+        sourceThreadId: opts.threadId,
+        newThreadId: opts.newThreadId,
+        resourceId: opts.resourceId,
+        title: opts.title,
+        metadata: opts.metadata as Record<string, unknown> | undefined,
+        options: opts.messageLimit !== undefined ? { messageLimit: opts.messageLimit } : undefined,
+      });
+      const record = toThreadRecord(cloned.thread);
+      this._emitter.emit({
+        type: 'thread_cloned',
+        threadId: record.id,
+        resourceId: record.resourceId,
+        sourceThreadId: opts.threadId,
+        title: record.title,
+      });
+      return record;
+    },
+
+    selectOrCreate: async (opts: ThreadSelectOrCreateOptions): Promise<ThreadRecord> => {
+      if (opts.threadId) {
+        const existing = await this.threads.get({
+          resourceId: opts.resourceId,
+          threadId: opts.threadId,
+        });
+        if (existing) return existing;
+        return this.threads.create({
+          resourceId: opts.resourceId,
+          threadId: opts.threadId,
+          title: opts.title,
+          metadata: opts.metadata,
+        });
+      }
+      return this.threads.create({
+        resourceId: opts.resourceId,
+        title: opts.title,
+        metadata: opts.metadata,
+      });
+    },
+
+    delete: async (opts: ThreadDeleteOptions): Promise<void> => {
+      const memory = await this._requireMemoryStorage('threads.delete()');
+      const existing = await memory.getThreadById({ threadId: opts.threadId });
+      if (!existing || existing.resourceId !== opts.resourceId) {
+        return;
+      }
+
+      let cascaded = false;
+      let storage: HarnessStorage | undefined;
+      try {
+        storage = this._requireStorage('threads.delete()');
+      } catch {
+        storage = undefined;
+      }
+      if (storage) {
+        const sessions = await storage.listSessions({ resourceId: opts.resourceId, includeClosed: false });
+        for (const summary of sessions) {
+          if (summary.threadId !== opts.threadId) continue;
+          cascaded = true;
+          const live = this._liveSessions.get(summary.id);
+          const stored = live ? undefined : await storage.loadSession({ sessionId: summary.id });
+          if (!live && (!stored || stored.closedAt !== undefined)) continue;
+          const session = live ?? (await this._hydrate(storage, stored!));
+          await this._closeSession(session);
+        }
+      }
+
+      await memory.deleteThread({ threadId: opts.threadId });
+      this._emitter.emit({
+        type: 'thread_deleted',
+        threadId: opts.threadId,
+        resourceId: opts.resourceId,
+        cascadedSessionClose: cascaded,
+      });
+    },
+
+    setSettings: async (opts: ThreadSetSettingsOptions): Promise<void> => {
+      const memory = await this._requireMemoryStorage('threads.setSettings()');
+      const existing = await memory.getThreadById({ threadId: opts.threadId });
+      if (!existing || existing.resourceId !== opts.resourceId) {
+        throw new HarnessThreadNotFoundError(opts.resourceId, opts.threadId);
+      }
+
+      const before = (existing.metadata as Record<string, unknown> | undefined) ?? {};
+      const next: Record<string, unknown> = { ...before };
+      const effectivePatch: Record<string, unknown> = {};
+      const removedKeys: string[] = [];
+
+      for (const [key, value] of Object.entries(opts.patch)) {
+        if (value === undefined) {
+          if (key in next) {
+            delete next[key];
+            removedKeys.push(key);
+          }
+          continue;
+        }
+        if (!Object.is(before[key], value)) {
+          next[key] = value;
+          effectivePatch[key] = value;
+        }
+      }
+
+      if (Object.keys(effectivePatch).length === 0 && removedKeys.length === 0) {
+        return;
+      }
+
+      await memory.saveThread({
+        thread: {
+          ...existing,
+          metadata: Object.keys(next).length > 0 ? next : undefined,
+          updatedAt: new Date(),
+        },
+      });
+
+      this._emitter.emit({
+        type: 'thread_settings_changed',
+        threadId: opts.threadId,
+        resourceId: opts.resourceId,
+        patch: effectivePatch,
+        removedKeys,
+      });
+    },
+
+    getSettings: async (opts: ThreadGetSettingsOptions): Promise<Readonly<Record<string, unknown>>> => {
+      const memory = await this._requireMemoryStorage('threads.getSettings()');
+      const existing = await memory.getThreadById({ threadId: opts.threadId });
+      if (!existing || existing.resourceId !== opts.resourceId) {
+        throw new HarnessThreadNotFoundError(opts.resourceId, opts.threadId);
+      }
+      const metadata = (existing.metadata as Record<string, unknown> | undefined) ?? {};
+      return Object.freeze({ ...metadata });
+    },
+
+    getSetting: async (opts: ThreadGetSettingOptions): Promise<unknown> => {
+      const settings = await this.threads.getSettings({
+        resourceId: opts.resourceId,
+        threadId: opts.threadId,
+      });
+      return settings[opts.key];
+    },
+  };
+
+  models = {
+    list: async (): Promise<readonly ModelInfo[]> => Object.freeze(Array.from(this._modelCatalog.values())),
+
+    get: async (modelId: string): Promise<ModelInfo | null> => this._modelCatalog.get(modelId) ?? null,
+
+    getAuthStatus: async (modelId: string): Promise<ModelAuthStatus> => {
+      if (!this._modelCatalog.has(modelId)) {
+        throw new HarnessModelNotFoundError(modelId);
+      }
+      if (!this._modelAuthStatusResolver) return 'unknown';
+      return await this._modelAuthStatusResolver(modelId);
+    },
+  };
+
+  attachments = {
+    upload: async (_opts: AttachmentUploadOptions): Promise<AttachmentRef> => {
+      throw new Error('Harness.attachments.upload: not implemented');
+    },
+    delete: async (_opts: AttachmentDeleteOptions): Promise<void> => {
+      throw new Error('Harness.attachments.delete: not implemented');
+    },
+  };
+
+  private _requireStorage(callsite: string): HarnessStorage {
+    if (this._storageOverride) return this._storageOverride;
+    if (this._mastra) {
+      const composite = this._mastra.getStorage();
+      const harness = composite?.stores?.harness;
+      if (harness) return harness;
+    }
+    throw new HarnessConfigError(
+      'sessions.storage',
+      `required for ${callsite} - pass storage in HarnessConfig.storage, HarnessConfig.sessions.storage, or via the Mastra instance backing this harness`,
+    );
+  }
+
+  private async _requireMemoryStorage(callsite: string) {
+    if (!this._mastra) {
+      throw new HarnessConfigError(
+        'mastra',
+        `required for ${callsite} - thread CRUD needs a Mastra instance bound to this harness so we can access the memory storage domain`,
+      );
+    }
+    const composite = this._mastra.getStorage();
+    if (!composite) {
+      throw new HarnessConfigError(
+        'storage',
+        `required for ${callsite} - the bound Mastra instance has no storage configured`,
+      );
+    }
+    const memory = await composite.getStore('memory');
+    if (!memory) {
+      throw new HarnessConfigError(
+        'storage.memory',
+        `required for ${callsite} - the bound Mastra storage has no memory domain registered`,
+      );
+    }
+    return memory;
+  }
+
+  async _internalTryGetMemoryStorage() {
+    if (!this._mastra) return null;
+    const composite = this._mastra.getStorage();
+    if (!composite) return null;
+    const memory = await composite.getStore('memory');
+    return memory ?? null;
+  }
+
+  private _mintThreadId(): string {
+    return `thread-${randomUUID()}`;
+  }
+
+  private async _persistOwnedThread(opts: { resourceId: string; threadId: string }): Promise<boolean> {
+    const memory = await this._requireMemoryStorage('session()');
+    const existing = await memory.getThreadById({ threadId: opts.threadId });
+    if (existing && existing.resourceId !== opts.resourceId) {
+      throw new HarnessConfigError('threadId', 'thread id already exists for another resource');
+    }
+    if (existing) return false;
+
+    const now = new Date();
+    await memory.saveThread({
+      thread: {
+        id: opts.threadId,
+        resourceId: opts.resourceId,
+        title: '',
+        createdAt: now,
+        updatedAt: now,
+      },
+    });
+    this._emitter.emit({
+      type: 'thread_created',
+      threadId: opts.threadId,
+      resourceId: opts.resourceId,
+      title: '',
+    });
+    return true;
+  }
+
+  private async _assertThreadIdAvailableForResource(opts: { resourceId: string; threadId: string }): Promise<void> {
+    const memory = await this._internalTryGetMemoryStorage();
+    if (!memory) return;
+    const existing = await memory.getThreadById({ threadId: opts.threadId });
+    if (existing && existing.resourceId !== opts.resourceId) {
+      throw new HarnessConfigError('threadId', 'thread id already exists for another resource');
+    }
+  }
+
+  private async _deleteOwnedThreadBestEffort(opts: { resourceId: string; threadId: string }): Promise<void> {
+    const memory = await this._internalTryGetMemoryStorage();
+    if (!memory) return;
+    const existing = await memory.getThreadById({ threadId: opts.threadId });
+    if (!existing || existing.resourceId !== opts.resourceId) return;
+    await memory.deleteThread({ threadId: opts.threadId }).catch(() => undefined);
+  }
+
+  private async _deleteUnleasedNewSessionBestEffort(
+    storage: HarnessStorage,
+    sessionId: string,
+    version: number,
+  ): Promise<boolean> {
+    const stored = await storage.loadSession({ sessionId }).catch(() => null);
+    if (!stored) return false;
+    if (stored.version !== version) return false;
+    if (stored.ownerId !== undefined || stored.leaseExpiresAt !== undefined) return false;
+    try {
+      await storage.deleteSession({ sessionId });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async _resolveInitialState(): Promise<unknown> {
+    const value =
+      typeof this._initialState === 'function'
+        ? await (this._initialState as () => TState | Promise<TState>)()
+        : this._initialState;
+    if (value === undefined || value === null) return {};
+    if (Array.isArray(value)) return [...value];
+    if (typeof value === 'object') return { ...(value as Record<string, unknown>) };
+    return value;
+  }
+
+  private async _resolveInitialModelId(opts: {
+    modelId?: string;
+    modeId: string;
+    resourceId: string;
+  }): Promise<string> {
+    if (opts.modelId !== undefined) return opts.modelId;
+    if (!this._resolveModel) return '';
+
+    const mode = this._modesById.get(opts.modeId);
+    const resolved = await this._resolveModel({
+      modeId: opts.modeId,
+      agentId: mode?.agentId,
+      resourceId: opts.resourceId,
+    });
+    return resolved ?? '';
+  }
+
+  private async _hasProviderAuth(provider: string, apiKeyEnvVar?: string): Promise<boolean> {
+    const customAuth = await this._modelAuthChecker?.(provider);
+    if (customAuth !== undefined) return customAuth;
+    const envVar = apiKeyEnvVar ?? (await this._getProviderApiKeyEnvVar(provider));
+    return envVar ? !!process.env[envVar] : false;
+  }
+
+  private async _getProviderApiKeyEnvVar(provider: string): Promise<string | undefined> {
+    try {
+      const { PROVIDER_REGISTRY } = await import('../../llm/model/provider-registry.js');
+      const registry = PROVIDER_REGISTRY as Record<string, { apiKeyEnvVar?: string | string[] }>;
+      const envVars = registry[provider]?.apiKeyEnvVar;
+      return Array.isArray(envVars) ? envVars[0] : envVars;
+    } catch {
+      return undefined;
+    }
+  }
+
+  _internalLiveSessionCount(): number {
+    return this._liveSessions.size;
+  }
+
+  get _internalMaxQueueDepth(): number {
+    return this._maxQueueDepth;
+  }
+
+  get _internalGoalDefaults(): Readonly<{ defaultJudgeModel?: string; defaultMaxTurns: number }> {
+    return this._goalDefaults;
+  }
+}
+
+function toThreadRecord(thread: {
+  id: string;
+  resourceId: string;
+  title?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  metadata?: Record<string, unknown>;
+}): ThreadRecord {
+  return {
+    id: thread.id,
+    resourceId: thread.resourceId,
+    title: thread.title,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+    metadata: thread.metadata,
+  };
+}
+
+function splitModelId(modelId: string, providerId: string): { provider: string; modelName: string } {
+  const prefix = `${providerId}/`;
+  if (modelId.startsWith(prefix)) {
+    return { provider: providerId, modelName: modelId.slice(prefix.length) };
+  }
+  const slash = modelId.indexOf('/');
+  if (slash > 0) {
+    return { provider: modelId.slice(0, slash), modelName: modelId.slice(slash + 1) };
+  }
+  return { provider: providerId, modelName: modelId };
+}
+
+function emptyPermissionRules(): PermissionRules {
+  return { categories: {}, tools: {} };
+}
+
+function emptySessionGrants(): SessionGrants {
+  return { categories: [], tools: [] };
+}
+
+function zeroTokenUsage(): TokenUsage {
+  return { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
 }

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -15,6 +15,7 @@ export {
   sessionCreatedPayload,
   suspensionRequiredFor,
 } from './events';
+export { nonDurableProvider } from './workspace-provider';
 
 export type {
   HarnessMessage,
@@ -34,6 +35,7 @@ export type {
   HarnessWorkspaceConfig,
   WorkspaceProvider,
   WorkspaceProviderContext,
+  WorkspaceOwnershipKind,
 } from './config';
 export type { HarnessRequestContext, RegisterPlanApprovalParams, RegisterQuestionParams, SetStateFn } from './context';
 export type {
@@ -42,6 +44,9 @@ export type {
   AttachmentDeleteOptions,
   AttachmentRef,
   AttachmentUploadOptions,
+  AvailableModel,
+  CustomAvailableModel,
+  CustomModelCatalogProvider,
   EffectiveHarnessMode,
   GoalJudgeDecision,
   GoalOptions,
@@ -58,7 +63,10 @@ export type {
   MessageOptionsStructured,
   MessageOverrides,
   ModelAuthStatus,
+  ModelAuthChecker,
   ModelInfo,
+  ModelUseCountProvider,
+  ModelUseCountTracker,
   PendingApproval,
   PendingBase,
   PendingPlanApproval,

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1,5 +1,164 @@
-export type { SessionLifecycleState } from './types';
+import type { HarnessStorage, SessionRecord } from '../../storage/domains/harness';
+import { EventEmitter } from './events';
+import type { HarnessEvent, HarnessEventListener, HarnessEventUnsubscribe, EmitInput } from './events';
+import type { Harness } from './harness';
+import type { SessionLifecycleState } from './types';
+
+export interface SessionConstructorOptions {
+  harness: Harness;
+  storage: HarnessStorage;
+  ownerId: string;
+  record: SessionRecord;
+  leaseExpiresAt: number;
+  leaseTtlMs: number;
+}
 
 export class Session {
-  constructor(readonly id: string) {}
+  private readonly harness: Harness;
+  private readonly storage: HarnessStorage;
+  private readonly ownerId: string;
+  private readonly leaseTtlMs: number;
+  private record: SessionRecord;
+  private readonly emitter: EventEmitter;
+  private lifecycle: SessionLifecycleState = 'live';
+  private leaseRenewTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(opts: SessionConstructorOptions) {
+    this.harness = opts.harness;
+    this.storage = opts.storage;
+    this.ownerId = opts.ownerId;
+    this.leaseTtlMs = opts.leaseTtlMs;
+    this.record = {
+      ...opts.record,
+      ownerId: opts.ownerId,
+      leaseExpiresAt: opts.leaseExpiresAt,
+    };
+    this.emitter = new EventEmitter({ sessionId: opts.record.id });
+    this.scheduleLeaseRenewal();
+  }
+
+  get id(): string {
+    return this.record.id;
+  }
+
+  get resourceId(): string {
+    return this.record.resourceId;
+  }
+
+  get threadId(): string {
+    return this.record.threadId;
+  }
+
+  get parentSessionId(): string | undefined {
+    return this.record.parentSessionId;
+  }
+
+  get modeId(): string {
+    return this.record.modeId;
+  }
+
+  get modelId(): string {
+    return this.record.modelId;
+  }
+
+  get lastActivityAt(): number {
+    return this.record.lastActivityAt;
+  }
+
+  get lifecycleState(): SessionLifecycleState {
+    return this.lifecycle;
+  }
+
+  get isClosed(): boolean {
+    return this.lifecycle !== 'live';
+  }
+
+  getRecord(): SessionRecord {
+    return this.record;
+  }
+
+  subscribe(listener: HarnessEventListener): HarnessEventUnsubscribe {
+    return this.emitter.subscribe(listener);
+  }
+
+  async close(): Promise<void> {
+    await this.harness._closeSession(this);
+  }
+
+  _emit(event: EmitInput): HarnessEvent {
+    return this.emitter.emit(event);
+  }
+
+  _markClosed(record: SessionRecord): void {
+    this.clearLeaseRenewal();
+    this.record = record;
+    this.lifecycle = 'closed';
+  }
+
+  _markEvicted(): void {
+    this.clearLeaseRenewal();
+    this.lifecycle = 'evicted';
+  }
+
+  _markWorkspaceLost(): void {
+    // Workspace APIs land in a later slice. The registry records the state
+    // here so future workspace calls can surface HarnessWorkspaceLostError.
+  }
+
+  async _kickQueueDrain(): Promise<void> {
+    // Queue draining lands with the Session operations slice. Keeping this
+    // no-op preserves the fork's hydration hook without starting work early.
+  }
+
+  /** @internal retained for future lease renewal/flush slices. */
+  _internalStorage(): HarnessStorage {
+    return this.storage;
+  }
+
+  /** @internal retained for future lease renewal/flush slices. */
+  _internalOwnerId(): string {
+    return this.ownerId;
+  }
+
+  private scheduleLeaseRenewal(): void {
+    if (this.lifecycle !== 'live') return;
+    this.clearLeaseRenewal();
+
+    const leaseExpiresAt = this.record.leaseExpiresAt ?? Date.now() + this.leaseTtlMs;
+    const msUntilExpiry = leaseExpiresAt - Date.now();
+    const halfTtl = Math.max(1, Math.floor(this.leaseTtlMs / 2));
+    const delay = Math.max(1, Math.min(halfTtl, msUntilExpiry > 1 ? msUntilExpiry - 1 : 1));
+
+    this.leaseRenewTimer = setTimeout(() => {
+      void this.renewLease();
+    }, delay);
+    this.leaseRenewTimer.unref?.();
+  }
+
+  private clearLeaseRenewal(): void {
+    if (!this.leaseRenewTimer) return;
+    clearTimeout(this.leaseRenewTimer);
+    this.leaseRenewTimer = undefined;
+  }
+
+  private async renewLease(): Promise<void> {
+    if (this.lifecycle !== 'live') return;
+
+    try {
+      const lease = await this.storage.renewSessionLease({
+        sessionId: this.id,
+        ownerId: this.ownerId,
+        ttlMs: this.leaseTtlMs,
+      });
+      this.record = {
+        ...this.record,
+        ownerId: this.ownerId,
+        leaseExpiresAt: lease.expiresAt,
+        version: lease.version,
+      };
+      this.scheduleLeaseRenewal();
+    } catch {
+      await this.harness._evictSession(this, 'lease_lost');
+    }
+  }
 }

--- a/packages/core/src/harness/v1/shared.ts
+++ b/packages/core/src/harness/v1/shared.ts
@@ -1,7 +1,21 @@
-import type { HarnessMode as LegacyHarnessMode } from '../types';
+import type { ToolsInput } from '../../agent/types';
 
 export type { ToolsInput as ToolsetInput } from '../../agent/types';
 export type { Workspace, WorkspaceConfig } from '../../workspace';
 export type { HarnessMessage, HarnessMessageContent, HarnessThread, ToolCategory } from '../types';
 
-export type HarnessMode<TState = unknown> = LegacyHarnessMode<TState>;
+export interface HarnessMode<TState = unknown> {
+  id: string;
+  agentId: string;
+  description?: string;
+  instructions?: string;
+  tools?: ToolsInput;
+  additionalTools?: ToolsInput;
+  transitionsTo?: string;
+  metadata?: Record<string, unknown>;
+  /**
+   * Reserved for callers that carry mode-specific UI/runtime state.
+   * The registry does not read it.
+   */
+  state?: TState;
+}

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -25,6 +25,22 @@ export type {
 
 export type PermissionPolicy = 'allow' | 'ask' | 'deny';
 
+export interface AvailableModel {
+  id: string;
+  provider: string;
+  modelName: string;
+  hasApiKey: boolean;
+  apiKeyEnvVar?: string;
+  useCount: number;
+}
+
+export type CustomAvailableModel = Omit<AvailableModel, 'useCount'>;
+
+export type ModelAuthChecker = (provider: string) => boolean | undefined | Promise<boolean | undefined>;
+export type ModelUseCountProvider = () => Record<string, number>;
+export type ModelUseCountTracker = (modelId: string) => void | Promise<void>;
+export type CustomModelCatalogProvider = () => CustomAvailableModel[] | Promise<CustomAvailableModel[]>;
+
 export interface ModelInfo {
   id: string;
   providerId: string;
@@ -50,7 +66,7 @@ export interface UseSkillOptions {
   modelOverride?: string;
 }
 
-export type SessionLifecycleState = 'active' | 'closed' | 'evicted';
+export type SessionLifecycleState = 'live' | 'closed' | 'evicted';
 
 export interface HarnessLease {
   ownerId: string;

--- a/packages/core/src/harness/v1/workspace-provider.ts
+++ b/packages/core/src/harness/v1/workspace-provider.ts
@@ -1,0 +1,31 @@
+import { randomUUID } from 'node:crypto';
+
+import type { Workspace } from '../../workspace';
+
+export type WorkspaceOwnershipKind = 'shared' | 'per-resource' | 'per-session';
+
+export interface WorkspaceProviderContext {
+  resourceId: string;
+  sessionId?: string;
+  parentSessionId?: string;
+  pushState: (state: unknown) => Promise<void>;
+}
+
+export interface WorkspaceProvider {
+  readonly providerId: string;
+  readonly resumable: boolean;
+  create(ctx: WorkspaceProviderContext): Promise<Workspace>;
+  resume?(ctx: WorkspaceProviderContext & { state: unknown }): Promise<Workspace>;
+  destroy?(workspace: Workspace, ctx: WorkspaceProviderContext): Promise<void>;
+}
+
+export function nonDurableProvider(
+  fn: (ctx: WorkspaceProviderContext) => Workspace | Promise<Workspace>,
+  opts?: { providerId?: string },
+): WorkspaceProvider {
+  return {
+    providerId: opts?.providerId ?? `non-durable-${randomUUID()}`,
+    resumable: false,
+    create: async ctx => Promise.resolve(fn(ctx)),
+  };
+}

--- a/packages/core/src/harness/v1/workspace-registry.ts
+++ b/packages/core/src/harness/v1/workspace-registry.ts
@@ -1,0 +1,518 @@
+import { RequestContext } from '../../request-context';
+import type { Workspace } from '../../workspace';
+import type { HarnessWorkspaceConfig } from './config';
+import { HarnessConfigError, HarnessWorkspaceInUseError, HarnessWorkspaceProvisioningError } from './errors';
+import type { EventEmitter } from './events';
+import { nonDurableProvider } from './workspace-provider';
+import type { WorkspaceProvider, WorkspaceProviderContext } from './workspace-provider';
+
+interface SharedEntry {
+  workspace?: Workspace;
+  resolving?: Promise<Workspace>;
+  initialized: boolean;
+}
+
+interface PerResourceEntry {
+  workspace: Workspace;
+  refCount: number;
+  provider: WorkspaceProvider;
+  ctx: WorkspaceProviderContext;
+}
+
+interface PerSessionEntry {
+  workspace: Workspace;
+  provider: WorkspaceProvider;
+  ctx: WorkspaceProviderContext;
+  refCount: number;
+  resourceId: string;
+}
+
+export interface AcquirePerResourceOpts {
+  resourceId: string;
+}
+
+export interface AcquirePerSessionOpts {
+  resourceId: string;
+  sessionId: string;
+  parentSessionId?: string;
+  storedProviderId?: string;
+  storedState?: unknown;
+  onStateUpdate: (state: unknown) => Promise<void>;
+}
+
+export interface InheritPerSessionOpts {
+  parentSessionId: string;
+  childSessionId: string;
+  resourceId: string;
+}
+
+export class WorkspaceRegistry {
+  private readonly _config?: HarnessWorkspaceConfig;
+  private readonly _emit: EventEmitter;
+  private readonly _shared: SharedEntry | undefined;
+  private readonly _perResource = new Map<string, PerResourceEntry>();
+  private readonly _perResourceResolving = new Map<string, Promise<PerResourceEntry>>();
+  private readonly _perSession = new Map<string, PerSessionEntry>();
+  private readonly _perSessionResolving = new Map<string, Promise<PerSessionEntry>>();
+  private readonly _resolvedProvider?: WorkspaceProvider;
+
+  constructor(opts: { config?: HarnessWorkspaceConfig; emitter: EventEmitter }) {
+    this._config = opts.config;
+    this._emit = opts.emitter;
+
+    if (!this._config) return;
+
+    if (this._config.kind === 'shared') {
+      this._shared = { initialized: false };
+      return;
+    }
+
+    if (this._config.kind === 'per-resource') {
+      const raw = this._config.provider;
+      this._resolvedProvider = typeof raw === 'function' ? nonDurableProvider(raw) : raw;
+      return;
+    }
+
+    const provider = this._config.provider;
+    if (typeof (provider as WorkspaceProvider)?.providerId !== 'string') {
+      throw new HarnessConfigError(
+        'workspace.provider',
+        'kind: "per-session" requires a WorkspaceProvider (bare factories are not durable)',
+      );
+    }
+    if (!provider.resumable) {
+      throw new HarnessConfigError(
+        'workspace.provider',
+        `workspace provider "${provider.providerId}" is not resumable; only kind: "shared" is supported`,
+      );
+    }
+    if (typeof provider.resume !== 'function') {
+      throw new HarnessConfigError(
+        'workspace.provider',
+        `workspace provider "${provider.providerId}" declares resumable: true but is missing the resume() method`,
+      );
+    }
+    this._resolvedProvider = provider;
+  }
+
+  get kind(): HarnessWorkspaceConfig['kind'] | undefined {
+    return this._config?.kind;
+  }
+
+  get providerId(): string | undefined {
+    return this._resolvedProvider?.providerId;
+  }
+
+  get resumable(): boolean {
+    return !!this._resolvedProvider?.resumable;
+  }
+
+  async acquireShared(): Promise<Workspace> {
+    if (!this._shared || !this._config || this._config.kind !== 'shared') {
+      throw new HarnessConfigError('workspace', 'no shared workspace configured');
+    }
+    if (this._shared.workspace) return this._shared.workspace;
+    if (this._shared.resolving) return this._shared.resolving;
+
+    const cfg = this._config;
+    const resolve = async (): Promise<Workspace> => {
+      const raw = cfg.workspace;
+      let workspace: Workspace;
+      if (typeof raw === 'function') {
+        const requestContext = new RequestContext();
+        this._emitStatus({ status: 'initializing' });
+        workspace = await Promise.resolve(raw({ requestContext }));
+      } else if (raw && typeof raw === 'object') {
+        workspace = raw as Workspace;
+      } else {
+        throw new HarnessConfigError('workspace.workspace', 'unsupported shape (expected Workspace or factory)');
+      }
+      if (!this._shared!.initialized) {
+        this._emitStatus({ status: 'initializing' });
+        try {
+          await this._initIfFresh(workspace);
+        } catch (err) {
+          await this._destroyWorkspace(workspace, undefined, undefined, { err });
+          throw err;
+        }
+        this._shared!.initialized = true;
+      }
+      this._shared!.workspace = workspace;
+      this._emitStatus({ status: 'ready' });
+      return workspace;
+    };
+
+    this._shared.resolving = resolve();
+    try {
+      return await this._shared.resolving;
+    } finally {
+      this._shared.resolving = undefined;
+    }
+  }
+
+  async destroyShared(): Promise<void> {
+    if (!this._shared) return;
+    if (this._shared.resolving) {
+      try {
+        await this._shared.resolving;
+      } catch (err) {
+        this._emitError({ err });
+      }
+    }
+    if (!this._shared.workspace) {
+      this._shared.initialized = false;
+      return;
+    }
+    const workspace = this._shared.workspace;
+    this._emitStatus({ status: 'destroying' });
+    try {
+      await workspace.destroy();
+    } catch (err) {
+      this._emitError({ err });
+    }
+    this._shared.workspace = undefined;
+    this._shared.initialized = false;
+    this._emitStatus({ status: 'destroyed' });
+  }
+
+  async acquirePerResource(opts: AcquirePerResourceOpts): Promise<Workspace> {
+    this._assertKind('per-resource');
+    const existing = this._perResource.get(opts.resourceId);
+    if (existing) {
+      existing.refCount += 1;
+      return existing.workspace;
+    }
+
+    const resolving = this._perResourceResolving.get(opts.resourceId);
+    if (resolving) {
+      const entry = await resolving;
+      entry.refCount += 1;
+      return entry.workspace;
+    }
+
+    const provider = this._resolvedProvider!;
+    const ctx: WorkspaceProviderContext = {
+      resourceId: opts.resourceId,
+      pushState: async () => undefined,
+    };
+
+    const createEntry = async (): Promise<PerResourceEntry> => {
+      this._emitStatus({ resourceId: opts.resourceId, providerId: provider.providerId, status: 'initializing' });
+      let workspace: Workspace;
+      try {
+        workspace = await provider.create(ctx);
+      } catch (cause) {
+        this._emitError({ resourceId: opts.resourceId, providerId: provider.providerId, err: cause });
+        throw new HarnessWorkspaceProvisioningError(provider.providerId, cause, undefined, opts.resourceId);
+      }
+      try {
+        await this._initIfFresh(workspace);
+      } catch (cause) {
+        await this._destroyWorkspace(workspace, provider, ctx, {
+          resourceId: opts.resourceId,
+          providerId: provider.providerId,
+          err: cause,
+        });
+        throw new HarnessWorkspaceProvisioningError(provider.providerId, cause, undefined, opts.resourceId);
+      }
+      const entry = { workspace, refCount: 1, provider, ctx };
+      this._perResource.set(opts.resourceId, entry);
+      this._emitStatus({ resourceId: opts.resourceId, providerId: provider.providerId, status: 'ready' });
+      return entry;
+    };
+
+    const pending = createEntry();
+    this._perResourceResolving.set(opts.resourceId, pending);
+    try {
+      const entry = await pending;
+      return entry.workspace;
+    } finally {
+      this._perResourceResolving.delete(opts.resourceId);
+    }
+  }
+
+  async releasePerResource(opts: { resourceId: string }): Promise<void> {
+    const entry = this._perResource.get(opts.resourceId);
+    if (!entry) return;
+    entry.refCount = Math.max(0, entry.refCount - 1);
+    if (entry.refCount > 0) return;
+    await this._destroyPerResourceEntry(opts.resourceId, entry);
+  }
+
+  async destroyResourceWorkspace(opts: { resourceId: string }): Promise<void> {
+    this._assertKind('per-resource');
+    const entry = this._perResource.get(opts.resourceId);
+    if (!entry) return;
+    if (entry.refCount > 0) {
+      throw new HarnessWorkspaceInUseError(opts.resourceId, entry.refCount);
+    }
+    await this._destroyPerResourceEntry(opts.resourceId, entry);
+  }
+
+  private async _destroyPerResourceEntry(resourceId: string, entry: PerResourceEntry): Promise<void> {
+    this._emitStatus({ resourceId, providerId: entry.provider.providerId, status: 'destroying' });
+    try {
+      if (entry.provider.destroy) {
+        await entry.provider.destroy(entry.workspace, entry.ctx);
+      } else {
+        await entry.workspace.destroy();
+      }
+    } catch (err) {
+      this._emitError({ resourceId, providerId: entry.provider.providerId, err });
+    }
+    this._perResource.delete(resourceId);
+    this._emitStatus({ resourceId, providerId: entry.provider.providerId, status: 'destroyed' });
+  }
+
+  async acquirePerSession(opts: AcquirePerSessionOpts): Promise<Workspace> {
+    this._assertKind('per-session');
+    const existing = this._perSession.get(opts.sessionId);
+    if (existing) {
+      return existing.workspace;
+    }
+    const resolving = this._perSessionResolving.get(opts.sessionId);
+    if (resolving) {
+      const entry = await resolving;
+      return entry.workspace;
+    }
+    const provider = this._resolvedProvider!;
+    const ctx: WorkspaceProviderContext = {
+      resourceId: opts.resourceId,
+      sessionId: opts.sessionId,
+      parentSessionId: opts.parentSessionId,
+      pushState: opts.onStateUpdate,
+    };
+
+    this._emitStatus({
+      sessionId: opts.sessionId,
+      resourceId: opts.resourceId,
+      providerId: provider.providerId,
+      status: 'initializing',
+    });
+
+    const createEntry = async (): Promise<PerSessionEntry> => {
+      let workspace: Workspace;
+      try {
+        if (opts.storedProviderId === provider.providerId && opts.storedState !== undefined && provider.resume) {
+          workspace = await provider.resume({ ...ctx, state: opts.storedState });
+        } else {
+          workspace = await provider.create(ctx);
+        }
+      } catch (cause) {
+        this._emitError({
+          sessionId: opts.sessionId,
+          resourceId: opts.resourceId,
+          providerId: provider.providerId,
+          err: cause,
+        });
+        throw new HarnessWorkspaceProvisioningError(provider.providerId, cause, opts.sessionId, opts.resourceId);
+      }
+      try {
+        await this._initIfFresh(workspace);
+      } catch (cause) {
+        await this._destroyWorkspace(workspace, provider, ctx, {
+          sessionId: opts.sessionId,
+          resourceId: opts.resourceId,
+          providerId: provider.providerId,
+          err: cause,
+        });
+        throw new HarnessWorkspaceProvisioningError(provider.providerId, cause, opts.sessionId, opts.resourceId);
+      }
+      const entry = {
+        workspace,
+        provider,
+        ctx,
+        refCount: 1,
+        resourceId: opts.resourceId,
+      };
+      this._perSession.set(opts.sessionId, entry);
+      this._emitStatus({
+        sessionId: opts.sessionId,
+        resourceId: opts.resourceId,
+        providerId: provider.providerId,
+        status: 'ready',
+      });
+      return entry;
+    };
+
+    const pending = createEntry();
+    this._perSessionResolving.set(opts.sessionId, pending);
+    try {
+      const entry = await pending;
+      return entry.workspace;
+    } finally {
+      this._perSessionResolving.delete(opts.sessionId);
+    }
+  }
+
+  inheritPerSession(opts: InheritPerSessionOpts): Workspace {
+    this._assertKind('per-session');
+    const parent = this._perSession.get(opts.parentSessionId);
+    if (!parent) {
+      throw new HarnessConfigError(
+        'workspace.subagent.inherit',
+        `parent session "${opts.parentSessionId}" has no workspace to inherit`,
+      );
+    }
+    parent.refCount += 1;
+    this._perSession.set(opts.childSessionId, parent);
+    return parent.workspace;
+  }
+
+  async releasePerSession(opts: { sessionId: string }): Promise<void> {
+    const entry = this._perSession.get(opts.sessionId);
+    if (!entry) return;
+    this._perSession.delete(opts.sessionId);
+    entry.refCount = Math.max(0, entry.refCount - 1);
+    if (entry.refCount > 0) return;
+
+    this._emitStatus({
+      sessionId: opts.sessionId,
+      resourceId: entry.resourceId,
+      providerId: entry.provider.providerId,
+      status: 'destroying',
+    });
+    try {
+      if (entry.provider.destroy) {
+        await entry.provider.destroy(entry.workspace, entry.ctx);
+      } else {
+        await entry.workspace.destroy();
+      }
+    } catch (err) {
+      this._emitError({
+        sessionId: opts.sessionId,
+        resourceId: entry.resourceId,
+        providerId: entry.provider.providerId,
+        err,
+      });
+    }
+    this._emitStatus({
+      sessionId: opts.sessionId,
+      resourceId: entry.resourceId,
+      providerId: entry.provider.providerId,
+      status: 'destroyed',
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    const pendingResources = Array.from(this._perResourceResolving.entries());
+    for (const [, pending] of pendingResources) {
+      await pending.catch(() => undefined);
+    }
+
+    const pendingSessions = Array.from(this._perSessionResolving.entries());
+    for (const [, pending] of pendingSessions) {
+      await pending.catch(() => undefined);
+    }
+
+    const seenSessionEntries = new Set<PerSessionEntry>();
+    for (const [sessionId, entry] of this._perSession.entries()) {
+      if (seenSessionEntries.has(entry)) continue;
+      seenSessionEntries.add(entry);
+      try {
+        if (entry.provider.destroy) {
+          await entry.provider.destroy(entry.workspace, entry.ctx);
+        } else {
+          await entry.workspace.destroy();
+        }
+      } catch (err) {
+        this._emitError({
+          sessionId,
+          resourceId: entry.resourceId,
+          providerId: entry.provider.providerId,
+          err,
+        });
+      }
+    }
+    this._perSession.clear();
+
+    for (const [resourceId, entry] of this._perResource.entries()) {
+      try {
+        if (entry.provider.destroy) {
+          await entry.provider.destroy(entry.workspace, entry.ctx);
+        } else {
+          await entry.workspace.destroy();
+        }
+      } catch (err) {
+        this._emitError({ resourceId, providerId: entry.provider.providerId, err });
+      }
+    }
+    this._perResource.clear();
+
+    await this.destroyShared();
+  }
+
+  private _assertKind(expected: HarnessWorkspaceConfig['kind']): void {
+    if (this._config?.kind !== expected) {
+      throw new HarnessConfigError(
+        'workspace.kind',
+        `expected "${expected}", got "${this._config?.kind ?? 'unconfigured'}"`,
+      );
+    }
+  }
+
+  private async _initIfFresh(workspace: Workspace): Promise<void> {
+    if (workspace.status === 'ready' || workspace.status === 'initializing') return;
+    try {
+      await workspace.init();
+    } catch (err) {
+      this._emitError({ err });
+      throw err;
+    }
+  }
+
+  private async _destroyWorkspace(
+    workspace: Workspace,
+    provider: WorkspaceProvider | undefined,
+    ctx: WorkspaceProviderContext | undefined,
+    opts: { sessionId?: string; resourceId?: string; providerId?: string; err?: unknown } = {},
+  ): Promise<void> {
+    try {
+      if (provider?.destroy && ctx) {
+        await provider.destroy(workspace, ctx);
+      } else {
+        await workspace.destroy();
+      }
+    } catch (err) {
+      this._emitError({
+        sessionId: opts.sessionId,
+        resourceId: opts.resourceId,
+        providerId: opts.providerId ?? provider?.providerId,
+        err,
+      });
+    }
+    if (opts.err !== undefined) {
+      this._emitError({ ...opts, err: opts.err });
+    }
+  }
+
+  private _emitStatus(opts: {
+    sessionId?: string;
+    resourceId?: string;
+    providerId?: string;
+    status: 'initializing' | 'ready' | 'destroying' | 'destroyed' | 'lost' | 'error';
+  }): void {
+    this._emit.emit(
+      {
+        type: 'workspace_status_changed',
+        resourceId: opts.resourceId,
+        providerId: opts.providerId,
+        status: opts.status,
+      },
+      opts.sessionId !== undefined ? { sessionId: opts.sessionId } : undefined,
+    );
+  }
+
+  private _emitError(opts: { sessionId?: string; resourceId?: string; providerId?: string; err: unknown }): void {
+    const err = opts.err instanceof Error ? opts.err : new Error(String(opts.err));
+    this._emit.emit(
+      {
+        type: 'workspace_error',
+        resourceId: opts.resourceId,
+        providerId: opts.providerId,
+        error: { name: err.name, message: err.message },
+      },
+      opts.sessionId !== undefined ? { sessionId: opts.sessionId } : undefined,
+    );
+  }
+}


### PR DESCRIPTION
## Description

Adds the first functional Harness v1 registry slice behind `@mastra/core/harness/v1`.

This ports the forked resolver and lifecycle foundation into the official stack: durable session find-or-create, lease ownership and renewal, lifecycle close/shutdown, model discovery helpers, thread utilities and settings, workspace provider registration, process-local intervals, and regression coverage for session/thread/workspace race paths.

This is PR 5 in the stacked Harness v1 extraction. Message execution, queue draining, permissions/tools, display state, OM, goals, subagents, adapter-backed harness storage, mastracode migration, and docs remain intentionally scoped to follow-up PRs.

Validation:
- `pnpm --filter ./packages/core test:unit src/harness/v1/harness.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check <changed files>`
- `pnpm build:core`

## Related issue(s)

Fixes #16841

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR