### PR TITLE
feat(core): add Harness v1 session state

### DIFF
--- a/.changeset/solid-news-open.md
+++ b/.changeset/solid-news-open.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added persistent Harness v1 session state, mode switching, and model selection APIs.

--- a/packages/core/src/harness/v1/session.mode-state.test.ts
+++ b/packages/core/src/harness/v1/session.mode-state.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+
+import { Agent } from '../../agent';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { HarnessConfigError, HarnessSessionClosedError } from './errors';
+import type { HarnessEvent } from './events';
+import { Harness } from './harness';
+
+function makeAgent(name: string) {
+  return new Agent({ id: name, name, instructions: 'fake', model: 'openai/gpt-4o-mini' as any });
+}
+
+function setup() {
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { a: makeAgent('a'), b: makeAgent('b') } as any,
+    modes: [
+      { id: 'modeA', agentId: 'a' },
+      { id: 'modeB', agentId: 'b' },
+    ],
+    defaultModeId: 'modeA',
+    sessions: { storage },
+  });
+  return { harness, storage };
+}
+
+class BlockingRenewStorage extends InMemoryHarness {
+  private releaseRenew!: () => void;
+  private resolveRenewStarted: () => void = () => undefined;
+  readonly renewStarted = new Promise<void>(resolve => {
+    this.resolveRenewStarted = resolve;
+  });
+  readonly renewGate = new Promise<void>(resolve => {
+    this.releaseRenew = resolve;
+  });
+
+  override async renewSessionLease(opts: Parameters<InMemoryHarness['renewSessionLease']>[0]) {
+    const result = await super.renewSessionLease(opts);
+    this.resolveRenewStarted();
+    await this.renewGate;
+    return result;
+  }
+
+  unblockRenewal(): void {
+    this.releaseRenew();
+  }
+}
+
+describe('Session mode and state', () => {
+  it('returns the mode object resolved from the session record', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    expect(session.getCurrentMode().id).toBe('modeA');
+    expect(session.getCurrentMode().agentId).toBe('a');
+  });
+
+  it('switches the active mode and persists it', async () => {
+    const { harness, storage } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.switchMode({ mode: 'modeB' });
+
+    expect(session.getCurrentMode().id).toBe('modeB');
+    await expect(storage.loadSession({ sessionId: session.id })).resolves.toMatchObject({ modeId: 'modeB' });
+  });
+
+  it('rejects unknown modes without mutating the record', async () => {
+    const { harness, storage } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.switchMode({ mode: 'does-not-exist' })).rejects.toThrow(HarnessConfigError);
+
+    await expect(storage.loadSession({ sessionId: session.id })).resolves.toMatchObject({ modeId: 'modeA' });
+  });
+
+  it('does not bump the record version when switching to the current mode', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const version = session._internalRecordVersion;
+
+    await session.switchMode({ mode: 'modeA' });
+
+    expect(session._internalRecordVersion).toBe(version);
+  });
+
+  it('reads and persists shallow-merged state updates', async () => {
+    const { harness, storage } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.setState<{ count: number; label?: string }>({ count: 1 });
+    await session.setState<{ count: number; label?: string }>({ label: 'ready' });
+
+    await expect(session.getState()).resolves.toEqual({ count: 1, label: 'ready' });
+    await expect(storage.loadSession({ sessionId: session.id })).resolves.toMatchObject({
+      state: { count: 1, label: 'ready' },
+    });
+  });
+
+  it('emits state_changed after a persisted state update', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const events: HarnessEvent[] = [];
+    session.subscribe(event => {
+      events.push(event);
+    });
+
+    await session.setState<{ count?: number; label?: string }>({ count: 1, label: 'ready' });
+    await session.setState<{ count?: number; label?: string }>({ count: 1 });
+
+    expect(events.filter(event => event.type === 'state_changed')).toEqual([
+      expect.objectContaining({ type: 'state_changed', changedKeys: ['count', 'label'] }),
+    ]);
+  });
+
+  it('serializes functional state updates through the session record version', async () => {
+    const { harness, storage } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await Promise.all([
+      session.setState<{ count: number }>(prev => ({ count: (prev.count ?? 0) + 1 })),
+      session.setState<{ count: number }>(prev => ({ count: (prev.count ?? 0) + 1 })),
+      session.setState<{ count: number }>(prev => ({ count: (prev.count ?? 0) + 1 })),
+    ]);
+
+    await expect(session.getState()).resolves.toEqual({ count: 3 });
+    await expect(storage.loadSession({ sessionId: session.id })).resolves.toMatchObject({ state: { count: 3 } });
+  });
+
+  it('does not let lease renewal lower the in-memory record version after a flush', async () => {
+    const storage = new BlockingRenewStorage({ db: new InMemoryDB() });
+    const harness = new Harness({
+      agents: { a: makeAgent('a') } as any,
+      modes: [{ id: 'modeA', agentId: 'a' }],
+      defaultModeId: 'modeA',
+      sessions: { storage, leaseTtlMs: 30_000 },
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const renewing = (session as unknown as { renewLease(): Promise<void> }).renewLease();
+
+    await storage.renewStarted;
+    await session.setState<{ count?: number }>({ count: 1 });
+    const versionAfterFlush = session._internalRecordVersion;
+    storage.unblockRenewal();
+    await renewing;
+
+    expect(session._internalRecordVersion).toBe(versionAfterFlush);
+    await expect(session.setState<{ count?: number; label?: string }>({ label: 'next' })).resolves.toBeUndefined();
+    await expect(session.getState()).resolves.toEqual({ count: 1, label: 'next' });
+    await session.close();
+  });
+
+  it('rejects mode and state mutations after close', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    await session.close();
+
+    expect(() => session.getCurrentMode()).toThrow(HarnessSessionClosedError);
+    await expect(session.switchMode({ mode: 'modeB' })).rejects.toThrow(HarnessSessionClosedError);
+    await expect(session.getState()).rejects.toThrow(HarnessSessionClosedError);
+    await expect(session.setState({ closed: true })).rejects.toThrow(HarnessSessionClosedError);
+  });
+});

--- a/packages/core/src/harness/v1/session.models.test.ts
+++ b/packages/core/src/harness/v1/session.models.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+
+import { Agent } from '../../agent';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { HarnessValidationError } from './errors';
+import type { HarnessEvent } from './events';
+import { Harness } from './harness';
+
+function makeAgent(name: string) {
+  return new Agent({ id: name, name, instructions: 'fake', model: 'openai/gpt-4o-mini' as any });
+}
+
+function setup(opts?: { models?: { id: string; providerId: string }[] }) {
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { a: makeAgent('a') } as any,
+    modes: [{ id: 'm', agentId: 'a' }],
+    defaultModeId: 'm',
+    sessions: { storage },
+    ...(opts?.models
+      ? {
+          models: opts.models,
+          modelAuthStatusResolver: (id: string) => (id === 'authed/model' ? 'authenticated' : 'needs_auth'),
+        }
+      : {}),
+  });
+  return { harness, storage };
+}
+
+describe('Session.models accessors', () => {
+  it('returns the current model from the record', async () => {
+    const { harness } = setup();
+    const session = await harness.session({
+      resourceId: 'u1',
+      threadId: { fresh: true },
+      modelId: 'gpt-5',
+    });
+
+    expect(session.models.current()).toBe('gpt-5');
+  });
+
+  it('tracks whether any top-level or subagent model was selected', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    expect(session.models.hasSelected()).toBe(false);
+
+    await session.models.setSubagent({ agentType: 'researcher', model: 'gpt-5-mini' });
+    expect(session.models.hasSelected()).toBe(true);
+  });
+
+  it("returns unknown auth status when no model is selected or the model isn't cataloged", async () => {
+    const { harness } = setup({ models: [{ id: 'authed/model', providerId: 'authed' }] });
+    const empty = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    expect(await empty.models.currentAuthStatus()).toBe('unknown');
+
+    const uncataloged = await harness.session({
+      resourceId: 'u2',
+      threadId: { fresh: true },
+      modelId: 'not-in-catalog',
+    });
+    expect(await uncataloged.models.currentAuthStatus()).toBe('unknown');
+  });
+
+  it('delegates currentAuthStatus to the harness catalog', async () => {
+    const { harness } = setup({
+      models: [
+        { id: 'authed/model', providerId: 'authed' },
+        { id: 'unauthed/model', providerId: 'unauthed' },
+      ],
+    });
+
+    const authed = await harness.session({
+      resourceId: 'u1',
+      threadId: { fresh: true },
+      modelId: 'authed/model',
+    });
+    expect(await authed.models.currentAuthStatus()).toBe('authenticated');
+
+    const unauthed = await harness.session({
+      resourceId: 'u2',
+      threadId: { fresh: true },
+      modelId: 'unauthed/model',
+    });
+    expect(await unauthed.models.currentAuthStatus()).toBe('needs_auth');
+  });
+});
+
+describe('Session.models.switch', () => {
+  it('persists the new model id and emits model_changed', async () => {
+    const { harness, storage } = setup();
+    const session = await harness.session({
+      resourceId: 'u1',
+      threadId: { fresh: true },
+      modelId: 'old',
+    });
+    const events: HarnessEvent[] = [];
+    session.subscribe(event => {
+      events.push(event);
+    });
+
+    await session.models.switch({ model: 'new' });
+
+    expect(session.models.current()).toBe('new');
+    await expect(storage.loadSession({ sessionId: session.id })).resolves.toMatchObject({ modelId: 'new' });
+    expect(events.find(event => event.type === 'model_changed')).toMatchObject({
+      type: 'model_changed',
+      modelId: 'new',
+      previousModelId: 'old',
+    });
+  });
+
+  it('is a no-op when switching to the same model id', async () => {
+    const { harness } = setup();
+    const session = await harness.session({
+      resourceId: 'u1',
+      threadId: { fresh: true },
+      modelId: 'same',
+    });
+    const version = session._internalRecordVersion;
+    const events: HarnessEvent[] = [];
+    session.subscribe(event => {
+      events.push(event);
+    });
+
+    await session.models.switch({ model: 'same' });
+
+    expect(session._internalRecordVersion).toBe(version);
+    expect(events.some(event => event.type === 'model_changed')).toBe(false);
+  });
+
+  it('rejects empty model strings', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.models.switch({ model: '' })).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+});
+
+describe('Session.models subagent overrides', () => {
+  it('persists the override and reads it back', async () => {
+    const { harness, storage } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.models.setSubagent({ agentType: 'researcher', model: 'gpt-5-mini' });
+
+    expect(session.models.getSubagent({ agentType: 'researcher' })).toBe('gpt-5-mini');
+    await expect(storage.loadSession({ sessionId: session.id })).resolves.toMatchObject({
+      subagentModelOverrides: { researcher: 'gpt-5-mini' },
+    });
+  });
+
+  it('returns null for an unset agentType', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    expect(session.models.getSubagent({ agentType: 'unset' })).toBeNull();
+  });
+
+  it('emits model_override_set with previousModelId', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const events: HarnessEvent[] = [];
+    session.subscribe(event => {
+      events.push(event);
+    });
+
+    await session.models.setSubagent({ agentType: 'researcher', model: 'v1' });
+    await session.models.setSubagent({ agentType: 'researcher', model: 'v2' });
+
+    const overrideEvents = events.filter(event => event.type === 'model_override_set');
+    expect(overrideEvents).toHaveLength(2);
+    expect(overrideEvents[0]).toMatchObject({ agentType: 'researcher', modelId: 'v1', previousModelId: null });
+    expect(overrideEvents[1]).toMatchObject({ agentType: 'researcher', modelId: 'v2', previousModelId: 'v1' });
+  });
+
+  it('is a no-op when setting the same agentType to the same model', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    await session.models.setSubagent({ agentType: 'researcher', model: 'gpt-5' });
+    const version = session._internalRecordVersion;
+
+    await session.models.setSubagent({ agentType: 'researcher', model: 'gpt-5' });
+
+    expect(session._internalRecordVersion).toBe(version);
+  });
+
+  it('rejects empty agentType or model strings', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.models.setSubagent({ agentType: '', model: 'm' })).rejects.toBeInstanceOf(
+      HarnessValidationError,
+    );
+    await expect(session.models.setSubagent({ agentType: 'a', model: '' })).rejects.toBeInstanceOf(
+      HarnessValidationError,
+    );
+    expect(() => session.models.getSubagent({ agentType: '' })).toThrow(HarnessValidationError);
+  });
+});

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1,8 +1,10 @@
 import type { HarnessStorage, SessionRecord } from '../../storage/domains/harness';
+import { HarnessSessionClosedError, HarnessValidationError } from './errors';
 import { EventEmitter } from './events';
 import type { HarnessEvent, HarnessEventListener, HarnessEventUnsubscribe, EmitInput } from './events';
 import type { Harness } from './harness';
-import type { SessionLifecycleState } from './types';
+import type { HarnessMode } from './shared';
+import type { ModelAuthStatus, SessionLifecycleState } from './types';
 
 export interface SessionConstructorOptions {
   harness: Harness;
@@ -22,6 +24,7 @@ export class Session {
   private readonly emitter: EventEmitter;
   private lifecycle: SessionLifecycleState = 'live';
   private leaseRenewTimer?: ReturnType<typeof setTimeout>;
+  private flushChain: Promise<void> = Promise.resolve();
 
   constructor(opts: SessionConstructorOptions) {
     this.harness = opts.harness;
@@ -73,7 +76,11 @@ export class Session {
     return this.lifecycle !== 'live';
   }
 
-  getRecord(): SessionRecord {
+  get _internalRecordVersion(): number {
+    return this.record.version;
+  }
+
+  getRecord(): Readonly<SessionRecord> {
     return this.record;
   }
 
@@ -87,6 +94,54 @@ export class Session {
 
   _emit(event: EmitInput): HarnessEvent {
     return this.emitter.emit(event);
+  }
+
+  getCurrentMode(): HarnessMode {
+    this.assertLive('getCurrentMode()');
+    return this.harness._getMode(this.record.modeId);
+  }
+
+  async switchMode(opts: { mode: string }): Promise<void> {
+    this.assertLive('switchMode()');
+    this.harness._getMode(opts.mode);
+    const previousModeId = this.record.modeId;
+    if (previousModeId === opts.mode) return;
+
+    await this.flushUpdate(prev => ({ ...prev, modeId: opts.mode }));
+    this.emitter.emit({ type: 'mode_changed', modeId: opts.mode, previousModeId });
+  }
+
+  readonly models = Object.freeze({
+    current: (): string => this.modelsCurrent(),
+    hasSelected: (): boolean => this.modelsHasSelected(),
+    currentAuthStatus: (): Promise<ModelAuthStatus> => this.modelsCurrentAuthStatus(),
+    switch: (opts: { model: string }): Promise<void> => this.modelsSwitch(opts),
+    setSubagent: (opts: { agentType: string; model: string }): Promise<void> => this.modelsSetSubagent(opts),
+    getSubagent: (opts: { agentType: string }): string | null => this.modelsGetSubagent(opts),
+  });
+
+  async getState<TState = unknown>(): Promise<TState> {
+    this.assertLive('getState()');
+    return (this.record.state ?? {}) as TState;
+  }
+
+  setState<TState = unknown>(updates: Partial<TState>): Promise<void>;
+  setState<TState = unknown>(updater: (prev: TState) => TState): Promise<void>;
+  async setState<TState = unknown>(updatesOrUpdater: Partial<TState> | ((prev: TState) => TState)): Promise<void> {
+    this.assertLive('setState()');
+    let changedKeys: string[] = [];
+    await this.flushUpdate(prev => {
+      const current = (prev.state ?? {}) as TState;
+      const next =
+        typeof updatesOrUpdater === 'function'
+          ? (updatesOrUpdater as (prev: TState) => TState)(current)
+          : ({ ...(current as object), ...(updatesOrUpdater as object) } as TState);
+      changedKeys = diffStateKeys(current, next);
+      return { ...prev, state: next };
+    });
+    if (changedKeys.length > 0) {
+      this.emitter.emit({ type: 'state_changed', changedKeys });
+    }
   }
 
   _markClosed(record: SessionRecord): void {
@@ -154,11 +209,116 @@ export class Session {
         ...this.record,
         ownerId: this.ownerId,
         leaseExpiresAt: lease.expiresAt,
-        version: lease.version,
+        version: Math.max(this.record.version, lease.version),
       };
       this.scheduleLeaseRenewal();
     } catch {
       await this.harness._evictSession(this, 'lease_lost');
     }
   }
+
+  private modelsCurrent(): string {
+    this.assertLive('models.current()');
+    return this.record.modelId;
+  }
+
+  private modelsHasSelected(): boolean {
+    this.assertLive('models.hasSelected()');
+    if (this.record.modelId && this.record.modelId.length > 0) return true;
+    if (Object.keys(this.record.subagentModelOverrides ?? {}).length > 0) return true;
+    return false;
+  }
+
+  private async modelsCurrentAuthStatus(): Promise<ModelAuthStatus> {
+    this.assertLive('models.currentAuthStatus()');
+    const modelId = this.record.modelId;
+    if (!modelId) return 'unknown';
+    const entry = await this.harness.models.get(modelId);
+    if (!entry) return 'unknown';
+    return this.harness.models.getAuthStatus(modelId);
+  }
+
+  private async modelsSwitch(opts: { model: string }): Promise<void> {
+    this.assertLive('models.switch()');
+    assertModelId('models.switch', opts.model);
+    const previousModelId = this.record.modelId;
+    if (previousModelId === opts.model) return;
+
+    await this.flushUpdate(prev => ({ ...prev, modelId: opts.model }));
+    this.emitter.emit({ type: 'model_changed', modelId: opts.model, previousModelId });
+  }
+
+  private async modelsSetSubagent(opts: { agentType: string; model: string }): Promise<void> {
+    this.assertLive('models.setSubagent()');
+    assertAgentType('models.setSubagent', opts.agentType);
+    assertModelId('models.setSubagent', opts.model);
+    const previousModelId = this.record.subagentModelOverrides?.[opts.agentType] ?? null;
+    if (previousModelId === opts.model) return;
+
+    await this.flushUpdate(prev => ({
+      ...prev,
+      subagentModelOverrides: {
+        ...(prev.subagentModelOverrides ?? {}),
+        [opts.agentType]: opts.model,
+      },
+    }));
+    this.emitter.emit({
+      type: 'model_override_set',
+      agentType: opts.agentType,
+      modelId: opts.model,
+      previousModelId,
+    });
+  }
+
+  private modelsGetSubagent(opts: { agentType: string }): string | null {
+    this.assertLive('models.getSubagent()');
+    assertAgentType('models.getSubagent', opts.agentType);
+    return this.record.subagentModelOverrides?.[opts.agentType] ?? null;
+  }
+
+  private flushUpdate(update: (prev: SessionRecord) => SessionRecord): Promise<void> {
+    const run = async (): Promise<void> => {
+      const next: SessionRecord = {
+        ...update(this.record),
+        lastActivityAt: Date.now(),
+      };
+      const saved = await this.storage.saveSession(next, {
+        ownerId: this.ownerId,
+        ifVersion: this.record.version,
+      });
+      this.record = { ...next, version: saved.version };
+    };
+    const next = this.flushChain.then(run, run);
+    this.flushChain = next.catch(() => {});
+    return next;
+  }
+
+  private assertLive(method: string): void {
+    if (this.lifecycle !== 'live') {
+      throw new HarnessSessionClosedError(this.id);
+    }
+    void method;
+  }
+}
+
+function assertAgentType(method: string, value: unknown): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new HarnessValidationError(method, 'agentType must be a non-empty string');
+  }
+}
+
+function assertModelId(method: string, value: unknown): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new HarnessValidationError(method, 'model must be a non-empty string');
+  }
+}
+
+function diffStateKeys(prev: unknown, next: unknown): string[] {
+  if (!isRecord(prev) || !isRecord(next)) return Object.is(prev, next) ? [] : ['*'];
+  const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
+  return [...keys].filter(key => !Object.is(prev[key], next[key]));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Description

Adds the Harness v1 Session state, mode, and model-selection layer behind `@mastra/core/harness/v1`.

This ports the forked Session state/mode/model slice into the stacked implementation: persistent `getState` / `setState`, active mode lookup and switching, session model selection, subagent model overrides, model auth-status lookup, CAS-backed record flushing, state/model events, and lease-renewal version regression coverage.

This is PR 6 in the stacked Harness v1 extraction. Message execution, queue draining, permissions/tools, display state, OM, goals, subagents, adapter-backed harness storage, mastracode migration, and docs remain intentionally scoped to follow-up PRs.

Validation:
- `pnpm --filter ./packages/core test:unit src/harness/v1/session.mode-state.test.ts src/harness/v1/session.models.test.ts`
- `pnpm --filter ./packages/core test:unit src/harness/v1/harness.test.ts src/harness/v1/session.mode-state.test.ts src/harness/v1/session.models.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check <changed files>`
- `pnpm build:core`

## Related issue(s)

Fixes #16844

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
