### PR TITLE
fix(core): merge thread metadata and working memory on partial updates

### DIFF
--- a/.changeset/perky-sloths-shake.md
+++ b/.changeset/perky-sloths-shake.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fixed thread metadata updates to merge with existing fields instead of replacing them. Previously, updating a thread's metadata would silently drop any fields not included in the update. Now existing metadata fields are preserved when updating.
+
+Fixed MockMemory working memory tool to support partial JSON updates when using schema-based working memory. Previously, sending a partial update would overwrite all existing data. Now for schema-based configs, unchanged fields are preserved automatically (matching @mastra/memory behavior).
+
+Fixed MockMemory constructor to preserve workingMemory config options (like schema) when enableWorkingMemory is true.

--- a/packages/core/src/agent/__tests__/memory-metadata.test.ts
+++ b/packages/core/src/agent/__tests__/memory-metadata.test.ts
@@ -186,6 +186,51 @@ function memoryMetadataTests(version: 'v1' | 'v2') {
       expect(thread?.metadata).toEqual({ client: 'updated' });
     });
 
+    it('should merge metadata with existing fields instead of replacing', async () => {
+      const mockMemory = new MockMemory();
+      const initialThread: StorageThreadType = {
+        id: 'thread-1',
+        resourceId: 'user-1',
+        metadata: { existingField: 'should-persist', client: 'initial' },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      await mockMemory.saveThread({ thread: initialThread });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'test',
+        model: dummyModel,
+        memory: mockMemory,
+      });
+
+      if (version === 'v1') {
+        await agent.generateLegacy('hello', {
+          memory: {
+            resource: 'user-1',
+            thread: {
+              id: 'thread-1',
+              metadata: { client: 'updated' },
+            },
+          },
+        });
+      } else {
+        await agent.generate('hello', {
+          memory: {
+            resource: 'user-1',
+            thread: {
+              id: 'thread-1',
+              metadata: { client: 'updated' },
+            },
+          },
+        });
+      }
+
+      const thread = await mockMemory.getThreadById({ threadId: 'thread-1' });
+      expect(thread?.metadata).toEqual({ existingField: 'should-persist', client: 'updated' });
+    });
+
     it('should not update metadata if it is the same using generate', async () => {
       const mockMemory = new MockMemory();
       const initialThread: StorageThreadType = {

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -398,7 +398,7 @@ export class AgentLegacyHandler {
             (thread.metadata && !deepEqual(existingThread.metadata, thread.metadata))
           ) {
             threadObject = await memory.saveThread({
-              thread: { ...existingThread, metadata: thread.metadata },
+              thread: { ...existingThread, metadata: { ...(existingThread.metadata ?? {}), ...thread.metadata } },
               memoryConfig,
             });
           } else {

--- a/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
@@ -151,7 +151,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
           (thread.metadata && !deepEqual(existingThread.metadata, thread.metadata))
         ) {
           threadObject = await memory.saveThread({
-            thread: { ...existingThread, metadata: thread.metadata },
+            thread: { ...existingThread, metadata: { ...(existingThread.metadata ?? {}), ...thread.metadata } },
             memoryConfig,
           });
         } else {

--- a/packages/core/src/memory/mock-working-memory-merge.test.ts
+++ b/packages/core/src/memory/mock-working-memory-merge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod/v4';
+import { MockMemory } from './mock';
+
+describe('MockMemory working memory merge semantics', () => {
+  const threadId = 'thread-1';
+  const resourceId = 'resource-1';
+
+  async function setupMemory(useSchema: boolean) {
+    const options: ConstructorParameters<typeof MockMemory>[0] = {
+      enableWorkingMemory: true,
+    };
+
+    if (useSchema) {
+      options.options = {
+        workingMemory: {
+          enabled: true,
+          schema: z.object({
+            name: z.string().optional(),
+            age: z.number().optional(),
+            location: z.string().optional(),
+          }),
+        },
+      };
+    }
+
+    const memory = new MockMemory(options);
+
+    // Create a thread so the tool doesn't error
+    await memory.createThread({ threadId, resourceId });
+
+    return memory;
+  }
+
+  async function callUpdateTool(memory: MockMemory, input: string) {
+    const config = (memory as any).getMergedThreadConfig();
+    const tools = memory.listTools(config);
+    const tool = tools.updateWorkingMemory;
+    if (!tool) throw new Error('updateWorkingMemory tool not found');
+
+    await (tool as any).execute({ memory: input }, { agent: { threadId, resourceId }, memory });
+  }
+
+  it('replaces working memory entirely for template-based (no schema)', async () => {
+    const memory = await setupMemory(false);
+
+    await callUpdateTool(memory, JSON.stringify({ name: 'Alice', age: 30, location: 'NYC' }));
+    await callUpdateTool(memory, JSON.stringify({ location: 'LA' }));
+
+    const wm = await memory.getWorkingMemory({ threadId, resourceId });
+    const parsed = JSON.parse(wm!);
+    expect(parsed).toEqual({ location: 'LA' });
+    expect(parsed.name).toBeUndefined();
+  });
+
+  it('merges working memory for schema-based configs', async () => {
+    const memory = await setupMemory(true);
+
+    await callUpdateTool(memory, JSON.stringify({ name: 'Alice', age: 30, location: 'NYC' }));
+    await callUpdateTool(memory, JSON.stringify({ location: 'LA' }));
+
+    const wm = await memory.getWorkingMemory({ threadId, resourceId });
+    const parsed = JSON.parse(wm!);
+    expect(parsed).toEqual({ name: 'Alice', age: 30, location: 'LA' });
+  });
+
+  it('overwrites fields in schema-based merge when explicitly provided', async () => {
+    const memory = await setupMemory(true);
+
+    await callUpdateTool(memory, JSON.stringify({ name: 'Alice', age: 30 }));
+    await callUpdateTool(memory, JSON.stringify({ name: 'Bob', age: 25 }));
+
+    const wm = await memory.getWorkingMemory({ threadId, resourceId });
+    const parsed = JSON.parse(wm!);
+    expect(parsed).toEqual({ name: 'Bob', age: 25 });
+  });
+
+  it('handles first write with no existing data in schema mode', async () => {
+    const memory = await setupMemory(true);
+
+    await callUpdateTool(memory, JSON.stringify({ name: 'Alice' }));
+
+    const wm = await memory.getWorkingMemory({ threadId, resourceId });
+    const parsed = JSON.parse(wm!);
+    expect(parsed).toEqual({ name: 'Alice' });
+  });
+});

--- a/packages/core/src/memory/mock-working-memory-merge.test.ts
+++ b/packages/core/src/memory/mock-working-memory-merge.test.ts
@@ -84,4 +84,72 @@ describe('MockMemory working memory merge semantics', () => {
     const parsed = JSON.parse(wm!);
     expect(parsed).toEqual({ name: 'Alice' });
   });
+
+  it('deep-merges nested objects in schema mode', async () => {
+    const memory = new MockMemory({
+      enableWorkingMemory: true,
+      options: {
+        workingMemory: {
+          enabled: true,
+          schema: z.object({
+            user: z.object({
+              name: z.string().optional(),
+              address: z
+                .object({
+                  city: z.string().optional(),
+                  state: z.string().optional(),
+                })
+                .optional(),
+            }),
+          }),
+        },
+      },
+    });
+    await memory.createThread({ threadId, resourceId });
+
+    await callUpdateTool(memory, JSON.stringify({ user: { name: 'Alice', address: { city: 'NYC', state: 'NY' } } }));
+    await callUpdateTool(memory, JSON.stringify({ user: { address: { city: 'LA' } } }));
+
+    const wm = await memory.getWorkingMemory({ threadId, resourceId });
+    const parsed = JSON.parse(wm!);
+    // Deep merge: name preserved, state preserved, only city changed
+    expect(parsed).toEqual({ user: { name: 'Alice', address: { city: 'LA', state: 'NY' } } });
+  });
+
+  it('deletes keys set to null in schema mode', async () => {
+    const memory = await setupMemory(true);
+
+    await callUpdateTool(memory, JSON.stringify({ name: 'Alice', age: 30, location: 'NYC' }));
+    await callUpdateTool(memory, JSON.stringify({ age: null }));
+
+    const wm = await memory.getWorkingMemory({ threadId, resourceId });
+    const parsed = JSON.parse(wm!);
+    // null deletes the key
+    expect(parsed).toEqual({ name: 'Alice', location: 'NYC' });
+    expect(parsed.age).toBeUndefined();
+  });
+
+  it('replaces arrays entirely in schema mode', async () => {
+    const memory = new MockMemory({
+      enableWorkingMemory: true,
+      options: {
+        workingMemory: {
+          enabled: true,
+          schema: z.object({
+            tags: z.array(z.string()).optional(),
+            count: z.number().optional(),
+          }),
+        },
+      },
+    });
+    await memory.createThread({ threadId, resourceId });
+
+    await callUpdateTool(memory, JSON.stringify({ tags: ['a', 'b', 'c'], count: 3 }));
+    await callUpdateTool(memory, JSON.stringify({ tags: ['x'] }));
+
+    const wm = await memory.getWorkingMemory({ threadId, resourceId });
+    const parsed = JSON.parse(wm!);
+    // Arrays replace, count preserved
+    expect(parsed).toEqual({ tags: ['x'], count: 3 });
+  });
 });

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -44,7 +44,7 @@ export class MockMemory extends MastraMemory {
       options: {
         ...options,
         workingMemory: enableWorkingMemory
-          ? ({ enabled: true, template: workingMemoryTemplate } as WorkingMemory)
+          ? ({ ...options?.workingMemory, enabled: true, template: workingMemoryTemplate } as WorkingMemory)
           : options?.workingMemory,
         lastMessages: enableMessageHistory ? (options?.lastMessages ?? 10) : options?.lastMessages,
       },
@@ -175,10 +175,15 @@ export class MockMemory extends MastraMemory {
       return {};
     }
 
+    const usesMergeSemantics = Boolean(mergedConfig.workingMemory?.schema);
+    const description = usesMergeSemantics
+      ? `Update the working memory with new information. Data is merged with existing memory - only include fields you want to add or update.`
+      : `Update the working memory with new information. Any data not included will be overwritten.`;
+
     return {
       updateWorkingMemory: createTool({
         id: 'update-working-memory',
-        description: `Update the working memory with new information. Any data not included will be overwritten.`,
+        description,
         inputSchema: z.object({ memory: z.string() }),
         execute: async (inputData, context) => {
           const threadId = context?.agent?.threadId;
@@ -218,8 +223,54 @@ export class MockMemory extends MastraMemory {
             }
           }
 
-          const workingMemory =
-            typeof inputData.memory === 'string' ? inputData.memory : JSON.stringify(inputData.memory);
+          let workingMemory: string;
+
+          if (usesMergeSemantics) {
+            const existingRaw = await memory.getWorkingMemory({
+              threadId,
+              resourceId,
+              memoryConfig: _config,
+            });
+
+            let existingData: Record<string, unknown> | null = null;
+            if (existingRaw) {
+              try {
+                existingData = typeof existingRaw === 'string' ? JSON.parse(existingRaw) : existingRaw;
+              } catch {
+                existingData = null;
+              }
+            }
+
+            const memoryInput = inputData.memory;
+            let newData: unknown;
+            if (typeof memoryInput === 'string') {
+              try {
+                newData = JSON.parse(memoryInput);
+              } catch {
+                newData = memoryInput;
+              }
+            } else {
+              newData = memoryInput;
+            }
+
+            if (
+              existingData &&
+              typeof existingData === 'object' &&
+              !Array.isArray(existingData) &&
+              newData &&
+              typeof newData === 'object' &&
+              !Array.isArray(newData)
+            ) {
+              workingMemory = JSON.stringify({
+                ...(existingData as Record<string, unknown>),
+                ...(newData as Record<string, unknown>),
+              });
+            } else {
+              workingMemory = typeof newData === 'string' ? newData : JSON.stringify(newData);
+            }
+          } else {
+            workingMemory = typeof inputData.memory === 'string' ? inputData.memory : JSON.stringify(inputData.memory);
+          }
 
           await memory.updateWorkingMemory({
             threadId,

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -24,6 +24,54 @@ import type {
   SharedMemoryConfig,
 } from './types';
 
+/**
+ * Deep-merge working memory objects.
+ * Matches the semantics of `deepMergeWorkingMemory` in `@mastra/memory`:
+ * - `null` values delete the corresponding key
+ * - Arrays are replaced entirely (not merged element-by-element)
+ * - Nested plain objects are merged recursively
+ * - Primitives and new keys are set directly
+ */
+function deepMergeWorkingMemory(
+  existing: Record<string, unknown> | null | undefined,
+  update: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  if (!update || typeof update !== 'object' || Object.keys(update).length === 0) {
+    return existing && typeof existing === 'object' ? { ...existing } : {};
+  }
+  if (!existing || typeof existing !== 'object') {
+    return update;
+  }
+
+  const result: Record<string, unknown> = { ...existing };
+
+  for (const key of Object.keys(update)) {
+    const updateValue = update[key];
+    const existingValue = result[key];
+
+    if (updateValue === null) {
+      delete result[key];
+    } else if (Array.isArray(updateValue)) {
+      result[key] = updateValue;
+    } else if (
+      typeof updateValue === 'object' &&
+      updateValue !== null &&
+      typeof existingValue === 'object' &&
+      existingValue !== null &&
+      !Array.isArray(existingValue)
+    ) {
+      result[key] = deepMergeWorkingMemory(
+        existingValue as Record<string, unknown>,
+        updateValue as Record<string, unknown>,
+      );
+    } else {
+      result[key] = updateValue;
+    }
+  }
+
+  return result;
+}
+
 export class MockMemory extends MastraMemory {
   constructor({
     storage,
@@ -44,7 +92,11 @@ export class MockMemory extends MastraMemory {
       options: {
         ...options,
         workingMemory: enableWorkingMemory
-          ? ({ ...options?.workingMemory, enabled: true, template: workingMemoryTemplate } as WorkingMemory)
+          ? ({
+              ...options?.workingMemory,
+              enabled: true,
+              ...(workingMemoryTemplate !== undefined ? { template: workingMemoryTemplate } : {}),
+            } as WorkingMemory)
           : options?.workingMemory,
         lastMessages: enableMessageHistory ? (options?.lastMessages ?? 10) : options?.lastMessages,
       },
@@ -253,18 +305,13 @@ export class MockMemory extends MastraMemory {
               newData = memoryInput;
             }
 
-            if (
-              existingData &&
-              typeof existingData === 'object' &&
-              !Array.isArray(existingData) &&
-              newData &&
-              typeof newData === 'object' &&
-              !Array.isArray(newData)
-            ) {
-              workingMemory = JSON.stringify({
-                ...(existingData as Record<string, unknown>),
-                ...(newData as Record<string, unknown>),
-              });
+            if (newData && typeof newData === 'object' && !Array.isArray(newData)) {
+              workingMemory = JSON.stringify(
+                deepMergeWorkingMemory(
+                  existingData as Record<string, unknown> | null,
+                  newData as Record<string, unknown>,
+                ),
+              );
             } else {
               workingMemory = typeof newData === 'string' ? newData : JSON.stringify(newData);
             }


### PR DESCRIPTION
## Summary

Thread metadata updates silently dropped existing fields not included in the update payload. Working memory updates in MockMemory replaced all data instead of merging, causing data loss on partial JSON updates.

## Changes

**Thread metadata merge (Bug 2 from #13990)**
- `prepare-memory-step.ts` and `agent-legacy.ts`: Changed metadata updates from full replace to shallow merge (`{ ...(existing ?? {}), ...incoming }`)
- Existing metadata fields are now preserved when updating a thread with partial metadata

**Working memory partial JSON updates (Bug 3 from #13990)**
- `mock.ts`: Added merge semantics in the `updateWorkingMemory` tool for schema-based configs, matching `@mastra/memory` behavior
- Fetches existing WM, parses both as JSON, merges if both are objects, falls back to full-replace for non-JSON/template-based formats
- Fixed MockMemory constructor to preserve `workingMemory` config options (like `schema`) when `enableWorkingMemory: true`

## Test Plan

- Added metadata merge test in `memory-metadata.test.ts` — verifies existing fields survive partial updates
- Added 4 tests in `mock-working-memory-merge.test.ts` — covers schema-based merge, template-based replace, field overwrite, and first-write scenarios
- All 60 memory-related tests pass, typecheck clean

Closes #13990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Previously, updating a part of a conversation's saved data would accidentally erase everything else on that note. This PR makes partial updates keep the existing data and only change the parts you send—so nothing important gets lost.

## Overview

This PR fixes data-loss and initialization bugs in thread metadata and working memory by changing replace semantics into merge semantics where appropriate, improving initial template handling, and preserving working-memory configuration options.

## Changes

### Thread metadata preservation
- Incoming thread metadata is now merged with existing metadata instead of replacing it, preserving unspecified fields.
- Files updated: prepare-memory-step.ts and agent-legacy.ts (shallow merge applied when persisting metadata).

### Working memory merge semantics (MockMemory)
- MockMemory.updateWorkingMemory now supports schema-based merge semantics:
  - When a schema is configured, the tool attempts to parse existing and incoming values as JSON and deep-merge plain objects (recursive merge), with these rules:
    - Nested plain objects are merged recursively.
    - Arrays are replaced entirely.
    - Setting a key to null deletes that key.
    - Primitives are overwritten directly.
  - When no schema is configured, behavior falls back to full-replace (store incoming value as string/JSON-stringified value).
- The tool's instructions/descriptions are updated to document partial JSON update behavior to reduce token usage.
- MockMemory constructor now preserves provided workingMemory options (e.g., schema, template) when enableWorkingMemory: true instead of overwriting them.

### generateEmptyFromSchema and initialization
- Improvements ensure empty templates are built robustly from string or object schemas and respect property default values so first-interaction working memory shows the expected structure.

### Tests
- Added/updated tests:
  - memory-metadata.test.ts: verifies metadata merge preserves existing fields.
  - mock-working-memory-merge.test.ts: covers schema-based deep-merge behaviors (nested merges, null deletes, array-replace), template/replace behaviors, explicit overwrites, and first-write initialization.
- All memory-related tests pass and typechecking is clean.

## Motivation / Context

Closes `#13990` — prevents data loss on partial updates, improves working-memory initialization and merge semantics so LLMs can send minimal diffs instead of full objects, and preserves configuration when enabling working memory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->