### PR TITLE
feat(core): add Harness v1 session accessors

### DIFF
--- a/.changeset/shaggy-crabs-brush.md
+++ b/.changeset/shaggy-crabs-brush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 session status and message history accessors.

--- a/packages/core/src/harness/_shared/message-conversion.ts
+++ b/packages/core/src/harness/_shared/message-conversion.ts
@@ -1,0 +1,337 @@
+/**
+ * Shared message-conversion helper used by both legacy `Harness` and v1
+ * `Session.listMessages`.
+ *
+ * Spec §11.1 keeps `HarnessMessage` as a stable shared shape. This mapper is
+ * intentionally pure so legacy and v1 can consume the same memory-storage row
+ * shape without coupling to either runtime.
+ */
+import { createSignal, mastraDBMessageToSignal } from '../../agent/signals';
+import type { AgentSignalContents } from '../../agent/signals';
+import type { MastraDBMessage } from '../../agent/types';
+import type { HarnessMessage, HarnessMessageContent } from '../types';
+
+/**
+ * Memory-storage row shape that both runtimes feed in. Storage adapters
+ * serialize message parts as JSON, so the converter narrows each part by
+ * `type` instead of assuming a concrete SDK message-part version.
+ */
+export interface StoredMessageRow {
+  id: string;
+  role: 'user' | 'assistant' | 'system' | 'signal';
+  createdAt: Date;
+  type?: string;
+  content: {
+    content?: string;
+    parts: Array<{
+      type: string;
+      text?: string;
+      reasoning?: string;
+      toolCallId?: string;
+      toolName?: string;
+      args?: unknown;
+      result?: unknown;
+      isError?: boolean;
+      providerMetadata?: Record<string, unknown>;
+      toolInvocation?: {
+        state: string;
+        toolCallId: string;
+        toolName: string;
+        args?: unknown;
+        result?: unknown;
+        isError?: boolean;
+      };
+      [key: string]: unknown;
+    }>;
+    metadata?: Record<string, unknown>;
+  };
+}
+
+function getStringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getRecordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function signalContentsToHarnessContent(contents: AgentSignalContents): HarnessMessageContent[] {
+  if (typeof contents === 'string') return [{ type: 'text', text: contents }];
+  return contents.flatMap((part): HarnessMessageContent[] => {
+    if (part.type === 'text') {
+      return [{ type: 'text', text: part.text }];
+    }
+    if (typeof part.data !== 'string') return [];
+    if (part.mediaType.startsWith('image/')) {
+      return [{ type: 'image', data: part.data, mimeType: part.mediaType }];
+    }
+    return [
+      {
+        type: 'file',
+        data: part.data,
+        mediaType: part.mediaType,
+        filename: part.filename,
+      },
+    ];
+  });
+}
+
+function toSystemReminderContent(
+  payload: Record<string, unknown>,
+): Extract<HarnessMessageContent, { type: 'system_reminder' }> | undefined {
+  const attributes = getRecordValue(payload.attributes);
+  const metadata = getRecordValue(payload.metadata);
+  const message = getStringValue(payload.contents);
+  if (message === undefined) return undefined;
+
+  return {
+    type: 'system_reminder',
+    message,
+    reminderType:
+      getStringValue(payload.reminderType) ?? getStringValue(attributes?.type) ?? getStringValue(payload.type),
+    path: getStringValue(payload.path) ?? getStringValue(attributes?.path),
+    precedesMessageId: getStringValue(payload.precedesMessageId) ?? getStringValue(attributes?.precedesMessageId),
+    gapText: getStringValue(payload.gapText) ?? getStringValue(attributes?.gapText),
+    gapMs:
+      typeof payload.gapMs === 'number'
+        ? payload.gapMs
+        : typeof attributes?.gapMs === 'number'
+          ? attributes.gapMs
+          : undefined,
+    timestamp: getStringValue(payload.timestamp) ?? getStringValue(attributes?.timestamp),
+    goalMaxTurns:
+      typeof payload.goalMaxTurns === 'number'
+        ? payload.goalMaxTurns
+        : typeof metadata?.goalMaxTurns === 'number'
+          ? metadata.goalMaxTurns
+          : undefined,
+    judgeModelId: getStringValue(payload.judgeModelId) ?? getStringValue(metadata?.judgeModelId),
+  };
+}
+
+function toUserSignalMessage(payload: Record<string, unknown>): HarnessMessage | undefined {
+  const id = getStringValue(payload.id);
+  const rawContents = payload.contents;
+  if (!id || rawContents === undefined) return undefined;
+
+  const signal = createSignal({
+    id,
+    type: 'user-message',
+    contents: rawContents as AgentSignalContents,
+    createdAt: getStringValue(payload.createdAt),
+  });
+  const content = signalContentsToHarnessContent(signal.contents);
+  if (content.length === 0) return undefined;
+
+  return {
+    id: signal.id,
+    role: 'user',
+    content,
+    createdAt: signal.createdAt,
+  };
+}
+
+export function convertStoredMessageToHarnessMessage(msg: StoredMessageRow): HarnessMessage {
+  const content: HarnessMessageContent[] = [];
+  const systemReminder = getRecordValue(msg.content.metadata?.systemReminder);
+
+  if (systemReminder && typeof systemReminder.type === 'string') {
+    const reminder = toSystemReminderContent({
+      ...systemReminder,
+      contents: typeof systemReminder.message === 'string' ? systemReminder.message : '',
+      reminderType: systemReminder.type,
+    });
+    if (reminder) {
+      content.push(reminder);
+    }
+
+    return { id: msg.id, role: msg.role === 'signal' ? 'user' : msg.role, content, createdAt: msg.createdAt };
+  }
+
+  if (msg.role === 'signal') {
+    const signal = mastraDBMessageToSignal(msg as MastraDBMessage);
+
+    if (signal.type === 'user-message') {
+      const signalContent = signalContentsToHarnessContent(signal.contents);
+      if (signalContent.length > 0) {
+        return {
+          id: msg.id,
+          role: 'user',
+          content: signalContent,
+          createdAt: msg.createdAt,
+        };
+      }
+    }
+
+    if (signal.type === 'system-reminder') {
+      const reminder = toSystemReminderContent({
+        type: signal.type,
+        contents:
+          typeof signal.contents === 'string'
+            ? signal.contents
+            : signal.contents
+                .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
+                .map(part => part.text)
+                .join('\n'),
+        attributes: signal.attributes ?? msg.content.metadata,
+        metadata: signal.metadata,
+      });
+      if (reminder) {
+        content.push(reminder);
+      }
+
+      return {
+        id: msg.id,
+        role: 'user',
+        content,
+        createdAt: msg.createdAt,
+      };
+    }
+  }
+
+  for (const part of msg.content.parts) {
+    switch (part.type) {
+      case 'text':
+        if (part.text) {
+          content.push({ type: 'text', text: part.text });
+        }
+        break;
+      case 'reasoning':
+        if (part.reasoning) {
+          content.push({ type: 'thinking', thinking: part.reasoning });
+        }
+        break;
+      case 'tool-invocation':
+        if (part.toolInvocation) {
+          const inv = part.toolInvocation;
+          content.push({ type: 'tool_call', id: inv.toolCallId, name: inv.toolName, args: inv.args });
+          if (inv.state === 'result') {
+            const partProviderMetadata = part.providerMetadata;
+            content.push({
+              type: 'tool_result',
+              id: inv.toolCallId,
+              name: inv.toolName,
+              result: inv.result,
+              isError: inv.isError ?? false,
+              ...(partProviderMetadata ? { providerMetadata: partProviderMetadata } : {}),
+            });
+          }
+        } else if (part.toolCallId && part.toolName) {
+          content.push({ type: 'tool_call', id: part.toolCallId, name: part.toolName, args: part.args });
+        }
+        break;
+      case 'tool-call':
+        if (part.toolCallId && part.toolName) {
+          content.push({ type: 'tool_call', id: part.toolCallId, name: part.toolName, args: part.args });
+        }
+        break;
+      case 'tool-result':
+        if (part.toolCallId && part.toolName) {
+          const resultProviderMetadata = part.providerMetadata;
+          content.push({
+            type: 'tool_result',
+            id: part.toolCallId,
+            name: part.toolName,
+            result: part.result,
+            isError: part.isError ?? false,
+            ...(resultProviderMetadata ? { providerMetadata: resultProviderMetadata } : {}),
+          });
+        }
+        break;
+      case 'data-om-observation-start': {
+        const data = (part as { data?: Record<string, unknown> }).data ?? {};
+        content.push({
+          type: 'om_observation_start',
+          tokensToObserve: (data.tokensToObserve as number) ?? 0,
+          operationType: (data.operationType as 'observation' | 'reflection') ?? 'observation',
+        });
+        break;
+      }
+      case 'data-om-observation-end': {
+        const data = (part as { data?: Record<string, unknown> }).data ?? {};
+        content.push({
+          type: 'om_observation_end',
+          tokensObserved: (data.tokensObserved as number) ?? 0,
+          observationTokens: (data.observationTokens as number) ?? 0,
+          durationMs: (data.durationMs as number) ?? 0,
+          operationType: (data.operationType as 'observation' | 'reflection') ?? 'observation',
+          observations: (data.observations as string) ?? undefined,
+          currentTask: (data.currentTask as string) ?? undefined,
+          suggestedResponse: (data.suggestedResponse as string) ?? undefined,
+        });
+        break;
+      }
+      case 'data-om-observation-failed': {
+        const data = (part as { data?: Record<string, unknown> }).data ?? {};
+        content.push({
+          type: 'om_observation_failed',
+          error: (data.error as string) ?? 'Unknown error',
+          tokensAttempted: (data.tokensAttempted as number) ?? 0,
+          operationType: (data.operationType as 'observation' | 'reflection') ?? 'observation',
+        });
+        break;
+      }
+      case 'data-user-message': {
+        const data = (part as { data?: Record<string, unknown> }).data ?? {};
+        const message = toUserSignalMessage(data);
+        if (message) {
+          content.push(...message.content);
+        }
+        break;
+      }
+      case 'data-system-reminder': {
+        const data = (part as { data?: Record<string, unknown> }).data ?? {};
+        const reminder = toSystemReminderContent(data);
+        if (reminder) {
+          content.push(reminder);
+        }
+        break;
+      }
+      case 'file':
+        if (typeof part.data !== 'string') {
+          console.warn('[Harness] Skipping file part with non-string data:', typeof part.data);
+          break;
+        }
+        content.push({
+          type: 'file',
+          data: part.data,
+          mediaType:
+            (part as { mediaType?: string }).mediaType ??
+            (part as { mimeType?: string }).mimeType ??
+            'application/octet-stream',
+          ...((part as { filename?: string }).filename ? { filename: (part as { filename?: string }).filename } : {}),
+        });
+        break;
+      case 'image': {
+        const imgData =
+          typeof part.data === 'string'
+            ? part.data
+            : typeof (part as { image?: string }).image === 'string'
+              ? (part as { image?: string }).image!
+              : '';
+        content.push({
+          type: 'image',
+          data: imgData,
+          mimeType:
+            (part as { mimeType?: string }).mimeType ?? (part as { mediaType?: string }).mediaType ?? 'image/png',
+        });
+        break;
+      }
+      case 'data-om-thread-update': {
+        const data = (part as { data?: Record<string, unknown> }).data ?? {};
+        if (data.newTitle) {
+          content.push({
+            type: 'om_thread_title_updated',
+            threadId: (data.threadId as string) ?? '',
+            oldTitle: (data.oldTitle as string) ?? undefined,
+            newTitle: data.newTitle as string,
+          });
+        }
+        break;
+      }
+      // Skip other part types (step-start, data-om-status, etc.).
+    }
+  }
+
+  return { id: msg.id, role: msg.role === 'signal' ? 'user' : msg.role, content, createdAt: msg.createdAt };
+}

--- a/packages/core/src/harness/v1/list-messages.test.ts
+++ b/packages/core/src/harness/v1/list-messages.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Harness v1 — `Session.listMessages()` (§4.2, §4.4).
+ *
+ * Ported from the fork to pin status-quo history readback semantics:
+ * memory rows map through the shared `HarnessMessage` converter,
+ * unlimited reads stay chronological, limited reads return the most recent N
+ * messages in chronological order, invalid limits reject, and closed sessions
+ * stop serving history.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { Agent } from '../../agent';
+import { createSignal } from '../../agent/signals';
+import type { MastraDBMessage } from '../../agent/types';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { HarnessValidationError } from './errors';
+import { Harness } from './harness';
+
+function makeAgent(name = 'default') {
+  return new Agent({
+    id: name,
+    name,
+    instructions: 'test',
+    model: 'openai/gpt-4o-mini' as any,
+  });
+}
+
+function setupHarness() {
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { default: makeAgent() },
+    modes: [{ id: 'default', agentId: 'default' }],
+    defaultModeId: 'default',
+    sessions: { storage },
+  });
+  return { harness, storage };
+}
+
+async function seedMessages(harness: Harness, messages: MastraDBMessage[]) {
+  const memory = await harness._internalTryGetMemoryStorage();
+  if (!memory) throw new Error('test setup expected memory storage');
+  await memory.saveMessages({ messages });
+}
+
+function makeUserMessage(
+  id: string,
+  threadId: string,
+  resourceId: string,
+  text: string,
+  createdAt: Date,
+): MastraDBMessage {
+  return {
+    id,
+    role: 'user',
+    threadId,
+    resourceId,
+    createdAt,
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text }],
+    },
+  } as MastraDBMessage;
+}
+
+function makeAssistantWithToolCall(
+  id: string,
+  threadId: string,
+  resourceId: string,
+  text: string,
+  toolCallId: string,
+  toolName: string,
+  args: unknown,
+  result: unknown,
+  createdAt: Date,
+): MastraDBMessage {
+  return {
+    id,
+    role: 'assistant',
+    threadId,
+    resourceId,
+    createdAt,
+    content: {
+      format: 2,
+      parts: [
+        { type: 'text', text },
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            state: 'result',
+            toolCallId,
+            toolName,
+            args,
+            result,
+          },
+        },
+      ],
+    },
+  } as MastraDBMessage;
+}
+
+describe('Session.listMessages', () => {
+  it('returns [] when the thread has no messages', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-empty', title: 't' });
+
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-empty' });
+    await expect(session.listMessages()).resolves.toEqual([]);
+  });
+
+  it('maps text content into the HarnessMessage partition', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-text', title: 't' });
+    await seedMessages(harness, [
+      makeUserMessage('m1', 'thread-text', 'r1', 'hello', new Date('2026-05-10T00:00:00Z')),
+    ]);
+
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-text' });
+    const messages = await session.listMessages();
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      id: 'm1',
+      role: 'user',
+      content: [{ type: 'text', text: 'hello' }],
+    });
+  });
+
+  it('splits a tool-invocation into separate tool_call and tool_result parts', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-tools', title: 't' });
+    await seedMessages(harness, [
+      makeAssistantWithToolCall(
+        'm1',
+        'thread-tools',
+        'r1',
+        'thinking...',
+        'tc-1',
+        'echo',
+        { value: 'hi' },
+        { ok: true, echoed: 'hi' },
+        new Date('2026-05-10T00:00:01Z'),
+      ),
+    ]);
+
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-tools' });
+    const [msg] = await session.listMessages();
+
+    expect(msg!.role).toBe('assistant');
+    expect(msg!.content).toEqual([
+      { type: 'text', text: 'thinking...' },
+      { type: 'tool_call', id: 'tc-1', name: 'echo', args: { value: 'hi' } },
+      { type: 'tool_result', id: 'tc-1', name: 'echo', result: { ok: true, echoed: 'hi' }, isError: false },
+    ]);
+  });
+
+  it('preserves completed tool invocations when the result payload is omitted', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-undefined-tool-result', title: 't' });
+    await seedMessages(harness, [
+      {
+        id: 'm1',
+        role: 'assistant',
+        threadId: 'thread-undefined-tool-result',
+        resourceId: 'r1',
+        createdAt: new Date('2026-05-10T00:00:01Z'),
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'tc-undefined',
+                toolName: 'noop',
+                args: {},
+              },
+            },
+          ],
+        },
+      } as MastraDBMessage,
+    ]);
+
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-undefined-tool-result' });
+    const [msg] = await session.listMessages();
+
+    expect(msg!.content).toEqual([
+      { type: 'tool_call', id: 'tc-undefined', name: 'noop', args: {} },
+      { type: 'tool_result', id: 'tc-undefined', name: 'noop', result: undefined, isError: false },
+    ]);
+  });
+
+  it('normalizes persisted user-message signal rows to user messages', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-user-signal', title: 't' });
+    await seedMessages(harness, [
+      createSignal({
+        id: 'sig-user',
+        type: 'user-message',
+        contents: 'from signal',
+        createdAt: '2026-05-10T00:00:02Z',
+      }).toDBMessage({ threadId: 'thread-user-signal', resourceId: 'r1' }),
+    ]);
+
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-user-signal' });
+    const [msg] = await session.listMessages();
+
+    expect(msg).toMatchObject({
+      id: 'sig-user',
+      role: 'user',
+      content: [{ type: 'text', text: 'from signal' }],
+    });
+  });
+
+  it('maps persisted system-reminder signal rows to system_reminder parts', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-reminder-signal', title: 't' });
+    await seedMessages(harness, [
+      createSignal({
+        id: 'sig-reminder',
+        type: 'system-reminder',
+        contents: 'remember this',
+        attributes: {
+          type: 'goal',
+          path: 'goal.judge',
+          gapText: 'after a while',
+          gapMs: 123,
+          timestamp: '2026-05-10T00:00:02Z',
+        },
+        metadata: { goalMaxTurns: 3, judgeModelId: 'judge-model' },
+        createdAt: '2026-05-10T00:00:02Z',
+      }).toDBMessage({ threadId: 'thread-reminder-signal', resourceId: 'r1' }),
+    ]);
+
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-reminder-signal' });
+    const [msg] = await session.listMessages();
+
+    expect(msg).toMatchObject({
+      id: 'sig-reminder',
+      role: 'user',
+      content: [
+        {
+          type: 'system_reminder',
+          message: 'remember this',
+          reminderType: 'goal',
+          path: 'goal.judge',
+          gapText: 'after a while',
+          gapMs: 123,
+          timestamp: '2026-05-10T00:00:02Z',
+          goalMaxTurns: 3,
+          judgeModelId: 'judge-model',
+        },
+      ],
+    });
+  });
+
+  it('maps data-system-reminder parts that carry contents and attributes', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-reminder-part', title: 't' });
+    const reminderPart = createSignal({
+      id: 'sig-part',
+      type: 'system-reminder',
+      contents: 'part reminder',
+      attributes: { type: 'time-gap', path: 'history', gapMs: 456 },
+      createdAt: '2026-05-10T00:00:03Z',
+    }).toDataPart();
+    await seedMessages(harness, [
+      {
+        id: 'm-reminder-part',
+        role: 'assistant',
+        threadId: 'thread-reminder-part',
+        resourceId: 'r1',
+        createdAt: new Date('2026-05-10T00:00:03Z'),
+        content: {
+          format: 2,
+          parts: [reminderPart],
+        },
+      } as MastraDBMessage,
+    ]);
+
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-reminder-part' });
+    const [msg] = await session.listMessages();
+
+    expect(msg!.content).toEqual([
+      {
+        type: 'system_reminder',
+        message: 'part reminder',
+        reminderType: 'time-gap',
+        path: 'history',
+        gapMs: 456,
+      },
+    ]);
+  });
+
+  it('returns messages oldest-first', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-order', title: 't' });
+    await seedMessages(harness, [
+      makeUserMessage('m1', 'thread-order', 'r1', 'first', new Date('2026-05-10T00:00:00Z')),
+      makeUserMessage('m2', 'thread-order', 'r1', 'second', new Date('2026-05-10T00:00:10Z')),
+      makeUserMessage('m3', 'thread-order', 'r1', 'third', new Date('2026-05-10T00:00:20Z')),
+    ]);
+
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-order' });
+    const messages = await session.listMessages();
+    expect(messages.map(m => m.id)).toEqual(['m1', 'm2', 'm3']);
+  });
+
+  it('scopes reads by the session resource when thread ids collide', async () => {
+    const { harness } = setupHarness();
+    await seedMessages(harness, [
+      makeUserMessage('m-r1', 'shared-thread', 'r1', 'resource one', new Date('2026-05-10T00:00:00Z')),
+      makeUserMessage('m-r2', 'shared-thread', 'r2', 'resource two', new Date('2026-05-10T00:00:10Z')),
+    ]);
+
+    const session = await harness.session({ resourceId: 'r2', threadId: 'shared-thread' });
+    const messages = await session.listMessages();
+
+    expect(messages.map(m => m.id)).toEqual(['m-r2']);
+    expect(messages[0]?.content).toEqual([{ type: 'text', text: 'resource two' }]);
+  });
+
+  it('limit caps to the most recent N messages, still oldest-first', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-limit', title: 't' });
+    await seedMessages(harness, [
+      makeUserMessage('m1', 'thread-limit', 'r1', 'first', new Date('2026-05-10T00:00:00Z')),
+      makeUserMessage('m2', 'thread-limit', 'r1', 'second', new Date('2026-05-10T00:00:10Z')),
+      makeUserMessage('m3', 'thread-limit', 'r1', 'third', new Date('2026-05-10T00:00:20Z')),
+      makeUserMessage('m4', 'thread-limit', 'r1', 'fourth', new Date('2026-05-10T00:00:30Z')),
+    ]);
+
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-limit' });
+    const messages = await session.listMessages({ limit: 2 });
+    expect(messages.map(m => m.id)).toEqual(['m3', 'm4']);
+  });
+
+  it('limit === 0 returns []', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-zero', title: 't' });
+    await seedMessages(harness, [makeUserMessage('m1', 'thread-zero', 'r1', 'hi', new Date('2026-05-10T00:00:00Z'))]);
+
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-zero' });
+    expect(await session.listMessages({ limit: 0 })).toEqual([]);
+  });
+
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])('rejects invalid limit (%s)', async (bad: number) => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-bad', title: 't' });
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-bad' });
+
+    await expect(session.listMessages({ limit: bad })).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+
+  it('returns [] when memory storage is not configured', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+    });
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-no-memory' });
+
+    await expect(session.listMessages()).resolves.toEqual([]);
+  });
+
+  it('still validates limit when memory storage is not configured', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+    });
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-no-memory' });
+
+    await expect(session.listMessages({ limit: -1 })).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+
+  it('throws once the session is closed', async () => {
+    const { harness } = setupHarness();
+    await harness.threads.create({ resourceId: 'r1', threadId: 'thread-closed', title: 't' });
+    const session = await harness.session({ resourceId: 'r1', threadId: 'thread-closed' });
+    await session.close();
+
+    await expect(session.listMessages()).rejects.toThrow(/is closed/);
+  });
+});

--- a/packages/core/src/harness/v1/session.accessors.test.ts
+++ b/packages/core/src/harness/v1/session.accessors.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Harness v1 — discrete Session accessors (§4.2).
+ *
+ * This ports the fork coverage for the status/readback surface that can land
+ * before the full message and queue drain runtime: busy/running state,
+ * queue-depth reads, token-usage copy semantics, and wait-for-idle boundaries.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { Agent } from '../../agent';
+import type { SessionRecord } from '../../storage/domains/harness';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { Harness } from './harness';
+
+function makeAgent(name = 'default') {
+  return new Agent({
+    id: name,
+    name,
+    instructions: 'test',
+    model: 'openai/gpt-4o-mini' as any,
+  });
+}
+
+function setupHarness() {
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { default: makeAgent() },
+    modes: [{ id: 'default', agentId: 'default' }],
+    defaultModeId: 'default',
+    sessions: { storage },
+  });
+  return { harness, storage };
+}
+
+function queueRecord(session: { getRecord(): Readonly<SessionRecord> }, id = 'queued-1') {
+  (session.getRecord() as SessionRecord).pendingQueue = [
+    {
+      id,
+      enqueuedAt: Date.now(),
+      content: 'queued',
+      attachments: [],
+      source: 'user',
+    },
+  ];
+}
+
+describe('Session discrete accessors', () => {
+  it('reports idle/running/queue state for a fresh session', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'r1', threadId: { fresh: true } });
+
+    expect(session.isRunning()).toBe(false);
+    expect(session.isBusy()).toBe(false);
+    expect(session.getQueueDepth()).toBe(0);
+    expect(session.getCurrentRunId()).toBeNull();
+    expect(session.getCurrentTraceId()).toBeNull();
+    await expect(session.waitForIdle()).resolves.toBeUndefined();
+  });
+
+  it('exposes the session creation timestamp from the record', async () => {
+    const { harness } = setupHarness();
+    const before = Date.now();
+    const session = await harness.session({ resourceId: 'r1', threadId: { fresh: true } });
+    const after = Date.now();
+
+    expect(session.createdAt).toBeGreaterThanOrEqual(before);
+    expect(session.createdAt).toBeLessThanOrEqual(after);
+  });
+
+  it('reflects pendingQueue in getQueueDepth and isBusy', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'r1', threadId: { fresh: true } });
+
+    queueRecord(session);
+
+    expect(session.getQueueDepth()).toBe(1);
+    expect(session.isRunning()).toBe(false);
+    expect(session.isBusy()).toBe(true);
+  });
+
+  it('getTokenUsage returns a fresh copy of the persisted aggregate', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'r1', threadId: { fresh: true } });
+    (session.getRecord() as SessionRecord).tokenUsage = {
+      promptTokens: 3,
+      completionTokens: 5,
+      totalTokens: 8,
+    };
+
+    const snapshot = session.getTokenUsage();
+    snapshot.promptTokens = 999;
+
+    expect(session.getTokenUsage()).toEqual({ promptTokens: 3, completionTokens: 5, totalTokens: 8 });
+  });
+
+  it('waitForIdle resolves after pending queue state clears and a flush observes idleness', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'r1', threadId: { fresh: true } });
+    queueRecord(session);
+
+    const idle = session.waitForIdle();
+    let resolved = false;
+    void idle.then(() => {
+      resolved = true;
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(resolved).toBe(false);
+
+    (session.getRecord() as SessionRecord).pendingQueue = [];
+    await session.setState({ touched: true });
+    await idle;
+    expect(session.isBusy()).toBe(false);
+  });
+
+  it('waitForIdle rejects when timeoutMs elapses', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'r1', threadId: { fresh: true } });
+    queueRecord(session);
+
+    await expect(session.waitForIdle({ timeoutMs: 20 })).rejects.toMatchObject({
+      name: 'HarnessValidationError',
+    });
+  });
+
+  it('waitForIdle rejects when the session closes while waiting', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'r1', threadId: { fresh: true } });
+    queueRecord(session);
+
+    const idle = session.waitForIdle();
+    const rejection = expect(idle).rejects.toMatchObject({ name: 'HarnessSessionClosedError' });
+    await session.close();
+
+    await rejection;
+  });
+});

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1,10 +1,12 @@
 import type { HarnessStorage, SessionRecord } from '../../storage/domains/harness';
+import { convertStoredMessageToHarnessMessage } from '../_shared/message-conversion';
+import type { StoredMessageRow } from '../_shared/message-conversion';
 import { HarnessSessionClosedError, HarnessValidationError } from './errors';
 import { EventEmitter } from './events';
 import type { HarnessEvent, HarnessEventListener, HarnessEventUnsubscribe, EmitInput } from './events';
 import type { Harness } from './harness';
-import type { HarnessMode } from './shared';
-import type { ModelAuthStatus, SessionLifecycleState } from './types';
+import type { HarnessMessage, HarnessMode } from './shared';
+import type { ListMessagesOptions, ModelAuthStatus, SessionLifecycleState, TokenUsage } from './types';
 
 export interface SessionConstructorOptions {
   harness: Harness;
@@ -13,6 +15,12 @@ export interface SessionConstructorOptions {
   record: SessionRecord;
   leaseExpiresAt: number;
   leaseTtlMs: number;
+}
+
+interface IdleWaiter {
+  check: () => boolean;
+  reject: (reason: unknown) => void;
+  cleanup: () => void;
 }
 
 export class Session {
@@ -25,6 +33,12 @@ export class Session {
   private lifecycle: SessionLifecycleState = 'live';
   private leaseRenewTimer?: ReturnType<typeof setTimeout>;
   private flushChain: Promise<void> = Promise.resolve();
+  private currentTurnAbortController?: AbortController;
+  private currentQueuedItemId?: string;
+  private currentRunId?: string;
+  private currentTraceId?: string;
+  private draining = false;
+  private readonly idleWaiters = new Set<IdleWaiter>();
 
   constructor(opts: SessionConstructorOptions) {
     this.harness = opts.harness;
@@ -50,6 +64,10 @@ export class Session {
 
   get threadId(): string {
     return this.record.threadId;
+  }
+
+  get createdAt(): number {
+    return this.record.createdAt;
   }
 
   get parentSessionId(): string | undefined {
@@ -144,15 +162,108 @@ export class Session {
     }
   }
 
+  isRunning(): boolean {
+    return this.currentTurnAbortController !== undefined;
+  }
+
+  isBusy(): boolean {
+    if (this.currentTurnAbortController !== undefined) return true;
+    if (this.draining) return true;
+    if (this.currentQueuedItemId !== undefined) return true;
+    if ((this.record.pendingQueue?.length ?? 0) > 0) return true;
+    if (this.record.pendingResume !== undefined) return true;
+    return false;
+  }
+
+  getQueueDepth(): number {
+    return this.record.pendingQueue?.length ?? 0;
+  }
+
+  getTokenUsage(): TokenUsage {
+    return { ...this.record.tokenUsage };
+  }
+
+  getCurrentRunId(): string | null {
+    return this.currentRunId ?? null;
+  }
+
+  getCurrentTraceId(): string | null {
+    return this.currentTraceId ?? null;
+  }
+
+  waitForIdle(opts?: { timeoutMs?: number }): Promise<void> {
+    this.assertLive('waitForIdle()');
+    if (!this.isBusy()) return Promise.resolve();
+
+    return new Promise<void>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const waiter: IdleWaiter = {
+        check: () => {
+          if (!this.isBusy()) {
+            cleanup();
+            resolve();
+            return true;
+          }
+          return false;
+        },
+        reject,
+        cleanup: () => {},
+      };
+      const cleanup = () => {
+        if (timer !== undefined) clearTimeout(timer);
+        this.idleWaiters.delete(waiter);
+      };
+      waiter.cleanup = cleanup;
+      this.idleWaiters.add(waiter);
+      if (opts?.timeoutMs !== undefined) {
+        timer = setTimeout(() => {
+          cleanup();
+          reject(new HarnessValidationError('waitForIdle()', `session did not become idle within ${opts.timeoutMs}ms`));
+        }, opts.timeoutMs);
+      }
+    });
+  }
+
+  async listMessages(opts?: ListMessagesOptions): Promise<HarnessMessage[]> {
+    this.assertLive('listMessages()');
+    const limit = opts?.limit;
+    if (limit !== undefined && (!Number.isFinite(limit) || limit < 0 || !Number.isInteger(limit))) {
+      throw new HarnessValidationError('limit', `\`limit\` must be a non-negative integer; received ${String(limit)}`);
+    }
+    if (limit === 0) return [];
+
+    const memory = await this.harness._internalTryGetMemoryStorage();
+    if (!memory) return [];
+
+    if (limit !== undefined) {
+      const result = await memory.listMessages({
+        threadId: this.threadId,
+        resourceId: this.resourceId,
+        perPage: limit,
+        page: 0,
+        orderBy: { field: 'createdAt', direction: 'DESC' },
+      });
+      return result.messages
+        .slice()
+        .reverse()
+        .map(msg => convertStoredMessageToHarnessMessage(msg as unknown as StoredMessageRow));
+    }
+
+    const result = await memory.listMessages({ threadId: this.threadId, resourceId: this.resourceId, perPage: false });
+    return result.messages.map(msg => convertStoredMessageToHarnessMessage(msg as unknown as StoredMessageRow));
+  }
+
   _markClosed(record: SessionRecord): void {
     this.clearLeaseRenewal();
     this.record = record;
     this.lifecycle = 'closed';
+    this.rejectIdleWaiters(new HarnessSessionClosedError(this.id));
   }
 
   _markEvicted(): void {
     this.clearLeaseRenewal();
     this.lifecycle = 'evicted';
+    this.rejectIdleWaiters(new HarnessSessionClosedError(this.id));
   }
 
   _markWorkspaceLost(): void {
@@ -287,10 +398,28 @@ export class Session {
         ifVersion: this.record.version,
       });
       this.record = { ...next, version: saved.version };
+      this.notifyMaybeIdle();
     };
     const next = this.flushChain.then(run, run);
     this.flushChain = next.catch(() => {});
     return next;
+  }
+
+  private notifyMaybeIdle(): void {
+    if (this.idleWaiters.size === 0) return;
+    if (this.isBusy()) return;
+    const waiters = Array.from(this.idleWaiters);
+    for (const waiter of waiters) waiter.check();
+  }
+
+  private rejectIdleWaiters(reason: unknown): void {
+    if (this.idleWaiters.size === 0) return;
+    const waiters = Array.from(this.idleWaiters);
+    this.idleWaiters.clear();
+    for (const waiter of waiters) {
+      waiter.cleanup();
+      waiter.reject(reason);
+    }
   }
 
   private assertLive(method: string): void {


### PR DESCRIPTION
## Description

Adds the next Harness v1 Session slice behind `@mastra/core/harness/v1`: status accessors, idle waiters, token usage reads, and message history readback.

This ports the forked status/history surface onto the stacked v1 implementation and adds a shared legacy-compatible message converter for `Session.listMessages()`. The converter covers text/tool rows, completed tool calls with omitted result payloads, provider metadata, persisted signal rows, system reminders, `data-user-message`, OM data parts, files/images, and thread-title update parts. `listMessages()` validates limits before storage access and scopes reads by both `threadId` and `resourceId`.

This is the next stacked Harness v1 extraction slice. The full agent streaming `message()` runtime, queue draining, signal delivery, tool approvals/suspensions, skills, goals, display state, OM, subagents, adapter-backed harness storage, mastracode migration, and docs remain intentionally scoped to follow-up PRs.

Validation:
- `pnpm --filter ./packages/core test:unit src/harness/v1/list-messages.test.ts src/harness/v1/session.accessors.test.ts src/harness/v1/session.mode-state.test.ts src/harness/v1/session.models.test.ts src/harness/v1/harness.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check <changed files>`
- `pnpm build:core`

## Related issue(s)

Fixes #16847

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR