### PR TITLE
fix(mastracode): use visible width for terminal output

### DIFF
--- a/.changeset/warm-rivers-clap.md
+++ b/.changeset/warm-rivers-clap.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed terminal rendering so command output and task lists stay aligned with wide characters.

--- a/.changeset/warm-rivers-clap.md
+++ b/.changeset/warm-rivers-clap.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Fixed terminal rendering so command output and task lists stay aligned with wide characters.
+Fixed terminal rendering so command output, task lists, and plan feedback input stay aligned while redrawing.

--- a/mastracode/src/tui/components/__tests__/ansi.test.ts
+++ b/mastracode/src/tui/components/__tests__/ansi.test.ts
@@ -11,6 +11,15 @@ describe('truncateAnsi', () => {
   it('returns the string unchanged when it exactly fills maxWidth', () => {
     expect(truncateAnsi('hello', 5)).toBe('hello');
     expect(truncateAnsi('abc界', 5)).toBe('abc界');
+    expect(truncateAnsi('\x1b[31mhello\x1b[0m', 5)).toBe('\x1b[31mhello\x1b[0m');
+  });
+
+  it('returns no visible text when maxWidth is zero', () => {
+    expect(truncateAnsi('hello', 0)).toBe('');
+
+    const out = truncateAnsi('\x1b[31mhello\x1b[0m', 0);
+    expect(stripAnsi(out)).toBe('');
+    expect(visibleWidth(stripAnsi(out))).toBe(0);
   });
 
   it('preserves SGR escape sequences without counting them toward width', () => {

--- a/mastracode/src/tui/components/__tests__/ansi.test.ts
+++ b/mastracode/src/tui/components/__tests__/ansi.test.ts
@@ -1,9 +1,16 @@
+import { visibleWidth } from '@mariozechner/pi-tui';
+import stripAnsi from 'strip-ansi';
 import { describe, it, expect } from 'vitest';
 import { truncateAnsi } from '../ansi.js';
 
 describe('truncateAnsi', () => {
   it('returns the string unchanged when within maxWidth', () => {
     expect(truncateAnsi('hello', 10)).toBe('hello');
+  });
+
+  it('returns the string unchanged when it exactly fills maxWidth', () => {
+    expect(truncateAnsi('hello', 5)).toBe('hello');
+    expect(truncateAnsi('abc界', 5)).toBe('abc界');
   });
 
   it('preserves SGR escape sequences without counting them toward width', () => {
@@ -23,6 +30,21 @@ describe('truncateAnsi', () => {
     // 4 chars + ellipsis + closers
     expect(out).toMatch(/^abcd…/);
     expect(out).toContain('\x1b[0m');
+  });
+
+  it('truncates wide characters by terminal display width', () => {
+    const out = truncateAnsi('界'.repeat(4), 5);
+
+    expect(stripAnsi(out)).toBe('界界…');
+    expect(visibleWidth(stripAnsi(out))).toBe(5);
+  });
+
+  it('preserves ANSI sequences while truncating wide characters by terminal display width', () => {
+    const out = truncateAnsi(`\x1b[31m${'界'.repeat(4)}\x1b[0m`, 5);
+
+    expect(out).toContain('\x1b[31m');
+    expect(stripAnsi(out)).toBe('界界…');
+    expect(visibleWidth(stripAnsi(out))).toBe(5);
   });
 
   it('runs in linear time on pathological input (no ReDoS)', () => {

--- a/mastracode/src/tui/components/__tests__/plan-approval-inline.test.ts
+++ b/mastracode/src/tui/components/__tests__/plan-approval-inline.test.ts
@@ -49,6 +49,29 @@ describe('PlanApprovalInlineComponent', () => {
     expect(rendered).toContain('╰');
   });
 
+  it('forces a full redraw when entering feedback mode', () => {
+    const ui = { requestRender: vi.fn() };
+    const component = new PlanApprovalInlineComponent(
+      {
+        planId: 'plan-1',
+        title: 'Ship it',
+        plan: 'Build the feature',
+        onApprove: vi.fn(),
+        onGoal: vi.fn(),
+        onReject: vi.fn(),
+      },
+      ui as any,
+    );
+
+    (component as any).handleSelection('edit');
+    component.handleInput('a');
+    const rendered = component.render(80).join('\n');
+
+    expect(ui.requestRender).toHaveBeenCalledWith(true);
+    expect(rendered).toContain('Provide feedback for revision:');
+    expect(rendered).toContain('a');
+  });
+
   it('renders requested changes below the plan after feedback is submitted', () => {
     const onReject = vi.fn();
     const component = new PlanApprovalInlineComponent(

--- a/mastracode/src/tui/components/__tests__/task-progress.test.ts
+++ b/mastracode/src/tui/components/__tests__/task-progress.test.ts
@@ -1,3 +1,4 @@
+import { visibleWidth } from '@mariozechner/pi-tui';
 import stripAnsi from 'strip-ansi';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -98,6 +99,22 @@ describe('TaskProgressComponent', () => {
     expect(lines[1]).toContain('1/3  ✓ Inspect task progress');
     expect(lines[2]).toBe('       ▶ Implementing item aware quiet task summary wrapping');
     expect(lines[3]).toBe('       ○ Verify quiet task wrapping');
+  });
+
+  it('wraps quiet summaries using terminal display width for wide characters', () => {
+    const component = new TaskProgressComponent();
+    component.setQuietMode(true);
+
+    component.updateTasks([
+      { id: 'one', content: '界'.repeat(35), activeForm: 'Doing wide work', status: 'pending' },
+      { id: 'two', content: 'Done', activeForm: 'Doing', status: 'pending' },
+    ]);
+
+    const lines = component.render(80).map(line => stripAnsi(line).trimEnd());
+
+    expect(lines).toHaveLength(3);
+    expect(visibleWidth(lines[1]!)).toBeLessThanOrEqual(80);
+    expect(lines[2]).toBe('       ○ Done');
   });
 
   it('updates between expanded and quiet task rendering', () => {

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -670,6 +670,33 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(boxLines.every(line => /[╮│┤╯]$/.test(stripAnsi(line).trimEnd()))).toBe(true);
   });
 
+  it('keeps quiet shell box borders aligned for multiline command input', () => {
+    const command = `gh pr create --base main --head fix/mastracode-visible-width-truncation --title "fix(mastracode): use visible width for terminal output" --body "This follows up on the quiet-mode terminal rendering work.
+
+It makes ANSI truncation and bordered command output measure terminal display width instead of raw string length, so wide characters and ANSI/OSC closers do not throw off alignment.
+
+Test plan:
+- pnpm test src/tui/components/__tests__/ansi.test.ts src/tui/components/__tests__/task-progress.test.ts src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot"`;
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    const rendered = component.render(100);
+    const topWidth = visibleWidth(rendered[0]!);
+    const boxLines = rendered.filter(line => /^[╭│╰]/.test(stripAnsi(line)));
+
+    const visible = stripAnsi(rendered.join('\n'));
+    expect(visible).toContain('This');
+    expect(visible).toContain('follows up on the quiet-mode terminal rendering work.');
+    expect(visible).not.toContain('…');
+    expect(boxLines.length).toBeGreaterThan(3);
+    expect(boxLines.every(line => visibleWidth(line) === topWidth)).toBe(true);
+    expect(boxLines.every(line => /[╮│╯]$/.test(stripAnsi(line).trimEnd()))).toBe(true);
+  });
+
   it('keeps quiet detail lines visible after completion', () => {
     const component = new ToolExecutionComponentEnhanced(
       'write_file',
@@ -750,7 +777,6 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
       .filter(line => line.startsWith('│') && line.trim() !== '│');
     expect(footerLines.length).toBeGreaterThan(1);
     expect(stripAnsi(output)).toContain('then fi"');
-    expect(output).toContain(chalk.white('then fi"'));
     expect(output).not.toContain(chalk.blue('then'));
   });
 

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -1,3 +1,4 @@
+import { visibleWidth } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import { describe, it, expect } from 'vitest';
 import { theme, tintHex, ensureTerminalGlyphContrast } from '../../theme.js';
@@ -641,6 +642,32 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(output).toContain('line 16');
     expect(lines.some(line => line.includes('line 1 ') || line.includes('line 1│'))).toBe(false);
     expect(lines.filter(line => line.includes('line '))).toHaveLength(15);
+  });
+
+  it('keeps quiet shell box borders aligned for long git output', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command: 'git remote -v' },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+    const remoteLine = 'fork_truffle-dev    https://github.com/truffle-dev/mastra.git (push)'.repeat(4);
+
+    component.updateResult(
+      {
+        content: [{ type: 'text', text: remoteLine }],
+        isError: false,
+      },
+      false,
+    );
+
+    const rendered = component.render(80);
+    const topWidth = visibleWidth(rendered[0]!);
+    const boxLines = rendered.filter(line => /^[╭│├╰]/.test(stripAnsi(line)));
+
+    expect(boxLines.length).toBeGreaterThan(1);
+    expect(boxLines.every(line => visibleWidth(line) === topWidth)).toBe(true);
+    expect(boxLines.every(line => /[╮│┤╯]$/.test(stripAnsi(line).trimEnd()))).toBe(true);
   });
 
   it('keeps quiet detail lines visible after completion', () => {

--- a/mastracode/src/tui/components/ansi.ts
+++ b/mastracode/src/tui/components/ansi.ts
@@ -2,6 +2,35 @@
  * Shared ANSI text-handling helpers for TUI components.
  */
 
+import { visibleWidth } from '@mariozechner/pi-tui';
+
+const ANSI_CLOSERS = '\x1b]8;;\x07\x1b[0m';
+const ELLIPSIS = '…';
+const ELLIPSIS_WIDTH = visibleWidth(ELLIPSIS);
+
+function fitVisibleText(text: string, maxWidth: number): { text: string; width: number; truncated: boolean } {
+  if (maxWidth <= 0) return { text: ELLIPSIS, width: ELLIPSIS_WIDTH, truncated: text.length > 0 };
+
+  const targetWidth = Math.max(0, maxWidth - ELLIPSIS_WIDTH);
+  let width = 0;
+  let result = '';
+  let resultWidth = 0;
+
+  for (const char of text) {
+    const charWidth = visibleWidth(char);
+    if (width + charWidth > maxWidth) {
+      return { text: `${result}${ELLIPSIS}`, width: resultWidth + ELLIPSIS_WIDTH, truncated: true };
+    }
+    if (width + charWidth <= targetWidth) {
+      result += char;
+      resultWidth += charWidth;
+    }
+    width += charWidth;
+  }
+
+  return { text, width, truncated: false };
+}
+
 /** Truncate a string with ANSI codes to a visible width.
  *  Handles both SGR sequences (\x1b[...m) and OSC 8 hyperlinks (\x1b]8;...;\x07).
  */
@@ -18,15 +47,15 @@ export function truncateAnsi(str: string, maxWidth: number): string {
   while ((match = ansiRegex.exec(str)) !== null) {
     // Add text before this ANSI code
     const textBefore = str.slice(lastIndex, match.index);
-    const remaining = maxWidth - visibleLength;
-    if (textBefore.length <= remaining) {
-      result += textBefore;
-      visibleLength += textBefore.length;
-    } else {
-      result += textBefore.slice(0, remaining - 1) + '…';
-      result += '\x1b]8;;\x07\x1b[0m'; // Close any open hyperlink + reset styles
+    const fitted = fitVisibleText(textBefore, maxWidth - visibleLength);
+    if (fitted.truncated) {
+      result += fitted.text;
+      result += ANSI_CLOSERS; // Close any open hyperlink + reset styles
       return result;
     }
+    result += fitted.text;
+    visibleLength += fitted.width;
+
     // Add the ANSI code (doesn't count toward visible length)
     result += match[0];
     lastIndex = match.index + match[0].length;
@@ -34,13 +63,9 @@ export function truncateAnsi(str: string, maxWidth: number): string {
 
   // Add remaining text after last ANSI code
   const remaining = str.slice(lastIndex);
-  const spaceLeft = maxWidth - visibleLength;
-  if (remaining.length <= spaceLeft) {
-    result += remaining;
-  } else {
-    result += remaining.slice(0, spaceLeft - 1) + '…';
-    result += '\x1b]8;;\x07\x1b[0m'; // Close hyperlink + reset
-  }
+  const fitted = fitVisibleText(remaining, maxWidth - visibleLength);
+  result += fitted.text;
+  if (fitted.truncated) result += ANSI_CLOSERS; // Close hyperlink + reset
 
   return result;
 }

--- a/mastracode/src/tui/components/ansi.ts
+++ b/mastracode/src/tui/components/ansi.ts
@@ -9,7 +9,7 @@ const ELLIPSIS = '…';
 const ELLIPSIS_WIDTH = visibleWidth(ELLIPSIS);
 
 function fitVisibleText(text: string, maxWidth: number): { text: string; width: number; truncated: boolean } {
-  if (maxWidth <= 0) return { text: ELLIPSIS, width: ELLIPSIS_WIDTH, truncated: text.length > 0 };
+  if (maxWidth <= 0) return { text: '', width: 0, truncated: text.length > 0 };
 
   const targetWidth = Math.max(0, maxWidth - ELLIPSIS_WIDTH);
   let width = 0;
@@ -35,6 +35,8 @@ function fitVisibleText(text: string, maxWidth: number): { text: string; width: 
  *  Handles both SGR sequences (\x1b[...m) and OSC 8 hyperlinks (\x1b]8;...;\x07).
  */
 export function truncateAnsi(str: string, maxWidth: number): string {
+  if (maxWidth <= 0) return '';
+
   // The OSC 8 hyperlink body is terminated by BEL (\x07). We also
   // break on a new ESC (\x1b) so a missing terminator cannot scan
   // unbounded input and amplify polynomial backtracking.

--- a/mastracode/src/tui/components/plan-approval-inline.ts
+++ b/mastracode/src/tui/components/plan-approval-inline.ts
@@ -75,7 +75,10 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     }
   }
 
-  constructor(options: PlanApprovalInlineOptions, private ui: TUI) {
+  constructor(
+    options: PlanApprovalInlineOptions,
+    private ui: TUI,
+  ) {
     super();
     this.planTitle = options.title;
     this.planContent = options.plan;

--- a/mastracode/src/tui/components/plan-approval-inline.ts
+++ b/mastracode/src/tui/components/plan-approval-inline.ts
@@ -75,7 +75,7 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     }
   }
 
-  constructor(options: PlanApprovalInlineOptions, _ui: TUI) {
+  constructor(options: PlanApprovalInlineOptions, private ui: TUI) {
     super();
     this.planTitle = options.title;
     this.planContent = options.plan;
@@ -262,6 +262,7 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     this.contentBox.addChild(
       new Text(theme.fg('dim', 'Enter to submit feedback  Esc to reject without feedback'), 0, 0),
     );
+    this.ui.requestRender(true);
   }
 
   private showResult(status: string, isApproved: boolean, feedback?: string): void {

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -555,37 +555,45 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       return chunk;
     };
 
-    for (const token of this.tokenizeQuietShellCommand(command)) {
-      let remaining = token.text;
+    const wrapSourceLine = (sourceLine: string) => {
+      for (const token of this.tokenizeQuietShellCommand(sourceLine)) {
+        let remaining = token.text;
 
-      while (remaining.length > 0) {
-        if (currentWidth === 0 && /^\s+$/.test(remaining)) break;
+        while (remaining.length > 0) {
+          if (currentWidth === 0 && /^\s+$/.test(remaining)) break;
 
-        const available = width - currentWidth;
-        if (available <= 0) {
+          const available = width - currentWidth;
+          if (available <= 0) {
+            pushCurrent();
+            continue;
+          }
+
+          const remainingWidth = visibleWidth(remaining);
+          if (remainingWidth <= available) {
+            current += token.color(remaining);
+            currentWidth += remainingWidth;
+            break;
+          }
+
+          if (currentWidth > 0 && !/^\s+$/.test(remaining)) {
+            pushCurrent();
+            continue;
+          }
+
+          const chunk = takeVisiblePrefix(remaining, available);
+          current += token.color(chunk);
+          currentWidth += visibleWidth(chunk);
+          remaining = remaining.slice(chunk.length);
           pushCurrent();
-          continue;
         }
-
-        const remainingWidth = visibleWidth(remaining);
-        if (remainingWidth <= available) {
-          current += token.color(remaining);
-          currentWidth += remainingWidth;
-          break;
-        }
-
-        if (currentWidth > 0 && !/^\s+$/.test(remaining)) {
-          pushCurrent();
-          continue;
-        }
-
-        const chunk = takeVisiblePrefix(remaining, available);
-        current += token.color(chunk);
-        currentWidth += visibleWidth(chunk);
-        remaining = remaining.slice(chunk.length);
-        pushCurrent();
       }
-    }
+    };
+
+    const sourceLines = command.split('\n');
+    sourceLines.forEach((sourceLine, index) => {
+      wrapSourceLine(sourceLine);
+      if (index < sourceLines.length - 1) pushCurrent();
+    });
 
     if (current) lines.push(current);
     return lines.length ? lines : [''];
@@ -1405,7 +1413,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         this.contentBox.addChild(new Text(displayOutput, 0, 0));
         this.contentBox.addChild(new Text(`${border('├')}${border(horizontal)}${border('┤')}`, 0, 0));
       }
-      const footerWrapWidth = Math.max(1, contentWidth - 2);
+      const footerWrapWidth = Math.max(1, contentWidth - 4);
       const footerLines = this.wrapQuietShellCommand(command, footerWrapWidth);
       const footerSuffixWidth = visibleWidth(footerSuffix);
       footerLines.forEach((footerLine, index) => {

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -4,7 +4,7 @@
  */
 
 import * as os from 'node:os';
-import { Box, Container, Spacer, Text } from '@mariozechner/pi-tui';
+import { Box, Container, Spacer, Text, visibleWidth } from '@mariozechner/pi-tui';
 import type { TUI } from '@mariozechner/pi-tui';
 import type { TaskItemInput } from '@mastra/core/harness';
 import chalk from 'chalk';
@@ -540,6 +540,21 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       currentWidth = 0;
     };
 
+    const takeVisiblePrefix = (text: string, maxWidth: number): string => {
+      let chunk = '';
+      let chunkWidth = 0;
+
+      for (const char of text) {
+        const charWidth = visibleWidth(char);
+        if (chunk && chunkWidth + charWidth > maxWidth) break;
+        chunk += char;
+        chunkWidth += charWidth;
+        if (chunkWidth >= maxWidth) break;
+      }
+
+      return chunk;
+    };
+
     for (const token of this.tokenizeQuietShellCommand(command)) {
       let remaining = token.text;
 
@@ -552,9 +567,10 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
           continue;
         }
 
-        if (remaining.length <= available) {
+        const remainingWidth = visibleWidth(remaining);
+        if (remainingWidth <= available) {
           current += token.color(remaining);
-          currentWidth += remaining.length;
+          currentWidth += remainingWidth;
           break;
         }
 
@@ -563,10 +579,10 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
           continue;
         }
 
-        const chunk = remaining.slice(0, available);
+        const chunk = takeVisiblePrefix(remaining, available);
         current += token.color(chunk);
-        currentWidth += chunk.length;
-        remaining = remaining.slice(available);
+        currentWidth += visibleWidth(chunk);
+        remaining = remaining.slice(chunk.length);
         pushCurrent();
       }
     }
@@ -1378,7 +1394,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       const horizontal = '─'.repeat(contentWidth + 2);
       const renderLine = (line: string, color: (value: string) => string = value => theme.fg('toolOutput', value)) => {
         const truncated = truncateAnsi(line, contentWidth);
-        const padding = ' '.repeat(Math.max(0, contentWidth - this.stripAnsi(truncated).length));
+        const padding = ' '.repeat(Math.max(0, contentWidth - visibleWidth(truncated)));
         return `${border('│')} ${color(truncated)}${padding} ${border('│')}`;
       };
       const displayOutput = outputLines.map(line => renderLine(line)).join('\n');
@@ -1391,11 +1407,11 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       }
       const footerWrapWidth = Math.max(1, contentWidth - 2);
       const footerLines = this.wrapQuietShellCommand(command, footerWrapWidth);
-      const footerSuffixWidth = this.stripAnsi(footerSuffix).length;
+      const footerSuffixWidth = visibleWidth(footerSuffix);
       footerLines.forEach((footerLine, index) => {
         const prefix = index === 0 ? footerPrompt : '  ';
         const isLast = index === footerLines.length - 1;
-        const suffixFits = isLast && this.stripAnsi(footerLine).length + footerSuffixWidth <= footerWrapWidth;
+        const suffixFits = isLast && visibleWidth(footerLine) + footerSuffixWidth <= footerWrapWidth;
         const suffix = suffixFits ? footerSuffix : '';
         this.contentBox.addChild(
           new Text(
@@ -1406,7 +1422,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         );
       });
       const lastFooterLine = footerLines[footerLines.length - 1] ?? '';
-      if (this.stripAnsi(lastFooterLine).length + footerSuffixWidth > footerWrapWidth) {
+      if (visibleWidth(lastFooterLine) + footerSuffixWidth > footerWrapWidth) {
         this.contentBox.addChild(
           new Text(
             renderLine(`  ${footerSuffix}`, value => value),

--- a/mastracode/src/tui/handlers/__tests__/prompts.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/prompts.test.ts
@@ -85,7 +85,8 @@ function createPlanApprovalCtx() {
       }),
       invalidate: vi.fn(),
     },
-    ui: { requestRender: vi.fn() },
+    ui: { requestRender: vi.fn(), setFocus: vi.fn() },
+    editor: {},
     pendingSubmitPlanComponents: new Map(),
     planStartedGoalId: undefined,
   } as any;
@@ -114,6 +115,7 @@ describe('handlePlanApproval goal mode', () => {
       planId: 'plan-1',
       response: { action: 'approved' },
     });
+    expect(state.ui.setFocus).toHaveBeenLastCalledWith(state.editor);
     // `startGoal` is invoked with the title+plan as the objective and the
     // default trigger — it owns sending the canonical goal-reminder signal
     // via `harness.sendSignal`, so the handler does not also send one.
@@ -154,6 +156,7 @@ describe('handlePlanApproval regular approval', () => {
 
     expect(state.chatContainer.children.filter((child: unknown) => child === streamedComponent)).toHaveLength(1);
     expect(state.activeInlinePlanApproval).toBe(streamedComponent);
+    expect(state.ui.setFocus).toHaveBeenCalledWith(streamedComponent);
     expect(streamedComponent.render(80).join('\n')).toContain('Use as /goal');
   });
 
@@ -170,6 +173,7 @@ describe('handlePlanApproval regular approval', () => {
       planId: 'plan-1',
       response: { action: 'approved' },
     });
+    expect(state.ui.setFocus).toHaveBeenLastCalledWith(state.editor);
     // The trigger goes through the structured signal pathway. We do not
     // also call `addUserMessage` or `fireMessage` — either would render
     // the reminder a second time.

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -255,6 +255,7 @@ export async function handlePlanApproval(
       plan,
       onApprove: async () => {
         state.activeInlinePlanApproval = undefined;
+        state.ui.setFocus(state.editor);
         await approvePlan(ctx, planId, title, plan);
 
         // Fire a structured system-reminder signal to wake the freshly
@@ -280,6 +281,7 @@ export async function handlePlanApproval(
       },
       onGoal: async () => {
         state.activeInlinePlanApproval = undefined;
+        state.ui.setFocus(state.editor);
         await approvePlan(ctx, planId, title, plan);
 
         // `approvePlan` waits for plan mode to idle before `startGoal` sends
@@ -296,6 +298,7 @@ export async function handlePlanApproval(
       },
       onReject: async (feedback?: string) => {
         state.activeInlinePlanApproval = undefined;
+        state.ui.setFocus(state.editor);
         await state.harness.respondToPlanApproval({
           planId,
           response: { action: 'rejected', feedback },
@@ -337,7 +340,7 @@ export async function handlePlanApproval(
     }
     state.ui.requestRender();
     state.chatContainer.invalidate();
-    approvalComponent.focused = true;
+    state.ui.setFocus(approvalComponent);
 
     ctx.notify('plan_approval', `Plan "${title}" requires approval`);
   });


### PR DESCRIPTION
This follows up on the quiet-mode terminal rendering work.

It makes ANSI truncation and bordered command output measure terminal display width instead of raw string length, so wide characters and ANSI/OSC closers do not throw off alignment. It also adds regression coverage for wide-character task summaries and long git command output staying inside the command box.

Test plan:
- pnpm test src/tui/components/__tests__/ansi.test.ts src/tui/components/__tests__/task-progress.test.ts src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot
- pnpm check
- pnpm lint --quiet
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes how the terminal UI measures and truncates text so that what you see (including wide characters like emojis/CJK and ANSI styling) lines up correctly in boxes and borders instead of breaking alignment.

---

## Changes

### Core implementation

- mastracode/src/tui/components/ansi.ts
  - Added ANSI_CLOSERS, ELLIPSIS, ELLIPSIS_WIDTH and a new fitVisibleText(text, maxWidth) helper that truncates by terminal visible width (using visibleWidth) and reports truncation.
  - Updated truncateAnsi to use fitVisibleText and to append ANSI_CLOSERS when truncation occurs; handles SGR and OSC 8 hyperlink sequences and avoids unbounded scanning by limiting OSC 8 body matching.

- mastracode/src/tui/components/tool-execution-enhanced.ts
  - Switched wrapping/truncation/padding logic to measure rendered width with visibleWidth instead of string.length.
  - Added helpers (e.g., takeVisiblePrefix / per-character visible width accounting) and updated quiet-mode command wrapping, footer truncation/padding, and box layout so borders remain aligned for wide characters and ANSI sequences.

- mastracode/src/tui/components/plan-approval-inline.ts
  - Stores the provided TUI instance (ui) as a private field and forces an immediate UI redraw via this.ui.requestRender(true) when entering feedback mode.

- .changeset/warm-rivers-clap.md
  - Added changeset noting the mastracode patch release describing terminal rendering fixes.

### Tests

- mastracode/src/tui/components/__tests__/ansi.test.ts
  - Tests updated to assert truncation by visible terminal width (using strip-ansi + visibleWidth).
  - Added boundary tests for exact-fit, maxWidth = 0, wide (double-width) character truncation, ANSI/OSC8 preservation, and a linear-time ReDoS regression test.

- mastracode/src/tui/components/__tests__/task-progress.test.ts
  - Added a test ensuring quiet-mode task summary wrapping uses terminal display width for wide characters (visibleWidth assertions).

- mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
  - Added quiet-mode assertions that long git output and multiline command inputs remain inside the bordered command box by measuring visible widths of box lines.
  - Adjusted an earlier expectation related to wrapped/highlighted output.

- mastracode/src/tui/handlers/prompts.ts and mastracode/src/tui/handlers/__tests__/prompts.test.ts
  - Adjusted focus handling in plan-approval flows: focus is applied via state.ui.setFocus(...) when activating/clearing inline approval components; tests updated to assert focus behavior.

### Notes / Test plan

- Run: pnpm test src/tui/components/__tests__/ansi.test.ts src/tui/components/__tests__/task-progress.test.ts src/tui/components/__tests__/tool-execution-enhanced.test.ts --bail 1 --reporter=dot
- Also: pnpm check, pnpm lint --quiet, and git diff --check

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->