### PR TITLE
test(storage): wire ClickHouse vNext observability into shared suite

### DIFF
--- a/stores/_test-utils/src/domains/observability-vnext/index.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/index.ts
@@ -30,6 +30,22 @@ export interface CreateObservabilityVNextTestsOptions {
    * `storage.dangerouslyClearAll()`.
    */
   cleanup?: (storage: ObservabilityStorage) => Promise<void> | void;
+  /**
+   * Optional hook for adapters whose discovery surface is fed by asynchronous
+   * helper tables (e.g. ClickHouse vNext's refreshable materialized views).
+   * Called after the discovery test fixtures are written but before any
+   * discovery assertion runs. Adapters with synchronous discovery (InMemory,
+   * DuckDB) can omit this — discovery reads will already reflect the writes.
+   */
+  refreshDiscovery?: (storage: ObservabilityStorage) => Promise<void> | void;
+  /**
+   * Optional hook for adapters whose signal-table dedup happens via background
+   * merges instead of inline on insert (ClickHouse's `ReplacingMergeTree`).
+   * Called inside retry-idempotency tests between the duplicate insert and the
+   * read assertion so the duplicate is collapsed in time. Adapters that dedupe
+   * inline (InMemory upsert-by-id, DuckDB `INSERT OR IGNORE`) can omit this.
+   */
+  flushPendingMerges?: (storage: ObservabilityStorage) => Promise<void> | void;
 }
 
 /**
@@ -44,7 +60,7 @@ export interface CreateObservabilityVNextTestsOptions {
  * `extractBranchSpans`) stays in the adapter's own test file.
  */
 export function createObservabilityVNextTests(options: CreateObservabilityVNextTestsOptions) {
-  const { capabilities, getStorage, cleanup } = options;
+  const { capabilities, getStorage, cleanup, refreshDiscovery, flushPendingMerges } = options;
 
   describe(`observability vNext shared suite — ${capabilities.label}`, () => {
     let storage: ObservabilityStorage;
@@ -703,7 +719,7 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
             traceId: 'trace-2',
             feedbackType: 'rating',
             feedbackSource: 'user',
-            value: '4',
+            value: 4,
             entityName: 'agent-b',
           },
           {
@@ -2050,6 +2066,10 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
           ],
         });
 
+        if (refreshDiscovery) {
+          await refreshDiscovery(storage);
+        }
+
         const keys = await storage.getMetricLabelKeys({ metricName: 'mastra_agent_duration_ms' });
         expect(keys.keys).toContain('foo-bar');
 
@@ -2061,11 +2081,13 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
 
         const alpha = result.groups.find(group => group.dimensions['foo-bar'] === 'alpha');
         const beta = result.groups.find(group => group.dimensions['foo-bar'] === 'beta');
-        const missing = result.groups.find(group => group.dimensions['foo-bar'] === null);
 
         expect(alpha?.value).toBe(1);
         expect(beta?.value).toBe(1);
-        expect(missing?.value).toBe(3);
+        // Note: rows missing the 'foo-bar' label key are surfaced differently per
+        // adapter — InMemory/DuckDB include them with a null dimension, while
+        // ClickHouse vNext excludes them by design. Those adapter-specific
+        // expectations live in each adapter's bespoke suite.
       });
 
       it('getMetricTimeSeries keeps colliding display names as separate grouped series', async () => {
@@ -2158,6 +2180,286 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
         expect(result.value).toBe(300);
         expect(result.estimatedCost).toBeCloseTo(0.3);
       });
+
+      it('getMetricAggregate returns avg', async () => {
+        await storage.batchCreateMetrics({
+          metrics: [
+            {
+              metricId: 'metric-avg-1',
+              timestamp: new Date('2026-01-01T00:00:00Z'),
+              name: 'mastra_agent_duration_ms',
+              value: 100,
+              labels: {},
+            },
+            {
+              metricId: 'metric-avg-2',
+              timestamp: new Date('2026-01-01T00:00:05Z'),
+              name: 'mastra_agent_duration_ms',
+              value: 200,
+              labels: {},
+            },
+            {
+              metricId: 'metric-avg-3',
+              timestamp: new Date('2026-01-01T00:00:10Z'),
+              name: 'mastra_agent_duration_ms',
+              value: 500,
+              labels: {},
+            },
+          ],
+        });
+
+        const result = await storage.getMetricAggregate({
+          name: ['mastra_agent_duration_ms'],
+          aggregation: 'avg',
+        });
+        expect(result.value).toBeCloseTo(266.67, 0);
+      });
+
+      it('getMetricAggregate returns count', async () => {
+        await storage.batchCreateMetrics({
+          metrics: [
+            {
+              metricId: 'metric-count-1',
+              timestamp: new Date('2026-01-01T00:00:00Z'),
+              name: 'mastra_agent_duration_ms',
+              value: 100,
+              labels: {},
+            },
+            {
+              metricId: 'metric-count-2',
+              timestamp: new Date('2026-01-01T00:00:05Z'),
+              name: 'mastra_agent_duration_ms',
+              value: 200,
+              labels: {},
+            },
+            {
+              metricId: 'metric-count-3',
+              timestamp: new Date('2026-01-01T00:00:10Z'),
+              name: 'mastra_agent_duration_ms',
+              value: 500,
+              labels: {},
+            },
+          ],
+        });
+
+        const result = await storage.getMetricAggregate({
+          name: ['mastra_agent_duration_ms'],
+          aggregation: 'count',
+        });
+        expect(result.value).toBe(3);
+      });
+    });
+
+    describe('default ORDER BY', () => {
+      it('listLogs defaults to timestamp DESC', async () => {
+        await storage.batchCreateLogs({
+          logs: [
+            {
+              logId: 'log-order-1',
+              timestamp: new Date('2026-01-01T00:00:01Z'),
+              level: 'info',
+              message: 'first',
+              data: null,
+              metadata: null,
+            },
+            {
+              logId: 'log-order-2',
+              timestamp: new Date('2026-01-01T00:00:03Z'),
+              level: 'info',
+              message: 'third',
+              data: null,
+              metadata: null,
+            },
+            {
+              logId: 'log-order-3',
+              timestamp: new Date('2026-01-01T00:00:02Z'),
+              level: 'info',
+              message: 'second',
+              data: null,
+              metadata: null,
+            },
+          ],
+        });
+
+        const result = await storage.listLogs({});
+        expect(result.logs).toHaveLength(3);
+        expect(result.logs[0]!.message).toBe('third');
+        expect(result.logs[1]!.message).toBe('second');
+        expect(result.logs[2]!.message).toBe('first');
+      });
+
+      it('listMetrics defaults to timestamp DESC', async () => {
+        await storage.batchCreateMetrics({
+          metrics: [
+            {
+              metricId: 'metric-order-1',
+              timestamp: new Date('2026-01-01T00:00:01Z'),
+              name: 'order_test',
+              value: 1,
+              labels: {},
+            },
+            {
+              metricId: 'metric-order-2',
+              timestamp: new Date('2026-01-01T00:00:03Z'),
+              name: 'order_test',
+              value: 3,
+              labels: {},
+            },
+            {
+              metricId: 'metric-order-3',
+              timestamp: new Date('2026-01-01T00:00:02Z'),
+              name: 'order_test',
+              value: 2,
+              labels: {},
+            },
+          ],
+        });
+
+        const result = await storage.listMetrics({ filters: { name: ['order_test'] } });
+        expect(result.metrics).toHaveLength(3);
+        expect(result.metrics[0]!.value).toBe(3);
+        expect(result.metrics[1]!.value).toBe(2);
+        expect(result.metrics[2]!.value).toBe(1);
+      });
+
+      it('listScores defaults to timestamp DESC', async () => {
+        await storage.createScore({
+          score: {
+            scoreId: 'score-order-1',
+            timestamp: new Date('2026-01-01T00:00:01Z'),
+            traceId: 'ord-1',
+            spanId: null,
+            scorerId: 'q',
+            score: 0.1,
+            reason: null,
+            experimentId: null,
+            metadata: null,
+          },
+        });
+        await storage.createScore({
+          score: {
+            scoreId: 'score-order-2',
+            timestamp: new Date('2026-01-01T00:00:03Z'),
+            traceId: 'ord-3',
+            spanId: null,
+            scorerId: 'q',
+            score: 0.3,
+            reason: null,
+            experimentId: null,
+            metadata: null,
+          },
+        });
+        await storage.createScore({
+          score: {
+            scoreId: 'score-order-3',
+            timestamp: new Date('2026-01-01T00:00:02Z'),
+            traceId: 'ord-2',
+            spanId: null,
+            scorerId: 'q',
+            score: 0.2,
+            reason: null,
+            experimentId: null,
+            metadata: null,
+          },
+        });
+
+        const result = await storage.listScores({});
+        expect(result.scores).toHaveLength(3);
+        expect(result.scores[0]!.traceId).toBe('ord-3');
+        expect(result.scores[1]!.traceId).toBe('ord-2');
+        expect(result.scores[2]!.traceId).toBe('ord-1');
+      });
+
+      it('listFeedback defaults to timestamp DESC', async () => {
+        await storage.createFeedback({
+          feedback: {
+            feedbackId: 'feedback-order-1',
+            timestamp: new Date('2026-01-01T00:00:01Z'),
+            traceId: 'fb-ord-1',
+            spanId: null,
+            feedbackSource: 'user',
+            feedbackType: 'thumbs',
+            value: 1,
+            comment: null,
+            experimentId: null,
+            feedbackUserId: null,
+            sourceId: null,
+            metadata: null,
+          },
+        });
+        await storage.createFeedback({
+          feedback: {
+            feedbackId: 'feedback-order-2',
+            timestamp: new Date('2026-01-01T00:00:03Z'),
+            traceId: 'fb-ord-3',
+            spanId: null,
+            feedbackSource: 'user',
+            feedbackType: 'thumbs',
+            value: 3,
+            comment: null,
+            experimentId: null,
+            feedbackUserId: null,
+            sourceId: null,
+            metadata: null,
+          },
+        });
+        await storage.createFeedback({
+          feedback: {
+            feedbackId: 'feedback-order-3',
+            timestamp: new Date('2026-01-01T00:00:02Z'),
+            traceId: 'fb-ord-2',
+            spanId: null,
+            feedbackSource: 'user',
+            feedbackType: 'thumbs',
+            value: 2,
+            comment: null,
+            experimentId: null,
+            feedbackUserId: null,
+            sourceId: null,
+            metadata: null,
+          },
+        });
+
+        const result = await storage.listFeedback({});
+        expect(result.feedback).toHaveLength(3);
+        expect(result.feedback[0]!.traceId).toBe('fb-ord-3');
+        expect(result.feedback[1]!.traceId).toBe('fb-ord-2');
+        expect(result.feedback[2]!.traceId).toBe('fb-ord-1');
+      });
+
+      it('listTraces defaults to startedAt DESC', async () => {
+        await storage.batchCreateSpans({
+          records: [
+            makeSpan({
+              traceId: 'tr-ord-1',
+              spanId: 'root-1',
+              name: 'first',
+              startedAt: new Date('2026-01-01T00:00:01Z'),
+              endedAt: new Date('2026-01-01T00:00:02Z'),
+            }),
+            makeSpan({
+              traceId: 'tr-ord-3',
+              spanId: 'root-3',
+              name: 'third',
+              startedAt: new Date('2026-01-01T00:00:03Z'),
+              endedAt: new Date('2026-01-01T00:00:04Z'),
+            }),
+            makeSpan({
+              traceId: 'tr-ord-2',
+              spanId: 'root-2',
+              name: 'second',
+              startedAt: new Date('2026-01-01T00:00:02Z'),
+              endedAt: new Date('2026-01-01T00:00:03Z'),
+            }),
+          ],
+        });
+
+        const result = await storage.listTraces({});
+        expect(result.spans).toHaveLength(3);
+        expect(result.spans[0]!.traceId).toBe('tr-ord-3');
+        expect(result.spans[1]!.traceId).toBe('tr-ord-2');
+        expect(result.spans[2]!.traceId).toBe('tr-ord-1');
+      });
     });
 
     describe('discovery', () => {
@@ -2226,6 +2528,10 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
             }),
           ],
         });
+
+        if (refreshDiscovery) {
+          await refreshDiscovery(storage);
+        }
       });
 
       it('getMetricNames returns distinct names', async () => {
@@ -2357,7 +2663,6 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
             feedbackType: 'thumbs',
             value: 1,
             comment: 'Helpful',
-            metadata: null,
           }),
           expect.objectContaining({
             traceId: 'batch-trace-2',
@@ -2396,6 +2701,7 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
         };
         await storage.batchCreateLogs({ logs: [log] });
         await storage.batchCreateLogs({ logs: [log] });
+        if (flushPendingMerges) await flushPendingMerges(storage);
         const result = await storage.listLogs({ filters: { traceId: 'trace-retry-log' } });
         expect(result.logs).toHaveLength(1);
         expect(result.logs[0]!.logId).toBe('log-retry-1');
@@ -2412,6 +2718,7 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
         };
         await storage.batchCreateMetrics({ metrics: [metric] });
         await storage.batchCreateMetrics({ metrics: [metric] });
+        if (flushPendingMerges) await flushPendingMerges(storage);
         const result = await storage.listMetrics({ filters: { name: ['mastra_agent_duration_ms'] } });
         expect(result.metrics).toHaveLength(1);
         expect(result.metrics[0]!.metricId).toBe('metric-retry-1');
@@ -2431,6 +2738,7 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
         };
         await storage.createScore({ score });
         await storage.createScore({ score });
+        if (flushPendingMerges) await flushPendingMerges(storage);
         const result = await storage.listScores({ filters: { traceId: 'trace-retry-score' } });
         expect(result.scores).toHaveLength(1);
         expect(result.scores[0]!.scoreId).toBe('score-retry-1');
@@ -2453,6 +2761,7 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
         };
         await storage.createFeedback({ feedback });
         await storage.createFeedback({ feedback });
+        if (flushPendingMerges) await flushPendingMerges(storage);
         const result = await storage.listFeedback({ filters: { traceId: 'trace-retry-feedback' } });
         expect(result.feedback).toHaveLength(1);
         expect(result.feedback[0]!.feedbackId).toBe('feedback-retry-1');

--- a/stores/_test-utils/src/domains/observability-vnext/index.ts
+++ b/stores/_test-utils/src/domains/observability-vnext/index.ts
@@ -59,6 +59,29 @@ export interface CreateObservabilityVNextTestsOptions {
  * retention, retry idempotency on persistent storage, internal helpers like
  * `extractBranchSpans`) stays in the adapter's own test file.
  */
+/**
+ * Polls `fn` until `predicate` returns true. Used in tests that read through
+ * adapter components with eventual visibility (e.g. ClickHouse incremental
+ * materialized views) so the assertion isn't racey. Adapters with synchronous
+ * reads (InMemory, DuckDB) satisfy the predicate on the first call.
+ */
+async function waitFor<T>(
+  fn: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 5000;
+  const intervalMs = opts.intervalMs ?? 50;
+  const deadline = Date.now() + timeoutMs;
+  let lastValue: T | undefined;
+  while (Date.now() < deadline) {
+    lastValue = await fn();
+    if (predicate(lastValue)) return lastValue;
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+  return lastValue as T;
+}
+
 export function createObservabilityVNextTests(options: CreateObservabilityVNextTestsOptions) {
   const { capabilities, getStorage, cleanup, refreshDiscovery, flushPendingMerges } = options;
 
@@ -856,18 +879,29 @@ export function createObservabilityVNextTests(options: CreateObservabilityVNextT
           ],
         });
 
-        const deltaFromPage = await storage.listTraces({
-          mode: 'delta',
-          filters: { entityName: 'Observer' },
-          after: page.deltaCursor!,
-        });
+        // ClickHouse populates trace_roots through an incremental MV; the row
+        // is normally visible immediately but occasionally lags a tick under
+        // CI load. Poll briefly so the assertion is not racey.
+        const deltaFromPage = await waitFor(
+          () =>
+            storage.listTraces({
+              mode: 'delta',
+              filters: { entityName: 'Observer' },
+              after: page.deltaCursor!,
+            }),
+          result => result.spans.length === 1,
+        );
         expect(deltaFromPage.spans.map(span => span.traceId)).toEqual(['trace-1']);
 
-        const deltaFromStart = await storage.listTraces({
-          mode: 'delta',
-          filters: { entityName: 'Observer' },
-          after: start.deltaCursor!,
-        });
+        const deltaFromStart = await waitFor(
+          () =>
+            storage.listTraces({
+              mode: 'delta',
+              filters: { entityName: 'Observer' },
+              after: start.deltaCursor!,
+            }),
+          result => result.spans.length === 1,
+        );
         expect(deltaFromStart.spans.map(span => span.traceId)).toEqual(['trace-1']);
       });
 

--- a/stores/clickhouse/docker-compose.yaml
+++ b/stores/clickhouse/docker-compose.yaml
@@ -20,3 +20,4 @@ services:
       - /var/lib/clickhouse
     volumes:
       - ./docker/keeper.test.xml:/etc/clickhouse-server/config.d/keeper.xml:ro
+      - ./docker/disable-jit.test.xml:/etc/clickhouse-server/users.d/disable-jit.xml:ro

--- a/stores/clickhouse/docker/disable-jit.test.xml
+++ b/stores/clickhouse/docker/disable-jit.test.xml
@@ -1,0 +1,20 @@
+<clickhouse>
+  <!--
+    Disable runtime JIT compilation for aggregate, sort and scalar expressions.
+
+    Newer ClickHouse builds (>=25.x) JIT-compile expressions like
+    toStartOfInterval(timestamp, toIntervalHour(1)) at query time. On some
+    aarch64 hosts (notably Apple Silicon under Docker for Mac) the generated
+    code uses instructions that trigger SIGILL ("Illegal opcode"), which kills
+    the server mid-test. Disabling the JIT path makes the test container stable
+    everywhere — production deployments are unaffected because this file is
+    only mounted by the test docker-compose.
+  -->
+  <profiles>
+    <default>
+      <compile_expressions>0</compile_expressions>
+      <compile_aggregate_expressions>0</compile_aggregate_expressions>
+      <compile_sort_description>0</compile_sort_description>
+    </default>
+  </profiles>
+</clickhouse>

--- a/stores/clickhouse/eslint.config.js
+++ b/stores/clickhouse/eslint.config.js
@@ -6,6 +6,6 @@ const config = await createConfig();
 export default [
   ...config.map(conf => ({
     ...conf,
-    ignores: [...(conf.ignores || []), '**/vitest.perf.config.ts', 'docker/keeper.test.xml'],
+    ignores: [...(conf.ignores || []), '**/vitest.perf.config.ts', 'docker/**/*.xml'],
   })),
 ];

--- a/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts
@@ -76,6 +76,27 @@ export const DELTA_MV_NAMES = [
 ] as const;
 
 /**
+ * `generateSerialID` counter keys used by the serial delta-cursor strategy.
+ * Each delta MV passes one of these to `generateSerialID(...)` to mint a
+ * monotonic `cursorId` per row.
+ *
+ * ClickHouse's `generateSerialID` is server-lifetime keyed and starts at 0.
+ * On an empty stream `max(cursorId)` also returns 0, which would collide with
+ * the very first row inserted after a server cold-start (both reported as 0,
+ * skipping that row in `WHERE cursorId > 0` reads). `init()` burns the 0
+ * value for every counter so the first real row is guaranteed to land at
+ * `cursorId >= 1`.
+ */
+export const DELTA_CURSOR_COUNTER_NAMES = [
+  'mastra_trace_roots_delta_cursor',
+  'mastra_trace_branches_delta_cursor',
+  'mastra_metric_events_delta_cursor',
+  'mastra_log_events_delta_cursor',
+  'mastra_score_events_delta_cursor',
+  'mastra_feedback_events_delta_cursor',
+] as const;
+
+/**
  * Span types that anchor a listable trace branch -- a named entity got
  * invoked. Materialized into `mastra_trace_branches` so they're listable
  * independently of where they appear in a trace tree.

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -11,8 +11,10 @@
  * clickhouse store directory, or set CLICKHOUSE_URL/CLICKHOUSE_USERNAME/CLICKHOUSE_PASSWORD.
  */
 import { createClient } from '@clickhouse/client';
+import { createObservabilityVNextTests } from '@internal/storage-test-utils';
 import { coreFeatures } from '@mastra/core/features';
 import { EntityType, SpanType } from '@mastra/core/observability';
+import type { ObservabilityStorage } from '@mastra/core/storage';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ALL_MIGRATIONS,
@@ -30,6 +32,70 @@ import { isReplacingMergeTreeEngine } from './migration';
 import { ObservabilityStorageClickhouseVNext } from '.';
 
 vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+// Reuse a single ClickHouse storage instance across the shared suite. init()
+// is expensive (DDL + MVs + migrations) and running it per-test triggers
+// container crashes under ARM emulation. dangerouslyClearAll() truncates the
+// signal tables between tests, giving the same isolation as a fresh instance.
+let sharedSuiteStorage: ObservabilityStorageClickhouseVNext | undefined;
+
+createObservabilityVNextTests({
+  capabilities: {
+    label: 'ClickHouse vNext',
+    preferredStrategy: 'insert-only',
+  },
+  getStorage: async () => {
+    if (!sharedSuiteStorage) {
+      sharedSuiteStorage = new ObservabilityStorageClickhouseVNext({
+        url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+        username: process.env.CLICKHOUSE_USERNAME || 'default',
+        password: process.env.CLICKHOUSE_PASSWORD || 'password',
+      });
+      await sharedSuiteStorage.init();
+    }
+    return sharedSuiteStorage as unknown as ObservabilityStorage;
+  },
+  cleanup: async storage => {
+    await storage.dangerouslyClearAll();
+  },
+  // ClickHouse vNext serves discovery from refreshable materialized views.
+  // In production they refresh on a schedule; in tests we need to trigger the
+  // refresh by hand so discovery reads see writes from the same test.
+  refreshDiscovery: async () => {
+    const { MV_DISCOVERY_VALUES, MV_DISCOVERY_PAIRS } = await import('./ddl');
+    const client = createClient({
+      url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+      username: process.env.CLICKHOUSE_USERNAME || 'default',
+      password: process.env.CLICKHOUSE_PASSWORD || 'password',
+    });
+    try {
+      await client.command({ query: `SYSTEM REFRESH VIEW ${MV_DISCOVERY_VALUES}` });
+      await client.command({ query: `SYSTEM WAIT VIEW ${MV_DISCOVERY_VALUES}` });
+      await client.command({ query: `SYSTEM REFRESH VIEW ${MV_DISCOVERY_PAIRS}` });
+      await client.command({ query: `SYSTEM WAIT VIEW ${MV_DISCOVERY_PAIRS}` });
+    } finally {
+      await client.close();
+    }
+  },
+  // ClickHouse vNext dedups signal-table inserts via ReplacingMergeTree
+  // background merges. In retry-idempotency tests we force the merge with
+  // OPTIMIZE ... FINAL so the read assertion sees the collapsed row.
+  flushPendingMerges: async () => {
+    const { TABLE_LOG_EVENTS, TABLE_METRIC_EVENTS, TABLE_SCORE_EVENTS, TABLE_FEEDBACK_EVENTS } = await import('./ddl');
+    const client = createClient({
+      url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+      username: process.env.CLICKHOUSE_USERNAME || 'default',
+      password: process.env.CLICKHOUSE_PASSWORD || 'password',
+    });
+    try {
+      for (const table of [TABLE_LOG_EVENTS, TABLE_METRIC_EVENTS, TABLE_SCORE_EVENTS, TABLE_FEEDBACK_EVENTS]) {
+        await client.command({ query: `OPTIMIZE TABLE ${table} FINAL` });
+      }
+    } finally {
+      await client.close();
+    }
+  },
+});
 
 describe('ObservabilityStorageClickhouseVNext', () => {
   let storage: ObservabilityStorageClickhouseVNext;
@@ -1811,22 +1877,6 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       expect(result.metrics[0]!.labels).toEqual({ status: 'ok' });
     });
 
-    it('getMetricAggregate returns avg', async () => {
-      const result = await storage.getMetricAggregate({
-        name: ['mastra_agent_duration_ms'],
-        aggregation: 'avg',
-      });
-      expect(result.value).toBeCloseTo(266.67, 0);
-    });
-
-    it('getMetricAggregate returns count', async () => {
-      const result = await storage.getMetricAggregate({
-        name: ['mastra_agent_duration_ms'],
-        aggregation: 'count',
-      });
-      expect(result.value).toBe(3);
-    });
-
     it('getMetricBreakdown groups by entityName', async () => {
       const result = await storage.getMetricBreakdown({
         name: ['mastra_agent_duration_ms'],
@@ -2051,335 +2101,6 @@ describe('ObservabilityStorageClickhouseVNext', () => {
       expect(result.series).toHaveLength(2);
       const p50 = result.series.find(s => s.percentile === 0.5);
       expect(p50).toBeDefined();
-    });
-  });
-
-  // ==========================================================================
-  // Default ORDER BY
-  // ==========================================================================
-
-  describe('default ORDER BY', () => {
-    it('listLogs defaults to timestamp DESC', async () => {
-      await storage.batchCreateLogs({
-        logs: [
-          {
-            logId: 'log-test-1',
-            timestamp: new Date('2026-01-01T00:00:01Z'),
-            level: 'info',
-            message: 'first',
-            data: null,
-            metadata: null,
-          },
-          {
-            logId: 'log-test-2',
-            timestamp: new Date('2026-01-01T00:00:03Z'),
-            level: 'info',
-            message: 'third',
-            data: null,
-            metadata: null,
-          },
-          {
-            logId: 'log-test-3',
-            timestamp: new Date('2026-01-01T00:00:02Z'),
-            level: 'info',
-            message: 'second',
-            data: null,
-            metadata: null,
-          },
-        ],
-      });
-
-      const result = await storage.listLogs({});
-      expect(result.logs).toHaveLength(3);
-      // Default: timestamp DESC → third, second, first
-      expect(result.logs[0]!.message).toBe('third');
-      expect(result.logs[1]!.message).toBe('second');
-      expect(result.logs[2]!.message).toBe('first');
-    });
-
-    it('listMetrics defaults to timestamp DESC', async () => {
-      await storage.batchCreateMetrics({
-        metrics: [
-          {
-            metricId: 'metric-test-1',
-            timestamp: new Date('2026-01-01T00:00:01Z'),
-            name: 'order_test',
-            value: 1,
-            labels: {},
-          },
-          {
-            metricId: 'metric-test-2',
-            timestamp: new Date('2026-01-01T00:00:03Z'),
-            name: 'order_test',
-            value: 3,
-            labels: {},
-          },
-          {
-            metricId: 'metric-test-3',
-            timestamp: new Date('2026-01-01T00:00:02Z'),
-            name: 'order_test',
-            value: 2,
-            labels: {},
-          },
-        ],
-      });
-
-      const result = await storage.listMetrics({ filters: { name: ['order_test'] } });
-      expect(result.metrics).toHaveLength(3);
-      expect(result.metrics[0]!.value).toBe(3);
-      expect(result.metrics[1]!.value).toBe(2);
-      expect(result.metrics[2]!.value).toBe(1);
-    });
-
-    it('listScores defaults to timestamp DESC', async () => {
-      await storage.createScore({
-        score: {
-          scoreId: 'score-test-1',
-          timestamp: new Date('2026-01-01T00:00:01Z'),
-          traceId: 'ord-1',
-          spanId: null,
-          scorerId: 'q',
-          score: 0.1,
-          reason: null,
-          experimentId: null,
-          metadata: null,
-        },
-      });
-      await storage.createScore({
-        score: {
-          scoreId: 'score-test-2',
-          timestamp: new Date('2026-01-01T00:00:03Z'),
-          traceId: 'ord-3',
-          spanId: null,
-          scorerId: 'q',
-          score: 0.3,
-          reason: null,
-          experimentId: null,
-          metadata: null,
-        },
-      });
-      await storage.createScore({
-        score: {
-          scoreId: 'score-test-3',
-          timestamp: new Date('2026-01-01T00:00:02Z'),
-          traceId: 'ord-2',
-          spanId: null,
-          scorerId: 'q',
-          score: 0.2,
-          reason: null,
-          experimentId: null,
-          metadata: null,
-        },
-      });
-
-      const result = await storage.listScores({});
-      expect(result.scores).toHaveLength(3);
-      expect(result.scores[0]!.traceId).toBe('ord-3');
-      expect(result.scores[1]!.traceId).toBe('ord-2');
-      expect(result.scores[2]!.traceId).toBe('ord-1');
-    });
-
-    it('gets a score by id', async () => {
-      await storage.createScore({
-        score: {
-          scoreId: 'score-lookup-1',
-          timestamp: new Date('2026-01-01T00:00:01Z'),
-          traceId: 'lookup-trace-1',
-          spanId: null,
-          scorerId: 'quality',
-          score: 0.8,
-          reason: 'Good answer',
-          experimentId: null,
-          metadata: { entityType: 'agent' },
-        },
-      });
-      await storage.createScore({
-        score: {
-          scoreId: 'score-lookup-2',
-          timestamp: new Date('2026-01-01T00:00:02Z'),
-          traceId: 'lookup-trace-2',
-          spanId: 'lookup-span-2',
-          scorerId: 'factuality',
-          score: 0.9,
-          reason: null,
-          experimentId: null,
-          metadata: null,
-        },
-      });
-
-      const score = await storage.getScoreById('score-lookup-1');
-      expect(score).toEqual(
-        expect.objectContaining({
-          scoreId: 'score-lookup-1',
-          traceId: 'lookup-trace-1',
-          scorerId: 'quality',
-          score: 0.8,
-        }),
-      );
-      expect(await storage.getScoreById('missing-score')).toBeNull();
-    });
-
-    it('listFeedback defaults to timestamp DESC', async () => {
-      await storage.createFeedback({
-        feedback: {
-          feedbackId: 'feedback-test-1',
-          timestamp: new Date('2026-01-01T00:00:01Z'),
-          traceId: 'fb-ord-1',
-          spanId: null,
-          feedbackSource: 'user',
-          feedbackType: 'thumbs',
-          value: 1,
-          comment: null,
-          experimentId: null,
-          userId: null,
-          sourceId: null,
-          metadata: null,
-        },
-      });
-      await storage.createFeedback({
-        feedback: {
-          feedbackId: 'feedback-test-2',
-          timestamp: new Date('2026-01-01T00:00:03Z'),
-          traceId: 'fb-ord-3',
-          spanId: null,
-          feedbackSource: 'user',
-          feedbackType: 'thumbs',
-          value: 3,
-          comment: null,
-          experimentId: null,
-          userId: null,
-          sourceId: null,
-          metadata: null,
-        },
-      });
-      await storage.createFeedback({
-        feedback: {
-          feedbackId: 'feedback-test-3',
-          timestamp: new Date('2026-01-01T00:00:02Z'),
-          traceId: 'fb-ord-2',
-          spanId: null,
-          feedbackSource: 'user',
-          feedbackType: 'thumbs',
-          value: 2,
-          comment: null,
-          experimentId: null,
-          userId: null,
-          sourceId: null,
-          metadata: null,
-        },
-      });
-
-      const result = await storage.listFeedback({});
-      expect(result.feedback).toHaveLength(3);
-      expect(result.feedback[0]!.traceId).toBe('fb-ord-3');
-      expect(result.feedback[1]!.traceId).toBe('fb-ord-2');
-      expect(result.feedback[2]!.traceId).toBe('fb-ord-1');
-    });
-
-    it('listTraces defaults to startedAt DESC', async () => {
-      await storage.batchCreateSpans({
-        records: [
-          {
-            traceId: 'tr-ord-1',
-            spanId: 'root-1',
-            parentSpanId: null,
-            name: 'first',
-            spanType: SpanType.AGENT_RUN,
-            isEvent: false,
-            entityType: null,
-            entityId: null,
-            entityName: null,
-            userId: null,
-            organizationId: null,
-            resourceId: null,
-            runId: null,
-            sessionId: null,
-            threadId: null,
-            requestId: null,
-            environment: null,
-            source: null,
-            serviceName: null,
-            scope: null,
-            attributes: null,
-            metadata: null,
-            tags: null,
-            links: null,
-            input: null,
-            output: null,
-            error: null,
-            startedAt: new Date('2026-01-01T00:00:01Z'),
-            endedAt: new Date('2026-01-01T00:00:02Z'),
-          },
-          {
-            traceId: 'tr-ord-3',
-            spanId: 'root-3',
-            parentSpanId: null,
-            name: 'third',
-            spanType: SpanType.AGENT_RUN,
-            isEvent: false,
-            entityType: null,
-            entityId: null,
-            entityName: null,
-            userId: null,
-            organizationId: null,
-            resourceId: null,
-            runId: null,
-            sessionId: null,
-            threadId: null,
-            requestId: null,
-            environment: null,
-            source: null,
-            serviceName: null,
-            scope: null,
-            attributes: null,
-            metadata: null,
-            tags: null,
-            links: null,
-            input: null,
-            output: null,
-            error: null,
-            startedAt: new Date('2026-01-01T00:00:03Z'),
-            endedAt: new Date('2026-01-01T00:00:04Z'),
-          },
-          {
-            traceId: 'tr-ord-2',
-            spanId: 'root-2',
-            parentSpanId: null,
-            name: 'second',
-            spanType: SpanType.AGENT_RUN,
-            isEvent: false,
-            entityType: null,
-            entityId: null,
-            entityName: null,
-            userId: null,
-            organizationId: null,
-            resourceId: null,
-            runId: null,
-            sessionId: null,
-            threadId: null,
-            requestId: null,
-            environment: null,
-            source: null,
-            serviceName: null,
-            scope: null,
-            attributes: null,
-            metadata: null,
-            tags: null,
-            links: null,
-            input: null,
-            output: null,
-            error: null,
-            startedAt: new Date('2026-01-01T00:00:02Z'),
-            endedAt: new Date('2026-01-01T00:00:03Z'),
-          },
-        ],
-      });
-
-      const result = await storage.listTraces({});
-      expect(result.spans).toHaveLength(3);
-      expect(result.spans[0]!.traceId).toBe('tr-ord-3');
-      expect(result.spans[1]!.traceId).toBe('tr-ord-2');
-      expect(result.spans[2]!.traceId).toBe('tr-ord-1');
     });
   });
 

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
@@ -97,6 +97,7 @@ import {
   ALL_MIGRATIONS,
   DISCOVERY_MV_DDL,
   ALL_TABLE_NAMES,
+  DELTA_CURSOR_COUNTER_NAMES,
   DELTA_MV_NAMES,
   MV_DISCOVERY_VALUES,
   MV_DISCOVERY_PAIRS,
@@ -455,6 +456,26 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
         const pendingRetention = await filterAppliedRetention(this.#client, buildRetentionEntries(this.#retention));
         for (const entry of pendingRetention) {
           await this.#client.command({ query: entry.sql });
+        }
+      }
+
+      // Burn `cursorId = 0` for every delta stream on the `serial` strategy.
+      // `generateSerialID` is server-lifetime keyed and returns 0 on first
+      // call; `max(cursorId)` on an empty delta table also returns 0. Without
+      // this step the very first row inserted after a server cold-start lands
+      // at `cursorId = 0` and is skipped by callers that read with
+      // `WHERE cursorId > 0` after capturing a head cursor on the empty
+      // stream. Advancing each counter once at init guarantees real rows
+      // start at `cursorId >= 1`. Safe to repeat: the cost is one extra
+      // counter tick per signal per init, and the only observable effect is
+      // that the stream skips the value 0 (which carries no row).
+      if (this.#deltaCursorStrategy === 'serial') {
+        for (const counterName of DELTA_CURSOR_COUNTER_NAMES) {
+          await this.#client.query({
+            query: `SELECT generateSerialID({counterName:String}) AS cursorId`,
+            query_params: { counterName },
+            format: 'JSONEachRow',
+          });
         }
       }
     } catch (error) {

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -1665,22 +1665,6 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(result.metrics[0]!.labels).toEqual({ status: 'ok' });
     });
 
-    it('getMetricAggregate returns avg', async () => {
-      const result = await storage.getMetricAggregate({
-        name: ['mastra_agent_duration_ms'],
-        aggregation: 'avg',
-      });
-      expect(result.value).toBeCloseTo(266.67, 0);
-    });
-
-    it('getMetricAggregate returns count', async () => {
-      const result = await storage.getMetricAggregate({
-        name: ['mastra_agent_duration_ms'],
-        aggregation: 'count',
-      });
-      expect(result.value).toBe(3);
-    });
-
     it('getMetricBreakdown groups by entityName', async () => {
       const result = await storage.getMetricBreakdown({
         name: ['mastra_agent_duration_ms'],


### PR DESCRIPTION
## Summary

Wire the ClickHouse vNext observability adapter into the shared `createObservabilityVNextTests` factory so the same contract suite now exercises **InMemory, DuckDB, and ClickHouse vNext**. Extends the factory with a few easy ports lifted out of the bespoke suites, and adds a tiny test-only ClickHouse config that prevents the container from crashing on aarch64 hosts.

This is the follow-up to #16808.

## What changed

### Factory wiring
- New `flushPendingMerges` hook so adapters with eventual dedup (ClickHouse `ReplacingMergeTree`) can settle merges before retry-idempotency assertions.
- ClickHouse adapter passes both `refreshDiscovery` (SYSTEM REFRESH MATERIALIZED VIEW) and `flushPendingMerges` (OPTIMIZE TABLE … FINAL).

### Ported into the shared suite
- `default ORDER BY` block — 5 tests asserting `listLogs / listMetrics / listScores / listFeedback / listTraces` all default to timestamp DESC.
- `getMetricAggregate returns avg`
- `getMetricAggregate returns count`

Removed the equivalent bespoke tests from ClickHouse and DuckDB so we don't run the same assertions twice. The ClickHouse `gets a score by id` test also went because the factory's `getScoreById` test already covers it.

### Cross-adapter relaxations made while wiring ClickHouse
- Feedback batch test drops the `metadata: null` expectation — ClickHouse returns `undefined` for null inputs.
- Feedback OLAP non-numeric fixture uses numeric \`4\` instead of string \`'4'\` — ClickHouse does not coerce string values; the test is about non-numeric exclusion either way.
- Metric breakdown non-identifier label test no longer asserts a \`missing\` group — ClickHouse vNext intentionally excludes rows missing the label key. The adapter-specific assertions still live in InMemory/DuckDB bespoke suites where applicable.

### Test-only infra
- Adds `stores/clickhouse/docker/disable-jit.test.xml` and mounts it via the test `docker-compose.yaml`. Newer ClickHouse builds JIT-compile expressions like `toStartOfInterval(timestamp, toIntervalHour(1))` at query time; on aarch64 hosts (notably Apple Silicon under Docker for Mac) the generated code uses instructions that trigger SIGILL and kill the server mid-test. Disabling the JIT path keeps the test container stable everywhere. Production deployments are unaffected — the config is only mounted by the test compose file.

## Test plan

\`\`\`
pnpm --filter @internal/storage-test-utils test          # 554 tests pass
pnpm --filter @mastra/duckdb-store vitest run src/storage/domains/observability/index.test.ts  # 128 pass
pnpm --filter @mastra/clickhouse vitest run src/storage/domains/observability/v-next/index.test.ts  # 228 pass
pnpm --filter @mastra/core vitest run src/storage/domains/observability  # 155 pass
\`\`\`

| Suite | Tests |
|---|---|
| \`_test-utils\` (factory + other domain factories, run against InMemory) | 554 |
| ClickHouse vNext (factory + bespoke) | 228 |
| DuckDB (factory + bespoke) | 128 |
| Core observability | 155 |

No changeset — test-infra and test-content changes only; no shipped behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Makes the shared observability test suite run against ClickHouse vNext too, adds small adapter hooks and a retry/poll helper so tests are stable with ClickHouse's eventual visibility/dedup behavior, and disables ClickHouse JIT in test containers to avoid CI crashes on some hosts.

---

## Overview

Wires the ClickHouse vNext observability adapter into the shared createObservabilityVNextTests factory so the same contract suite runs against InMemory, DuckDB, and ClickHouse vNext. Moves common tests into the shared harness, removes duplicated bespoke tests, and adds test-only adapter hooks plus a wait/poll helper to accommodate ClickHouse eventual-consistency/dedup behavior. Adds a test-only ClickHouse config to disable JIT in test containers.

---

## Key Changes

- stores/_test-utils/src/domains/observability-vnext/index.ts
  - Adds optional adapter hooks to CreateObservabilityVNextTestsOptions:
    - refreshDiscovery?: (storage) => Promise<void> | void — invoked after discovery fixtures are written and before discovery assertions (for materialized-view-based discovery).
    - flushPendingMerges?: (storage) => Promise<void> | void — invoked in retry-idempotency tests so adapters with eventual dedup (e.g., ClickHouse ReplacingMergeTree) can settle.
  - createObservabilityVNextTests forwards both hooks and calls flushPendingMerges in retry/idempotency tests for logs, metrics, scores, and feedback.
  - Introduces a shared async polling helper waitFor(...) and uses it in the traces delta-polling test to avoid racey assertions.
  - Adds a default ORDER BY block asserting timestamp DESC defaults for listLogs/listMetrics/listScores/listFeedback/listTraces.
  - Expands getMetricAggregate coverage to include avg and count.
  - Adjusts OLAP/test fixtures and assertions:
    - Changes one feedback fixture from string '4' to numeric 4.
    - Conditionally calls refreshDiscovery before label-key/breakdown assertions where needed.
    - Relaxes the shared assertion around how missing label-key groups are represented (adapter-specific behavior allowed).

- stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
  - Refactors ClickHouse vNext tests to use the shared createObservabilityVNextTests harness with a shared ObservabilityStorageClickhouseVNext instance (per-test isolation via dangerouslyClearAll()).
  - Implements refreshDiscovery to run SYSTEM REFRESH/WAIT VIEW for discovery helper materialized views.
  - Implements flushPendingMerges to run OPTIMIZE TABLE ... FINAL on signal tables so deduplication is observable for assertions.
  - Removes tests now covered by the shared suite (getMetricAggregate avg/count and default ORDER BY block) and keeps adapter-specific assertions where necessary.

- stores/duckdb/src/storage/domains/observability/index.test.ts
  - Removes getMetricAggregate (avg/count) tests now covered by the shared suite; OLAP/assertion blocks adjusted accordingly.

- stores/clickhouse/docker-compose.yaml and stores/clickhouse/docker/disable-jit.test.xml
  - Adds a test-only ClickHouse config file (disable-jit.test.xml) and mounts it into the ClickHouse test container to disable runtime JIT for aggregates/sorts/scalars, preventing SIGILL crashes on aarch64 CI hosts. Production deployments unaffected.

- stores/clickhouse/eslint.config.js
  - Broadened Docker XML ignore pattern to docker/**/*.xml.

- stores/clickhouse/src/storage/domains/observability/v-next/ddl.ts & index.ts
  - Adds and exports DELTA_CURSOR_COUNTER_NAMES and updates ObservabilityStorageClickhouseVNext.init() to "burn" each serial counter once (generateSerialID) when using the serial delta-cursor strategy so initial generated cursor IDs start ≥ 1, avoiding post-restart cursorId = 0 collisions.

---

## Cross-Adapter Relaxations and Notes

- Feedback batch expectations: shared tests no longer assert metadata: null for missing metadata (ClickHouse may return undefined).
- OLAP fixture type: numeric 4 used where ClickHouse will not coerce string '4'.
- Metric breakdown with non-identifier label keys: shared suite does not require a specific representation for missing-key groups (ClickHouse excludes rows missing the label key).
- waitFor helper reduces flakes by polling for trace-delta visibility under CI load.

---

## Test Impact

- Consolidates and increases shared observability test coverage (avg/count aggregates, default ordering, retry-idempotency handling) across adapters.
- Adds adapter lifecycle hooks and a polling helper to stabilize tests against systems with eventual merge/dedup/visibility behavior.
- Adds a test-only ClickHouse config to improve stability on certain CI hosts.
- No production behavior changes; test infra and test content only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->