### PR TITLE
feat(core): expose agent thread run outputs

### DIFF
--- a/.changeset/calm-showers-build.md
+++ b/.changeset/calm-showers-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added thread run output lookup for signal-started agent runs.

--- a/packages/core/src/agent/__tests__/agent-thread-run-output.test.ts
+++ b/packages/core/src/agent/__tests__/agent-thread-run-output.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MastraModelOutput } from '../../stream/base/output';
+import { Agent } from '../agent';
+import type { AgentExecutionOptions } from '../agent.types';
+import { AgentThreadStreamRuntime } from '../thread-stream-runtime';
+
+function createOutput(runId: string): { output: MastraModelOutput; finish: () => void } {
+  let status: 'running' | 'finished' = 'running';
+  let resolveFinished!: () => void;
+  const finished = new Promise<void>(resolve => {
+    resolveFinished = resolve;
+  });
+
+  const output = {
+    runId,
+    get status() {
+      return status;
+    },
+    fullStream: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    _waitUntilFinished: async () => finished,
+    getFullOutput: async () => ({
+      text: 'ok',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      finishReason: 'stop',
+      object: undefined,
+      steps: [],
+      warnings: [],
+      providerMetadata: undefined,
+      request: {},
+      reasoning: [],
+      reasoningText: undefined,
+      toolCalls: [],
+      toolResults: [],
+      sources: [],
+      files: [],
+      response: { id: 'response-id', timestamp: new Date(0), modelId: 'mock-model', messages: [], uiMessages: [] },
+      totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      error: undefined,
+      tripwire: undefined,
+      traceId: undefined,
+      spanId: undefined,
+      runId,
+      suspendPayload: undefined,
+      messages: [],
+      rememberedMessages: [],
+    }),
+  } as unknown as MastraModelOutput;
+
+  return {
+    output,
+    finish: () => {
+      status = 'finished';
+      resolveFinished();
+    },
+  };
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    if (condition()) return;
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  expect(condition()).toBe(true);
+}
+
+class SignalRunAgent extends Agent<any, any, any> {
+  lastMessages: unknown;
+  lastOptions: AgentExecutionOptions | undefined;
+  streamError?: Error;
+
+  constructor() {
+    super({
+      id: 'signal-run-agent',
+      name: 'Signal Run Agent',
+      instructions: 'test',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+  }
+
+  async stream(messages: any, options?: any): Promise<any> {
+    this.lastMessages = messages;
+    this.lastOptions = options;
+    if (this.streamError) {
+      throw this.streamError;
+    }
+    const runId = options?.runId ?? 'missing-run-id';
+    const { output } = createOutput(runId);
+    this._internalRegisterStreamRun(output, options);
+    return output;
+  }
+}
+
+describe('agent thread run output lookup', () => {
+  it('resolves waiters when a run output is registered and clears the lookup after finish', async () => {
+    const agent = new SignalRunAgent();
+    const pending = agent.waitForRunOutput('run-1');
+    const { output, finish } = createOutput('run-1');
+
+    agent._internalRegisterStreamRun(output, {
+      memory: { thread: 'thread-1', resource: 'resource-1' },
+    } as AgentExecutionOptions);
+
+    await expect(pending).resolves.toBe(output);
+    expect(agent.getRunOutput('run-1')).toBe(output);
+
+    finish();
+    await waitFor(() => agent.getRunOutput('run-1') === undefined);
+  });
+
+  it('exposes the output for a signal-started idle run', async () => {
+    const agent = new SignalRunAgent();
+
+    const dispatched = agent.sendSignal(
+      { type: 'user-message', contents: 'hello' },
+      {
+        resourceId: 'resource-2',
+        threadId: 'thread-2',
+        ifIdle: {
+          streamOptions: {
+            memory: { thread: 'thread-2', resource: 'resource-2' },
+          },
+        },
+      },
+    );
+
+    const output = await agent.waitForRunOutput(dispatched.runId);
+
+    expect(output.runId).toBe(dispatched.runId);
+    expect(agent.getRunOutput(dispatched.runId)).toBe(output);
+    expect(agent.lastMessages).toMatchObject({
+      type: 'user-message',
+      contents: 'hello',
+    });
+    expect(agent.lastOptions).toMatchObject({
+      runId: dispatched.runId,
+      memory: { thread: 'thread-2', resource: 'resource-2' },
+    });
+  });
+
+  it('rejects waiters when a signal-started idle run fails before registering output', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    let rejectStream!: (error: Error) => void;
+    const stream = vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectStream = reject;
+        }),
+    );
+
+    const dispatched = runtime.sendSignal(
+      { id: 'failing-idle-agent', stream } as any,
+      { type: 'user-message', contents: 'hello' },
+      {
+        resourceId: 'resource-3',
+        threadId: 'thread-3',
+        ifIdle: {
+          streamOptions: {
+            memory: { thread: 'thread-3', resource: 'resource-3' },
+          },
+        },
+      },
+    );
+
+    const waiter = runtime.waitForRunOutput(dispatched.runId);
+    rejectStream(new Error('idle stream failed'));
+
+    await expect(waiter).rejects.toThrow('idle stream failed');
+    await expect(runtime.waitForRunOutput(dispatched.runId)).rejects.toThrow('idle stream failed');
+  });
+
+  it('allows waiters to be aborted without consuming later registration', async () => {
+    const agent = new SignalRunAgent();
+    const abortController = new AbortController();
+
+    const waiter = agent.waitForRunOutput('run-abortable', { abortSignal: abortController.signal });
+    abortController.abort(new Error('stop waiting'));
+
+    await expect(waiter).rejects.toThrow('stop waiting');
+
+    const { output } = createOutput('run-abortable');
+    agent._internalRegisterStreamRun(output, {
+      memory: { thread: 'thread-4', resource: 'resource-4' },
+    } as AgentExecutionOptions);
+
+    await expect(agent.waitForRunOutput('run-abortable')).resolves.toBe(output);
+  });
+
+  it('rejects waiters when a run is aborted before it is prepared', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const waiter = runtime.waitForRunOutput('unprepared-run');
+
+    expect(runtime.abortRun('unprepared-run')).toBe(false);
+
+    await expect(waiter).rejects.toThrow('has been aborted');
+    await expect(runtime.waitForRunOutput('unprepared-run')).rejects.toThrow('has been aborted');
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6247,6 +6247,42 @@ export class Agent<
   }
 
   /**
+   * @internal Test-only hook for duck-typed agents that override `stream()`
+   * without going through the normal execution loop. Production `stream()`
+   * registers its output through the same thread-stream runtime path.
+   */
+  _internalRegisterStreamRun<OUTPUT = TOutput>(
+    output: MastraModelOutput<OUTPUT>,
+    streamOptions: AgentExecutionOptions<OUTPUT>,
+  ): void {
+    agentThreadStreamRuntime.registerRun(this as Agent<any, any, any, any>, output, streamOptions, this.getPubSub());
+  }
+
+  /**
+   * Look up the output for a registered thread-stream run. Returns `undefined`
+   * after the run has finished and the runtime has cleaned it up.
+   */
+  getRunOutput<OUTPUT = TOutput>(runId: string): MastraModelOutput<OUTPUT> | undefined {
+    return agentThreadStreamRuntime.getRunOutput<OUTPUT>(runId, this.getPubSub());
+  }
+
+  /**
+   * Resolves when a thread-stream run registers its output, or immediately if
+   * it is already registered. Useful after `sendSignal()` returns a `runId`
+   * before the idle-wake stream has attached its output.
+   */
+  waitForRunOutput<OUTPUT = TOutput>(
+    runId: string,
+    options?: { abortSignal?: AbortSignal; signal?: AbortSignal },
+  ): Promise<MastraModelOutput<OUTPUT>> {
+    return agentThreadStreamRuntime.waitForRunOutput<OUTPUT>(
+      runId,
+      this.getPubSub(),
+      options?.abortSignal ?? options?.signal,
+    );
+  }
+
+  /**
    * @experimental Agent signals are experimental and may change in a future release.
    */
   sendSignal<OUTPUT = TOutput>(signal: AgentSignal, target: SendAgentSignalOptions<OUTPUT>): SendAgentSignalResult {

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -60,6 +60,11 @@ type AgentThreadRuntimeState = {
   activeThreadRunIds: Map<string, string>;
   pendingSignalsByThread: Map<string, CreatedAgentSignal[]>;
   pendingIdleSignalsByThread: Map<string, PendingIdleSignal<any>[]>;
+  pendingOutputWaiters: Map<
+    string,
+    Array<{ resolve: (out: MastraModelOutput<any>) => void; reject: (error: unknown) => void }>
+  >;
+  rejectedRunErrorsByRunId: Map<string, unknown>;
   watchedThreadRunIds: Set<string>;
   preparedRunsById: Map<string, PreparedThreadRun>;
   abortedRunIds: Set<string>;
@@ -81,6 +86,8 @@ function createRuntimeState(): AgentThreadRuntimeState {
     activeThreadRunIds: new Map(),
     pendingSignalsByThread: new Map(),
     pendingIdleSignalsByThread: new Map(),
+    pendingOutputWaiters: new Map(),
+    rejectedRunErrorsByRunId: new Map(),
     watchedThreadRunIds: new Set(),
     preparedRunsById: new Map(),
     abortedRunIds: new Set(),
@@ -225,6 +232,7 @@ export class AgentThreadStreamRuntime {
     const preparedRun = state.preparedRunsById.get(runId);
     if (!preparedRun) {
       state.abortedRunIds.add(runId);
+      this.#rejectRunOutputWaiters(state, runId, new Error(`Agent thread run id "${runId}" has been aborted`));
       return false;
     }
 
@@ -235,6 +243,7 @@ export class AgentThreadStreamRuntime {
     if (key) {
       this.#publish(pubsub, key, { type: 'run-aborted', runId });
     }
+    this.#rejectRunOutputWaiters(state, runId, new Error(`Agent thread run id "${runId}" has been aborted`));
 
     return true;
   }
@@ -245,6 +254,69 @@ export class AgentThreadStreamRuntime {
     const activeRunId = state.activeThreadRunIds.get(key);
     if (!activeRunId) return false;
     return this.abortRun(activeRunId, pubsub);
+  }
+
+  /**
+   * Returns the output for a registered thread run. The value is local to the
+   * runtime state backing this agent's PubSub and is removed when the run
+   * finishes.
+   */
+  getRunOutput<OUTPUT = unknown>(runId: string, pubsub?: PubSub): MastraModelOutput<OUTPUT> | undefined {
+    const state = this.#getState(pubsub);
+    const record = state.threadRunsById.get(runId);
+    return record?.output as MastraModelOutput<OUTPUT> | undefined;
+  }
+
+  /**
+   * Resolves when a thread run registers its output, or immediately if it is
+   * already registered. This pairs with `sendSignal()`, which returns a run id
+   * before the idle-wake stream necessarily has its output registered.
+   */
+  waitForRunOutput<OUTPUT = unknown>(
+    runId: string,
+    pubsub?: PubSub,
+    abortSignal?: AbortSignal,
+  ): Promise<MastraModelOutput<OUTPUT>> {
+    const state = this.#getState(pubsub);
+    const existing = state.threadRunsById.get(runId);
+    if (existing) return Promise.resolve(existing.output as MastraModelOutput<OUTPUT>);
+    if (abortSignal?.aborted) {
+      return Promise.reject(abortSignal.reason ?? new Error(`Agent thread run id "${runId}" wait was aborted`));
+    }
+    if (state.abortedRunIds.has(runId)) {
+      return Promise.reject(new Error(`Agent thread run id "${runId}" has been aborted`));
+    }
+    if (state.rejectedRunErrorsByRunId.has(runId)) {
+      return Promise.reject(state.rejectedRunErrorsByRunId.get(runId));
+    }
+    return new Promise<MastraModelOutput<OUTPUT>>((resolve, reject) => {
+      const waiters = state.pendingOutputWaiters.get(runId) ?? [];
+      let waiter: { resolve: (out: MastraModelOutput<any>) => void; reject: (error: unknown) => void };
+      const cleanup = () => abortSignal?.removeEventListener('abort', onAbort);
+      const onAbort = () => {
+        const currentWaiters = state.pendingOutputWaiters.get(runId);
+        const index = currentWaiters?.indexOf(waiter) ?? -1;
+        if (index !== -1) {
+          currentWaiters!.splice(index, 1);
+          if (currentWaiters!.length === 0) state.pendingOutputWaiters.delete(runId);
+        }
+        cleanup();
+        reject(abortSignal?.reason ?? new Error(`Agent thread run id "${runId}" wait was aborted`));
+      };
+      waiter = {
+        resolve: out => {
+          cleanup();
+          resolve(out);
+        },
+        reject: error => {
+          cleanup();
+          reject(error);
+        },
+      };
+      abortSignal?.addEventListener('abort', onAbort, { once: true });
+      waiters.push(waiter);
+      state.pendingOutputWaiters.set(runId, waiters);
+    });
   }
 
   /** @internal */
@@ -269,6 +341,8 @@ export class AgentThreadStreamRuntime {
     state.activeThreadRunIds.clear();
     state.pendingSignalsByThread.clear();
     state.pendingIdleSignalsByThread.clear();
+    state.pendingOutputWaiters.clear();
+    state.rejectedRunErrorsByRunId.clear();
     state.watchedThreadRunIds.clear();
     state.preparedRunsById.clear();
     state.abortedRunIds.clear();
@@ -278,6 +352,14 @@ export class AgentThreadStreamRuntime {
     state.preparedRunsById.get(runId)?.cleanup();
     state.preparedRunsById.delete(runId);
     state.abortedRunIds.delete(runId);
+  }
+
+  #rejectRunOutputWaiters(state: AgentThreadRuntimeState, runId: string, error: unknown) {
+    state.rejectedRunErrorsByRunId.set(runId, error);
+    const waiters = state.pendingOutputWaiters.get(runId);
+    if (!waiters) return;
+    state.pendingOutputWaiters.delete(runId);
+    for (const waiter of waiters) waiter.reject(error);
   }
 
   async #persistSignal(
@@ -318,6 +400,12 @@ export class AgentThreadStreamRuntime {
     state.threadRunsById.set(output.runId, record);
     state.threadKeysByRunId.set(output.runId, key);
     state.activeThreadRunIds.set(key, output.runId);
+    state.rejectedRunErrorsByRunId.delete(output.runId);
+    const waiters = state.pendingOutputWaiters.get(output.runId);
+    if (waiters) {
+      state.pendingOutputWaiters.delete(output.runId);
+      for (const waiter of waiters) waiter.resolve(outputForSubscribers);
+    }
     this.#publish(pubsub, key, { type: 'run-registered', runId: output.runId });
     this.#watchThreadRunCompletion(state, pubsub, key, record);
   }
@@ -412,9 +500,10 @@ export class AgentThreadStreamRuntime {
           this.#watchThreadRunCompletion(state, pubsub, key, nextRecord);
         }
       }
-    } catch {
+    } catch (err) {
       state.threadKeysByRunId.delete(pendingIdle.runId);
       this.#cleanupPreparedRun(state, pendingIdle.runId);
+      this.#rejectRunOutputWaiters(state, pendingIdle.runId, err);
       if (state.activeThreadRunIds.get(key) === pendingIdle.runId) {
         state.activeThreadRunIds.delete(key);
       }
@@ -808,9 +897,10 @@ export class AgentThreadStreamRuntime {
         runId,
         memory: withThreadMemory(target.ifIdle?.streamOptions?.memory, resourceId, threadId),
       })
-      .catch(() => {
+      .catch(err => {
         state.threadKeysByRunId.delete(runId);
         this.#cleanupPreparedRun(state, runId);
+        this.#rejectRunOutputWaiters(state, runId, err);
         if (state.activeThreadRunIds.get(key) === runId) {
           state.activeThreadRunIds.delete(key);
         }


### PR DESCRIPTION
## Description

Adds the Agent/thread-stream runtime prerequisite needed by the latest Harness v1 Session runtime. Signal-routed callers can now recover the `MastraModelOutput` for a run id returned by `Agent.sendSignal()` via `getRunOutput()` / `waitForRunOutput()`.

The waiter resolves when `registerRun()` attaches the output and rejects if the run is aborted or the idle wake stream fails before output registration. The Agent surface also gets an internal registration hook for test agents that override `stream()` without going through the normal execution loop.

Validation:
- `pnpm --filter ./packages/core test:unit src/agent/__tests__/agent-thread-run-output.test.ts src/agent/__tests__/agent-signals.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check <changed files>`
- `pnpm build:core`

## Related issue(s)

Fixes #16852

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
