### PR TITLE
fix(server): forward DELETE custom route bodies

### DIFF
--- a/.changeset/fix-delete-custom-route-body.md
+++ b/.changeset/fix-delete-custom-route-body.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fix DELETE custom routes forwarding JSON request bodies.

--- a/packages/server/src/server/server-adapter/index.test.ts
+++ b/packages/server/src/server/server-adapter/index.test.ts
@@ -14,6 +14,19 @@ class TestMastraServer extends MastraServer<any, any, any> {
   registerContextMiddleware = vi.fn();
   registerAuthMiddleware = vi.fn();
   registerHttpLoggingMiddleware = vi.fn();
+
+  buildCustomRouteHandlerForTest() {
+    return this.buildCustomRouteHandler();
+  }
+
+  handleCustomRouteRequestForTest(
+    url: string,
+    method: string,
+    headers: Record<string, string | string[] | undefined>,
+    body: unknown,
+  ) {
+    return this.handleCustomRouteRequest(url, method, headers, body);
+  }
 }
 
 function createMockFGAProvider(authorized = true): IFGAProvider {
@@ -23,6 +36,45 @@ function createMockFGAProvider(authorized = true): IFGAProvider {
     filterAccessible: vi.fn(),
   };
 }
+
+describe('custom route forwarding', () => {
+  it('should forward DELETE JSON bodies to custom routes', async () => {
+    const mastra = new Mastra({
+      logger: false,
+      server: {
+        apiRoutes: [
+          {
+            path: '/items/:id',
+            method: 'DELETE',
+            handler: async c => {
+              const body = await c.req.json();
+              const { id } = c.req.param();
+
+              return c.json({ deleted: id, reason: body.reason });
+            },
+          },
+        ],
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    await expect(adapter.buildCustomRouteHandlerForTest()).resolves.toBe(true);
+
+    const response = await adapter.handleCustomRouteRequestForTest(
+      'http://localhost/items/123',
+      'DELETE',
+      { 'content-type': 'application/json' },
+      { reason: 'no longer needed' },
+    );
+
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(200);
+    await expect(response!.json()).resolves.toEqual({
+      deleted: '123',
+      reason: 'no longer needed',
+    });
+  });
+});
 
 describe('FGA Middleware - checkRouteFGA', () => {
   let checkRouteFGA: (

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -791,7 +791,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     }
 
     const init: RequestInit = { method, headers: fetchHeaders };
-    if (['POST', 'PUT', 'PATCH'].includes(method) && body !== undefined) {
+    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method) && body !== undefined) {
       if (body instanceof ArrayBuffer || body instanceof Uint8Array || body instanceof ReadableStream) {
         init.body = body as any;
         if (body instanceof ReadableStream) {


### PR DESCRIPTION
Fixes #16855.

DELETE custom routes now receive JSON request bodies like POST/PUT/PATCH handlers do.

Checks:
- pnpm --filter @mastra/server test src/server/server-adapter/index.test.ts
- pnpm exec prettier --check .changeset/fix-delete-custom-route-body.md packages/server/src/server/server-adapter/index.ts packages/server/src/server/server-adapter/index.test.ts
- pnpm --filter @mastra/server exec eslint src/server/server-adapter/index.ts src/server/server-adapter/index.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a bug where DELETE requests sent to custom API routes were losing their data. Imagine you're trying to delete something and need to send information along with it—previously that information was getting thrown away. The fix simply makes DELETE requests work the same way as POST, PUT, and PATCH requests by passing the data along correctly.

## Overview

Fixes issue `#16855` by restoring DELETE request body forwarding for custom routes in the ServerAdapter. DELETE requests with JSON bodies registered via `registerApiRoute()` were having their request bodies dropped, causing handlers to receive empty bodies. This regression was introduced in v1.29.0 when custom route handling was centralized into `ServerAdapter.handleCustomRouteRequest()`.

## Changes

### `packages/server/src/server/server-adapter/index.ts`
Modified the `handleCustomRouteRequest` method to include `DELETE` in the list of HTTP methods that support request body forwarding. Previously, only `POST`, `PUT`, and `PATCH` had their bodies forwarded; now `DELETE` is treated consistently with these methods.

### `packages/server/src/server/server-adapter/index.test.ts`
Added a new test suite ("custom route forwarding") that verifies DELETE requests with JSON bodies are properly forwarded to configured custom routes. The test confirms that custom handlers can successfully parse request bodies using `c.req.json()` and return expected JSON responses.

### `.changeset/fix-delete-custom-route-body.md`
Added a Changesets entry documenting the patch-level fix for `@mastra/server`.

## Impact

- Restores DELETE request body handling for custom routes, making it consistent with POST/PUT/PATCH behavior
- Affects `@mastra/server` (≥1.29.0) and dependent adapters (`@mastra/hono`, Express, Fastify, Koa server adapters)
- Low-risk change: single method condition update with test coverage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->