### PR TITLE
fix(mcp): restore OAuth client credentials on token requests

### DIFF
--- a/.changeset/upset-jobs-vanish.md
+++ b/.changeset/upset-jobs-vanish.md
@@ -2,4 +2,4 @@
 '@mastra/mcp': patch
 ---
 
-Fixed OAuth token requests silently dropping client_id and client_secret when using MCPOAuthClientProvider. Confidential-client flows now correctly send credentials to the token endpoint. See https://github.com/mastra-ai/mastra/issues/16854
+Fixed OAuth authentication failing for confidential clients. Client credentials are now correctly included in token requests. See https://github.com/mastra-ai/mastra/issues/16854

--- a/.changeset/upset-jobs-vanish.md
+++ b/.changeset/upset-jobs-vanish.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed OAuth token requests silently dropping client_id and client_secret when using MCPOAuthClientProvider. Confidential-client flows now correctly send credentials to the token endpoint. See https://github.com/mastra-ai/mastra/issues/16854

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,7 +26,7 @@
     "build:lib": "tsup --silent --config tsup.config.ts",
     "prepack": "pnpx tsx ../../scripts/generate-package-docs.ts",
     "build:watch": "pnpm build:lib --watch",
-    "test:client": "vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts",
+    "test:client": "vitest run ./src/client/client.test.ts ./src/client/configuration.test.ts ./src/client/oauth-provider.test.ts",
     "test:server": "vitest run ./src/server/server.test.ts",
     "test:integration": "cd integration-tests && pnpm test:mcp",
     "test": "pnpm test:server && pnpm test:client && pnpm test:integration",

--- a/packages/mcp/src/client/oauth-provider.test.ts
+++ b/packages/mcp/src/client/oauth-provider.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for MCPOAuthClientProvider
+ *
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import type { OAuthClientProvider } from '../shared/oauth-types.js';
+import { exchangeAuthorization, refreshAuthorization } from '../shared/oauth-types.js';
+import { MCPOAuthClientProvider } from './oauth-provider.js';
+
+const BASE_METADATA = {
+  issuer: 'https://auth.example.com',
+  authorization_endpoint: 'https://auth.example.com/authorize',
+  token_endpoint: 'https://auth.example.com/token',
+  response_types_supported: ['code'] as string[],
+};
+
+function makeProvider(opts?: { clientInformation?: { client_id: string; client_secret: string } }) {
+  return new MCPOAuthClientProvider({
+    redirectUrl: 'http://localhost:3000/callback',
+    clientMetadata: {
+      redirect_uris: ['http://localhost:3000/callback'],
+      client_name: 'Test Client',
+    },
+    clientInformation: opts?.clientInformation,
+  });
+}
+
+function makeTokenMock() {
+  const captured: { url: string; headers: Record<string, string>; body: string }[] = [];
+  const fetchFn = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    captured.push({
+      url: url.toString(),
+      headers: Object.fromEntries(new Headers(init?.headers as HeadersInit).entries()),
+      body: init?.body?.toString() ?? '',
+    });
+    return new Response(
+      JSON.stringify({ access_token: 'new-token', token_type: 'Bearer', expires_in: 3600, refresh_token: 'rt' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  });
+  return { fetchFn, captured };
+}
+
+function getAddClientAuthentication(provider: MCPOAuthClientProvider) {
+  return (provider as OAuthClientProvider).addClientAuthentication;
+}
+
+describe('MCPOAuthClientProvider.addClientAuthentication', () => {
+  it('is undefined so the SDK default credential path runs (issue #16854)', () => {
+    const provider = makeProvider();
+    expect(getAddClientAuthentication(provider)).toBeUndefined();
+  });
+
+  it('attaches client_id and client_secret via client_secret_post on token exchange', async () => {
+    const { fetchFn, captured } = makeTokenMock();
+
+    const provider = makeProvider({ clientInformation: { client_id: 'cid', client_secret: 'csec' } });
+
+    await exchangeAuthorization('https://auth.example.com', {
+      metadata: {
+        ...BASE_METADATA,
+        token_endpoint_auth_methods_supported: ['client_secret_post'],
+      },
+      clientInformation: { client_id: 'cid', client_secret: 'csec' },
+      authorizationCode: 'code-123',
+      codeVerifier: 'verifier-abc',
+      redirectUri: 'http://localhost:3000/callback',
+      addClientAuthentication: getAddClientAuthentication(provider),
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+
+    expect(captured).toHaveLength(1);
+    const body = new URLSearchParams(captured[0]!.body);
+    expect(body.get('client_id')).toBe('cid');
+    expect(body.get('client_secret')).toBe('csec');
+  });
+
+  it('attaches credentials via Authorization: Basic on client_secret_basic token exchange', async () => {
+    const { fetchFn, captured } = makeTokenMock();
+
+    const provider = makeProvider({ clientInformation: { client_id: 'cid', client_secret: 'csec' } });
+
+    await exchangeAuthorization('https://auth.example.com', {
+      metadata: {
+        ...BASE_METADATA,
+        token_endpoint_auth_methods_supported: ['client_secret_basic'],
+      },
+      clientInformation: { client_id: 'cid', client_secret: 'csec' },
+      authorizationCode: 'code-456',
+      codeVerifier: 'verifier-def',
+      redirectUri: 'http://localhost:3000/callback',
+      addClientAuthentication: getAddClientAuthentication(provider),
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.headers['authorization']).toMatch(/^Basic /);
+    // body should NOT contain client_secret for Basic auth
+    const body = new URLSearchParams(captured[0]!.body);
+    expect(body.get('client_secret')).toBeNull();
+  });
+
+  it('attaches credentials on token refresh', async () => {
+    const { fetchFn, captured } = makeTokenMock();
+
+    const provider = makeProvider({ clientInformation: { client_id: 'cid', client_secret: 'csec' } });
+
+    await refreshAuthorization('https://auth.example.com', {
+      metadata: {
+        ...BASE_METADATA,
+        token_endpoint_auth_methods_supported: ['client_secret_post'],
+      },
+      clientInformation: { client_id: 'cid', client_secret: 'csec' },
+      refreshToken: 'old-refresh-token',
+      addClientAuthentication: getAddClientAuthentication(provider),
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+
+    expect(captured).toHaveLength(1);
+    const body = new URLSearchParams(captured[0]!.body);
+    expect(body.get('client_id')).toBe('cid');
+    expect(body.get('client_secret')).toBe('csec');
+    expect(body.get('grant_type')).toBe('refresh_token');
+  });
+});

--- a/packages/mcp/src/client/oauth-provider.ts
+++ b/packages/mcp/src/client/oauth-provider.ts
@@ -13,7 +13,6 @@ import type {
   OAuthClientInformation,
   OAuthClientInformationFull,
   OAuthTokens,
-  AuthorizationServerMetadata,
 } from '../shared/oauth-types.js';
 
 /**
@@ -277,24 +276,9 @@ export class MCPOAuthClientProvider implements OAuthClientProvider {
   }
 
   /**
-   * Optional: Custom client authentication for token requests.
-   * Uses default behavior if not implemented.
-   */
-  async addClientAuthentication?(
-    _headers: Headers,
-    _params: URLSearchParams,
-    _url: string | URL,
-    _metadata?: AuthorizationServerMetadata,
-  ): Promise<void> {
-    // Use default MCP SDK behavior
-  }
-
-  /**
    * Invalidate credentials when server indicates they're no longer valid.
    */
-  async invalidateCredentials(
-    scope: 'all' | 'client' | 'tokens' | 'verifier',
-  ): Promise<void> {
+  async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier'): Promise<void> {
     switch (scope) {
       case 'all':
         await this.storage.delete('tokens');


### PR DESCRIPTION
## Summary

- Removes the empty `addClientAuthentication` stub from `MCPOAuthClientProvider` that was overriding the MCP SDK default and silently dropping `client_id`/`client_secret` from token requests
- Adds client-only regression tests covering token exchange (`client_secret_post`, `client_secret_basic`) and token refresh
- Wires `oauth-provider.test.ts` into `test:client` so OAuth credential attachment is enforced in CI

Fixes #16854

## Test plan

- [x] `pnpm --filter ./packages/mcp exec vitest run ./src/client/oauth-provider.test.ts` — 4/4 pass
- [x] Before/after validation: fixed provider sends credentials; simulated empty stub does not
- [ ] CI `test:client`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

A no-op helper was accidentally blocking the normal process that adds login credentials to OAuth token requests; this PR removes that helper so confidential clients' credentials are correctly attached again.

---

## What Changed

- Removed the optional addClientAuthentication hook from MCPOAuthClientProvider in packages/mcp/src/client/oauth-provider.ts so the MCP SDK's default client-authentication logic runs.
- Added tests in packages/mcp/src/client/oauth-provider.test.ts covering:
  - provider.addClientAuthentication is undefined (SDK default path used),
  - client_secret_post attaches client_id and client_secret for token exchange and refresh,
  - client_secret_basic sends Authorization: Basic and omits client_secret in the body.
- Wired the new test into packages/mcp/package.json test:client script.
- Added a patch changeset (.changeset/upset-jobs-vanish.md) documenting the fix and referencing issue `#16854`.

## Rationale

Presence of an empty addClientAuthentication method caused the SDK to call the stub instead of using its RFC 6749 §2.3.1 implementations (client_secret_basic, client_secret_post, none), resulting in token requests from confidential clients omitting client_id/client_secret and causing token endpoint errors. Removing the stub restores the SDK's standard behavior.

## Testing & Verification

- Local vitest run of ./src/client/oauth-provider.test.ts passes (4/4).
- Tests validate token exchange and refresh behavior for client_secret_post and client_secret_basic, and confirm the provider no longer supplies a custom addClientAuthentication.
- The test file is executed as part of the package's test:client CI job to prevent regressions.

## Changeset

Patch-level changelog entry: "Fixed OAuth authentication failing for confidential clients. Client credentials are now correctly included in token requests." (references issue `#16854`)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->