### PR TITLE
fix(core): remove hardcoded /api/ prefix check from registerApiRoute()

### DIFF
--- a/.changeset/remove-hardcoded-api-prefix-check.md
+++ b/.changeset/remove-hardcoded-api-prefix-check.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Remove hardcoded `/api/` prefix check from `registerApiRoute()`. The check incorrectly rejected custom routes starting with `/api/` even when users configured a different `apiPrefix`. Reserved-path validation is already handled at the server adapter level using the actual configured prefix.

--- a/docs/src/content/en/reference/server/register-api-route.mdx
+++ b/docs/src/content/en/reference/server/register-api-route.mdx
@@ -27,7 +27,7 @@ The URL path for the route. Supports path parameters using `:param` syntax.
 registerApiRoute("/items/:itemId", { ... })
 ```
 
-**Note:** Paths can't start with `/api/` as this prefix is reserved for Mastra server routes.
+**Note:** Custom route paths can't start with the server's configured `apiPrefix` (default: `/api`), as that prefix is reserved for built-in Mastra routes. If you set a custom `apiPrefix`, only that prefix is reserved — for example, with `apiPrefix: '/mastra/api'`, paths like `/api/my-endpoint` are allowed.
 
 ### options
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -29,9 +29,6 @@ type ParamsFromPath<P extends string> = {
   [K in P extends `${string}:${infer Param}/${string}` | `${string}:${infer Param}` ? Param : never]: string;
 };
 
-type RegisterApiRoutePathError = `Param 'path' must not start with '/api', it is reserved for internal API routes.`;
-type ValidatePath<P extends string, T> = P extends `/api/${string}` ? RegisterApiRoutePathError : T;
-
 /**
  * Variables available in the Hono context for custom API route handlers.
  * These are set by the server middleware and available via c.get().
@@ -79,13 +76,8 @@ type RegisterApiRouteOptions<P extends string> = {
   fga?: ApiRoute['fga'];
 };
 
-function validateOptions<P extends string>(
-  path: P,
-  options: RegisterApiRoutePathError | RegisterApiRouteOptions<P>,
-): asserts options is RegisterApiRouteOptions<P> {
-  const opts = options as RegisterApiRouteOptions<P>;
-
-  if (opts.method === undefined) {
+function validateOptions<P extends string>(path: P, options: RegisterApiRouteOptions<P>): void {
+  if (options.method === undefined) {
     throw new MastraError({
       id: 'MASTRA_SERVER_API_INVALID_ROUTE_OPTIONS',
       text: `Invalid options for route "${path}", missing "method" property`,
@@ -94,7 +86,7 @@ function validateOptions<P extends string>(
     });
   }
 
-  if (opts.handler === undefined && opts.createHandler === undefined) {
+  if (options.handler === undefined && options.createHandler === undefined) {
     throw new MastraError({
       id: 'MASTRA_SERVER_API_INVALID_ROUTE_OPTIONS',
       text: `Invalid options for route "${path}", you must define a "handler" or "createHandler" property`,
@@ -103,7 +95,7 @@ function validateOptions<P extends string>(
     });
   }
 
-  if (opts.handler !== undefined && opts.createHandler !== undefined) {
+  if (options.handler !== undefined && options.createHandler !== undefined) {
     throw new MastraError({
       id: 'MASTRA_SERVER_API_INVALID_ROUTE_OPTIONS',
       text: `Invalid options for route "${path}", you can only define one of the following properties: "handler" or "createHandler"`,
@@ -113,19 +105,7 @@ function validateOptions<P extends string>(
   }
 }
 
-export function registerApiRoute<P extends string>(
-  path: P,
-  options: ValidatePath<P, RegisterApiRouteOptions<P>>,
-): ValidatePath<P, ApiRoute> {
-  if (path.startsWith('/api/')) {
-    throw new MastraError({
-      id: 'MASTRA_SERVER_API_PATH_RESERVED',
-      text: 'Path must not start with "/api", it\'s reserved for internal API routes',
-      domain: ErrorDomain.MASTRA_SERVER,
-      category: ErrorCategory.USER,
-    });
-  }
-
+export function registerApiRoute<P extends string>(path: P, options: RegisterApiRouteOptions<P>): ApiRoute {
   validateOptions(path, options);
 
   return {
@@ -139,7 +119,7 @@ export function registerApiRoute<P extends string>(
     requiresAuth: options.requiresAuth,
     requiresPermission: options.requiresPermission,
     fga: options.fga,
-  } as unknown as ValidatePath<P, ApiRoute>;
+  } as ApiRoute;
 }
 
 export function defineAuth<TUser>(config: MastraAuthConfig<TUser>): MastraAuthConfig<TUser> {

--- a/packages/core/src/server/server.test.ts
+++ b/packages/core/src/server/server.test.ts
@@ -12,14 +12,10 @@ describe('registerApiRoute', () => {
       handler: mockHandler,
     });
 
-    expect(route).toEqual({
+    expect(route).toMatchObject({
       path: '/test',
       method,
       handler: mockHandler,
-      createHandler: undefined,
-      openapi: undefined,
-      middleware: undefined,
-      requiresAuth: undefined,
     });
 
     route = registerApiRoute('/test', {
@@ -27,14 +23,10 @@ describe('registerApiRoute', () => {
       createHandler: mockCreateHandler,
     });
 
-    expect(route).toEqual({
+    expect(route).toMatchObject({
       path: '/test',
       method,
       createHandler: mockCreateHandler,
-      handler: undefined,
-      openapi: undefined,
-      middleware: undefined,
-      requiresAuth: undefined,
     });
   });
 
@@ -48,13 +40,17 @@ describe('registerApiRoute', () => {
     expect(route.requiresAuth).toBe(false);
   });
 
-  it('should throw if path starts with /api', () => {
-    expect(() => {
-      registerApiRoute('/api/test', {
-        method: 'GET',
-        handler: mockHandler,
-      } as any);
-    }).toThrow(/Path must not start with "\/api", it's reserved for internal API routes/);
+  it('should allow paths starting with /api when custom apiPrefix is used', () => {
+    const route = registerApiRoute('/api/test', {
+      method: 'GET',
+      handler: mockHandler,
+    });
+
+    expect(route).toMatchObject({
+      path: '/api/test',
+      method: 'GET',
+      handler: mockHandler,
+    });
   });
 
   it('should throw if method is missing', () => {

--- a/packages/server/src/server/server-adapter/index.test.ts
+++ b/packages/server/src/server/server-adapter/index.test.ts
@@ -27,6 +27,10 @@ class TestMastraServer extends MastraServer<any, any, any> {
   ) {
     return this.handleCustomRouteRequest(url, method, headers, body);
   }
+
+  validateCustomRoutePathsForTest(routes: Parameters<typeof this.validateCustomRoutePaths>[0]) {
+    return this.validateCustomRoutePaths(routes);
+  }
 }
 
 function createMockFGAProvider(authorized = true): IFGAProvider {
@@ -648,5 +652,74 @@ describe('FGA policy coverage validation', () => {
     const adapter = new TestMastraServer({ app: {}, mastra });
 
     await expect(adapter.validateFGAPolicyCoverage()).rejects.toThrow('protected routes are missing FGA metadata');
+  });
+});
+
+describe('validateCustomRoutePaths', () => {
+  const mockHandler = vi.fn();
+
+  it('should throw when a custom route collides with the default /api prefix', () => {
+    const mastra = new Mastra({ logger: false });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    expect(() =>
+      adapter.validateCustomRoutePathsForTest([{ path: '/api/foo', method: 'GET', handler: mockHandler }]),
+    ).toThrow(/must not start with "\/api"/);
+  });
+
+  it('should throw when a custom route exactly matches the prefix', () => {
+    const mastra = new Mastra({ logger: false });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    expect(() =>
+      adapter.validateCustomRoutePathsForTest([{ path: '/api', method: 'GET', handler: mockHandler }]),
+    ).toThrow(/must not start with "\/api"/);
+  });
+
+  it('should allow routes outside the default /api prefix', () => {
+    const mastra = new Mastra({ logger: false });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    expect(() =>
+      adapter.validateCustomRoutePathsForTest([{ path: '/webhooks/stripe', method: 'POST', handler: mockHandler }]),
+    ).not.toThrow();
+  });
+
+  it('should allow /api/ routes when a custom prefix is configured', () => {
+    const mastra = new Mastra({ logger: false });
+    const adapter = new TestMastraServer({ app: {}, mastra, prefix: '/mastra/api' });
+
+    expect(() =>
+      adapter.validateCustomRoutePathsForTest([{ path: '/api/my-endpoint', method: 'GET', handler: mockHandler }]),
+    ).not.toThrow();
+  });
+
+  it('should throw when a custom route collides with a custom prefix', () => {
+    const mastra = new Mastra({ logger: false });
+    const adapter = new TestMastraServer({ app: {}, mastra, prefix: '/mastra/api' });
+
+    expect(() =>
+      adapter.validateCustomRoutePathsForTest([{ path: '/mastra/api/agents', method: 'GET', handler: mockHandler }]),
+    ).toThrow(/must not start with "\/mastra\/api"/);
+  });
+
+  it('should skip internal routes marked with _mastraInternal', () => {
+    const mastra = new Mastra({ logger: false });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    expect(() =>
+      adapter.validateCustomRoutePathsForTest([
+        { path: '/api/agents', method: 'GET', handler: mockHandler, _mastraInternal: true },
+      ]),
+    ).not.toThrow();
+  });
+
+  it('should not throw when prefix is empty', () => {
+    const mastra = new Mastra({ logger: false });
+    const adapter = new TestMastraServer({ app: {}, mastra, prefix: '' });
+
+    expect(() =>
+      adapter.validateCustomRoutePathsForTest([{ path: '/api/anything', method: 'GET', handler: mockHandler }]),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Removes the compile-time `ValidatePath` type and runtime `/api/` prefix check from `registerApiRoute()`. These hardcoded `/api/` as reserved, which is incorrect when users configure a custom `apiPrefix` (e.g. `/mastra/api`).

The actual reserved-path validation already exists at the server adapter level via `MastraServer.validateCustomRoutePaths()`, which checks routes against the **real configured prefix** at registration time.

## What Changed

- **Removed** `ValidatePath<P, T>` and `RegisterApiRoutePathError` types from `packages/core/src/server/index.ts`
- **Removed** runtime `if (path.startsWith('/api/'))` throw from `registerApiRoute()`
- **Cleaned up** `validateOptions()` — removed unnecessary type assertion and cast
- **Updated** test — replaced "should throw if path starts with /api" with "should allow paths starting with /api when custom apiPrefix is used"
- **Added** changeset

## Why

`registerApiRoute('/api/my-endpoint', ...)` would fail with both a compile-time type error and a runtime throw, even when the user's Mastra instance used a custom `apiPrefix` like `/mastra/api`. The real protection against route collisions already lives in `MastraServer.validateCustomRoutePaths()` (line 690 of server-adapter/index.ts), which uses the actual configured prefix.

## Test Plan

- `pnpm --filter ./packages/core run test -- --run src/server/server.test.ts` — 11 tests pass
- Routes starting with `/api/` are now accepted by `registerApiRoute()`
- Reserved-path enforcement still works at server boot via `validateCustomRoutePaths()`

Closes #14484
Supersedes #14499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR stops the helper registerApiRoute() from hard-blocking paths that start with "/api/". Instead, reserved-path checks are left to the server startup logic which uses whatever API prefix you configured.

## Changes

- packages/core/src/server/index.ts
  - Removed the compile-time ValidatePath type and RegisterApiRoutePathError.
  - Removed the runtime check that threw for paths starting with "/api/".
  - Simplified registerApiRoute() signature to accept RegisterApiRouteOptions<P> and return ApiRoute (no hardcoded path gating).
  - Simplified validateOptions() by removing an unnecessary type assertion and keeping validation of required fields (method, and either handler or createHandler).

- packages/core/src/server/server.test.ts
  - Updated tests to assert relevant route properties via toMatchObject (path, method, handler/createHandler).
  - Replaced the test that expected an error for "/api/..." with one that verifies such paths are allowed when using a custom apiPrefix.

- packages/server/src/server/server-adapter/index.test.ts
  - Added a test-only wrapper validateCustomRoutePathsForTest and new tests verifying validateCustomRoutePaths behavior (default prefix collisions, custom prefix handling, acceptance of non-reserved routes, _mastraInternal bypass, and empty prefix behavior).

- .changeset/remove-hardcoded-api-prefix-check.md
  - Added a changeset documenting the removal of the hardcoded `/api` prefix check and noting that reserved-path validation is handled by the server using the configured apiPrefix.

## Motivation

registerApiRoute previously enforced a static "/api/" reservation at both type and runtime levels, causing TypeScript errors and runtime throws when a custom apiPrefix (e.g., "/mastra/api") was used. The server already enforces reserved prefixes at bootstrap via MastraServer.validateCustomRoutePaths(); this PR removes the redundant, hardcoded checks from the helper.

## Impact

- registerApiRoute() now accepts paths starting with "/api/" (and other prefixes) without error.
- Reserved-path enforcement remains centralized in server bootstrap via validateCustomRoutePaths() using the configured apiPrefix.
- Fixes the behavior described in issue `#14484` and supersedes `#14499`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->