### PR TITLE
docs(memory): add multi-user threads page

### DIFF
--- a/docs/src/content/en/docs/memory/multi-user-threads.mdx
+++ b/docs/src/content/en/docs/memory/multi-user-threads.mdx
@@ -1,0 +1,208 @@
+---
+title: "Multi-user threads | Memory"
+description: "Share one Mastra thread between multiple users by carrying speaker identity in the message body."
+packages:
+  - "@mastra/core"
+  - "@mastra/libsql"
+  - "@mastra/memory"
+---
+
+# Multi-user threads
+
+A single Mastra thread can be shared by multiple users, each with their own name and functional role. You carry speaker identity in the message body so the agent can tell users apart while reading from a single shared thread.
+
+## When to use multi-user threads
+
+Use multi-user threads when several people collaborate on the same subject through one agent:
+
+- Collaborative documents with editors, reviewers, and approvers
+- Group chats where one assistant serves many participants
+- Multi-stakeholder reviews where different roles have different authority
+
+## Share one `resourceId` across all participants
+
+A thread belongs to exactly one `resourceId`, so all participants on a shared thread need to pass the same value. Instead of using a user id (the default for single-user apps), key `resourceId` on the conversation itself — for example `doc_${docId}` for a shared document, or `room_${roomId}` for a group chat. With everyone pointing at the same `resourceId`, they read and write the same history.
+
+## Tag each user message with the speaker's identity
+
+The model needs to know who's talking on every turn. Since the message body is the one place that survives into history and back into context, wrap each user message in a small `<turn>` tag with the speaker's id, name, and role. The tag stays attached to the message, so when prior turns are recalled the model still sees who said what.
+
+Build the tag with a small helper. The example below is one way to do it — copy it into your project and adapt it to your shape of user data:
+
+```typescript title="src/mastra/identity.ts"
+export type Speaker = {
+  id: string
+  name: string
+  role: string
+}
+
+export function asUserTurn(speaker: Speaker, text: string) {
+  return {
+    role: 'user' as const,
+    content: `<turn author_id="${speaker.id}" author_name="${speaker.name}" functional_role="${speaker.role}">
+${text}
+</turn>`,
+  }
+}
+```
+
+Teach the agent how to read the `<turn>` tag in its instructions. The agent must have `memory` configured so it can be called with a `thread` and `resource`:
+
+```typescript title="src/mastra/agents/collab.ts"
+import { Agent } from '@mastra/core/agent'
+import { Memory } from '@mastra/memory'
+import { LibSQLStore } from '@mastra/libsql'
+
+const memory = new Memory({
+  storage: new LibSQLStore({ url: 'file:./collab.db' }),
+  options: {
+    lastMessages: 20,
+  },
+})
+
+export const collabAgent = new Agent({
+  id: 'collab',
+  name: 'CollabAgent',
+  model: 'openai/gpt-5.4-mini',
+  memory,
+  instructions: `
+You are a collaborative document assistant. Multiple users talk to you in the SAME thread.
+
+Every user message is wrapped in a <turn> tag carrying the user's identity:
+
+  <turn author_id="u_alice" author_name="Alice" functional_role="editor">
+  ...message text...
+  </turn>
+
+Rules:
+1. Address users by their author_name.
+2. Respect functional_role: editors propose changes, reviewers approve.
+3. When attributing past statements, read author_name from the surrounding <turn> tag.
+4. Do not echo the <turn> tags back at users.
+  `.trim(),
+})
+```
+
+Call the agent with the wrapped message. Every participant shares the same `thread` and `resource`:
+
+```typescript title="src/mastra/call.ts"
+import { asUserTurn } from './identity'
+
+const docResourceId = 'doc_42'
+const docThreadId = 'doc_42'
+
+const alice = { id: 'u_alice', name: 'Alice', role: 'editor' }
+const bob = { id: 'u_bob', name: 'Bob', role: 'reviewer' }
+
+await collabAgent.generate([asUserTurn(alice, 'My favorite color is teal.')], {
+  memory: { thread: docThreadId, resource: docResourceId },
+})
+
+await collabAgent.generate([asUserTurn(bob, 'I want QA sign-off before publish.')], {
+  memory: { thread: docThreadId, resource: docResourceId },
+})
+```
+
+The `<turn>` tag persists in the message body, so when history is recalled on later turns the model still sees who said what.
+
+## Combining with memory layers
+
+The user-tagging pattern composes with every memory layer. Pick the layer based on how long the conversation needs to remember per-user facts:
+
+- **Short conversations** (a single session, or a thread small enough to fit in `lastMessages`), or when you need a verbatim record of who said what: use [message history alone](#message-history-alone). The user tags in history are enough; no extra memory layer needed.
+- **Long-running threads** (conversations that outgrow `lastMessages`, where you need per-user facts to survive history eviction): use [observational memory](#with-observational-memory-recommended).
+- **Need a structured participants list, or your storage adapter doesn't support OM** (OM requires LibSQL, PG, or MongoDB): use [working memory](#with-working-memory).
+
+We recommend using observational memory or working memory, not both — they cover overlapping needs, and running both at once adds latency and token cost without much benefit.
+
+### Message history alone
+
+For short conversations, or when you need a verbatim record of who said what, the user tags in history are enough. `lastMessages` brings prior turns back into context with their attribution intact:
+
+```typescript title="src/mastra/agents/collab-basic.ts"
+import { Memory } from '@mastra/memory'
+import { LibSQLStore } from '@mastra/libsql'
+
+const memory = new Memory({
+  storage: new LibSQLStore({ url: 'file:./collab.db' }),
+  options: {
+    lastMessages: 20,
+  },
+})
+```
+
+The model reads identity from the `<turn>` tag on the current message and from prior tagged messages brought back through `lastMessages`.
+
+### With observational memory (recommended)
+
+[Observational Memory](../memory/observational-memory) (OM) extracts per-user facts into a background log without burning the agent's tool budget. The default Observer model reads `<turn>` tags natively and produces named attribution like `Alice stated her favorite color is teal.` and `Bob asked for QA sign-off before publish.`
+
+Prefer OM over working memory for multi-user threads when your storage supports it. OM extracts facts automatically, scales to any number of participants, and doesn't need template upkeep. Enable it with no overrides:
+
+```typescript title="src/mastra/agents/collab-om.ts"
+import { Memory } from '@mastra/memory'
+import { LibSQLStore } from '@mastra/libsql'
+
+const memory = new Memory({
+  storage: new LibSQLStore({ url: 'file:./collab.db' }),
+  options: {
+    lastMessages: 20,
+    observationalMemory: true,
+  },
+})
+```
+
+OM requires a storage adapter that supports it: `@mastra/libsql`, `@mastra/pg`, or `@mastra/mongodb`.
+
+:::note
+
+If you switch the Observer to a weaker model and see facts collapse to a generic `User`, use [`observation.instruction`](/reference/memory/observational-memory) to teach the Observer how to read the `<turn>` tag.
+
+:::
+
+### With working memory
+
+Use working memory when OM isn't an option — for example, when your storage adapter doesn't support OM, or when you need a structured, deterministic participants list the agent can read and write on every turn.
+
+The default [working memory](../memory/working-memory) template assumes one user per thread ("First Name", "Last Name", etc.). For multi-user threads, provide a template with a participants list:
+
+```typescript title="src/mastra/agents/collab-wm.ts"
+import { Memory } from '@mastra/memory'
+import { LibSQLStore } from '@mastra/libsql'
+
+const memory = new Memory({
+  storage: new LibSQLStore({ url: 'file:./collab.db' }),
+  options: {
+    lastMessages: 20,
+    workingMemory: {
+      enabled: true,
+      scope: 'thread',
+      template: `# Document Collaboration State
+
+## Participants
+<!-- One entry per known collaborator. Use author_id as the stable key. -->
+<!-- - **<author_name>** (<author_id>, <functional_role>): <their position> -->
+
+## Open Questions
+
+## Decisions
+`,
+    },
+  },
+})
+```
+
+Set `scope: 'thread'` so the participants list belongs to the document, not to any individual user. Add one instruction telling the agent to append new participants to the list whenever a new `author_id` shows up in a `<turn>`.
+
+For more on templates, see [Custom templates](../memory/working-memory#custom-templates).
+
+## Security
+
+Set the `speaker` from your authenticated request context, never from the request body. If a client can choose its own `author_id`, one user can impersonate another. Use [Request Context](/docs/server/request-context) to read the verified user from your auth layer and build the `<turn>` tag on the server before calling the agent.
+
+## Related
+
+- [Working memory](../memory/working-memory)
+- [Observational memory](../memory/observational-memory)
+- [Share memory between agents](../memory/overview#share-memory-between-agents)
+- [`Memory` reference](/reference/memory/memory-class)

--- a/docs/src/content/en/docs/memory/multi-user-threads.mdx
+++ b/docs/src/content/en/docs/memory/multi-user-threads.mdx
@@ -36,10 +36,21 @@ export type Speaker = {
   role: string
 }
 
+function escapeAttr(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
 export function asUserTurn(speaker: Speaker, text: string) {
+  const id = escapeAttr(speaker.id)
+  const name = escapeAttr(speaker.name)
+  const role = escapeAttr(speaker.role)
   return {
     role: 'user' as const,
-    content: `<turn author_id="${speaker.id}" author_name="${speaker.name}" functional_role="${speaker.role}">
+    content: `<turn author_id="${id}" author_name="${name}" functional_role="${role}">
 ${text}
 </turn>`,
   }

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -593,6 +593,7 @@ No manual migration needed. OM reads existing messages and observes them lazily 
 - **[Message history](/docs/memory/message-history)**: High-fidelity record of the current conversation
 - **[Working memory](/docs/memory/working-memory)**: Small, structured state (JSON or markdown) for user preferences, names, goals
 - **[Semantic Recall](/docs/memory/semantic-recall)**: RAG-based retrieval of relevant past messages
+- **[Multi-user threads](/docs/memory/multi-user-threads)**: How OM attributes facts to individual users when several people share a single thread
 
 If you're using working memory to store conversation summaries or ongoing state that grows over time, OM is a better fit. Working memory is for small, structured data; OM is for long-running event logs. OM also manages message history automatically—the `messageTokens` setting controls how much raw history remains before observation runs.
 

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -19,6 +19,7 @@ Mastra agents can be configured to store [message history](/docs/memory/message-
 - [Observational Memory](../memory/observational-memory) (Recommended): Uses background agents to maintain a dense observation log that replaces raw message history as it grows. This keeps the context window small while preserving long-term memory.
 - [Working memory](../memory/working-memory): Stores persistent, structured user data such as names, preferences, and goals.
 - [Semantic recall](../memory/semantic-recall): Retrieves relevant past messages based on semantic meaning rather than exact keywords.
+- [Multi-user threads](../memory/multi-user-threads): Share one thread between multiple users.
 
 If the combined memory exceeds the model's context limit, [memory processors](/docs/memory/memory-processors) can filter, trim, or prioritize content so the most relevant information is preserved.
 

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -144,7 +144,7 @@ Resource-scoped working memory requires specific storage adapters that support t
 
 ## Custom templates
 
-Templates guide the agent on what information to track and update in working memory. While a default template is used if none is provided, you'll typically want to define a custom template tailored to your agent's specific use case to ensure it remembers the most relevant information.
+Templates guide the agent on what information to track and update in working memory. While a default template is used if none is provided, you'll typically want to define a custom template tailored to your agent's specific use case to ensure it remembers the most relevant information. For threads shared by multiple users, see [Multi-user threads](./multi-user-threads).
 
 Here's an example of a custom template. In this example the agent will store the users name, location, timezone, etc as soon as the user sends a message containing any of the info:
 

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -214,6 +214,11 @@ const sidebars = {
           id: 'memory/memory-processors',
           label: 'Memory Processors',
         },
+        {
+          type: 'doc',
+          id: 'memory/multi-user-threads',
+          label: 'Multi-user Threads',
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary

Adds a new documentation page covering how to share a single agent thread between multiple users (collaborative documents, group chats, multi-stakeholder reviews) — a pattern the existing memory docs don't cover.

The page is anchored on the constraint that a Mastra thread belongs to exactly one `resourceId`. Readers who hit this without guidance end up using per-user `resourceId`s, which silently routes each participant to a different thread.

## What's new

`docs/src/content/en/docs/memory/multi-user-threads.mdx` covers:

- **Share one `resourceId` across all participants** — key it on the conversation (`doc_${docId}`, `room_${roomId}`), not on the user.
- **Tag each user message with the speaker's identity** — wrap each user message in a small `<turn>` tag carrying user id, name, and role, so the model can attribute statements across turns.
- **Combining with memory layers** — guidance on picking the right layer:
  - Short conversations: message history alone.
  - Long-running threads: observational memory (recommended).
  - Need a structured participants list, or the storage adapter doesn't support OM: working memory.
- **Security** — set the speaker server-side from your auth layer, never from the request body.

All code snippets use `openai/gpt-5.4-mini`. The observational memory section uses pure defaults (no `model`, `scope`, or `instruction` overrides) — the default Observer handles `<turn>` tags natively.

## Cross-links

- `memory/overview.mdx` — added bullet in the feature list.
- `memory/working-memory.mdx` — short pointer from the "Custom templates" section, because the default WM template assumes a single user.
- `memory/observational-memory.mdx` — bullet in the "Comparing OM with other memory features" section.

## Test plan

- Prettier, remark, and Vale all pass on the four changed files.
- New page renders correctly and all internal links resolve.

## Out of scope

- No code changes. No new APIs. Purely additive documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a how-to guide that explains how to let multiple people share the same AI conversation thread (e.g., shared docs or group chats). It shows how to tag each message with who said it so the agent can tell people apart, and warns to set speaker identity server-side from authenticated context.

## Changes

**New documentation page:** `docs/src/content/en/docs/memory/multi-user-threads.mdx`

Highlights:
- Explains that a Mastra thread belongs to exactly one `resourceId` and recommends keying `resourceId` to the shared conversation (e.g., `doc_${docId}`, `room_${roomId}`) rather than per-user IDs.
- Introduces a `<turn>` wrapper pattern to carry speaker identity (author_id, author_name, functional_role) in the message body so attribution survives history.
- Provides a safe helper implementation (with escaping) to build `<turn>` tags and sample call-site code showing all participants using the same `thread`/`resource`.
- Includes agent instruction examples that show how to read attributed past statements without echoing the `<turn>` tags.
- Shows how the pattern composes with memory options:
  - Message history alone for short sessions or verbatim records.
  - Observational Memory (recommended) for long-running threads (requires LibSQL/PG/MongoDB); notes how to override Observer instructions if needed.
  - Working Memory for structured participants lists or when OM isn't available; includes a participants-list template and guidance to set `scope: 'thread'`.
- Security guidance: build the `<turn>` tag server-side from authenticated request context (do not accept speaker identity from the request body).

**Other doc updates:**
- `docs/src/content/en/docs/memory/overview.mdx`: added "Multi-user threads" to optional memory features list.
- `docs/src/content/en/docs/memory/observational-memory.mdx`: added cross-link to the new page.
- `docs/src/content/en/docs/memory/working-memory.mdx`: added note pointing to multi-user threads for shared-thread templates.
- `docs/src/content/en/docs/sidebars.js`: added sidebar entry for "Multi-user Threads" under Memory.

Tests reported: Prettier, remark, and Vale pass on changed files; the new page renders and internal links resolve. Documentation-only change; no code or API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->