### PR TITLE
fix(mcp): restore OAuth client credentials on token requests

### DIFF
--- a/.changeset/eighty-yaks-march.md
+++ b/.changeset/eighty-yaks-march.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed an issue where OAuth token requests dropped `client_id` and `client_secret` for confidential clients. The provider previously shipped an empty `addClientAuthentication` method that satisfied the MCP SDK's existence check and short-circuited its default credential attachment, causing `invalid_request` errors on token exchange and refresh against confidential-client OAuth servers. The empty stub has been removed so the SDK's built-in client authentication runs again. See [#16854](https://github.com/mastra-ai/mastra/issues/16854).

--- a/packages/mcp/src/client/oauth-provider.ts
+++ b/packages/mcp/src/client/oauth-provider.ts
@@ -13,7 +13,6 @@ import type {
   OAuthClientInformation,
   OAuthClientInformationFull,
   OAuthTokens,
-  AuthorizationServerMetadata,
 } from '../shared/oauth-types.js';
 
 /**
@@ -277,24 +276,9 @@ export class MCPOAuthClientProvider implements OAuthClientProvider {
   }
 
   /**
-   * Optional: Custom client authentication for token requests.
-   * Uses default behavior if not implemented.
-   */
-  async addClientAuthentication?(
-    _headers: Headers,
-    _params: URLSearchParams,
-    _url: string | URL,
-    _metadata?: AuthorizationServerMetadata,
-  ): Promise<void> {
-    // Use default MCP SDK behavior
-  }
-
-  /**
    * Invalidate credentials when server indicates they're no longer valid.
    */
-  async invalidateCredentials(
-    scope: 'all' | 'client' | 'tokens' | 'verifier',
-  ): Promise<void> {
+  async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier'): Promise<void> {
     switch (scope) {
       case 'all':
         await this.storage.delete('tokens');

--- a/packages/mcp/src/client/oauth.test.ts
+++ b/packages/mcp/src/client/oauth.test.ts
@@ -16,10 +16,15 @@ import { randomUUID } from 'node:crypto';
 import { createServer } from 'node:http';
 import type { Server as HttpServer, IncomingMessage, ServerResponse } from 'node:http';
 
+import { exchangeAuthorization, refreshAuthorization } from '@modelcontextprotocol/sdk/client/auth.js';
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 
 import type { OAuthMiddlewareResult } from '../server/oauth-middleware.js';
-import { createOAuthMiddleware, createStaticTokenValidator, createIntrospectionValidator } from '../server/oauth-middleware.js';
+import {
+  createOAuthMiddleware,
+  createStaticTokenValidator,
+  createIntrospectionValidator,
+} from '../server/oauth-middleware.js';
 import { MCPServer } from '../server/server.js';
 import type { MCPServerOAuthConfig } from '../shared/oauth-types.js';
 import {
@@ -76,9 +81,7 @@ describe('OAuth Types and Helpers', () => {
       const header = generateWWWAuthenticateHeader({
         resourceMetadataUrl: 'https://mcp.example.com/.well-known/oauth-protected-resource',
       });
-      expect(header).toBe(
-        'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"',
-      );
+      expect(header).toBe('Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"');
     });
 
     it('should include additional params', () => {
@@ -262,6 +265,112 @@ describe('MCPOAuthClientProvider', () => {
     });
 
     expect(await provider.state?.()).toBe(customState);
+  });
+
+  // Regression for https://github.com/mastra-ai/mastra/issues/16854.
+  // The MCP SDK only attaches client_id/client_secret to token requests when
+  // the provider does NOT implement addClientAuthentication. A previous empty
+  // stub on this provider was truthy and short-circuited that default,
+  // dropping credentials and breaking confidential-client OAuth.
+  it('should not implement addClientAuthentication so the SDK attaches client credentials by default', () => {
+    const provider = new MCPOAuthClientProvider({
+      redirectUrl: 'http://localhost:3000/callback',
+      clientMetadata: {
+        redirect_uris: ['http://localhost:3000/callback'],
+        client_name: 'Test Client',
+      },
+    });
+
+    // Bracket access since the property is intentionally absent from the type.
+    expect((provider as unknown as Record<string, unknown>)['addClientAuthentication']).toBeUndefined();
+  });
+
+  // End-to-end checks that drive the real MCP SDK token-exchange path with a
+  // mocked fetch. These prove the bug fix from the consumer's perspective:
+  // when our provider's (undefined) addClientAuthentication is forwarded to
+  // the SDK, client_id and client_secret end up on the wire.
+  describe('SDK token requests include client credentials', () => {
+    const clientInformation = {
+      client_id: 'test-client-id',
+      client_secret: 'test-client-secret',
+      redirect_uris: ['http://localhost:3000/callback'],
+    };
+
+    const makeProvider = () =>
+      new MCPOAuthClientProvider({
+        redirectUrl: 'http://localhost:3000/callback',
+        clientMetadata: {
+          redirect_uris: ['http://localhost:3000/callback'],
+          client_name: 'Test Client',
+        },
+      });
+
+    const mockTokenFetch = () => {
+      const fetchFn = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ access_token: 'new-access-token', token_type: 'Bearer' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+      );
+      return fetchFn as unknown as typeof fetch;
+    };
+
+    // Reads addClientAuthentication off the provider the same way the SDK would,
+    // via bracket access since the property is intentionally absent from the type.
+    type AddClientAuthentication = Parameters<typeof exchangeAuthorization>[1]['addClientAuthentication'];
+    const readAddClientAuthentication = (provider: MCPOAuthClientProvider): AddClientAuthentication =>
+      (provider as unknown as Record<string, AddClientAuthentication>)['addClientAuthentication'];
+
+    // Force client_secret_post so credentials land in the request body,
+    // which is the exact failure mode described in the issue.
+    const postAuthMetadata = {
+      issuer: 'https://auth.example.com',
+      authorization_endpoint: 'https://auth.example.com/authorize',
+      token_endpoint: 'https://auth.example.com/token',
+      response_types_supported: ['code'],
+      token_endpoint_auth_methods_supported: ['client_secret_post'],
+    };
+
+    it('attaches client_id and client_secret during authorization code exchange', async () => {
+      const provider = makeProvider();
+      const fetchFn = mockTokenFetch();
+
+      await exchangeAuthorization('https://auth.example.com', {
+        metadata: postAuthMetadata,
+        clientInformation,
+        authorizationCode: 'auth-code',
+        codeVerifier: 'code-verifier',
+        redirectUri: 'http://localhost:3000/callback',
+        addClientAuthentication: readAddClientAuthentication(provider),
+        fetchFn,
+      });
+
+      const fetchMock = fetchFn as unknown as ReturnType<typeof vi.fn>;
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = fetchMock.mock.calls[0]![1]!.body as URLSearchParams;
+      expect(body.get('client_id')).toBe('test-client-id');
+      expect(body.get('client_secret')).toBe('test-client-secret');
+    });
+
+    it('attaches client_id and client_secret during refresh', async () => {
+      const provider = makeProvider();
+      const fetchFn = mockTokenFetch();
+
+      await refreshAuthorization('https://auth.example.com', {
+        metadata: postAuthMetadata,
+        clientInformation,
+        refreshToken: 'refresh-token',
+        addClientAuthentication: readAddClientAuthentication(provider),
+        fetchFn,
+      });
+
+      const fetchMock = fetchFn as unknown as ReturnType<typeof vi.fn>;
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = fetchMock.mock.calls[0]![1]!.body as URLSearchParams;
+      expect(body.get('client_id')).toBe('test-client-id');
+      expect(body.get('client_secret')).toBe('test-client-secret');
+    });
   });
 });
 
@@ -507,7 +616,7 @@ describe('OAuth Middleware Integration', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer invalid-token',
+        Authorization: 'Bearer invalid-token',
       },
       body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
     });
@@ -526,7 +635,7 @@ describe('OAuth Middleware Integration', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${VALID_TOKEN}`,
+        Authorization: `Bearer ${VALID_TOKEN}`,
       },
       body: JSON.stringify({
         jsonrpc: '2.0',


### PR DESCRIPTION
Fixes #16854.

`MCPOAuthClientProvider` shipped an empty `addClientAuthentication` method. The MCP SDK only attaches `client_id`/`client_secret` to token requests when the provider does **not** implement that method, so the empty stub silently dropped credentials and broke confidential-client OAuth with `invalid_request` errors.

Removing the stub lets the SDK's built-in client authentication run on both the authorization code exchange and refresh paths.

Before:
```ts
class MCPOAuthClientProvider {
  async addClientAuthentication() {
    // empty — overrode the SDK default, dropping client_id/client_secret
  }
}
```

After:
```ts
class MCPOAuthClientProvider {
  // no addClientAuthentication — SDK attaches credentials via
  // client_secret_basic / client_secret_post per server metadata
}
```

Test plan: added a structural regression test plus two SDK-level behavioral tests that drive `exchangeAuthorization` and `refreshAuthorization` against a mocked `fetch` and assert `client_id`/`client_secret` land on the wire. Verified red without the fix, green with it. `pnpm test:client` and full `oauth.test.ts` pass; `tsc --noEmit` and `eslint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

An empty placeholder method in the OAuth code was accidentally stopping the real authentication code from running, which meant login requests weren't sending the required credentials. This PR removes that placeholder so the real code can run again and properly send the credentials that the login server needs.

## Summary

This PR fixes a bug in the MCP OAuth client provider where `client_id` and `client_secret` were not being included in token requests, causing `invalid_request` errors from OAuth token endpoints.

### Root Cause

The `MCPOAuthClientProvider` class included an empty stub for the `addClientAuthentication` method. At runtime, this stub prevented the MCP SDK's built-in client authentication logic from executing, which is responsible for attaching OAuth client credentials to token requests per RFC 6749.

### Changes

**oauth-provider.ts:**
- Removed the empty `addClientAuthentication` method stub from `MCPOAuthClientProvider`
- Removed the unused `AuthorizationServerMetadata` import
- This allows the MCP SDK's default client authentication to execute for both authorization code exchange and refresh token flows

**oauth.test.ts:**
- Added a structural regression test verifying that `MCPOAuthClientProvider` does not expose the `addClientAuthentication` method
- Added two SDK-level behavioral tests using mocked `exchangeAuthorization` and `refreshAuthorization` functions to verify that `client_id` and `client_secret` are included in token request bodies for both authorization code and refresh flows
- Updated HTTP integration test formatting for Bearer token assertions

**.changeset:**
- Documented the fix for the `@mastra/mcp` package patch release

### Testing

All tests pass including unit tests for the structural change, behavioral tests for OAuth flows, type checking (`tsc --noEmit`), and linting (`eslint`).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->