### PR TITLE
feat(channels): add toolDisplay modes for tool call rendering

### DIFF
--- a/.changeset/channels-tool-display.md
+++ b/.changeset/channels-tool-display.md
@@ -1,0 +1,22 @@
+---
+'@mastra/core': minor
+'@mastra/slack': patch
+---
+
+Add `toolDisplay` config to channel adapters for controlling how tool calls
+render in chat:
+
+- `'cards'` (default) — per-tool running/result cards (unchanged behavior).
+- `'timeline'` — task chunks streamed inline with text (Slack only today).
+- `'grouped'` — task chunks combined into one plan block (Slack only today).
+- `'hidden'` — tools run silently; only the typing status indicates work.
+
+`'timeline'` and `'grouped'` require `streaming: true` and rely on the
+underlying chat adapter to render `task_update` chunks. If `streaming` is
+disabled, the channel logs a one-time warning and falls back to `'cards'`.
+Adapters without native `task_update` support (e.g. Discord today) may render
+a placeholder.
+
+Approve/deny prompts (`requireApproval`) always render as a separate card
+regardless of mode, because inline task entries can't carry interactive
+buttons.

--- a/channels/slack/src/provider.ts
+++ b/channels/slack/src/provider.ts
@@ -761,8 +761,9 @@ export class SlackProvider implements ChannelProvider {
    */
   #resolveSlackAdapterConfig(): SlackAdapterChannelConfig {
     // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional read of deprecated alias for back-compat
-    const { adapterConfig, cors, gateway, cards, formatToolCall, formatError, streaming } = this.#channelConfig;
-    const topLevel = { cors, gateway, cards, formatToolCall, formatError, streaming };
+    const { adapterConfig, cors, gateway, cards, formatToolCall, formatError, streaming, toolDisplay } =
+      this.#channelConfig;
+    const topLevel = { cors, gateway, cards, formatToolCall, formatError, streaming, toolDisplay };
     const filteredTopLevel = Object.fromEntries(Object.entries(topLevel).filter(([, value]) => value !== undefined));
     // Slack supports native message streaming, so SlackProvider defaults `streaming: true`.
     // Users can opt out by passing `streaming: false` at the top level (or via `adapterConfig`).

--- a/channels/slack/src/types.ts
+++ b/channels/slack/src/types.ts
@@ -1,4 +1,9 @@
-import type { ChannelAdapterConfig, ChannelConfig, ChannelHandlers } from '@mastra/core/channels';
+import type {
+  ChannelAdapterCardsConfig,
+  ChannelAdapterConfig,
+  ChannelConfig,
+  ChannelHandlers,
+} from '@mastra/core/channels';
 import type { ChannelsStorage } from '@mastra/core/storage';
 import type { SlackAdapterConfig } from '@chat-adapter/slack';
 import type { SlackInstallation } from './schemas';
@@ -20,12 +25,18 @@ export interface SlackAdapterChannelConfig {
    * Use rich card formatting for tool calls, approvals, and results.
    * Set to `false` to fall back to plain text.
    *
+   * Only applies when `toolDisplay` is `'cards'` (the default).
+   *
    * @default true
    */
-  cards?: ChannelAdapterConfig['cards'];
+  cards?: ChannelAdapterCardsConfig['cards'];
 
-  /** Override how tool calls are rendered in Slack messages. */
-  formatToolCall?: ChannelAdapterConfig['formatToolCall'];
+  /**
+   * Override how tool calls are rendered in Slack messages.
+   *
+   * Only applies when `toolDisplay` is `'cards'` (the default).
+   */
+  formatToolCall?: ChannelAdapterCardsConfig['formatToolCall'];
 
   /** Override how errors are rendered in Slack messages. */
   formatError?: ChannelAdapterConfig['formatError'];
@@ -42,6 +53,23 @@ export interface SlackAdapterChannelConfig {
    * @default true
    */
   streaming?: boolean | { updateIntervalMs?: number };
+
+  /**
+   * How tool calls are rendered in Slack.
+   *
+   * - `'cards'` (default) — per-tool "Running…" → "Result" cards.
+   * - `'timeline'` — render tools as inline task entries beside the streaming
+   *   text (requires `streaming: true`, which is the Slack default).
+   * - `'grouped'` — render tools together inside a single plan block.
+   * - `'hidden'` — execute tools silently; only the typing status indicates work.
+   *
+   * Approve/deny prompts (`requireApproval`) always render as a separate card,
+   * regardless of mode, because inline task entries can't carry interactive
+   * buttons.
+   *
+   * @default 'cards'
+   */
+  toolDisplay?: ChannelAdapterConfig['toolDisplay'];
 }
 
 // =============================================================================
@@ -72,12 +100,18 @@ export interface SlackProviderConfig {
    * Use rich card formatting for tool calls, approvals, and results.
    * Set to `false` to fall back to plain text.
    *
+   * Only applies when `toolDisplay` is `'cards'` (the default).
+   *
    * @default true
    */
-  cards?: ChannelAdapterConfig['cards'];
+  cards?: ChannelAdapterCardsConfig['cards'];
 
-  /** Override how tool calls are rendered in Slack messages. */
-  formatToolCall?: ChannelAdapterConfig['formatToolCall'];
+  /**
+   * Override how tool calls are rendered in Slack messages.
+   *
+   * Only applies when `toolDisplay` is `'cards'` (the default).
+   */
+  formatToolCall?: ChannelAdapterCardsConfig['formatToolCall'];
 
   /** Override how errors are rendered in Slack messages. */
   formatError?: ChannelAdapterConfig['formatError'];
@@ -94,6 +128,23 @@ export interface SlackProviderConfig {
    * @default true
    */
   streaming?: boolean | { updateIntervalMs?: number };
+
+  /**
+   * How tool calls are rendered in Slack.
+   *
+   * - `'cards'` (default) — per-tool "Running…" → "Result" cards.
+   * - `'timeline'` — render tools as inline task entries beside the streaming
+   *   text (requires `streaming: true`, which is the Slack default).
+   * - `'grouped'` — render tools together inside a single plan block.
+   * - `'hidden'` — execute tools silently; only the typing status indicates work.
+   *
+   * Approve/deny prompts (`requireApproval`) always render as a separate card,
+   * regardless of mode, because inline task entries can't carry interactive
+   * buttons.
+   *
+   * @default 'cards'
+   */
+  toolDisplay?: ChannelAdapterConfig['toolDisplay'];
 
   // ---------------------------------------------------------------------------
   // Forwarded AgentChannels-level options

--- a/docs/src/content/en/reference/agents/channels.mdx
+++ b/docs/src/content/en/reference/agents/channels.mdx
@@ -158,7 +158,7 @@ const agent = new Agent({
     isOptional: true,
     defaultValue: 'true',
     description:
-      'Render tool calls as interactive rich cards with buttons. Set to `false` to use plain text formatting instead. When disabled and a tool requires approval, the agent uses `autoResumeSuspendedTools` to let the LLM decide based on conversation context.',
+      'Render tool calls as interactive rich cards with buttons. Only applies when `toolDisplay` is `"cards"` (the default). When disabled and a tool requires approval, the agent uses `autoResumeSuspendedTools` to let the LLM decide based on conversation context.',
   },
   {
     name: 'cors',
@@ -172,7 +172,7 @@ const agent = new Agent({
     type: '(info: { toolName, args, result, isError? }) => PostableMessage | null',
     isOptional: true,
     description:
-      'Override how tool calls are rendered in the chat. Called once per tool invocation after the result is available. Return `null` to suppress the message entirely.',
+      'Override how tool calls are rendered in the chat. Only applies when `toolDisplay` is `"cards"` (the default). Called once per tool invocation after the result is available. Return `null` to suppress the message entirely.',
   },
   {
     name: 'formatError',
@@ -182,8 +182,63 @@ const agent = new Agent({
     description:
       'Override how errors are rendered in the chat. Return a user-friendly message instead of exposing the raw error.',
   },
+  {
+    name: 'streaming',
+    type: 'boolean | { updateIntervalMs?: number }',
+    isOptional: true,
+    defaultValue: 'false (true for Slack)',
+    description:
+      'Stream agent text deltas to the channel as the agent generates them instead of buffering and posting once per step. Requires the underlying adapter to support post-and-edit streaming. Slack defaults to `true`; other adapters default to `false`.',
+  },
+  {
+    name: 'toolDisplay',
+    type: "'cards' | 'timeline' | 'grouped' | 'hidden'",
+    isOptional: true,
+    defaultValue: "'cards'",
+    description:
+      'How tool calls are rendered in the channel. `"cards"` posts per-tool running/result cards. `"timeline"` and `"grouped"` stream tool state as inline `task_update` chunks (requires `streaming: true`; Slack only today — other adapters may render a placeholder). `"hidden"` executes tools silently. Approve/deny prompts always render as a separate card regardless of mode.',
+  },
 ]}
 />
+
+## Tool display modes
+
+`toolDisplay` controls how tool calls render in chat. The default `'cards'`
+posts a "Running…" card per tool and edits it with the result, matching the
+behavior in earlier versions.
+
+`'timeline'` and `'grouped'` stream tool state as inline `task_update` chunks
+alongside the agent's text. These modes require `streaming: true` and rely on
+the chat adapter to render the chunks. Slack supports both natively; other
+adapters may render a placeholder until they ship support. If `streaming` is
+disabled, the channel logs a one-time warning and falls back to `'cards'`.
+
+`'hidden'` executes tools silently. Only the typing status indicates work in
+progress.
+
+Approve/deny prompts (`requireApproval`) always render as a separate card
+regardless of mode, because inline task entries can't carry interactive
+buttons.
+
+```typescript title="src/mastra/agents/streaming.ts"
+import { Agent } from '@mastra/core/agent'
+import { createSlackAdapter } from '@chat-adapter/slack'
+
+const agent = new Agent({
+  name: 'Streaming Agent',
+  instructions: '...',
+  model: 'openai/gpt-5.4',
+  channels: {
+    adapters: {
+      slack: {
+        adapter: createSlackAdapter(),
+        streaming: true, // already the Slack default
+        toolDisplay: 'timeline',
+      },
+    },
+  },
+})
+```
 
 ## Handlers
 

--- a/packages/core/src/channels/__tests__/consume-agent-stream.test.ts
+++ b/packages/core/src/channels/__tests__/consume-agent-stream.test.ts
@@ -461,7 +461,7 @@ describe('consumeAgentStream', () => {
   });
 
   describe('adaptive typing status', () => {
-    it('emits Thinking → Typing → Using {tool} → Thinking transitions', async () => {
+    it('emits Typing → Calling {tool} → Typing transitions (no Thinking… on reasoning/tool-result)', async () => {
       const { channels, calls, sdkThread } = makeChannels({ streaming: false });
       await drive(
         channels,
@@ -483,7 +483,7 @@ describe('consumeAgentStream', () => {
         sdkThread,
       );
       const typingStatuses = calls.filter(c => c.kind === 'startTyping').map(c => (c as any).status);
-      expect(typingStatuses).toEqual(['Thinking…', 'Typing…', 'Calling weather…', 'Thinking…', 'Typing…']);
+      expect(typingStatuses).toEqual(['Typing…', 'Calling weather…', 'Typing…']);
     });
 
     it('dedups consecutive same-status calls', async () => {

--- a/packages/core/src/channels/__tests__/consume-agent-stream.test.ts
+++ b/packages/core/src/channels/__tests__/consume-agent-stream.test.ts
@@ -278,10 +278,21 @@ describe('consumeAgentStream', () => {
       );
 
       const posts = calls.filter(c => c.kind === 'post');
-      expect(posts).toHaveLength(1);
+      // Text-before-tools triggers a session flush so the leading text posts
+      // as its own platform message; the tool widget + trailing text post as
+      // a second message. Without the flush, Slack's AI Assistant widget
+      // would always render tasks above text within a single post.
+      expect(posts).toHaveLength(2);
       expect(calls.find(c => c.kind === 'editMessage')).toBeUndefined();
 
-      const planArg = (posts[0] as Extract<Call, { kind: 'post' }>).arg as any;
+      // First post: streaming text only (no task_update chunks).
+      const firstPost = (posts[0] as Extract<Call, { kind: 'post' }>).arg as any;
+      const firstDrained = await drainStreamingPlan(firstPost);
+      const firstText = firstDrained.filter((p): p is string => typeof p === 'string').join('');
+      expect(firstText).toContain('thinking');
+
+      // Second post: tool widget + trailing text.
+      const planArg = (posts[1] as Extract<Call, { kind: 'post' }>).arg as any;
       // `'timeline'` mode tells StreamingPlan to render each task inline.
       expect(planArg.options?.groupTasks).toBe('timeline');
 
@@ -297,7 +308,6 @@ describe('consumeAgentStream', () => {
       // the existing task entry by id, so re-sending would render duplicates.
       expect(taskUpdates[1].details).toBeUndefined();
       const text = drained.filter((p): p is string => typeof p === 'string').join('');
-      expect(text).toContain('thinking');
       expect(text).toContain('done');
     });
 
@@ -363,13 +373,21 @@ describe('consumeAgentStream', () => {
       );
 
       // Streaming text still posts; tools render nothing.
+      // Hidden mode flushes pending text on tool-call so the leading text
+      // posts before the silent tool runs (otherwise the user sees the
+      // typing status with no leading message until the tool resolves).
       const posts = calls.filter(c => c.kind === 'post');
-      expect(posts).toHaveLength(1);
+      expect(posts).toHaveLength(2);
       expect(calls.find(c => c.kind === 'editMessage')).toBeUndefined();
 
-      const drained = await drainStreamingPlan((posts[0] as Extract<Call, { kind: 'post' }>).arg);
-      const taskUpdates = drained.filter(p => typeof p === 'object' && (p as any).type === 'task_update');
+      const allDrained = (
+        await Promise.all(posts.map(p => drainStreamingPlan((p as Extract<Call, { kind: 'post' }>).arg)))
+      ).flat();
+      const taskUpdates = allDrained.filter(p => typeof p === 'object' && (p as any).type === 'task_update');
       expect(taskUpdates).toHaveLength(0);
+      const text = allDrained.filter((p): p is string => typeof p === 'string').join('');
+      expect(text).toContain('thinking');
+      expect(text).toContain('done');
     });
 
     it("'timeline' without streaming: warns once and falls back to cards", async () => {

--- a/packages/core/src/channels/__tests__/consume-agent-stream.test.ts
+++ b/packages/core/src/channels/__tests__/consume-agent-stream.test.ts
@@ -64,10 +64,33 @@ async function* chunkStream(chunks: any[]): AsyncIterable<any> {
   for (const c of chunks) yield c;
 }
 
-function makeChannels(opts: { streaming?: boolean | { updateIntervalMs?: number } } = {}) {
+function makeChannels(
+  opts: {
+    streaming?: boolean | { updateIntervalMs?: number };
+    toolDisplay?: 'cards' | 'timeline' | 'grouped' | 'hidden';
+    cards?: boolean;
+    formatToolCall?: (info: {
+      toolName: string;
+      args: Record<string, unknown>;
+      result: unknown;
+      isError?: boolean;
+    }) => any;
+  } = {},
+) {
   const recording = createRecording();
+  // Build the adapter config as the right discriminated-union variant.
+  const baseAdapter = { adapter: recording.adapter, streaming: opts.streaming ?? false };
+  const adapterConfig =
+    !opts.toolDisplay || opts.toolDisplay === 'cards'
+      ? {
+          ...baseAdapter,
+          ...(opts.toolDisplay ? { toolDisplay: opts.toolDisplay } : {}),
+          ...(opts.cards !== undefined ? { cards: opts.cards } : {}),
+          ...(opts.formatToolCall ? { formatToolCall: opts.formatToolCall } : {}),
+        }
+      : { ...baseAdapter, toolDisplay: opts.toolDisplay };
   const channels = new AgentChannels({
-    adapters: { test: { adapter: recording.adapter, streaming: opts.streaming ?? false } },
+    adapters: { test: adapterConfig as any },
   });
   return { channels, ...recording };
 }
@@ -83,9 +106,9 @@ async function drive(
 
 // Drain a StreamingPlan's underlying iterable so we can assert on the
 // pieces that would have been streamed to the platform.
-async function drainStreamingPlan(plan: any): Promise<string[]> {
-  const pieces: string[] = [];
-  for await (const piece of plan.stream as AsyncIterable<string>) {
+async function drainStreamingPlan(plan: any): Promise<Array<string | Record<string, unknown>>> {
+  const pieces: Array<string | Record<string, unknown>> = [];
+  for await (const piece of plan.stream as AsyncIterable<string | Record<string, unknown>>) {
     pieces.push(piece);
   }
   return pieces;
@@ -205,12 +228,14 @@ describe('consumeAgentStream', () => {
       expect(await drainStreamingPlan((plans[1] as Extract<Call, { kind: 'post' }>).arg)).toEqual(['second']);
     });
 
-    it('closes the streaming session before posting an out-of-band tool card', async () => {
+    it('streams tool cards as separate posts in the default cards mode', async () => {
+      // When `toolDisplay` is left at the default `'cards'`, tools render via
+      // running/result cards (one post per tool) regardless of streaming.
       const { channels, calls, sdkThread } = makeChannels({ streaming: true });
       await drive(
         channels,
         [
-          { type: 'text-delta', payload: { text: 'thinking' } },
+          { type: 'text-delta', payload: { text: 'thinking ' } },
           {
             type: 'tool-call',
             payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'Vancouver' } },
@@ -223,16 +248,197 @@ describe('consumeAgentStream', () => {
         ],
         sdkThread,
       );
-      // Ordering: stream post lands before tool card; nothing posts AFTER tool card
-      // since the post for the running card returned a messageId and the result
-      // edits that same card.
-      const kinds = calls.map(c => c.kind);
-      const firstPostIdx = kinds.indexOf('post');
-      const secondPostIdx = kinds.indexOf('post', firstPostIdx + 1);
-      const editIdx = kinds.indexOf('editMessage');
-      expect(firstPostIdx).toBeGreaterThanOrEqual(0); // streaming plan
-      expect(secondPostIdx).toBeGreaterThan(firstPostIdx); // running card
-      expect(editIdx).toBeGreaterThan(secondPostIdx); // result edit
+      // Running card posts as its own message; the result edits that card.
+      const posts = calls.filter(c => c.kind === 'post');
+      // One StreamingPlan post for the text segment + one card post for the running tool.
+      expect(posts.length).toBeGreaterThanOrEqual(2);
+      expect(calls.find(c => c.kind === 'editMessage')).toBeDefined();
+    });
+  });
+
+  describe('toolDisplay modes', () => {
+    it("'timeline': emits task_update chunks into the streaming session (one task per tool)", async () => {
+      const { channels, calls, sdkThread } = makeChannels({ streaming: true, toolDisplay: 'timeline' });
+      await drive(
+        channels,
+        [
+          { type: 'text-delta', payload: { text: 'thinking ' } },
+          {
+            type: 'tool-call',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'Vancouver' } },
+          },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'Vancouver' }, result: 'sunny' },
+          },
+          { type: 'text-delta', payload: { text: 'done' } },
+          { type: 'finish', payload: {} },
+        ],
+        sdkThread,
+      );
+
+      const posts = calls.filter(c => c.kind === 'post');
+      expect(posts).toHaveLength(1);
+      expect(calls.find(c => c.kind === 'editMessage')).toBeUndefined();
+
+      const planArg = (posts[0] as Extract<Call, { kind: 'post' }>).arg as any;
+      // `'timeline'` mode tells StreamingPlan to render each task inline.
+      expect(planArg.options?.groupTasks).toBe('timeline');
+
+      const drained = await drainStreamingPlan(planArg);
+      const taskUpdates = drained.filter(
+        (p): p is { type: 'task_update'; status: string; id: string; output?: string; details?: string } =>
+          typeof p === 'object' && (p as any).type === 'task_update',
+      );
+      expect(taskUpdates).toHaveLength(2);
+      expect(taskUpdates[0]).toMatchObject({ id: 't1', status: 'in_progress' });
+      expect(taskUpdates[1]).toMatchObject({ id: 't1', status: 'complete' });
+      // The completion chunk must not repeat `details` — Chat SDK appends to
+      // the existing task entry by id, so re-sending would render duplicates.
+      expect(taskUpdates[1].details).toBeUndefined();
+      const text = drained.filter((p): p is string => typeof p === 'string').join('');
+      expect(text).toContain('thinking');
+      expect(text).toContain('done');
+    });
+
+    it("'grouped': renders task_updates inside a single plan block (groupTasks: 'plan')", async () => {
+      const { channels, calls, sdkThread } = makeChannels({ streaming: true, toolDisplay: 'grouped' });
+      await drive(
+        channels,
+        [
+          {
+            type: 'tool-call',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } },
+          },
+          {
+            type: 'tool-call',
+            payload: { toolCallId: 't2', toolName: 'weather', args: { city: 'LA' } },
+          },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' }, result: 'rainy' },
+          },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't2', toolName: 'weather', args: { city: 'LA' }, result: 'sunny' },
+          },
+          { type: 'finish', payload: {} },
+        ],
+        sdkThread,
+      );
+
+      const posts = calls.filter(c => c.kind === 'post');
+      expect(posts).toHaveLength(1);
+      const planArg = (posts[0] as Extract<Call, { kind: 'post' }>).arg as any;
+      expect(planArg.options?.groupTasks).toBe('plan');
+
+      const drained = await drainStreamingPlan(planArg);
+      const taskUpdates = drained.filter(
+        (p): p is { type: 'task_update'; id: string; status: string } =>
+          typeof p === 'object' && (p as any).type === 'task_update',
+      );
+      // 2 tools × 2 updates each (in_progress + complete) → 4 chunks total.
+      expect(taskUpdates).toHaveLength(4);
+      expect(new Set(taskUpdates.map(t => t.id))).toEqual(new Set(['t1', 't2']));
+    });
+
+    it("'hidden': drops tool-call/result chunks entirely (no card, no task_update)", async () => {
+      const { channels, calls, sdkThread } = makeChannels({ streaming: true, toolDisplay: 'hidden' });
+      await drive(
+        channels,
+        [
+          { type: 'text-delta', payload: { text: 'thinking ' } },
+          {
+            type: 'tool-call',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'Vancouver' } },
+          },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'Vancouver' }, result: 'sunny' },
+          },
+          { type: 'text-delta', payload: { text: 'done' } },
+          { type: 'finish', payload: {} },
+        ],
+        sdkThread,
+      );
+
+      // Streaming text still posts; tools render nothing.
+      const posts = calls.filter(c => c.kind === 'post');
+      expect(posts).toHaveLength(1);
+      expect(calls.find(c => c.kind === 'editMessage')).toBeUndefined();
+
+      const drained = await drainStreamingPlan((posts[0] as Extract<Call, { kind: 'post' }>).arg);
+      const taskUpdates = drained.filter(p => typeof p === 'object' && (p as any).type === 'task_update');
+      expect(taskUpdates).toHaveLength(0);
+    });
+
+    it("'timeline' without streaming: warns once and falls back to cards", async () => {
+      const { channels, calls, sdkThread } = makeChannels({ streaming: false, toolDisplay: 'timeline' });
+      const warn = vi.fn();
+      (channels as any).__setLogger({
+        info: vi.fn(),
+        warn,
+        error: vi.fn(),
+        debug: vi.fn(),
+      });
+
+      // Two runs in a row — the warn should fire on the first and stay quiet on the second.
+      const chunks = [
+        {
+          type: 'tool-call',
+          payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'Vancouver' } },
+        },
+        {
+          type: 'tool-result',
+          payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'Vancouver' }, result: 'sunny' },
+        },
+        { type: 'finish', payload: {} },
+      ];
+      await drive(channels, chunks, sdkThread);
+      await drive(channels, chunks, sdkThread);
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain("toolDisplay: 'timeline' requires streaming: true");
+
+      // Fallback behavior should be `'cards'`: running card posted, edited on result.
+      const posts = calls.filter(c => c.kind === 'post');
+      const edits = calls.filter(c => c.kind === 'editMessage');
+      expect(posts.length).toBeGreaterThan(0);
+      expect(edits.length).toBeGreaterThan(0);
+    });
+
+    it("'timeline' with parallel tool calls: each gets its own task entry", async () => {
+      const { channels, calls, sdkThread } = makeChannels({ streaming: true, toolDisplay: 'timeline' });
+      await drive(
+        channels,
+        [
+          { type: 'tool-call', payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' } } },
+          { type: 'tool-call', payload: { toolCallId: 't2', toolName: 'weather', args: { city: 'LA' } } },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't1', toolName: 'weather', args: { city: 'NYC' }, result: 'rainy' },
+          },
+          {
+            type: 'tool-result',
+            payload: { toolCallId: 't2', toolName: 'weather', args: { city: 'LA' }, result: 'sunny' },
+          },
+          { type: 'finish', payload: {} },
+        ],
+        sdkThread,
+      );
+
+      const posts = calls.filter(c => c.kind === 'post');
+      const drained = await drainStreamingPlan((posts[0] as Extract<Call, { kind: 'post' }>).arg);
+      const taskUpdates = drained.filter(
+        (p): p is { type: 'task_update'; id: string; status: string } =>
+          typeof p === 'object' && (p as any).type === 'task_update',
+      );
+      expect(taskUpdates.map(t => `${t.id}:${t.status}`)).toEqual([
+        't1:in_progress',
+        't2:in_progress',
+        't1:complete',
+        't2:complete',
+      ]);
     });
   });
 
@@ -259,7 +465,7 @@ describe('consumeAgentStream', () => {
         sdkThread,
       );
       const typingStatuses = calls.filter(c => c.kind === 'startTyping').map(c => (c as any).status);
-      expect(typingStatuses).toEqual(['Thinking…', 'Typing…', 'Using weather…', 'Thinking…', 'Typing…']);
+      expect(typingStatuses).toEqual(['Thinking…', 'Typing…', 'Calling weather…', 'Thinking…', 'Typing…']);
     });
 
     it('dedups consecutive same-status calls', async () => {

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -1,4 +1,4 @@
-import type { Chat, Adapter, CardElement, ChatConfig, Message, StateAdapter, Thread } from 'chat';
+import type { Chat, Adapter, CardElement, ChatConfig, Message, StateAdapter, StreamChunk, Thread } from 'chat';
 import { z } from 'zod';
 
 import type { Agent } from '../agent/agent';
@@ -35,8 +35,8 @@ const DEFAULT_INLINE_MEDIA_TYPES: string[] = ['image/png', 'image/jpeg', 'image/
 /** Message content that can be posted to a channel. */
 export type PostableMessage = string | CardElement;
 
-/** Per-adapter configuration. */
-export interface ChannelAdapterConfig {
+/** Per-adapter configuration shared across all `toolDisplay` modes. */
+export interface ChannelAdapterBaseConfig {
   adapter: Adapter;
   /**
    * CORS configuration for the generated webhook route for this adapter.
@@ -51,29 +51,6 @@ export interface ChannelAdapterConfig {
    * serverless deployments that only need slash commands via HTTP Interactions.
    */
   gateway?: boolean;
-
-  /**
-   * Use rich card formatting for tool calls, approvals, and results.
-   * Set to `false` to use plain text formatting instead.
-   *
-   * Some platforms (e.g. Discord) may have rendering issues with cards.
-   * @default true
-   */
-  cards?: boolean;
-
-  /**
-   * Override how tool calls are rendered in the chat.
-   * Called once per tool invocation after the result is available.
-   * Return `null` to suppress the message entirely.
-   *
-   * @default - A Card showing the function-call signature and result.
-   */
-  formatToolCall?: (info: {
-    toolName: string;
-    args: Record<string, unknown>;
-    result: unknown;
-    isError?: boolean;
-  }) => PostableMessage | null;
 
   /**
    * Override how errors are rendered in the chat.
@@ -96,6 +73,84 @@ export interface ChannelAdapterConfig {
    * @default false
    */
   streaming?: boolean | { updateIntervalMs?: number };
+}
+
+/**
+ * `'cards'` mode (default): per-tool "Running…" → "Result" cards. This is the
+ * only mode where `cards` and `formatToolCall` apply.
+ */
+export interface ChannelAdapterCardsConfig extends ChannelAdapterBaseConfig {
+  /**
+   * How tool calls are rendered in the channel.
+   *
+   * - `'cards'` (default) — per-tool "Running…" → "Result" cards. Only this
+   *   mode accepts `cards` and `formatToolCall`.
+   * - `'timeline'` — emit `task_update` chunks into the active streaming
+   *   session so each tool renders as an inline task card alongside text.
+   *   Requires `streaming: true`. Slack renders this natively; other adapters
+   *   may render a placeholder or omit the result.
+   * - `'grouped'` — same as `'timeline'` but tasks combine into a single plan
+   *   block (`StreamingPlan({ groupTasks: 'plan' })`). Requires `streaming: true`.
+   * - `'hidden'` — execute tools silently. Only the typing status indicates work.
+   *
+   * @default 'cards'
+   */
+  toolDisplay?: 'cards';
+
+  /**
+   * Use rich card formatting for tool calls, approvals, and results.
+   * Set to `false` to use plain text formatting instead.
+   *
+   * Some platforms (e.g. Discord) may have rendering issues with cards.
+   *
+   * @default true
+   */
+  cards?: boolean;
+
+  /**
+   * Override how tool calls are rendered in the chat.
+   * Called once per tool invocation after the result is available.
+   * Return `null` to suppress the message entirely.
+   *
+   * Only available in `'cards'` mode (the default). To use a different
+   * rendering strategy, set `toolDisplay` to `'timeline'`, `'grouped'`, or
+   * `'hidden'` instead.
+   *
+   * @default - A Card showing the function-call signature and result.
+   */
+  formatToolCall?: (info: {
+    toolName: string;
+    args: Record<string, unknown>;
+    result: unknown;
+    isError?: boolean;
+  }) => PostableMessage | null;
+}
+
+/**
+ * Non-`'cards'` modes: tool calls route through the streaming session (or run
+ * silently). `cards` and `formatToolCall` are not available here — they only
+ * apply to the `'cards'` renderer.
+ */
+export interface ChannelAdapterStreamingToolsConfig extends ChannelAdapterBaseConfig {
+  /** See {@link ChannelAdapterCardsConfig.toolDisplay} for mode descriptions. */
+  toolDisplay: 'timeline' | 'grouped' | 'hidden';
+}
+
+/**
+ * Per-adapter configuration. `toolDisplay` is a discriminator: in `'cards'`
+ * mode (the default) `cards` and `formatToolCall` are available; in
+ * `'timeline'` / `'grouped'` / `'hidden'` they are not, because those modes
+ * render through the streaming session instead of per-tool cards.
+ */
+export type ChannelAdapterConfig = ChannelAdapterCardsConfig | ChannelAdapterStreamingToolsConfig;
+
+/**
+ * Narrow an adapter config to the `'cards'` variant (where `cards` and
+ * `formatToolCall` live), or `undefined` if the adapter is in a non-cards mode.
+ */
+function asCardsConfig(config: ChannelAdapterConfig | undefined): ChannelAdapterCardsConfig | undefined {
+  if (!config) return undefined;
+  return !config.toolDisplay || config.toolDisplay === 'cards' ? config : undefined;
 }
 
 /**
@@ -436,6 +491,13 @@ export class AgentChannels {
     { messageId?: string; displayName: string; argsSummary: string; startedAt: number }
   >();
 
+  /**
+   * Platforms we've already warned about for misconfigured `toolDisplay` (e.g.
+   * `'timeline'` without `streaming: true`). Keeps log output to one warn per
+   * platform per AgentChannels instance.
+   */
+  private warnedToolDisplayFallback = new Set<string>();
+
   constructor(config: ChannelConfig) {
     // Normalize: extract adapters and per-adapter configs
     const adapters: Record<string, Adapter> = {};
@@ -699,7 +761,7 @@ export class AgentChannels {
           // Build the card header with tool name and args
           const displayName = toolName ? stripToolPrefix(toolName) : 'tool';
           const argsSummary = toolArgs ? formatArgsSummary(toolArgs) : '';
-          const useCards = adapterConfig?.cards !== false;
+          const useCards = asCardsConfig(adapterConfig)?.cards !== false;
 
           if (!approved) {
             const byUser = sdkThread.isDM ? undefined : event.user.fullName || event.user.userName || 'User';
@@ -1275,7 +1337,7 @@ export class AgentChannels {
     // message into an already-running agent loop or wakes the thread with an idle stream
     // using the same options we used to pass to agent.stream().
     const adapterConfig = this.adapterConfigs[platform];
-    const useCards = adapterConfig?.cards !== false;
+    const useCards = asCardsConfig(adapterConfig)?.cards !== false;
 
     const { channelContext, attributes, providerOptions } = this.buildEventContext({
       sdkThread,
@@ -1477,13 +1539,33 @@ export class AgentChannels {
   ): Promise<void> {
     const adapter = this.adapters[platform]!;
     const adapterConfig = this.adapterConfigs[platform];
-    const useCards = adapterConfig?.cards !== false;
+    const cardsConfig = asCardsConfig(adapterConfig);
+    const useCards = cardsConfig?.cards !== false;
 
     // Streaming is configured per-adapter so platforms with native streaming (e.g. Slack)
     // can opt in independently of platforms that fall back to noisy post + edit (e.g. Discord).
     const streamingConfig = adapterConfig?.streaming ?? false;
     const streamingEnabled = streamingConfig !== false;
     const streamingOptions = streamingConfig === true ? {} : streamingConfig === false ? undefined : streamingConfig;
+
+    // Resolve the tool-display mode once per run. `'timeline'` and `'grouped'`
+    // require streaming because they push `task_update` chunks into the
+    // streaming session — fall back to `'cards'` (with a one-time warn) if a
+    // user asks for them without enabling streaming.
+    const requestedToolDisplay = adapterConfig?.toolDisplay ?? 'cards';
+    let toolDisplay: 'cards' | 'timeline' | 'grouped' | 'hidden' = requestedToolDisplay;
+    if ((toolDisplay === 'timeline' || toolDisplay === 'grouped') && !streamingEnabled) {
+      if (!this.warnedToolDisplayFallback.has(platform)) {
+        this.warnedToolDisplayFallback.add(platform);
+        this.log(
+          'warn',
+          `[${platform}] toolDisplay: '${toolDisplay}' requires streaming: true; falling back to 'cards'.`,
+        );
+      }
+      toolDisplay = 'cards';
+    }
+    const groupTasks: 'plan' | 'timeline' | undefined =
+      toolDisplay === 'timeline' ? 'timeline' : toolDisplay === 'grouped' ? 'plan' : undefined;
 
     interface TrackedTool {
       displayName: string;
@@ -1517,14 +1599,14 @@ export class AgentChannels {
     // closes on step-finish / finish / error / abort / out-of-band chunk so the
     // next message (tool card, file, follow-up text) lands in the right order.
     interface StreamingSession {
-      push: (piece: string) => void;
+      push: (piece: string | StreamChunk) => void;
       close: () => void;
       done: Promise<void>;
     }
     let streamingSession: StreamingSession | null = null;
 
     const openStreamingSession = (): StreamingSession => {
-      let buffer: string[] = [];
+      let buffer: (string | StreamChunk)[] = [];
       let closed = false;
       let resolveNext: (() => void) | undefined;
       const waitForNext = () =>
@@ -1532,7 +1614,7 @@ export class AgentChannels {
           resolveNext = resolve;
         });
 
-      async function* iterate(): AsyncGenerator<string> {
+      async function* iterate(): AsyncGenerator<string | StreamChunk> {
         while (true) {
           while (buffer.length > 0) {
             yield buffer.shift()!;
@@ -1543,9 +1625,13 @@ export class AgentChannels {
       }
 
       const iterable = iterate();
+      // When `toolDisplay` is `'timeline'` or `'grouped'` we let `StreamingPlan`
+      // group the `task_update` chunks for us — `'timeline'` keeps each tool as
+      // its own inline card; `'grouped'` collapses them into one plan block.
       const postable = streamingOptions
         ? new (chatModule().StreamingPlan)(iterable, {
             updateIntervalMs: streamingOptions.updateIntervalMs,
+            ...(groupTasks ? { groupTasks } : {}),
           })
         : iterable;
 
@@ -1555,12 +1641,13 @@ export class AgentChannels {
         } catch (e) {
           this.logger?.warn('[CHANNEL] streaming post failed, falling back to buffered text', { error: e });
           // Drain whatever was queued plus anything pushed after the failure
-          // and post it as a single buffered message.
-          const fallback = buffer.join('');
+          // and post it as a single buffered message. Drop non-string chunks
+          // (task_update etc.) since the buffered fallback is text-only.
+          const fallback = buffer.filter((p): p is string => typeof p === 'string').join('');
           buffer = [];
           if (!closed) {
             await waitForNext();
-            fallback.concat(buffer.join(''));
+            fallback.concat(buffer.filter((p): p is string => typeof p === 'string').join(''));
           }
           const cleaned = fallback.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
           if (cleaned) {
@@ -1738,19 +1825,58 @@ export class AgentChannels {
         continue;
       }
 
-      // --- Tool call: post eager "Running…" card ---
+      // --- Tool call ---
       if (chunk.type === 'tool-call') {
         if (this.channelToolNames.has(chunk.payload.toolName)) continue;
-        await flushText();
         const displayName = stripToolPrefix(chunk.payload.toolName);
-        setTypingStatus(`Using ${displayName}…`);
+        setTypingStatus(`Calling ${displayName}…`);
         const rawArgs = (
           typeof chunk.payload.args === 'object' && chunk.payload.args != null ? chunk.payload.args : {}
         ) as Record<string, unknown>;
         const argsSummary = formatArgsSummary(rawArgs);
 
+        // `'hidden'`: never render anything — just track the call so the result
+        // handler can correlate, but skip cards and `task_update` chunks alike.
+        if (toolDisplay === 'hidden') {
+          toolCalls.set(chunk.payload.toolCallId, {
+            displayName,
+            argsSummary,
+            startedAt: Date.now(),
+            messageId: undefined,
+          });
+          continue;
+        }
+
+        // `'timeline'` / `'grouped'`: push a `task_update` into the active
+        // streaming session so the platform renders the tool inline with the
+        // streaming text (Slack natively; other adapters may render a
+        // placeholder). The session is shared with text-deltas so chunks
+        // interleave in platform message order under one StreamingPlan post.
+        if (toolDisplay === 'timeline' || toolDisplay === 'grouped') {
+          if (!streamingSession) streamingSession = openStreamingSession();
+          streamingSession.push({
+            type: 'task_update',
+            id: chunk.payload.toolCallId,
+            title: displayName,
+            status: 'in_progress',
+            details: argsSummary || undefined,
+          });
+          toolCalls.set(chunk.payload.toolCallId, {
+            displayName,
+            argsSummary,
+            startedAt: Date.now(),
+            messageId: undefined,
+          });
+          continue;
+        }
+
+        // `'cards'` (default): post an eager "Running…" card that the result
+        // handler will edit in place. Skip the eager post when a custom
+        // `formatToolCall` is configured — that runs once on tool-result with
+        // the full result and we don't want a leading placeholder card.
+        await flushText();
         let messageId: string | undefined;
-        if (!adapterConfig?.formatToolCall) {
+        if (!cardsConfig?.formatToolCall) {
           const sentMessage = await sdkThread.post(formatToolRunning(displayName, argsSummary, useCards));
           messageId = sentMessage?.id;
         }
@@ -1764,7 +1890,7 @@ export class AgentChannels {
         continue;
       }
 
-      // --- Tool result: edit the "Running…" card with the outcome ---
+      // --- Tool result ---
       if (chunk.type === 'tool-result') {
         if (this.channelToolNames.has(chunk.payload.toolName)) continue;
         // Tool finished — revert status until the next text/tool/reasoning chunk
@@ -1788,8 +1914,28 @@ export class AgentChannels {
         const channelMsgId = tracked?.messageId;
         const durationMs = tracked?.startedAt != null ? Date.now() - tracked.startedAt : undefined;
 
-        if (adapterConfig?.formatToolCall) {
-          const custom = adapterConfig.formatToolCall({
+        // `'hidden'`: drop the result silently.
+        if (toolDisplay === 'hidden') continue;
+
+        // `'timeline'` / `'grouped'`: complete the task in place. We don't
+        // repeat `details` here — the Chat SDK appends to the existing task
+        // entry by id, so re-sending the args would show them twice.
+        if (toolDisplay === 'timeline' || toolDisplay === 'grouped') {
+          if (!streamingSession) streamingSession = openStreamingSession();
+          streamingSession.push({
+            type: 'task_update',
+            id: chunk.payload.toolCallId,
+            title: displayName,
+            status: chunk.payload.isError ? 'error' : 'complete',
+            output: resultText || undefined,
+          });
+          continue;
+        }
+
+        // `'cards'`: edit the "Running…" card with the result, or post the
+        // user-provided custom formatting.
+        if (cardsConfig?.formatToolCall) {
+          const custom = cardsConfig.formatToolCall({
             toolName: displayName,
             args: (chunk.payload.args ?? {}) as Record<string, unknown>,
             result: chunk.payload.result,
@@ -1812,7 +1958,11 @@ export class AgentChannels {
         continue;
       }
 
-      // --- Tool approval: edit the "Running…" card to show Approve/Deny ---
+      // --- Tool approval: post an out-of-band Approve/Deny card. ---
+      // Approvals always render as a separate card because `task_update` chunks
+      // can't carry interactive buttons. In non-`'cards'` modes we close the
+      // streaming session first so the approval card lands cleanly after the
+      // timeline/grouped block instead of getting swallowed by it.
       if (chunk.type === 'tool-call-approval') {
         const { toolCallId, toolName, args: toolArgs } = chunk.payload;
         const tracked = toolCalls.get(toolCallId);
@@ -1820,6 +1970,12 @@ export class AgentChannels {
         const argsSummary = tracked?.argsSummary || formatArgsSummary(toolArgs);
         const channelMsgId = tracked?.messageId;
 
+        if (toolDisplay !== 'cards') {
+          await closeStreamingSession();
+        }
+
+        // `useCards` is always true here so the approve/deny buttons render as
+        // a Block Kit actions block; non-cards modes never set `cards: false`.
         const approvalMessage = formatToolApproval(displayName, argsSummary, toolCallId, useCards);
 
         await this.editOrPost(adapter, sdkThread, channelMsgId, approvalMessage);
@@ -1978,10 +2134,12 @@ export class AgentChannels {
     void reconnect();
   }
 
-  private log(level: 'info' | 'error' | 'debug', message: string, ...args: unknown[]): void {
+  private log(level: 'info' | 'warn' | 'error' | 'debug', message: string, ...args: unknown[]): void {
     if (!this.logger) return;
     if (level === 'error') {
       this.logger.error(message, { args });
+    } else if (level === 'warn') {
+      this.logger.warn(message, { args });
     } else if (level === 'debug') {
       this.logger.debug(message, { args });
     } else {

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -488,7 +488,23 @@ export class AgentChannels {
    */
   private pendingApprovalCards = new Map<
     string,
-    { messageId?: string; displayName: string; argsSummary: string; startedAt: number }
+    {
+      messageId?: string;
+      displayName: string;
+      argsSummary: string;
+      startedAt: number;
+      /**
+       * runId for the suspended workflow run. Stashed when the approval card is
+       * posted so the click handler can resume the correct run by `toolCallId`
+       * without crawling persisted message metadata. The metadata path keys by
+       * `toolName` and collides when the LLM calls the same tool in parallel
+       * (e.g. weather(Vancouver) + weather(SF)) — only the latest write
+       * survives, so a lookup for the earlier call's toolCallId would miss.
+       */
+      runId?: string;
+      toolName?: string;
+      args?: Record<string, unknown>;
+    }
   >();
 
   /**
@@ -669,6 +685,10 @@ export class AgentChannels {
         try {
           const approved = actionId.startsWith('tool_approve:');
           const toolCallId = actionId.split(':')[1];
+          if (!toolCallId) {
+            this.log('info', `Missing toolCallId in action event actionId=${actionId}`);
+            return;
+          }
 
           const sdkThread = event.thread as Thread | null;
           if (!sdkThread) {
@@ -719,37 +739,50 @@ export class AgentChannels {
             mastra,
           });
 
-          // Find the runId from pendingToolApprovals in message history
-          const storage = mastra.getStorage();
-          const memoryStore = storage ? await storage.getStore('memory') : undefined;
-          if (!memoryStore) {
-            throw new Error('Storage is required for tool approval lookups');
-          }
-
-          const { messages } = await memoryStore.listMessages({
-            threadId: mastraThread.id,
-            perPage: 50,
-            orderBy: { field: 'createdAt', direction: 'DESC' },
-          });
-
-          // Search for the pendingToolApprovals metadata containing our toolCallId
+          // Look up the runId for this toolCallId. Prefer the in-memory
+          // `pendingApprovalCards` map (set when the approval card was posted)
+          // because it's keyed by toolCallId and survives parallel same-tool
+          // approvals. Fall back to the persisted `pendingToolApprovals`
+          // metadata for cases where the bot restarted between card post and
+          // click (the metadata path is lossy for parallel same-tool calls
+          // since core keys those by toolName — only the latest survives).
           let runId: string | undefined;
           let toolName: string | undefined;
           let toolArgs: Record<string, unknown> | undefined;
-          for (const msg of messages) {
-            const pending = msg.content?.metadata?.pendingToolApprovals as
-              | Record<string, { toolCallId: string; runId: string; toolName: string; args: Record<string, unknown> }>
-              | undefined;
-            if (pending) {
-              for (const toolData of Object.values(pending)) {
-                if (toolData.toolCallId === toolCallId) {
-                  runId = toolData.runId;
-                  toolName = toolData.toolName;
-                  toolArgs = toolData.args;
-                  break;
+
+          const stashed = this.pendingApprovalCards.get(toolCallId);
+          if (stashed?.runId) {
+            runId = stashed.runId;
+            toolName = stashed.toolName;
+            toolArgs = stashed.args;
+          } else {
+            const storage = mastra.getStorage();
+            const memoryStore = storage ? await storage.getStore('memory') : undefined;
+            if (!memoryStore) {
+              throw new Error('Storage is required for tool approval lookups');
+            }
+
+            const { messages } = await memoryStore.listMessages({
+              threadId: mastraThread.id,
+              perPage: 50,
+              orderBy: { field: 'createdAt', direction: 'DESC' },
+            });
+
+            for (const msg of messages) {
+              const pending = msg.content?.metadata?.pendingToolApprovals as
+                | Record<string, { toolCallId: string; runId: string; toolName: string; args: Record<string, unknown> }>
+                | undefined;
+              if (pending) {
+                for (const toolData of Object.values(pending)) {
+                  if (toolData.toolCallId === toolCallId) {
+                    runId = toolData.runId;
+                    toolName = toolData.toolName;
+                    toolArgs = toolData.args;
+                    break;
+                  }
                 }
+                if (runId) break;
               }
-              if (runId) break;
             }
           }
 
@@ -815,6 +848,10 @@ export class AgentChannels {
               } else {
                 throw err;
               }
+            } finally {
+              // Stash entry is no longer needed; the resumed decline stream
+              // won't emit a tool-result for this call.
+              this.pendingApprovalCards.delete(toolCallId);
             }
             return;
           }
@@ -2005,6 +2042,21 @@ export class AgentChannels {
         const approvalMessage = formatToolApproval(displayName, argsSummary, toolCallId, useCards);
 
         await this.editOrPost(adapter, sdkThread, channelMsgId, approvalMessage);
+
+        // Stash the runId by toolCallId so the click handler can resume the
+        // correct run directly, without crawling persisted message metadata.
+        // The metadata path keys by toolName and collides on parallel
+        // same-tool approvals — only the latest write survives, so the
+        // earlier call's click would silently miss.
+        this.pendingApprovalCards.set(toolCallId, {
+          messageId: channelMsgId,
+          displayName,
+          argsSummary,
+          startedAt: Date.now(),
+          runId: chunk.runId,
+          toolName,
+          args: toolArgs,
+        });
         continue;
       }
 

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -1749,6 +1749,13 @@ export class AgentChannels {
         continue;
       }
 
+      // Flush as soon as the model finishes a text block so the message
+      // posts before any subsequent tool call status updates.
+      if (chunk.type === 'text-end') {
+        await flushText();
+        continue;
+      }
+
       if (chunk.type === 'reasoning-delta') {
         setTypingStatus('Thinking…');
         continue;
@@ -1837,7 +1844,11 @@ export class AgentChannels {
 
         // `'hidden'`: never render anything — just track the call so the result
         // handler can correlate, but skip cards and `task_update` chunks alike.
+        // Flush any pending text first so it posts before the silent tool runs;
+        // otherwise the user sees the "Calling…" typing status with no leading
+        // message until the tool resolves.
         if (toolDisplay === 'hidden') {
+          await flushText();
           toolCalls.set(chunk.payload.toolCallId, {
             displayName,
             argsSummary,
@@ -1853,7 +1864,22 @@ export class AgentChannels {
         // placeholder). The session is shared with text-deltas so chunks
         // interleave in platform message order under one StreamingPlan post.
         if (toolDisplay === 'timeline' || toolDisplay === 'grouped') {
+          // Close any active text-only session first so preceding text posts
+          // as its own platform message. Slack's AI Assistant widget always
+          // renders tasks above markdown body within a single post, so
+          // interleaving text and tools requires separate messages.
+          if (streamingSession && toolCalls.size === 0) {
+            await closeStreamingSession();
+          }
           if (!streamingSession) streamingSession = openStreamingSession();
+          // Track the active task as the plan title so Slack's AI Assistant
+          // Thinking Steps widget shows the current tool instead of the
+          // default "Thinking…"/"completed" labels. Mirrors the behavior of
+          // Chat SDK `Plan.addTask` which overwrites the plan title on each
+          // new task.
+          if (toolDisplay === 'grouped') {
+            streamingSession.push({ type: 'plan_update', title: displayName });
+          }
           streamingSession.push({
             type: 'task_update',
             id: chunk.payload.toolCallId,

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -1793,10 +1793,11 @@ export class AgentChannels {
         continue;
       }
 
-      if (chunk.type === 'reasoning-delta') {
-        setTypingStatus('Thinking…');
-        continue;
-      }
+      // Note: we intentionally do NOT set a `Thinking…` typing status on
+      // `reasoning-delta` or `tool-result`. The platform's own typing
+      // indicator already conveys "the agent is doing something"; layering
+      // `Thinking…` on top tended to get stuck on screen after the run
+      // finished and added noise between tool calls.
 
       // --- File (e.g. model-generated image): post as attachment ---
       if (chunk.type === 'file') {
@@ -1825,6 +1826,10 @@ export class AgentChannels {
 
       // --- Text flush triggers ---
       if (chunk.type === 'step-finish') {
+        // In `'grouped'` mode keep the streaming session open across steps
+        // so the whole run renders as a single StreamingPlan post instead
+        // of one widget per step.
+        if (toolDisplay === 'grouped') continue;
         await flushText();
         continue;
       }
@@ -1873,7 +1878,12 @@ export class AgentChannels {
       if (chunk.type === 'tool-call') {
         if (this.channelToolNames.has(chunk.payload.toolName)) continue;
         const displayName = stripToolPrefix(chunk.payload.toolName);
-        setTypingStatus(`Calling ${displayName}…`);
+        // `'timeline'` / `'grouped'` already render the in-progress task in the
+        // streaming widget — a `Calling X…` typing indicator on top of that is
+        // just visual noise.
+        if (toolDisplay !== 'timeline' && toolDisplay !== 'grouped') {
+          setTypingStatus(`Calling ${displayName}…`);
+        }
         const rawArgs = (
           typeof chunk.payload.args === 'object' && chunk.payload.args != null ? chunk.payload.args : {}
         ) as Record<string, unknown>;
@@ -1905,7 +1915,11 @@ export class AgentChannels {
           // as its own platform message. Slack's AI Assistant widget always
           // renders tasks above markdown body within a single post, so
           // interleaving text and tools requires separate messages.
-          if (streamingSession && toolCalls.size === 0) {
+          // In `'grouped'` mode we keep the streaming session open across
+          // text+tool turns so the plan widget accumulates every task in one
+          // post. Splitting on the first tool produced one widget per step,
+          // which buried earlier tool calls.
+          if (streamingSession && toolCalls.size === 0 && toolDisplay !== 'grouped') {
             await closeStreamingSession();
           }
           if (!streamingSession) streamingSession = openStreamingSession();
@@ -1917,12 +1931,17 @@ export class AgentChannels {
           if (toolDisplay === 'grouped') {
             streamingSession.push({ type: 'plan_update', title: displayName });
           }
+          // For `'grouped'` fold args inline into the title so the at-a-glance
+          // widget stays a single line per call (e.g. `read_file foo.md`).
+          // `'timeline'` keeps args on a second `details` line — each task has
+          // its own row so the extra line reads fine and is more scannable.
+          const taskTitle = toolDisplay === 'grouped' && argsSummary ? `${displayName} ${argsSummary}` : displayName;
           streamingSession.push({
             type: 'task_update',
             id: chunk.payload.toolCallId,
-            title: displayName,
+            title: taskTitle,
             status: 'in_progress',
-            details: argsSummary || undefined,
+            details: toolDisplay === 'grouped' ? undefined : argsSummary || undefined,
           });
           toolCalls.set(chunk.payload.toolCallId, {
             displayName,
@@ -1956,9 +1975,6 @@ export class AgentChannels {
       // --- Tool result ---
       if (chunk.type === 'tool-result') {
         if (this.channelToolNames.has(chunk.payload.toolName)) continue;
-        // Tool finished — revert status until the next text/tool/reasoning chunk
-        // sets a more specific one.
-        setTypingStatus('Thinking…');
 
         // Look in the per-run tracked tools first; fall back to any approval card that was
         // posted by the click handler (the resumed run's tool-result arrives via the thread
@@ -1983,14 +1999,24 @@ export class AgentChannels {
         // `'timeline'` / `'grouped'`: complete the task in place. We don't
         // repeat `details` here — the Chat SDK appends to the existing task
         // entry by id, so re-sending the args would show them twice.
+        //
+        // For `'grouped'` we suppress the full result body and just mark the
+        // task complete — `grouped` is an at-a-glance summary of what the
+        // agent did, not a detailed trace. Errors still get the full text so
+        // failures stay debuggable. `'timeline'` shows the full result.
         if (toolDisplay === 'timeline' || toolDisplay === 'grouped') {
           if (!streamingSession) streamingSession = openStreamingSession();
+          // Mirror the inline-args title from the tool-call handler so the
+          // completed task keeps the same `read_file foo.md` label instead
+          // of collapsing back to the bare tool name.
+          const taskTitle = toolDisplay === 'grouped' && argsSummary ? `${displayName} ${argsSummary}` : displayName;
+          const groupedOutput = chunk.payload.isError ? resultText || undefined : undefined;
           streamingSession.push({
             type: 'task_update',
             id: chunk.payload.toolCallId,
-            title: displayName,
+            title: taskTitle,
             status: chunk.payload.isError ? 'error' : 'complete',
-            output: resultText || undefined,
+            output: toolDisplay === 'grouped' ? groupedOutput : resultText || undefined,
           });
           continue;
         }

--- a/packages/core/src/channels/index.ts
+++ b/packages/core/src/channels/index.ts
@@ -1,6 +1,9 @@
 export { AgentChannels } from './agent-channels';
 export type {
+  ChannelAdapterBaseConfig,
+  ChannelAdapterCardsConfig,
   ChannelAdapterConfig,
+  ChannelAdapterStreamingToolsConfig,
   ChannelConfig,
   ChannelHandler,
   ChannelHandlerConfig,


### PR DESCRIPTION
Stacked on #16801.

Adds a `toolDisplay` config to `ChannelAdapterConfig` so adapter authors and users can pick how tool calls render in chat surfaces.

## Modes

| Mode | Behavior | Streaming required |
|---|---|---|
| `'cards'` (default) | Per-tool "Running…" → "Result" cards. Unchanged behavior. | No |
| `'timeline'` | Each tool emits inline `task_update` chunks alongside text via `StreamingPlan({ groupTasks: 'timeline' })`. Slack only. | Yes |
| `'grouped'` | Same chunks as `'timeline'` but combined into a single plan block via `StreamingPlan({ groupTasks: 'plan' })`. Slack only. | Yes |
| `'hidden'` | Tools execute silently. Only the typing status ("Calling weather…") indicates work is happening. | No |

If `'timeline'` or `'grouped'` is set without `streaming: true`, the channel falls back to `'cards'` and logs a one-time warn per platform.

## Per-adapter, not global

`toolDisplay` lives on `ChannelAdapterConfig` so different adapters can pick the best mode for each surface:

```ts
new SlackProvider({
  toolDisplay: 'timeline',
  streaming: true,
  // ...
});
```

Slack renders `task_update` chunks natively. Discord today renders a placeholder; the fix belongs in the chat adapter layer (no auto-fallback here).

## Type-level exclusivity

`ChannelAdapterConfig` is now a discriminated union:

- `ChannelAdapterCardsConfig` — `toolDisplay?: 'cards'`, `cards`, `formatToolCall`
- `ChannelAdapterStreamingToolsConfig` — `toolDisplay: 'timeline' | 'grouped' | 'hidden'`, no `cards`/`formatToolCall`

This makes the mutual exclusivity of `formatToolCall` and the streaming modes explicit at the type level — TypeScript prevents users from setting `formatToolCall` alongside `'timeline'` mode, where it would be a silent no-op.

## What's not in this PR

- `plan?: true | { toolDisplay?: 'inline' | 'hidden' }` + `createPlanTools()` factory + auto-injection — follow-up PR.
- Parallel tool approval resume inversion bug (logged separately) — orthogonal core agent issue.

## Test plan

- ✅ 97/97 channels tests (5 new toolDisplay scenarios: cards/timeline/grouped/hidden + timeline-without-streaming-fallback)
- ✅ 63/63 slack tests
- ✅ typecheck clean
- ✅ build clean
- ✅ Smoke-tested in Slack DM + thread (all four modes) and Discord DM (documented `…` placeholder limitation)
