### PR TITLE
fix(voice): stop sending deprecated OpenAI-Beta realtime header

### DIFF
--- a/.changeset/quick-eagles-cheer.md
+++ b/.changeset/quick-eagles-cheer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-openai-realtime': patch
+---
+
+Stop sending the deprecated `OpenAI-Beta: realtime=v1` request header when connecting to the OpenAI Realtime API. OpenAI removed the beta interface on 2026-05-12, so this header caused the WebSocket connection to be rejected.

--- a/voice/openai-realtime-api/src/index.test.ts
+++ b/voice/openai-realtime-api/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WebSocket } from 'ws';
 import { OpenAIRealtimeVoice } from './index';
 
 // Mock RealtimeClient
@@ -83,6 +84,17 @@ describe('OpenAIRealtimeVoice', () => {
 
       await voice.connect();
       voice.send(testArray);
+    });
+  });
+
+  describe('connect', () => {
+    it('should not send the deprecated OpenAI-Beta header', async () => {
+      await voice.connect();
+
+      expect(WebSocket).toHaveBeenCalled();
+      const headers = vi.mocked(WebSocket).mock.calls[0]?.[2]?.headers as Record<string, string>;
+      expect(headers).toHaveProperty('Authorization');
+      expect(headers).not.toHaveProperty('OpenAI-Beta');
     });
   });
 

--- a/voice/openai-realtime-api/src/index.test.ts
+++ b/voice/openai-realtime-api/src/index.test.ts
@@ -92,9 +92,14 @@ describe('OpenAIRealtimeVoice', () => {
       await voice.connect();
 
       expect(WebSocket).toHaveBeenCalled();
-      const headers = vi.mocked(WebSocket).mock.calls[0]?.[2]?.headers as Record<string, string>;
-      expect(headers).toHaveProperty('Authorization');
-      expect(headers).not.toHaveProperty('OpenAI-Beta');
+      const firstCall = vi.mocked(WebSocket).mock.calls[0];
+      expect(firstCall).toBeDefined();
+      expect(firstCall[2]).toBeDefined();
+
+      const options = firstCall[2] as { headers: Record<string, string> };
+      expect(options.headers).toBeDefined();
+      expect(options.headers.Authorization).toBe('Bearer test-api-key');
+      expect(options.headers).not.toHaveProperty('OpenAI-Beta');
     });
   });
 

--- a/voice/openai-realtime-api/src/index.ts
+++ b/voice/openai-realtime-api/src/index.ts
@@ -387,7 +387,6 @@ export class OpenAIRealtimeVoice extends MastraVoice {
     this.ws = new WebSocket(url, undefined, {
       headers: {
         Authorization: 'Bearer ' + apiKey,
-        'OpenAI-Beta': 'realtime=v1',
       },
     });
 


### PR DESCRIPTION
## Summary

`@mastra/voice-openai-realtime` sends the `OpenAI-Beta: realtime=v1` request
header when opening the WebSocket in `connect()`. OpenAI removed the Realtime
API beta interface on 2026-05-12, so this header now causes the connection to
be rejected for models that target the GA endpoint (e.g.
`gpt-4o-realtime-preview`, `gpt-realtime`).

This PR removes the deprecated header so connections go to the GA endpoint.

## Changes

- Remove the `OpenAI-Beta: realtime=v1` header from `connect()` in
  `voice/openai-realtime-api/src/index.ts`.
- Add a unit test asserting the connect headers no longer include `OpenAI-Beta`
  (and still include `Authorization`).
- Add a changeset (patch for `@mastra/voice-openai-realtime`).

## Test plan

- [x] `pnpm --filter "@mastra/voice-openai-realtime" test` — new `connect` test passes
- [x] `pnpm --filter "@mastra/voice-openai-realtime" lint` — clean

Fixes #16875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR stops the package from sending an old, now-broken instruction header (`OpenAI-Beta: realtime=v1`) when opening a voice WebSocket connection to OpenAI, so connections no longer get rejected.

## Overview

OpenAI removed the Realtime API beta interface on 2026-05-12; the package `@mastra/voice-openai-realtime` was still sending the deprecated `OpenAI-Beta: realtime=v1` header in connect(), causing WebSocket connections to be rejected for GA-targeted models. This PR removes that header so connections go to the GA endpoint.

## Changes

Implementation (voice/openai-realtime-api/src/index.ts)
- Removed the deprecated `OpenAI-Beta: realtime=v1` header from the WebSocket connection options in connect().
- Left the `Authorization: Bearer <apiKey>` header intact.

Testing (voice/openai-realtime-api/src/index.test.ts)
- Added a unit test that imports `WebSocket` from `ws` and asserts:
  - `WebSocket` is constructed when connect() is called.
  - Request headers include `Authorization: Bearer test-api-key`.
  - Request headers do NOT include `OpenAI-Beta`.

Release (changeset)
- Added a changeset declaring a patch release for `@mastra/voice-openai-realtime` documenting removal of the deprecated header.

## Impact

- Fixes WebSocket connection rejections when connecting to OpenAI's Realtime GA endpoint (e.g., gpt-4o-realtime-preview, gpt-realtime).
- Low-risk, small change limited to removing an unsupported header and adding a focused unit test.

## Related

Fixes `#16875`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->