### PR TITLE
feat(core): add Harness v1 event id helpers

### DIFF
--- a/.changeset/fruity-mirrors-matter.md
+++ b/.changeset/fruity-mirrors-matter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added stable Harness v1 event id helpers.

--- a/packages/core/src/harness/v1/events.test.ts
+++ b/packages/core/src/harness/v1/events.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HarnessValidationError } from './errors';
+import { EventEmitter, formatHarnessEventId, parseHarnessEventId, snapshotHarnessEventForJson } from './events';
+
+describe('Harness v1 event ids', () => {
+  it('formats and parses stable harness-v1 event ids', () => {
+    expect(formatHarnessEventId('epoch-1', 0)).toBe('harness-v1:epoch-1:0');
+    expect(formatHarnessEventId('epoch-1', 42)).toBe('harness-v1:epoch-1:42');
+    expect(parseHarnessEventId('harness-v1:epoch-1:42')).toEqual({ epoch: 'epoch-1', sequence: 42 });
+  });
+
+  it('rejects malformed event ids', () => {
+    expect(() => formatHarnessEventId('', 0)).toThrow(HarnessValidationError);
+    expect(() => formatHarnessEventId('bad:epoch', 0)).toThrow(HarnessValidationError);
+    expect(() => formatHarnessEventId('epoch', -1)).toThrow(HarnessValidationError);
+    expect(() => parseHarnessEventId('epoch-1-0')).toThrow(HarnessValidationError);
+    expect(() => parseHarnessEventId('harness-v1:epoch-1:01')).toThrow(HarnessValidationError);
+  });
+
+  it('stamps events with deterministic epoch and sequence values', () => {
+    const onEvent = vi.fn();
+    const listener = vi.fn();
+    const emitter = new EventEmitter({ sessionId: 'session-1' }, { epoch: 'epoch-1', nextSequence: 7, onEvent });
+    emitter.subscribe(listener);
+
+    const first = emitter.emit({ type: 'agent_start' });
+    const second = emitter.emit({ type: 'message_start', messageId: 'message-1' });
+
+    expect(first).toMatchObject({ id: 'harness-v1:epoch-1:7', sessionId: 'session-1' });
+    expect(second).toMatchObject({ id: 'harness-v1:epoch-1:8', sessionId: 'session-1' });
+    expect(onEvent).toHaveBeenCalledWith(first);
+    expect(listener).toHaveBeenCalledWith(first);
+  });
+
+  it('dispatches against a listener snapshot when subscribers unsubscribe during emit', () => {
+    const emitter = new EventEmitter(undefined, { epoch: 'epoch-1' });
+    const second = vi.fn();
+    let unsubscribeFirst = () => {};
+    const first = vi.fn(() => unsubscribeFirst());
+    unsubscribeFirst = emitter.subscribe(first);
+    emitter.subscribe(second);
+
+    emitter.emit({ type: 'agent_start' });
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('snapshotHarnessEventForJson', () => {
+  it('projects errors into public JSON objects', () => {
+    const err = new Error('boom') as Error & { code?: string };
+    err.code = 'custom.failure';
+
+    expect(snapshotHarnessEventForJson({ error: err })).toEqual({
+      error: {
+        name: 'Error',
+        code: 'custom.failure',
+        message: 'boom',
+      },
+    });
+  });
+
+  it('rejects values that cannot be serialized as JSON', () => {
+    expect(() => snapshotHarnessEventForJson({ value: 1n })).toThrow(HarnessValidationError);
+    expect(() => snapshotHarnessEventForJson({ value: undefined })).toThrow(HarnessValidationError);
+    expect(() => snapshotHarnessEventForJson({ value: Number.NaN })).toThrow(HarnessValidationError);
+  });
+});

--- a/packages/core/src/harness/v1/events.ts
+++ b/packages/core/src/harness/v1/events.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
+import type { JsonValue } from '../../storage/domains/harness';
 import type { TaskItem } from '../tools';
 import { HarnessEventSerializationError, HarnessValidationError } from './errors';
 import type { EventSerializationReason } from './errors';
@@ -380,6 +381,101 @@ export type HarnessEvent =
 export type HarnessEventListener = (event: HarnessEvent) => void | Promise<void>;
 export type HarnessEventUnsubscribe = () => void;
 
+export const HARNESS_EVENT_ID_PREFIX = 'harness-v1';
+
+export interface ParsedHarnessEventId {
+  epoch: string;
+  sequence: number;
+}
+
+export function formatHarnessEventId(epoch: string, sequence: number): string {
+  if (epoch.length === 0 || epoch.includes(':')) {
+    throw new HarnessValidationError('eventId.epoch', 'epoch must be non-empty and must not contain ":"');
+  }
+  if (!Number.isSafeInteger(sequence) || sequence < 0) {
+    throw new HarnessValidationError('eventId.sequence', 'sequence must be a non-negative safe integer');
+  }
+  return `${HARNESS_EVENT_ID_PREFIX}:${epoch}:${sequence}`;
+}
+
+export function parseHarnessEventId(eventId: string): ParsedHarnessEventId {
+  const parts = eventId.split(':');
+  if (parts.length !== 3 || parts[0] !== HARNESS_EVENT_ID_PREFIX || parts[1] === '' || parts[2] === '') {
+    throw new HarnessValidationError('lastEventId', 'expected event id grammar harness-v1:<epoch>:<seq>');
+  }
+  const sequenceText = parts[2]!;
+  if (!/^(0|[1-9][0-9]*)$/.test(sequenceText)) {
+    throw new HarnessValidationError('lastEventId', 'event id sequence must be an unsigned decimal integer');
+  }
+  const sequence = Number(sequenceText);
+  if (!Number.isSafeInteger(sequence)) {
+    throw new HarnessValidationError('lastEventId', 'event id sequence must be within JavaScript safe integer range');
+  }
+  return { epoch: parts[1]!, sequence };
+}
+
+export function snapshotHarnessEventForJson(value: unknown, path = 'event'): JsonValue {
+  const seen = new WeakSet<object>();
+  return snapshotJsonValue(value, path, seen);
+}
+
+export function projectHarnessPublicError(err: unknown): { code: string; message: string } {
+  if (err instanceof Error) {
+    return { code: (err as { code?: string }).code ?? err.name ?? 'harness.message_failed', message: err.message };
+  }
+  return { code: 'harness.message_failed', message: String(err) };
+}
+
+function snapshotJsonValue(value: unknown, path: string, seen: WeakSet<object>): JsonValue {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      ...projectHarnessPublicError(value),
+    };
+  }
+
+  if (value === null) return null;
+  const type = typeof value;
+  if (type === 'string' || type === 'boolean') return value as JsonValue;
+  if (type === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new HarnessValidationError(path, 'must be JSON-serializable for event replay');
+    }
+    return value as JsonValue;
+  }
+  if (type === 'undefined' || type === 'function' || type === 'symbol' || type === 'bigint') {
+    throw new HarnessValidationError(path, 'must be JSON-serializable for event replay');
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) throw new HarnessValidationError(path, 'must be JSON-serializable for event replay');
+    seen.add(value);
+    const snapshot = value.map((item, index) => snapshotJsonValue(item, `${path}[${index}]`, seen));
+    seen.delete(value);
+    return snapshot;
+  }
+
+  if (value instanceof Date || value instanceof Map || value instanceof Set) {
+    throw new HarnessValidationError(path, 'must be JSON-serializable for event replay');
+  }
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+    throw new HarnessValidationError(path, 'must be JSON-serializable for event replay');
+  }
+
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== null && proto !== Object.prototype) {
+    throw new HarnessValidationError(path, 'must be JSON-serializable for event replay');
+  }
+  if (seen.has(value as object)) throw new HarnessValidationError(path, 'must be JSON-serializable for event replay');
+  seen.add(value as object);
+  const snapshot: Record<string, JsonValue> = {};
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    snapshot[key] = snapshotJsonValue((value as Record<string, unknown>)[key], `${path}.${key}`, seen);
+  }
+  seen.delete(value as object);
+  return snapshot;
+}
+
 type DistributiveOmit<T, K extends keyof never> = T extends unknown ? Omit<T, K> : never;
 
 export type EmitInput = DistributiveOmit<HarnessEvent, 'id' | 'timestamp' | 'sessionId'>;
@@ -390,12 +486,20 @@ export interface EmitterScope {
 
 export class EventEmitter {
   private readonly listeners: HarnessEventListener[] = [];
-  private readonly epoch: string = randomUUID();
-  private seq = 0;
+  private readonly epoch: string;
+  private seq: number;
   private readonly scope: EmitterScope;
+  private readonly onEvent?: HarnessEventListener;
 
-  constructor(scope: EmitterScope = {}) {
+  constructor(
+    scope: EmitterScope = {},
+    opts: { onEvent?: HarnessEventListener; epoch?: string; nextSequence?: number } = {},
+  ) {
     this.scope = scope;
+    this.onEvent = opts.onEvent;
+    this.epoch = opts.epoch ?? randomUUID();
+    this.seq = opts.nextSequence ?? 0;
+    formatHarnessEventId(this.epoch, this.seq);
   }
 
   subscribe(listener: HarnessEventListener): HarnessEventUnsubscribe {
@@ -410,7 +514,7 @@ export class EventEmitter {
     const sessionId = overrides?.sessionId ?? this.scope.sessionId;
     const stamped = {
       ...event,
-      id: `${this.epoch}-${this.seq++}`,
+      id: formatHarnessEventId(this.epoch, this.seq++),
       timestamp: Date.now(),
       ...(sessionId !== undefined && { sessionId }),
     } as HarnessEvent;
@@ -431,6 +535,16 @@ export class EventEmitter {
   }
 
   private dispatch(event: HarnessEvent): void {
+    if (this.onEvent) {
+      try {
+        const result = this.onEvent(event);
+        if (result && typeof (result as Promise<void>).catch === 'function') {
+          (result as Promise<void>).catch(err => console.error('[harness/v1] event persistence rejected:', err));
+        }
+      } catch (err) {
+        console.error('[harness/v1] event persistence threw:', err);
+      }
+    }
     for (const listener of [...this.listeners]) {
       try {
         const result = listener(event);

--- a/packages/core/src/harness/v1/export-map.test.ts
+++ b/packages/core/src/harness/v1/export-map.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import * as legacyHarnessEntry from '../index';
+import * as harnessV1Entry from './index';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const packageJson = JSON.parse(readFileSync(resolve(packageRoot, 'package.json'), 'utf8')) as {
+  exports: Record<string, unknown>;
+};
+
+describe('Harness v1 package export acceptance', () => {
+  it('maps @mastra/core/harness/v1 to v1 dist targets without replacing the legacy harness entry', () => {
+    expect(packageJson.exports['./harness/v1']).toEqual({
+      import: {
+        types: './dist/harness/v1/index.d.ts',
+        default: './dist/harness/v1/index.js',
+      },
+      require: {
+        types: './dist/harness/v1/index.d.ts',
+        default: './dist/harness/v1/index.cjs',
+      },
+    });
+    expect(packageJson.exports['./harness']).toEqual({
+      import: {
+        types: './dist/harness/index.d.ts',
+        default: './dist/harness/index.js',
+      },
+      require: {
+        types: './dist/harness/index.d.ts',
+        default: './dist/harness/index.cjs',
+      },
+    });
+
+    expect(harnessV1Entry.Harness).toBeDefined();
+    expect(harnessV1Entry.Session).toBeDefined();
+    expect(harnessV1Entry.formatHarnessEventId).toBeTypeOf('function');
+    expect(harnessV1Entry.Harness).not.toBe(legacyHarnessEntry.Harness);
+  });
+});

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -10,9 +10,13 @@ export { Harness } from './harness';
 export { Session } from './session';
 export {
   EventEmitter,
+  HARNESS_EVENT_ID_PREFIX,
   assertCustomEventType,
   assertJsonSerializable,
+  formatHarnessEventId,
+  parseHarnessEventId,
   sessionCreatedPayload,
+  snapshotHarnessEventForJson,
   suspensionRequiredFor,
 } from './events';
 export { nonDurableProvider } from './workspace-provider';

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -141,6 +141,8 @@ export interface GoalState {
   lastDecision?: GoalJudgeDecision;
 }
 
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
 /**
  * Per-session workspace state, only populated under a resumable per-session
  * workspace provider.


### PR DESCRIPTION
## Description

Adds stable Harness v1 event id helpers for the live event stream. Event ids now use the `harness-v1:<epoch>:<seq>` grammar, with parser/formatter helpers exported from `@mastra/core/harness/v1`.

This also adds a JSON snapshot helper for replay-safe event payloads, keeps listener dispatch stable when subscribers unsubscribe during an emit, and adds focused tests for event ids and the v1 export map. This is a small reviewable slice from the latest Harness v1 foundation sync.

Validation:
- `pnpm build:core`
- `pnpm --filter ./packages/core test:unit src/harness/v1`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check <changed files>`

## Related issue(s)

Part of #16878

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR