### PR TITLE
feat(core): add Harness v1 admission storage

### DIFF
--- a/.changeset/tangy-coats-act.md
+++ b/.changeset/tangy-coats-act.md
@@ -1,0 +1,26 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 admission evidence storage so storage adapters can make message and queue submissions idempotent.
+
+**What's new**
+
+- Detect duplicate message and queue admissions by `admissionId` and payload hash.
+- Surface same-key conflicts before a request is executed twice.
+- Store completed operations efficiently while preserving retry resolution.
+
+```ts
+const duplicate = await harnessStorage.resolveOperationAdmissionEvidence({
+  sessionId,
+  resourceId,
+  threadId,
+  kind: 'message',
+  admissionId: 'send-message-1',
+  attemptedAdmissionHash: hash,
+});
+
+if (duplicate.status === 'duplicate') {
+  return duplicate.evidence;
+}
+```

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -1,9 +1,14 @@
 import { StorageDomain } from '../base';
 import type {
   AcquireSessionLeaseInput,
+  AgentSignalResultEvidence,
+  AgentSignalResultStatus,
   AttachmentRecord,
   ListSessionsInput,
   LoadedAttachment,
+  OperationAdmissionEvidence,
+  OperationAdmissionTombstone,
+  QueueAdmissionReceipt,
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentInput,
@@ -13,6 +18,11 @@ import type {
   SessionRecord,
   SessionSummary,
 } from './types';
+
+export interface WriteMessageResultEvidenceResult {
+  created: boolean;
+  evidence?: AgentSignalResultEvidence | OperationAdmissionTombstone;
+}
 
 /**
  * Thrown by `saveSession` when `ifVersion` does not match the record's
@@ -57,6 +67,19 @@ export class HarnessStorageSessionNotFoundError extends Error {
 
   constructor(public readonly sessionId: string) {
     super(`Session "${sessionId}" not found in harness storage`);
+  }
+}
+
+export class HarnessStorageAdmissionConflictError extends Error {
+  readonly name = 'HarnessStorageAdmissionConflictError';
+  readonly code = 'harness.storage.admission_conflict' as const;
+
+  constructor(
+    public readonly sessionId: string,
+    public readonly kind: 'message' | 'queue',
+    public readonly admissionId: string,
+  ) {
+    super(`Admission "${admissionId}" for ${kind} in session "${sessionId}" conflicts with stored evidence`);
   }
 }
 
@@ -158,6 +181,52 @@ export abstract class HarnessStorage extends StorageDomain {
    * Look up the index row only, without bytes.
    */
   abstract getAttachmentRecord(opts: { sessionId: string; attachmentId: string }): Promise<AttachmentRecord | null>;
+
+  abstract loadMessageResultEvidence(opts: {
+    sessionId: string;
+    resourceId: string;
+    threadId: string;
+    signalId: string;
+  }): Promise<AgentSignalResultStatus | OperationAdmissionTombstone | null>;
+
+  abstract writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<WriteMessageResultEvidenceResult>;
+
+  abstract loadQueueResultEvidence(opts: {
+    sessionId: string;
+    resourceId: string;
+    queuedItemId: string;
+  }): Promise<QueueAdmissionReceipt | OperationAdmissionTombstone | null>;
+
+  abstract resolveOperationAdmissionEvidence(opts: {
+    sessionId: string;
+    resourceId: string;
+    threadId?: string;
+    kind: 'message' | 'queue';
+    admissionId: string;
+    attemptedAdmissionHash: string;
+  }): Promise<{
+    status: 'none' | 'duplicate' | 'conflict';
+    evidence?: OperationAdmissionEvidence;
+    storedAdmissionHash?: string;
+  }>;
+
+  abstract writeOperationAdmissionTombstone(record: OperationAdmissionTombstone): Promise<void>;
+
+  abstract compactOperationResultEvidence(opts: {
+    sessionId: string;
+    resourceId: string;
+    kind: 'message' | 'queue';
+    signalId?: string;
+    queuedItemId?: string;
+    now: number;
+  }): Promise<OperationAdmissionTombstone | null>;
+
+  abstract deleteOperationAdmissionTombstonesForSession(opts: {
+    sessionId: string;
+    resourceId: string;
+    threadId?: string;
+    signalId?: string;
+  }): Promise<void>;
 
   /**
    * Drop all session records, leases, and attachments held by this domain.

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { InMemoryDB } from '../inmemory-db';
 import {
+  HarnessStorageAdmissionConflictError,
   HarnessStorageLeaseConflictError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageVersionConflictError,
@@ -272,6 +273,385 @@ describe('InMemoryHarness', () => {
     await expect(storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'b' })).resolves.toBeNull();
   });
 
+  it('deletes admission evidence on session delete', async () => {
+    await storage.saveSession(makeSession(), { ownerId: 'owner-1', ifVersion: 0 });
+    await storage.writeMessageResultEvidence({
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      signalId: 'signal-1',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      status: 'pending',
+      createdAt: 1_000,
+      updatedAt: 1_000,
+    });
+    await storage.writeOperationAdmissionTombstone({
+      kind: 'message',
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      signalId: 'signal-2',
+      admissionId: 'admission-2',
+      admissionHash: 'hash-2',
+      terminalAt: 1_100,
+      compactedAt: 1_200,
+      expiresAt: 1_300,
+    });
+
+    await storage.deleteSession({ sessionId: 'session-1' });
+
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        kind: 'message',
+        admissionId: 'admission-2',
+        attemptedAdmissionHash: 'hash-2',
+      }),
+    ).resolves.toEqual({ status: 'none' });
+  });
+
+  it('stores message admission evidence and detects duplicate admission hashes', async () => {
+    const evidence = {
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      signalId: 'signal-1',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      status: 'pending' as const,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+    };
+
+    await expect(storage.writeMessageResultEvidence(evidence)).resolves.toEqual({ created: true });
+    await expect(
+      storage.writeMessageResultEvidence({
+        ...evidence,
+        status: 'completed',
+        runId: 'run-1',
+        result: { ok: true },
+        updatedAt: 1_100,
+      }),
+    ).resolves.toMatchObject({
+      created: false,
+      evidence: { createdAt: 1_000, updatedAt: 1_100 },
+    });
+
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        kind: 'message',
+        admissionId: 'admission-1',
+        attemptedAdmissionHash: 'hash-1',
+      }),
+    ).resolves.toMatchObject({ status: 'duplicate', storedAdmissionHash: 'hash-1' });
+
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        kind: 'message',
+        admissionId: 'admission-1',
+        attemptedAdmissionHash: 'hash-2',
+      }),
+    ).resolves.toMatchObject({ status: 'conflict', storedAdmissionHash: 'hash-1' });
+
+    await expect(
+      storage.writeMessageResultEvidence({
+        ...evidence,
+        signalId: 'signal-2',
+        status: 'pending',
+        updatedAt: 1_200,
+      }),
+    ).resolves.toMatchObject({
+      created: false,
+      evidence: { signalId: 'signal-1', admissionId: 'admission-1' },
+    });
+
+    await expect(storage.writeMessageResultEvidence({ ...evidence, admissionHash: 'hash-2' })).rejects.toBeInstanceOf(
+      HarnessStorageAdmissionConflictError,
+    );
+    await expect(
+      storage.writeMessageResultEvidence({
+        ...evidence,
+        signalId: 'signal-3',
+        admissionHash: 'hash-2',
+      }),
+    ).rejects.toBeInstanceOf(HarnessStorageAdmissionConflictError);
+  });
+
+  it('compacts terminal message evidence into tombstones', async () => {
+    await storage.writeMessageResultEvidence({
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      signalId: 'signal-1',
+      runId: 'run-1',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      status: 'completed',
+      result: { ok: true },
+      createdAt: 1_000,
+      updatedAt: 1_200,
+    });
+
+    await expect(
+      storage.compactOperationResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        kind: 'message',
+        signalId: 'signal-1',
+        now: 2_000,
+      }),
+    ).resolves.toMatchObject({
+      kind: 'message',
+      sessionId: 'session-1',
+      signalId: 'signal-1',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      terminalAt: 1_200,
+      compactedAt: 2_000,
+    });
+
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+      }),
+    ).resolves.toMatchObject({ kind: 'message', admissionId: 'admission-1' });
+
+    await expect(
+      storage.writeMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-2',
+        admissionId: 'admission-1',
+        admissionHash: 'hash-1',
+        status: 'pending',
+        createdAt: 2_100,
+        updatedAt: 2_100,
+      }),
+    ).resolves.toMatchObject({
+      created: false,
+      evidence: { kind: 'message', admissionId: 'admission-1' },
+    });
+    await expect(
+      storage.writeMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-3',
+        admissionId: 'admission-1',
+        admissionHash: 'hash-2',
+        status: 'pending',
+        createdAt: 2_200,
+        updatedAt: 2_200,
+      }),
+    ).rejects.toBeInstanceOf(HarnessStorageAdmissionConflictError);
+  });
+
+  it('rejects conflicting tombstones for the same admission id', async () => {
+    await storage.writeOperationAdmissionTombstone({
+      kind: 'message',
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      signalId: 'signal-1',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      terminalAt: 1_000,
+      compactedAt: 1_000,
+      expiresAt: 1_000,
+    });
+
+    await expect(
+      storage.writeOperationAdmissionTombstone({
+        kind: 'message',
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-2',
+        admissionId: 'admission-1',
+        admissionHash: 'hash-2',
+        terminalAt: 1_100,
+        compactedAt: 1_100,
+        expiresAt: 1_100,
+      }),
+    ).rejects.toBeInstanceOf(HarnessStorageAdmissionConflictError);
+
+    await expect(
+      storage.writeOperationAdmissionTombstone({
+        kind: 'message',
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-2',
+        admissionId: 'admission-1',
+        admissionHash: 'hash-1',
+        terminalAt: 1_100,
+        compactedAt: 1_100,
+        expiresAt: 1_100,
+      }),
+    ).resolves.toBeUndefined();
+    expect(db.harnessOperationTombstones.size).toBe(1);
+  });
+
+  it('resolves queue admission receipts and compacts terminal queue evidence', async () => {
+    await storage.saveSession(
+      makeSession({
+        queueAdmissionReceipts: {
+          'queued-1': {
+            admissionId: 'admission-1',
+            admissionHash: 'hash-1',
+            queuedItemId: 'queued-1',
+            status: 'completed',
+            runId: 'run-1',
+            signalId: 'signal-1',
+            result: { ok: true },
+            attempts: 1,
+            enqueuedAt: 1_000,
+            completedAt: 1_500,
+            updatedAt: 1_500,
+          },
+        },
+      }),
+      { ownerId: 'owner-1', ifVersion: 0 },
+    );
+
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        kind: 'queue',
+        admissionId: 'admission-1',
+        attemptedAdmissionHash: 'hash-1',
+      }),
+    ).resolves.toMatchObject({ status: 'duplicate', storedAdmissionHash: 'hash-1' });
+
+    await expect(
+      storage.loadQueueResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        queuedItemId: 'queued-1',
+      }),
+    ).resolves.toMatchObject({ status: 'completed', admissionId: 'admission-1' });
+
+    const compacted = storage.compactOperationResultEvidence({
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      kind: 'queue',
+      queuedItemId: 'queued-1',
+      now: 2_000,
+    });
+    await expect(storage.loadSession({ sessionId: 'session-1' })).resolves.toMatchObject({
+      version: 2,
+      queueAdmissionReceipts: undefined,
+    });
+    await expect(compacted).resolves.toMatchObject({
+      kind: 'queue',
+      queuedItemId: 'queued-1',
+      admissionId: 'admission-1',
+      terminalAt: 1_500,
+    });
+
+    await expect(
+      storage.loadQueueResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        queuedItemId: 'queued-1',
+      }),
+    ).resolves.toMatchObject({ kind: 'queue', admissionId: 'admission-1' });
+
+    await expect(
+      storage.saveSession(
+        makeSession({
+          version: 1,
+          queueAdmissionReceipts: {
+            'queued-1': {
+              admissionId: 'admission-1',
+              admissionHash: 'hash-1',
+              queuedItemId: 'queued-1',
+              status: 'completed',
+              attempts: 1,
+              enqueuedAt: 1_000,
+              updatedAt: 1_500,
+            },
+          },
+        }),
+        { ownerId: 'owner-1', ifVersion: 1 },
+      ),
+    ).rejects.toBeInstanceOf(HarnessStorageVersionConflictError);
+  });
+
+  it('deletes admission evidence scoped to a session and resource', async () => {
+    await storage.writeMessageResultEvidence({
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      signalId: 'signal-1',
+      runId: 'run-1',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      status: 'completed',
+      result: {},
+      createdAt: 1_000,
+      updatedAt: 1_000,
+    });
+    await storage.writeOperationAdmissionTombstone({
+      kind: 'message',
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      signalId: 'signal-2',
+      admissionId: 'admission-2',
+      admissionHash: 'hash-2',
+      terminalAt: 1_000,
+      compactedAt: 1_000,
+      expiresAt: 1_000,
+    });
+
+    await storage.deleteOperationAdmissionTombstonesForSession({
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+    });
+
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-2',
+      }),
+    ).resolves.toBeNull();
+  });
+
   it('clears all harness records from the shared in-memory database', async () => {
     await storage.saveSession(makeSession(), { ownerId: 'owner-1', ifVersion: 0 });
     await storage.saveAttachment({
@@ -287,5 +667,7 @@ describe('InMemoryHarness', () => {
     expect(db.harnessSessions.size).toBe(0);
     expect(db.harnessAttachmentRecords.size).toBe(0);
     expect(db.harnessAttachmentBytes.size).toBe(0);
+    expect(db.harnessMessageResultEvidence.size).toBe(0);
+    expect(db.harnessOperationTombstones.size).toBe(0);
   });
 });

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -1,15 +1,22 @@
 import type { InMemoryDB } from '../inmemory-db';
 import {
   HarnessStorage,
+  HarnessStorageAdmissionConflictError,
   HarnessStorageLeaseConflictError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageVersionConflictError,
 } from './base';
+import type { WriteMessageResultEvidenceResult } from './base';
 import type {
   AcquireSessionLeaseInput,
+  AgentSignalResultEvidence,
+  AgentSignalResultStatus,
   AttachmentRecord,
   ListSessionsInput,
   LoadedAttachment,
+  OperationAdmissionEvidence,
+  OperationAdmissionTombstone,
+  QueueAdmissionReceipt,
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentInput,
@@ -103,6 +110,7 @@ export class InMemoryHarness extends HarnessStorage {
   async deleteSession({ sessionId }: { sessionId: string }): Promise<void> {
     this.db.harnessSessions.delete(sessionId);
     await this.deleteAttachmentsForSession({ sessionId });
+    this.deleteAdmissionEvidenceForSession({ sessionId });
   }
 
   async acquireSessionLease({ sessionId, ownerId, ttlMs }: AcquireSessionLeaseInput): Promise<SessionLeaseResult> {
@@ -215,15 +223,384 @@ export class InMemoryHarness extends HarnessStorage {
     return this.db.harnessAttachmentRecords.get(attachmentKey(sessionId, attachmentId)) ?? null;
   }
 
+  async loadMessageResultEvidence({
+    sessionId,
+    resourceId,
+    threadId,
+    signalId,
+  }: {
+    sessionId: string;
+    resourceId: string;
+    threadId: string;
+    signalId: string;
+  }): Promise<AgentSignalResultStatus | OperationAdmissionTombstone | null> {
+    const retained = this.db.harnessMessageResultEvidence.get(messageEvidenceKey(sessionId, signalId));
+    if (retained && retained.resourceId === resourceId && retained.threadId === threadId) {
+      return clone(retained);
+    }
+    const tombstone = this.findTombstone(
+      t =>
+        t.kind === 'message' &&
+        t.sessionId === sessionId &&
+        t.resourceId === resourceId &&
+        t.threadId === threadId &&
+        t.signalId === signalId,
+    );
+    return tombstone ? clone(tombstone) : null;
+  }
+
+  async writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<WriteMessageResultEvidenceResult> {
+    const key = messageEvidenceKey(record.sessionId, record.signalId);
+    if (record.admissionId !== undefined) {
+      for (const [existingKey, existing] of this.db.harnessMessageResultEvidence) {
+        if (existingKey === key) continue;
+        if (
+          existing.sessionId !== record.sessionId ||
+          existing.resourceId !== record.resourceId ||
+          existing.threadId !== record.threadId ||
+          existing.admissionId !== record.admissionId
+        ) {
+          continue;
+        }
+        if (existing.admissionHash !== record.admissionHash) {
+          throw new HarnessStorageAdmissionConflictError(record.sessionId, 'message', record.admissionId);
+        }
+        return { created: false, evidence: clone(existing) };
+      }
+
+      const tombstone = this.findTombstone(
+        existing =>
+          existing.kind === 'message' &&
+          existing.sessionId === record.sessionId &&
+          existing.resourceId === record.resourceId &&
+          existing.threadId === record.threadId &&
+          existing.admissionId === record.admissionId,
+      );
+      if (tombstone) {
+        if (tombstone.admissionHash !== record.admissionHash) {
+          throw new HarnessStorageAdmissionConflictError(record.sessionId, 'message', record.admissionId);
+        }
+        return { created: false, evidence: clone(tombstone) };
+      }
+    }
+    const existing = this.db.harnessMessageResultEvidence.get(key);
+    if (existing && !sameMessageEvidenceIdentity(existing, record)) {
+      throw new HarnessStorageAdmissionConflictError(
+        record.sessionId,
+        'message',
+        record.admissionId ?? record.signalId,
+      );
+    }
+    if (existing && isTerminalMessageEvidence(existing)) {
+      return { created: false, evidence: clone(existing) };
+    }
+    const stored = {
+      ...record,
+      createdAt: existing?.createdAt ?? record.createdAt,
+    };
+    this.db.harnessMessageResultEvidence.set(key, clone(stored));
+    return existing === undefined ? { created: true } : { created: false, evidence: clone(stored) };
+  }
+
+  async loadQueueResultEvidence({
+    sessionId,
+    resourceId,
+    queuedItemId,
+  }: {
+    sessionId: string;
+    resourceId: string;
+    queuedItemId: string;
+  }): Promise<QueueAdmissionReceipt | OperationAdmissionTombstone | null> {
+    const session = this.db.harnessSessions.get(sessionId);
+    if (session && session.resourceId !== resourceId) return null;
+    const receipt = session?.queueAdmissionReceipts?.[queuedItemId];
+    if (receipt) return clone(receipt);
+    const tombstone = this.findTombstone(
+      t =>
+        t.kind === 'queue' &&
+        t.sessionId === sessionId &&
+        t.resourceId === resourceId &&
+        t.queuedItemId === queuedItemId,
+    );
+    return tombstone ? clone(tombstone) : null;
+  }
+
+  async resolveOperationAdmissionEvidence({
+    sessionId,
+    resourceId,
+    threadId,
+    kind,
+    admissionId,
+    attemptedAdmissionHash,
+  }: {
+    sessionId: string;
+    resourceId: string;
+    threadId?: string;
+    kind: 'message' | 'queue';
+    admissionId: string;
+    attemptedAdmissionHash: string;
+  }): Promise<{
+    status: 'none' | 'duplicate' | 'conflict';
+    evidence?: OperationAdmissionEvidence;
+    storedAdmissionHash?: string;
+  }> {
+    if (kind === 'message') {
+      for (const evidence of this.db.harnessMessageResultEvidence.values()) {
+        if (
+          evidence.sessionId !== sessionId ||
+          evidence.resourceId !== resourceId ||
+          (threadId !== undefined && evidence.threadId !== threadId) ||
+          evidence.admissionId !== admissionId
+        ) {
+          continue;
+        }
+        if (evidence.admissionHash !== attemptedAdmissionHash) {
+          return { status: 'conflict', evidence: clone(evidence), storedAdmissionHash: evidence.admissionHash };
+        }
+        return { status: 'duplicate', evidence: clone(evidence), storedAdmissionHash: evidence.admissionHash };
+      }
+    }
+
+    if (kind === 'queue') {
+      const session = this.db.harnessSessions.get(sessionId);
+      if (session && (session.resourceId !== resourceId || (threadId !== undefined && session.threadId !== threadId))) {
+        return { status: 'none' };
+      }
+      for (const receipt of Object.values(session?.queueAdmissionReceipts ?? {})) {
+        if (receipt.admissionId !== admissionId) continue;
+        if (receipt.admissionHash !== attemptedAdmissionHash) {
+          return { status: 'conflict', evidence: clone(receipt), storedAdmissionHash: receipt.admissionHash };
+        }
+        return { status: 'duplicate', evidence: clone(receipt), storedAdmissionHash: receipt.admissionHash };
+      }
+    }
+
+    const tombstone = this.findTombstone(
+      t =>
+        t.sessionId === sessionId &&
+        t.resourceId === resourceId &&
+        (threadId === undefined || t.threadId === threadId) &&
+        t.kind === kind &&
+        t.admissionId === admissionId,
+    );
+    if (!tombstone) return { status: 'none' };
+    if (tombstone.admissionHash !== attemptedAdmissionHash) {
+      return { status: 'conflict', evidence: clone(tombstone), storedAdmissionHash: tombstone.admissionHash };
+    }
+    return { status: 'duplicate', evidence: clone(tombstone), storedAdmissionHash: tombstone.admissionHash };
+  }
+
+  async writeOperationAdmissionTombstone(record: OperationAdmissionTombstone): Promise<void> {
+    this.writeOperationAdmissionTombstoneSync(record);
+  }
+
+  private writeOperationAdmissionTombstoneSync(record: OperationAdmissionTombstone): void {
+    const key = tombstoneKey(record);
+    if (record.admissionId !== undefined) {
+      for (const [existingKey, existing] of this.db.harnessOperationTombstones) {
+        if (existingKey === key) continue;
+        if (
+          existing.sessionId !== record.sessionId ||
+          existing.resourceId !== record.resourceId ||
+          existing.threadId !== record.threadId ||
+          existing.kind !== record.kind ||
+          existing.admissionId !== record.admissionId
+        ) {
+          continue;
+        }
+        if (existing.admissionHash !== record.admissionHash) {
+          throw new HarnessStorageAdmissionConflictError(record.sessionId, record.kind, record.admissionId);
+        }
+        return;
+      }
+    }
+    const existing = this.db.harnessOperationTombstones.get(key);
+    if (existing && !sameTombstoneIdentity(existing, record)) {
+      throw new HarnessStorageAdmissionConflictError(record.sessionId, record.kind, record.admissionId ?? key);
+    }
+    this.db.harnessOperationTombstones.set(key, clone(record));
+  }
+
+  async compactOperationResultEvidence({
+    sessionId,
+    resourceId,
+    kind,
+    signalId,
+    queuedItemId,
+    now,
+  }: {
+    sessionId: string;
+    resourceId: string;
+    kind: 'message' | 'queue';
+    signalId?: string;
+    queuedItemId?: string;
+    now: number;
+  }): Promise<OperationAdmissionTombstone | null> {
+    if (kind === 'message') {
+      const key = signalId ? messageEvidenceKey(sessionId, signalId) : undefined;
+      const retained = key ? this.db.harnessMessageResultEvidence.get(key) : undefined;
+      if (!retained || retained.resourceId !== resourceId || retained.status === 'pending') return null;
+      const tombstone: OperationAdmissionTombstone = {
+        kind: 'message',
+        sessionId,
+        resourceId,
+        threadId: retained.threadId,
+        ...(retained.admissionId !== undefined ? { admissionId: retained.admissionId } : {}),
+        ...(retained.admissionHash !== undefined ? { admissionHash: retained.admissionHash } : {}),
+        signalId: retained.signalId,
+        ...(retained.runId !== undefined ? { runId: retained.runId } : {}),
+        terminalAt: retained.updatedAt,
+        compactedAt: now,
+        expiresAt: now,
+      };
+      this.writeOperationAdmissionTombstoneSync(tombstone);
+      this.db.harnessMessageResultEvidence.delete(messageEvidenceKey(sessionId, retained.signalId));
+      return clone(tombstone);
+    }
+
+    const session = this.db.harnessSessions.get(sessionId);
+    if (session && session.resourceId !== resourceId) return null;
+    const receipt = queuedItemId ? session?.queueAdmissionReceipts?.[queuedItemId] : undefined;
+    if (!session || !receipt) return null;
+    if (!isTerminalQueueReceipt(receipt)) return null;
+    const tombstone: OperationAdmissionTombstone = {
+      kind: 'queue',
+      sessionId,
+      resourceId,
+      threadId: session.threadId,
+      admissionId: receipt.admissionId,
+      admissionHash: receipt.admissionHash,
+      queuedItemId: receipt.queuedItemId,
+      ...(receipt.signalId !== undefined ? { signalId: receipt.signalId } : {}),
+      ...(receipt.runId !== undefined ? { runId: receipt.runId } : {}),
+      terminalAt: receipt.completedAt ?? receipt.failedAt ?? receipt.deadAt ?? now,
+      compactedAt: now,
+      expiresAt: now,
+    };
+    this.writeOperationAdmissionTombstoneSync(tombstone);
+    const nextReceipts = { ...(session.queueAdmissionReceipts ?? {}) };
+    delete nextReceipts[queuedItemId!];
+    this.db.harnessSessions.set(sessionId, {
+      ...session,
+      queueAdmissionReceipts: Object.keys(nextReceipts).length > 0 ? nextReceipts : undefined,
+      version: session.version + 1,
+    });
+    return clone(tombstone);
+  }
+
+  async deleteOperationAdmissionTombstonesForSession({
+    sessionId,
+    resourceId,
+    threadId,
+    signalId,
+  }: {
+    sessionId: string;
+    resourceId: string;
+    threadId?: string;
+    signalId?: string;
+  }): Promise<void> {
+    for (const [key, evidence] of this.db.harnessMessageResultEvidence) {
+      if (
+        evidence.sessionId === sessionId &&
+        evidence.resourceId === resourceId &&
+        (threadId === undefined || evidence.threadId === threadId) &&
+        (signalId === undefined || evidence.signalId === signalId)
+      ) {
+        this.db.harnessMessageResultEvidence.delete(key);
+      }
+    }
+    for (const [key, tombstone] of this.db.harnessOperationTombstones) {
+      if (
+        tombstone.sessionId === sessionId &&
+        tombstone.resourceId === resourceId &&
+        (threadId === undefined || tombstone.threadId === threadId) &&
+        (signalId === undefined || tombstone.signalId === signalId)
+      ) {
+        this.db.harnessOperationTombstones.delete(key);
+      }
+    }
+  }
+
   async dangerouslyClearAll(): Promise<void> {
     this.db.harnessSessions.clear();
     this.db.harnessAttachmentRecords.clear();
     this.db.harnessAttachmentBytes.clear();
+    this.db.harnessMessageResultEvidence.clear();
+    this.db.harnessOperationTombstones.clear();
+  }
+
+  private deleteAdmissionEvidenceForSession({ sessionId }: { sessionId: string }): void {
+    for (const [key, evidence] of this.db.harnessMessageResultEvidence) {
+      if (evidence.sessionId === sessionId) {
+        this.db.harnessMessageResultEvidence.delete(key);
+      }
+    }
+
+    for (const [key, tombstone] of this.db.harnessOperationTombstones) {
+      if (tombstone.sessionId === sessionId) {
+        this.db.harnessOperationTombstones.delete(key);
+      }
+    }
+  }
+
+  private findTombstone(
+    predicate: (tombstone: OperationAdmissionTombstone) => boolean,
+  ): OperationAdmissionTombstone | null {
+    for (const tombstone of this.db.harnessOperationTombstones.values()) {
+      if (predicate(tombstone)) return tombstone;
+    }
+    return null;
   }
 }
 
 function attachmentKey(sessionId: string, attachmentId: string): string {
   return `${sessionId}\u0000${attachmentId}`;
+}
+
+function messageEvidenceKey(sessionId: string, signalId: string): string {
+  return `${sessionId}\u0000${signalId}`;
+}
+
+function tombstoneKey(record: OperationAdmissionTombstone): string {
+  const publicId = record.kind === 'message' ? record.signalId : record.queuedItemId;
+  return `${record.sessionId}\u0000${record.kind}\u0000${publicId ?? record.admissionId ?? record.compactedAt}`;
+}
+
+function isTerminalMessageEvidence(record: AgentSignalResultEvidence): boolean {
+  return record.status === 'completed' || record.status === 'failed';
+}
+
+function isTerminalQueueReceipt(receipt: QueueAdmissionReceipt): boolean {
+  return receipt.status === 'completed' || receipt.status === 'failed' || receipt.status === 'dead';
+}
+
+function sameMessageEvidenceIdentity(a: AgentSignalResultEvidence, b: AgentSignalResultEvidence): boolean {
+  return (
+    a.sessionId === b.sessionId &&
+    a.resourceId === b.resourceId &&
+    a.threadId === b.threadId &&
+    a.signalId === b.signalId &&
+    a.admissionId === b.admissionId &&
+    a.admissionHash === b.admissionHash
+  );
+}
+
+function sameTombstoneIdentity(a: OperationAdmissionTombstone, b: OperationAdmissionTombstone): boolean {
+  return (
+    a.kind === b.kind &&
+    a.sessionId === b.sessionId &&
+    a.resourceId === b.resourceId &&
+    a.threadId === b.threadId &&
+    a.admissionId === b.admissionId &&
+    a.admissionHash === b.admissionHash &&
+    a.queuedItemId === b.queuedItemId &&
+    a.signalId === b.signalId &&
+    a.runId === b.runId
+  );
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
 }
 
 function assertLeaseHolder(existing: SessionRecord, ownerId: string): void {

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -55,6 +55,10 @@ export type PersistedAttachment =
  */
 export interface QueuedItem {
   id: string;
+  /** Idempotency key captured when the queue item was admitted. */
+  admissionId?: string;
+  /** Stable hash of the admitted queue inputs. */
+  admissionHash?: string;
   enqueuedAt: number;
   content: string;
   attachments: PersistedAttachment[];
@@ -188,6 +192,7 @@ export interface SessionRecord {
     observerModelId?: string;
     reflectorModelId?: string;
   };
+  queueAdmissionReceipts?: Record<string, QueueAdmissionReceipt>;
   goal?: GoalState;
   workspace?: SessionWorkspaceState;
   state: unknown;
@@ -281,6 +286,88 @@ export interface SessionLeaseResult {
   /** Epoch ms when the lease expires if not renewed. */
   expiresAt: number;
 }
+
+export type HarnessOperationKind = 'message' | 'queue';
+
+export interface HarnessStoredPublicError {
+  code: string;
+  message: string;
+}
+
+export type AgentSignalResultStatus =
+  | { status: 'pending'; signalId: string; runId?: string }
+  | { status: 'completed'; signalId: string; runId: string; result: unknown }
+  | { status: 'failed'; signalId: string; runId?: string; error: HarnessStoredPublicError };
+
+export interface AgentSignalAccepted {
+  runId: string;
+  signalId: string;
+  duplicate: boolean;
+  admissionId?: string;
+  admissionHash?: string;
+}
+
+export type AgentSignalResultEvidence = AgentSignalResultStatus & {
+  sessionId: string;
+  resourceId: string;
+  threadId: string;
+  admissionId?: string;
+  admissionHash?: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export interface HarnessRuntimeDependencyRefs {
+  modeId: string;
+  agentId?: string;
+  modelId?: string;
+  workspaceProviderId?: string | null;
+}
+
+export interface QueueAdmissionReceipt {
+  admissionId: string;
+  admissionHash: string;
+  queuedItemId: string;
+  modeId?: string;
+  runtimeDependencies?: HarnessRuntimeDependencyRefs;
+  status: 'queued' | 'admitting' | 'accepted' | 'completed' | 'admission_failed' | 'failed' | 'dead';
+  runId?: string;
+  signalId?: string;
+  result?: unknown;
+  error?: HarnessStoredPublicError;
+  attempts: number;
+  enqueuedAt: number;
+  admittingAt?: number;
+  acceptedAt?: number;
+  postRunFinalizedAt?: number;
+  completedAt?: number;
+  failedAt?: number;
+  deadAt?: number;
+  nextAttemptAt?: number;
+  updatedAt: number;
+}
+
+export interface OperationAdmissionTombstone {
+  kind: HarnessOperationKind;
+  sessionId: string;
+  resourceId: string;
+  threadId: string;
+  admissionId?: string;
+  admissionHash?: string;
+  queuedItemId?: string;
+  signalId?: string;
+  runId?: string;
+  terminalAt: number;
+  compactedAt: number;
+  expiresAt: number;
+}
+
+export type OperationAdmissionEvidence =
+  | AgentSignalAccepted
+  | AgentSignalResultEvidence
+  | AgentSignalResultStatus
+  | QueueAdmissionReceipt
+  | OperationAdmissionTombstone;
 
 export interface SaveAttachmentInput {
   sessionId: string;

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -21,7 +21,12 @@ import type {
   ExperimentResult,
 } from '../types';
 import type { AgentVersion } from './agents';
-import type { AttachmentRecord, SessionRecord } from './harness';
+import type {
+  AgentSignalResultEvidence,
+  AttachmentRecord,
+  OperationAdmissionTombstone,
+  SessionRecord,
+} from './harness';
 import type { MCPClientVersion } from './mcp-clients';
 import type { MCPServerVersion } from './mcp-servers';
 import type { TraceEntry } from './observability';
@@ -104,6 +109,8 @@ export class InMemoryDB {
   readonly harnessSessions = new Map<string, SessionRecord>();
   readonly harnessAttachmentRecords = new Map<string, AttachmentRecord>();
   readonly harnessAttachmentBytes = new Map<string, Uint8Array>();
+  readonly harnessMessageResultEvidence = new Map<string, AgentSignalResultEvidence>();
+  readonly harnessOperationTombstones = new Map<string, OperationAdmissionTombstone>();
 
   /**
    * Clears all data from all collections.
@@ -154,5 +161,7 @@ export class InMemoryDB {
     this.harnessSessions.clear();
     this.harnessAttachmentRecords.clear();
     this.harnessAttachmentBytes.clear();
+    this.harnessMessageResultEvidence.clear();
+    this.harnessOperationTombstones.clear();
   }
 }


### PR DESCRIPTION
## Description

Adds Harness v1 admission evidence storage for message and queue submissions. The storage domain can now record message result evidence, resolve duplicate/conflicting admissions by admissionId and payload hash, compact terminal evidence into retained retry metadata, and keep queue receipt compaction under the session version contract.

This is a small prerequisite for porting the latest fork Session message/queue runtime without pulling the oversized foundation sync into one PR.

Validation:
- pnpm build:core
- pnpm --filter ./packages/core test:unit src/storage/domains/harness
- pnpm --filter ./packages/core check
- pnpm --filter ./packages/core lint
- pnpm prettier --check <changed files>

## Related issue(s)

Part of #16878

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR