### PR TITLE
docs(mcp): add local WorkPaper server example

### DIFF
--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -62,6 +62,40 @@ For connecting to OAuth-protected MCP servers, see the [OAuth Authentication](/r
 
 :::
 
+## Connecting to local project files
+
+Some stdio MCP servers work against local files in your project instead of a remote API. For example, a formula workbook server can let an agent update input cells, recalculate outputs, and persist the workbook state as JSON.
+
+This configuration starts [Bilig WorkPaper](https://github.com/proompteng/bilig) as a local writable MCP server and stores the workbook at `./pricing.workpaper.json`:
+
+```typescript title="src/mastra/mcp/workpaper-mcp-client.ts"
+import { MCPClient } from '@mastra/mcp'
+
+export const workpaperMcpClient = new MCPClient({
+  id: 'workpaper-mcp-client',
+  servers: {
+    bilig: {
+      command: 'npm',
+      args: [
+        'exec',
+        '--yes',
+        '--package',
+        '@bilig/workpaper',
+        '--',
+        'bilig-workpaper-mcp',
+        '--workpaper',
+        './pricing.workpaper.json',
+        '--init-demo-workpaper',
+        '--writable',
+      ],
+      requireToolApproval: true,
+    },
+  },
+})
+```
+
+Because this server can write to disk, `requireToolApproval: true` keeps each workbook edit behind Mastra's human approval flow. Pass `await workpaperMcpClient.listTools()` to an agent, then ask it to update workbook inputs, read calculated outputs, and verify the persisted JSON before returning an answer.
+
 ## Using `MCPClient` with an agent
 
 To use tools from an MCP server in an agent, import your `MCPClient` and call `.listTools()` in the `tools` parameter. This loads from the defined MCP servers, making them available to the agent.


### PR DESCRIPTION
## Description

Adds a docs example for launching a local stdio MCP server through `MCPClient` when the server reads or writes a project file.

The example uses Bilig WorkPaper as the concrete server because it exposes a writable JSON formula workbook over MCP. The docs show the important Mastra pattern rather than a Bilig-specific workflow:

- launch a local stdio MCP server with `MCPClient`
- pass a project file path into the server command
- set `requireToolApproval: true` because tool calls can persist changes to disk
- use the MCP tools for deterministic local file-backed calculations without browser automation or a hosted spreadsheet API

## Related issue(s)

Closes #16887

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Local validation:

```bash
pnpm dlx prettier@3.8.3 --check docs/src/content/en/docs/mcp/overview.mdx
git diff --check
npm exec --yes --package @bilig/workpaper -- bilig-workpaper-mcp --help
```

No tests were added because this is a docs-only example in an existing MCP overview page. CodeRabbit reported no actionable comments.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a simple guide to Mastra's documentation showing developers how to connect to small programs running locally on their computer that can read and write project files (like spreadsheets). It explains when to ask for permission before making changes and provides a concrete working example.

## Overview

This documentation update adds a new subsection, "Connecting to local project files," to the MCP overview guide. It demonstrates how to use `MCPClient` to launch a stdio MCP server that reads and writes local files, addressing the requirements from issue `#16887`.

## Changes

**File modified:**
- `docs/src/content/en/docs/mcp/overview.mdx` (+34 lines)

**Content added:**
- New documentation subsection explaining how to connect to local project files via stdio MCP servers
- Code example showing `MCPClient` configuration that launches `bilig-workpaper-mcp` (from `@bilig/headless`) as a subprocess
- Configuration that passes a writable `./pricing.workpaper.json` file to the server
- Explanation of when to use `requireToolApproval: true` for tools that persist changes to disk
- Clear pattern for deterministic local file-backed calculations without browser automation or hosted APIs

## Impact

- **Type:** Documentation only
- **Breaking changes:** None
- **Test coverage:** Not applicable (documentation example)
- **Related issue:** Closes `#16887`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->