### PR TITLE
feat(playground): add "Show only selected" filter to Agent Builder Tools picker

### DIFF
--- a/.changeset/spicy-readers-dig.md
+++ b/.changeset/spicy-readers-dig.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Added a "Show only selected" filter checkbox to the Tools picker in Agent Builder. The checkbox sits inline with the search input and adopts the agent's color when active so users can quickly narrow the list to tools they've already selected.

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-builder-title.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-builder-title.tsx
@@ -16,8 +16,8 @@ export interface AgentBuilderTitleProps {
   disabled?: boolean;
 }
 
-const MODE_BADGE: Record<WorkspaceMode, { label: string; variant: 'success' | 'neutral'; testId: string }> = {
-  build: { label: 'Edit mode', variant: 'success', testId: 'agent-builder-mode-badge-build' },
+const MODE_BADGE: Record<WorkspaceMode, { label: string; variant: 'neutral'; testId: string }> = {
+  build: { label: 'Edit mode', variant: 'neutral', testId: 'agent-builder-mode-badge-build' },
   test: { label: 'View mode', variant: 'neutral', testId: 'agent-builder-mode-badge-test' },
 };
 

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/browser.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/browser.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
-import { TooltipProvider } from '@mastra/playground-ui';
+import { TooltipProvider, stringToColor } from '@mastra/playground-ui';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { afterEach, describe, expect, it } from 'vitest';
+import { AgentColorProvider } from '../../../../contexts/agent-color-context';
 import type { AgentBuilderEditFormValues } from '../../../../schemas';
 import { Browser } from '../browser';
 
@@ -26,7 +27,9 @@ const Wrapper = ({
   });
   return (
     <TooltipProvider>
-      <FormProvider {...methods}>{children}</FormProvider>
+      <FormProvider {...methods}>
+        <AgentColorProvider>{children}</AgentColorProvider>
+      </FormProvider>
     </TooltipProvider>
   );
 };
@@ -79,5 +82,37 @@ describe('Browser', () => {
     );
 
     expect((getByTestId('agent-browser-toggle') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('paints the enabled switch with the agent tint color (lightness 50) derived from the form name', () => {
+    const { getByTestId } = render(
+      <Wrapper defaultValues={{ name: 'Support agent', browserEnabled: true }}>
+        <Browser />
+      </Wrapper>,
+    );
+
+    // jsdom normalizes inline colors to rgb(...); compare via a probe element fed the same hsl().
+    const probe = document.createElement('div');
+    probe.style.backgroundColor = stringToColor('Support agent', 50);
+    const expected = probe.style.backgroundColor;
+    expect(expected).not.toBe('');
+
+    const toggle = getByTestId('agent-browser-toggle') as HTMLButtonElement;
+    expect(toggle.style.backgroundColor).toBe(expected);
+    // It must NOT match the foreground (lightness 20) value that the switch previously used.
+    const fgProbe = document.createElement('div');
+    fgProbe.style.backgroundColor = stringToColor('Support agent', 20);
+    expect(toggle.style.backgroundColor).not.toBe(fgProbe.style.backgroundColor);
+  });
+
+  it('does not apply an inline background color to the switch when browserEnabled is false', () => {
+    const { getByTestId } = render(
+      <Wrapper defaultValues={{ name: 'Support agent', browserEnabled: false }}>
+        <Browser />
+      </Wrapper>,
+    );
+
+    const toggle = getByTestId('agent-browser-toggle') as HTMLButtonElement;
+    expect(toggle.style.backgroundColor).toBe('');
   });
 });

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/models.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/models.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -104,5 +104,140 @@ describe('Models', () => {
     expect(container.className).toContain('border-border1');
     expect(container.className).toContain('focus-visible:!border-[var(--agent-color-bg)]');
     expect(container.className).not.toContain('focus-visible:ring');
+  });
+
+  it('renders an uppercase text-neutral3 section title per provider, grouping cards under each', () => {
+    const { getByTestId } = render(
+      <FormHarness>
+        <Models />
+      </FormHarness>,
+    );
+
+    const openaiTitle = getByTestId('model-provider-section-title-openai');
+    expect(openaiTitle.textContent).toBe('OpenAI');
+    expect(openaiTitle.className).toContain('text-neutral3');
+    expect(openaiTitle.className).toContain('uppercase');
+    expect(openaiTitle.className).toContain('text-ui-sm');
+
+    const anthropicTitle = getByTestId('model-provider-section-title-anthropic');
+    expect(anthropicTitle.textContent).toBe('Anthropic');
+
+    const openaiSection = getByTestId('model-provider-section-openai');
+    const openaiCard = getByTestId('model-card-openai-gpt-4o');
+    const anthropicCard = getByTestId('model-card-anthropic-claude-3-5-sonnet');
+    expect(openaiSection.contains(openaiCard)).toBe(true);
+    expect(openaiSection.contains(anthropicCard)).toBe(false);
+  });
+
+  it('renders one provider-filter badge per provider, all checked by default', () => {
+    const { getByTestId } = render(
+      <FormHarness>
+        <Models />
+      </FormHarness>,
+    );
+
+    const openaiBadge = getByTestId('model-provider-filter-badge-openai');
+    const anthropicBadge = getByTestId('model-provider-filter-badge-anthropic');
+    expect(openaiBadge).toBeTruthy();
+    expect(anthropicBadge).toBeTruthy();
+
+    const openaiCheckbox = getByTestId('model-provider-filter-checkbox-openai');
+    const anthropicCheckbox = getByTestId('model-provider-filter-checkbox-anthropic');
+    expect(openaiCheckbox.getAttribute('aria-checked')).toBe('true');
+    expect(anthropicCheckbox.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('unchecking a provider badge hides that provider section and cards', () => {
+    const { getByTestId, queryByTestId } = render(
+      <FormHarness>
+        <Models />
+      </FormHarness>,
+    );
+
+    fireEvent.click(getByTestId('model-provider-filter-checkbox-anthropic'));
+
+    expect(queryByTestId('model-provider-section-anthropic')).toBeNull();
+    expect(queryByTestId('model-card-anthropic-claude-3-5-sonnet')).toBeNull();
+    expect(queryByTestId('model-provider-section-openai')).toBeTruthy();
+    expect(queryByTestId('model-card-openai-gpt-4o')).toBeTruthy();
+  });
+
+  it('re-checking a provider badge restores it', () => {
+    const { getByTestId, queryByTestId } = render(
+      <FormHarness>
+        <Models />
+      </FormHarness>,
+    );
+
+    const anthropicCheckbox = getByTestId('model-provider-filter-checkbox-anthropic');
+    fireEvent.click(anthropicCheckbox);
+    expect(queryByTestId('model-provider-section-anthropic')).toBeNull();
+
+    fireEvent.click(getByTestId('model-provider-filter-checkbox-anthropic'));
+    expect(queryByTestId('model-provider-section-anthropic')).toBeTruthy();
+    expect(queryByTestId('model-card-anthropic-claude-3-5-sonnet')).toBeTruthy();
+  });
+
+  it('unchecking all providers shows the dedicated empty-state copy', () => {
+    const { getByTestId, getByText } = render(
+      <FormHarness>
+        <Models />
+      </FormHarness>,
+    );
+
+    fireEvent.click(getByTestId('model-provider-filter-checkbox-openai'));
+    fireEvent.click(getByTestId('model-provider-filter-checkbox-anthropic'));
+
+    expect(getByText('Select at least one provider to see models')).toBeTruthy();
+  });
+
+  it('paints the checked provider badge with agent color when an agent name is set', () => {
+    const { getByTestId } = render(
+      <FormHarness agentName="Support agent">
+        <Models />
+      </FormHarness>,
+    );
+
+    const badge = getByTestId('model-provider-filter-badge-openai') as HTMLLabelElement;
+    expect(badge.style.borderColor).toMatch(/^(rgb|hsl)\(/);
+    expect(badge.style.color).toMatch(/^(rgb|hsl)\(/);
+    expect(badge.style.backgroundColor).toBe('');
+    expect(badge.className).not.toContain('border-accent1');
+
+    const checkbox = getByTestId('model-provider-filter-checkbox-openai') as HTMLButtonElement;
+    expect(checkbox.style.backgroundColor).toMatch(/^(rgb|hsl)\(/);
+    expect(checkbox.style.borderColor).toMatch(/^(rgb|hsl)\(/);
+  });
+
+  it('falls back to accent classes on the checked provider badge when no agent name is set', () => {
+    const { getByTestId } = render(
+      <FormHarness>
+        <Models />
+      </FormHarness>,
+    );
+
+    const badge = getByTestId('model-provider-filter-badge-openai') as HTMLLabelElement;
+    expect(badge.getAttribute('style')).toBeNull();
+    expect(badge.className).toContain('border-accent1');
+
+    const checkbox = getByTestId('model-provider-filter-checkbox-openai') as HTMLButtonElement;
+    expect(checkbox.getAttribute('style')).toBeNull();
+    expect(checkbox.className).toContain('data-[state=checked]:bg-accent1');
+  });
+
+  it('combines provider filter and search: searching for a hidden provider yields the search empty state', async () => {
+    const { getByTestId, findByText } = render(
+      <FormHarness agentName="Support agent">
+        <Models />
+      </FormHarness>,
+    );
+
+    fireEvent.click(getByTestId('model-provider-filter-checkbox-anthropic'));
+
+    const searchInput = getByTestId('model-card-picker-search').querySelector('input');
+    expect(searchInput).toBeTruthy();
+    fireEvent.change(searchInput!, { target: { value: 'claude' } });
+
+    await findByText('No models match "claude"');
   });
 });

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/tools.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/tools.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -89,5 +89,136 @@ describe('Tools', () => {
     expect(container.className).toContain('border-border1');
     expect(container.className).toContain('focus-visible:!border-[var(--agent-color-bg)]');
     expect(container.className).not.toContain('focus-visible:ring');
+  });
+
+  it('renders the "Show only selected" filter checkbox unchecked by default with both tool cards visible', () => {
+    const { getByTestId } = render(
+      <FormHarness>
+        <Tools availableAgentTools={availableTools} />
+      </FormHarness>,
+    );
+
+    const checkbox = getByTestId('tools-only-selected-filter-checkbox');
+    expect(checkbox.getAttribute('aria-checked')).toBe('false');
+    expect(getByTestId('tool-card-tool-checked-tool')).toBeTruthy();
+    expect(getByTestId('tool-card-tool-unchecked-tool')).toBeTruthy();
+  });
+
+  it('checking the filter hides unselected tools and keeps selected ones', () => {
+    const { getByTestId, queryByTestId } = render(
+      <FormHarness>
+        <Tools availableAgentTools={availableTools} />
+      </FormHarness>,
+    );
+
+    fireEvent.click(getByTestId('tools-only-selected-filter-checkbox'));
+
+    expect(queryByTestId('tool-card-tool-checked-tool')).toBeTruthy();
+    expect(queryByTestId('tool-card-tool-unchecked-tool')).toBeNull();
+  });
+
+  it('unchecking the filter restores hidden tools', () => {
+    const { getByTestId, queryByTestId } = render(
+      <FormHarness>
+        <Tools availableAgentTools={availableTools} />
+      </FormHarness>,
+    );
+
+    const checkbox = getByTestId('tools-only-selected-filter-checkbox');
+    fireEvent.click(checkbox);
+    expect(queryByTestId('tool-card-tool-unchecked-tool')).toBeNull();
+
+    fireEvent.click(checkbox);
+    expect(queryByTestId('tool-card-tool-checked-tool')).toBeTruthy();
+    expect(queryByTestId('tool-card-tool-unchecked-tool')).toBeTruthy();
+  });
+
+  it('shows the empty-state copy when the filter is on and nothing is selected', () => {
+    const noneSelected = [
+      { id: 'a', name: 'a', isChecked: false, type: 'tool' as const },
+      { id: 'b', name: 'b', isChecked: false, type: 'tool' as const },
+    ];
+    const { getByTestId, getByText } = render(
+      <FormHarness>
+        <Tools availableAgentTools={noneSelected} />
+      </FormHarness>,
+    );
+
+    fireEvent.click(getByTestId('tools-only-selected-filter-checkbox'));
+
+    expect(getByText('No tools selected yet')).toBeTruthy();
+  });
+
+  it('combines the filter with search to show the dedicated empty-state copy', async () => {
+    const { getByTestId, findByText } = render(
+      <FormHarness>
+        <Tools availableAgentTools={availableTools} />
+      </FormHarness>,
+    );
+
+    const searchInput = getByTestId('tools-card-picker-search').querySelector('input');
+    expect(searchInput).toBeTruthy();
+    fireEvent.change(searchInput!, { target: { value: 'unchecked' } });
+
+    fireEvent.click(getByTestId('tools-only-selected-filter-checkbox'));
+
+    await findByText('No selected tools match "unchecked"');
+  });
+
+  it('uses the small-size classes matching the provider-filter checkbox in models.tsx', () => {
+    const { getByTestId } = render(
+      <FormHarness>
+        <Tools availableAgentTools={availableTools} />
+      </FormHarness>,
+    );
+
+    const checkbox = getByTestId('tools-only-selected-filter-checkbox');
+    expect(checkbox.className).toContain('h-3');
+    expect(checkbox.className).toContain('w-3');
+    expect(checkbox.className).toContain('[&_svg]:h-2.5');
+  });
+
+  it('paints the filter checkbox with the agent color when checked and a name is set', () => {
+    const { getByTestId } = render(
+      <FormHarness agentName="Support agent">
+        <Tools availableAgentTools={availableTools} />
+      </FormHarness>,
+    );
+
+    const checkbox = getByTestId('tools-only-selected-filter-checkbox') as HTMLButtonElement;
+    expect(checkbox.getAttribute('style')).toBeNull();
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox.style.backgroundColor).toMatch(/^(rgb|hsl)\(/);
+    expect(checkbox.style.borderColor).toMatch(/^(rgb|hsl)\(/);
+  });
+
+  it('does not apply an inline style to the filter checkbox when no agent name is set', () => {
+    const { getByTestId } = render(
+      <FormHarness>
+        <Tools availableAgentTools={availableTools} />
+      </FormHarness>,
+    );
+
+    const checkbox = getByTestId('tools-only-selected-filter-checkbox') as HTMLButtonElement;
+    fireEvent.click(checkbox);
+
+    expect(checkbox.getAttribute('style')).toBeNull();
+  });
+
+  it('renders the search input and the filter checkbox in the same flex row', () => {
+    const { getByTestId } = render(
+      <FormHarness>
+        <Tools availableAgentTools={availableTools} />
+      </FormHarness>,
+    );
+
+    const searchWrapper = getByTestId('tools-card-picker-search');
+    const filterLabel = getByTestId('tools-only-selected-filter');
+
+    expect(searchWrapper.parentElement).toBe(filterLabel.parentElement);
+    expect(filterLabel.parentElement?.className).toContain('flex');
+    expect(filterLabel.parentElement?.className).toContain('justify-between');
   });
 });

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-browser-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-browser-step.tsx
@@ -1,0 +1,35 @@
+import { Button, Icon } from '@mastra/playground-ui';
+
+import { ArrowRightIcon } from 'lucide-react';
+import { AgentStepContainer } from './agent-step-container';
+import { Browser } from './browser';
+import { useStreamRunning } from '@/domains/agent-builder/contexts/stream-chat-context';
+import { useWizard } from '@/domains/agent-builder/contexts/wizard-context';
+import { startViewTransition } from '@/lib/routing';
+
+export const AgentProfileBrowserStep = () => {
+  const { next } = useWizard();
+  const isStreaming = useStreamRunning();
+
+  const handleContinue = () => {
+    startViewTransition(() => {
+      next();
+    });
+  };
+
+  return (
+    <AgentStepContainer
+      title="Browser"
+      cta={
+        <Button onClick={handleContinue} disabled={isStreaming}>
+          Continue{' '}
+          <Icon>
+            <ArrowRightIcon />
+          </Icon>
+        </Button>
+      }
+    >
+      <Browser editable={!isStreaming} />
+    </AgentStepContainer>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-details.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-details.tsx
@@ -1,7 +1,5 @@
 import { cn } from '@mastra/playground-ui';
-import type { CSSProperties } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
-import { useAgentColor } from '../../../contexts/agent-color-context';
 import type { AgentBuilderEditFormValues } from '../../../schemas';
 
 export interface AgentProfileDetailsProps {
@@ -11,13 +9,12 @@ export interface AgentProfileDetailsProps {
 }
 
 const HIGHLIGHTED_CLASSNAME =
-  'px-24 justify-center items-center text-center [&_input]:text-center [&_textarea]:text-center [&_input]:text-[var(--agent-color-fg)] [&_textarea]:text-[var(--agent-color-fg)]';
+  'px-24 justify-center items-center text-center [&_input]:text-center [&_textarea]:text-center';
 
 export const AgentProfileDetails = ({ disabled = false, className, mode = 'default' }: AgentProfileDetailsProps) => {
   const { setValue, control } = useFormContext<AgentBuilderEditFormValues>();
   const draftName = useWatch({ control, name: 'name' }) ?? '';
   const draftDescription = useWatch({ control, name: 'description' }) ?? '';
-  const agentColor = useAgentColor();
 
   const handleDraftNameChange = (value: string) => {
     if (disabled) return;
@@ -29,11 +26,6 @@ export const AgentProfileDetails = ({ disabled = false, className, mode = 'defau
   };
 
   const isHighlighted = mode === 'highlighted';
-  const wrapperStyle = isHighlighted
-    ? ({
-        ['--agent-color-fg']: agentColor?.background,
-      } as CSSProperties)
-    : undefined;
 
   return (
     <div
@@ -42,7 +34,6 @@ export const AgentProfileDetails = ({ disabled = false, className, mode = 'defau
         isHighlighted && HIGHLIGHTED_CLASSNAME,
         className,
       )}
-      style={wrapperStyle}
     >
       <input
         type="text"

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-initial-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-initial-step.tsx
@@ -1,4 +1,5 @@
-import { Button, Skeleton } from '@mastra/playground-ui';
+import { Button, Skeleton, Icon } from '@mastra/playground-ui';
+import { ArrowRightIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { AgentStepContainer } from './agent-step-container';
 import { useStreamRunning } from '@/domains/agent-builder/contexts/stream-chat-context';
@@ -25,7 +26,10 @@ export const AgentProfileInitialStep = ({ avatar, details, isPreparing }: AgentP
     <AgentStepContainer
       cta={
         <Button onClick={handleContinue} disabled={isStreaming}>
-          Continue
+          Continue{' '}
+          <Icon>
+            <ArrowRightIcon />
+          </Icon>
         </Button>
       }
     >

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-instructions-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-instructions-step.tsx
@@ -1,0 +1,35 @@
+import { Button, Icon } from '@mastra/playground-ui';
+
+import { ArrowRightIcon } from 'lucide-react';
+import { AgentStepContainer } from './agent-step-container';
+import { Instructions } from './instructions';
+import { useStreamRunning } from '@/domains/agent-builder/contexts/stream-chat-context';
+import { useWizard } from '@/domains/agent-builder/contexts/wizard-context';
+import { startViewTransition } from '@/lib/routing';
+
+export const AgentProfileInstructionsStep = () => {
+  const { next } = useWizard();
+  const isStreaming = useStreamRunning();
+
+  const handleContinue = () => {
+    startViewTransition(() => {
+      next();
+    });
+  };
+
+  return (
+    <AgentStepContainer
+      title="Instructions"
+      cta={
+        <Button onClick={handleContinue} disabled={isStreaming}>
+          Continue{' '}
+          <Icon>
+            <ArrowRightIcon />
+          </Icon>
+        </Button>
+      }
+    >
+      <Instructions editable={!isStreaming} />
+    </AgentStepContainer>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-integrations-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-integrations-step.tsx
@@ -1,0 +1,37 @@
+import { Button, Icon } from '@mastra/playground-ui';
+
+import { ArrowRightIcon } from 'lucide-react';
+import { AgentStepContainer } from './agent-step-container';
+import { Integrations } from './integrations';
+import { useEditPage } from '@/domains/agent-builder/contexts/edit-page-context';
+import { useStreamRunning } from '@/domains/agent-builder/contexts/stream-chat-context';
+import { useWizard } from '@/domains/agent-builder/contexts/wizard-context';
+import { startViewTransition } from '@/lib/routing';
+
+export const AgentProfileIntegrationsStep = () => {
+  const { agentId } = useEditPage();
+  const { next } = useWizard();
+  const isStreaming = useStreamRunning();
+
+  const handleContinue = () => {
+    startViewTransition(() => {
+      next();
+    });
+  };
+
+  return (
+    <AgentStepContainer
+      title="Integrations"
+      cta={
+        <Button onClick={handleContinue} disabled={isStreaming}>
+          Continue{' '}
+          <Icon>
+            <ArrowRightIcon />
+          </Icon>
+        </Button>
+      }
+    >
+      <Integrations agentId={agentId} editable={!isStreaming} />
+    </AgentStepContainer>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-model-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-model-step.tsx
@@ -1,5 +1,6 @@
-import { Badge, Button } from '@mastra/playground-ui';
+import { Badge, Button, Icon } from '@mastra/playground-ui';
 
+import { ArrowRightIcon } from 'lucide-react';
 import { useWatch } from 'react-hook-form';
 import { AgentStepContainer } from './agent-step-container';
 import { Models } from './models';
@@ -43,7 +44,10 @@ export const AgentProfileModelStep = () => {
       }
       cta={
         <Button onClick={handleContinue} disabled={isStreaming}>
-          Continue
+          Continue{' '}
+          <Icon>
+            <ArrowRightIcon />
+          </Icon>
         </Button>
       }
     >

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-skills-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-skills-step.tsx
@@ -1,0 +1,37 @@
+import { Button, Icon } from '@mastra/playground-ui';
+
+import { ArrowRightIcon } from 'lucide-react';
+import { AgentStepContainer } from './agent-step-container';
+import { Skills } from './skills';
+import { useEditPage } from '@/domains/agent-builder/contexts/edit-page-context';
+import { useStreamRunning } from '@/domains/agent-builder/contexts/stream-chat-context';
+import { useWizard } from '@/domains/agent-builder/contexts/wizard-context';
+import { startViewTransition } from '@/lib/routing';
+
+export const AgentProfileSkillsStep = () => {
+  const { availableSkills } = useEditPage();
+  const { next } = useWizard();
+  const isStreaming = useStreamRunning();
+
+  const handleContinue = () => {
+    startViewTransition(() => {
+      next();
+    });
+  };
+
+  return (
+    <AgentStepContainer
+      title="Skills"
+      cta={
+        <Button onClick={handleContinue} disabled={isStreaming}>
+          Continue{' '}
+          <Icon>
+            <ArrowRightIcon />
+          </Icon>
+        </Button>
+      }
+    >
+      <Skills availableSkills={availableSkills} editable={!isStreaming} />
+    </AgentStepContainer>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-tools-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-tools-step.tsx
@@ -1,0 +1,37 @@
+import { Button, Icon } from '@mastra/playground-ui';
+
+import { ArrowRightIcon } from 'lucide-react';
+import { AgentStepContainer } from './agent-step-container';
+import { Tools } from './tools';
+import { useEditPage } from '@/domains/agent-builder/contexts/edit-page-context';
+import { useStreamRunning } from '@/domains/agent-builder/contexts/stream-chat-context';
+import { useWizard } from '@/domains/agent-builder/contexts/wizard-context';
+import { startViewTransition } from '@/lib/routing';
+
+export const AgentProfileToolsStep = () => {
+  const { availableAgentTools } = useEditPage();
+  const { next } = useWizard();
+  const isStreaming = useStreamRunning();
+
+  const handleContinue = () => {
+    startViewTransition(() => {
+      next();
+    });
+  };
+
+  return (
+    <AgentStepContainer
+      title="Available tools"
+      cta={
+        <Button onClick={handleContinue} disabled={isStreaming}>
+          Continue{' '}
+          <Icon>
+            <ArrowRightIcon />
+          </Icon>
+        </Button>
+      }
+    >
+      <Tools availableAgentTools={availableAgentTools} editable={!isStreaming} />
+    </AgentStepContainer>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/browser.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/browser.tsx
@@ -26,7 +26,7 @@ export const Browser = ({ editable = true }: BrowserProps) => {
     : undefined;
 
   const switchStyle: CSSProperties | undefined =
-    browserEnabled && agentColor ? { backgroundColor: agentColor.foreground } : undefined;
+    browserEnabled && agentColor ? { backgroundColor: agentColor.tint } : undefined;
 
   return (
     <div className="flex h-full min-h-0 items-center justify-center px-6 py-8" data-testid="browser-detail-picker">

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/index.ts
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/index.ts
@@ -5,3 +5,8 @@ export { AgentProfileDetails } from './agent-profile-details';
 export { AgentProfileTabs } from './agent-profile-tabs';
 export { AgentProfileInitialStep } from './agent-profile-initial-step';
 export { AgentProfileModelStep } from './agent-profile-model-step';
+export { AgentProfileToolsStep } from './agent-profile-tools-step';
+export { AgentProfileInstructionsStep } from './agent-profile-instructions-step';
+export { AgentProfileSkillsStep } from './agent-profile-skills-step';
+export { AgentProfileBrowserStep } from './agent-profile-browser-step';
+export { AgentProfileIntegrationsStep } from './agent-profile-integrations-step';

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/models.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/models.tsx
@@ -1,8 +1,10 @@
 import { isModelAllowed } from '@mastra/core/agent-builder/ee';
-import { Skeleton, Txt } from '@mastra/playground-ui';
+import { Checkbox, Skeleton, Txt, cn } from '@mastra/playground-ui';
 import { LockIcon, TriangleAlertIcon } from 'lucide-react';
+import type { CSSProperties } from 'react';
 import { useMemo, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+import { useAgentColor } from '../../../contexts/agent-color-context';
 import type { AgentBuilderEditFormValues } from '../../../schemas';
 import { AgentSearchbar } from '../agent-searchbar';
 import { AgentSelectableCard } from '../agent-selectable-card';
@@ -41,6 +43,11 @@ interface ModelPickerProps {
   disabled?: boolean;
 }
 
+interface ProviderEntry {
+  providerId: string;
+  providerName: string;
+}
+
 const ModelPicker = ({ disabled = false }: ModelPickerProps) => {
   const { setValue, control } = useFormContext<AgentBuilderEditFormValues>();
   const model = useWatch({ control, name: 'model' });
@@ -53,6 +60,36 @@ const ModelPicker = ({ disabled = false }: ModelPickerProps) => {
 
   const policyAllowedModels = useBuilderFilteredModels(allModels, policy);
   const [search, setSearch] = useState('');
+  const [selectedProviders, setSelectedProviders] = useState<Set<string> | null>(null);
+
+  const providerOptions = useMemo<ProviderEntry[]>(() => {
+    const seen = new Map<string, string>();
+    for (const m of policyAllowedModels) {
+      const id = cleanProviderId(m.provider);
+      if (!seen.has(id)) {
+        seen.set(id, m.providerName);
+      }
+    }
+    return Array.from(seen.entries())
+      .map(([providerId, providerName]) => ({ providerId, providerName }))
+      .sort((a, b) => a.providerName.localeCompare(b.providerName));
+  }, [policyAllowedModels]);
+
+  const isProviderChecked = (providerId: string) =>
+    selectedProviders === null || selectedProviders.has(providerId);
+
+  const handleToggleProvider = (providerId: string) => {
+    setSelectedProviders(prev => {
+      const base = prev ?? new Set(providerOptions.map(p => p.providerId));
+      const next = new Set(base);
+      if (next.has(providerId)) {
+        next.delete(providerId);
+      } else {
+        next.add(providerId);
+      }
+      return next;
+    });
+  };
 
   if (isLoading) {
     return <Skeleton className="h-40 w-full" />;
@@ -64,12 +101,13 @@ const ModelPicker = ({ disabled = false }: ModelPickerProps) => {
   const isSet = Boolean(provider && modelId);
   const isStale = isSet && policy.active && !isModelAllowed(policy.allowed, { provider, modelId });
 
-  const visibleEntries = filterProvidersModel(policyAllowedModels, provider, search);
+  const groups = groupModelsByProvider(policyAllowedModels, selectedProviders, search, provider);
+  const allProvidersUnchecked = selectedProviders !== null && selectedProviders.size === 0;
 
   return (
     <div className="h-full overflow-y-auto">
       <div
-        className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-6 px-6 overflow-y-auto"
+        className="grid h-full min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] gap-4 px-6 overflow-y-auto"
         data-testid="model-card-picker"
       >
         <div data-testid="model-card-picker-search" className="shrink-0 max-w-[30ch]">
@@ -82,15 +120,28 @@ const ModelPicker = ({ disabled = false }: ModelPickerProps) => {
           />
         </div>
 
-        {visibleEntries.length === 0 ? (
+        {providerOptions.length > 0 && (
+          <ProviderFilterBadges
+            providers={providerOptions}
+            isProviderChecked={isProviderChecked}
+            onToggle={handleToggleProvider}
+            disabled={disabled}
+          />
+        )}
+
+        {groups.length === 0 ? (
           <div className="flex min-h-0 items-center justify-center">
             <Txt variant="ui-md" className="text-neutral3">
-              {search.trim() ? `No models match "${search.trim()}"` : 'No models available'}
+              {search.trim()
+                ? `No models match "${search.trim()}"`
+                : allProvidersUnchecked
+                  ? 'Select at least one provider to see models'
+                  : 'No models available'}
             </Txt>
           </div>
         ) : (
-          <ModelList
-            visibleEntries={visibleEntries}
+          <ModelGroups
+            groups={groups}
             selectedProvider={provider}
             selectedModel={modelId}
             disabled={disabled}
@@ -104,35 +155,122 @@ const ModelPicker = ({ disabled = false }: ModelPickerProps) => {
   );
 };
 
-interface ModelListProps {
-  visibleEntries: ModelInfo[];
+interface ProviderFilterBadgesProps {
+  providers: ProviderEntry[];
+  isProviderChecked: (providerId: string) => boolean;
+  onToggle: (providerId: string) => void;
+  disabled?: boolean;
+}
+
+const ProviderFilterBadges = ({ providers, isProviderChecked, onToggle, disabled }: ProviderFilterBadgesProps) => {
+  const agentColor = useAgentColor();
+
+  return (
+    <div className="flex flex-wrap gap-2 shrink-0" data-testid="model-provider-filter">
+      {providers.map(({ providerId, providerName }) => {
+        const checked = isProviderChecked(providerId);
+        const useAgentColors = checked && agentColor !== null;
+
+        const labelStyle: CSSProperties | undefined = useAgentColors
+          ? {
+              borderColor: agentColor.background,
+              color: agentColor.background,
+            }
+          : undefined;
+
+        const checkboxStyle: CSSProperties | undefined = useAgentColors
+          ? {
+              backgroundColor: agentColor.background,
+              borderColor: agentColor.background,
+              color: agentColor.foreground,
+            }
+          : undefined;
+
+        return (
+          <label
+            key={providerId}
+            data-testid={`model-provider-filter-badge-${providerId}`}
+            data-checked={checked ? 'true' : 'false'}
+            style={labelStyle}
+            className={cn(
+              'inline-flex items-center gap-2 rounded-full border px-2.5 h-badge-default text-ui-sm font-mono cursor-pointer select-none transition-colors',
+              !useAgentColors &&
+                (checked
+                  ? 'border-accent1 bg-surface4 text-neutral6'
+                  : 'border-border1 bg-surface3 text-neutral5 hover:bg-surface4'),
+              disabled && 'cursor-not-allowed opacity-60',
+            )}
+          >
+            <Checkbox
+              variant={useAgentColors ? 'neutral' : 'primary'}
+              checked={checked}
+              disabled={disabled}
+              onCheckedChange={() => onToggle(providerId)}
+              style={checkboxStyle}
+              data-testid={`model-provider-filter-checkbox-${providerId}`}
+              className="h-3 w-3 shadow-none [&_svg]:h-2.5 [&_svg]:w-2.5"
+            />
+            <span>{providerName}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+};
+
+interface ModelGroup {
+  providerId: string;
+  providerName: string;
+  models: ModelInfo[];
+}
+
+interface ModelGroupsProps {
+  groups: ModelGroup[];
   selectedProvider: string;
   selectedModel: string;
   disabled: boolean;
   onChange: (provider: string, model: string) => void;
 }
 
-const ModelList = ({ visibleEntries, selectedProvider, selectedModel, disabled, onChange }: ModelListProps) => {
+const ModelGroups = ({ groups, selectedProvider, selectedModel, disabled, onChange }: ModelGroupsProps) => {
   return (
-    <div className="grid min-h-0 grid-cols-1 content-start gap-2 lg:gap-6 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3">
-      {visibleEntries.map(entry => {
-        const cleanedProvider = cleanProviderId(entry.provider);
-        const isSelected = cleanedProvider === selectedProvider && entry.model === selectedModel;
+    <div className="flex min-h-0 flex-col gap-6 overflow-y-auto">
+      {groups.map(group => (
+        <section
+          key={group.providerId}
+          data-testid={`model-provider-section-${group.providerId}`}
+          className="flex flex-col gap-3"
+        >
+          <Txt
+            variant="ui-sm"
+            as="h3"
+            className="text-neutral3 uppercase tracking-wide"
+            data-testid={`model-provider-section-title-${group.providerId}`}
+          >
+            {group.providerName}
+          </Txt>
+          <div className="grid grid-cols-1 content-start gap-2 lg:gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {group.models.map(entry => {
+              const cleanedProvider = cleanProviderId(entry.provider);
+              const isSelected = cleanedProvider === selectedProvider && entry.model === selectedModel;
 
-        return (
-          <AgentSelectableCard
-            key={`${entry.provider}__${entry.model}`}
-            icon={<ProviderLogo providerId={entry.provider} size={32} />}
-            title={entry.model}
-            subtitle={entry.providerName}
-            isSelected={isSelected}
-            disabled={disabled}
-            onClick={() => onChange(entry.provider, entry.model)}
-            testId={`model-card-${entry.provider}-${entry.model}`}
-            checkTestId={`model-card-check-${entry.provider}-${entry.model}`}
-          />
-        );
-      })}
+              return (
+                <AgentSelectableCard
+                  key={`${entry.provider}__${entry.model}`}
+                  icon={<ProviderLogo providerId={entry.provider} size={32} />}
+                  title={entry.model}
+                  subtitle={entry.providerName}
+                  isSelected={isSelected}
+                  disabled={disabled}
+                  onClick={() => onChange(entry.provider, entry.model)}
+                  testId={`model-card-${entry.provider}-${entry.model}`}
+                  checkTestId={`model-card-check-${entry.provider}-${entry.model}`}
+                />
+              );
+            })}
+          </div>
+        </section>
+      ))}
     </div>
   );
 };
@@ -180,21 +318,43 @@ const LockedModelChip = ({ provider, modelId }: LockedModelChipProps) => (
   </div>
 );
 
-function filterProvidersModel(modelInfo: ModelInfo[], selectedProvider: string, search: string) {
-  return modelInfo
-    .filter(m => {
-      if (m.provider.toLowerCase().includes(search.toLowerCase())) return true;
-      if (m.model.toLowerCase().includes(search.toLowerCase())) return true;
-      return false;
-    })
-    .sort((a, b) => {
-      const aSelectedProvider = cleanProviderId(a.provider) === selectedProvider ? 0 : 1;
-      const bSelectedProvider = cleanProviderId(b.provider) === selectedProvider ? 0 : 1;
-      if (aSelectedProvider !== bSelectedProvider) return aSelectedProvider - bSelectedProvider;
+function groupModelsByProvider(
+  modelInfo: ModelInfo[],
+  selectedProviders: Set<string> | null,
+  search: string,
+  selectedProvider: string,
+): ModelGroup[] {
+  const searchLower = search.toLowerCase();
 
-      const providerCompare = a.providerName.localeCompare(b.providerName);
-      if (providerCompare !== 0) return providerCompare;
+  const filtered = modelInfo.filter(m => {
+    const providerId = cleanProviderId(m.provider);
+    if (selectedProviders !== null && !selectedProviders.has(providerId)) return false;
 
-      return a.model.localeCompare(b.model);
-    });
+    if (!searchLower) return true;
+    if (m.provider.toLowerCase().includes(searchLower)) return true;
+    if (m.model.toLowerCase().includes(searchLower)) return true;
+    return false;
+  });
+
+  const groupsById = new Map<string, ModelGroup>();
+  for (const entry of filtered) {
+    const providerId = cleanProviderId(entry.provider);
+    let group = groupsById.get(providerId);
+    if (!group) {
+      group = { providerId, providerName: entry.providerName, models: [] };
+      groupsById.set(providerId, group);
+    }
+    group.models.push(entry);
+  }
+
+  for (const group of groupsById.values()) {
+    group.models.sort((a, b) => a.model.localeCompare(b.model));
+  }
+
+  return Array.from(groupsById.values()).sort((a, b) => {
+    const aSelected = a.providerId === selectedProvider ? 0 : 1;
+    const bSelected = b.providerId === selectedProvider ? 0 : 1;
+    if (aSelected !== bSelected) return aSelected - bSelected;
+    return a.providerName.localeCompare(b.providerName);
+  });
 }

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/tools.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/tools.tsx
@@ -1,7 +1,8 @@
-import { Txt } from '@mastra/playground-ui';
-import type { ReactNode } from 'react';
+import { Checkbox, Txt, cn } from '@mastra/playground-ui';
+import type { CSSProperties, ReactNode } from 'react';
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useAgentColor } from '../../../contexts/agent-color-context';
 import type { AgentBuilderEditFormValues } from '../../../schemas';
 import type { AgentTool } from '../../../types/agent-tool';
 import { AgentSearchbar } from '../agent-searchbar';
@@ -14,7 +15,18 @@ interface ToolsProps {
 
 export const Tools = ({ editable = true, availableAgentTools = [] }: ToolsProps) => {
   const { setValue, getValues } = useFormContext<AgentBuilderEditFormValues>();
+  const agentColor = useAgentColor();
   const [search, setSearch] = useState('');
+  const [onlySelected, setOnlySelected] = useState(false);
+
+  const filterCheckboxStyle: CSSProperties | undefined =
+    onlySelected && agentColor
+      ? {
+          backgroundColor: agentColor.background,
+          borderColor: agentColor.background,
+          color: agentColor.foreground,
+        }
+      : undefined;
 
   const toggle = (item: AgentTool, next: boolean) => {
     const fieldName = item.type === 'agent' ? 'agents' : item.type === 'workflow' ? 'workflows' : 'tools';
@@ -26,28 +38,56 @@ export const Tools = ({ editable = true, availableAgentTools = [] }: ToolsProps)
     return <ToolListEmptyState details={'No tools available in this project'} />;
   }
 
-  const visibleTools = getVisibleTools(availableAgentTools, search);
+  const visibleTools = getVisibleTools(availableAgentTools, search, onlySelected);
+  const trimmedSearch = search.trim();
+
+  let emptyStateDetails: ReactNode;
+  if (onlySelected && trimmedSearch === '') {
+    emptyStateDetails = 'No tools selected yet';
+  } else if (onlySelected) {
+    emptyStateDetails = <>No selected tools match "{trimmedSearch}"</>;
+  } else {
+    emptyStateDetails = (
+      <>
+        No tools match <strong>"${trimmedSearch}"</strong>
+      </>
+    );
+  }
 
   return (
     <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-6 px-6" data-testid="tools-card-picker">
-      <div data-testid="tools-card-picker-search" className="shrink-0 max-w-[30ch]">
-        <AgentSearchbar
-          onSearch={setSearch}
-          label="Search tools"
-          placeholder="Search tools..."
-          size="lg"
-          debounceMs={0}
-        />
+      <div className="flex shrink-0 items-center justify-between gap-4">
+        <div data-testid="tools-card-picker-search" className="max-w-[30ch] flex-1">
+          <AgentSearchbar
+            onSearch={setSearch}
+            label="Search tools"
+            placeholder="Search tools..."
+            size="lg"
+            debounceMs={0}
+          />
+        </div>
+
+        <label
+          data-testid="tools-only-selected-filter"
+          className={cn(
+            'inline-flex items-center gap-2 text-ui-xs text-neutral3 select-none cursor-pointer',
+            !editable && 'cursor-not-allowed opacity-60',
+          )}
+        >
+          <Checkbox
+            checked={onlySelected}
+            onCheckedChange={value => setOnlySelected(value === true)}
+            disabled={!editable}
+            data-testid="tools-only-selected-filter-checkbox"
+            style={filterCheckboxStyle}
+            className="h-3 w-3 shadow-none [&_svg]:h-2.5 [&_svg]:w-2.5 data-[state=checked]:shadow-none"
+          />
+          <span>Show only selected</span>
+        </label>
       </div>
 
       {visibleTools.length === 0 ? (
-        <ToolListEmptyState
-          details={
-            <>
-              No tools match <strong>"${search.trim()}"</strong>
-            </>
-          }
-        />
+        <ToolListEmptyState details={emptyStateDetails} />
       ) : (
         <div className="grid min-h-0 grid-cols-1 content-start gap-2 lg:gap-6 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3">
           {visibleTools.map(item => (
@@ -83,11 +123,12 @@ const ToolListEmptyState = ({ details }: ToolListEmptyStateProps) => {
   );
 };
 
-function getVisibleTools(availableAgentTools: AgentTool[], search: string) {
+function getVisibleTools(availableAgentTools: AgentTool[], search: string, onlySelected: boolean) {
   const term = search.trim().toLowerCase();
-  if (!term) return availableAgentTools;
 
-  return availableAgentTools.filter(
-    item => item.name.toLowerCase().includes(term) || (item.description?.toLowerCase().includes(term) ?? false),
-  );
+  return availableAgentTools.filter(item => {
+    if (onlySelected && !item.isChecked) return false;
+    if (!term) return true;
+    return item.name.toLowerCase().includes(term) || (item.description?.toLowerCase().includes(term) ?? false);
+  });
 }

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -169,7 +169,7 @@ export const Txtmessage = ({ txt, role }: { txt: string; role: MastraUIMessage['
           className="bg-white text-black rounded-2xl px-4 py-2.5 max-w-[80%] [&_ul]:!space-y-1 [&_ol]:!space-y-1 [&_li]:!my-0 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_li]:!leading-normal"
           as="div"
         >
-          <MarkdownRenderer className="space-y-2">{txt}</MarkdownRenderer>
+          <MarkdownRenderer>{txt}</MarkdownRenderer>
         </Txt>
       </div>
     );
@@ -182,7 +182,7 @@ export const Txtmessage = ({ txt, role }: { txt: string; role: MastraUIMessage['
         className="text-neutral4 max-w-[80%] [&_ul]:!space-y-1 [&_ol]:!space-y-1 [&_li]:!my-0 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_li]:!leading-normal"
         as="div"
       >
-        <MarkdownRenderer className="space-y-2">{txt}</MarkdownRenderer>
+        <MarkdownRenderer>{txt}</MarkdownRenderer>
       </Txt>
     );
   }

--- a/packages/playground/src/domains/agent-builder/contexts/__tests__/agent-color-context.test.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/__tests__/agent-color-context.test.tsx
@@ -17,7 +17,14 @@ interface HarnessProps {
 const Consumer = ({ observed }: { observed: AgentColors[] }) => {
   const color = useAgentColor();
   observed.push(color);
-  return <div data-testid="consumer" data-bg={color?.background ?? ''} data-fg={color?.foreground ?? ''} />;
+  return (
+    <div
+      data-testid="consumer"
+      data-bg={color?.background ?? ''}
+      data-fg={color?.foreground ?? ''}
+      data-tint={color?.tint ?? ''}
+    />
+  );
 };
 
 const Harness = ({ initialName, observed }: HarnessProps) => {
@@ -69,15 +76,17 @@ describe('AgentColorProvider', () => {
     expect(getByTestId('consumer').getAttribute('data-bg')).toBe('');
   });
 
-  it('derives an hsl background and a darker hsl foreground from the trimmed name', () => {
+  it('derives an hsl background, a darker hsl foreground, and a mid-lightness tint from the trimmed name', () => {
     const observed: AgentColors[] = [];
     const { getByTestId } = render(<Harness initialName="  Support agent  " observed={observed} />);
     const consumer = getByTestId('consumer');
     expect(consumer.getAttribute('data-bg')).toBe(stringToColor('Support agent'));
     expect(consumer.getAttribute('data-fg')).toBe(stringToColor('Support agent', 20));
-    // Background uses lightness 90%, foreground uses lightness 20%.
+    expect(consumer.getAttribute('data-tint')).toBe(stringToColor('Support agent', 50));
+    // Background uses lightness 90%, foreground uses lightness 20%, tint uses lightness 50%.
     expect(consumer.getAttribute('data-bg')).toMatch(/hsl\(-?\d+, 100%, 90%\)/);
     expect(consumer.getAttribute('data-fg')).toMatch(/hsl\(-?\d+, 100%, 20%\)/);
+    expect(consumer.getAttribute('data-tint')).toMatch(/hsl\(-?\d+, 100%, 50%\)/);
   });
 
   it('updates the consumer when the form name changes', () => {

--- a/packages/playground/src/domains/agent-builder/contexts/__tests__/wizard-context.test.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/__tests__/wizard-context.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import type { StoredSkillResponse } from '@mastra/client-js';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
@@ -26,9 +27,14 @@ const DEFAULT_FEATURES: Features = {
 };
 
 let featuresMock: Features = { ...DEFAULT_FEATURES };
+let skillsMock: StoredSkillResponse[] = [];
 
 vi.mock('@/domains/agent-builder/hooks/use-builder-agent-features', () => ({
   useBuilderAgentFeatures: () => featuresMock,
+}));
+
+vi.mock('@/domains/agent-builder/contexts/agent-primitives-context', () => ({
+  useAgentPrimitives: () => ({ availableSkills: skillsMock }),
 }));
 
 const BASE_URL = 'http://localhost:4111';
@@ -78,6 +84,7 @@ const flushPlatforms = () => act(async () => new Promise(resolve => setTimeout(r
 describe('WizardProvider', () => {
   beforeEach(() => {
     featuresMock = { ...DEFAULT_FEATURES };
+    skillsMock = [];
     usePlatformsHandler([]);
   });
 
@@ -122,6 +129,7 @@ describe('WizardProvider', () => {
       skills: true,
       browser: true,
     };
+    skillsMock = [{ id: 'skill-a' } as StoredSkillResponse];
     usePlatformsHandler([{ id: 'slack', name: 'Slack', isConfigured: true }]);
 
     const { getByTestId } = renderWizard({ initialStep: 'initial' });
@@ -171,6 +179,26 @@ describe('WizardProvider', () => {
     await flushPlatforms();
 
     expect(getByTestId('steps').textContent).toBe('initial>tools>instructions>end');
+  });
+
+  it('excludes skills when features.skills is on but no skills are available', async () => {
+    featuresMock = { ...DEFAULT_FEATURES, skills: true };
+    skillsMock = [];
+
+    const { getByTestId } = renderWizard({ initialStep: 'initial' });
+    await flushPlatforms();
+
+    expect(getByTestId('steps').textContent).toBe('initial>instructions>end');
+  });
+
+  it('includes skills when features.skills is on and skills are available', async () => {
+    featuresMock = { ...DEFAULT_FEATURES, skills: true };
+    skillsMock = [{ id: 'skill-a' } as StoredSkillResponse];
+
+    const { getByTestId } = renderWizard({ initialStep: 'initial' });
+    await flushPlatforms();
+
+    expect(getByTestId('steps').textContent).toBe('initial>instructions>skills>end');
   });
 
   it('excludes integrations when no platform is configured', async () => {

--- a/packages/playground/src/domains/agent-builder/contexts/agent-color-context.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/agent-color-context.tsx
@@ -8,6 +8,7 @@ import type { AgentBuilderEditFormValues } from '../schemas';
 export type AgentColors = {
   background: string;
   foreground: string;
+  tint: string;
 } | null;
 
 export const AgentColorContext = createContext<AgentColors>(null);
@@ -27,6 +28,7 @@ export const AgentColorProvider = ({ children }: AgentColorProviderProps) => {
     return {
       background: stringToColor(trimmed),
       foreground: stringToColor(trimmed, 20),
+      tint: stringToColor(trimmed, 50),
     };
   }, [trimmed]);
 

--- a/packages/playground/src/domains/agent-builder/contexts/agent-primitives-context.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/agent-primitives-context.tsx
@@ -89,7 +89,7 @@ export const AgentPrimitivesProvider = ({ agentId, children }: AgentPrimitivesPr
   const value = useMemo<AgentPrimitivesValue>(
     () => ({
       agentId: agentId!,
-      storedAgent,
+      storedAgent: storedAgent ?? undefined,
       toolsData: toolsData ?? {},
       agentsData: agentsData ?? {},
       workflowsData: workflowsData ?? {},

--- a/packages/playground/src/domains/agent-builder/contexts/wizard-context.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/wizard-context.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useBuilderAgentFeatures } from '../hooks/use-builder-agent-features';
+import { useAgentPrimitives } from './agent-primitives-context';
 import { useChannelPlatforms } from '@/domains/agents/hooks/use-channels';
 
 export type WizardStep = 'initial' | 'end' | 'tools' | 'model' | 'instructions' | 'browser' | 'integrations' | 'skills';
@@ -28,10 +29,16 @@ const STEP_ORDER: WizardStep[] = [
 interface BuildStepsInput {
   features: ReturnType<typeof useBuilderAgentFeatures>;
   hasConfiguredIntegration: boolean;
+  hasSkills: boolean;
   includeInitial: boolean;
 }
 
-const buildWizardSteps = ({ features, hasConfiguredIntegration, includeInitial }: BuildStepsInput): WizardStep[] => {
+const buildWizardSteps = ({
+  features,
+  hasConfiguredIntegration,
+  hasSkills,
+  includeInitial,
+}: BuildStepsInput): WizardStep[] => {
   const result: WizardStep[] = [];
   for (const step of STEP_ORDER) {
     switch (step) {
@@ -48,7 +55,10 @@ const buildWizardSteps = ({ features, hasConfiguredIntegration, includeInitial }
         result.push(step);
         break;
       case 'skills':
-        if (features.skills) result.push(step);
+        // Mirrors `skillsTabEnabled` in `agent-profile-tabs.tsx`: only surface
+        // the step when the feature is on *and* there is at least one skill
+        // for the user to pick from.
+        if (features.skills && hasSkills) result.push(step);
         break;
       case 'browser':
         if (features.browser) result.push(step);
@@ -89,17 +99,20 @@ interface WizardProviderProps {
  */
 export const WizardProvider = ({ initialStep = 'end', children }: WizardProviderProps) => {
   const features = useBuilderAgentFeatures();
+  const { availableSkills } = useAgentPrimitives();
   const platformsQuery = useChannelPlatforms();
   const hasConfiguredIntegration = (platformsQuery.data ?? []).some(p => p.isConfigured);
+  const hasSkills = availableSkills.length > 0;
 
   const steps = useMemo(
     () =>
       buildWizardSteps({
         features,
         hasConfiguredIntegration,
+        hasSkills,
         includeInitial: initialStep === 'initial',
       }),
-    [features, hasConfiguredIntegration, initialStep],
+    [features, hasConfiguredIntegration, hasSkills, initialStep],
   );
 
   const [step, setStep] = useState<WizardStep>(() => {

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
@@ -112,11 +112,9 @@ function AccessDeniedScreen() {
           descriptionSlot="You don't have permission to access the Agent Builder."
         />
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" asChild>
-            <a href="/agents">
-              <ArrowLeft className="h-3.5 w-3.5" />
-              Back to Studio
-            </a>
+          <Button as="a" href="/agents" variant="outline" size="sm">
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to Studio
           </Button>
           {isImpersonating && (
             <Button variant="default" size="sm" onClick={stopImpersonation}>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-chat-composer.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-chat-composer.tsx
@@ -166,7 +166,6 @@ export function SkillChatComposer({
         canSubmit={!!trimmed && !isRunning}
         isRunning={isRunning}
         placeholder={hasFields ? 'Ask the agent to refine…' : 'Describe your skill…'}
-        tone="info"
         inputTestId="skill-builder-conversation-input"
         submitTestId="skill-builder-conversation-submit"
         containerTestId="skill-builder-conversation-composer"

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
@@ -265,14 +265,14 @@ export function SkillEditDialog({
         </span>
         <div className="flex items-center gap-2 mr-6">
           {isViewMode && isOwner && (
-            <Button variant="secondary" size="sm" onClick={() => setIsEditing(true)}>
+            <Button variant="outline" size="sm" onClick={() => setIsEditing(true)}>
               <Pencil className="h-3.5 w-3.5" /> Edit
             </Button>
           )}
           {isViewMode && !isOwner && onCopy && skill && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="secondary" size="sm" onClick={() => onCopy(skill)}>
+                <Button variant="outline" size="sm" onClick={() => onCopy(skill)}>
                   <CopyIcon className="h-3.5 w-3.5" /> Copy
                 </Button>
               </TooltipTrigger>

--- a/packages/playground/src/pages/agent-builder/agents/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/edit.tsx
@@ -7,6 +7,11 @@ import {
   AgentProfile,
   AgentProfileInitialStep,
   AgentProfileModelStep,
+  AgentProfileToolsStep,
+  AgentProfileInstructionsStep,
+  AgentProfileSkillsStep,
+  AgentProfileBrowserStep,
+  AgentProfileIntegrationsStep,
   AgentProfileAvatar,
   AgentProfileDetails,
   AgentProfileHero,
@@ -171,6 +176,26 @@ const ProfileSlot = () => {
 
   if (step === 'model') {
     return <AgentProfileModelStep />;
+  }
+
+  if (step === 'tools') {
+    return <AgentProfileToolsStep />;
+  }
+
+  if (step === 'instructions') {
+    return <AgentProfileInstructionsStep />;
+  }
+
+  if (step === 'skills') {
+    return <AgentProfileSkillsStep />;
+  }
+
+  if (step === 'browser') {
+    return <AgentProfileBrowserStep />;
+  }
+
+  if (step === 'integrations') {
+    return <AgentProfileIntegrationsStep />;
   }
 
   return (


### PR DESCRIPTION
## Summary

Adds a "Show only selected" filter to the Tools tab of Agent Builder's Agent Profile so users can quickly narrow the picker to the tools they've already chosen.

- A small checkbox now sits inline with the search input on the same row, with the search input flexing to take the available width and the filter label aligned to the right.
- When toggled on, the cards are restricted to entries with `isChecked: true`. The filter composes with the existing search input.
- When checked, the checkbox uses the agent's color (background + foreground), matching the styling of the selected tool tiles in the picker. Without an agent name set, it falls back to the default accent styling.
- Empty-state copy now reflects the filter context: "No tools selected yet" (filter on, no search), `No selected tools match "<term>"` (filter on + search), or the existing `No tools match "<term>"` otherwise.
- Label is rendered as small muted text (`text-ui-xs text-neutral3`) to keep the control unobtrusive.

## Test plan

- `pnpm --filter @internal/playground exec vitest run src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/tools.test.tsx` — 12/12 passing, covering: default unchecked state, filter hides unselected, toggle restores, dedicated "nothing selected" empty state, filter + search empty state, small-size class contract, agent-color styling on checked, no inline style without an agent name, and the inline flex-row layout.
- `pnpm --filter @internal/playground typecheck` — clean.