### PR TITLE
refactor(playground): migrate SkillsTable to DataList

### DIFF
--- a/.changeset/clever-webs-speak.md
+++ b/.changeset/clever-webs-speak.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Refactored the workspace Skills list to use the `DataList` primitives, matching the visual style of the Traces, Logs, and Dataset Items lists. The skill path moved to its own monospace. Removed the decorative skill icon and the mount badge (the mount prefix is visible in the path itself). The row update and remove buttons now use the ghost button variant.

--- a/.changeset/eleven-adults-stay.md
+++ b/.changeset/eleven-adults-stay.md
@@ -2,4 +2,19 @@
 '@mastra/playground-ui': patch
 ---
 
-Added `colEnd` and `flushRight` props to `DataList.RowButton` and `DataList.RowLink` so compound rows can host a trailing cell (mirrors the existing `colStart`/`flushLeft` for leading cells). `DataList.Row` now carries the row separator and `.data-list-row` marker itself, so wrapped rows render a full-width separator that extends through any leading or trailing cells. Added an optional `height` prop to `DataList.MonoCell` so non-compact lists can use it without forcing compact padding.
+Added support for trailing cells in `DataList` rows. `DataList.RowButton` and `DataList.RowLink` now accept `colEnd` and `flushRight` (mirrors of the existing `colStart`/`flushLeft`), so a row can sit beside a non-interactive trailing cell (e.g. an actions column) and stay aligned with the header. Rows wrapped in `DataList.Row` now render a full-width separator that extends through the leading and trailing cells. `DataList.MonoCell` also gained an optional `height` prop so non-compact lists can use it without forcing compact padding.
+
+**Usage**
+
+```tsx
+<DataList.Row>
+  <DataList.RowButton flushLeft flushRight colEnd={-2} onClick={onClick}>
+    {/* main row content */}
+  </DataList.RowButton>
+  <DataList.Cell>
+    {/* trailing actions, e.g. icon buttons */}
+  </DataList.Cell>
+</DataList.Row>
+
+<DataList.MonoCell height="default">long mono text…</DataList.MonoCell>
+```

--- a/.changeset/eleven-adults-stay.md
+++ b/.changeset/eleven-adults-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added `colEnd` and `flushRight` props to `DataList.RowButton` and `DataList.RowLink` so compound rows can host a trailing cell (mirrors the existing `colStart`/`flushLeft` for leading cells). `DataList.Row` now carries the row separator and `.data-list-row` marker itself, so wrapped rows render a full-width separator that extends through any leading or trailing cells. Added an optional `height` prop to `DataList.MonoCell` so non-compact lists can use it without forcing compact padding.

--- a/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-cells.tsx
@@ -21,7 +21,7 @@ export function DataListCell({ children, className, height = 'default', as, ...r
     <Component
       className={cn(
         'relative grid items-center text-ui-md whitespace-nowrap text-neutral3',
-        height === 'compact' ? 'py-2' : 'py-4',
+        height === 'compact' ? 'py-2' : 'py-3',
         className,
       )}
       {...rest}
@@ -104,15 +104,17 @@ export interface DataListMonoCellProps {
   children: ReactNode;
   /** Override classes on the inner span (e.g. swap the default `text-neutral3` tone). */
   className?: string;
+  /** Cell vertical padding. Defaults to `compact` to match other identifier cells. */
+  height?: 'default' | 'compact';
 }
 
 /**
- * Compact mono-typography cell with truncation. Shared by any column that
+ * Mono-typography cell with truncation. Shared by any column that
  * shows code-like text (input previews, JSON summaries, identifiers, etc.).
  */
-export function DataListMonoCell({ children, className }: DataListMonoCellProps) {
+export function DataListMonoCell({ children, className, height = 'compact' }: DataListMonoCellProps) {
   return (
-    <DataListCell height="compact" className="min-w-0">
+    <DataListCell height={height} className="min-w-0">
       <span className={cn('block text-ui-smd font-mono text-neutral3 truncate', className)}>{children}</span>
     </DataListCell>
   );

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
@@ -11,11 +11,12 @@ export type DataListRowButtonProps = ComponentPropsWithoutRef<'button'> & DataLi
  * can attach a ref and `data-index` to each rendered row.
  */
 export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButtonProps>(
-  ({ children, className, type = 'button', flushLeft, flushRight, colStart, colEnd, featured, style, ...rest }, ref) => {
+  (
+    { children, className, type = 'button', flushLeft, flushRight, colStart, colEnd, featured, style, ...rest },
+    ref,
+  ) => {
     const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
-    const resolvedStyle = hasColumnOverride
-      ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` }
-      : style;
+    const resolvedStyle = hasColumnOverride ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` } : style;
     return (
       <button
         ref={ref}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-button.tsx
@@ -11,13 +11,24 @@ export type DataListRowButtonProps = ComponentPropsWithoutRef<'button'> & DataLi
  * can attach a ref and `data-index` to each rendered row.
  */
 export const DataListRowButton = forwardRef<HTMLButtonElement, DataListRowButtonProps>(
-  ({ children, className, type = 'button', flushLeft, colStart, featured, style, ...rest }, ref) => {
+  ({ children, className, type = 'button', flushLeft, flushRight, colStart, colEnd, featured, style, ...rest }, ref) => {
+    const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
+    const resolvedStyle = hasColumnOverride
+      ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` }
+      : style;
     return (
       <button
         ref={ref}
         type={type}
-        className={cn(...dataListRowStyles, 'text-left', flushLeft && 'ml-0!', featured && 'bg-surface4', className)}
-        style={colStart ? { ...style, gridColumn: `${colStart} / -1` } : style}
+        className={cn(
+          ...dataListRowStyles,
+          'text-left',
+          flushLeft && 'ml-0!',
+          flushRight && 'mr-0!',
+          featured && 'bg-surface4',
+          className,
+        )}
+        style={resolvedStyle}
         {...rest}
       >
         {children}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
@@ -25,9 +25,7 @@ export function DataListRowLink({
   featured,
 }: DataListRowLinkProps) {
   const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
-  const resolvedStyle = hasColumnOverride
-    ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` }
-    : style;
+  const resolvedStyle = hasColumnOverride ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` } : style;
   return (
     <Link
       href={to}

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row-link.tsx
@@ -19,14 +19,26 @@ export function DataListRowLink({
   style,
   LinkComponent: Link,
   flushLeft,
+  flushRight,
   colStart,
+  colEnd,
   featured,
 }: DataListRowLinkProps) {
+  const hasColumnOverride = colStart !== undefined || colEnd !== undefined;
+  const resolvedStyle = hasColumnOverride
+    ? { ...style, gridColumn: `${colStart ?? 1} / ${colEnd ?? -1}` }
+    : style;
   return (
     <Link
       href={to}
-      className={cn(...dataListRowStyles, flushLeft && 'ml-0!', featured && 'bg-surface4', className)}
-      style={colStart ? { ...style, gridColumn: `${colStart} / -1` } : style}
+      className={cn(
+        ...dataListRowStyles,
+        flushLeft && 'ml-0!',
+        flushRight && 'mr-0!',
+        featured && 'bg-surface4',
+        className,
+      )}
+      style={resolvedStyle}
     >
       {children}
     </Link>

--- a/packages/playground-ui/src/ds/components/DataList/data-list-row.tsx
+++ b/packages/playground-ui/src/ds/components/DataList/data-list-row.tsx
@@ -1,18 +1,22 @@
 import { forwardRef } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
+import { dataListRowOuterStyles } from './shared';
 import { cn } from '@/lib/utils';
 
 export type DataListRowProps = ComponentPropsWithoutRef<'div'>;
 
 /**
- * Non-interactive grid wrapper. Used to host a leading cell (e.g. a selection
- * checkbox) alongside a `DataList.RowButton` so hover/focus/click only apply to
- * the button portion. For standalone interactive rows, use `DataList.RowButton`
- * directly without this wrapper.
+ * Non-interactive grid wrapper. Used to host a leading or trailing cell (e.g. a
+ * selection checkbox or row actions) alongside a `DataList.RowButton` so
+ * hover/focus/click only apply to the button portion. For standalone
+ * interactive rows, use `DataList.RowButton` directly without this wrapper.
+ *
+ * Carries the row-level border + `.data-list-row` marker so separators and
+ * sibling-aware rules behave the same in wrapped and standalone rows.
  */
 export const DataListRow = forwardRef<HTMLDivElement, DataListRowProps>(({ children, className, ...rest }, ref) => {
   return (
-    <div ref={ref} className={cn('grid grid-cols-subgrid gap-0 col-span-full ml-1', className)} {...rest}>
+    <div ref={ref} className={cn('grid grid-cols-subgrid gap-0 mx-1', ...dataListRowOuterStyles, className)} {...rest}>
       {children}
     </div>
   );

--- a/packages/playground-ui/src/ds/components/DataList/shared.ts
+++ b/packages/playground-ui/src/ds/components/DataList/shared.ts
@@ -1,11 +1,24 @@
-export const dataListRowStyles = [
-  'mx-1 data-list-row grid grid-cols-subgrid gap-8 col-span-full px-5 outline-none cursor-pointer border-y border-b-border1 border-t-transparent',
-  'hover:bg-surface4 hover:border-transparent focus-visible:bg-surface4 focus-visible:border-transparent focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent1',
+/**
+ * Row-level styling shared by anything that participates in the row sibling
+ * chain — applied to `DataList.RowButton` / `DataList.RowLink` when used
+ * standalone, and to `DataList.Row` when used as a wrapper around them.
+ *
+ * Contains the `.data-list-row` marker class (used by the sibling-aware border
+ * rules), the bottom/top border treatment, and rounded corners.
+ */
+export const dataListRowOuterStyles = [
+  'data-list-row col-span-full border-y border-b-border1 border-t-transparent',
   '[.data-list-row:hover+&]:border-t-transparent [.data-list-row:focus-visible+&]:border-t-transparent',
   '[.data-list-subheader+&]:border-t-transparent',
   '[&:has(+.data-list-subheader)]:border-b-transparent',
   '[&:not(:has(~.data-list-row))]:border-b-transparent',
   'transition-colors duration-200 rounded-lg',
+] as const;
+
+export const dataListRowStyles = [
+  'mx-1 grid grid-cols-subgrid gap-8 px-5 outline-none cursor-pointer',
+  'hover:bg-surface4 hover:border-transparent focus-visible:bg-surface4 focus-visible:border-transparent focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent1',
+  ...dataListRowOuterStyles,
 ] as const;
 
 /**
@@ -20,11 +33,22 @@ export type DataListRowSharedProps = {
    */
   flushLeft?: boolean;
   /**
-   * Place the row starting at this column line, spanning through to the last
-   * column. Defaults to the full grid (`col-span-full`). Use when the row
-   * sits beside a leading cell that owns column 1.
+   * Drop the row's default right margin. Use when the row is wrapped in a
+   * `DataList.Row` that owns the trailing inset (e.g. for rows with a
+   * trailing actions cell on the right).
+   */
+  flushRight?: boolean;
+  /**
+   * Place the row starting at this column line. Defaults to column 1. Use
+   * when the row sits beside a leading cell that owns column 1.
    */
   colStart?: number;
+  /**
+   * Place the row ending at this column line (use negative values to count
+   * from the end, e.g. `-2`). Defaults to `-1` (the last line). Use when the
+   * row sits beside a trailing cell that owns the last column.
+   */
+  colEnd?: number;
   /**
    * Apply the highlighted background. Use to mark the row that is currently
    * featured (e.g. the row whose detail is open in a side panel).

--- a/packages/playground/src/domains/workspace/components/skill-actions.tsx
+++ b/packages/playground/src/domains/workspace/components/skill-actions.tsx
@@ -12,7 +12,7 @@ export interface SkillUpdateButtonProps {
  */
 export function SkillUpdateButton({ skillName, onUpdate, isUpdating }: SkillUpdateButtonProps) {
   return (
-    <Button variant="default" size="icon-sm" disabled={isUpdating} tooltip={`Update ${skillName}`} onClick={onUpdate}>
+    <Button variant="ghost" size="icon-md" disabled={isUpdating} tooltip={`Update ${skillName}`} onClick={onUpdate}>
       {isUpdating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
     </Button>
   );
@@ -31,7 +31,7 @@ export function SkillRemoveButton({ skillName, onRemove, isRemoving }: SkillRemo
   return (
     <AlertDialog>
       <AlertDialog.Trigger asChild>
-        <Button variant="default" size="icon-sm" disabled={isRemoving} tooltip={`Remove ${skillName}`}>
+        <Button variant="ghost" size="icon-md" disabled={isRemoving} tooltip={`Remove ${skillName}`}>
           {isRemoving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
         </Button>
       </AlertDialog.Trigger>

--- a/packages/playground/src/domains/workspace/components/skills-table.tsx
+++ b/packages/playground/src/domains/workspace/components/skills-table.tsx
@@ -132,7 +132,7 @@ export function SkillsTable({
                 <DataList.RowButton flushRight flushLeft colEnd={-2} onClick={onClick}>
                   {rowContent}
                 </DataList.RowButton>
-                <DataList.Cell>
+                <DataList.Cell className="py-0">
                   <div className="flex items-center justify-end gap-1 pl-2 w-full pr-3">
                     {isDownloaded(skill) && (
                       <>

--- a/packages/playground/src/domains/workspace/components/skills-table.tsx
+++ b/packages/playground/src/domains/workspace/components/skills-table.tsx
@@ -1,4 +1,4 @@
-import { Button, EntryList, Icon, SkillIcon } from '@mastra/playground-ui';
+import { Button, DataList, DataListSkeleton, Icon, SkillIcon } from '@mastra/playground-ui';
 import { AlertTriangle, BookOpen, Plus } from 'lucide-react';
 import type { SkillMetadata } from '../types';
 import { SkillRemoveButton, SkillUpdateButton } from './skill-actions';
@@ -22,33 +22,18 @@ export interface SkillsTableProps {
   updatingSkillName?: string;
   /** Name of the skill currently being removed (if any) */
   removingSkillName?: string;
-  /** Mount paths for labeling skills by mount (only used when multiple mounts exist) */
-  mountPaths?: string[];
 }
 
 /** Path segment that identifies skills installed via the skills CLI */
 const DOWNLOADED_SKILLS_PATH = '.agents/skills/';
 
-const columns = [
-  { name: 'name', label: 'Skill', size: '1fr' },
-  { name: 'description', label: 'Description', size: '2fr' },
-];
+const baseColumns = [
+  { label: 'Skill', size: 'minmax(8rem,auto)' },
+  { label: 'Path', size: 'minmax(8rem,1fr)' },
+  { label: 'Description', size: 'minmax(0,2fr)' },
+] as const;
 
-const columnsWithActions = [...columns, { name: 'actions', label: '', size: '48px' }];
-
-/**
- * Derive a mount label for a skill by matching its path against known mount paths.
- * Returns the mount path or display name if multiple mounts exist.
- */
-function getMountLabel(skillPath: string | undefined, mountPaths: string[] | undefined): string | null {
-  if (!skillPath || !mountPaths || mountPaths.length === 0) return null;
-  for (const mp of mountPaths) {
-    if (skillPath.startsWith(mp + '/') || skillPath === mp) {
-      return mp;
-    }
-  }
-  return null;
-}
+const columnsWithActions = [...baseColumns, { label: '', size: 'auto' }] as const;
 
 export function SkillsTable({
   skills,
@@ -61,33 +46,24 @@ export function SkillsTable({
   onRemoveSkill,
   updatingSkillName,
   removingSkillName,
-  mountPaths,
 }: SkillsTableProps) {
   const { navigate } = useLinkComponent();
-  const showMountBadges = mountPaths && mountPaths.length > 0;
 
-  // Helper to check if a skill is downloaded (installed via skills CLI)
   const isDownloaded = (skill: SkillMetadata) => skill.path?.includes(DOWNLOADED_SKILLS_PATH) ?? false;
-
-  // Check if any skill is downloaded (for determining if we need the actions column)
-  const hasDownloadedSkills = skills.some(isDownloaded);
-  // For skeleton, assume actions column is needed if callbacks are provided
   const hasActionCallbacks = !!onRemoveSkill || !!onUpdateSkill;
-  const hasRowActions = hasActionCallbacks && hasDownloadedSkills;
-
-  const effectiveColumns = hasRowActions ? columnsWithActions : columns;
+  const activeColumns = hasActionCallbacks ? columnsWithActions : baseColumns;
+  const gridColumns = activeColumns.map(c => c.size).join(' ');
 
   if (!isSkillsConfigured && !isLoading) {
     return <SkillsNotConfigured onAddSkill={onAddSkill} />;
   }
 
   if (isLoading) {
-    return <SkillsTableSkeleton hasRowActions={hasActionCallbacks} />;
+    return <DataListSkeleton columns={gridColumns} />;
   }
 
   return (
     <div className="space-y-4">
-      {/* Header Actions */}
       {onAddSkill && (
         <div className="flex items-center gap-4">
           <Button variant="default" size="sm" onClick={onAddSkill}>
@@ -99,7 +75,6 @@ export function SkillsTable({
         </div>
       )}
 
-      {/* Warning for undiscovered skills */}
       {hasUndiscoveredAgentSkills && (
         <div className="flex items-start gap-3 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
           <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" />
@@ -113,115 +88,78 @@ export function SkillsTable({
         </div>
       )}
 
-      <EntryList>
-        <EntryList.Trim>
-          <EntryList.Header columns={effectiveColumns} />
-          {skills.length > 0 ? (
-            <EntryList.Entries>
-              {skills.map(skill => {
-                const entry = {
-                  id: skill.path,
-                  name: skill.name,
-                  description: skill.description || '—',
-                };
-                const mountLabel = showMountBadges ? getMountLabel(skill.path, mountPaths) : null;
-
-                return (
-                  <EntryList.Entry
-                    key={skill.path}
-                    entry={entry}
-                    columns={effectiveColumns}
-                    onClick={() => {
-                      const url = `${basePath}/${encodeURIComponent(skill.name)}?path=${encodeURIComponent(skill.path)}`;
-                      navigate(url);
-                    }}
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="p-1.5 rounded bg-surface5">
-                        <SkillIcon className="h-3.5 w-3.5 text-neutral4" />
-                      </div>
-                      <div className="min-w-0">
-                        <span className="font-medium text-neutral6">{skill.name}</span>
-                        {skill.path && (
-                          <div className="flex items-center gap-1.5 mt-0.5">
-                            {mountLabel && (
-                              <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface4 text-neutral3 shrink-0">
-                                {mountLabel}
-                              </span>
-                            )}
-                            <span className="text-[11px] text-neutral3 truncate" title={skill.path}>
-                              {skill.path}
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                    <EntryList.EntryText>{skill.description || '—'}</EntryList.EntryText>
-                    {hasRowActions && (
-                      <div className="flex justify-end gap-1" onClick={e => e.stopPropagation()}>
-                        {/* Only show actions for downloaded skills */}
-                        {isDownloaded(skill) && (
-                          <>
-                            {onUpdateSkill && (
-                              <SkillUpdateButton
-                                skillName={skill.name}
-                                onUpdate={() => onUpdateSkill(skill.name)}
-                                isUpdating={updatingSkillName === skill.name}
-                              />
-                            )}
-                            {onRemoveSkill && (
-                              <SkillRemoveButton
-                                skillName={skill.name}
-                                onRemove={() => onRemoveSkill(skill.name)}
-                                isRemoving={removingSkillName === skill.name}
-                              />
-                            )}
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </EntryList.Entry>
-                );
-              })}
-            </EntryList.Entries>
-          ) : (
-            <EntryList.Message
-              message={
-                onAddSkill
-                  ? 'No skills discovered. Click "Add Skill" to install from skills.sh.'
-                  : 'No skills discovered. Add SKILL.md files to your skills directory.'
-              }
-            />
-          )}
-        </EntryList.Trim>
-      </EntryList>
-    </div>
-  );
-}
-
-function SkillsTableSkeleton({ hasRowActions }: { hasRowActions?: boolean }) {
-  const effectiveColumns = hasRowActions ? columnsWithActions : columns;
-  return (
-    <EntryList>
-      <EntryList.Trim>
-        <EntryList.Header columns={effectiveColumns} />
-        <EntryList.Entries>
-          {Array.from({ length: 3 }).map((_, i) => (
-            <EntryList.Entry key={i} columns={effectiveColumns} isLoading>
-              <div className="flex items-center gap-3">
-                <div className="h-7 w-7 rounded bg-surface4 animate-pulse" />
-                <div>
-                  <div className="h-4 w-32 rounded bg-surface4 animate-pulse" />
-                  <div className="h-3 w-40 rounded bg-surface4 animate-pulse mt-1" />
-                </div>
-              </div>
-              <div className="h-4 w-48 rounded bg-surface4 animate-pulse" />
-              {hasRowActions && <div className="h-4 w-6 rounded bg-surface4 animate-pulse" />}
-            </EntryList.Entry>
+      <DataList columns={gridColumns}>
+        <DataList.Top>
+          {activeColumns.map(col => (
+            <DataList.TopCell key={col.label}>{col.label}</DataList.TopCell>
           ))}
-        </EntryList.Entries>
-      </EntryList.Trim>
-    </EntryList>
+        </DataList.Top>
+
+        {skills.length === 0 ? (
+          <DataList.NoMatch
+            message={
+              onAddSkill
+                ? 'No skills discovered. Click "Add Skill" to install from skills.sh.'
+                : 'No skills discovered. Add SKILL.md files to your skills directory.'
+            }
+          />
+        ) : (
+          skills.map(skill => {
+            const onClick = () => {
+              navigate(`${basePath}/${encodeURIComponent(skill.name)}?path=${encodeURIComponent(skill.path)}`);
+            };
+
+            const rowContent = (
+              <>
+                <DataList.Cell className="font-medium text-neutral6">{skill.name}</DataList.Cell>
+                <DataList.MonoCell height="default">{skill.path}</DataList.MonoCell>
+                <DataList.Cell className="min-w-0">
+                  <span className="block truncate">{skill.description || '—'}</span>
+                </DataList.Cell>
+              </>
+            );
+
+            if (!hasActionCallbacks) {
+              return (
+                <DataList.RowButton key={skill.path} onClick={onClick}>
+                  {rowContent}
+                </DataList.RowButton>
+              );
+            }
+
+            return (
+              <DataList.Row key={skill.path}>
+                <DataList.RowButton flushRight flushLeft colEnd={-2} onClick={onClick}>
+                  {rowContent}
+                </DataList.RowButton>
+                <DataList.Cell>
+                  <div className="flex items-center justify-end gap-1 pl-2 w-full pr-3">
+                    {isDownloaded(skill) && (
+                      <>
+                        {onUpdateSkill && (
+                          <SkillUpdateButton
+                            skillName={skill.name}
+                            onUpdate={() => onUpdateSkill(skill.name)}
+                            isUpdating={updatingSkillName === skill.name}
+                          />
+                        )}
+                        {onRemoveSkill && (
+                          <SkillRemoveButton
+                            skillName={skill.name}
+                            onRemove={() => onRemoveSkill(skill.name)}
+                            isRemoving={removingSkillName === skill.name}
+                          />
+                        )}
+                      </>
+                    )}
+                  </div>
+                </DataList.Cell>
+              </DataList.Row>
+            );
+          })
+        )}
+      </DataList>
+    </div>
   );
 }
 

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -164,12 +164,11 @@ export default function Workspace() {
   // None of these operations require sandbox - all are done via GitHub API + filesystem
   const canManageSkills = hasFilesystem && !isReadOnly;
 
-  // Derive writable mounts and mount paths for CompositeFilesystem
+  // Derive writable mounts for CompositeFilesystem
   const mounts = workspaceInfo?.mounts;
   const writableMounts = mounts
     ?.filter(m => !m.readOnly)
     .map(m => ({ path: m.path, displayName: m.displayName, icon: m.icon, provider: m.provider, name: m.name }));
-  const mountPaths = mounts && mounts.length > 1 ? mounts.map(m => m.path) : undefined;
 
   // Skills.sh handlers
   const handleInstallSkill = useCallback(
@@ -555,7 +554,6 @@ export default function Workspace() {
                   onRemoveSkill={canManageSkills ? handleRemoveSkill : undefined}
                   updatingSkillName={updatingSkillName ?? undefined}
                   removingSkillName={removingSkillName ?? undefined}
-                  mountPaths={mountPaths}
                 />
               </TabContent>
             )}


### PR DESCRIPTION
## Summary

before 

<img width="1440" height="640" alt="Screenshot 2026-05-21 at 13 02 09" src="https://github.com/user-attachments/assets/4ff55960-708d-48ba-bee9-49644b7ac497" />


after

<img width="1441" height="699" alt="Screenshot 2026-05-21 at 13 10 22" src="https://github.com/user-attachments/assets/f4a0e566-3fbf-4811-8c54-76d0050d5fdd" />




- Refactors the workspace Skills list from `EntryList` to the shared `DataList` primitives, matching the visual style of Traces / Logs / Dataset Items.
- The skill path moves to its own monospace column with truncation; the description column also truncates instead of forcing horizontal scroll. Drops the decorative skill icon and the mount badge (the mount prefix is already visible in the path).
- Row update / remove buttons switch to the ghost variant.

## DS-level changes (`@mastra/playground-ui`)

- `DataList.RowButton` / `DataList.RowLink` gain `colEnd` + `flushRight` props (mirroring the existing `colStart` / `flushLeft`) so compound rows can host a trailing cell — used here for the per-row actions.
- `DataList.Row` now carries the row separator and `.data-list-row` marker itself, so wrapped rows render a full-width separator that extends through any leading or trailing cells.
- `DataList.MonoCell` gains an optional `height` prop for non-compact lists.

## Stack

Base: `span-feedback-list-update` (PR #16830).

## Test plan

- [ ] Open Workspaces → Skills tab: rows render with full-width separators, path/description truncate cleanly, no horizontal scrollbar.
- [ ] Hover a row: action buttons remain reachable; clicking the row opens the skill detail; clicking an action button does not navigate.
- [ ] Verify standalone `DataList.RowButton` lists (Traces, Logs) are visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR redesigns how the Skills list appears in the Mastra Studio workspace to look and work more like other lists in the app (like Traces or Logs). Instead of cramming skill names and paths together, it splits them into separate columns so each type of information is easier to read, and it prevents the table from scrolling sideways when text is too long.

## Changes Overview

**Playground UI Components** — Extended `DataList` primitives to support more flexible trailing cells:
- `DataList.RowButton` and `DataList.RowLink` now accept `colEnd` and `flushRight` props for positioning action buttons at the end of rows
- `DataList.Row` now owns the full-width row separator and `.data-list-row` marker for consistent visual styling
- `DataList.MonoCell` gains an optional `height` prop (defaults to `'compact'`) to support non-compact list heights
- Updated shared row styles to use a reusable `dataListRowOuterStyles` constant for DRY border/separator handling

**Skills Table Refactor** — Migrated from `EntryList` to `DataList` primitives:
- Replaced custom table structure with `DataList.Top` headers and `DataList.Row` containers with monospace PATH and DESCRIPTION columns
- Path text truncates in a dedicated monospace column; description text also truncates to prevent horizontal scroll
- Removed decorative skill icon and mount badge (mount prefix remains visible in the path)
- Per-row update/remove action buttons switched to ghost variant styling
- Empty state messaging updated to use `DataList.NoMatch` with context-aware text
- Removed `mountPaths` prop from `SkillsTableProps` since mount information is no longer separately tracked

**Action Buttons** — Updated button styling in `skill-actions.tsx`:
- Changed from `variant="default"` with `size="icon-sm"` to `variant="ghost"` with `size="icon-md"`

**Related Updates** — Dropped vertical padding on the trailing actions cell to let per-row buttons determine row height; updated workspace page to derive only writable mounts and removed unused mount path computation.

## Files Changed

- 2 changesets added (playground patch, playground-ui patch)
- 7 component/config files updated in playground-ui (DataList cells, row buttons, row links, rows, shared styles)
- 3 files updated in playground (skill actions, skills table, workspace page)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->