### PR TITLE
feat(core): add Harness v1 attachments

### DIFF
--- a/.changeset/ten-cobras-smash.md
+++ b/.changeset/ten-cobras-smash.md
@@ -1,0 +1,30 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 attachment management: upload and delete attachments with support for files, primitives, and elements.
+
+Usage example:
+
+```ts
+const fileRef = await harness.attachments.upload({
+  sessionId,
+  kind: 'file',
+  filename: 'document.pdf',
+  contentType: 'application/pdf',
+  data: fileBuffer,
+});
+
+const primitiveRef = await harness.attachments.upload({
+  sessionId,
+  kind: 'primitive',
+  name: 'selection.json',
+  primitiveType: 'selection',
+  value: { ids: ['paper-1', 'paper-2'] },
+});
+
+await harness.attachments.delete({
+  sessionId,
+  attachmentId: fileRef.attachmentId,
+});
+```

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../../agent';
@@ -15,8 +17,10 @@ import {
   HarnessSessionNotFoundError,
   HarnessStorageError,
   HarnessThreadNotFoundError,
+  HarnessValidationError,
   HarnessWorkspaceProviderMismatchError,
 } from './errors';
+import { snapshotHarnessEventForJson } from './events';
 import { Harness } from './harness';
 import { nonDurableProvider } from './workspace-provider';
 
@@ -42,6 +46,21 @@ class LeaseStealingStorage extends InMemoryHarness {
       await super.acquireSessionLease({ ...opts, ownerId: 'other-owner' });
     }
     return super.acquireSessionLease(opts);
+  }
+}
+
+class FailingAttachmentStorage extends InMemoryHarness {
+  failSaveAttachment = false;
+  failDeleteAttachment = false;
+
+  override async saveAttachment(opts: Parameters<InMemoryHarness['saveAttachment']>[0]) {
+    if (this.failSaveAttachment) throw new Error('save attachment failed');
+    return super.saveAttachment(opts);
+  }
+
+  override async deleteAttachment(opts: Parameters<InMemoryHarness['deleteAttachment']>[0]) {
+    if (this.failDeleteAttachment) throw new Error('delete attachment failed');
+    return super.deleteAttachment(opts);
   }
 }
 
@@ -144,6 +163,414 @@ describe('Harness v1 construction', () => {
           sessions: { storage: makeStorage() },
         }),
     ).toThrow(HarnessConfigError);
+  });
+
+  it('validates attachment limit configuration up front', () => {
+    expect(() =>
+      makeHarness({
+        files: { maxAttachmentBytes: 0 },
+      }),
+    ).toThrow(HarnessConfigError);
+
+    expect(() =>
+      makeHarness({
+        files: { allowedContentTypes: ['text/plain', 'image/*'] },
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      makeHarness({
+        files: { allowedContentTypes: [''] },
+      }),
+    ).toThrow(HarnessConfigError);
+  });
+});
+
+describe('Harness.attachments', () => {
+  it('uploads attachments with digest metadata and deletes them by attachment id', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const source = Buffer.from('hello attachment');
+    const expectedSha256 = createHash('sha256').update(source).digest('hex');
+
+    const result = await harness.attachments.upload({
+      sessionId: session.id,
+      data: source,
+      filename: 'note.txt',
+      contentType: 'text/plain',
+    });
+
+    expect(result).toMatchObject({
+      resourceId: 'u',
+      ownerSessionId: session.id,
+      bytes: source.length,
+      sha256: expectedSha256,
+      source: 'preupload',
+      kind: 'file',
+      name: 'note.txt',
+      mimeType: 'text/plain',
+    });
+
+    source[0] = 'j'.charCodeAt(0);
+    await expect(storage.loadAttachment({ sessionId: session.id, attachmentId: result.attachmentId })).resolves.toEqual(
+      expect.objectContaining({
+        name: 'note.txt',
+        mimeType: 'text/plain',
+        bytes: Buffer.byteLength('hello attachment'),
+        sha256: expectedSha256,
+        data: new Uint8Array(Buffer.from('hello attachment')),
+        semantic: { kind: 'file' },
+      }),
+    );
+
+    await harness.attachments.delete({ attachmentId: result.attachmentId, sessionId: session.id });
+    await expect(
+      storage.loadAttachment({ sessionId: session.id, attachmentId: result.attachmentId }),
+    ).resolves.toBeNull();
+  });
+
+  it('uploads arbitrary binary files such as images, videos, and documents', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const inputs = [
+      { filename: 'diagram.png', contentType: 'image/png', data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]) },
+      { filename: 'clip.mp4', contentType: 'video/mp4', data: new Uint8Array([0x00, 0x00, 0x00, 0x18]) },
+      { filename: 'brief.pdf', contentType: 'application/pdf', data: Buffer.from('%PDF-1.7') },
+      {
+        filename: 'notes.docx',
+        contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        data: new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
+      },
+    ];
+
+    for (const input of inputs) {
+      const result = await harness.attachments.upload({ sessionId: session.id, ...input });
+      const expected = createHash('sha256').update(input.data).digest('hex');
+
+      expect(result).toMatchObject({
+        name: input.filename,
+        mimeType: input.contentType,
+        kind: 'file',
+        bytes: input.data.byteLength,
+        sha256: expected,
+      });
+      await expect(
+        storage.loadAttachment({ sessionId: session.id, attachmentId: result.attachmentId }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          name: input.filename,
+          mimeType: input.contentType,
+          data: new Uint8Array(input.data),
+        }),
+      );
+    }
+  });
+
+  it('enforces configured attachment size and content type limits', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({
+      sessions: { storage },
+      files: { maxAttachmentBytes: 64, allowedContentTypes: ['image/*', 'application/json'] },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        data: new Uint8Array(65),
+        filename: 'too-big.png',
+        contentType: 'image/png',
+      }),
+    ).rejects.toMatchObject({ field: 'attachments.upload().data' });
+
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        data: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array(32));
+            controller.enqueue(new Uint8Array(33));
+            controller.close();
+          },
+        }),
+        filename: 'too-big-stream.png',
+        contentType: 'image/png',
+      }),
+    ).rejects.toMatchObject({ field: 'attachments.upload().data' });
+
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        data: new Uint8Array([1]),
+        filename: 'note.txt',
+        contentType: 'text/plain',
+      }),
+    ).rejects.toMatchObject({ field: 'attachments.upload().contentType' });
+
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        kind: 'primitive',
+        name: 'flags',
+        primitiveType: 'custom.agentic.value',
+        value: { ok: true },
+      }),
+    ).resolves.toMatchObject({ mimeType: 'application/json', primitiveType: 'custom.agentic.value' });
+  });
+
+  it('uploads primitive attachments as canonical bytes with semantic metadata', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const result = await harness.attachments.upload({
+      sessionId: session.id,
+      kind: 'primitive',
+      name: 'selection.json',
+      primitiveType: 'selection',
+      value: { z: 1, a: ['paper-1', 'paper-2'] },
+      metadata: { label: 'Selected papers' },
+    });
+
+    const expectedBytes = Buffer.from('{"a":["paper-1","paper-2"],"z":1}');
+    expect(result).toMatchObject({
+      resourceId: 'u',
+      ownerSessionId: session.id,
+      kind: 'primitive',
+      name: 'selection.json',
+      mimeType: 'application/json',
+      primitiveType: 'selection',
+      metadata: { label: 'Selected papers' },
+      bytes: expectedBytes.length,
+      sha256: createHash('sha256').update(expectedBytes).digest('hex'),
+    });
+
+    const loaded = await storage.loadAttachment({ sessionId: session.id, attachmentId: result.attachmentId });
+    expect(Buffer.from(loaded!.data).toString()).toBe('{"a":["paper-1","paper-2"],"z":1}');
+    expect(loaded?.semantic).toMatchObject({ kind: 'primitive', primitiveType: 'selection' });
+  });
+
+  it('preserves JSON keys that would otherwise mutate object prototypes', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const value = JSON.parse('{"__proto__":{"x":1},"a":2}') as Record<string, unknown>;
+
+    const result = await harness.attachments.upload({
+      sessionId: session.id,
+      kind: 'primitive',
+      name: 'proto.json',
+      primitiveType: 'json',
+      value: value as never,
+    });
+
+    const loaded = await storage.loadAttachment({ sessionId: session.id, attachmentId: result.attachmentId });
+    expect(Buffer.from(loaded!.data).toString()).toBe('{"__proto__":{"x":1},"a":2}');
+  });
+
+  it('rejects invalid primitive and element attachment JSON payloads', async () => {
+    const harness = makeHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const cyclicPrimitive: Record<string, unknown> = { title: 'loop' };
+    cyclicPrimitive.self = cyclicPrimitive;
+    const cyclicElement: unknown[] = [];
+    cyclicElement.push(cyclicElement);
+    const sparsePrimitive: unknown[] = [];
+    sparsePrimitive[1] = 'missing zero';
+
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        kind: 'primitive',
+        name: 'loop.json',
+        primitiveType: 'json',
+        value: cyclicPrimitive as never,
+      }),
+    ).rejects.toMatchObject({ field: 'attachments.upload().value.self' });
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        kind: 'element',
+        name: 'loop-element.json',
+        elementType: 'loop',
+        payload: cyclicElement as never,
+      }),
+    ).rejects.toMatchObject({ field: 'attachments.upload().payload[0]' });
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        kind: 'primitive',
+        name: 'sparse.json',
+        primitiveType: 'json',
+        value: sparsePrimitive as never,
+      }),
+    ).rejects.toMatchObject({ field: 'attachments.upload().value[0]' });
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        data: new Uint8Array([1]),
+        filename: 'metadata.bin',
+        contentType: 'application/octet-stream',
+        metadata: ['not-a-record'] as never,
+      }),
+    ).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        kind: 'primitive',
+        name: 'null-metadata.json',
+        primitiveType: 'json',
+        value: {},
+        metadata: null as never,
+      }),
+    ).rejects.toMatchObject({ field: 'attachments.upload().metadata' });
+  });
+
+  it('accepts custom primitive attachment types and rejects missing ones', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const uploaded = await harness.attachments.upload({
+      sessionId: session.id,
+      kind: 'primitive',
+      name: 'agent-card.json',
+      primitiveType: 'agent-card',
+      value: { agentId: 'researcher' },
+    });
+
+    expect(uploaded).toMatchObject({ primitiveType: 'agent-card' });
+    await expect(
+      storage.loadAttachment({ sessionId: session.id, attachmentId: uploaded.attachmentId }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        semantic: expect.objectContaining({ primitiveType: 'agent-card' }),
+      }),
+    );
+  });
+
+  it('rejects primitive attachments with missing primitive types', async () => {
+    const harness = makeHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        kind: 'primitive',
+        name: 'missing-type.json',
+        primitiveType: undefined as never,
+        value: {},
+      }),
+    ).rejects.toMatchObject({ field: 'attachments.upload().primitiveType' });
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        kind: 'primitive',
+        name: 'empty-type.json',
+        primitiveType: '' as never,
+        value: {},
+      }),
+    ).rejects.toMatchObject({ field: 'attachments.upload().primitiveType' });
+  });
+
+  it('wraps attachment storage failures with harness storage errors', async () => {
+    const storage = new FailingAttachmentStorage({ db: new InMemoryDB() });
+    const harness = makeHarness({ sessions: { storage } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    storage.failSaveAttachment = true;
+    await expect(
+      harness.attachments.upload({
+        sessionId: session.id,
+        data: new Uint8Array([1]),
+        filename: 'fail.bin',
+        contentType: 'application/octet-stream',
+      }),
+    ).rejects.toMatchObject({
+      sessionId: session.id,
+      operation: 'attachment',
+      cause: expect.any(Error),
+    });
+
+    storage.failSaveAttachment = false;
+    const uploaded = await harness.attachments.upload({
+      sessionId: session.id,
+      data: new Uint8Array([1]),
+      filename: 'ok.bin',
+      contentType: 'application/octet-stream',
+    });
+
+    storage.failDeleteAttachment = true;
+    await expect(
+      harness.attachments.delete({ sessionId: session.id, attachmentId: uploaded.attachmentId }),
+    ).rejects.toBeInstanceOf(HarnessStorageError);
+    await expect(
+      harness.attachments.delete({ sessionId: session.id, attachmentId: uploaded.attachmentId }),
+    ).rejects.toMatchObject({ sessionId: session.id, operation: 'attachment' });
+  });
+
+  it('uses the explicit owning session instead of the most recent resource session', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const older = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const newer = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const result = await harness.attachments.upload({
+      sessionId: older.id,
+      resourceId: 'u',
+      data: new Uint8Array([1, 2, 3]),
+      filename: 'older.bin',
+      contentType: 'application/octet-stream',
+    });
+
+    await expect(
+      storage.getAttachmentRecord({ sessionId: older.id, attachmentId: result.attachmentId }),
+    ).resolves.toMatchObject({
+      ownerSessionId: older.id,
+    });
+    await expect(
+      storage.getAttachmentRecord({ sessionId: newer.id, attachmentId: result.attachmentId }),
+    ).resolves.toBeNull();
+
+    await harness.attachments.delete({ sessionId: older.id, attachmentId: result.attachmentId });
+    await expect(
+      storage.getAttachmentRecord({ sessionId: older.id, attachmentId: result.attachmentId }),
+    ).resolves.toBeNull();
+  });
+
+  it('requires the attachment caller to hold or acquire the session lease', async () => {
+    const storage = makeStorage();
+    const ownerHarness = makeHarness({ sessions: { storage } });
+    const competingHarness = makeHarness({ sessions: { storage } });
+    const session = await ownerHarness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await expect(
+      competingHarness.attachments.upload({
+        sessionId: session.id,
+        data: new Uint8Array([1]),
+        filename: 'locked.bin',
+        contentType: 'application/octet-stream',
+      }),
+    ).rejects.toBeInstanceOf(HarnessSessionLockedError);
+
+    await ownerHarness.shutdown();
+    const uploaded = await competingHarness.attachments.upload({
+      sessionId: session.id,
+      data: new Uint8Array([1]),
+      filename: 'released.bin',
+      contentType: 'application/octet-stream',
+    });
+
+    await expect(
+      storage.getAttachmentRecord({ sessionId: session.id, attachmentId: uploaded.attachmentId }),
+    ).resolves.toMatchObject({ name: 'released.bin' });
+    await expect(storage.loadSession({ sessionId: session.id })).resolves.toMatchObject({
+      ownerId: undefined,
+      leaseExpiresAt: undefined,
+    });
   });
 });
 
@@ -335,15 +762,28 @@ describe('Harness v1 session resolution', () => {
   });
 
   it('renews the live session lease before another harness can take it', async () => {
-    const session = await makeHarness({ sessions: { storage, leaseTtlMs: 25 } }).session({
-      threadId: 'thread-a',
-      resourceId: 'resource-a',
-    });
-    const competingHarness = makeHarness({ sessions: { storage, leaseTtlMs: 25 } });
+    vi.useFakeTimers();
+    const ownerHarness = makeHarness({ sessions: { storage, leaseTtlMs: 25 } });
+    try {
+      const session = await ownerHarness.session({
+        threadId: 'thread-a',
+        resourceId: 'resource-a',
+      });
+      const firstLeaseExpiresAt = session.getRecord().leaseExpiresAt;
+      const competingHarness = makeHarness({ sessions: { storage, leaseTtlMs: 25 } });
 
-    await new Promise(resolve => setTimeout(resolve, 80));
+      await vi.advanceTimersByTimeAsync(13);
 
-    await expect(competingHarness.session({ sessionId: session.id })).rejects.toThrow(HarnessSessionLockedError);
+      await expect(storage.loadSession({ sessionId: session.id })).resolves.toMatchObject({
+        ownerId: ownerHarness.ownerId,
+        leaseExpiresAt: expect.any(Number),
+      });
+      expect(session.getRecord().leaseExpiresAt).toBeGreaterThan(firstLeaseExpiresAt ?? 0);
+      await expect(competingHarness.session({ sessionId: session.id })).rejects.toThrow(HarnessSessionLockedError);
+    } finally {
+      await ownerHarness.shutdown();
+      vi.useRealTimers();
+    }
   });
 
   it('does not delete a newly inserted session when another owner wins the lease race', async () => {
@@ -456,6 +896,33 @@ describe('Harness v1 lifecycle and discovery', () => {
     await expect(harness.getWorkspace()).rejects.toThrow('Harness is shut down');
     expect(workspace.init).toHaveBeenCalledTimes(1);
     expect(workspace.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits serializable shared workspace status events without undefined optional fields', async () => {
+    const workspace = {
+      init: vi.fn(async () => undefined),
+      destroy: vi.fn(async () => undefined),
+    } as unknown as Workspace;
+    const harness = new Harness({
+      modes: [],
+      workspace: { kind: 'shared', workspace },
+    });
+    const events: unknown[] = [];
+    harness.subscribe(event => events.push(event));
+
+    await harness.getWorkspace();
+
+    const readyEvent = events.find(
+      event =>
+        (event as { type?: string; status?: string }).type === 'workspace_status_changed' &&
+        (event as { status?: string }).status === 'ready',
+    );
+    expect(snapshotHarnessEventForJson(readyEvent)).toMatchObject({
+      type: 'workspace_status_changed',
+      status: 'ready',
+    });
+    expect(readyEvent).not.toHaveProperty('resourceId');
+    expect(readyEvent).not.toHaveProperty('providerId');
   });
 
   it('destroys a shared workspace that finishes acquiring during shutdown', async () => {

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -3,7 +3,10 @@ import { randomUUID } from 'node:crypto';
 import type { Agent } from '../../agent';
 import { Mastra } from '../../mastra';
 import type {
+  AttachmentSemanticMetadata,
+  HarnessPrimitiveType,
   HarnessStorage,
+  JsonValue,
   PermissionRules,
   SessionGrants,
   SessionRecord,
@@ -26,6 +29,7 @@ import {
   HarnessSessionNotFoundError,
   HarnessStorageError,
   HarnessThreadNotFoundError,
+  HarnessValidationError,
   HarnessWorkspaceProviderMismatchError,
 } from './errors';
 import { EventEmitter } from './events';
@@ -85,6 +89,8 @@ export class Harness<TState = unknown> {
   private readonly _sessionResolutions = new Map<string, Promise<Session>>();
   private readonly _leaseTtlMs: number;
   private readonly _maxQueueDepth: number;
+  private readonly _maxAttachmentBytes?: number;
+  private readonly _allowedAttachmentContentTypes?: readonly string[];
   private readonly _subagentTypes: ReadonlyMap<string, SubagentDefinition>;
   private readonly _subagentMaxDepth: number;
   private readonly _goalDefaults: { defaultJudgeModel?: string; defaultMaxTurns: number };
@@ -119,6 +125,21 @@ export class Harness<TState = unknown> {
     this._initialState = config.initialState;
     this._configuredIntervals = config.intervals ?? [];
     this._resolveModel = config.resolveModel;
+    if (config.files?.maxAttachmentBytes !== undefined) {
+      if (!Number.isSafeInteger(config.files.maxAttachmentBytes) || config.files.maxAttachmentBytes < 1) {
+        throw new HarnessConfigError('files.maxAttachmentBytes', 'must be a positive safe integer');
+      }
+      this._maxAttachmentBytes = config.files.maxAttachmentBytes;
+    }
+    if (config.files?.allowedContentTypes !== undefined) {
+      if (
+        !Array.isArray(config.files.allowedContentTypes) ||
+        config.files.allowedContentTypes.some(type => typeof type !== 'string' || type.length === 0)
+      ) {
+        throw new HarnessConfigError('files.allowedContentTypes', 'must be an array of non-empty strings');
+      }
+      this._allowedAttachmentContentTypes = [...config.files.allowedContentTypes];
+    }
 
     if (this._leaseTtlMs < 1) {
       throw new HarnessConfigError('sessions.leaseTtlMs', 'must be a positive integer');
@@ -1332,13 +1353,109 @@ export class Harness<TState = unknown> {
   };
 
   attachments = {
-    upload: async (_opts: AttachmentUploadOptions): Promise<AttachmentRef> => {
-      throw new Error('Harness.attachments.upload: not implemented');
+    upload: async (opts: AttachmentUploadOptions): Promise<AttachmentRef> => {
+      const storage = this._requireStorage('attachments.upload()');
+      const payload = await normalizeAttachmentUpload(opts, this._maxAttachmentBytes);
+      this.validateAttachmentPayload(payload);
+      const lease = await this.loadSessionForAttachment('attachments.upload()', opts.sessionId, opts.resourceId);
+      try {
+        let saved;
+        try {
+          saved = await storage.saveAttachment({
+            sessionId: lease.record.id,
+            attachmentId: `att-${randomUUID()}`,
+            name: payload.name,
+            mimeType: payload.mimeType,
+            source: 'preupload',
+            data: payload.data,
+            semantic: payload.semantic,
+          });
+        } catch (err) {
+          throw new HarnessStorageError(lease.record.id, 'attachment', err);
+        }
+        return {
+          attachmentId: saved.attachmentId,
+          resourceId: lease.record.resourceId,
+          ownerSessionId: lease.record.id,
+          bytes: saved.bytes,
+          sha256: saved.sha256,
+          source: 'preupload',
+          ...(payload.semantic?.kind ? { kind: payload.semantic.kind } : {}),
+          name: payload.name,
+          mimeType: payload.mimeType,
+          ...(payload.semantic?.primitiveType ? { primitiveType: payload.semantic.primitiveType } : {}),
+          ...(payload.semantic?.elementType ? { elementType: payload.semantic.elementType } : {}),
+          ...(payload.semantic?.renderer ? { renderer: { ...payload.semantic.renderer } } : {}),
+          ...(payload.semantic?.schemaId ? { schemaId: payload.semantic.schemaId } : {}),
+          ...(payload.semantic?.metadata ? { metadata: structuredClone(payload.semantic.metadata) } : {}),
+          ...(payload.semantic?.object ? { object: { ...payload.semantic.object } } : {}),
+        };
+      } finally {
+        await lease.release();
+      }
     },
-    delete: async (_opts: AttachmentDeleteOptions): Promise<void> => {
-      throw new Error('Harness.attachments.delete: not implemented');
+    delete: async (opts: AttachmentDeleteOptions): Promise<void> => {
+      const storage = this._requireStorage('attachments.delete()');
+      const lease = await this.loadSessionForAttachment('attachments.delete()', opts.sessionId, opts.resourceId);
+      try {
+        try {
+          await storage.deleteAttachment({ sessionId: lease.record.id, attachmentId: opts.attachmentId });
+        } catch (err) {
+          throw new HarnessStorageError(lease.record.id, 'attachment', err);
+        }
+      } finally {
+        await lease.release();
+      }
     },
   };
+
+  private async loadSessionForAttachment(
+    callsite: string,
+    sessionId: string,
+    resourceId: string | undefined,
+  ): Promise<{ record: SessionRecord; release: () => Promise<void> }> {
+    if (typeof sessionId !== 'string' || sessionId.length === 0) {
+      throw new HarnessValidationError(`${callsite}.sessionId`, 'sessionId must be a non-empty string');
+    }
+    const storage = this._requireStorage(callsite);
+    const record = await storage.loadSession({ sessionId });
+    if (!record) throw new HarnessSessionNotFoundError(sessionId);
+    if (record.closedAt !== undefined) throw new HarnessSessionClosedError(sessionId);
+    if (resourceId !== undefined && record.resourceId !== resourceId) {
+      throw new HarnessSessionNotFoundError(sessionId);
+    }
+    const live = this._liveSessions.get(sessionId);
+    if (live) {
+      if (live.resourceId !== record.resourceId) throw new HarnessSessionNotFoundError(sessionId);
+      return { record, release: async () => undefined };
+    }
+    await this._acquireLease(storage, sessionId);
+    return {
+      record,
+      release: async () => {
+        await storage.releaseSessionLease({ sessionId, ownerId: this.ownerId }).catch(() => undefined);
+      },
+    };
+  }
+
+  private validateAttachmentPayload(payload: NormalizedAttachmentUpload): void {
+    if (this._maxAttachmentBytes !== undefined && payload.data.byteLength > this._maxAttachmentBytes) {
+      throw new HarnessValidationError(
+        'attachments.upload().data',
+        `attachment size ${payload.data.byteLength} exceeds configured limit ${this._maxAttachmentBytes}`,
+      );
+    }
+
+    if (
+      this._allowedAttachmentContentTypes !== undefined &&
+      !matchesAllowedContentType(payload.mimeType, this._allowedAttachmentContentTypes)
+    ) {
+      throw new HarnessValidationError(
+        'attachments.upload().contentType',
+        `content type "${payload.mimeType}" is not allowed by files.allowedContentTypes`,
+      );
+    }
+  }
 
   private _requireStorage(callsite: string): HarnessStorage {
     if (this._storageOverride) return this._storageOverride;
@@ -1507,6 +1624,203 @@ export class Harness<TState = unknown> {
   get _internalGoalDefaults(): Readonly<{ defaultJudgeModel?: string; defaultMaxTurns: number }> {
     return this._goalDefaults;
   }
+}
+
+type NormalizedAttachmentUpload = {
+  name: string;
+  mimeType: string;
+  data: Uint8Array;
+  semantic: AttachmentSemanticMetadata;
+};
+
+async function normalizeAttachmentUpload(
+  opts: AttachmentUploadOptions,
+  maxBytes?: number,
+): Promise<NormalizedAttachmentUpload> {
+  if (opts.kind === 'primitive') {
+    if (!opts.name) throw new HarnessValidationError('attachments.upload().name', 'name must be a non-empty string');
+    const primitiveType = assertAttachmentPrimitiveType(opts.primitiveType);
+    const value = assertAttachmentJsonValue(opts.value, 'attachments.upload().value');
+    const data = new TextEncoder().encode(stableJsonStringify(value));
+    return {
+      name: opts.name,
+      mimeType: opts.mimeType ?? 'application/json',
+      data,
+      semantic: {
+        kind: 'primitive',
+        primitiveType,
+        ...(opts.metadata !== undefined
+          ? { metadata: assertAttachmentJsonRecord(opts.metadata, 'attachments.upload().metadata') }
+          : {}),
+      },
+    };
+  }
+
+  if (opts.kind === 'element') {
+    if (!opts.name) throw new HarnessValidationError('attachments.upload().name', 'name must be a non-empty string');
+    if (!opts.elementType) {
+      throw new HarnessValidationError('attachments.upload().elementType', 'elementType must be a non-empty string');
+    }
+    const payload = assertAttachmentJsonValue(opts.payload, 'attachments.upload().payload');
+    const data = new TextEncoder().encode(stableJsonStringify(payload));
+    return {
+      name: opts.name,
+      mimeType: opts.mimeType ?? 'application/json',
+      data,
+      semantic: {
+        kind: 'element',
+        elementType: opts.elementType,
+        ...(opts.renderer ? { renderer: { ...opts.renderer } } : {}),
+        ...(opts.schemaId ? { schemaId: opts.schemaId } : {}),
+        ...(opts.metadata !== undefined
+          ? { metadata: assertAttachmentJsonRecord(opts.metadata, 'attachments.upload().metadata') }
+          : {}),
+      },
+    };
+  }
+
+  if (!opts.filename) {
+    throw new HarnessValidationError('attachments.upload().filename', 'filename must be a non-empty string');
+  }
+  if (!opts.contentType) {
+    throw new HarnessValidationError('attachments.upload().contentType', 'contentType must be a non-empty string');
+  }
+  return {
+    name: opts.filename,
+    mimeType: opts.contentType,
+    data: await readAttachmentBytes(opts.data, maxBytes),
+    semantic: {
+      kind: 'file',
+      ...(opts.metadata !== undefined
+        ? { metadata: assertAttachmentJsonRecord(opts.metadata, 'attachments.upload().metadata') }
+        : {}),
+    },
+  };
+}
+
+function matchesAllowedContentType(mimeType: string, allowed: readonly string[]): boolean {
+  return allowed.some(pattern => {
+    if (pattern === mimeType || pattern === '*/*') return true;
+    if (!pattern.endsWith('/*')) return false;
+    return mimeType.startsWith(`${pattern.slice(0, -2)}/`);
+  });
+}
+
+function assertAttachmentPrimitiveType(value: unknown): HarnessPrimitiveType {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new HarnessValidationError('attachments.upload().primitiveType', 'primitiveType must be a non-empty string');
+  }
+  return value as HarnessPrimitiveType;
+}
+
+async function readAttachmentBytes(
+  data: Buffer | Uint8Array | ReadableStream<Uint8Array>,
+  maxBytes?: number,
+): Promise<Uint8Array> {
+  if (data instanceof Uint8Array) {
+    if (maxBytes !== undefined && data.byteLength > maxBytes) {
+      throw new HarnessValidationError(
+        'attachments.upload().data',
+        `attachment size ${data.byteLength} exceeds configured limit ${maxBytes}`,
+      );
+    }
+    return new Uint8Array(data);
+  }
+  const reader = data.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      chunks.push(next.value);
+      total += next.value.byteLength;
+      if (maxBytes !== undefined && total > maxBytes) {
+        throw new HarnessValidationError(
+          'attachments.upload().data',
+          `attachment stream exceeds configured limit ${maxBytes}`,
+        );
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+function assertAttachmentJsonRecord(value: unknown, field: string): Record<string, JsonValue> {
+  if (!isPlainRecord(value)) {
+    throw new HarnessValidationError(field, 'attachment metadata must be a JSON object');
+  }
+  return assertAttachmentJsonValue(value, field) as Record<string, JsonValue>;
+}
+
+function assertAttachmentJsonValue(value: unknown, field: string, seen: WeakSet<object> = new WeakSet()): JsonValue {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new HarnessValidationError(field, 'attachment JSON values must be finite numbers');
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) throw new HarnessValidationError(field, 'attachment value must not contain cycles');
+    seen.add(value);
+    const out: JsonValue[] = [];
+    try {
+      for (let index = 0; index < value.length; index += 1) {
+        if (!(index in value)) {
+          throw new HarnessValidationError(`${field}[${index}]`, 'attachment arrays must not contain holes');
+        }
+        out.push(assertAttachmentJsonValue(value[index], `${field}[${index}]`, seen));
+      }
+    } finally {
+      seen.delete(value);
+    }
+    return out;
+  }
+  if (isPlainRecord(value)) {
+    if (seen.has(value)) throw new HarnessValidationError(field, 'attachment value must not contain cycles');
+    seen.add(value);
+    const out = Object.create(null) as Record<string, JsonValue>;
+    try {
+      for (const [key, child] of Object.entries(value)) {
+        Object.defineProperty(out, key, {
+          value: assertAttachmentJsonValue(child, `${field}.${key}`, seen),
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      }
+    } finally {
+      seen.delete(value);
+    }
+    return out;
+  }
+  throw new HarnessValidationError(field, 'attachment value must be JSON-serializable');
+}
+
+function stableJsonStringify(value: JsonValue): string {
+  if (Array.isArray(value)) return `[${value.map(item => stableJsonStringify(item)).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableJsonStringify(value[key]!)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function toThreadRecord(thread: {

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -3,14 +3,33 @@ import type { z } from 'zod';
 import type { AgentExecutionOptionsBase } from '../../agent/agent.types';
 import type { CreatedAgentSignal } from '../../agent/signals';
 import type { ToolsInput } from '../../agent/types';
-import type { GoalState, PendingResume, PermissionRules, SessionGrants } from '../../storage/domains/harness';
+import type {
+  AttachmentObjectPointer,
+  AttachmentRendererDescriptor,
+  AttachmentSource,
+  GoalState,
+  HarnessAttachmentKind,
+  HarnessPrimitiveType,
+  JsonValue,
+  PendingResume,
+  PermissionRules,
+  SessionGrants,
+} from '../../storage/domains/harness';
 import type { MastraModelOutput, FullOutput } from '../../stream/base/output';
 import type { HarnessMode } from './shared';
 
 export type {
+  AttachmentObjectPointer,
   AttachmentRecord,
+  AttachmentRendererDescriptor,
+  AttachmentSemanticMetadata,
+  AttachmentSource,
   GoalJudgeDecision,
   GoalState,
+  HarnessAttachmentKind,
+  HarnessKnownPrimitiveType,
+  HarnessPrimitiveType,
+  JsonValue,
   LoadedAttachment,
   PendingResume,
   PermissionRules,
@@ -76,10 +95,21 @@ export interface HarnessLease {
 }
 
 export interface AttachmentRef {
-  id: string;
-  filename?: string;
-  contentType?: string;
-  url?: string;
+  attachmentId: string;
+  resourceId: string;
+  ownerSessionId?: string;
+  bytes?: number;
+  sha256?: string;
+  source?: AttachmentSource;
+  kind?: HarnessAttachmentKind;
+  name?: string;
+  mimeType?: string;
+  primitiveType?: HarnessPrimitiveType;
+  elementType?: string;
+  renderer?: AttachmentRendererDescriptor;
+  schemaId?: string;
+  metadata?: Record<string, JsonValue>;
+  object?: AttachmentObjectPointer;
 }
 
 export interface PendingBase {
@@ -281,16 +311,49 @@ export interface SessionLoadByIdOptions {
   includeClosed?: boolean;
 }
 
-export interface AttachmentUploadOptions {
-  resourceId: string;
-  data: Buffer | ReadableStream<Uint8Array>;
+export interface FileAttachmentUploadOptions {
+  sessionId: string;
+  resourceId?: string;
+  kind?: 'file';
+  data: Buffer | Uint8Array | ReadableStream<Uint8Array>;
   filename: string;
   contentType: string;
+  metadata?: Record<string, JsonValue>;
 }
+
+export interface PrimitiveAttachmentUploadOptions {
+  sessionId: string;
+  resourceId?: string;
+  kind: 'primitive';
+  name: string;
+  primitiveType: HarnessPrimitiveType;
+  value: JsonValue;
+  mimeType?: string;
+  metadata?: Record<string, JsonValue>;
+}
+
+export interface ElementAttachmentUploadOptions {
+  sessionId: string;
+  resourceId?: string;
+  kind: 'element';
+  name: string;
+  elementType: string;
+  payload: JsonValue;
+  renderer?: AttachmentRendererDescriptor;
+  schemaId?: string;
+  mimeType?: string;
+  metadata?: Record<string, JsonValue>;
+}
+
+export type AttachmentUploadOptions =
+  | FileAttachmentUploadOptions
+  | PrimitiveAttachmentUploadOptions
+  | ElementAttachmentUploadOptions;
 
 export interface AttachmentDeleteOptions {
   attachmentId: string;
-  resourceId: string;
+  sessionId: string;
+  resourceId?: string;
 }
 
 export interface ShutdownOptions {

--- a/packages/core/src/harness/v1/workspace-registry.ts
+++ b/packages/core/src/harness/v1/workspace-registry.ts
@@ -495,8 +495,8 @@ export class WorkspaceRegistry {
     this._emit.emit(
       {
         type: 'workspace_status_changed',
-        resourceId: opts.resourceId,
-        providerId: opts.providerId,
+        ...(opts.resourceId !== undefined ? { resourceId: opts.resourceId } : {}),
+        ...(opts.providerId !== undefined ? { providerId: opts.providerId } : {}),
         status: opts.status,
       },
       opts.sessionId !== undefined ? { sessionId: opts.sessionId } : undefined,

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -12,6 +12,7 @@ import type {
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentInput,
+  SaveAttachmentResult,
   SaveSessionOptions,
   SaveSessionResult,
   SessionLeaseResult,
@@ -159,7 +160,7 @@ export abstract class HarnessStorage extends StorageDomain {
   /**
    * Persist an attachment's bytes and index row.
    */
-  abstract saveAttachment(opts: SaveAttachmentInput): Promise<void>;
+  abstract saveAttachment(opts: SaveAttachmentInput): Promise<SaveAttachmentResult>;
 
   /**
    * Load an attachment by (sessionId, attachmentId). Returns null when the row

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { InMemoryDB } from '../inmemory-db';
@@ -211,12 +213,35 @@ describe('InMemoryHarness', () => {
 
   it('stores attachment metadata and copied bytes', async () => {
     const data = new Uint8Array([1, 2, 3]);
-    await storage.saveAttachment({
-      sessionId: 'session-1',
+    const expectedSha256 = createHash('sha256').update(data).digest('hex');
+    await expect(
+      storage.saveAttachment({
+        sessionId: 'session-1',
+        attachmentId: 'attachment-1',
+        name: 'file.txt',
+        mimeType: 'text/plain',
+        source: 'preupload',
+        data,
+        semantic: { kind: 'primitive', primitiveType: 'selection', metadata: { label: 'Selected' } },
+      }),
+    ).resolves.toEqual({
       attachmentId: 'attachment-1',
-      name: 'file.txt',
-      mimeType: 'text/plain',
-      data,
+      bytes: 3,
+      sha256: expectedSha256,
+    });
+    await expect(
+      storage.saveAttachment({
+        sessionId: 'session-1',
+        attachmentId: 'attachment-1',
+        name: 'ignored.txt',
+        mimeType: 'application/octet-stream',
+        source: 'inline',
+        data: new Uint8Array([9]),
+      }),
+    ).resolves.toEqual({
+      attachmentId: 'attachment-1',
+      bytes: 3,
+      sha256: expectedSha256,
     });
     data[0] = 9;
 
@@ -224,14 +249,19 @@ describe('InMemoryHarness', () => {
     expect(loaded).toEqual({
       name: 'file.txt',
       mimeType: 'text/plain',
+      bytes: 3,
+      sha256: expectedSha256,
       data: new Uint8Array([1, 2, 3]),
+      semantic: { kind: 'primitive', primitiveType: 'selection', metadata: { label: 'Selected' } },
     });
 
     loaded!.data[1] = 9;
+    loaded!.semantic!.metadata!.label = 'Changed';
     await expect(
       storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
     ).resolves.toMatchObject({
       data: new Uint8Array([1, 2, 3]),
+      semantic: { metadata: { label: 'Selected' } },
     });
 
     await expect(
@@ -239,12 +269,33 @@ describe('InMemoryHarness', () => {
     ).resolves.toEqual(
       expect.objectContaining({
         attachmentId: 'attachment-1',
+        ownerSessionId: 'session-1',
         sessionId: 'session-1',
         name: 'file.txt',
         mimeType: 'text/plain',
-        sizeBytes: 3,
+        bytes: 3,
+        sha256: expectedSha256,
+        source: 'preupload',
+        kind: 'primitive',
+        primitiveType: 'selection',
+        metadata: { label: 'Selected' },
       }),
     );
+  });
+
+  it('stores attachment bytes when semantic metadata is omitted', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    await storage.saveAttachment({
+      sessionId: 'session-1',
+      attachmentId: 'attachment-1',
+      name: 'file.txt',
+      mimeType: 'text/plain',
+      source: 'preupload',
+      data,
+    });
+
+    const loaded = await storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'attachment-1' });
+    expect(loaded?.semantic).toBeUndefined();
   });
 
   it('deletes single attachments, session attachments, and attachments on session delete', async () => {
@@ -254,6 +305,7 @@ describe('InMemoryHarness', () => {
       attachmentId: 'a',
       name: 'a.txt',
       mimeType: 'text/plain',
+      source: 'preupload',
       data: new Uint8Array([1]),
     });
     await storage.saveAttachment({
@@ -261,6 +313,7 @@ describe('InMemoryHarness', () => {
       attachmentId: 'b',
       name: 'b.txt',
       mimeType: 'text/plain',
+      source: 'preupload',
       data: new Uint8Array([2]),
     });
 
@@ -659,6 +712,7 @@ describe('InMemoryHarness', () => {
       attachmentId: 'attachment-1',
       name: 'file.txt',
       mimeType: 'text/plain',
+      source: 'preupload',
       data: new Uint8Array([1]),
     });
 

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { InMemoryDB } from '../inmemory-db';
 import {
   HarnessStorage,
@@ -20,6 +22,7 @@ import type {
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentInput,
+  SaveAttachmentResult,
   SaveSessionOptions,
   SaveSessionResult,
   SessionLeaseResult,
@@ -168,19 +171,44 @@ export class InMemoryHarness extends HarnessStorage {
     this.db.harnessSessions.set(sessionId, updated);
   }
 
-  async saveAttachment({ sessionId, attachmentId, name, mimeType, data }: SaveAttachmentInput): Promise<void> {
+  async saveAttachment({
+    sessionId,
+    attachmentId,
+    name,
+    mimeType,
+    source,
+    data,
+    semantic,
+  }: SaveAttachmentInput): Promise<SaveAttachmentResult> {
     const key = attachmentKey(sessionId, attachmentId);
+    const existing = this.db.harnessAttachmentRecords.get(key);
+    if (existing) {
+      return { attachmentId: existing.attachmentId, bytes: existing.bytes, sha256: existing.sha256 };
+    }
+    const bytes = data.byteLength;
+    const sha256 = sha256Hex(data);
     const record: AttachmentRecord = {
+      ownerSessionId: sessionId,
       attachmentId,
       sessionId,
       name,
       mimeType,
-      sizeBytes: data.byteLength,
+      bytes,
+      sha256,
+      source,
+      ...(semantic?.kind ? { kind: semantic.kind } : {}),
+      ...(semantic?.primitiveType ? { primitiveType: semantic.primitiveType } : {}),
+      ...(semantic?.elementType ? { elementType: semantic.elementType } : {}),
+      ...(semantic?.renderer ? { renderer: { ...semantic.renderer } } : {}),
+      ...(semantic?.schemaId ? { schemaId: semantic.schemaId } : {}),
+      ...(semantic?.metadata ? { metadata: clone(semantic.metadata) } : {}),
+      ...(semantic?.object ? { object: { ...semantic.object } } : {}),
       createdAt: Date.now(),
     };
     this.db.harnessAttachmentRecords.set(key, record);
     // Copy the bytes so callers can reuse their buffer.
     this.db.harnessAttachmentBytes.set(key, new Uint8Array(data));
+    return { attachmentId, bytes, sha256 };
   }
 
   async loadAttachment({
@@ -194,7 +222,14 @@ export class InMemoryHarness extends HarnessStorage {
     const record = this.db.harnessAttachmentRecords.get(key);
     const bytes = this.db.harnessAttachmentBytes.get(key);
     if (!record || !bytes) return null;
-    return { name: record.name, mimeType: record.mimeType, data: new Uint8Array(bytes) };
+    return {
+      name: record.name,
+      mimeType: record.mimeType,
+      bytes: record.bytes,
+      sha256: record.sha256,
+      data: new Uint8Array(bytes),
+      semantic: attachmentSemantic(record),
+    };
   }
 
   async deleteAttachment({ sessionId, attachmentId }: { sessionId: string; attachmentId: string }): Promise<void> {
@@ -555,6 +590,23 @@ export class InMemoryHarness extends HarnessStorage {
 
 function attachmentKey(sessionId: string, attachmentId: string): string {
   return `${sessionId}\u0000${attachmentId}`;
+}
+
+function sha256Hex(data: Uint8Array): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+function attachmentSemantic(record: AttachmentRecord) {
+  const semantic = {
+    ...(record.kind ? { kind: record.kind } : {}),
+    ...(record.primitiveType ? { primitiveType: record.primitiveType } : {}),
+    ...(record.elementType ? { elementType: record.elementType } : {}),
+    ...(record.renderer ? { renderer: { ...record.renderer } } : {}),
+    ...(record.schemaId ? { schemaId: record.schemaId } : {}),
+    ...(record.metadata ? { metadata: clone(record.metadata) } : {}),
+    ...(record.object ? { object: { ...record.object } } : {}),
+  };
+  return Object.keys(semantic).length > 0 ? semantic : undefined;
 }
 
 function messageEvidenceKey(sessionId: string, signalId: string): string {

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -147,6 +147,43 @@ export interface GoalState {
 
 export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
 
+export type AttachmentSource = 'inline' | 'preupload' | 'url' | 'provider';
+
+export type HarnessAttachmentKind = 'file' | 'primitive' | 'element';
+
+export type HarnessKnownPrimitiveType =
+  | 'text'
+  | 'markdown'
+  | 'json'
+  | 'table'
+  | 'chart-data'
+  | 'selection'
+  | 'citation';
+
+export type HarnessPrimitiveType = HarnessKnownPrimitiveType | (string & {});
+
+export interface AttachmentRendererDescriptor {
+  id: string;
+  version?: string;
+}
+
+export interface AttachmentObjectPointer {
+  providerId: string;
+  objectKey: string;
+  etag?: string;
+  storageClass?: string;
+}
+
+export interface AttachmentSemanticMetadata {
+  kind?: HarnessAttachmentKind;
+  primitiveType?: HarnessPrimitiveType;
+  elementType?: string;
+  renderer?: AttachmentRendererDescriptor;
+  schemaId?: string;
+  metadata?: Record<string, JsonValue>;
+  object?: AttachmentObjectPointer;
+}
+
 /**
  * Per-session workspace state, only populated under a resumable per-session
  * workspace provider.
@@ -226,6 +263,8 @@ export interface SessionSummary {
  * Metadata index row for a persisted file attachment.
  */
 export interface AttachmentRecord {
+  /** Session that owns the attachment bytes. */
+  ownerSessionId: string;
   /** Stable identifier referenced by `PersistedAttachment.attachmentId`. */
   attachmentId: string;
   /** Owning session - bytes are deleted with the session. */
@@ -235,7 +274,19 @@ export interface AttachmentRecord {
   /** MIME type, validated at upload. */
   mimeType: string;
   /** Size of the underlying bytes. */
-  sizeBytes: number;
+  bytes: number;
+  /** Hex SHA-256 digest of the underlying bytes. */
+  sha256: string;
+  /** Where the attachment came from. */
+  source: AttachmentSource;
+  /** Semantic class for UI/replay consumers. Defaults to `file` for legacy rows. */
+  kind?: HarnessAttachmentKind;
+  primitiveType?: HarnessPrimitiveType;
+  elementType?: string;
+  renderer?: AttachmentRendererDescriptor;
+  schemaId?: string;
+  metadata?: Record<string, JsonValue>;
+  object?: AttachmentObjectPointer;
   /** Epoch ms. */
   createdAt: number;
 }
@@ -374,11 +425,22 @@ export interface SaveAttachmentInput {
   attachmentId: string;
   name: string;
   mimeType: string;
+  source: AttachmentSource;
   data: Uint8Array;
+  semantic?: AttachmentSemanticMetadata;
+}
+
+export interface SaveAttachmentResult {
+  attachmentId: string;
+  bytes: number;
+  sha256: string;
 }
 
 export interface LoadedAttachment {
   name: string;
   mimeType: string;
+  bytes: number;
+  sha256: string;
   data: Uint8Array;
+  semantic?: AttachmentSemanticMetadata;
 }


### PR DESCRIPTION
## Description

Adds the next small Harness v1 slice: session-owned attachment upload/delete support on top of the harness storage domain.

This PR wires `harness.attachments.upload()` and `harness.attachments.delete()` to persisted attachment rows and bytes, records SHA-256 digest metadata, supports binary files such as images/videos/documents, and preserves semantic metadata for primitive and element attachments. Primitive attachment types remain extensible strings so applications can introduce their own agentic semantics.

## Related issue(s)

Part of #16878.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Validation:

- `pnpm --filter ./packages/core test:unit src/storage/domains/harness src/harness/v1/harness.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check .changeset/ten-cobras-smash.md packages/core/src/harness/v1/harness.ts packages/core/src/harness/v1/harness.test.ts packages/core/src/harness/v1/types.ts packages/core/src/storage/domains/harness/base.ts packages/core/src/storage/domains/harness/inmemory.ts packages/core/src/storage/domains/harness/inmemory.test.ts packages/core/src/storage/domains/harness/types.ts`
- `pnpm build:core`
