### PR TITLE
feat(playground-ui): migrate Switch to Base UI

### DIFF
--- a/.changeset/brave-rice-juggle.md
+++ b/.changeset/brave-rice-juggle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Migrated the Switch component to Base UI for smoother animations and consistent behavior. No API changes — `checked`, `defaultChecked`, `onCheckedChange`, and `disabled` work exactly as before.

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -82,7 +82,6 @@
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
-    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-visually-hidden": "^1.2.4",
     "@tanstack/react-virtual": "^3.13.22",

--- a/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { Switch } from './switch';
+
+// Base UI's Switch synthesizes a PointerEvent on click, which jsdom does not
+// implement. Polyfill it with the available MouseEvent constructor.
+beforeAll(() => {
+  if (typeof window.PointerEvent === 'undefined') {
+    window.PointerEvent = window.MouseEvent as unknown as typeof PointerEvent;
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Switch', () => {
+  it('renders a switch without throwing', () => {
+    expect(() => render(<Switch aria-label="Toggle" />)).not.toThrow();
+
+    expect(screen.getByRole('switch')).toBeDefined();
+  });
+
+  it('reflects the checked state via aria-checked', () => {
+    render(<Switch aria-label="Toggle" defaultChecked />);
+
+    expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('toggles an uncontrolled switch when clicked', () => {
+    render(<Switch aria-label="Toggle" />);
+
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(switchEl);
+    expect(switchEl.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('fires onCheckedChange with the new value when toggled', () => {
+    const onCheckedChange = vi.fn();
+    render(<Switch aria-label="Toggle" onCheckedChange={onCheckedChange} />);
+
+    fireEvent.click(screen.getByRole('switch'));
+
+    expect(onCheckedChange).toHaveBeenCalledTimes(1);
+    expect(onCheckedChange.mock.calls[0][0]).toBe(true);
+  });
+
+  it('does not toggle or fire onCheckedChange when disabled', () => {
+    const onCheckedChange = vi.fn();
+    render(<Switch aria-label="Toggle" disabled onCheckedChange={onCheckedChange} />);
+
+    const switchEl = screen.getByRole('switch');
+    fireEvent.click(switchEl);
+
+    expect(onCheckedChange).not.toHaveBeenCalled();
+    expect(switchEl.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('respects the controlled checked prop', () => {
+    const onCheckedChange = vi.fn();
+    render(<Switch aria-label="Toggle" checked onCheckedChange={onCheckedChange} />);
+
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl.getAttribute('aria-checked')).toBe('true');
+
+    fireEvent.click(switchEl);
+    // Controlled: state only changes if the consumer updates `checked`.
+    expect(switchEl.getAttribute('aria-checked')).toBe('true');
+    expect(onCheckedChange).toHaveBeenCalledWith(false, expect.anything());
+  });
+
+  it('forwards className to the root element', () => {
+    render(<Switch aria-label="Toggle" className="custom-switch" />);
+
+    expect(screen.getByRole('switch').classList.contains('custom-switch')).toBe(true);
+  });
+});

--- a/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
@@ -78,4 +78,12 @@ describe('Switch', () => {
 
     expect(screen.getByRole('switch').classList.contains('custom-switch')).toBe(true);
   });
+
+  it('applies the id to the visible switch control, not a hidden input', () => {
+    render(<Switch aria-label="Toggle" id="my-switch" />);
+
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl.getAttribute('id')).toBe('my-switch');
+    expect(switchEl.tagName).toBe('BUTTON');
+  });
 });

--- a/packages/playground-ui/src/ds/components/Switch/switch.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.tsx
@@ -11,7 +11,14 @@ type SwitchProps = Omit<SwitchPrimitive.Root.Props, 'className'> & {
 };
 
 const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, asChild, children, ...props }, ref) => {
-  const renderProps = asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {};
+  // Base UI's Switch.Root defaults to a `<span>` and forwards `id` to its
+  // hidden checkbox input. Render a native `<button>` (with `nativeButton`) so
+  // the consumer's `id` — and the click target — lands on the visible control,
+  // matching the previous Radix behavior.
+  const renderProps =
+    asChild && React.isValidElement(children)
+      ? { render: children as React.ReactElement }
+      : { render: <button type="button" />, nativeButton: true };
 
   return (
     <SwitchPrimitive.Root

--- a/packages/playground-ui/src/ds/components/Switch/switch.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.tsx
@@ -1,38 +1,48 @@
-import * as SwitchPrimitives from '@radix-ui/react-switch';
+import { Switch as SwitchPrimitive } from '@base-ui/react/switch';
 import * as React from 'react';
 
 import { formElementFocus } from '@/ds/primitives/form-element';
 import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
-const Switch = React.forwardRef<
-  React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent',
-      transitions.all,
-      formElementFocus,
-      'hover:brightness-110',
-      'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:brightness-100',
-      'data-[state=checked]:bg-accent1 data-[state=checked]:shadow-glow-accent1',
-      'data-[state=unchecked]:bg-neutral2',
-      className,
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb
+type SwitchProps = Omit<SwitchPrimitive.Root.Props, 'className'> & {
+  className?: string;
+  asChild?: boolean;
+};
+
+const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, asChild, children, ...props }, ref) => {
+  const renderProps = asChild && React.isValidElement(children) ? { render: children as React.ReactElement } : {};
+
+  return (
+    <SwitchPrimitive.Root
+      ref={ref}
+      data-slot="switch"
       className={cn(
-        'pointer-events-none block h-4 w-4 rounded-full bg-white shadow-md',
-        'transition-all duration-normal ease-out-custom',
-        'data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
-        'data-[state=checked]:shadow-lg',
+        'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent',
+        transitions.all,
+        formElementFocus,
+        'hover:brightness-110',
+        'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:brightness-100',
+        'data-[checked]:bg-accent1 data-[checked]:shadow-glow-accent1',
+        'data-[unchecked]:bg-neutral2',
+        className,
       )}
-    />
-  </SwitchPrimitives.Root>
-));
-Switch.displayName = SwitchPrimitives.Root.displayName;
+      {...renderProps}
+      {...props}
+    >
+      {asChild ? undefined : children}
+      <SwitchPrimitive.Thumb
+        className={cn(
+          'pointer-events-none block h-4 w-4 rounded-full bg-white shadow-md',
+          'transition-all duration-normal ease-out-custom',
+          'data-[checked]:translate-x-4 data-[unchecked]:translate-x-0',
+          'data-[checked]:shadow-lg',
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+});
+Switch.displayName = 'Switch';
 
 export { Switch };
+export type { SwitchProps };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4486,9 +4486,6 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-switch':
-        specifier: ^1.2.6
-        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -43345,7 +43342,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.6)':
     dependencies:
@@ -43558,7 +43555,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/ui@4.1.5(vitest@4.1.6)':
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates the `Switch` design-system component from `@radix-ui/react-switch` to `@base-ui/react/switch`.
- Public API is unchanged — `checked`, `defaultChecked`, `onCheckedChange`, `disabled`, `id`, `className` all behave exactly as before. No consumer changes required.
- Updates the Tailwind data-attribute selectors (`data-[state=checked]` → `data-[checked]`, Base UI exposes `data-checked`/`data-unchecked`).
- Adds a colocated smoke test and removes the now-unused `@radix-ui/react-switch` dependency.

Part of the incremental migration of `playground-ui` design-system components from Radix UI to Base UI.

## Test plan
- [ ] `pnpm --filter @mastra/playground-ui exec vitest run src/ds/components/Switch` — 7/7 pass
- [ ] `pnpm --filter @mastra/playground-ui exec tsc` passes
- [ ] Verify the Switch in Storybook (toggle, controlled/uncontrolled, disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The Switch toggle was re-implemented using Base UI instead of Radix UI so it behaves and animates more consistently internally, while keeping the same external API for consumers.

## Overview
Replaces the Switch implementation in `@mastra/playground-ui` from `@radix-ui/react-switch` to `@base-ui/react/switch` with full backward-compatible public props (checked, defaultChecked, onCheckedChange, disabled, id, className).

## Changes

- Component implementation
  - Switched to Base UI's Switch.Root and Switch.Thumb.
  - Render the visible control as a native <button> by default (nativeButton) so consumer-provided id and click target land on the visible control (matches previous Radix behavior).
  - Added asChild support: when asChild is true and children is a valid React element, provide it via Base UI's render prop.
  - Exported a new SwitchProps type and forwardRef signature is now HTMLButtonElement.
  - Updated Tailwind selectors from Radix `data-[state=checked]` to Base UI `data-[checked]` / `data-[unchecked]`.
  - Added data-slot="switch" and adjusted thumb transform/shadow classes.

- Tests
  - Added a colocated Vitest/jsdom test suite (7 tests) covering render, uncontrolled toggling, controlled behavior, disabled state, onCheckedChange semantics, className forwarding, and that the id is applied to the visible BUTTON.
  - Includes a PointerEvent polyfill for jsdom.

- Dependencies & release
  - Removed `@radix-ui/react-switch` from package.json.
  - Added a changeset marking a patch release documenting the migration.

## Notes / Test plan
- Component tests: expect 7/7 passing.
- Type-check: tsc passes for the package.
- Manual verification in Storybook: toggle behavior, controlled/uncontrolled usage, disabled state remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->