### PR TITLE
feat(playground-ui): migrate Label off Radix UI

### DIFF
--- a/.changeset/fine-trains-dig.md
+++ b/.changeset/fine-trains-dig.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Migrated the Label component off Radix UI. It now renders a native `<label>` element with the same props and styling — `htmlFor`, `className`, and children behave exactly as before.

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -77,7 +77,6 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-hover-card": "^1.1.15",
-    "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",

--- a/packages/playground-ui/src/ds/components/Label/label.test.tsx
+++ b/packages/playground-ui/src/ds/components/Label/label.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Label } from './label';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Label', () => {
+  it('renders its text content', () => {
+    render(<Label>Email address</Label>);
+
+    expect(screen.getByText('Email address')).toBeDefined();
+  });
+
+  it('renders a native <label> element', () => {
+    render(<Label>Name</Label>);
+
+    expect(screen.getByText('Name').tagName).toBe('LABEL');
+  });
+
+  it('associates with a control via htmlFor', () => {
+    render(
+      <>
+        <Label htmlFor="email">Email</Label>
+        <input id="email" />
+      </>,
+    );
+
+    const label = screen.getByText('Email') as HTMLLabelElement;
+    expect(label.htmlFor).toBe('email');
+    expect(label.control).toBe(screen.getByRole('textbox'));
+  });
+
+  it('merges a custom className with the base classes', () => {
+    render(<Label className="custom-label">Username</Label>);
+
+    const label = screen.getByText('Username');
+    expect(label.classList.contains('custom-label')).toBe(true);
+    expect(label.classList.contains('text-sm')).toBe(true);
+  });
+
+  it('forwards a ref to the underlying <label> element', () => {
+    const ref = createRef<HTMLLabelElement>();
+    render(<Label ref={ref}>Ref label</Label>);
+
+    expect(ref.current).toBeInstanceOf(HTMLLabelElement);
+    expect(ref.current?.textContent).toBe('Ref label');
+  });
+});

--- a/packages/playground-ui/src/ds/components/Label/label.tsx
+++ b/packages/playground-ui/src/ds/components/Label/label.tsx
@@ -1,18 +1,13 @@
-import * as LabelPrimitive from '@radix-ui/react-label';
 import { cva } from 'class-variance-authority';
-import type { VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
 const labelVariants = cva('text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70');
 
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
-));
-Label.displayName = LabelPrimitive.Root.displayName;
+const Label = React.forwardRef<HTMLLabelElement, React.ComponentPropsWithoutRef<'label'>>(
+  ({ className, ...props }, ref) => <label ref={ref} className={cn(labelVariants(), className)} {...props} />,
+);
+Label.displayName = 'Label';
 
 export { Label };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4471,9 +4471,6 @@ importers:
       '@radix-ui/react-hover-card':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-label':
-        specifier: ^2.1.8
-        version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -39416,15 +39413,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
   '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -43345,7 +43333,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.6)':
     dependencies:
@@ -43558,7 +43546,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/ui@4.1.5(vitest@4.1.6)':
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates the `Label` design-system component off `@radix-ui/react-label`. Base UI ships no `Label` component, so it now renders a native `<label>` element.
- `@radix-ui/react-label` was a thin wrapper around a native `<label>`, so this is behavior-preserving — `htmlFor`, `className`, children and ref forwarding all work exactly as before. No consumer changes required.
- Adds a colocated smoke test and removes the now-unused `@radix-ui/react-label` dependency.

Part of the incremental migration of `playground-ui` design-system components from Radix UI to Base UI.

## Test plan
- [ ] `pnpm --filter @mastra/playground-ui exec vitest run src/ds/components/Label` — 5/5 pass
- [ ] `pnpm --filter @mastra/playground-ui exec tsc` passes
- [ ] Verify labels still associate with their controls in Storybook / the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR simplifies the `Label` component in the design system by removing dependency on Radix UI. Instead of using a wrapper library, it now uses plain HTML's `<label>` element directly—like using a simpler LEGO brick that does the same job without extra layers. All the features users need (linking labels to form fields, custom styling, etc.) still work exactly the same way.

---

## Changes

### Component Migration
The `Label` component was refactored from a Radix UI wrapper to a native HTML `<label>` element. The component maintains full backward compatibility:
- Continues to support `htmlFor` prop for linking to form controls
- Supports `className` and `children` props
- Maintains ref forwarding to the underlying `<label>` element
- Display name properly set for debugging/dev tools

### Dependencies
Removed the `@radix-ui/react-label` dependency from `packages/playground-ui/package.json`.

### Testing
Added a comprehensive test suite (`label.test.tsx`) with 5 passing tests that verify:
- Text rendering
- Native `<label>` element output
- `htmlFor` attribute functionality for form control association
- Custom `className` merging with base styles
- Ref forwarding to the underlying element

### Changeset
Added a patch-level changeset documenting the migration for release notes.

---

## Type Changes
The component signature was updated from Radix UI's `LabelPrimitive.Root` types to `React.ComponentPropsWithoutRef<'label'>` with `ref: HTMLLabelElement`, aligning the TypeScript definitions with the native HTML implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->