### PR TITLE
feat(core): add Harness v1 session signals

### DIFF
--- a/.changeset/late-rice-peel.md
+++ b/.changeset/late-rice-peel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 session signal routing.

--- a/packages/core/src/harness/v1/session.signal.test.ts
+++ b/packages/core/src/harness/v1/session.signal.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Agent } from '../../agent';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import type { MastraModelOutput } from '../../stream/base/output';
+import type { HarnessEvent } from './events';
+import { Harness } from './harness';
+
+interface FakeCall {
+  messages: unknown;
+  options: any;
+}
+
+class FakeAgent extends Agent<any, any, any> {
+  calls: FakeCall[] = [];
+  text = 'ok';
+  chunks: unknown[] = [];
+
+  constructor(id = 'default') {
+    super({ id, name: id, instructions: 'fake', model: 'openai/gpt-4o-mini' as any });
+  }
+
+  async stream(messages: unknown, options?: any): Promise<MastraModelOutput> {
+    this.calls.push({ messages, options });
+    const output = buildOutput({
+      runId: options?.runId ?? `${this.id}-run`,
+      text: this.text,
+      chunks: this.chunks,
+    });
+    this._internalRegisterStreamRun(output, (options ?? {}) as any);
+    return output;
+  }
+}
+
+function setup() {
+  const agent = new FakeAgent('default');
+  const other = new FakeAgent('other');
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { default: agent, other } as any,
+    modes: [
+      { id: 'default', agentId: 'default' },
+      { id: 'other', agentId: 'other', tools: { modeTool: vi.fn() as never } },
+    ],
+    defaultModeId: 'default',
+    sessions: { storage },
+  });
+  return { harness, agent, other };
+}
+
+describe('Session.signal()', () => {
+  it('admits a user signal and exposes the eventual agent result', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+    const events: HarnessEvent[] = [];
+    session.subscribe(event => events.push(event));
+
+    const receipt = await session.signal({ content: 'follow up' });
+    const result = await receipt.result;
+
+    expect(receipt).toMatchObject({
+      accepted: true,
+      willInterleave: false,
+      runId: 'default-run',
+    });
+    expect(receipt.signal).toMatchObject({
+      __isCreatedSignal: true,
+      type: 'user-message',
+      contents: 'follow up',
+    });
+    expect(result.text).toBe('ok');
+    expect(agent.calls[0]!.messages).toBe(receipt.signal);
+    expect(events.map(event => event.type)).toEqual(['agent_start', 'agent_end']);
+    expect(session.isRunning()).toBe(false);
+  });
+
+  it('supports mode and tool overrides on an admitted signal', async () => {
+    const { harness, other } = setup();
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    await session.signal({
+      content: 'route elsewhere',
+      mode: 'other',
+      additionalTools: { callTool: vi.fn() as never },
+    });
+
+    expect(other.calls).toHaveLength(1);
+    expect(Object.keys(other.calls[0]!.options.toolsets)).toEqual(['mode:other', 'call:additional']);
+    expect(other.calls[0]!.options.requestContext.get('harness')).toMatchObject({
+      sessionId: session.id,
+      modeId: 'other',
+    });
+  });
+});
+
+describe('Session.injectSystemReminder()', () => {
+  it('dispatches a system-reminder signal with attributes and metadata', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    const receipt = await session.injectSystemReminder('remember the goal', {
+      attributes: { reason: 'goal' },
+      metadata: { source: 'test' },
+    });
+    await session.waitForIdle({ timeoutMs: 1000 });
+
+    expect(receipt).toMatchObject({
+      accepted: true,
+      willInterleave: false,
+      runId: 'default-run',
+      signal: {
+        __isCreatedSignal: true,
+        type: 'system-reminder',
+        contents: 'remember the goal',
+        attributes: { reason: 'goal' },
+        metadata: { source: 'test' },
+      },
+    });
+    expect(agent.calls[0]!.messages).toBe(receipt.signal);
+  });
+});
+
+function buildOutput(opts: { runId: string; text: string; chunks: unknown[] }): MastraModelOutput {
+  const fullOutput = {
+    text: opts.text,
+    usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+    finishReason: 'stop',
+    object: undefined,
+    steps: [],
+    warnings: [],
+    providerMetadata: undefined,
+    request: {},
+    reasoning: [],
+    reasoningText: undefined,
+    toolCalls: [],
+    toolResults: [],
+    sources: [],
+    files: [],
+    response: { id: 'response-1', timestamp: new Date(), modelId: 'fake', messages: [], uiMessages: [] },
+    totalUsage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+    error: undefined,
+    tripwire: undefined,
+    traceId: undefined,
+    spanId: undefined,
+    runId: opts.runId,
+    suspendPayload: undefined,
+    messages: [],
+    rememberedMessages: [],
+  };
+  let finished!: () => void;
+  const finishedPromise = new Promise<void>(resolve => {
+    finished = resolve;
+  });
+  const fullStream = (async function* () {
+    for (const chunk of opts.chunks) yield chunk;
+    finished();
+  })();
+  return {
+    runId: opts.runId,
+    getFullOutput: async () => fullOutput,
+    fullStream,
+    text: Promise.resolve(fullOutput.text),
+    finishReason: Promise.resolve(fullOutput.finishReason),
+    usage: Promise.resolve(fullOutput.usage),
+    _waitUntilFinished: () => finishedPromise,
+  } as unknown as MastraModelOutput;
+}

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -29,7 +29,11 @@ import type {
   MessageOptionsStream,
   MessageOptionsStructured,
   ModelAuthStatus,
+  SessionInjectSystemReminderOptions,
+  SessionInjectSystemReminderResult,
   SessionLifecycleState,
+  SessionSignalOptions,
+  SessionSignalResult,
   TokenUsage,
 } from './types';
 
@@ -288,6 +292,91 @@ export class Session {
       } finally {
         this.endTurn(turnAbortController);
       }
+    } catch (err) {
+      this.endTurn(turnAbortController);
+      throw err;
+    }
+  }
+
+  async signal(opts: SessionSignalOptions): Promise<SessionSignalResult> {
+    this.assertLive('signal()');
+    this.assertCanStartTurn('signal()');
+    if (typeof opts.content !== 'string' || opts.content.length === 0) {
+      throw new HarnessValidationError('signal().content', 'content must be a non-empty string');
+    }
+
+    const effectiveModeId = opts.mode ?? this.record.modeId;
+    const mode = this.harness._getMode(effectiveModeId);
+    const agent = this.harness.getAgentForMode(effectiveModeId);
+    const turnAbortController = this.beginTurn(opts.abortSignal);
+
+    try {
+      const execOptions = this.buildExecutionOptions({
+        mode,
+        modeId: effectiveModeId,
+        modelId: this.record.modelId,
+        abortSignal: turnAbortController.signal,
+        additionalTools: opts.additionalTools,
+      });
+      const signal = createSignal({ type: 'user-message', contents: opts.content });
+      this._emit({ type: 'agent_start' });
+      const output = (await agent.stream(signal, execOptions as never)) as MastraModelOutput<unknown>;
+      this.currentRunId = output.runId;
+      const result = this.finishSignalResultTurn(output, turnAbortController);
+      void result.catch(() => undefined);
+      return {
+        id: signal.id,
+        runId: output.runId,
+        willInterleave: false,
+        accepted: true,
+        signal,
+        result,
+      };
+    } catch (err) {
+      this.endTurn(turnAbortController);
+      throw err;
+    }
+  }
+
+  async injectSystemReminder(
+    content: string,
+    opts?: SessionInjectSystemReminderOptions,
+  ): Promise<SessionInjectSystemReminderResult> {
+    this.assertLive('injectSystemReminder()');
+    this.assertCanStartTurn('injectSystemReminder()');
+    if (typeof content !== 'string' || content.length === 0) {
+      throw new HarnessValidationError('injectSystemReminder().content', 'content must be a non-empty string');
+    }
+
+    const mode = this.harness._getMode(this.record.modeId);
+    const agent = this.harness.getAgentForMode(this.record.modeId);
+    const turnAbortController = this.beginTurn(undefined);
+
+    try {
+      const execOptions = this.buildExecutionOptions({
+        mode,
+        modeId: this.record.modeId,
+        modelId: this.record.modelId,
+        abortSignal: turnAbortController.signal,
+      });
+      const signal = createSignal({
+        type: 'system-reminder',
+        contents: content,
+        ...(opts?.attributes ? { attributes: opts.attributes } : {}),
+        ...(opts?.metadata ? { metadata: opts.metadata } : {}),
+      });
+      this._emit({ type: 'agent_start' });
+      const output = (await agent.stream(signal, execOptions as never)) as MastraModelOutput<unknown>;
+      this.currentRunId = output.runId;
+      const result = this.finishSignalResultTurn(output, turnAbortController);
+      void result.catch(() => undefined);
+      return {
+        id: signal.id,
+        runId: output.runId,
+        willInterleave: false,
+        accepted: true,
+        signal,
+      };
     } catch (err) {
       this.endTurn(turnAbortController);
       throw err;
@@ -617,6 +706,24 @@ export class Session {
     return Object.keys(toolsets).length === 0 ? undefined : toolsets;
   }
 
+  private buildExecutionOptions(opts: {
+    mode: HarnessMode;
+    modeId: string;
+    modelId?: string;
+    abortSignal: AbortSignal;
+    additionalTools?: ToolsInput;
+  }): AgentExecutionOptionsBase<unknown> {
+    const toolsets = this.buildToolsets(opts.mode, opts.additionalTools);
+    return {
+      memory: { thread: this.threadId, resource: this.resourceId },
+      abortSignal: opts.abortSignal,
+      requestContext: this.buildRequestContext({ modeId: opts.modeId, abortSignal: opts.abortSignal }),
+      ...(opts.modelId ? { model: opts.modelId as never } : {}),
+      ...(toolsets ? { toolsets } : {}),
+      ...(opts.mode.instructions ? { instructions: opts.mode.instructions } : {}),
+    };
+  }
+
   private async buildSignalContents(content: string, attachments: AttachmentRef[]) {
     if (attachments.length === 0) return content;
 
@@ -736,6 +843,26 @@ export class Session {
       this._emit({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
     } catch {
       this._emit({ type: 'agent_end', reason: 'error', runId: output.runId });
+    }
+  }
+
+  private async finishSignalResultTurn(
+    output: MastraModelOutput<unknown>,
+    controller: AbortController,
+  ): Promise<AgentResult> {
+    const streamDrain = this.consumeAgentStream(output);
+    void streamDrain.catch(() => undefined);
+    try {
+      const full = (await output.getFullOutput()) as FullOutput<unknown>;
+      await streamDrain;
+      await this.recordTurnCompletion(full);
+      this._emit({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
+      return full as AgentResult;
+    } catch (err) {
+      this._emit({ type: 'agent_end', reason: 'error', runId: output.runId });
+      throw err;
+    } finally {
+      this.endTurn(controller);
     }
   }
 


### PR DESCRIPTION
## Description

Adds the next focused Harness v1 slice: session-level signal routing.

This PR implements `Session.signal()` and `Session.injectSystemReminder()` on top of the new message turn machinery. Both APIs dispatch created agent signals with Harness request context, preserve turn events and run bookkeeping, and settle the session back to idle after the underlying agent run completes.

Queue admission, inbox responses, goals, skills, and subagents stay in later stacked PRs.

## Related issue(s)

Part of #16878.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Validation:

- `pnpm --filter ./packages/core test:unit src/harness/v1/session.signal.test.ts`
- `pnpm --filter ./packages/core test:unit src/harness`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'`
- `pnpm build:core`
