### PR TITLE
feat(core): add Harness v1 session queue

### DIFF
--- a/.changeset/tiny-apes-swim.md
+++ b/.changeset/tiny-apes-swim.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 session queue execution.

--- a/packages/core/src/harness/v1/errors.ts
+++ b/packages/core/src/harness/v1/errors.ts
@@ -66,6 +66,19 @@ export class HarnessQueueFullError extends Error {
   }
 }
 
+export class HarnessAdmissionConflictError extends Error {
+  readonly name = 'HarnessAdmissionConflictError';
+
+  constructor(
+    public readonly sessionId: string,
+    public readonly admissionId: string,
+    public readonly storedAdmissionHash: string,
+    public readonly attemptedAdmissionHash: string,
+  ) {
+    super(`Admission "${admissionId}" for session "${sessionId}" conflicts with stored admission evidence`);
+  }
+}
+
 export class HarnessSubagentDepthExceededError extends Error {
   readonly name = 'HarnessSubagentDepthExceededError';
 

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest';
+
+import { Agent } from '../../agent';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import type { MastraModelOutput } from '../../stream/base/output';
+import { HarnessAdmissionConflictError, HarnessQueueFullError } from './errors';
+import type { HarnessEvent } from './events';
+import { Harness } from './harness';
+
+interface FakeCall {
+  messages: unknown;
+  options: any;
+}
+
+interface FakeRun {
+  text?: string;
+  runId?: string;
+  chunks?: unknown[];
+  holdUntil?: Promise<void>;
+}
+
+class FakeAgent extends Agent<any, any, any> {
+  calls: FakeCall[] = [];
+  runs: FakeRun[] = [];
+
+  constructor(id = 'default') {
+    super({ id, name: id, instructions: 'fake', model: 'openai/gpt-4o-mini' as any });
+  }
+
+  enqueueRun(run: FakeRun): void {
+    this.runs.push(run);
+  }
+
+  async stream(messages: unknown, options?: any): Promise<MastraModelOutput> {
+    this.calls.push({ messages, options });
+    const run = this.runs.shift() ?? {};
+    const output = buildOutput({
+      ...run,
+      runId: run.runId ?? options?.runId ?? `${this.id}-run-${this.calls.length}`,
+    });
+    this._internalRegisterStreamRun(output, (options ?? {}) as any);
+    return output;
+  }
+}
+
+function setup(opts?: { maxQueueDepth?: number }) {
+  const agent = new FakeAgent('default');
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { default: agent } as any,
+    modes: [{ id: 'default', agentId: 'default' }],
+    defaultModeId: 'default',
+    sessions: { storage, ...(opts?.maxQueueDepth !== undefined ? { maxQueueDepth: opts.maxQueueDepth } : {}) },
+  });
+  return { harness, agent, storage };
+}
+
+describe('Session.queue()', () => {
+  it('appends a queued turn, drains it, and resolves with the agent result', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({ text: 'queued reply' });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    const result = await session.queue({ content: 'do work' });
+
+    expect(result.text).toBe('queued reply');
+    expect(agent.calls).toHaveLength(1);
+    expect(agent.calls[0]!.messages).toMatchObject({
+      __isCreatedSignal: true,
+      type: 'user-message',
+      contents: 'do work',
+    });
+    expect(session.getQueueDepth()).toBe(0);
+    expect(session.getRecord().pendingQueue).toEqual([]);
+  });
+
+  it('drains queued turns in FIFO order', async () => {
+    const { harness, agent } = setup();
+    let releaseFirst!: () => void;
+    agent.enqueueRun({
+      text: 'first reply',
+      holdUntil: new Promise(resolve => {
+        releaseFirst = resolve;
+      }),
+    });
+    agent.enqueueRun({ text: 'second reply' });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    const first = session.queue({ content: 'first' });
+    await new Promise(resolve => setImmediate(resolve));
+    const second = session.queue({ content: 'second' });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(session.getQueueDepth()).toBe(2);
+    expect(agent.calls).toHaveLength(1);
+    releaseFirst();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.text).toBe('first reply');
+    expect(secondResult.text).toBe('second reply');
+    expect(agent.calls).toHaveLength(2);
+    expect(extractSignalContents(agent.calls[0]!.messages)).toBe('first');
+    expect(extractSignalContents(agent.calls[1]!.messages)).toBe('second');
+    expect(session.getQueueDepth()).toBe(0);
+  });
+
+  it('rejects admission when pendingQueue reaches maxQueueDepth', async () => {
+    const { harness, agent } = setup({ maxQueueDepth: 1 });
+    let releaseFirst!: () => void;
+    agent.enqueueRun({
+      text: 'first reply',
+      holdUntil: new Promise(resolve => {
+        releaseFirst = resolve;
+      }),
+    });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    const first = session.queue({ content: 'first' });
+    await new Promise(resolve => setImmediate(resolve));
+
+    await expect(session.queue({ content: 'second' })).rejects.toBeInstanceOf(HarnessQueueFullError);
+    releaseFirst();
+    await first;
+  });
+
+  it('dedupes exact admissionId retries without appending a second item', async () => {
+    const { harness, agent } = setup();
+    let release!: () => void;
+    agent.enqueueRun({
+      text: 'queued reply',
+      holdUntil: new Promise(resolve => {
+        release = resolve;
+      }),
+    });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    const first = session.queue({ content: 'do work', admissionId: 'queue-1' });
+    await new Promise(resolve => setImmediate(resolve));
+    const second = session.queue({ content: 'do work', admissionId: 'queue-1' });
+
+    expect(session.getRecord().pendingQueue).toHaveLength(1);
+    release();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.text).toBe('queued reply');
+    expect(secondResult.text).toBe('queued reply');
+    expect(agent.calls).toHaveLength(1);
+    expect(Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0]).toMatchObject({
+      admissionId: 'queue-1',
+      status: 'completed',
+      result: expect.objectContaining({ text: 'queued reply' }),
+    });
+  });
+
+  it('rejects conflicting admissionId retries', async () => {
+    const { harness, agent } = setup();
+    let release!: () => void;
+    agent.enqueueRun({
+      text: 'queued reply',
+      holdUntil: new Promise(resolve => {
+        release = resolve;
+      }),
+    });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    const first = session.queue({ content: 'do work', admissionId: 'queue-conflict' });
+    await new Promise(resolve => setImmediate(resolve));
+
+    await expect(session.queue({ content: 'different work', admissionId: 'queue-conflict' })).rejects.toBeInstanceOf(
+      HarnessAdmissionConflictError,
+    );
+    release();
+    await first;
+  });
+
+  it('admits remote queue items and emits queued turn events with queuedItemId', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      text: 'queued reply',
+      chunks: [
+        { type: 'text-start', payload: { id: 'msg-1' } },
+        { type: 'text-delta', payload: { id: 'msg-1', text: 'hi' } },
+        { type: 'text-end', payload: { id: 'msg-1' } },
+      ],
+    });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+    const events: HarnessEvent[] = [];
+    session.subscribe(event => events.push(event));
+
+    const admitted = await session.admitQueue({ content: 'do work', admissionId: 'queue-admit-1' });
+    const duplicate = await session.admitQueue({ content: 'do work', admissionId: 'queue-admit-1' });
+    await session.waitForIdle({ timeoutMs: 1000 });
+
+    expect(duplicate).toEqual({ accepted: true, queuedItemId: admitted.queuedItemId, duplicate: true });
+    expect(events.find(event => event.type === 'queue_item_started')).toMatchObject({
+      queuedItemId: admitted.queuedItemId,
+    });
+    expect(events.filter(event => event.type !== 'queue_item_started')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'agent_start', queuedItemId: admitted.queuedItemId }),
+        expect.objectContaining({ type: 'message_update', queuedItemId: admitted.queuedItemId, delta: 'hi' }),
+        expect.objectContaining({ type: 'agent_end', queuedItemId: admitted.queuedItemId }),
+      ]),
+    );
+  });
+
+  it('persists queued attachment references and replays them into the message signal', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({ text: 'queued reply' });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+    const attachment = await harness.attachments.upload({
+      sessionId: session.id,
+      data: new Uint8Array([1, 2, 3]),
+      filename: 'clip.mp4',
+      contentType: 'video/mp4',
+    });
+
+    await session.queue({ content: 'use this', attachments: [attachment] });
+
+    expect(agent.calls[0]!.messages).toMatchObject({
+      __isCreatedSignal: true,
+      contents: [
+        { type: 'text', text: 'use this' },
+        { type: 'file', mediaType: 'video/mp4', filename: 'clip.mp4' },
+      ],
+    });
+  });
+});
+
+function buildOutput(run: FakeRun): MastraModelOutput {
+  const fullOutput = {
+    text: run.text ?? 'ok',
+    usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+    finishReason: 'stop',
+    object: undefined,
+    steps: [],
+    warnings: [],
+    providerMetadata: undefined,
+    request: {},
+    reasoning: [],
+    reasoningText: undefined,
+    toolCalls: [],
+    toolResults: [],
+    sources: [],
+    files: [],
+    response: { id: 'response-1', timestamp: new Date(), modelId: 'fake', messages: [], uiMessages: [] },
+    totalUsage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+    error: undefined,
+    tripwire: undefined,
+    traceId: undefined,
+    spanId: undefined,
+    runId: run.runId ?? 'fake-run',
+    suspendPayload: undefined,
+    messages: [],
+    rememberedMessages: [],
+  };
+  let finished!: () => void;
+  const finishedPromise = new Promise<void>(resolve => {
+    finished = resolve;
+  });
+  const fullStream = (async function* () {
+    for (const chunk of run.chunks ?? []) yield chunk;
+    if (run.holdUntil) await run.holdUntil;
+    finished();
+  })();
+  return {
+    runId: fullOutput.runId,
+    getFullOutput: async () => {
+      if (run.holdUntil) await run.holdUntil;
+      return fullOutput;
+    },
+    fullStream,
+    text: Promise.resolve(fullOutput.text),
+    finishReason: Promise.resolve(fullOutput.finishReason),
+    usage: Promise.resolve(fullOutput.usage),
+    _waitUntilFinished: () => finishedPromise,
+  } as unknown as MastraModelOutput;
+}
+
+function extractSignalContents(messages: unknown): unknown {
+  if (!messages || typeof messages !== 'object') return undefined;
+  return (messages as { contents?: unknown }).contents;
+}

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1,17 +1,26 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import type { z } from 'zod';
 
 import type { AgentExecutionOptionsBase } from '../../agent/agent.types';
 import { createSignal } from '../../agent/signals';
 import type { ToolsInput } from '../../agent/types';
 import { RequestContext } from '../../request-context';
-import type { HarnessStorage, SessionRecord } from '../../storage/domains/harness';
+import type {
+  HarnessStorage,
+  OperationAdmissionTombstone,
+  PersistedAttachment,
+  QueueAdmissionReceipt,
+  QueuedItem,
+  SessionRecord,
+} from '../../storage/domains/harness';
 import type { FullOutput, MastraModelOutput } from '../../stream/base/output';
 import { convertStoredMessageToHarnessMessage } from '../_shared/message-conversion';
 import type { StoredMessageRow } from '../_shared/message-conversion';
 import {
   HarnessConfigError,
+  HarnessAdmissionConflictError,
   HarnessOverrideConflictError,
+  HarnessQueueFullError,
   HarnessSessionClosedError,
   HarnessValidationError,
 } from './errors';
@@ -29,6 +38,8 @@ import type {
   MessageOptionsStream,
   MessageOptionsStructured,
   ModelAuthStatus,
+  QueueAdmissionResult,
+  QueueOptions,
   SessionInjectSystemReminderOptions,
   SessionInjectSystemReminderResult,
   SessionLifecycleState,
@@ -52,6 +63,19 @@ interface IdleWaiter {
   cleanup: () => void;
 }
 
+interface QueueWaiter {
+  promise: Promise<AgentResult>;
+  resolve: (result: AgentResult) => void;
+  reject: (reason: unknown) => void;
+}
+
+type QueueAdmissionInternalResult = QueueAdmissionResult & {
+  terminalResult?: AgentResult;
+};
+
+const QUEUE_DUPLICATE_WAIT_TIMEOUT_MS = 30_000;
+const QUEUE_DUPLICATE_WAIT_INTERVAL_MS = 100;
+
 export class Session {
   private readonly harness: Harness;
   private readonly storage: HarnessStorage;
@@ -69,6 +93,7 @@ export class Session {
   private draining = false;
   private readonly idleWaiters = new Set<IdleWaiter>();
   private readonly activeToolNames = new Map<string, string>();
+  private readonly queueWaiters = new Map<string, QueueWaiter>();
 
   constructor(opts: SessionConstructorOptions) {
     this.harness = opts.harness;
@@ -141,6 +166,13 @@ export class Session {
   }
 
   _emit(event: EmitInput): HarnessEvent {
+    return this.emitter.emit(event);
+  }
+
+  private emitTurnEvent(event: EmitInput): HarnessEvent {
+    if (this.currentQueuedItemId !== undefined && (event as { queuedItemId?: string }).queuedItemId === undefined) {
+      return this.emitter.emit({ ...event, queuedItemId: this.currentQueuedItemId } as EmitInput);
+    }
     return this.emitter.emit(event);
   }
 
@@ -260,19 +292,19 @@ export class Session {
       };
 
       if (opts.output !== undefined && opts.sync === true) {
-        this._emit({ type: 'agent_start' });
+        this.emitTurnEvent({ type: 'agent_start' });
         const full = (await agent.generate(opts.content, {
           ...execOptions,
           structuredOutput: { schema: opts.output as never },
         } as never)) as FullOutput<unknown>;
         await this.recordTurnCompletion(full);
-        this._emit({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
+        this.emitTurnEvent({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
         return full.object;
       }
 
       const signalContents = await this.buildSignalContents(opts.content, opts.attachments ?? []);
       const signal = createSignal({ type: 'user-message', contents: signalContents });
-      this._emit({ type: 'agent_start' });
+      this.emitTurnEvent({ type: 'agent_start' });
       const output = (await agent.stream(signal, execOptions as never)) as MastraModelOutput<unknown>;
       this.currentRunId = output.runId;
 
@@ -287,7 +319,7 @@ export class Session {
         const full = (await output.getFullOutput()) as FullOutput<unknown>;
         await streamDrain;
         await this.recordTurnCompletion(full);
-        this._emit({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
+        this.emitTurnEvent({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
         return full as AgentResult;
       } finally {
         this.endTurn(turnAbortController);
@@ -319,7 +351,7 @@ export class Session {
         additionalTools: opts.additionalTools,
       });
       const signal = createSignal({ type: 'user-message', contents: opts.content });
-      this._emit({ type: 'agent_start' });
+      this.emitTurnEvent({ type: 'agent_start' });
       const output = (await agent.stream(signal, execOptions as never)) as MastraModelOutput<unknown>;
       this.currentRunId = output.runId;
       const result = this.finishSignalResultTurn(output, turnAbortController);
@@ -365,7 +397,7 @@ export class Session {
         ...(opts?.attributes ? { attributes: opts.attributes } : {}),
         ...(opts?.metadata ? { metadata: opts.metadata } : {}),
       });
-      this._emit({ type: 'agent_start' });
+      this.emitTurnEvent({ type: 'agent_start' });
       const output = (await agent.stream(signal, execOptions as never)) as MastraModelOutput<unknown>;
       this.currentRunId = output.runId;
       const result = this.finishSignalResultTurn(output, turnAbortController);
@@ -381,6 +413,32 @@ export class Session {
       this.endTurn(turnAbortController);
       throw err;
     }
+  }
+
+  async queue(opts: QueueOptions): Promise<AgentResult> {
+    this.assertLive('queue()');
+    const admission = await this.admitQueueInternal(opts, 'queue()');
+    if (admission.terminalResult !== undefined) return admission.terminalResult;
+    if (
+      admission.duplicate &&
+      !this.queueWaiters.has(admission.queuedItemId) &&
+      !(this.record.pendingQueue ?? []).some(item => item.id === admission.queuedItemId)
+    ) {
+      return this.waitForDuplicateQueueResult(admission.queuedItemId);
+    }
+    const waiter = this.getOrCreateQueueWaiter(admission.queuedItemId);
+    void this._kickQueueDrain();
+    return waiter.promise;
+  }
+
+  async admitQueue(opts: QueueOptions): Promise<QueueAdmissionResult> {
+    this.assertLive('admitQueue()');
+    if (typeof opts.admissionId !== 'string' || opts.admissionId.length === 0) {
+      throw new HarnessValidationError('admitQueue().admissionId', 'admissionId must be a non-empty string');
+    }
+    const admission = await this.admitQueueInternal(opts, 'admitQueue()');
+    void this._kickQueueDrain();
+    return admission;
   }
 
   waitForIdle(opts?: { timeoutMs?: number }): Promise<void> {
@@ -464,8 +522,7 @@ export class Session {
   }
 
   async _kickQueueDrain(): Promise<void> {
-    // Queue draining lands with the Session operations slice. Keeping this
-    // no-op preserves the fork's hydration hook without starting work early.
+    await this.maybeDrainQueue();
   }
 
   /** @internal retained for future lease renewal/flush slices. */
@@ -658,6 +715,9 @@ export class Session {
       this.currentQueuedItemId = undefined;
       this.activeToolNames.clear();
       this.notifyMaybeIdle();
+      if ((this.record.pendingQueue?.length ?? 0) > 0) {
+        void this._kickQueueDrain();
+      }
     }
   }
 
@@ -789,18 +849,18 @@ export class Session {
     switch (record.type) {
       case 'text-start': {
         const messageId = stringField(payload, 'id') ?? stringField(payload, 'messageId');
-        if (messageId) this._emit({ type: 'message_start', messageId });
+        if (messageId) this.emitTurnEvent({ type: 'message_start', messageId });
         break;
       }
       case 'text-delta': {
         const messageId = stringField(payload, 'id') ?? stringField(payload, 'messageId');
         const delta = stringField(payload, 'text') ?? stringField(payload, 'delta');
-        if (messageId && delta !== undefined) this._emit({ type: 'message_update', messageId, delta });
+        if (messageId && delta !== undefined) this.emitTurnEvent({ type: 'message_update', messageId, delta });
         break;
       }
       case 'text-end': {
         const messageId = stringField(payload, 'id') ?? stringField(payload, 'messageId');
-        if (messageId) this._emit({ type: 'message_end', messageId });
+        if (messageId) this.emitTurnEvent({ type: 'message_end', messageId });
         break;
       }
       case 'tool-call': {
@@ -808,7 +868,7 @@ export class Session {
         const toolName = stringField(payload, 'toolName');
         if (toolCallId && toolName) {
           this.activeToolNames.set(toolCallId, toolName);
-          this._emit({ type: 'tool_start', toolCallId, toolName, args: payload.args });
+          this.emitTurnEvent({ type: 'tool_start', toolCallId, toolName, args: payload.args });
         }
         break;
       }
@@ -817,7 +877,7 @@ export class Session {
         const toolCallId = stringField(payload, 'toolCallId');
         if (toolCallId) {
           const isError = record.type === 'tool-error';
-          this._emit({
+          this.emitTurnEvent({
             type: 'tool_end',
             toolCallId,
             result: isError ? projectErrorLike(payload.error) : payload.result,
@@ -830,7 +890,7 @@ export class Session {
         const data = (record.data && typeof record.data === 'object' ? record.data : undefined) as
           | { tasks?: unknown }
           | undefined;
-        if (Array.isArray(data?.tasks)) this._emit({ type: 'task_updated', tasks: data.tasks as never });
+        if (Array.isArray(data?.tasks)) this.emitTurnEvent({ type: 'task_updated', tasks: data.tasks as never });
         break;
       }
     }
@@ -840,9 +900,9 @@ export class Session {
     try {
       const full = (await output.getFullOutput()) as FullOutput<unknown>;
       await this.recordTurnCompletion(full);
-      this._emit({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
+      this.emitTurnEvent({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
     } catch {
-      this._emit({ type: 'agent_end', reason: 'error', runId: output.runId });
+      this.emitTurnEvent({ type: 'agent_end', reason: 'error', runId: output.runId });
     }
   }
 
@@ -856,10 +916,10 @@ export class Session {
       const full = (await output.getFullOutput()) as FullOutput<unknown>;
       await streamDrain;
       await this.recordTurnCompletion(full);
-      this._emit({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
+      this.emitTurnEvent({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
       return full as AgentResult;
     } catch (err) {
-      this._emit({ type: 'agent_end', reason: 'error', runId: output.runId });
+      this.emitTurnEvent({ type: 'agent_end', reason: 'error', runId: output.runId });
       throw err;
     } finally {
       this.endTurn(controller);
@@ -880,6 +940,322 @@ export class Session {
         totalTokens: prev.tokenUsage.totalTokens + usage.totalTokens,
       },
     }));
+  }
+
+  private async admitQueueInternal(
+    opts: QueueOptions,
+    methodName: 'queue()' | 'admitQueue()',
+  ): Promise<QueueAdmissionInternalResult> {
+    if (typeof opts.content !== 'string' || opts.content.length === 0) {
+      throw new HarnessValidationError(`${methodName}.content`, 'content must be a non-empty string');
+    }
+    const effectiveModeId = opts.mode ?? this.record.modeId;
+    this.harness._getMode(effectiveModeId);
+    const attachments = await this.resolveQueueAttachments(`${methodName}.attachments`, opts.attachments ?? []);
+    const admissionId = opts.admissionId ?? `queue-${randomUUID()}`;
+    const admissionHash = computeQueueAdmissionHash({
+      content: opts.content,
+      mode: opts.mode,
+      model: opts.model,
+      yolo: opts.yolo,
+      attachments,
+    });
+
+    if (opts.admissionId !== undefined) {
+      const duplicate = await this.resolveQueueAdmissionDuplicate({
+        admissionId,
+        admissionHash,
+      });
+      if (duplicate) {
+        const queuedItemId = duplicate.queuedItemId;
+        if (!queuedItemId) {
+          throw new HarnessValidationError(`${methodName}.admissionId`, 'duplicate queue evidence is missing item id');
+        }
+        if (methodName === 'queue()') {
+          const terminal = this.queueTerminalResultFromEvidence(duplicate);
+          if (terminal.status === 'completed') {
+            return { accepted: true, queuedItemId, duplicate: true, terminalResult: terminal.result };
+          }
+          if (terminal.status === 'failed') throw terminal.error;
+        }
+        return { accepted: true, queuedItemId, duplicate: true };
+      }
+    }
+
+    const now = Date.now();
+    const queuedItem: QueuedItem = {
+      id: `q-${randomUUID()}`,
+      admissionId,
+      admissionHash,
+      enqueuedAt: now,
+      content: opts.content,
+      attachments,
+      ...(opts.model !== undefined ? { model: opts.model } : {}),
+      ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
+      ...(opts.yolo !== undefined ? { yolo: opts.yolo } : {}),
+      source: 'user',
+    };
+    const receipt: QueueAdmissionReceipt = {
+      admissionId,
+      admissionHash,
+      queuedItemId: queuedItem.id,
+      modeId: effectiveModeId,
+      runtimeDependencies: {
+        modeId: effectiveModeId,
+        modelId: opts.model ?? this.record.modelId,
+      },
+      status: 'queued',
+      attempts: 0,
+      enqueuedAt: now,
+      updatedAt: now,
+    };
+
+    let duplicateDuringFlush: QueueAdmissionReceipt | undefined;
+    await this.flushUpdate(prev => {
+      for (const existing of Object.values(prev.queueAdmissionReceipts ?? {})) {
+        if (existing.admissionId !== admissionId) continue;
+        if (existing.admissionHash !== admissionHash) {
+          throw new HarnessAdmissionConflictError(this.id, admissionId, existing.admissionHash, admissionHash);
+        }
+        duplicateDuringFlush = existing;
+        return prev;
+      }
+      const pendingQueue = prev.pendingQueue ?? [];
+      if (pendingQueue.length >= this.harness._internalMaxQueueDepth) {
+        throw new HarnessQueueFullError(this.id, this.harness._internalMaxQueueDepth);
+      }
+      return {
+        ...prev,
+        pendingQueue: [...pendingQueue, queuedItem],
+        queueAdmissionReceipts: {
+          ...(prev.queueAdmissionReceipts ?? {}),
+          [queuedItem.id]: receipt,
+        },
+      };
+    });
+    if (duplicateDuringFlush) {
+      return { accepted: true, queuedItemId: duplicateDuringFlush.queuedItemId, duplicate: true };
+    }
+
+    return { accepted: true, queuedItemId: queuedItem.id, duplicate: false };
+  }
+
+  private async resolveQueueAdmissionDuplicate(opts: {
+    admissionId: string;
+    admissionHash: string;
+  }): Promise<QueueAdmissionReceipt | OperationAdmissionTombstone | undefined> {
+    const resolved = await this.storage.resolveOperationAdmissionEvidence({
+      sessionId: this.id,
+      resourceId: this.resourceId,
+      threadId: this.threadId,
+      kind: 'queue',
+      admissionId: opts.admissionId,
+      attemptedAdmissionHash: opts.admissionHash,
+    });
+    if (resolved.status === 'none') return undefined;
+    if (resolved.status === 'conflict') {
+      throw new HarnessAdmissionConflictError(
+        this.id,
+        opts.admissionId,
+        resolved.storedAdmissionHash ?? 'unknown',
+        opts.admissionHash,
+      );
+    }
+    return resolved.evidence as QueueAdmissionReceipt | OperationAdmissionTombstone | undefined;
+  }
+
+  private queueTerminalResultFromEvidence(
+    evidence: QueueAdmissionReceipt | OperationAdmissionTombstone,
+  ): { status: 'completed'; result: AgentResult } | { status: 'failed'; error: Error } | { status: 'pending' } {
+    if ('kind' in evidence)
+      return { status: 'failed', error: new HarnessValidationError('queue()', 'queue result expired') };
+    if (evidence.status === 'completed' && evidence.result !== undefined) {
+      return { status: 'completed', result: evidence.result as AgentResult };
+    }
+    if (evidence.status === 'failed' || evidence.status === 'admission_failed' || evidence.status === 'dead') {
+      return {
+        status: 'failed',
+        error: new HarnessValidationError('queue()', evidence.error?.message ?? 'queued turn failed'),
+      };
+    }
+    return { status: 'pending' };
+  }
+
+  private getOrCreateQueueWaiter(queuedItemId: string): QueueWaiter {
+    const existing = this.queueWaiters.get(queuedItemId);
+    if (existing) return existing;
+    let resolve!: (result: AgentResult) => void;
+    let reject!: (reason: unknown) => void;
+    const promise = new Promise<AgentResult>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    const waiter = { promise, resolve, reject };
+    this.queueWaiters.set(queuedItemId, waiter);
+    return waiter;
+  }
+
+  private async waitForDuplicateQueueResult(queuedItemId: string): Promise<AgentResult> {
+    const deadline = Date.now() + QUEUE_DUPLICATE_WAIT_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const evidence = await this.storage.loadQueueResultEvidence({
+        sessionId: this.id,
+        resourceId: this.resourceId,
+        queuedItemId,
+      });
+      if (evidence) {
+        const terminal = this.queueTerminalResultFromEvidence(evidence);
+        if (terminal.status === 'completed') return terminal.result;
+        if (terminal.status === 'failed') throw terminal.error;
+      }
+      await delay(Math.min(QUEUE_DUPLICATE_WAIT_INTERVAL_MS, Math.max(0, deadline - Date.now())));
+    }
+    throw new HarnessValidationError('queue().admissionId', 'duplicate queue result was not available before timeout');
+  }
+
+  private async maybeDrainQueue(): Promise<void> {
+    if (this.draining || this.currentTurnAbortController !== undefined) return;
+    if (this.lifecycle !== 'live') return;
+    this.draining = true;
+    try {
+      while (this.lifecycle === 'live' && this.currentTurnAbortController === undefined) {
+        const item = this.record.pendingQueue?.[0];
+        if (!item) break;
+        this.currentQueuedItemId = item.id;
+        await this.updateQueueAdmissionReceipt(item.id, (receipt, now) => ({
+          ...receipt,
+          status: receipt.status === 'queued' ? 'admitting' : receipt.status,
+          attempts: receipt.attempts + 1,
+          admittingAt: receipt.admittingAt ?? now,
+          updatedAt: now,
+        }));
+        this.emitter.emit({ type: 'queue_item_started', queuedItemId: item.id });
+
+        try {
+          const result = (await this.message({
+            content: item.content,
+            ...(item.mode !== undefined ? { mode: item.mode } : {}),
+            ...(item.model !== undefined ? { model: item.model } : {}),
+            attachments: item.attachments.map(queuedAttachmentToRef),
+          })) as AgentResult;
+          await this.completeQueuedItem(item, result);
+        } catch (err) {
+          await this.failQueuedItem(item, err);
+        } finally {
+          if (this.currentQueuedItemId === item.id) this.currentQueuedItemId = undefined;
+        }
+      }
+    } finally {
+      this.draining = false;
+      this.notifyMaybeIdle();
+    }
+  }
+
+  private async completeQueuedItem(item: QueuedItem, result: AgentResult): Promise<void> {
+    await this.flushUpdate(prev => {
+      const receipt = prev.queueAdmissionReceipts?.[item.id];
+      const now = Date.now();
+      const nextReceipts = { ...(prev.queueAdmissionReceipts ?? {}) };
+      if (receipt) {
+        nextReceipts[item.id] = {
+          ...receipt,
+          status: 'completed',
+          runId: result.runId,
+          result,
+          postRunFinalizedAt: now,
+          completedAt: now,
+          updatedAt: now,
+        };
+      }
+      return {
+        ...prev,
+        pendingQueue: (prev.pendingQueue ?? []).filter(queued => queued.id !== item.id),
+        queueAdmissionReceipts: nextReceipts,
+      };
+    });
+    const waiter = this.queueWaiters.get(item.id);
+    if (waiter) {
+      this.queueWaiters.delete(item.id);
+      waiter.resolve(result);
+    }
+  }
+
+  private async failQueuedItem(item: QueuedItem, reason: unknown): Promise<void> {
+    const error = toPublicQueueError(reason);
+    await this.flushUpdate(prev => {
+      const receipt = prev.queueAdmissionReceipts?.[item.id];
+      const now = Date.now();
+      const nextReceipts = { ...(prev.queueAdmissionReceipts ?? {}) };
+      if (receipt) {
+        nextReceipts[item.id] = {
+          ...receipt,
+          status: 'failed',
+          error,
+          failedAt: now,
+          updatedAt: now,
+        };
+      }
+      return {
+        ...prev,
+        pendingQueue: (prev.pendingQueue ?? []).filter(queued => queued.id !== item.id),
+        queueAdmissionReceipts: nextReceipts,
+      };
+    });
+    const waiter = this.queueWaiters.get(item.id);
+    if (waiter) {
+      this.queueWaiters.delete(item.id);
+      waiter.reject(reason);
+    }
+  }
+
+  private async updateQueueAdmissionReceipt(
+    queuedItemId: string,
+    update: (receipt: QueueAdmissionReceipt, now: number) => QueueAdmissionReceipt,
+  ): Promise<void> {
+    await this.flushUpdate(prev => {
+      const receipt = prev.queueAdmissionReceipts?.[queuedItemId];
+      if (!receipt) return prev;
+      return {
+        ...prev,
+        queueAdmissionReceipts: {
+          ...(prev.queueAdmissionReceipts ?? {}),
+          [queuedItemId]: update(receipt, Date.now()),
+        },
+      };
+    });
+  }
+
+  private async resolveQueueAttachments(field: string, attachments: AttachmentRef[]): Promise<PersistedAttachment[]> {
+    const persisted: PersistedAttachment[] = [];
+    for (let i = 0; i < attachments.length; i += 1) {
+      const attachment = attachments[i]!;
+      if (!attachment.attachmentId) {
+        throw new HarnessValidationError(`${field}[${i}].attachmentId`, 'attachmentId is required');
+      }
+      if (attachment.ownerSessionId !== undefined && attachment.ownerSessionId !== this.id) {
+        throw new HarnessValidationError(`${field}[${i}].ownerSessionId`, 'attachment must belong to this session');
+      }
+      const record = await this.storage.getAttachmentRecord({
+        sessionId: attachment.ownerSessionId ?? this.id,
+        attachmentId: attachment.attachmentId,
+      });
+      if (!record) {
+        throw new HarnessValidationError(`${field}[${i}].attachmentId`, 'attachment was not found');
+      }
+      if (attachment.bytes !== undefined && attachment.bytes !== record.bytes) {
+        throw new HarnessValidationError(`${field}[${i}].bytes`, 'attachment byte count does not match storage');
+      }
+      if (attachment.sha256 !== undefined && attachment.sha256 !== record.sha256) {
+        throw new HarnessValidationError(`${field}[${i}].sha256`, 'attachment digest does not match storage');
+      }
+      persisted.push({
+        kind: 'ref',
+        attachmentId: record.attachmentId,
+        name: record.name,
+        mimeType: record.mimeType,
+      });
+    }
+    return persisted;
   }
 }
 
@@ -925,6 +1301,42 @@ function numberField(record: Record<string, unknown>, key: string): number | und
 function projectErrorLike(value: unknown): { name: string; message: string } | unknown {
   if (value instanceof Error) return { name: value.name, message: value.message };
   return value;
+}
+
+function queuedAttachmentToRef(attachment: PersistedAttachment): AttachmentRef {
+  if (attachment.kind === 'url') {
+    throw new HarnessValidationError('queue().attachments', 'queued URL attachments are not supported yet');
+  }
+  return {
+    attachmentId: attachment.attachmentId,
+    resourceId: '',
+    name: attachment.name,
+    mimeType: attachment.mimeType,
+  };
+}
+
+function computeQueueAdmissionHash(value: unknown): string {
+  return createHash('sha256').update(stableStringify(value)).digest('hex');
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .filter(key => record[key] !== undefined)
+    .sort()
+    .map(key => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(',')}}`;
+}
+
+function toPublicQueueError(reason: unknown): { code: string; message: string } {
+  if (reason instanceof Error) return { code: reason.name, message: reason.message };
+  return { code: 'Error', message: String(reason) };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 function cloneJsonLike<T>(value: T): T {

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -406,7 +406,14 @@ export interface QueueOverrides {
 
 export interface QueueOptions extends QueueOverrides {
   content: string;
+  admissionId?: string;
   attachments?: AttachmentRef[];
+}
+
+export interface QueueAdmissionResult {
+  accepted: true;
+  queuedItemId: string;
+  duplicate: boolean;
 }
 
 export interface ListMessagesOptions {


### PR DESCRIPTION
## Description

Adds the focused Harness v1 session queue slice on top of the existing harness storage receipt model. `Session.queue()` and `Session.admitQueue()` now persist queued turns to `pendingQueue`, drain them FIFO through the v1 message runtime, stamp turn events with `queuedItemId`, enforce `sessions.maxQueueDepth`, and handle duplicate or conflicting admission ids.

This keeps the slice scoped to the Harness v1 runtime. Follow-up PRs will layer suspensions, inbox responses, permissions, and the remaining fork behavior onto this queue path.

## Related issue(s)

Part of #16878.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Validation:

- `pnpm --filter ./packages/core test:unit src/harness/v1/session.queue.test.ts`
- `pnpm --filter ./packages/core test:unit src/harness`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'`
- `pnpm build:core`
