### PR TITLE
feat(core): add Harness v1 session permissions

### DIFF
--- a/.changeset/dirty-lizards-obey.md
+++ b/.changeset/dirty-lizards-obey.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 session permission controls.

--- a/packages/core/src/harness/v1/session.permissions.test.ts
+++ b/packages/core/src/harness/v1/session.permissions.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+
+import { Agent } from '../../agent';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { HarnessConfigError, HarnessValidationError } from './errors';
+import type { HarnessEvent } from './events';
+import { Harness } from './harness';
+import type { ToolCategory } from './shared';
+
+class FakeAgent extends Agent<any, any, any> {
+  constructor(id = 'default') {
+    super({ id, name: id, instructions: 'fake', model: 'openai/gpt-4o-mini' as any });
+  }
+}
+
+function setup(opts?: { toolCategoryResolver?: (toolName: string) => ToolCategory | null | undefined }) {
+  const agent = new FakeAgent('default');
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { default: agent } as any,
+    modes: [{ id: 'default', agentId: 'default' }],
+    defaultModeId: 'default',
+    sessions: { storage },
+    ...(opts?.toolCategoryResolver ? { toolCategoryResolver: opts.toolCategoryResolver } : {}),
+  });
+  return { harness, storage };
+}
+
+async function openSession() {
+  const { harness, storage } = setup();
+  const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+  return { harness, storage, session };
+}
+
+function collectEvents(session: Awaited<ReturnType<typeof openSession>>['session']) {
+  const events: HarnessEvent[] = [];
+  session.subscribe(event => {
+    events.push(event);
+  });
+  return events;
+}
+
+describe('Session.permissions', () => {
+  it('persists category grants and emits permission_granted once', async () => {
+    const { session } = await openSession();
+    const events = collectEvents(session);
+
+    await session.permissions.grantCategory({ category: 'read' });
+    await session.permissions.grantCategory({ category: 'read' });
+
+    expect(session.permissions.getGrants().categories).toEqual(['read']);
+    expect(events.filter(event => event.type === 'permission_granted')).toEqual([
+      expect.objectContaining({ type: 'permission_granted', category: 'read' }),
+    ]);
+  });
+
+  it('revokes category grants idempotently', async () => {
+    const { session } = await openSession();
+    await session.permissions.grantCategory({ category: 'execute' });
+    const events = collectEvents(session);
+
+    await session.permissions.revokeCategory({ category: 'execute' });
+    await session.permissions.revokeCategory({ category: 'execute' });
+
+    expect(session.permissions.getGrants().categories).toEqual([]);
+    expect(events.filter(event => event.type === 'permission_revoked')).toEqual([
+      expect.objectContaining({ type: 'permission_revoked', category: 'execute' }),
+    ]);
+  });
+
+  it('persists tool grants independently from category grants', async () => {
+    const { session } = await openSession();
+    const events = collectEvents(session);
+
+    await session.permissions.grantTool({ toolName: 'fs.write' });
+    await session.permissions.grantTool({ toolName: 'shell' });
+
+    expect(session.permissions.getGrants()).toEqual({ categories: [], tools: ['fs.write', 'shell'] });
+    expect(events.filter(event => event.type === 'permission_granted')).toEqual([
+      expect.objectContaining({ type: 'permission_granted', toolName: 'fs.write' }),
+      expect.objectContaining({ type: 'permission_granted', toolName: 'shell' }),
+    ]);
+  });
+
+  it('revokes tool grants idempotently', async () => {
+    const { session } = await openSession();
+    await session.permissions.grantTool({ toolName: 'shell' });
+    const events = collectEvents(session);
+
+    await session.permissions.revokeTool({ toolName: 'shell' });
+    await session.permissions.revokeTool({ toolName: 'shell' });
+
+    expect(session.permissions.getGrants().tools).toEqual([]);
+    expect(events.filter(event => event.type === 'permission_revoked')).toEqual([
+      expect.objectContaining({ type: 'permission_revoked', toolName: 'shell' }),
+    ]);
+  });
+
+  it('sets category and tool policies with previous values', async () => {
+    const { session } = await openSession();
+    const events = collectEvents(session);
+
+    await session.permissions.setPolicy({ category: 'edit', policy: 'ask' });
+    await session.permissions.setPolicy({ category: 'edit', policy: 'deny' });
+    await session.permissions.setPolicy({ toolName: 'shell.echo', policy: 'allow' });
+
+    expect(session.permissions.getRules()).toEqual({
+      categories: { edit: 'deny' },
+      tools: { 'shell.echo': 'allow' },
+    });
+    expect(events.filter(event => event.type === 'permission_policy_changed')).toEqual([
+      expect.objectContaining({ category: 'edit', oldPolicy: null, newPolicy: 'ask' }),
+      expect.objectContaining({ category: 'edit', oldPolicy: 'ask', newPolicy: 'deny' }),
+      expect.objectContaining({ toolName: 'shell.echo', oldPolicy: null, newPolicy: 'allow' }),
+    ]);
+  });
+
+  it('does not emit when setting an existing policy to the same value', async () => {
+    const { session } = await openSession();
+    await session.permissions.setPolicy({ category: 'read', policy: 'allow' });
+    const events = collectEvents(session);
+
+    await session.permissions.setPolicy({ category: 'read', policy: 'allow' });
+
+    expect(events.filter(event => event.type === 'permission_policy_changed')).toHaveLength(0);
+  });
+
+  it('returns defensive frozen snapshots', async () => {
+    const { session } = await openSession();
+    await session.permissions.grantCategory({ category: 'read' });
+    await session.permissions.setPolicy({ category: 'edit', policy: 'deny' });
+
+    const grants = session.permissions.getGrants();
+    const rules = session.permissions.getRules();
+
+    expect(Object.isFrozen(grants)).toBe(true);
+    expect(Object.isFrozen(rules)).toBe(true);
+
+    await session.permissions.grantCategory({ category: 'execute' });
+    expect(grants.categories).toEqual(['read']);
+    expect(session.permissions.getGrants().categories).toEqual(['read', 'execute']);
+  });
+
+  it('writes grants and rules to the SessionRecord', async () => {
+    const { storage, session } = await openSession();
+
+    await session.permissions.grantCategory({ category: 'read' });
+    await session.permissions.grantTool({ toolName: 'shell' });
+    await session.permissions.setPolicy({ category: 'execute', policy: 'deny' });
+    await session.permissions.setPolicy({ toolName: 'fs.write', policy: 'allow' });
+
+    const persisted = await storage.loadSession({ sessionId: session.id });
+    expect(persisted?.sessionGrants).toEqual({ categories: ['read'], tools: ['shell'] });
+    expect(persisted?.permissionRules).toEqual({
+      categories: { execute: 'deny' },
+      tools: { 'fs.write': 'allow' },
+    });
+  });
+
+  it('validates categories, tool names, policies, and policy target shape', async () => {
+    const { session } = await openSession();
+
+    await expect(session.permissions.grantCategory({ category: 'nope' as ToolCategory })).rejects.toBeInstanceOf(
+      HarnessValidationError,
+    );
+    await expect(session.permissions.grantTool({ toolName: '' })).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(session.permissions.setPolicy({ category: 'read', policy: 'maybe' as any })).rejects.toBeInstanceOf(
+      HarnessValidationError,
+    );
+    await expect(
+      // @ts-expect-error runtime validation still protects wire callers.
+      session.permissions.setPolicy({ category: 'read', toolName: 'shell', policy: 'allow' }),
+    ).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+});
+
+describe('Harness permission configuration', () => {
+  it('returns configured tool categories', () => {
+    const { harness } = setup({
+      toolCategoryResolver: name => (name === 'shell' ? 'execute' : name === 'fs.read' ? 'read' : null),
+    });
+
+    expect(harness.getToolCategory({ toolName: 'shell' })).toBe('execute');
+    expect(harness.getToolCategory({ toolName: 'fs.read' })).toBe('read');
+    expect(harness.getToolCategory({ toolName: 'unknown' })).toBeNull();
+  });
+
+  it('rejects invalid permission config', () => {
+    expect(
+      () =>
+        new Harness({
+          agents: {} as any,
+          modes: [],
+          defaultPermissionPolicy: 'maybe' as any,
+        }),
+    ).toThrow(HarnessConfigError);
+    expect(
+      () =>
+        new Harness({
+          agents: {} as any,
+          modes: [],
+          toolCategoryResolver: 'not-a-function' as any,
+        }),
+    ).toThrow(HarnessConfigError);
+  });
+});

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -8,9 +8,11 @@ import { RequestContext } from '../../request-context';
 import type {
   HarnessStorage,
   OperationAdmissionTombstone,
+  PermissionRules,
   PersistedAttachment,
   QueueAdmissionReceipt,
   QueuedItem,
+  SessionGrants,
   SessionRecord,
 } from '../../storage/domains/harness';
 import type { FullOutput, MastraModelOutput } from '../../stream/base/output';
@@ -27,7 +29,7 @@ import {
 import { EventEmitter } from './events';
 import type { HarnessEvent, HarnessEventListener, HarnessEventUnsubscribe, EmitInput } from './events';
 import type { Harness } from './harness';
-import type { HarnessMessage, HarnessMode } from './shared';
+import type { HarnessMessage, HarnessMode, ToolCategory } from './shared';
 import type {
   AgentResult,
   AgentStream,
@@ -38,6 +40,7 @@ import type {
   MessageOptionsStream,
   MessageOptionsStructured,
   ModelAuthStatus,
+  PermissionPolicy,
   QueueAdmissionResult,
   QueueOptions,
   SessionInjectSystemReminderOptions,
@@ -75,6 +78,8 @@ type QueueAdmissionInternalResult = QueueAdmissionResult & {
 
 const QUEUE_DUPLICATE_WAIT_TIMEOUT_MS = 30_000;
 const QUEUE_DUPLICATE_WAIT_INTERVAL_MS = 100;
+const TOOL_CATEGORIES: readonly ToolCategory[] = ['read', 'edit', 'execute', 'mcp', 'other'];
+const PERMISSION_POLICIES: readonly PermissionPolicy[] = ['allow', 'ask', 'deny'];
 
 export class Session {
   private readonly harness: Harness;
@@ -198,6 +203,20 @@ export class Session {
     switch: (opts: { model: string }): Promise<void> => this.modelsSwitch(opts),
     setSubagent: (opts: { agentType: string; model: string }): Promise<void> => this.modelsSetSubagent(opts),
     getSubagent: (opts: { agentType: string }): string | null => this.modelsGetSubagent(opts),
+  });
+
+  readonly permissions = Object.freeze({
+    grantCategory: (opts: { category: ToolCategory }): Promise<void> => this.permissionsGrantCategory(opts),
+    grantTool: (opts: { toolName: string }): Promise<void> => this.permissionsGrantTool(opts),
+    revokeCategory: (opts: { category: ToolCategory }): Promise<void> => this.permissionsRevokeCategory(opts),
+    revokeTool: (opts: { toolName: string }): Promise<void> => this.permissionsRevokeTool(opts),
+    getGrants: (): Readonly<SessionGrants> => this.permissionsGetGrants(),
+    getRules: (): Readonly<PermissionRules> => this.permissionsGetRules(),
+    setPolicy: (
+      opts:
+        | { category: ToolCategory; toolName?: never; policy: PermissionPolicy }
+        | { toolName: string; category?: never; policy: PermissionPolicy },
+    ): Promise<void> => this.permissionsSetPolicy(opts),
   });
 
   async getState<TState = unknown>(): Promise<TState> {
@@ -634,6 +653,125 @@ export class Session {
     this.assertLive('models.getSubagent()');
     assertAgentType('models.getSubagent', opts.agentType);
     return this.record.subagentModelOverrides?.[opts.agentType] ?? null;
+  }
+
+  private async permissionsGrantCategory(opts: { category: ToolCategory }): Promise<void> {
+    this.assertLive('permissions.grantCategory()');
+    assertToolCategory('permissions.grantCategory', opts.category);
+    if (this.record.sessionGrants.categories.includes(opts.category)) return;
+    await this.flushUpdate(prev => ({
+      ...prev,
+      sessionGrants: {
+        ...prev.sessionGrants,
+        categories: [...prev.sessionGrants.categories, opts.category],
+      },
+    }));
+    this.emitter.emit({ type: 'permission_granted', category: opts.category });
+  }
+
+  private async permissionsGrantTool(opts: { toolName: string }): Promise<void> {
+    this.assertLive('permissions.grantTool()');
+    assertToolName('permissions.grantTool', opts.toolName);
+    if (this.record.sessionGrants.tools.includes(opts.toolName)) return;
+    await this.flushUpdate(prev => ({
+      ...prev,
+      sessionGrants: {
+        ...prev.sessionGrants,
+        tools: [...prev.sessionGrants.tools, opts.toolName],
+      },
+    }));
+    this.emitter.emit({ type: 'permission_granted', toolName: opts.toolName });
+  }
+
+  private async permissionsRevokeCategory(opts: { category: ToolCategory }): Promise<void> {
+    this.assertLive('permissions.revokeCategory()');
+    assertToolCategory('permissions.revokeCategory', opts.category);
+    if (!this.record.sessionGrants.categories.includes(opts.category)) return;
+    await this.flushUpdate(prev => ({
+      ...prev,
+      sessionGrants: {
+        ...prev.sessionGrants,
+        categories: prev.sessionGrants.categories.filter(category => category !== opts.category),
+      },
+    }));
+    this.emitter.emit({ type: 'permission_revoked', category: opts.category });
+  }
+
+  private async permissionsRevokeTool(opts: { toolName: string }): Promise<void> {
+    this.assertLive('permissions.revokeTool()');
+    assertToolName('permissions.revokeTool', opts.toolName);
+    if (!this.record.sessionGrants.tools.includes(opts.toolName)) return;
+    await this.flushUpdate(prev => ({
+      ...prev,
+      sessionGrants: {
+        ...prev.sessionGrants,
+        tools: prev.sessionGrants.tools.filter(toolName => toolName !== opts.toolName),
+      },
+    }));
+    this.emitter.emit({ type: 'permission_revoked', toolName: opts.toolName });
+  }
+
+  private permissionsGetGrants(): Readonly<SessionGrants> {
+    this.assertLive('permissions.getGrants()');
+    return Object.freeze({
+      categories: [...this.record.sessionGrants.categories],
+      tools: [...this.record.sessionGrants.tools],
+    });
+  }
+
+  private permissionsGetRules(): Readonly<PermissionRules> {
+    this.assertLive('permissions.getRules()');
+    return Object.freeze({
+      categories: { ...this.record.permissionRules.categories },
+      tools: { ...this.record.permissionRules.tools },
+    });
+  }
+
+  private async permissionsSetPolicy(
+    opts:
+      | { category: ToolCategory; toolName?: never; policy: PermissionPolicy }
+      | { toolName: string; category?: never; policy: PermissionPolicy },
+  ): Promise<void> {
+    this.assertLive('permissions.setPolicy()');
+    if ((opts.category === undefined) === (opts.toolName === undefined)) {
+      throw new HarnessValidationError('permissions.setPolicy', 'must set exactly one of "category" or "toolName"');
+    }
+    assertPolicy('permissions.setPolicy', opts.policy);
+    if (opts.category !== undefined) {
+      assertToolCategory('permissions.setPolicy', opts.category);
+      const oldPolicy = this.record.permissionRules.categories[opts.category] ?? null;
+      if (oldPolicy === opts.policy) return;
+      await this.flushUpdate(prev => ({
+        ...prev,
+        permissionRules: {
+          ...prev.permissionRules,
+          categories: { ...prev.permissionRules.categories, [opts.category!]: opts.policy },
+        },
+      }));
+      this.emitter.emit({
+        type: 'permission_policy_changed',
+        category: opts.category,
+        oldPolicy,
+        newPolicy: opts.policy,
+      });
+      return;
+    }
+    assertToolName('permissions.setPolicy', opts.toolName);
+    const oldPolicy = this.record.permissionRules.tools[opts.toolName] ?? null;
+    if (oldPolicy === opts.policy) return;
+    await this.flushUpdate(prev => ({
+      ...prev,
+      permissionRules: {
+        ...prev.permissionRules,
+        tools: { ...prev.permissionRules.tools, [opts.toolName!]: opts.policy },
+      },
+    }));
+    this.emitter.emit({
+      type: 'permission_policy_changed',
+      toolName: opts.toolName,
+      oldPolicy,
+      newPolicy: opts.policy,
+    });
   }
 
   private flushUpdate(update: (prev: SessionRecord) => SessionRecord): Promise<void> {
@@ -1262,6 +1400,24 @@ export class Session {
 function assertAgentType(method: string, value: unknown): asserts value is string {
   if (typeof value !== 'string' || value.length === 0) {
     throw new HarnessValidationError(method, 'agentType must be a non-empty string');
+  }
+}
+
+function assertToolCategory(method: string, value: unknown): asserts value is ToolCategory {
+  if (typeof value !== 'string' || !TOOL_CATEGORIES.includes(value as ToolCategory)) {
+    throw new HarnessValidationError(method, `unknown ToolCategory ${JSON.stringify(value)}`);
+  }
+}
+
+function assertToolName(method: string, value: unknown): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new HarnessValidationError(method, 'toolName must be a non-empty string');
+  }
+}
+
+function assertPolicy(method: string, value: unknown): asserts value is PermissionPolicy {
+  if (typeof value !== 'string' || !PERMISSION_POLICIES.includes(value as PermissionPolicy)) {
+    throw new HarnessValidationError(method, `policy must be one of ${PERMISSION_POLICIES.join(' | ')}`);
   }
 }
 


### PR DESCRIPTION
## Description

Adds the focused Harness v1 session permissions slice. `Session.permissions` now supports category/tool grants, revokes, policy reads/writes, defensive snapshots, persistence through `SessionRecord.sessionGrants` and `SessionRecord.permissionRules`, and the existing permission events.

This keeps the slice limited to session permission state and Harness tool-category configuration. Suspensions, inbox receipts, and built-in permission enforcement land in follow-up PRs.

## Related issue(s)

Part of #16878.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Validation:

- `pnpm --filter ./packages/core test:unit src/harness/v1/session.permissions.test.ts`
- `pnpm --filter ./packages/core test:unit src/harness`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'`
- `pnpm build:core`
