### PR TITLE
feat(core): add Harness v1 session suspensions

### DIFF
--- a/.changeset/icy-mangos-stand.md
+++ b/.changeset/icy-mangos-stand.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 suspension resume handling.

--- a/packages/core/src/harness/v1/session.suspension.test.ts
+++ b/packages/core/src/harness/v1/session.suspension.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest';
+
+import { Agent } from '../../agent';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import type { MastraModelOutput } from '../../stream/base/output';
+import { HarnessValidationError } from './errors';
+import type { HarnessEvent } from './events';
+import { Harness } from './harness';
+
+interface FakeRun {
+  finishReason: 'stop' | 'suspended';
+  text?: string;
+  runId?: string;
+  suspendPayload?: {
+    toolCallId: string;
+    toolName: string;
+    args?: unknown;
+    suspendPayload?: unknown;
+  };
+}
+
+class FakeAgent extends Agent<any, any, any> {
+  runs: FakeRun[] = [];
+  resumeCalls: Array<{ resumeData: unknown; options: any }> = [];
+
+  constructor(id = 'default') {
+    super({ id, name: id, instructions: 'fake', model: 'openai/gpt-4o-mini' as any });
+  }
+
+  enqueueRun(run: FakeRun): void {
+    this.runs.push(run);
+  }
+
+  async stream(_messages: unknown, options?: any): Promise<MastraModelOutput> {
+    const run = this.runs.shift();
+    if (!run) throw new Error('FakeAgent: no stream run enqueued');
+    const output = buildOutput({ ...run, runId: run.runId ?? options?.runId ?? 'fake-run' });
+    this._internalRegisterStreamRun(output, (options ?? {}) as any);
+    return output;
+  }
+
+  async resumeStream(resumeData: unknown, options?: any): Promise<MastraModelOutput> {
+    this.resumeCalls.push({ resumeData, options });
+    const run = this.runs.shift();
+    if (!run) throw new Error('FakeAgent: no resume run enqueued');
+    const output = buildOutput({ ...run, runId: run.runId ?? options?.runId ?? 'fake-run' });
+    this._internalRegisterStreamRun(output, (options ?? {}) as any);
+    return output;
+  }
+}
+
+function setup(modes?: any[]) {
+  const agent = new FakeAgent('default');
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const resolvedModes = modes ?? [{ id: 'default', agentId: 'default' }];
+  const harness = new Harness({
+    agents: { default: agent } as any,
+    modes: resolvedModes,
+    defaultModeId: resolvedModes[0]!.id,
+    sessions: { storage },
+  });
+  return { harness, agent };
+}
+
+describe('Session suspensions', () => {
+  it('captures tool approval suspensions and emits suspension_required', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-approval',
+      suspendPayload: { toolCallId: 'tc-1', toolName: 'shell', args: { cmd: 'rm -rf /tmp/x' } },
+    });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+    const events: HarnessEvent[] = [];
+    session.subscribe(event => events.push(event));
+
+    const result = await session.message({ content: 'do it' });
+
+    expect(result.finishReason).toBe('suspended');
+    expect(session.getRecord().pendingResume).toMatchObject({
+      kind: 'tool-approval',
+      runId: 'run-approval',
+      toolCallId: 'tc-1',
+      toolName: 'shell',
+      payload: { input: { cmd: 'rm -rf /tmp/x' } },
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'suspension_required', kind: 'tool-approval', toolCallId: 'tc-1' }),
+      ]),
+    );
+  });
+
+  it('resumes a pending approval and clears pendingResume', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-approval',
+      suspendPayload: { toolCallId: 'tc-1', toolName: 'shell', args: { cmd: 'echo ok' } },
+    });
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-approval', text: 'approved' });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true }, modelId: 'gpt-5' });
+
+    await session.message({ content: 'do it' });
+    const result = await session.respondToToolApproval({ approved: true, reason: 'ok' });
+
+    expect(result.text).toBe('approved');
+    expect(agent.resumeCalls).toHaveLength(1);
+    expect(agent.resumeCalls[0]!.resumeData).toEqual({ approved: true, reason: 'ok' });
+    expect(agent.resumeCalls[0]!.options).toMatchObject({ runId: 'run-approval', toolCallId: 'tc-1', model: 'gpt-5' });
+    expect(session.getRecord().pendingResume).toBeUndefined();
+  });
+
+  it('classifies questions and forwards answer resume data', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-question',
+      suspendPayload: {
+        toolCallId: 'tc-question',
+        toolName: 'ask_user',
+        args: {
+          question: 'pick one',
+          options: [{ label: 'red' }, { label: 'blue' }],
+          selectionMode: 'single_select',
+        },
+      },
+    });
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-question', text: 'answered' });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    await session.message({ content: 'ask' });
+    expect(session.getRecord().pendingResume).toMatchObject({
+      kind: 'question',
+      payload: {
+        question: 'pick one',
+        options: [{ label: 'red' }, { label: 'blue' }],
+        selectionMode: 'single_select',
+      },
+    });
+
+    await session.respondToQuestion({ answer: 'red' });
+    expect(agent.resumeCalls[0]!.resumeData).toEqual({ answer: 'red' });
+  });
+
+  it('applies plan approval mode transitions', async () => {
+    const { harness, agent } = setup([
+      { id: 'planner', agentId: 'default', transitionsTo: 'builder' },
+      { id: 'builder', agentId: 'default' },
+    ]);
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-plan',
+      suspendPayload: {
+        toolCallId: 'tc-plan',
+        toolName: 'submit_plan',
+        args: { title: 'Plan', plan: 'do it' },
+      },
+    });
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-plan', text: 'approved' });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    await session.message({ content: 'plan' });
+    expect(session.getRecord().pendingResume).toMatchObject({
+      kind: 'plan-approval',
+      transitionModeId: 'builder',
+      payload: { title: 'Plan', plan: 'do it' },
+    });
+
+    await session.respondToPlanApproval({ approved: true });
+    expect(session.getCurrentMode().id).toBe('builder');
+  });
+
+  it('rejects wrong-kind responses', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-approval',
+      suspendPayload: { toolCallId: 'tc-1', toolName: 'shell' },
+    });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    await session.message({ content: 'do it' });
+
+    await expect(session.respondToQuestion({ answer: 'nope' })).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+
+  it('parks queued work on suspension and resolves the queue promise after resume', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-queued',
+      suspendPayload: { toolCallId: 'tc-queue', toolName: 'shell' },
+    });
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-queued', text: 'queued done' });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    const queued = session.queue({ content: 'queued work' });
+    await waitFor(() => session.getRecord().pendingResume !== undefined, 'queued suspension');
+
+    expect(session.getQueueDepth()).toBe(1);
+    expect(session.getRecord().pendingResume).toMatchObject({
+      kind: 'tool-approval',
+      queuedItemId: expect.any(String),
+    });
+
+    await session.respondToToolApproval({ approved: true });
+    await expect(queued).resolves.toMatchObject({ text: 'queued done' });
+    expect(session.getQueueDepth()).toBe(0);
+  });
+});
+
+function buildOutput(run: FakeRun): MastraModelOutput {
+  const fullOutput = {
+    text: run.text ?? '',
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    finishReason: run.finishReason,
+    object: undefined,
+    steps: [],
+    warnings: [],
+    providerMetadata: undefined,
+    request: {},
+    reasoning: [],
+    reasoningText: undefined,
+    toolCalls: [],
+    toolResults: [],
+    sources: [],
+    files: [],
+    response: { id: 'response-1', timestamp: new Date(), modelId: 'fake', messages: [], uiMessages: [] },
+    totalUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    error: undefined,
+    tripwire: undefined,
+    traceId: undefined,
+    spanId: undefined,
+    runId: run.runId ?? 'fake-run',
+    suspendPayload: run.suspendPayload,
+    messages: [],
+    rememberedMessages: [],
+  };
+  const fullStream = (async function* () {})();
+  return {
+    runId: fullOutput.runId,
+    getFullOutput: async () => fullOutput,
+    fullStream,
+    text: Promise.resolve(fullOutput.text),
+    finishReason: Promise.resolve(fullOutput.finishReason),
+    usage: Promise.resolve(fullOutput.usage),
+    _waitUntilFinished: () => Promise.resolve(),
+  } as unknown as MastraModelOutput;
+}
+
+async function waitFor(predicate: () => boolean, label: string, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
+    await new Promise(resolve => setImmediate(resolve));
+  }
+}

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -8,6 +8,7 @@ import { RequestContext } from '../../request-context';
 import type {
   HarnessStorage,
   OperationAdmissionTombstone,
+  PendingResume,
   PermissionRules,
   PersistedAttachment,
   QueueAdmissionReceipt,
@@ -80,6 +81,8 @@ const QUEUE_DUPLICATE_WAIT_TIMEOUT_MS = 30_000;
 const QUEUE_DUPLICATE_WAIT_INTERVAL_MS = 100;
 const TOOL_CATEGORIES: readonly ToolCategory[] = ['read', 'edit', 'execute', 'mcp', 'other'];
 const PERMISSION_POLICIES: readonly PermissionPolicy[] = ['allow', 'ask', 'deny'];
+const ASK_USER_TOOL_NAME = 'ask_user';
+const SUBMIT_PLAN_TOOL_NAME = 'submit_plan';
 
 export class Session {
   private readonly harness: Harness;
@@ -432,6 +435,41 @@ export class Session {
       this.endTurn(turnAbortController);
       throw err;
     }
+  }
+
+  async respondToToolApproval(opts: { approved: boolean; reason?: string; toolCallId?: string }): Promise<AgentResult> {
+    return this.resumePending('tool-approval', compactJsonObject({ approved: opts.approved, reason: opts.reason }), {
+      toolCallId: opts.toolCallId,
+    });
+  }
+
+  async respondToToolSuspension(opts: { resumeData: unknown; toolCallId?: string }): Promise<AgentResult> {
+    return this.resumePending('tool-suspension', opts.resumeData, { toolCallId: opts.toolCallId });
+  }
+
+  async respondToQuestion(opts: { answer: unknown; toolCallId?: string }): Promise<AgentResult> {
+    return this.resumePending('question', { answer: opts.answer }, { toolCallId: opts.toolCallId });
+  }
+
+  async respondToPlanApproval(opts: {
+    approved: boolean;
+    revision?: string;
+    transitionToMode?: string;
+    toolCallId?: string;
+  }): Promise<AgentResult> {
+    if (opts.transitionToMode !== undefined) this.harness._getMode(opts.transitionToMode);
+    return this.resumePending(
+      'plan-approval',
+      compactJsonObject({
+        approved: opts.approved,
+        revision: opts.revision,
+        transitionToMode: opts.transitionToMode,
+      }),
+      {
+        toolCallId: opts.toolCallId,
+        transitionToMode: opts.approved ? opts.transitionToMode : undefined,
+      },
+    );
   }
 
   async queue(opts: QueueOptions): Promise<AgentResult> {
@@ -1078,6 +1116,46 @@ export class Session {
         totalTokens: prev.tokenUsage.totalTokens + usage.totalTokens,
       },
     }));
+    await this.maybeCaptureSuspend(full);
+  }
+
+  private async maybeCaptureSuspend(full: FullOutput<unknown>): Promise<void> {
+    if (full.finishReason !== 'suspended') return;
+    const payload = full.suspendPayload as
+      | { toolCallId?: unknown; toolName?: unknown; args?: unknown; suspendPayload?: unknown }
+      | undefined;
+    if (!payload || typeof payload.toolCallId !== 'string' || typeof payload.toolName !== 'string' || !full.runId) {
+      return;
+    }
+    const suspendPayload = {
+      toolCallId: payload.toolCallId,
+      toolName: payload.toolName,
+      args: payload.args,
+      suspendPayload: payload.suspendPayload,
+    };
+    const kind = classifyResumeKind(suspendPayload);
+    const pending: PendingResume = {
+      kind,
+      runId: full.runId,
+      toolCallId: suspendPayload.toolCallId,
+      toolName: suspendPayload.toolName,
+      source: (this.record.subagentDepth ?? 0) > 0 ? 'subagent' : 'parent',
+      requestedAt: Date.now(),
+      ...(this.currentQueuedItemId !== undefined ? { queuedItemId: this.currentQueuedItemId } : {}),
+      payload: buildResumePayload(kind, suspendPayload),
+    };
+    if (kind === 'plan-approval') {
+      const transitionModeId = this.getCurrentMode().transitionsTo;
+      if (transitionModeId) pending.transitionModeId = transitionModeId;
+    }
+    await this.flushUpdate(prev => ({ ...prev, pendingResume: pending }));
+    this.emitTurnEvent({
+      type: 'suspension_required',
+      kind,
+      toolCallId: pending.toolCallId,
+      toolName: pending.toolName,
+      runId: pending.runId,
+    });
   }
 
   private async admitQueueInternal(
@@ -1276,6 +1354,16 @@ export class Session {
             ...(item.model !== undefined ? { model: item.model } : {}),
             attachments: item.attachments.map(queuedAttachmentToRef),
           })) as AgentResult;
+          if (result.finishReason === 'suspended') {
+            await this.updateQueueAdmissionReceipt(item.id, (receipt, now) => ({
+              ...receipt,
+              status: 'accepted',
+              runId: result.runId,
+              acceptedAt: receipt.acceptedAt ?? now,
+              updatedAt: now,
+            }));
+            break;
+          }
           await this.completeQueuedItem(item, result);
         } catch (err) {
           await this.failQueuedItem(item, err);
@@ -1395,6 +1483,105 @@ export class Session {
     }
     return persisted;
   }
+
+  private async resumePending(
+    expectedKind: PendingResume['kind'],
+    resumeData: unknown,
+    opts: { toolCallId?: string; transitionToMode?: string },
+  ): Promise<AgentResult> {
+    this.assertLive(`respondTo(${expectedKind})`);
+    this.assertCanStartTurn(`respondTo(${expectedKind})`);
+    const pending = this.record.pendingResume;
+    if (!pending) {
+      throw new HarnessValidationError(`respondTo(${expectedKind})`, 'no pending suspension exists');
+    }
+    if (pending.kind !== expectedKind) {
+      throw new HarnessValidationError(
+        `respondTo(${expectedKind})`,
+        `pending suspension is "${pending.kind}", not "${expectedKind}"`,
+      );
+    }
+    if (opts.toolCallId !== undefined && opts.toolCallId !== pending.toolCallId) {
+      throw new HarnessValidationError(`respondTo(${expectedKind}).toolCallId`, 'does not match pending suspension');
+    }
+    if (pending.resumedAt !== undefined) {
+      throw new HarnessValidationError(`respondTo(${expectedKind})`, 'pending suspension has already been resumed');
+    }
+
+    const resumedAt = Date.now();
+    await this.flushUpdate(prev => {
+      if (!prev.pendingResume || prev.pendingResume.toolCallId !== pending.toolCallId) return prev;
+      return { ...prev, pendingResume: { ...prev.pendingResume, resumedAt } };
+    });
+
+    const mode = this.harness._getMode(this.record.modeId);
+    const agent = this.harness.getAgentForMode(this.record.modeId);
+    const resumeStream = (agent as { resumeStream?: (resumeData: unknown, opts?: unknown) => Promise<unknown> })
+      .resumeStream;
+    if (!resumeStream) {
+      throw new HarnessConfigError('respondTo()', 'current agent does not support resumeStream');
+    }
+    const turnAbortController = this.beginTurn(undefined);
+    this.currentQueuedItemId = pending.queuedItemId;
+
+    try {
+      this.emitTurnEvent({ type: 'agent_start' });
+      const output = (await resumeStream.call(agent, resumeData, {
+        runId: pending.runId,
+        toolCallId: pending.toolCallId,
+        ...this.buildExecutionOptions({
+          mode,
+          modeId: this.record.modeId,
+          modelId: this.record.modelId,
+          abortSignal: turnAbortController.signal,
+        }),
+      })) as MastraModelOutput<unknown>;
+      this.currentRunId = output.runId;
+      const streamDrain = this.consumeAgentStream(output);
+      void streamDrain.catch(() => undefined);
+      const full = (await output.getFullOutput()) as FullOutput<unknown>;
+      await streamDrain;
+      await this.recordTurnCompletion(full);
+      if (full.finishReason !== 'suspended') {
+        const queuedItemId = pending.queuedItemId;
+        if (opts.transitionToMode ?? pending.transitionModeId) {
+          const transitionModeId = opts.transitionToMode ?? pending.transitionModeId!;
+          await this.flushUpdate(prev => ({
+            ...prev,
+            modeId: transitionModeId,
+            pendingResume: undefined,
+          }));
+          this.emitter.emit({
+            type: 'mode_changed',
+            modeId: transitionModeId,
+            previousModeId: mode.id,
+          });
+        } else {
+          await this.flushUpdate(prev => ({ ...prev, pendingResume: undefined }));
+        }
+        this.emitTurnEvent({
+          type: 'suspension_resolved',
+          kind: pending.kind,
+          toolCallId: pending.toolCallId,
+          runId: full.runId,
+        });
+        if (queuedItemId !== undefined) {
+          const queuedItem = this.record.pendingQueue.find(item => item.id === queuedItemId);
+          if (queuedItem) await this.completeQueuedItem(queuedItem, full as AgentResult);
+        }
+      }
+      this.emitTurnEvent({ type: 'agent_end', reason: agentEndReason(full), runId: full.runId });
+      return full as AgentResult;
+    } catch (err) {
+      this.emitTurnEvent({ type: 'agent_end', reason: 'error', runId: this.currentRunId ?? pending.runId });
+      throw err;
+    } finally {
+      this.endTurn(turnAbortController);
+      if ((this.record.pendingQueue?.length ?? 0) > 0 && this.record.pendingResume === undefined) {
+        void this._kickQueueDrain();
+      }
+    }
+  }
 }
 
 function assertAgentType(method: string, value: unknown): asserts value is string {
@@ -1493,6 +1680,52 @@ function toPublicQueueError(reason: unknown): { code: string; message: string } 
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function compactJsonObject<T extends Record<string, unknown>>(value: T): Partial<T> {
+  const compacted: Partial<T> = {};
+  for (const [key, entry] of Object.entries(value) as Array<[keyof T, T[keyof T]]>) {
+    if (entry !== undefined) compacted[key] = entry;
+  }
+  return compacted;
+}
+
+function classifyResumeKind(payload: { toolName: string; suspendPayload?: unknown }): PendingResume['kind'] {
+  if (payload.toolName === ASK_USER_TOOL_NAME) return 'question';
+  if (payload.toolName === SUBMIT_PLAN_TOOL_NAME) return 'plan-approval';
+  if ('suspendPayload' in payload && payload.suspendPayload !== undefined) return 'tool-suspension';
+  return 'tool-approval';
+}
+
+function buildResumePayload(
+  kind: PendingResume['kind'],
+  payload: { args?: unknown; suspendPayload?: unknown },
+): PendingResume['payload'] {
+  switch (kind) {
+    case 'tool-approval':
+      return { input: payload.args };
+    case 'tool-suspension':
+      return { input: payload.args, suspendData: payload.suspendPayload };
+    case 'question': {
+      const args = (payload.args ?? {}) as {
+        question?: string;
+        options?: { label: string; description?: string }[];
+        selectionMode?: 'single_select' | 'multi_select';
+      };
+      return {
+        question: args.question ?? '',
+        ...(args.options !== undefined ? { options: args.options } : {}),
+        ...(args.selectionMode !== undefined ? { selectionMode: args.selectionMode } : {}),
+      };
+    }
+    case 'plan-approval': {
+      const args = (payload.args ?? {}) as { title?: string; plan?: string };
+      return {
+        title: args.title ?? '',
+        plan: args.plan ?? '',
+      };
+    }
+  }
 }
 
 function cloneJsonLike<T>(value: T): T {

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -88,6 +88,8 @@ export interface PendingResume {
   source: 'parent' | 'subagent';
   subagentToolCallId?: string;
   requestedAt: number;
+  /** Set when the suspension belongs to the head queue item. */
+  queuedItemId?: string;
   /**
    * Idempotency marker. Set by the resume helper before calling
    * `agent.resumeStream(...)` and observed on replay so a crash between


### PR DESCRIPTION
## Description

Adds the focused Harness v1 suspension slice. Suspended agent output now persists a `PendingResume`, emits suspension events, exposes the typed `respondToToolApproval`, `respondToToolSuspension`, `respondToQuestion`, and `respondToPlanApproval` methods, and parks queued work until the suspended run is resumed.

This keeps the PR scoped to the session runtime and pending pointer storage. Built-in tool definitions and durable inbox receipt APIs remain follow-up slices.

## Related issue(s)

Part of #16878.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Validation:

- `pnpm --filter ./packages/core test:unit src/harness/v1/session.suspension.test.ts`
- `pnpm --filter ./packages/core test:unit src/harness`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'`
- `pnpm build:core`
