### PR TITLE
feat(core): add Harness v1 built-in tools

### DIFF
--- a/.changeset/honest-sides-rescue.md
+++ b/.changeset/honest-sides-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 built-in tools.

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -9,6 +9,22 @@
 export { Harness } from './harness';
 export { Session } from './session';
 export {
+  ASK_USER_TOOL_ID,
+  SUBMIT_PLAN_TOOL_ID,
+  TASK_CHECK_TOOL_ID,
+  TASK_METADATA_KEY,
+  TASK_METADATA_NAMESPACE,
+  TASK_WRITE_TOOL_ID,
+  askUser,
+  askUserOptionSchema,
+  askUserSelectionModeSchema,
+  harnessBuiltInTools,
+  submitPlan,
+  taskCheck,
+  taskItemSchema,
+  taskWrite,
+} from './tools';
+export {
   EventEmitter,
   HARNESS_EVENT_ID_PREFIX,
   assertCustomEventType,
@@ -21,6 +37,7 @@ export {
 } from './events';
 export { nonDurableProvider } from './workspace-provider';
 
+export type { AskUserOption, AskUserSelectionMode, TaskItem } from './tools';
 export type {
   HarnessMessage,
   HarnessMessageContent,

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -100,7 +100,7 @@ describe('Session.message()', () => {
     expect(other.calls).toHaveLength(1);
     expect(other.calls[0]!.options.model).toBe('openai/gpt-4.1');
     expect(other.calls[0]!.options.instructions).toBe('other instructions');
-    expect(Object.keys(other.calls[0]!.options.toolsets)).toEqual(['mode:other', 'call:additional']);
+    expect(Object.keys(other.calls[0]!.options.toolsets)).toEqual(['harness:builtin', 'mode:other', 'call:additional']);
     expect(other.calls[0]!.options.requestContext.get('harness')).toMatchObject({
       sessionId: session.id,
       threadId: session.threadId,

--- a/packages/core/src/harness/v1/session.signal.test.ts
+++ b/packages/core/src/harness/v1/session.signal.test.ts
@@ -86,7 +86,7 @@ describe('Session.signal()', () => {
     });
 
     expect(other.calls).toHaveLength(1);
-    expect(Object.keys(other.calls[0]!.options.toolsets)).toEqual(['mode:other', 'call:additional']);
+    expect(Object.keys(other.calls[0]!.options.toolsets)).toEqual(['harness:builtin', 'mode:other', 'call:additional']);
     expect(other.calls[0]!.options.requestContext.get('harness')).toMatchObject({
       sessionId: session.id,
       modeId: 'other',

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -31,6 +31,7 @@ import { EventEmitter } from './events';
 import type { HarnessEvent, HarnessEventListener, HarnessEventUnsubscribe, EmitInput } from './events';
 import type { Harness } from './harness';
 import type { HarnessMessage, HarnessMode, ToolCategory } from './shared';
+import { ASK_USER_TOOL_ID, harnessBuiltInTools, SUBMIT_PLAN_TOOL_ID } from './tools';
 import type {
   AgentResult,
   AgentStream,
@@ -81,8 +82,8 @@ const QUEUE_DUPLICATE_WAIT_TIMEOUT_MS = 30_000;
 const QUEUE_DUPLICATE_WAIT_INTERVAL_MS = 100;
 const TOOL_CATEGORIES: readonly ToolCategory[] = ['read', 'edit', 'execute', 'mcp', 'other'];
 const PERMISSION_POLICIES: readonly PermissionPolicy[] = ['allow', 'ask', 'deny'];
-const ASK_USER_TOOL_NAME = 'ask_user';
-const SUBMIT_PLAN_TOOL_NAME = 'submit_plan';
+const ASK_USER_TOOL_NAME = ASK_USER_TOOL_ID;
+const SUBMIT_PLAN_TOOL_NAME = SUBMIT_PLAN_TOOL_ID;
 
 export class Session {
   private readonly harness: Harness;
@@ -935,7 +936,7 @@ export class Session {
   }
 
   private buildToolsets(mode: HarnessMode, callAdditional?: ToolsInput): Record<string, ToolsInput> | undefined {
-    const toolsets: Record<string, ToolsInput> = {};
+    const toolsets: Record<string, ToolsInput> = { 'harness:builtin': harnessBuiltInTools };
     if (mode.tools) toolsets[`mode:${mode.id}`] = mode.tools;
     if (mode.additionalTools) toolsets[`mode:${mode.id}:add`] = mode.additionalTools;
     if (callAdditional) toolsets['call:additional'] = callAdditional;

--- a/packages/core/src/harness/v1/tools.test.ts
+++ b/packages/core/src/harness/v1/tools.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Agent } from '../../agent';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import type { MastraModelOutput } from '../../stream/base/output';
+import { Harness } from './harness';
+import {
+  ASK_USER_TOOL_ID,
+  SUBMIT_PLAN_TOOL_ID,
+  TASK_CHECK_TOOL_ID,
+  TASK_WRITE_TOOL_ID,
+  askUser,
+  harnessBuiltInTools,
+  submitPlan,
+  taskCheck,
+  taskWrite,
+} from './tools';
+
+class FakeAgent extends Agent<any, any, any> {
+  calls: Array<{ messages: unknown; options: any }> = [];
+
+  constructor(id = 'default') {
+    super({ id, name: id, instructions: 'fake', model: 'openai/gpt-4o-mini' as any });
+  }
+
+  async stream(messages: unknown, options?: any): Promise<MastraModelOutput> {
+    this.calls.push({ messages, options });
+    const output = buildOutput();
+    this._internalRegisterStreamRun(output, (options ?? {}) as any);
+    return output;
+  }
+}
+
+describe('Harness v1 built-in tools', () => {
+  it('exports the built-in toolset under stable ids', () => {
+    expect(Object.keys(harnessBuiltInTools).sort()).toEqual(
+      [ASK_USER_TOOL_ID, SUBMIT_PLAN_TOOL_ID, TASK_CHECK_TOOL_ID, TASK_WRITE_TOOL_ID].sort(),
+    );
+  });
+
+  it('askUser suspends first and returns resume data after resume', async () => {
+    const suspend = vi.fn(async () => undefined);
+
+    await askUser.execute!({ question: 'pick one', options: [{ label: 'red' }], selectionMode: 'single_select' }, {
+      agent: { agentId: 'agent', toolCallId: 'tc-1', messages: [], suspend },
+    } as any);
+
+    expect(suspend).toHaveBeenCalledWith({}, undefined);
+    await expect(
+      askUser.execute!({ question: 'pick one' }, {
+        agent: { agentId: 'agent', toolCallId: 'tc-1', messages: [], suspend, resumeData: { answer: 'red' } },
+      } as any),
+    ).resolves.toEqual({ answer: 'red' });
+  });
+
+  it('submitPlan suspends with the submitted plan and returns approval resume data', async () => {
+    const suspend = vi.fn(async () => undefined);
+
+    await submitPlan.execute!({ title: 'Plan', plan: 'Do it' }, {
+      agent: { agentId: 'agent', toolCallId: 'tc-1', messages: [], suspend },
+    } as any);
+
+    expect(suspend).toHaveBeenCalledWith({ title: 'Plan', plan: 'Do it' }, undefined);
+    await expect(
+      submitPlan.execute!({ plan: 'Do it' }, {
+        agent: {
+          agentId: 'agent',
+          toolCallId: 'tc-1',
+          messages: [],
+          suspend,
+          resumeData: { approved: true, revision: 'ship it' },
+        },
+      } as any),
+    ).resolves.toEqual({ approved: true, revision: 'ship it' });
+  });
+
+  it('taskWrite emits task updates and taskCheck handles missing storage', async () => {
+    const writer = { custom: vi.fn(async () => undefined) };
+    const tasks = [{ content: 'Implement queue', status: 'completed' as const, activeForm: 'Implementing queue' }];
+
+    await expect(taskWrite.execute!({ tasks }, { writer } as any)).resolves.toMatchObject({
+      written: 1,
+      completed: 1,
+    });
+    expect(writer.custom).toHaveBeenCalledWith({ type: 'data-task-updated', data: { tasks } });
+    await expect(taskCheck.execute!({}, {} as any)).resolves.toEqual({
+      total: 0,
+      pending: 0,
+      inProgress: 0,
+      completed: 0,
+      allComplete: false,
+      tasks: [],
+    });
+  });
+
+  it('injects built-in tools into the Harness v1 session toolset', async () => {
+    const agent = new FakeAgent('default');
+    const harness = new Harness({
+      agents: { default: agent } as any,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
+    });
+    const session = await harness.session({ resourceId: 'resource-a', threadId: { fresh: true } });
+
+    await session.message({ content: 'hello' });
+
+    expect(agent.calls[0]!.options.toolsets['harness:builtin']).toMatchObject({
+      [ASK_USER_TOOL_ID]: askUser,
+      [SUBMIT_PLAN_TOOL_ID]: submitPlan,
+      [TASK_WRITE_TOOL_ID]: taskWrite,
+      [TASK_CHECK_TOOL_ID]: taskCheck,
+    });
+  });
+});
+
+function buildOutput(): MastraModelOutput {
+  const fullOutput = {
+    text: 'ok',
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    finishReason: 'stop',
+    object: undefined,
+    steps: [],
+    warnings: [],
+    providerMetadata: undefined,
+    request: {},
+    reasoning: [],
+    reasoningText: undefined,
+    toolCalls: [],
+    toolResults: [],
+    sources: [],
+    files: [],
+    response: { id: 'response-1', timestamp: new Date(), modelId: 'fake', messages: [], uiMessages: [] },
+    totalUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    error: undefined,
+    tripwire: undefined,
+    traceId: undefined,
+    spanId: undefined,
+    runId: 'fake-run',
+    suspendPayload: undefined,
+    messages: [],
+    rememberedMessages: [],
+  };
+  return {
+    runId: fullOutput.runId,
+    getFullOutput: async () => fullOutput,
+    fullStream: (async function* () {})(),
+    text: Promise.resolve(fullOutput.text),
+    finishReason: Promise.resolve(fullOutput.finishReason),
+    usage: Promise.resolve(fullOutput.usage),
+    _waitUntilFinished: () => Promise.resolve(),
+  } as unknown as MastraModelOutput;
+}

--- a/packages/core/src/harness/v1/tools.ts
+++ b/packages/core/src/harness/v1/tools.ts
@@ -1,0 +1,225 @@
+import { z } from 'zod';
+
+import { createTool } from '../../tools/tool';
+
+export const ASK_USER_TOOL_ID = 'ask_user';
+export const SUBMIT_PLAN_TOOL_ID = 'submit_plan';
+export const TASK_WRITE_TOOL_ID = 'task_write';
+export const TASK_CHECK_TOOL_ID = 'task_check';
+
+export const TASK_METADATA_NAMESPACE = 'mastra' as const;
+export const TASK_METADATA_KEY = 'tasks' as const;
+
+export const askUserOptionSchema = z.object({
+  label: z.string(),
+  description: z.string().optional(),
+});
+
+export type AskUserOption = z.infer<typeof askUserOptionSchema>;
+
+export const askUserSelectionModeSchema = z.enum(['single_select', 'multi_select']);
+export type AskUserSelectionMode = z.infer<typeof askUserSelectionModeSchema>;
+
+export const taskItemSchema = z.object({
+  content: z.string().describe('Task description in imperative form'),
+  status: z.enum(['pending', 'in_progress', 'completed']),
+  activeForm: z.string().describe('Present-continuous form shown during execution'),
+});
+
+export type TaskItem = z.infer<typeof taskItemSchema>;
+
+const askUserInputSchema = z.object({
+  question: z.string().describe('The question to ask the user. Should be clear and specific.'),
+  options: z
+    .array(askUserOptionSchema)
+    .optional()
+    .describe('Optional choices. If provided, shows a selection list. If omitted, shows a free-text input.'),
+  selectionMode: askUserSelectionModeSchema
+    .optional()
+    .describe('Controls how many options the user can select. Defaults to single_select when options are provided.'),
+});
+
+const askUserOutputSchema = z.object({
+  answer: z.unknown().describe("The user's response."),
+});
+
+export const askUser = createTool({
+  id: ASK_USER_TOOL_ID,
+  description: 'Ask the user a question and wait for their response. Use for clarification, validation, or decisions.',
+  inputSchema: askUserInputSchema,
+  outputSchema: askUserOutputSchema,
+  suspendSchema: z.object({}),
+  resumeSchema: askUserOutputSchema,
+  execute: async (_input, ctx) => {
+    const resumeData = ctx.agent?.resumeData as z.infer<typeof askUserOutputSchema> | undefined;
+    if (resumeData !== undefined) return resumeData;
+
+    if (!ctx.agent?.suspend) {
+      throw new Error(`${ASK_USER_TOOL_ID} requires an agent execution context with suspend support.`);
+    }
+
+    await ctx.agent.suspend({});
+    return { answer: undefined };
+  },
+});
+
+const submitPlanInputSchema = z.object({
+  title: z.string().optional().describe('Short title for the plan.'),
+  plan: z.string().describe('The full plan content in markdown format.'),
+});
+
+const submitPlanOutputSchema = z.object({
+  approved: z.boolean(),
+  revision: z.string().optional().describe('Free-text revision notes supplied by the reviewer.'),
+  transitionToMode: z.string().optional().describe('Mode id to switch to on approval.'),
+});
+
+export const submitPlan = createTool({
+  id: SUBMIT_PLAN_TOOL_ID,
+  description:
+    'Submit a completed implementation plan for user review. The user can approve, reject, or request revisions.',
+  inputSchema: submitPlanInputSchema,
+  outputSchema: submitPlanOutputSchema,
+  suspendSchema: submitPlanInputSchema,
+  resumeSchema: submitPlanOutputSchema,
+  execute: async (_input, ctx) => {
+    const input = _input as z.infer<typeof submitPlanInputSchema>;
+    const resumeData = ctx.agent?.resumeData as z.infer<typeof submitPlanOutputSchema> | undefined;
+    if (resumeData !== undefined) return resumeData;
+
+    if (!ctx.agent?.suspend) {
+      throw new Error(`${SUBMIT_PLAN_TOOL_ID} requires an agent execution context with suspend support.`);
+    }
+
+    await ctx.agent.suspend(input);
+    return { approved: false };
+  },
+});
+
+const taskWriteInputSchema = z.object({
+  tasks: z.array(taskItemSchema).describe('The complete updated task list.'),
+});
+
+const taskWriteOutputSchema = z.object({
+  written: z.number().int().nonnegative(),
+  pending: z.number().int().nonnegative(),
+  inProgress: z.number().int().nonnegative(),
+  completed: z.number().int().nonnegative(),
+  summary: z.string(),
+});
+
+export const taskWrite = createTool({
+  id: TASK_WRITE_TOOL_ID,
+  description: 'Create and manage a structured task list for the current conversation.',
+  inputSchema: taskWriteInputSchema,
+  outputSchema: taskWriteOutputSchema,
+  execute: async (input, ctx) => {
+    const tasks = input.tasks ?? [];
+    const counts = summarizeTasks(tasks);
+
+    await ctx.writer?.custom({ type: 'data-task-updated', data: { tasks } });
+
+    const threadId = ctx.agent?.threadId;
+    const storage = ctx.mastra?.getStorage?.();
+    if (!threadId || !storage) {
+      return {
+        ...counts,
+        summary:
+          counts.summary +
+          (threadId
+            ? ' (no memory storage configured - tasks not persisted)'
+            : ' (no thread context - tasks not persisted)'),
+      };
+    }
+
+    const memory = await storage.getStore('memory');
+    if (!memory) return { ...counts, summary: counts.summary + ' (memory store unavailable - tasks not persisted)' };
+
+    const existing = await memory.getThreadById({ threadId });
+    if (!existing) return { ...counts, summary: counts.summary + ' (thread not found - tasks not persisted)' };
+
+    const existingMetadata = (existing.metadata ?? {}) as Record<string, unknown>;
+    const existingNamespace = (existingMetadata[TASK_METADATA_NAMESPACE] ?? {}) as Record<string, unknown>;
+    await memory.updateThread({
+      id: threadId,
+      title: existing.title ?? '',
+      metadata: {
+        ...existingMetadata,
+        [TASK_METADATA_NAMESPACE]: {
+          ...existingNamespace,
+          [TASK_METADATA_KEY]: tasks,
+        },
+      },
+    });
+
+    return counts;
+  },
+});
+
+const taskCheckOutputSchema = z.object({
+  total: z.number().int().nonnegative(),
+  pending: z.number().int().nonnegative(),
+  inProgress: z.number().int().nonnegative(),
+  completed: z.number().int().nonnegative(),
+  allComplete: z.boolean(),
+  tasks: z.array(taskItemSchema),
+});
+
+export const taskCheck = createTool({
+  id: TASK_CHECK_TOOL_ID,
+  description: 'Check the completion status of the current task list. Returns counts and tasks.',
+  inputSchema: z.object({}),
+  outputSchema: taskCheckOutputSchema,
+  execute: async (_input, ctx) => {
+    const threadId = ctx.agent?.threadId;
+    const storage = ctx.mastra?.getStorage?.();
+    if (!threadId || !storage) return summarizeTaskCheck([]);
+
+    const memory = await storage.getStore('memory');
+    if (!memory) return summarizeTaskCheck([]);
+
+    const thread = await memory.getThreadById({ threadId });
+    const metadata = (thread?.metadata ?? {}) as Record<string, unknown>;
+    const namespace = (metadata[TASK_METADATA_NAMESPACE] ?? {}) as Record<string, unknown>;
+    const parsed = z.array(taskItemSchema).safeParse(namespace[TASK_METADATA_KEY]);
+    return summarizeTaskCheck(parsed.success ? parsed.data : []);
+  },
+});
+
+export const harnessBuiltInTools = {
+  [ASK_USER_TOOL_ID]: askUser,
+  [SUBMIT_PLAN_TOOL_ID]: submitPlan,
+  [TASK_WRITE_TOOL_ID]: taskWrite,
+  [TASK_CHECK_TOOL_ID]: taskCheck,
+};
+
+function summarizeTasks(tasks: TaskItem[]) {
+  const counts = countTasks(tasks);
+  return {
+    written: tasks.length,
+    ...counts,
+    summary: `${tasks.length} task(s): ${counts.pending} pending, ${counts.inProgress} in progress, ${counts.completed} completed`,
+  };
+}
+
+function summarizeTaskCheck(tasks: TaskItem[]) {
+  const counts = countTasks(tasks);
+  return {
+    total: tasks.length,
+    ...counts,
+    allComplete: tasks.length > 0 && counts.completed === tasks.length,
+    tasks,
+  };
+}
+
+function countTasks(tasks: TaskItem[]) {
+  let pending = 0;
+  let inProgress = 0;
+  let completed = 0;
+  for (const task of tasks) {
+    if (task.status === 'pending') pending += 1;
+    if (task.status === 'in_progress') inProgress += 1;
+    if (task.status === 'completed') completed += 1;
+  }
+  return { pending, inProgress, completed };
+}


### PR DESCRIPTION
## Description

Adds the Harness v1 built-in tools under `packages/core/src/harness/v1`. The v1 subpath now exports `askUser`, `submitPlan`, `taskWrite`, `taskCheck`, their stable ids, and `harnessBuiltInTools`; sessions inject them as the `harness:builtin` toolset for message, signal, queue, and resume execution.

This intentionally keeps the built-ins out of the top-level core tools export. Suspensions already classify `ask_user` and `submit_plan`, so this PR wires the tool definitions into that path without expanding the public `@mastra/core/tools` surface.

## Related issue(s)

Part of #16878.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Validation:

- `pnpm --filter ./packages/core test:unit src/harness/v1/tools.test.ts`
- `pnpm --filter ./packages/core test:unit src/harness`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'`
- `pnpm build:core`
