### PR TITLE
feat(core): add Harness v1 display state

### DIFF
--- a/.changeset/plain-geese-sniff.md
+++ b/.changeset/plain-geese-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 session display state snapshots.

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -62,6 +62,8 @@ export type { HarnessRequestContext, RegisterPlanApprovalParams, RegisterQuestio
 export type {
   AgentResult,
   AgentStream,
+  ActiveSubagentState,
+  ActiveToolState,
   AttachmentDeleteOptions,
   AttachmentRef,
   AttachmentUploadOptions,
@@ -106,6 +108,8 @@ export type {
   SessionInjectSystemReminderOptions,
   SessionInjectSystemReminderResult,
   SessionLifecycleState,
+  SessionDisplayPending,
+  SessionDisplayState,
   SessionListOptions,
   SessionLoadByIdOptions,
   SessionResolveById,

--- a/packages/core/src/harness/v1/session.display-state.test.ts
+++ b/packages/core/src/harness/v1/session.display-state.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for Session.getDisplayState() adapted from the fork's v1 display-state
+ * coverage. The v1 shape is session-scoped: identity fields, transient run
+ * fields, activity projections, cumulative token usage, pending interrupts,
+ * queue depth, and optional goal state.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { Agent } from '../../agent';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import type { MastraModelOutput } from '../../stream/base/output';
+import { Harness } from './harness';
+
+interface FakeRun {
+  text?: string;
+  runId?: string;
+  traceId?: string;
+  finishReason?: 'stop' | 'suspended';
+  chunks?: unknown[];
+  holdUntil?: Promise<void>;
+  suspendPayload?: {
+    toolCallId: string;
+    toolName: string;
+    args?: unknown;
+    suspendPayload?: unknown;
+  };
+}
+
+class FakeAgent extends Agent<any, any, any> {
+  runs: FakeRun[] = [];
+
+  constructor(id = 'default') {
+    super({ id, name: id, instructions: 'fake', model: 'openai/gpt-4o-mini' as any });
+  }
+
+  enqueueRun(run: FakeRun): void {
+    this.runs.push(run);
+  }
+
+  async stream(_messages: unknown, options?: any): Promise<MastraModelOutput> {
+    const run = this.runs.shift() ?? {};
+    const output = buildOutput({
+      ...run,
+      runId: run.runId ?? options?.runId ?? 'fake-run',
+    });
+    this._internalRegisterStreamRun(output, (options ?? {}) as any);
+    return output;
+  }
+}
+
+function setup() {
+  const agent = new FakeAgent('default');
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { default: agent } as any,
+    modes: [{ id: 'default', agentId: 'default' }],
+    defaultModeId: 'default',
+    sessions: { storage },
+  });
+  return { harness, agent };
+}
+
+describe('Session.getDisplayState()', () => {
+  it('reports the documented identity fields', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const ds = session.getDisplayState();
+
+    expect(ds.sessionId).toBe(session.id);
+    expect(ds.threadId).toBe(session.threadId);
+    expect(ds.resourceId).toBe('u');
+    expect(ds.lifecycleState).toBe('live');
+    expect(ds.modeId).toBeTypeOf('string');
+    expect(ds.modelId).toBeTypeOf('string');
+    expect(ds.createdAt).toBe(session.createdAt);
+    expect(ds.lastActivityAt).toBeTypeOf('number');
+  });
+
+  it('idle state has no run fields, empty activity maps, zero usage, and no pending work', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const ds = session.getDisplayState();
+
+    expect(ds.isRunning).toBe(false);
+    expect(ds.currentRunId).toBeUndefined();
+    expect(ds.currentMessageId).toBeUndefined();
+    expect(ds.currentTraceId).toBeUndefined();
+    expect(ds.activeTools).toEqual({});
+    expect(ds.toolInputBuffers).toEqual({});
+    expect(ds.activeSubagents).toEqual({});
+    expect(ds.tokenUsage).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+    expect(ds.pending).toBeNull();
+    expect(ds.queueDepth).toBe(0);
+    expect(ds.currentQueuedItemId).toBeUndefined();
+    expect(ds.goal).toBeUndefined();
+  });
+
+  it('flips isRunning while a turn is in flight and clears run fields after completion', async () => {
+    const { harness, agent } = setup();
+    let release!: () => void;
+    agent.enqueueRun({
+      runId: 'run-display',
+      finishReason: 'stop',
+      holdUntil: new Promise(resolve => {
+        release = resolve;
+      }),
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const inFlight = session.message({ content: 'hi' });
+    while (!session.isRunning()) await Promise.resolve();
+
+    expect(session.getDisplayState().isRunning).toBe(true);
+
+    release();
+    await inFlight;
+
+    const after = session.getDisplayState();
+    expect(after.isRunning).toBe(false);
+    expect(after.currentRunId).toBeUndefined();
+    expect(after.tokenUsage.totalTokens).toBeGreaterThanOrEqual(2);
+  });
+
+  it('accumulates token usage across multiple turns', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({ runId: 'r1', finishReason: 'stop' });
+    agent.enqueueRun({ runId: 'r2', finishReason: 'stop' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await session.message({ content: 'one' });
+    const after1 = session.getDisplayState().tokenUsage.totalTokens;
+    await session.message({ content: 'two' });
+    const after2 = session.getDisplayState().tokenUsage.totalTokens;
+
+    expect(after2).toBeGreaterThan(after1);
+  });
+
+  it('surfaces full pending payloads instead of legacy booleans', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-pending',
+      suspendPayload: {
+        toolCallId: 'tc-1',
+        toolName: 'ask_user',
+        args: { question: 'pick one', options: [{ label: 'a' }, { label: 'b' }] },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await session.message({ content: 'ask' });
+
+    const ds = session.getDisplayState();
+    expect(ds.pending).toMatchObject({
+      kind: 'question',
+      toolCallId: 'tc-1',
+      payload: {
+        question: 'pick one',
+        options: [{ label: 'a' }, { label: 'b' }],
+      },
+    });
+    expect((ds as unknown as Record<string, unknown>).hasPendingQuestion).toBeUndefined();
+  });
+
+  it('returns fresh activity collections and token usage on each call', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const a = session.getDisplayState();
+    const b = session.getDisplayState();
+
+    expect(a.activeTools).not.toBe(b.activeTools);
+    expect(a.toolInputBuffers).not.toBe(b.toolInputBuffers);
+    expect(a.activeSubagents).not.toBe(b.activeSubagents);
+    expect(a.tokenUsage).not.toBe(b.tokenUsage);
+  });
+
+  it('tracks active tool calls from stream chunks', async () => {
+    const { harness, agent } = setup();
+    let release!: () => void;
+    agent.enqueueRun({
+      runId: 'run-tools',
+      finishReason: 'stop',
+      chunks: [{ type: 'tool-call', payload: { toolCallId: 'tc-1', toolName: 'shell', args: { cmd: 'pwd' } } }],
+      holdUntil: new Promise(resolve => {
+        release = resolve;
+      }),
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const inFlight = session.message({ content: 'tool' });
+    await waitFor(() => session.getDisplayState().activeTools['tc-1'] !== undefined);
+
+    expect(session.getDisplayState().activeTools['tc-1']).toMatchObject({
+      toolCallId: 'tc-1',
+      toolName: 'shell',
+      args: { cmd: 'pwd' },
+    });
+
+    release();
+    await inFlight;
+    expect(session.getDisplayState().activeTools).toEqual({});
+  });
+
+  it('omits parentSessionId for top-level sessions', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    expect(session.getDisplayState().parentSessionId).toBeUndefined();
+  });
+});
+
+async function waitFor(check: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (check()) return;
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  throw new Error('condition was not met before timeout');
+}
+
+function buildOutput(run: FakeRun): MastraModelOutput {
+  const fullOutput = {
+    text: run.text ?? 'ok',
+    usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+    finishReason: run.finishReason ?? 'stop',
+    object: undefined,
+    steps: [],
+    warnings: [],
+    providerMetadata: undefined,
+    request: {},
+    reasoning: [],
+    reasoningText: undefined,
+    toolCalls: [],
+    toolResults: [],
+    sources: [],
+    files: [],
+    response: { id: 'response-1', timestamp: new Date(), modelId: 'fake', messages: [], uiMessages: [] },
+    totalUsage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+    error: undefined,
+    tripwire: undefined,
+    traceId: run.traceId,
+    spanId: undefined,
+    runId: run.runId ?? 'fake-run',
+    suspendPayload: run.suspendPayload,
+    messages: [],
+    rememberedMessages: [],
+  };
+  let finished!: () => void;
+  const finishedPromise = new Promise<void>(resolve => {
+    finished = resolve;
+  });
+  const fullStream = (async function* () {
+    for (const chunk of run.chunks ?? []) yield chunk;
+    if (run.holdUntil) await run.holdUntil;
+    finished();
+  })();
+  return {
+    runId: fullOutput.runId,
+    getFullOutput: async () => {
+      if (run.holdUntil) await run.holdUntil;
+      return fullOutput;
+    },
+    fullStream,
+    text: Promise.resolve(fullOutput.text),
+    finishReason: Promise.resolve(fullOutput.finishReason),
+    usage: Promise.resolve(fullOutput.usage),
+    _waitUntilFinished: () => finishedPromise,
+  } as unknown as MastraModelOutput;
+}

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -35,6 +35,8 @@ import { ASK_USER_TOOL_ID, harnessBuiltInTools, SUBMIT_PLAN_TOOL_ID } from './to
 import type {
   AgentResult,
   AgentStream,
+  ActiveSubagentState,
+  ActiveToolState,
   AttachmentRef,
   ListMessagesOptions,
   MessageOptions,
@@ -48,6 +50,8 @@ import type {
   SessionInjectSystemReminderOptions,
   SessionInjectSystemReminderResult,
   SessionLifecycleState,
+  SessionDisplayPending,
+  SessionDisplayState,
   SessionSignalOptions,
   SessionSignalResult,
   TokenUsage,
@@ -85,6 +89,11 @@ const PERMISSION_POLICIES: readonly PermissionPolicy[] = ['allow', 'ask', 'deny'
 const ASK_USER_TOOL_NAME = ASK_USER_TOOL_ID;
 const SUBMIT_PLAN_TOOL_NAME = SUBMIT_PLAN_TOOL_ID;
 
+function pendingResumeForDisplay(pending: SessionRecord['pendingResume']): SessionDisplayPending | null {
+  if (!pending) return null;
+  return cloneJsonLike(pending) as SessionDisplayPending;
+}
+
 export class Session {
   private readonly harness: Harness;
   private readonly storage: HarnessStorage;
@@ -101,7 +110,9 @@ export class Session {
   private currentTraceId?: string;
   private draining = false;
   private readonly idleWaiters = new Set<IdleWaiter>();
-  private readonly activeToolNames = new Map<string, string>();
+  private readonly activeTools = new Map<string, ActiveToolState>();
+  private readonly toolInputBuffers = new Map<string, { toolName: string; text: string }>();
+  private readonly activeSubagents = new Map<string, ActiveSubagentState>();
   private readonly queueWaiters = new Map<string, QueueWaiter>();
 
   constructor(opts: SessionConstructorOptions) {
@@ -168,6 +179,33 @@ export class Session {
 
   subscribe(listener: HarnessEventListener): HarnessEventUnsubscribe {
     return this.emitter.subscribe(listener);
+  }
+
+  getDisplayState(): SessionDisplayState {
+    this.assertLive('getDisplayState()');
+    const snapshot: SessionDisplayState = {
+      sessionId: this.id,
+      threadId: this.threadId,
+      resourceId: this.resourceId,
+      lifecycleState: this.lifecycle,
+      modeId: this.record.modeId,
+      modelId: this.record.modelId,
+      createdAt: this.createdAt,
+      lastActivityAt: this.record.lastActivityAt,
+      isRunning: this.isRunning(),
+      activeTools: Object.fromEntries(this.activeTools.entries()),
+      toolInputBuffers: Object.fromEntries(this.toolInputBuffers.entries()),
+      activeSubagents: Object.fromEntries(this.activeSubagents.entries()),
+      tokenUsage: { ...this.record.tokenUsage },
+      pending: pendingResumeForDisplay(this.record.pendingResume),
+      queueDepth: this.record.pendingQueue.length,
+    };
+    if (this.parentSessionId !== undefined) snapshot.parentSessionId = this.parentSessionId;
+    if (this.isRunning() && this.currentRunId !== undefined) snapshot.currentRunId = this.currentRunId;
+    if (this.isRunning() && this.currentTraceId !== undefined) snapshot.currentTraceId = this.currentTraceId;
+    if (this.currentQueuedItemId !== undefined) snapshot.currentQueuedItemId = this.currentQueuedItemId;
+    if (this.record.goal !== undefined) snapshot.goal = cloneJsonLike(this.record.goal);
+    return snapshot;
   }
 
   async close(): Promise<void> {
@@ -869,7 +907,8 @@ export class Session {
     this.currentTurnAbortController = controller;
     this.currentRunId = undefined;
     this.currentTraceId = undefined;
-    this.activeToolNames.clear();
+    this.activeTools.clear();
+    this.toolInputBuffers.clear();
 
     if (callerSignal) {
       if (callerSignal.aborted) {
@@ -890,7 +929,8 @@ export class Session {
     if (this.currentTurnAbortController === controller) {
       this.currentTurnAbortController = undefined;
       this.currentQueuedItemId = undefined;
-      this.activeToolNames.clear();
+      this.activeTools.clear();
+      this.toolInputBuffers.clear();
       this.notifyMaybeIdle();
       if ((this.record.pendingQueue?.length ?? 0) > 0) {
         void this._kickQueueDrain();
@@ -1044,7 +1084,7 @@ export class Session {
         const toolCallId = stringField(payload, 'toolCallId');
         const toolName = stringField(payload, 'toolName');
         if (toolCallId && toolName) {
-          this.activeToolNames.set(toolCallId, toolName);
+          this.activeTools.set(toolCallId, { toolCallId, toolName, args: payload.args, startedAt: Date.now() });
           this.emitTurnEvent({ type: 'tool_start', toolCallId, toolName, args: payload.args });
         }
         break;
@@ -1054,6 +1094,8 @@ export class Session {
         const toolCallId = stringField(payload, 'toolCallId');
         if (toolCallId) {
           const isError = record.type === 'tool-error';
+          this.activeTools.delete(toolCallId);
+          this.toolInputBuffers.delete(toolCallId);
           this.emitTurnEvent({
             type: 'tool_end',
             toolCallId,
@@ -1104,7 +1146,9 @@ export class Session {
   }
 
   private async recordTurnCompletion(full: FullOutput<unknown>): Promise<void> {
-    if (full.runId) this.currentRunId = full.runId;
+    if (full.runId) {
+      this.currentRunId = full.runId;
+    }
     if (typeof (full as { traceId?: unknown }).traceId === 'string') {
       this.currentTraceId = (full as { traceId: string }).traceId;
     }

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -12,8 +12,7 @@ import type {
   HarnessPrimitiveType,
   JsonValue,
   PendingResume,
-  PermissionRules,
-  SessionGrants,
+  TokenUsage,
 } from '../../storage/domains/harness';
 import type { MastraModelOutput, FullOutput } from '../../stream/base/output';
 import type { HarnessMode } from './shared';
@@ -175,23 +174,49 @@ export interface HarnessRunOperationalState {
   abortReason?: 'requested' | 'shutdown' | 'session_closed' | 'superseded';
 }
 
-export interface HarnessDisplayStateSnapshotV1<TState = unknown> {
-  version: 1;
+export interface ActiveToolState {
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+  startedAt: number;
+  subagentSessionId?: string;
+}
+
+export interface ActiveSubagentState {
+  subagentSessionId: string;
+  agentType: string;
+  task: string;
+  parentToolCallId: string;
+  startedAt: number;
+}
+
+export type SessionDisplayPending = Omit<NonNullable<PendingResume>, 'runtimeDependencies'>;
+
+export interface SessionDisplayState {
   sessionId: string;
-  resourceId: string;
   threadId: string;
+  resourceId: string;
+  parentSessionId?: string;
+  lifecycleState: SessionLifecycleState;
   modeId: string;
   modelId: string;
-  state: TState;
-  lifecycleState: SessionLifecycleState;
-  operationalState: HarnessRunOperationalState;
-  pendingResume?: PendingResume | null;
-  pendingQueueDepth: number;
-  goal?: GoalState | null;
-  grants?: SessionGrants;
-  permissionRules?: PermissionRules;
-  updatedAt: number;
+  createdAt: number;
+  lastActivityAt: number;
+  isRunning: boolean;
+  currentRunId?: string;
+  currentMessageId?: string;
+  currentTraceId?: string;
+  activeTools: Record<string, ActiveToolState>;
+  toolInputBuffers: Record<string, { toolName: string; text: string }>;
+  activeSubagents: Record<string, ActiveSubagentState>;
+  tokenUsage: TokenUsage;
+  pending: SessionDisplayPending | null;
+  queueDepth: number;
+  currentQueuedItemId?: string;
+  goal?: GoalState;
 }
+
+export type HarnessDisplayStateSnapshotV1 = SessionDisplayState;
 
 export interface ListPage<T> {
   items: T[];


### PR DESCRIPTION
## Description

Adds the Harness v1 `Session.getDisplayState()` surface from the fork, adapted to the current stacked implementation:

- returns the session-scoped `SessionDisplayState` shape with identity, lifecycle, mode/model, transient run state, activity projections, token usage, pending interrupt payload, queue depth, and goal state
- tracks active tool calls from stream chunks for display-state consumers
- exports the new display-state types from `@mastra/core/harness/v1`
- adds focused display-state unit coverage adapted from the fork

Validation run:

- `pnpm --filter ./packages/core test:unit src/harness/v1/session.display-state.test.ts`
- `pnpm --filter ./packages/core test:unit src/harness`
- `pnpm --filter ./packages/core lint`
- `pnpm --filter ./packages/core check`
- `pnpm prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'`
- `pnpm build:core`

## Related issue(s)

Part of #16878.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR
