### PR TITLE
feat(core): add Harness v1 goals

### DIFF
--- a/.changeset/tangy-pillows-jam.md
+++ b/.changeset/tangy-pillows-jam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 session goal lifecycle APIs.

--- a/packages/core/src/harness/v1/session.goal.test.ts
+++ b/packages/core/src/harness/v1/session.goal.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Harness v1 Session goals, adapted from the fork's goal lifecycle coverage.
+ *
+ * This slice covers durable goal state and goal-owned queue continuations.
+ * The judge loop is intentionally left for a later stacked PR.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { Agent } from '../../agent';
+import type { GoalState } from '../../storage/domains/harness';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { HarnessValidationError } from './errors';
+import type { HarnessEvent } from './events';
+import { Harness } from './harness';
+import type { Session } from './session';
+
+class FakeAgent extends Agent<any, any, any> {
+  constructor(id = 'default') {
+    super({ id, name: id, instructions: 'fake', model: 'openai/gpt-4o-mini' as any });
+  }
+}
+
+function setup(opts?: { goals?: { defaultJudgeModel?: string; defaultMaxTurns?: number } }) {
+  const agent = new FakeAgent('default');
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { default: agent } as any,
+    modes: [{ id: 'default', agentId: 'default' }],
+    defaultModeId: 'default',
+    sessions: { storage },
+    ...(opts?.goals ? { goals: opts.goals } : {}),
+  });
+  return { harness, agent, storage };
+}
+
+function record(session: Session, types?: HarnessEvent['type'][]): HarnessEvent[] {
+  const events: HarnessEvent[] = [];
+  session.subscribe(event => {
+    if (!types || types.includes(event.type)) events.push(event);
+  });
+  return events;
+}
+
+describe('Session.setGoal()', () => {
+  it('persists a goal, emits goal_set, and returns the active state', async () => {
+    const { harness, storage } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const events = record(session, ['goal_set', 'goal_cleared']);
+
+    const goal = await session.setGoal({ objective: 'ship the thing', kickoff: false });
+
+    expect(goal.objective).toBe('ship the thing');
+    expect(goal.status).toBe('active');
+    expect(goal.turnsUsed).toBe(0);
+    expect(goal.maxTurns).toBe(50);
+    expect(goal.judgeModelId).toBe('judge:test');
+    expect(session.getGoal()?.id).toBe(goal.id);
+    expect(session.getRecord().goal?.id).toBe(goal.id);
+    await expect(storage.loadSession({ sessionId: session.id })).resolves.toMatchObject({
+      goal: { id: goal.id, objective: 'ship the thing' },
+    });
+    expect(events.map(event => event.type)).toEqual(['goal_set']);
+  });
+
+  it('emits goal_cleared for the prior goal before goal_set when replaced', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const first = await session.setGoal({ objective: 'first goal', kickoff: false });
+    const events = record(session, ['goal_set', 'goal_cleared']);
+    const second = await session.setGoal({ objective: 'second goal', kickoff: false });
+
+    expect(events.map(event => event.type)).toEqual(['goal_cleared', 'goal_set']);
+    expect((events[0] as { goalId: string }).goalId).toBe(first.id);
+    expect((events[1] as { goal: GoalState }).goal.id).toBe(second.id);
+  });
+
+  it('rejects when no judge model is provided and none is configured', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await expect(session.setGoal({ objective: 'go' })).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+
+  it('rejects empty objectives and non-positive maxTurns', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await expect(session.setGoal({ objective: '' })).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(session.setGoal({ objective: 'go', maxTurns: 0 })).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(session.setGoal({ objective: 'go', maxTurns: -2 })).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+});
+
+describe('Session goal lifecycle', () => {
+  it('pauseGoal flips status to paused and emits goal_paused(reason: requested)', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.setGoal({ objective: 'go', kickoff: false });
+    const events = record(session, ['goal_paused']);
+
+    const paused = await session.pauseGoal();
+
+    expect(paused?.status).toBe('paused');
+    expect(events).toHaveLength(1);
+    expect((events[0] as { reason: string }).reason).toBe('requested');
+  });
+
+  it('resumeGoal flips status back to active, emits goal_resumed, and queues a continuation', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.setGoal({ objective: 'ship the thing', kickoff: false });
+    await session.pauseGoal();
+    const events = record(session, ['goal_resumed']);
+
+    const resumed = await session.resumeGoal();
+
+    expect(resumed?.status).toBe('active');
+    expect(events).toHaveLength(1);
+    expect(session.getRecord().pendingQueue).toHaveLength(1);
+    expect(session.getRecord().pendingQueue[0]).toMatchObject({
+      content: 'Continue working toward the goal: ship the thing',
+      source: 'goal',
+      goalId: resumed?.id,
+    });
+  });
+
+  it('clearGoal removes the goal and emits goal_cleared', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const goal = await session.setGoal({ objective: 'go', kickoff: false });
+    const events = record(session, ['goal_cleared']);
+
+    await session.clearGoal();
+
+    expect(session.getGoal()).toBeUndefined();
+    expect(session.getRecord().goal).toBeUndefined();
+    expect(events).toHaveLength(1);
+    expect((events[0] as { goalId: string }).goalId).toBe(goal.id);
+  });
+
+  it('throws when setGoal is called on a subagent session', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const parent = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const child = await harness.session({
+      resourceId: 'u',
+      threadId: { fresh: true },
+      parentSessionId: parent.id,
+      origin: 'subagent-tool',
+    });
+
+    await expect(child.setGoal({ objective: 'sub' })).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+});
+
+describe('Session goal continuation wording', () => {
+  it('setGoal kickoff wraps the objective in <system-reminder type="goal">', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await session.setGoal({ objective: 'ship the thing' });
+
+    const queued = session.getRecord().pendingQueue;
+    expect(queued).toHaveLength(1);
+    expect(queued[0]).toMatchObject({
+      content: '<system-reminder type="goal">ship the thing</system-reminder>',
+      source: 'goal',
+      goalId: session.getGoal()?.id,
+    });
+  });
+
+  it('setGoal kickoff escapes XML special characters in the objective', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await session.setGoal({ objective: 'fix <bug> & ship it' });
+
+    expect(session.getRecord().pendingQueue[0]!.content).toBe(
+      '<system-reminder type="goal">fix &lt;bug&gt; &amp; ship it</system-reminder>',
+    );
+  });
+});
+
+describe('Session.updateJudgeDefaults()', () => {
+  it('updates judge model on the in-flight goal without resetting turnsUsed', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const goal = await session.setGoal({ objective: 'go', kickoff: false });
+    (session as unknown as { record: { goal?: GoalState } }).record.goal = { ...goal, turnsUsed: 3 };
+
+    const updated = await session.updateJudgeDefaults({ judgeModelId: 'judge:new' });
+
+    expect(updated?.judgeModelId).toBe('judge:new');
+    expect(updated?.turnsUsed).toBe(3);
+    expect(session.getRecord().goal?.judgeModelId).toBe('judge:new');
+  });
+
+  it('updates maxTurns without changing other fields', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.setGoal({ objective: 'go', maxTurns: 10, kickoff: false });
+
+    const updated = await session.updateJudgeDefaults({ maxTurns: 25 });
+
+    expect(updated?.maxTurns).toBe(25);
+    expect(updated?.objective).toBe('go');
+  });
+
+  it('rejects non-positive maxTurns', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.setGoal({ objective: 'go', kickoff: false });
+
+    await expect(session.updateJudgeDefaults({ maxTurns: 0 })).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(session.updateJudgeDefaults({ maxTurns: -5 })).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+
+  it('returns undefined when no goal is set', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const result = await session.updateJudgeDefaults({ judgeModelId: 'judge:other' });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('does not emit goal_paused or goal_resumed', async () => {
+    const { harness } = setup({ goals: { defaultJudgeModel: 'judge:test' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.setGoal({ objective: 'go', kickoff: false });
+    const events = record(session);
+    events.length = 0;
+
+    await session.updateJudgeDefaults({ judgeModelId: 'judge:new', maxTurns: 99 });
+
+    expect(events.find(event => event.type === 'goal_paused' || event.type === 'goal_resumed')).toBeUndefined();
+  });
+});

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -38,6 +38,8 @@ import type {
   ActiveSubagentState,
   ActiveToolState,
   AttachmentRef,
+  GoalOptions,
+  GoalState,
   ListMessagesOptions,
   MessageOptions,
   MessageOptionsDefault,
@@ -88,6 +90,18 @@ const TOOL_CATEGORIES: readonly ToolCategory[] = ['read', 'edit', 'execute', 'mc
 const PERMISSION_POLICIES: readonly PermissionPolicy[] = ['allow', 'ask', 'deny'];
 const ASK_USER_TOOL_NAME = ASK_USER_TOOL_ID;
 const SUBMIT_PLAN_TOOL_NAME = SUBMIT_PLAN_TOOL_ID;
+
+function escapeGoalXml(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function buildKickoffContinuation(objective: string): string {
+  return `<system-reminder type="goal">${escapeGoalXml(objective)}</system-reminder>`;
+}
+
+function buildResumeContinuation(objective: string): string {
+  return `Continue working toward the goal: ${objective}`;
+}
 
 function pendingResumeForDisplay(pending: SessionRecord['pendingResume']): SessionDisplayPending | null {
   if (!pending) return null;
@@ -509,6 +523,107 @@ export class Session {
         transitionToMode: opts.approved ? opts.transitionToMode : undefined,
       },
     );
+  }
+
+  async setGoal(opts: GoalOptions): Promise<GoalState> {
+    this.assertLive('setGoal()');
+    if (this.parentSessionId !== undefined || this.record.origin === 'subagent-tool') {
+      throw new HarnessValidationError('setGoal', 'goals cannot be set on subagent sessions (parent owns the loop)');
+    }
+    if (typeof opts.objective !== 'string' || opts.objective.length === 0) {
+      throw new HarnessValidationError('setGoal.objective', 'must be a non-empty string');
+    }
+    if (opts.maxTurns !== undefined && (!Number.isInteger(opts.maxTurns) || opts.maxTurns < 1)) {
+      throw new HarnessValidationError('setGoal.maxTurns', 'must be a positive integer');
+    }
+
+    const defaults = this.harness._internalGoalDefaults;
+    const judgeModelId = opts.judgeModel ?? defaults.defaultJudgeModel;
+    if (typeof judgeModelId !== 'string' || judgeModelId.length === 0) {
+      throw new HarnessValidationError(
+        'setGoal.judgeModel',
+        'no judge model provided and `goals.defaultJudgeModel` is not configured',
+      );
+    }
+
+    const priorId = this.record.goal?.id;
+    const goal: GoalState = {
+      id: `goal-${randomUUID()}`,
+      objective: opts.objective,
+      status: 'active',
+      turnsUsed: 0,
+      maxTurns: opts.maxTurns ?? defaults.defaultMaxTurns,
+      judgeModelId,
+      createdAt: Date.now(),
+    };
+
+    await this.flushUpdate(prev => ({ ...prev, goal }));
+    if (priorId !== undefined) {
+      this._emit({ type: 'goal_cleared', goalId: priorId });
+    }
+    this._emit({ type: 'goal_set', goal });
+
+    if (opts.kickoff !== false) {
+      await this.enqueueGoalContinuation(goal, buildKickoffContinuation(opts.objective));
+    }
+
+    return goal;
+  }
+
+  getGoal(): GoalState | undefined {
+    this.assertLive('getGoal()');
+    return this.record.goal;
+  }
+
+  async pauseGoal(): Promise<GoalState | undefined> {
+    this.assertLive('pauseGoal()');
+    const goal = this.record.goal;
+    if (!goal || goal.status === 'paused') return goal;
+    const updated: GoalState = { ...goal, status: 'paused' };
+    await this.flushUpdate(prev => ({ ...prev, goal: updated }));
+    this._emit({ type: 'goal_paused', goalId: goal.id, reason: 'requested' });
+    return updated;
+  }
+
+  async resumeGoal(): Promise<GoalState | undefined> {
+    this.assertLive('resumeGoal()');
+    const goal = this.record.goal;
+    if (!goal) return undefined;
+    if (goal.status === 'active') return goal;
+    const updated: GoalState = { ...goal, status: 'active' };
+    await this.flushUpdate(prev => ({ ...prev, goal: updated }));
+    this._emit({ type: 'goal_resumed', goalId: goal.id });
+    await this.enqueueGoalContinuation(updated, buildResumeContinuation(updated.objective));
+    return updated;
+  }
+
+  async clearGoal(): Promise<void> {
+    this.assertLive('clearGoal()');
+    const goal = this.record.goal;
+    if (!goal) return;
+    await this.flushUpdate(prev => {
+      const next = { ...prev };
+      delete next.goal;
+      return next;
+    });
+    this._emit({ type: 'goal_cleared', goalId: goal.id });
+  }
+
+  async updateJudgeDefaults(opts: { judgeModelId?: string; maxTurns?: number }): Promise<GoalState | undefined> {
+    this.assertLive('updateJudgeDefaults()');
+    const goal = this.record.goal;
+    if (!goal) return undefined;
+    if (opts.judgeModelId === undefined && opts.maxTurns === undefined) return goal;
+    if (opts.maxTurns !== undefined && (!Number.isFinite(opts.maxTurns) || opts.maxTurns <= 0)) {
+      throw new HarnessValidationError('maxTurns', 'maxTurns must be a positive number');
+    }
+    const updated: GoalState = {
+      ...goal,
+      ...(opts.judgeModelId !== undefined ? { judgeModelId: opts.judgeModelId } : {}),
+      ...(opts.maxTurns !== undefined ? { maxTurns: opts.maxTurns } : {}),
+    };
+    await this.flushUpdate(prev => ({ ...prev, goal: updated }));
+    return updated;
   }
 
   async queue(opts: QueueOptions): Promise<AgentResult> {
@@ -1201,6 +1316,55 @@ export class Session {
       toolName: pending.toolName,
       runId: pending.runId,
     });
+  }
+
+  private async enqueueGoalContinuation(goal: GoalState, content: string): Promise<void> {
+    if ((this.record.pendingQueue?.length ?? 0) >= this.harness._internalMaxQueueDepth) {
+      return;
+    }
+    const now = Date.now();
+    const admissionId = `goal-${goal.id}-${now}`;
+    const admissionHash = computeQueueAdmissionHash({
+      content,
+      mode: this.record.modeId,
+      model: this.record.modelId,
+      source: 'goal',
+      goalId: goal.id,
+    });
+    const queuedItem: QueuedItem = {
+      id: `q-${randomUUID()}`,
+      admissionId,
+      admissionHash,
+      enqueuedAt: now,
+      content,
+      attachments: [],
+      mode: this.record.modeId,
+      source: 'goal',
+      goalId: goal.id,
+    };
+    const receipt: QueueAdmissionReceipt = {
+      admissionId,
+      admissionHash,
+      queuedItemId: queuedItem.id,
+      modeId: this.record.modeId,
+      runtimeDependencies: {
+        modeId: this.record.modeId,
+        modelId: this.record.modelId,
+      },
+      status: 'queued',
+      attempts: 0,
+      enqueuedAt: now,
+      updatedAt: now,
+    };
+
+    await this.flushUpdate(prev => ({
+      ...prev,
+      pendingQueue: [...(prev.pendingQueue ?? []), queuedItem],
+      queueAdmissionReceipts: {
+        ...(prev.queueAdmissionReceipts ?? {}),
+        [queuedItem.id]: receipt,
+      },
+    }));
   }
 
   private async admitQueueInternal(


### PR DESCRIPTION
## Description

Adds the next Harness v1 session goal slice from the fork, adapted to the current stacked implementation:

- adds `setGoal`, `getGoal`, `pauseGoal`, `resumeGoal`, `clearGoal`, and `updateJudgeDefaults`
- persists goal state on `SessionRecord.goal` and emits the existing goal lifecycle events
- enqueues goal-owned kickoff/resume continuations with fork-compatible wording and XML escaping
- adds focused unit coverage for goal lifecycle, validation, continuation wording, and persistence

The goal judge loop is intentionally left for a later stacked PR so this review stays focused.

Validation run:

- `pnpm --filter ./packages/core test:unit src/harness/v1/session.goal.test.ts`
- `pnpm --filter ./packages/core test:unit src/harness`
- `pnpm --filter ./packages/core lint`
- `pnpm --filter ./packages/core check`
- `pnpm prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'`
- `pnpm build:core`

## Related issue(s)

Part of #16878.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR
