### PR TITLE
feat(playground-ui): migrate RadioGroup to Base UI

### DIFF
--- a/.changeset/tough-dryers-visit.md
+++ b/.changeset/tough-dryers-visit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Migrated the RadioGroup component to Base UI. The public API (`RadioGroup`, `RadioGroupItem`, `value`, `onValueChange`, `disabled`) is unchanged. Also fixes the radio indicator sizing/centering — the control now stays square and the inner dot is properly centered.

--- a/.changeset/tough-dryers-visit.md
+++ b/.changeset/tough-dryers-visit.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Migrated the RadioGroup component to Base UI. The public API (`RadioGroup`, `RadioGroupItem`, `value`, `onValueChange`, `disabled`) is unchanged. Also fixes the radio indicator sizing/centering — the control now stays square and the inner dot is properly centered.
+Improved the RadioGroup component by migrating it to Base UI. The public API (`RadioGroup`, `RadioGroupItem`, `value`, `onValueChange`, `disabled`) is unchanged. Also fixes the radio indicator sizing/centering — the control now stays square and the inner dot is properly centered.

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -78,7 +78,6 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
-    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { RadioGroup, RadioGroupItem } from './radio-group';
+
+// Base UI's Radio synthesizes a PointerEvent on click, which jsdom does not
+// implement. Polyfill it with the available MouseEvent constructor.
+beforeAll(() => {
+  if (typeof window.PointerEvent === 'undefined') {
+    window.PointerEvent = window.MouseEvent as unknown as typeof PointerEvent;
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('RadioGroup', () => {
+  it('renders all radio options without throwing', () => {
+    expect(() =>
+      render(
+        <RadioGroup aria-label="Plan">
+          <RadioGroupItem value="option-1" aria-label="Option 1" />
+          <RadioGroupItem value="option-2" aria-label="Option 2" />
+        </RadioGroup>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('reflects the selected value via aria-checked', () => {
+    render(
+      <RadioGroup aria-label="Plan" defaultValue="option-2">
+        <RadioGroupItem value="option-1" aria-label="Option 1" />
+        <RadioGroupItem value="option-2" aria-label="Option 2" />
+      </RadioGroup>,
+    );
+
+    expect(screen.getByLabelText('Option 1').getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByLabelText('Option 2').getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('selects an option when clicked', () => {
+    render(
+      <RadioGroup aria-label="Plan">
+        <RadioGroupItem value="option-1" aria-label="Option 1" />
+        <RadioGroupItem value="option-2" aria-label="Option 2" />
+      </RadioGroup>,
+    );
+
+    const optionTwo = screen.getByLabelText('Option 2');
+    expect(optionTwo.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(optionTwo);
+    expect(optionTwo.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('fires onValueChange with the selected value', () => {
+    const onValueChange = vi.fn();
+    render(
+      <RadioGroup aria-label="Plan" onValueChange={onValueChange}>
+        <RadioGroupItem value="option-1" aria-label="Option 1" />
+        <RadioGroupItem value="option-2" aria-label="Option 2" />
+      </RadioGroup>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Option 2'));
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange.mock.calls[0][0]).toBe('option-2');
+  });
+
+  it('does not select or fire onValueChange when the group is disabled', () => {
+    const onValueChange = vi.fn();
+    render(
+      <RadioGroup aria-label="Plan" disabled onValueChange={onValueChange}>
+        <RadioGroupItem value="option-1" aria-label="Option 1" />
+        <RadioGroupItem value="option-2" aria-label="Option 2" />
+      </RadioGroup>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Option 2'));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Option 2').getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('respects the controlled value prop', () => {
+    const onValueChange = vi.fn();
+    render(
+      <RadioGroup aria-label="Plan" value="option-1" onValueChange={onValueChange}>
+        <RadioGroupItem value="option-1" aria-label="Option 1" />
+        <RadioGroupItem value="option-2" aria-label="Option 2" />
+      </RadioGroup>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Option 2'));
+
+    // Controlled: state only changes if the consumer updates `value`.
+    expect(screen.getByLabelText('Option 1').getAttribute('aria-checked')).toBe('true');
+    expect(onValueChange).toHaveBeenCalledWith('option-2', expect.anything());
+  });
+
+  it('forwards className to the group element', () => {
+    render(
+      <RadioGroup aria-label="Plan" className="custom-group">
+        <RadioGroupItem value="option-1" aria-label="Option 1" />
+      </RadioGroup>,
+    );
+
+    expect(screen.getByRole('radiogroup').classList.contains('custom-group')).toBe(true);
+  });
+});

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.tsx
@@ -34,7 +34,8 @@ const RadioGroupItem = React.forwardRef<HTMLSpanElement, RadioGroupItemProps>(({
         transitions.all,
         'hover:border-neutral5 hover:shadow-md',
         formElementFocus,
-        'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-neutral3 disabled:hover:shadow-sm',
+        // Base UI's Radio.Root is a `<span>`, so `:disabled` never matches — target `data-disabled`.
+        'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:hover:border-neutral3 data-[disabled]:hover:shadow-sm',
         // Base UI exposes `data-checked`/`data-unchecked` instead of Radix's `data-state`.
         'data-[checked]:border-accent1 data-[checked]:shadow-glow-accent1',
         className,

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.tsx
@@ -1,4 +1,5 @@
-import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { Radio as RadioPrimitive } from '@base-ui/react/radio';
+import { RadioGroup as RadioGroupPrimitive } from '@base-ui/react/radio-group';
 import { Circle } from 'lucide-react';
 import * as React from 'react';
 
@@ -6,44 +7,51 @@ import { formElementFocus } from '@/ds/primitives/form-element';
 import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
-const RadioGroup = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
->(({ className, ...props }, ref) => {
-  return <RadioGroupPrimitive.Root className={cn('grid gap-2', className)} {...props} ref={ref} />;
-});
-RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+type RadioGroupProps = Omit<RadioGroupPrimitive.Props, 'className'> & {
+  className?: string;
+};
 
-const RadioGroupItem = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
->(({ className, ...props }, ref) => {
+const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(({ className, ...props }, ref) => {
+  return <RadioGroupPrimitive ref={ref} className={cn('grid gap-2', className)} {...props} />;
+});
+RadioGroup.displayName = 'RadioGroup';
+
+type RadioGroupItemProps = Omit<RadioPrimitive.Root.Props, 'className'> & {
+  className?: string;
+};
+
+const RadioGroupItem = React.forwardRef<HTMLSpanElement, RadioGroupItemProps>(({ className, ...props }, ref) => {
   return (
-    <RadioGroupPrimitive.Item
+    <RadioPrimitive.Root
       ref={ref}
       className={cn(
+        // Base UI's Radio.Root renders a `<span>` (inline) — unlike Radix's
+        // `<button>`. `flex` + `shrink-0` make the sizing/centering classes
+        // take effect and keep the control square inside flex rows.
+        'flex shrink-0 items-center justify-center',
         'aspect-square h-4 w-4 rounded-full border border-neutral3 text-neutral6',
         'shadow-sm',
         transitions.all,
         'hover:border-neutral5 hover:shadow-md',
         formElementFocus,
         'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-neutral3 disabled:hover:shadow-sm',
-        'data-[state=checked]:border-accent1 data-[state=checked]:shadow-glow-accent1',
+        // Base UI exposes `data-checked`/`data-unchecked` instead of Radix's `data-state`.
+        'data-[checked]:border-accent1 data-[checked]:shadow-glow-accent1',
         className,
       )}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator
+      <RadioPrimitive.Indicator
         className={cn(
           'flex items-center justify-center',
-          'data-[state=checked]:animate-in data-[state=checked]:zoom-in-50 data-[state=checked]:duration-150',
+          'data-[checked]:animate-in data-[checked]:zoom-in-50 data-[checked]:duration-150',
         )}
       >
         <Circle className="h-2 w-2 fill-accent1 text-accent1" />
-      </RadioGroupPrimitive.Indicator>
-    </RadioGroupPrimitive.Item>
+      </RadioPrimitive.Indicator>
+    </RadioPrimitive.Root>
   );
 });
-RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+RadioGroupItem.displayName = 'RadioGroupItem';
 
 export { RadioGroup, RadioGroupItem };

--- a/packages/playground-ui/src/ds/components/ThemeToggle/theme-toggle.tsx
+++ b/packages/playground-ui/src/ds/components/ThemeToggle/theme-toggle.tsx
@@ -1,4 +1,5 @@
-import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { Radio as RadioPrimitive } from '@base-ui/react/radio';
+import { RadioGroup as RadioGroupPrimitive } from '@base-ui/react/radio-group';
 import { Monitor, Moon, Sun } from 'lucide-react';
 
 import { useTheme } from '../ThemeProvider';
@@ -22,9 +23,11 @@ const ITEM_WIDTH = 28;
 const ITEM_GAP = 2;
 
 type RadioRootProps = Omit<
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>,
-  'value' | 'onChange' | 'onValueChange' | 'orientation' | 'defaultValue'
->;
+  RadioGroupPrimitive.Props,
+  'value' | 'onChange' | 'onValueChange' | 'defaultValue' | 'className'
+> & {
+  className?: string;
+};
 
 type ControlledProps = { value: Theme; onChange: (next: Theme) => void };
 type UncontrolledProps = { value?: undefined; onChange?: undefined };
@@ -46,7 +49,7 @@ export const ThemeToggle = ({
   const commit = onChange ?? setTheme;
   const effectiveCurrent = options.some(option => option.value === current) ? current : (options[0]?.value ?? 'system');
 
-  const handleChange = (next: string) => {
+  const handleChange = (next: unknown) => {
     const match = options.find(opt => opt.value === next);
     if (match) commit(match.value);
   };
@@ -58,11 +61,10 @@ export const ThemeToggle = ({
   const indicatorOffset = activeIndex * (ITEM_WIDTH + ITEM_GAP);
 
   return (
-    <RadioGroupPrimitive.Root
+    <RadioGroupPrimitive
       {...rest}
       value={effectiveCurrent}
       onValueChange={handleChange}
-      orientation="horizontal"
       aria-label={ariaLabel}
       className={cn(
         'relative inline-flex w-fit items-center gap-0.5 rounded-full border border-border1 bg-surface3 p-0.5',
@@ -78,14 +80,15 @@ export const ThemeToggle = ({
         style={{ width: ITEM_WIDTH, transform: `translateX(${indicatorOffset}px)` }}
       />
       {options.map(option => (
-        <RadioGroupPrimitive.Item
+        <RadioPrimitive.Root
           key={option.value}
           value={option.value}
           aria-label={option.label}
           style={{ width: ITEM_WIDTH }}
           className={cn(
             'relative inline-flex h-6 cursor-pointer items-center justify-center rounded-full',
-            '[&_svg]:size-3.5 text-icon3 hover:text-icon6 data-[state=checked]:text-icon6',
+            // Base UI exposes `data-checked` instead of Radix's `data-state="checked"`.
+            '[&_svg]:size-3.5 text-icon3 hover:text-icon6 data-[checked]:text-icon6',
             'focus-visible:outline-hidden',
             'active:scale-90 motion-reduce:transition-none',
             transitions.colors,
@@ -95,8 +98,8 @@ export const ThemeToggle = ({
           <span aria-hidden="true" className="pointer-events-none inline-flex items-center justify-center">
             {option.icon}
           </span>
-        </RadioGroupPrimitive.Item>
+        </RadioPrimitive.Root>
       ))}
-    </RadioGroupPrimitive.Root>
+    </RadioGroupPrimitive>
   );
 };

--- a/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
@@ -49,16 +49,16 @@ test.describe('agent panels', () => {
     });
 
     test('model trigger modes', async ({ page }) => {
-      const generateRadio = page.getByLabel('Generate');
+      const generateRadio = page.getByRole('radio', { name: 'Generate' });
       await page.click('text=Model settings');
 
       await expect(generateRadio).toBeVisible();
       await expect(generateRadio).toHaveAttribute('aria-checked', 'false');
-      const streamRadio = page.getByLabel('Stream');
+      const streamRadio = page.getByRole('radio', { name: 'Stream' });
       await expect(streamRadio).toBeVisible();
       await expect(streamRadio).toHaveAttribute('aria-checked', 'true');
 
-      const networkRadio = page.getByLabel('Network');
+      const networkRadio = page.getByRole('radio', { name: 'Network' });
       await expect(networkRadio).toBeVisible();
     });
 

--- a/packages/playground/e2e/tests/cms/scorers/create/page.spec.ts
+++ b/packages/playground/e2e/tests/cms/scorers/create/page.spec.ts
@@ -60,9 +60,9 @@ async function fillScorerFields(
 
   if (options.samplingType !== undefined) {
     if (options.samplingType === 'ratio') {
-      await page.getByLabel('Ratio').click();
+      await page.getByRole('radio', { name: 'Ratio' }).click();
     } else {
-      await page.getByLabel('None').click();
+      await page.getByRole('radio', { name: 'None' }).click();
     }
   }
 

--- a/packages/playground/e2e/tests/cms/scorers/edit/page.spec.ts
+++ b/packages/playground/e2e/tests/cms/scorers/edit/page.spec.ts
@@ -60,9 +60,9 @@ async function fillScorerFields(
 
   if (options.samplingType !== undefined) {
     if (options.samplingType === 'ratio') {
-      await page.getByLabel('Ratio').click();
+      await page.getByRole('radio', { name: 'Ratio' }).click();
     } else {
-      await page.getByLabel('None').click();
+      await page.getByRole('radio', { name: 'None' }).click();
     }
   }
 

--- a/packages/playground/src/domains/agents/components/agent-settings.tsx
+++ b/packages/playground/src/domains/agents/components/agent-settings.tsx
@@ -111,7 +111,6 @@ export const AgentSettings = ({ agentId }: AgentSettingsProps) => {
       <section className="space-y-7 @container">
         <Entry label="Chat Method">
           <RadioGroup
-            orientation="horizontal"
             value={radioValue}
             disabled={!canEditSettings}
             onValueChange={(value: string) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4474,9 +4474,6 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-radio-group':
-        specifier: ^1.3.8
-        version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
## Summary
- Migrates the `RadioGroup` design-system component from `@radix-ui/react-radio-group` to `@base-ui/react` (`radio-group` + `radio`).
- Public API is unchanged — `RadioGroup`, `RadioGroupItem`, `value`, `onValueChange`, `disabled`, `className` all behave as before.
- **Fixes a sizing/positioning regression:** Base UI's `Radio.Root` renders a `<span>` (Radix rendered a `<button>`, which centered its content for free). The item now gets explicit `flex shrink-0 items-center justify-center` so the control stays square and the inner dot is correctly centered — visible in the agent settings panel.
- Migrates the `ThemeToggle` consumer, which imported the radix primitive directly.
- Drops the `orientation` prop from the agent-settings `RadioGroup` usage — Base UI's RadioGroup has no `orientation` prop; the horizontal layout is already driven by flex classes.
- Adds a colocated smoke test and removes the now-unused `@radix-ui/react-radio-group` dependency.

Part of the incremental migration of `playground-ui` design-system components from Radix UI to Base UI.

## Test plan
- [ ] `pnpm --filter @mastra/playground-ui exec vitest run src/ds/components/RadioGroup` — 7/7 pass
- [ ] `pnpm --filter @mastra/playground-ui exec tsc` passes
- [ ] Verify the radio dot is centered and square in Storybook and in the agent settings "Chat Method" panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR replaces the radio-button implementation from Radix UI with Base UI, keeps the public API the same for consumers, and fixes a visual bug so radio buttons stay square with the inner dot centered.

---

## Changes Overview

### Changeset
- Adds a `.changeset` entry documenting the RadioGroup migration to Base UI and the radio indicator sizing/centering fix.

### Dependency
- packages/playground-ui now depends on `@base-ui/react` (radio + radio-group); the Radix radio-group primitive was removed from dependencies.

### RadioGroup Component Migration
- File: packages/playground-ui/src/ds/components/RadioGroup/radio-group.tsx
  - Reimplemented RadioGroup and RadioGroupItem using Base UI primitives (`@base-ui/react/radio-group` and `@base-ui/react/radio`).
  - Preserves public API surface (RadioGroup, RadioGroupItem, value, onValueChange, disabled, className).
  - Updated prop/ref types to match Base UI (RadioGroup forwards HTMLDivElement; RadioGroupItem forwards HTMLSpanElement).
  - Switched styling to Base UI data attributes (data-[checked], data-[disabled]) and adjusted indicator animation.
  - Fixed sizing/positioning regression by adding explicit flex, shrink-0, centering, and aspect-square classes so the control stays square and the inner dot is centered.

### Tests
- File: packages/playground-ui/src/ds/components/RadioGroup/radio-group.test.tsx
  - Added Vitest/jsdom test suite (7 tests) covering render, aria-checked behavior, click interactions, onValueChange, disabled behavior, controlled-value behavior, and className forwarding.
  - Polyfills window.PointerEvent with MouseEvent to support Base UI behavior in jsdom.

### ThemeToggle Consumer
- File: packages/playground-ui/src/ds/components/ThemeToggle/theme-toggle.tsx
  - Migrated ThemeToggle to Base UI primitives and updated props/typing to derive from Base UI’s RadioGroup props.
  - Replaced Radix data-state checks with Base UI data-[checked].
  - Removed explicit orientation="horizontal" (layout handled via CSS/flex).

### Agent Settings Usage
- File: packages/playground/src/domains/agents/components/agent-settings.tsx
  - Removed explicit orientation prop from the "Chat Method" RadioGroup; layout is handled with flex classes. Behavior and settings mapping unchanged.

### E2E/Test Adjustments
- Playwright and helper tests updated to target accessible radio controls via role-based locators (getByRole('radio', { name })) instead of label-based clicks to account for Base UI rendering a role="radio" span alongside an aria-hidden input.
- Component tests updated to select the accessible radio control rather than label-based queries that previously matched multiple elements.

---

## Commit/test notes
- Tests were updated because Base UI renders a <span role="radio"> alongside an aria-hidden <input>; selectors now target the accessible radio role.
- Test plan: run vitest for the component (expect 7/7), TypeScript build (pnpm --filter `@mastra/playground-ui` exec tsc), and visually verify radio dot centering in Storybook and the agent settings "Chat Method" panel.

---

## Public API Stability
- Consumer-facing API remains stable: RadioGroup, RadioGroupItem, value, onValueChange, disabled, and className continue to work without required consumer changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->