### PR TITLE
fix(core): inject _background/resume override via JSON Schema, not Zod v4 .extend()

### DIFF
--- a/.changeset/grumpy-planes-count.md
+++ b/.changeset/grumpy-planes-count.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a crash when tools with Zod v3 input schemas are used with backgroundTasks enabled. The framework injected its `_background` override field via Zod v4 `.extend()` into the user's Zod v3 schema, mixing v3 and v4 internals and causing `keyValidator._parse is not a function` at tool execution time. The injection now flows through the framework's standard JSON-Schema interop path, so it works uniformly across Zod v3, Zod v4, and JsonSchema-based tools.

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -13,7 +13,7 @@ import {
 } from '@mastra/schema-compat';
 import { z } from 'zod/v4';
 import { MastraFGAPermissions } from '../../auth/ee';
-import { backgroundOverrideJsonSchema, backgroundOverrideZodSchema } from '../../background-tasks';
+import { backgroundOverrideJsonSchema } from '../../background-tasks';
 import { MastraBase } from '../../base';
 import { ErrorCategory, MastraError, ErrorDomain } from '../../error';
 import type { Mastra } from '../../mastra';
@@ -26,7 +26,6 @@ import type { StandardSchemaWithJSON } from '../../schema';
 import { isVercelTool, isProviderDefinedTool } from '../../tools/toolchecks';
 import type { ToolOptions } from '../../utils';
 import { safeStringify } from '../../utils';
-import { isZodObject } from '../../utils/zod-utils';
 
 import type { SuspendOptions } from '../../workflows';
 import { ToolStream } from '../stream';
@@ -96,48 +95,35 @@ export class CoreToolBuilder extends MastraBase {
           schema = z.object({});
         }
 
-        if (isZodObject(schema)) {
-          let nextSchema = schema;
+        // Unified JSON-schema path: normalize the user's input schema (Zod v3,
+        // Zod v4, or a JsonSchemaWrapper) into a Standard Schema, extract its
+        // JSON Schema, add the framework's override fields, and re-wrap. This
+        // matches the codebase's general schema-interop pattern and avoids
+        // splicing a Zod v4 ZodOptional into a Zod v3 ZodObject's shape, which
+        // would crash later in `ZodObject._parse` with
+        // `keyValidator._parse is not a function`.
+        const standardSchema = isStandardSchemaWithJSON(schema as any)
+          ? (schema as any)
+          : toStandardSchema(schema as any);
+        const jsonSchema = standardSchemaToJSONSchema(standardSchema, { io: 'input' });
+
+        if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
+          const properties = { ...(jsonSchema.properties ?? {}) };
+
           if (isBackgroundEligible) {
-            nextSchema = nextSchema.extend({
-              _background: backgroundOverrideZodSchema,
-            });
+            properties._background = backgroundOverrideJsonSchema;
           }
           if (isResumableTool) {
-            nextSchema = nextSchema.extend({
-              suspendedToolRunId: z.string().describe('The runId of the suspended tool').nullable().optional(),
-              resumeData: z
-                .any()
-                .describe('The resumeData object created from the resumeSchema of suspended tool')
-                .optional(),
-            });
+            properties.suspendedToolRunId = {
+              type: ['string', 'null'],
+              description: 'The runId of the suspended tool',
+            };
+            properties.resumeData = {
+              description: 'The resumeData object created from the resumeSchema of suspended tool',
+            };
           }
-          this.originalTool.inputSchema = nextSchema;
-        } else {
-          // Non-Zod StandardSchemaWithJSON (e.g. JsonSchemaWrapper from JSONSchema7).
-          // Extract JSON Schema, add suspend/resume fields, re-wrap.
-          const jsonSchema = standardSchemaToJSONSchema(schema as any, { io: 'input' });
-          if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
-            if (isBackgroundEligible) {
-              jsonSchema.properties = {
-                ...jsonSchema.properties,
-                _background: backgroundOverrideJsonSchema,
-              };
-            }
-            if (isResumableTool) {
-              jsonSchema.properties = {
-                ...jsonSchema.properties,
-                suspendedToolRunId: {
-                  type: ['string', 'null'],
-                  description: 'The runId of the suspended tool',
-                },
-                resumeData: {
-                  description: 'The resumeData object created from the resumeSchema of suspended tool',
-                },
-              };
-            }
-            this.originalTool.inputSchema = toStandardSchema(jsonSchema) as any;
-          }
+
+          this.originalTool.inputSchema = toStandardSchema({ ...jsonSchema, properties }) as any;
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes a tool-execution crash that surfaces as:

```
TypeError: keyValidator._parse is not a function
  at ZodObject._parse (zod/v3/types.js)
  at safeValidate (@mastra/core/.../chunk-*.js)
  at validateToolInput (@mastra/core/.../chunk-*.js)
  at Tool.execute (@mastra/core/.../chunk-*.js)
```

The bug is triggered when a Mastra app:
- uses tools whose `inputSchema` is authored with **Zod v3**, **and**
- enables `backgroundTasks` on the `Mastra` instance (or uses any resumable tool, since the same code path also injects `suspendedToolRunId` / `resumeData`).

Every tool execution then crashes with the above stack — both direct (`POST /api/tools/:tool/execute`), agent-scoped, agent-driven (LLM tool calls), and MCP. The corruption persists across requests for the lifetime of the process.

## Root cause

`CoreToolBuilder` (`packages/core/src/tools/tool-builder/builder.ts`) injects framework-controlled override fields into each background-eligible or resumable tool's input schema at construction time.

The previous implementation branched on whether the user's input schema was a Zod object:

```ts
// before
if (isZodObject(schema)) {
  let nextSchema = schema;
  if (isBackgroundEligible) {
    nextSchema = nextSchema.extend({
      _background: backgroundOverrideZodSchema, // ← from `import { z } from 'zod/v4'`
    });
  }
  if (isResumableTool) {
    nextSchema = nextSchema.extend({
      suspendedToolRunId: z.string()...,         // ← also v4 `z`
      resumeData: z.any()...,
    });
  }
  this.originalTool.inputSchema = nextSchema;    // ← persistent mutation
} else {
  // JSON-Schema path (already correct)
  ...
}
```

`backgroundOverrideZodSchema` is created with `import { z } from 'zod/v4'` (`packages/core/src/background-tasks/schema-injection.ts`), so it is always a **Zod v4** `ZodOptional`. When the user authors their tool with Zod v3:

1. `nextSchema.extend({ _background: <v4 schema> })` creates a Zod v3 `ZodObject` whose `shape._background` is a Zod v4 object.
2. The result is stored back onto `originalTool.inputSchema`, so the corruption is persistent (not request-scoped).
3. Later, `validateToolInput` → `safeValidate` → the schema's `~standard.validate` calls `ZodObject._parse` (Zod v3), which iterates `shape` and calls `keyValidator._parse(...)` on each child.
4. Zod v4 schemas have no `_parse` method (renamed to `_zod`/`.parse`), so the call throws `TypeError: keyValidator._parse is not a function`.

### Why this is environment-dependent

The crash depends on package resolution. `@mastra/core` declares `peerDependencies: { zod: '^3.25.0 || ^4.0.0' }` and internally imports both `'zod/v3'` and `'zod/v4'` subpaths. When the user's tool code imports bare `zod`, two outcomes are possible:

- **Bare `zod` resolves to `zod@4.x`** (e.g. when zod 4 is the only or hoisted version, or via a v3 compat shim in zod 4). User's `z.object({...})` produces a v4 ZodObject; `.extend({_background: <v4>})` mixes v4-with-v4 → no crash.
- **Bare `zod` resolves to `zod@3.x`** (e.g. when the app explicitly depends on zod 3, hoisted differently on Linux vs macOS by pnpm). User's `z.object({...})` produces a v3 ZodObject; `.extend({_background: <v4>})` stuffs a v4 child into a v3 shape → **crash on first tool execution**.

In our smoke matrix, the Zod 4 matrix passed everywhere; the Zod 3 matrix crashed on CI Linux but not local macOS, because pnpm hoisted `zod` differently across platforms even with identical lockfiles.

### Why partial test runs could pass

`tools/tools.test.ts` happens to call the `/api/tools/:tool/execute` route, but each test gets a fresh tool registration from a clean fixture instance. The crash only manifests after `CoreToolBuilder` has run with `isBackgroundEligible || isResumableTool` true for a given tool — and after `this.originalTool.inputSchema = nextSchema` poisons the shared reference. That made the failure look order-dependent and flaky during investigation; in reality it was deterministic given the right resolution + `backgroundTasks: { enabled: true }` config.

## Fix

Unify the Zod and non-Zod branches into a single JSON-Schema-based injection path, which is already the framework's standard schema-interop pattern (used in `agent.ts`, `prepare-tools.ts`, processors, etc.):

```ts
// after
const standardSchema = isStandardSchemaWithJSON(schema as any)
  ? (schema as any)
  : toStandardSchema(schema as any);
const jsonSchema = standardSchemaToJSONSchema(standardSchema, { io: 'input' });

if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
  const properties = { ...(jsonSchema.properties ?? {}) };

  if (isBackgroundEligible) {
    properties._background = backgroundOverrideJsonSchema;
  }
  if (isResumableTool) {
    properties.suspendedToolRunId = {
      type: ['string', 'null'],
      description: 'The runId of the suspended tool',
    };
    properties.resumeData = {
      description: 'The resumeData object created from the resumeSchema of suspended tool',
    };
  }

  this.originalTool.inputSchema = toStandardSchema({ ...jsonSchema, properties }) as any;
}
```

- The override fields are always expressed as **JSON Schema** (`backgroundOverrideJsonSchema` already exists and is the same data the v4 zod constant was modelling).
- The final stored value is a `JsonSchemaWrapper` — version-neutral. No `_parse` is ever called on the override field's validator regardless of which Zod version the user's `~standard.validate` is dispatched against.
- The non-Zod path (`JsonSchemaWrapper` inputs) is unchanged in behaviour — both paths just go through the same code now.

`backgroundOverrideZodSchema` and the `isZodObject` import in this file become dead code and are dropped. `backgroundOverrideZodSchema` is still exported from `packages/core/src/background-tasks` for any external consumer.

## Verification

Reproduced and fixed against `e2e-tests/smoke` (a Mastra app with `backgroundTasks: { enabled: true }`, tools authored with `import { z } from 'zod'`, and the `.mastra/output/node_modules/zod` symlink forced to `zod@3.25.76` to mirror CI Linux pnpm hoisting):

| Matrix | Before fix | After fix |
|---|---|---|
| Zod 3 path (`zod@3.25.76`) | 21 failed / 275 passed (incl. all tool-execution paths: direct, agent, generate, stream, tool-approval, MCP) | **295/296 passed**, 1 unrelated LLM-latency flake (passes on rerun) |
| Zod 4 path (`zod@4.4.3`) | 296/296 passed | **296/296 passed** (no regression) |

The 10 previously-failing tool-execution tests (with the exact `keyValidator._parse is not a function` stack on the Zod 3 path) all pass after the fix.

## Reproduction recipe

For anyone wanting to verify locally without the smoke fixture:

```bash
# In any Mastra app with a tool authored with `import { z } from 'zod'`:
pnpm add zod@3.25.76
# In Mastra config, set:
#   new Mastra({ backgroundTasks: { enabled: true }, ... })
pnpm mastra build
# Force bare zod inside the build output to resolve to v3 (simulates CI Linux):
cd .mastra/output/node_modules
rm zod && ln -s .pnpm/zod@3.25.76/node_modules/zod zod
cd -
node .mastra/output/index.mjs &
# Then call any tool with a Zod v3 input schema:
curl -X POST http://localhost:4111/api/tools/<your-tool>/execute \
  -H 'content-type: application/json' \
  -d '{"data": {...valid input...}}'
# → before fix: 500 {"error":"keyValidator._parse is not a function"}
# → after fix:  200 {...tool result...}
```

## Notes / follow-ups (not required for this fix)

- `this.originalTool.inputSchema = ...` still mutates a (potentially) shared `originalTool` reference. After this fix it's safe (the new value is version-neutral), but it's a smell worth cleaning up later — `CoreToolBuilder` should not be mutating its input.
- This is the same class of bug pattern as #16782 and #16783 (framework-controlled state silently grafted onto user schemas) — worth a sweep for any other call sites that splice `import { z } from 'zod/v4'` schemas into user-provided schemas.

## Changeset

Patch bump for `@mastra/core`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a crash that happened when using background task features with a popular data validation library called Zod. The problem was that the framework was mixing two different versions of Zod in the same tool, like trying to use parts from two different instruction manuals. The fix changes the approach to use a universal format (JSON Schema) instead, so it works correctly no matter which version of Zod users have.

---

## Summary

The PR resolves a tool-execution crash caused by mixing Zod v4-derived override schemas into user-provided Zod v3 object schemas. When `CoreToolBuilder` detected Zod objects and used `.extend()` to inject framework-controlled fields (`_background`, `suspendedToolRunId`, `resumeData`), the injected schema for `_background` was a Zod v4 construct. This resulted in a Zod v3 object containing a Zod v4 child, causing runtime failures (`TypeError: keyValidator._parse is not a function`) during validation.

**The fix** unifies the Zod and non-Zod branches by:
- Converting the tool input schema to the framework's standard schema format
- Translating it to JSON Schema
- Injecting override fields as JSON Schema properties (using the existing `backgroundOverrideJsonSchema` and inline JSON for resume fields)
- Converting back to a standard schema

This approach yields a version-neutral `JsonSchemaWrapper` and eliminates the mixing of Zod versions entirely.

**Changes:**
- Updated `packages/core/src/tools/tool-builder/builder.ts` to use the unified JSON-schema pathway instead of Zod-specific extension logic
- Removed the now-unused `isZodObject` import and `backgroundOverrideZodSchema` references
- Added a Changesets entry documenting the patch bump for `@mastra/core`

**Verification:** E2E smoke tests pass on both Zod v3.25.76 and v4.4.3 matrices, with previously failing tool-execution tests now fixed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->