### PR TITLE
fix(core): inject _background/resume override via JSON Schema, not Zod v4 .extend()

### DIFF
--- a/.changeset/grumpy-planes-count.md
+++ b/.changeset/grumpy-planes-count.md
@@ -2,4 +2,6 @@
 '@mastra/core': patch
 ---
 
-Fixed a crash when tools with Zod v3 input schemas are used with backgroundTasks enabled. The framework injected its `_background` override field via Zod v4 `.extend()` into the user's Zod v3 schema, mixing v3 and v4 internals and causing `keyValidator._parse is not a function` at tool execution time. The injection now flows through the framework's standard JSON-Schema interop path, so it works uniformly across Zod v3, Zod v4, and JsonSchema-based tools.
+Fixed a crash that could occur when background execution is enabled for tools with Zod v3 input schemas.
+
+Tools with Zod v3, Zod v4, and JSON Schema input definitions now work consistently with background execution.

--- a/.changeset/grumpy-planes-count.md
+++ b/.changeset/grumpy-planes-count.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a crash when tools with Zod v3 input schemas are used with backgroundTasks enabled. The framework injected its `_background` override field via Zod v4 `.extend()` into the user's Zod v3 schema, mixing v3 and v4 internals and causing `keyValidator._parse is not a function` at tool execution time. The injection now flows through the framework's standard JSON-Schema interop path, so it works uniformly across Zod v3, Zod v4, and JsonSchema-based tools.

--- a/packages/core/src/tools/tool-builder/background-override-injection.test.ts
+++ b/packages/core/src/tools/tool-builder/background-override-injection.test.ts
@@ -121,6 +121,34 @@ describe('CoreToolBuilder background override injection', () => {
       const [parsed] = execute.mock.calls[0]!;
       expect(parsed).toMatchObject({ query: 'DOCS', mode: 'fast', _background: { enabled: true } });
     });
+
+    // The JSON-fallback validate wrapper used to strip injected fields, run the
+    // original validator on the rest, then merge injected back untouched —
+    // letting malformed `_background` payloads (e.g. `enabled: "yes"`) reach
+    // `execute()`. Lock in that the injected subset is now validated against
+    // the override JSON Schema, matching the Zod v4 `.extend()` path.
+    // https://github.com/mastra-ai/mastra/pull/16915#discussion_r3282600679
+    it('rejects malformed _background payload on the JSON fallback path', async () => {
+      const execute = vi.fn();
+      const tool = createTool({
+        id: 'v3-bad-bg-tool',
+        description: 'Zod v3 tool with malformed _background guard',
+        inputSchema: z3.object({ query: z3.string() }),
+        execute,
+      });
+
+      new CoreToolBuilder({
+        originalTool: tool,
+        options: baseOptions(),
+        backgroundTaskEnabled: true,
+      });
+
+      const schema = tool.inputSchema as any;
+      const result = schema['~standard'].validate({ query: 'ok', _background: { enabled: 'yes' } });
+      const resolved = result && typeof result.then === 'function' ? await result : result;
+      expect(resolved).toHaveProperty('issues');
+      expect((resolved as { issues: readonly unknown[] }).issues.length).toBeGreaterThan(0);
+    });
   });
 
   describe('Zod v4 input schema', () => {

--- a/packages/core/src/tools/tool-builder/background-override-injection.test.ts
+++ b/packages/core/src/tools/tool-builder/background-override-injection.test.ts
@@ -1,0 +1,206 @@
+import { jsonSchema as vercelJsonSchema } from '@mastra/schema-compat';
+import { describe, expect, it, vi } from 'vitest';
+import { z as z3 } from 'zod/v3';
+import { z as z4 } from 'zod/v4';
+import { RequestContext } from '../../request-context';
+import { isStandardSchemaWithJSON, standardSchemaToJSONSchema } from '../../schema';
+import { createTool } from '../../tools';
+import { CoreToolBuilder } from './builder';
+
+// Regression coverage for the bug where `backgroundTaskEnabled: true` would
+// mutate a Zod v3 user input schema by `.extend()`ing it with a Zod v4
+// optional, then crash downstream in `ZodObject._parse` with
+// `keyValidator._parse is not a function`. The fix normalizes the user's
+// schema into a JSON Schema, splices in the override fields, and re-wraps
+// — so all supported input-schema kinds (Zod v3, Zod v4, JSON Schema)
+// flow through the same code path.
+
+function baseOptions() {
+  return {
+    name: 'test-tool',
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trackException: vi.fn(),
+    } as any,
+    requestContext: new RequestContext(),
+  };
+}
+
+function extractJsonProperties(tool: { inputSchema?: unknown }) {
+  const schema = tool.inputSchema;
+  expect(schema).toBeDefined();
+  expect(isStandardSchemaWithJSON(schema)).toBe(true);
+  const json = standardSchemaToJSONSchema(schema as any, { io: 'input' });
+  expect(json && typeof json === 'object' && (json as any).type === 'object').toBe(true);
+  return (json as any).properties as Record<string, any>;
+}
+
+describe('CoreToolBuilder background override injection', () => {
+  describe('Zod v3 input schema', () => {
+    it('does not crash when backgroundTaskEnabled is true (regression for keyValidator._parse)', async () => {
+      const execute = vi.fn().mockResolvedValue({ ok: true });
+      const tool = createTool({
+        id: 'v3-tool',
+        description: 'Zod v3 tool',
+        inputSchema: z3.object({ query: z3.string() }),
+        execute,
+      });
+
+      // Constructing the builder is where the schema is mutated. With the
+      // pre-fix code, this would silently produce a broken schema and the
+      // crash would surface during execute(). We assert both happen cleanly.
+      const builder = new CoreToolBuilder({
+        originalTool: tool,
+        options: baseOptions(),
+        backgroundTaskEnabled: true,
+      });
+
+      const built = builder.build();
+      await expect(built.execute!({ query: 'docs' }, { toolCallId: 'call-1', messages: [] })).resolves.toEqual({
+        ok: true,
+      });
+      expect(execute).toHaveBeenCalledWith(
+        { query: 'docs' },
+        expect.objectContaining({ requestContext: expect.any(RequestContext) }),
+      );
+    });
+
+    it('injects _background into the resulting JSON Schema properties', () => {
+      const tool = createTool({
+        id: 'v3-tool',
+        description: 'Zod v3 tool',
+        inputSchema: z3.object({ query: z3.string() }),
+        execute: vi.fn(),
+      });
+
+      new CoreToolBuilder({
+        originalTool: tool,
+        options: baseOptions(),
+        backgroundTaskEnabled: true,
+      });
+
+      const properties = extractJsonProperties(tool);
+      expect(properties).toHaveProperty('query');
+      expect(properties).toHaveProperty('_background');
+    });
+  });
+
+  describe('Zod v4 input schema', () => {
+    it('still injects _background and accepts valid input', async () => {
+      const execute = vi.fn().mockResolvedValue({ ok: true });
+      const tool = createTool({
+        id: 'v4-tool',
+        description: 'Zod v4 tool',
+        inputSchema: z4.object({ query: z4.string() }),
+        execute,
+      });
+
+      const builder = new CoreToolBuilder({
+        originalTool: tool,
+        options: baseOptions(),
+        backgroundTaskEnabled: true,
+      });
+
+      const built = builder.build();
+      await expect(built.execute!({ query: 'docs' }, { toolCallId: 'call-1', messages: [] })).resolves.toEqual({
+        ok: true,
+      });
+
+      const properties = extractJsonProperties(tool);
+      expect(properties).toHaveProperty('query');
+      expect(properties).toHaveProperty('_background');
+    });
+  });
+
+  describe('Raw JSON Schema (Vercel jsonSchema wrapper) input', () => {
+    it('injects _background without crashing on a non-Zod schema', async () => {
+      const execute = vi.fn().mockResolvedValue({ ok: true });
+      const tool = createTool({
+        id: 'json-tool',
+        description: 'JSON Schema tool',
+        inputSchema: vercelJsonSchema({
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        }) as any,
+        execute,
+      });
+
+      const builder = new CoreToolBuilder({
+        originalTool: tool,
+        options: baseOptions(),
+        backgroundTaskEnabled: true,
+      });
+
+      const built = builder.build();
+      await expect(built.execute!({ query: 'docs' }, { toolCallId: 'call-1', messages: [] })).resolves.toEqual({
+        ok: true,
+      });
+
+      const properties = extractJsonProperties(tool);
+      expect(properties).toHaveProperty('query');
+      expect(properties).toHaveProperty('_background');
+    });
+  });
+
+  describe('Resumable tools (agent-/workflow- prefixed ids)', () => {
+    it('injects suspendedToolRunId and resumeData for agent- tools', () => {
+      const tool = createTool({
+        id: 'agent-foo',
+        description: 'Agent-as-tool',
+        inputSchema: z3.object({ message: z3.string() }),
+        execute: vi.fn(),
+      });
+
+      new CoreToolBuilder({
+        originalTool: tool,
+        options: baseOptions(),
+      });
+
+      const properties = extractJsonProperties(tool);
+      expect(properties).toHaveProperty('message');
+      expect(properties).toHaveProperty('suspendedToolRunId');
+      expect(properties).toHaveProperty('resumeData');
+    });
+
+    it('injects resume fields for workflow- tools as well', () => {
+      const tool = createTool({
+        id: 'workflow-bar',
+        description: 'Workflow-as-tool',
+        inputSchema: z4.object({ message: z4.string() }),
+        execute: vi.fn(),
+      });
+
+      new CoreToolBuilder({
+        originalTool: tool,
+        options: baseOptions(),
+      });
+
+      const properties = extractJsonProperties(tool);
+      expect(properties).toHaveProperty('suspendedToolRunId');
+      expect(properties).toHaveProperty('resumeData');
+    });
+  });
+
+  describe('Schema is left untouched when neither flag applies', () => {
+    it('does not inject override fields when backgroundTaskEnabled is false and id is not resumable', () => {
+      const tool = createTool({
+        id: 'plain-tool',
+        description: 'A plain tool',
+        inputSchema: z3.object({ query: z3.string() }),
+        execute: vi.fn(),
+      });
+      const originalSchema = tool.inputSchema;
+
+      new CoreToolBuilder({
+        originalTool: tool,
+        options: baseOptions(),
+      });
+
+      // No injection => the builder should not have replaced inputSchema.
+      expect(tool.inputSchema).toBe(originalSchema);
+    });
+  });
+});

--- a/packages/core/src/tools/tool-builder/background-override-injection.test.ts
+++ b/packages/core/src/tools/tool-builder/background-override-injection.test.ts
@@ -163,6 +163,16 @@ describe('CoreToolBuilder background override injection', () => {
       expect(properties).toHaveProperty('message');
       expect(properties).toHaveProperty('suspendedToolRunId');
       expect(properties).toHaveProperty('resumeData');
+
+      // The injected JSON Schema must match the pre-PR shape so existing
+      // provider-compat layers and LLM-recording hashes stay stable.
+      expect(properties.suspendedToolRunId).toEqual({
+        type: ['string', 'null'],
+        description: 'The runId of the suspended tool',
+      });
+      expect(properties.resumeData).toEqual({
+        description: 'The resumeData object created from the resumeSchema of suspended tool',
+      });
     });
 
     it('injects resume fields for workflow- tools as well', () => {

--- a/packages/core/src/tools/tool-builder/background-override-injection.test.ts
+++ b/packages/core/src/tools/tool-builder/background-override-injection.test.ts
@@ -85,6 +85,42 @@ describe('CoreToolBuilder background override injection', () => {
       expect(properties).toHaveProperty('query');
       expect(properties).toHaveProperty('_background');
     });
+
+    // The JSON Schema fallback used to replace the original Zod v3 schema with
+    // an Ajv-only wrapper, silently dropping `.transform()` / `.default()` /
+    // `.refine()` parsing before `execute()` saw the args. Lock that behavior
+    // in: the inner execute() must still receive the *parsed* value.
+    // https://github.com/mastra-ai/mastra/pull/16915#discussion_r3282520408
+    it('preserves Zod v3 transforms and defaults through to execute()', async () => {
+      const execute = vi.fn().mockResolvedValue({ ok: true });
+      const tool = createTool({
+        id: 'v3-transform-tool',
+        description: 'Zod v3 tool with transform + default',
+        inputSchema: z3.object({
+          query: z3.string().transform(s => s.toUpperCase()),
+          mode: z3.string().default('fast'),
+        }) as any,
+        execute,
+      });
+
+      const builder = new CoreToolBuilder({
+        originalTool: tool,
+        options: baseOptions(),
+        backgroundTaskEnabled: true,
+      });
+
+      const built = builder.build();
+      await built.execute!({ query: 'docs', _background: { enabled: true } } as any, {
+        toolCallId: 'call-1',
+        messages: [],
+      });
+
+      // Transform ran ("docs" -> "DOCS"), default filled ("mode" -> "fast"),
+      // and the injected `_background` key was preserved on the parsed value.
+      expect(execute).toHaveBeenCalledTimes(1);
+      const [parsed] = execute.mock.calls[0]!;
+      expect(parsed).toMatchObject({ query: 'DOCS', mode: 'fast', _background: { enabled: true } });
+    });
   });
 
   describe('Zod v4 input schema', () => {
@@ -189,6 +225,30 @@ describe('CoreToolBuilder background override injection', () => {
       });
 
       const properties = extractJsonProperties(tool);
+      expect(properties).toHaveProperty('suspendedToolRunId');
+      expect(properties).toHaveProperty('resumeData');
+    });
+
+    // Both gates can fire at once: a resumable id AND backgroundTaskEnabled.
+    // Ensure all three injected fields end up in the same schema.
+    // https://github.com/mastra-ai/mastra/pull/16915#pullrequestreview
+    it('merges _background and resume fields when both gates apply', () => {
+      const tool = createTool({
+        id: 'agent-combo',
+        description: 'Agent-as-tool with background tasks',
+        inputSchema: z4.object({ message: z4.string() }),
+        execute: vi.fn(),
+      });
+
+      new CoreToolBuilder({
+        originalTool: tool,
+        options: baseOptions(),
+        backgroundTaskEnabled: true,
+      });
+
+      const properties = extractJsonProperties(tool);
+      expect(properties).toHaveProperty('message');
+      expect(properties).toHaveProperty('_background');
       expect(properties).toHaveProperty('suspendedToolRunId');
       expect(properties).toHaveProperty('resumeData');
     });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -71,6 +71,72 @@ function isZodV4Schema(schema: unknown): boolean {
   return !!def && typeof def.type === 'string' && !def.typeName;
 }
 
+/**
+ * Build a Standard Schema that:
+ *  - exposes the spliced JSON Schema (with `_background`/`suspendedToolRunId`/
+ *    `resumeData` properties added) so provider compat layers see the override
+ *    fields when serializing the tool to an LLM, and
+ *  - delegates runtime `validate` to the *original* schema so Zod v3
+ *    `.transform()` / `.default()` / `.refine()` and other Standard Schema
+ *    parsing behavior still run before `execute()` sees the args.
+ *
+ * Injected override keys (`_background`, `suspendedToolRunId`, `resumeData`)
+ * are stripped from the input before delegating, then merged back into the
+ * validated value so the inner `execute()` still receives them — matching the
+ * Zod v4 `.extend()` path's behavior.
+ *
+ * If the original schema has no `~standard.validate` (e.g. a raw JSON Schema
+ * with no Standard Schema wrapper), fall back to validating against the
+ * spliced JSON Schema directly.
+ */
+function buildJsonOverrideSchema(
+  originalSchema: unknown,
+  splicedJsonSchema: JSONSchema7Definition,
+  injectedKeys: readonly string[],
+): StandardSchemaWithJSON {
+  const fallback = toStandardSchema(splicedJsonSchema as any);
+  const original = originalSchema as { '~standard'?: { validate?: (v: unknown) => any } } | undefined;
+  const originalValidate = original?.['~standard']?.validate?.bind(original['~standard']);
+
+  const stripInjected = (input: unknown) => {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) return { stripped: input, injected: {} };
+    const injected: Record<string, unknown> = {};
+    const stripped: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+      if (injectedKeys.includes(k)) injected[k] = v;
+      else stripped[k] = v;
+    }
+    return { stripped, injected };
+  };
+
+  const validate = (input: unknown) => {
+    if (!originalValidate) return fallback['~standard'].validate(input);
+    const { stripped, injected } = stripInjected(input);
+    const result = originalValidate(stripped) as
+      | { value: unknown }
+      | { issues: readonly unknown[] }
+      | Promise<{ value: unknown } | { issues: readonly unknown[] }>;
+    const merge = (r: { value: unknown } | { issues: readonly unknown[] }) => {
+      if ('value' in r && r.value && typeof r.value === 'object' && !Array.isArray(r.value)) {
+        return { value: { ...(r.value as Record<string, unknown>), ...injected } };
+      }
+      return r;
+    };
+    return result && typeof (result as Promise<unknown>).then === 'function'
+      ? (result as Promise<{ value: unknown } | { issues: readonly unknown[] }>).then(merge)
+      : merge(result as { value: unknown } | { issues: readonly unknown[] });
+  };
+
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'mastra-json-override',
+      validate,
+      jsonSchema: fallback['~standard'].jsonSchema,
+    },
+  } as StandardSchemaWithJSON;
+}
+
 export class CoreToolBuilder extends MastraBase {
   private originalTool: ToolToConvert;
   private options: ToolOptions;
@@ -143,9 +209,11 @@ export class CoreToolBuilder extends MastraBase {
 
           if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
             const properties: Record<string, JSONSchema7Definition> = { ...(jsonSchema.properties ?? {}) };
+            const injectedKeys: string[] = [];
 
             if (isBackgroundEligible) {
               properties._background = backgroundOverrideJsonSchema;
+              injectedKeys.push('_background');
             }
             if (isResumableTool) {
               // Match the pre-PR JSON Schema shape so existing provider compat
@@ -157,9 +225,18 @@ export class CoreToolBuilder extends MastraBase {
               properties.resumeData = {
                 description: 'The resumeData object created from the resumeSchema of suspended tool',
               };
+              injectedKeys.push('suspendedToolRunId', 'resumeData');
             }
 
-            this.originalTool.inputSchema = toStandardSchema({ ...jsonSchema, properties });
+            // Preserve the original schema's runtime validator (Zod v3
+            // `.transform()` / `.default()` / `.refine()` etc.) while exposing
+            // the spliced JSON Schema for provider serialization. See
+            // https://github.com/mastra-ai/mastra/pull/16915#discussion_r3282520408
+            this.originalTool.inputSchema = buildJsonOverrideSchema(
+              schema,
+              { ...jsonSchema, properties },
+              injectedKeys,
+            );
           }
         }
       }

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -98,6 +98,25 @@ function buildJsonOverrideSchema(
   const original = originalSchema as { '~standard'?: { validate?: (v: unknown) => any } } | undefined;
   const originalValidate = original?.['~standard']?.validate?.bind(original['~standard']);
 
+  // Standard Schema for *just* the injected override fields, so we can validate
+  // malformed override payloads (e.g. `_background: { enabled: "yes" }`) before
+  // merging them into the result. Matches the Zod v4 `.extend()` path's
+  // behavior, which validates these fields as part of the object.
+  // See https://github.com/mastra-ai/mastra/pull/16915#discussion_r3282600679
+  const splicedProperties =
+    splicedJsonSchema && typeof splicedJsonSchema === 'object' && 'properties' in splicedJsonSchema
+      ? ((splicedJsonSchema.properties ?? {}) as Record<string, JSONSchema7Definition>)
+      : {};
+  const injectedProperties: Record<string, JSONSchema7Definition> = {};
+  for (const key of injectedKeys) {
+    if (splicedProperties[key] !== undefined) injectedProperties[key] = splicedProperties[key];
+  }
+  const injectedValidator = toStandardSchema({
+    type: 'object',
+    properties: injectedProperties,
+    additionalProperties: false,
+  } as any);
+
   const stripInjected = (input: unknown) => {
     if (!input || typeof input !== 'object' || Array.isArray(input)) return { stripped: input, injected: {} };
     const injected: Record<string, unknown> = {};
@@ -110,21 +129,52 @@ function buildJsonOverrideSchema(
   };
 
   const validate = (input: unknown) => {
-    if (!originalValidate) return fallback['~standard'].validate(input);
     const { stripped, injected } = stripInjected(input);
-    const result = originalValidate(stripped) as
-      | { value: unknown }
-      | { issues: readonly unknown[] }
-      | Promise<{ value: unknown } | { issues: readonly unknown[] }>;
-    const merge = (r: { value: unknown } | { issues: readonly unknown[] }) => {
-      if ('value' in r && r.value && typeof r.value === 'object' && !Array.isArray(r.value)) {
-        return { value: { ...(r.value as Record<string, unknown>), ...injected } };
+
+    const baseResult = originalValidate
+      ? (originalValidate(stripped) as
+          | { value: unknown }
+          | { issues: readonly unknown[] }
+          | Promise<{ value: unknown } | { issues: readonly unknown[] }>)
+      : fallback['~standard'].validate(stripped);
+
+    const injectedResult = injectedValidator['~standard'].validate(injected);
+
+    const combine = (
+      base: { value: unknown } | { issues: readonly unknown[] },
+      inj: { value: unknown } | { issues: readonly unknown[] },
+    ) => {
+      const baseIssues = 'issues' in base ? (base.issues ?? []) : [];
+      const injIssues = 'issues' in inj ? (inj.issues ?? []) : [];
+      if (baseIssues.length || injIssues.length) {
+        return { issues: [...baseIssues, ...injIssues] };
       }
-      return r;
+      const baseValue = (base as { value: unknown }).value;
+      const injValue = (inj as { value: unknown }).value;
+      if (baseValue && typeof baseValue === 'object' && !Array.isArray(baseValue)) {
+        const injMerged =
+          injValue && typeof injValue === 'object' && !Array.isArray(injValue)
+            ? (injValue as Record<string, unknown>)
+            : injected;
+        return { value: { ...(baseValue as Record<string, unknown>), ...injMerged } };
+      }
+      return base;
     };
-    return result && typeof (result as Promise<unknown>).then === 'function'
-      ? (result as Promise<{ value: unknown } | { issues: readonly unknown[] }>).then(merge)
-      : merge(result as { value: unknown } | { issues: readonly unknown[] });
+
+    const baseIsPromise = baseResult && typeof (baseResult as Promise<unknown>).then === 'function';
+    const injIsPromise = injectedResult && typeof (injectedResult as Promise<unknown>).then === 'function';
+    if (baseIsPromise || injIsPromise) {
+      return Promise.all([baseResult, injectedResult]).then(([b, i]) =>
+        combine(
+          b as { value: unknown } | { issues: readonly unknown[] },
+          i as { value: unknown } | { issues: readonly unknown[] },
+        ),
+      );
+    }
+    return combine(
+      baseResult as { value: unknown } | { issues: readonly unknown[] },
+      injectedResult as { value: unknown } | { issues: readonly unknown[] },
+    );
   };
 
   return {

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -14,7 +14,7 @@ import {
 import type { JSONSchema7Definition } from 'json-schema';
 import { z } from 'zod/v4';
 import { MastraFGAPermissions } from '../../auth/ee';
-import { backgroundOverrideJsonSchema } from '../../background-tasks';
+import { backgroundOverrideJsonSchema, backgroundOverrideZodSchema } from '../../background-tasks';
 import { MastraBase } from '../../base';
 import { ErrorCategory, MastraError, ErrorDomain } from '../../error';
 import type { Mastra } from '../../mastra';
@@ -27,6 +27,7 @@ import type { StandardSchemaWithJSON } from '../../schema';
 import { isVercelTool, isProviderDefinedTool } from '../../tools/toolchecks';
 import type { ToolOptions } from '../../utils';
 import { safeStringify } from '../../utils';
+import { isZodObject } from '../../utils/zod-utils';
 
 import type { SuspendOptions } from '../../workflows';
 import { ToolStream } from '../stream';
@@ -57,6 +58,17 @@ interface LogMessageOptions {
   start: string;
   error: string;
   logData: Record<string, unknown>;
+}
+
+/**
+ * Detect Zod v4 schemas. Zod v3 stores the type name as `_def.typeName`
+ * (e.g. "ZodObject"); Zod v4 stores it as `_def.type` (e.g. "object"). We
+ * cannot use `instanceof` here because both Zod versions may be loaded in the
+ * same process and the prototype identity is not guaranteed.
+ */
+function isZodV4Schema(schema: unknown): boolean {
+  const def = (schema as any)?._def;
+  return !!def && typeof def.type === 'string' && !def.typeName;
 }
 
 export class CoreToolBuilder extends MastraBase {
@@ -96,33 +108,59 @@ export class CoreToolBuilder extends MastraBase {
           schema = z.object({});
         }
 
-        // Unified JSON-schema path: normalize the user's input schema (Zod v3,
-        // Zod v4, or a JsonSchemaWrapper) into a Standard Schema, extract its
-        // JSON Schema, add the framework's override fields, and re-wrap. This
-        // matches the codebase's general schema-interop pattern and avoids
-        // splicing a Zod v4 ZodOptional into a Zod v3 ZodObject's shape, which
-        // would crash later in `ZodObject._parse` with
-        // `keyValidator._parse is not a function`.
-        const standardSchema = isStandardSchemaWithJSON(schema) ? schema : toStandardSchema(schema);
-        const jsonSchema = standardSchemaToJSONSchema(standardSchema, { io: 'input' });
-
-        if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
-          const properties: Record<string, JSONSchema7Definition> = { ...(jsonSchema.properties ?? {}) };
-
+        // Preferred path: when the user's input schema is a Zod v4 ZodObject
+        // (the common case for tools authored with `zod` / `zod/v4`), keep using
+        // `.extend()`. This preserves the exact JSON Schema shape that existing
+        // provider compat layers + LLM recordings expect.
+        //
+        // Fallback path: for everything else (Zod v3 ZodObject, raw JSON Schema,
+        // `JsonSchemaWrapper`, etc.) splice the override fields directly into a
+        // JSON Schema. Mixing a Zod v4 wrapper (`backgroundOverrideZodSchema`,
+        // `.nullable()`, `.optional()`) into a Zod v3 ZodObject's `.shape` is
+        // what triggered the original crash:
+        //   `TypeError: keyValidator._parse is not a function`.
+        if (isZodObject(schema) && isZodV4Schema(schema)) {
+          let nextSchema: z.ZodObject<any> = schema as z.ZodObject<any>;
           if (isBackgroundEligible) {
-            properties._background = backgroundOverrideJsonSchema;
+            nextSchema = nextSchema.extend({
+              _background: backgroundOverrideZodSchema,
+            });
           }
           if (isResumableTool) {
-            properties.suspendedToolRunId = {
-              type: ['string', 'null'],
-              description: 'The runId of the suspended tool',
-            };
-            properties.resumeData = {
-              description: 'The resumeData object created from the resumeSchema of suspended tool',
-            };
+            nextSchema = nextSchema.extend({
+              suspendedToolRunId: z.string().describe('The runId of the suspended tool').nullable().optional(),
+              resumeData: z
+                .any()
+                .describe('The resumeData object created from the resumeSchema of suspended tool')
+                .optional(),
+            });
           }
+          this.originalTool.inputSchema = nextSchema;
+        } else {
+          // Normalize to Standard Schema, extract JSON Schema, splice overrides.
+          const standardSchema = isStandardSchemaWithJSON(schema) ? schema : toStandardSchema(schema);
+          const jsonSchema = standardSchemaToJSONSchema(standardSchema, { io: 'input' });
 
-          this.originalTool.inputSchema = toStandardSchema({ ...jsonSchema, properties });
+          if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
+            const properties: Record<string, JSONSchema7Definition> = { ...(jsonSchema.properties ?? {}) };
+
+            if (isBackgroundEligible) {
+              properties._background = backgroundOverrideJsonSchema;
+            }
+            if (isResumableTool) {
+              // Match the pre-PR JSON Schema shape so existing provider compat
+              // layers + LLM recordings collapse it identically.
+              properties.suspendedToolRunId = {
+                type: ['string', 'null'],
+                description: 'The runId of the suspended tool',
+              };
+              properties.resumeData = {
+                description: 'The resumeData object created from the resumeSchema of suspended tool',
+              };
+            }
+
+            this.originalTool.inputSchema = toStandardSchema({ ...jsonSchema, properties });
+          }
         }
       }
     }

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -13,7 +13,7 @@ import {
 } from '@mastra/schema-compat';
 import { z } from 'zod/v4';
 import { MastraFGAPermissions } from '../../auth/ee';
-import { backgroundOverrideJsonSchema, backgroundOverrideZodSchema } from '../../background-tasks';
+import { backgroundOverrideJsonSchema } from '../../background-tasks';
 import { MastraBase } from '../../base';
 import { ErrorCategory, MastraError, ErrorDomain } from '../../error';
 import type { Mastra } from '../../mastra';
@@ -26,7 +26,6 @@ import type { StandardSchemaWithJSON } from '../../schema';
 import { isVercelTool, isProviderDefinedTool } from '../../tools/toolchecks';
 import type { ToolOptions } from '../../utils';
 import { safeStringify } from '../../utils';
-import { isZodObject } from '../../utils/zod-utils';
 
 import type { SuspendOptions } from '../../workflows';
 import { ToolStream } from '../stream';
@@ -96,48 +95,35 @@ export class CoreToolBuilder extends MastraBase {
           schema = z.object({});
         }
 
-        if (isZodObject(schema)) {
-          let nextSchema = schema;
+        // Unified JSON-schema path: normalize the user's input schema (Zod v3,
+        // Zod v4, or a JsonSchemaWrapper) into a Standard Schema, extract its
+        // JSON Schema, add the framework's override fields, and re-wrap. This
+        // matches the codebase's general schema-interop pattern and avoids
+        // splicing a Zod v4 ZodOptional into a Zod v3 ZodObject's shape, which
+        // would crash later in `ZodObject._parse` with
+        // `keyValidator._parse is not a function`.
+        const standardSchema = isStandardSchemaWithJSON(schema as any)
+          ? (schema as any)
+          : toStandardSchema(schema as any);
+        const jsonSchema = standardSchemaToJSONSchema(standardSchema, { io: 'input' });
+
+        if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
+          const properties = { ...(jsonSchema.properties ?? {}) };
+
           if (isBackgroundEligible) {
-            nextSchema = nextSchema.extend({
-              _background: backgroundOverrideZodSchema,
-            });
+            properties._background = backgroundOverrideJsonSchema;
           }
           if (isResumableTool) {
-            nextSchema = nextSchema.extend({
-              suspendedToolRunId: z.string().describe('The runId of the suspended tool').nullable().optional(),
-              resumeData: z
-                .any()
-                .describe('The resumeData object created from the resumeSchema of suspended tool')
-                .optional(),
-            });
+            properties.suspendedToolRunId = {
+              type: ['string', 'null'],
+              description: 'The runId of the suspended tool',
+            };
+            properties.resumeData = {
+              description: 'The resumeData object created from the resumeSchema of suspended tool',
+            };
           }
-          this.originalTool.inputSchema = nextSchema;
-        } else {
-          // Non-Zod StandardSchemaWithJSON (e.g. JsonSchemaWrapper from JSONSchema7).
-          // Extract JSON Schema, add suspend/resume fields, re-wrap.
-          const jsonSchema = standardSchemaToJSONSchema(schema as any, { io: 'input' });
-          if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
-            if (isBackgroundEligible) {
-              jsonSchema.properties = {
-                ...jsonSchema.properties,
-                _background: backgroundOverrideJsonSchema,
-              };
-            }
-            if (isResumableTool) {
-              jsonSchema.properties = {
-                ...jsonSchema.properties,
-                suspendedToolRunId: {
-                  type: ['string', 'null'],
-                  description: 'The runId of the suspended tool',
-                },
-                resumeData: {
-                  description: 'The resumeData object created from the resumeSchema of suspended tool',
-                },
-              };
-            }
-            this.originalTool.inputSchema = toStandardSchema(jsonSchema) as any;
-          }
+
+          this.originalTool.inputSchema = toStandardSchema({ ...jsonSchema, properties }) as any;
         }
       }
     }

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -11,6 +11,7 @@ import {
   convertZodSchemaToAISDKSchema,
   jsonSchema,
 } from '@mastra/schema-compat';
+import type { JSONSchema7Definition } from 'json-schema';
 import { z } from 'zod/v4';
 import { MastraFGAPermissions } from '../../auth/ee';
 import { backgroundOverrideJsonSchema } from '../../background-tasks';
@@ -102,13 +103,11 @@ export class CoreToolBuilder extends MastraBase {
         // splicing a Zod v4 ZodOptional into a Zod v3 ZodObject's shape, which
         // would crash later in `ZodObject._parse` with
         // `keyValidator._parse is not a function`.
-        const standardSchema = isStandardSchemaWithJSON(schema as any)
-          ? (schema as any)
-          : toStandardSchema(schema as any);
+        const standardSchema = isStandardSchemaWithJSON(schema) ? schema : toStandardSchema(schema);
         const jsonSchema = standardSchemaToJSONSchema(standardSchema, { io: 'input' });
 
         if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
-          const properties = { ...(jsonSchema.properties ?? {}) };
+          const properties: Record<string, JSONSchema7Definition> = { ...(jsonSchema.properties ?? {}) };
 
           if (isBackgroundEligible) {
             properties._background = backgroundOverrideJsonSchema;
@@ -123,7 +122,7 @@ export class CoreToolBuilder extends MastraBase {
             };
           }
 
-          this.originalTool.inputSchema = toStandardSchema({ ...jsonSchema, properties }) as any;
+          this.originalTool.inputSchema = toStandardSchema({ ...jsonSchema, properties });
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes a tool-execution crash that surfaces as:

```
TypeError: keyValidator._parse is not a function
  at ZodObject._parse (zod/v3/types.js)
  at safeValidate (@mastra/core/.../chunk-*.js)
  at validateToolInput (@mastra/core/.../chunk-*.js)
  at Tool.execute (@mastra/core/.../chunk-*.js)
```

The bug is triggered when a Mastra app:
- uses tools whose `inputSchema` is authored with **Zod v3**, **and**
- enables `backgroundTasks` on the `Mastra` instance (or uses any resumable tool, since the same code path also injects `suspendedToolRunId` / `resumeData`).

Every tool execution then crashes with the above stack — both direct (`POST /api/tools/:tool/execute`), agent-scoped, agent-driven (LLM tool calls), and MCP. The corruption persists across requests for the lifetime of the process.

## Root cause

`CoreToolBuilder` (`packages/core/src/tools/tool-builder/builder.ts`) injects framework-controlled override fields into each background-eligible or resumable tool's input schema at construction time.

The previous implementation branched on whether the user's input schema was a Zod object:

```ts
// before
if (isZodObject(schema)) {
  let nextSchema = schema;
  if (isBackgroundEligible) {
    nextSchema = nextSchema.extend({
      _background: backgroundOverrideZodSchema, // ← from `import { z } from 'zod/v4'`
    });
  }
  if (isResumableTool) {
    nextSchema = nextSchema.extend({
      suspendedToolRunId: z.string()...,         // ← also v4 `z`
      resumeData: z.any()...,
    });
  }
  this.originalTool.inputSchema = nextSchema;    // ← persistent mutation
} else {
  // JSON-Schema path (already correct)
  ...
}
```

`backgroundOverrideZodSchema` is created with `import { z } from 'zod/v4'` (`packages/core/src/background-tasks/schema-injection.ts`), so it is always a **Zod v4** `ZodOptional`. When the user authors their tool with Zod v3:

1. `nextSchema.extend({ _background: <v4 schema> })` creates a Zod v3 `ZodObject` whose `shape._background` is a Zod v4 object.
2. The result is stored back onto `originalTool.inputSchema`, so the corruption is persistent (not request-scoped).
3. Later, `validateToolInput` → `safeValidate` → the schema's `~standard.validate` calls `ZodObject._parse` (Zod v3), which iterates `shape` and calls `keyValidator._parse(...)` on each child.
4. Zod v4 schemas have no `_parse` method (renamed to `_zod`/`.parse`), so the call throws `TypeError: keyValidator._parse is not a function`.

### Why this is environment-dependent

The crash depends on package resolution. `@mastra/core` declares `peerDependencies: { zod: '^3.25.0 || ^4.0.0' }` and internally imports both `'zod/v3'` and `'zod/v4'` subpaths. When the user's tool code imports bare `zod`, two outcomes are possible:

- **Bare `zod` resolves to `zod@4.x`** (e.g. when zod 4 is the only or hoisted version, or via a v3 compat shim in zod 4). User's `z.object({...})` produces a v4 ZodObject; `.extend({_background: <v4>})` mixes v4-with-v4 → no crash.
- **Bare `zod` resolves to `zod@3.x`** (e.g. when the app explicitly depends on zod 3, hoisted differently on Linux vs macOS by pnpm). User's `z.object({...})` produces a v3 ZodObject; `.extend({_background: <v4>})` stuffs a v4 child into a v3 shape → **crash on first tool execution**.

In our smoke matrix, the Zod 4 matrix passed everywhere; the Zod 3 matrix crashed on CI Linux but not local macOS, because pnpm hoisted `zod` differently across platforms even with identical lockfiles.

### Why partial test runs could pass

`tools/tools.test.ts` happens to call the `/api/tools/:tool/execute` route, but each test gets a fresh tool registration from a clean fixture instance. The crash only manifests after `CoreToolBuilder` has run with `isBackgroundEligible || isResumableTool` true for a given tool — and after `this.originalTool.inputSchema = nextSchema` poisons the shared reference. That made the failure look order-dependent and flaky during investigation; in reality it was deterministic given the right resolution + `backgroundTasks: { enabled: true }` config.

## Fix

Unify the Zod and non-Zod branches into a single JSON-Schema-based injection path, which is already the framework's standard schema-interop pattern (used in `agent.ts`, `prepare-tools.ts`, processors, etc.):

```ts
// after
const standardSchema = isStandardSchemaWithJSON(schema as any)
  ? (schema as any)
  : toStandardSchema(schema as any);
const jsonSchema = standardSchemaToJSONSchema(standardSchema, { io: 'input' });

if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.type === 'object') {
  const properties = { ...(jsonSchema.properties ?? {}) };

  if (isBackgroundEligible) {
    properties._background = backgroundOverrideJsonSchema;
  }
  if (isResumableTool) {
    properties.suspendedToolRunId = {
      type: ['string', 'null'],
      description: 'The runId of the suspended tool',
    };
    properties.resumeData = {
      description: 'The resumeData object created from the resumeSchema of suspended tool',
    };
  }

  this.originalTool.inputSchema = toStandardSchema({ ...jsonSchema, properties }) as any;
}
```

- The override fields are always expressed as **JSON Schema** (`backgroundOverrideJsonSchema` already exists and is the same data the v4 zod constant was modelling).
- The final stored value is a `JsonSchemaWrapper` — version-neutral. No `_parse` is ever called on the override field's validator regardless of which Zod version the user's `~standard.validate` is dispatched against.
- The non-Zod path (`JsonSchemaWrapper` inputs) is unchanged in behaviour — both paths just go through the same code now.

`backgroundOverrideZodSchema` and the `isZodObject` import in this file become dead code and are dropped. `backgroundOverrideZodSchema` is still exported from `packages/core/src/background-tasks` for any external consumer.

## Verification

Reproduced and fixed against `e2e-tests/smoke` (a Mastra app with `backgroundTasks: { enabled: true }`, tools authored with `import { z } from 'zod'`, and the `.mastra/output/node_modules/zod` symlink forced to `zod@3.25.76` to mirror CI Linux pnpm hoisting):

| Matrix | Before fix | After fix |
|---|---|---|
| Zod 3 path (`zod@3.25.76`) | 21 failed / 275 passed (incl. all tool-execution paths: direct, agent, generate, stream, tool-approval, MCP) | **295/296 passed**, 1 unrelated LLM-latency flake (passes on rerun) |
| Zod 4 path (`zod@4.4.3`) | 296/296 passed | **296/296 passed** (no regression) |

The 10 previously-failing tool-execution tests (with the exact `keyValidator._parse is not a function` stack on the Zod 3 path) all pass after the fix.

## Reproduction recipe

For anyone wanting to verify locally without the smoke fixture:

```bash
# In any Mastra app with a tool authored with `import { z } from 'zod'`:
pnpm add zod@3.25.76
# In Mastra config, set:
#   new Mastra({ backgroundTasks: { enabled: true }, ... })
pnpm mastra build
# Force bare zod inside the build output to resolve to v3 (simulates CI Linux):
cd .mastra/output/node_modules
rm zod && ln -s .pnpm/zod@3.25.76/node_modules/zod zod
cd -
node .mastra/output/index.mjs &
# Then call any tool with a Zod v3 input schema:
curl -X POST http://localhost:4111/api/tools/<your-tool>/execute \
  -H 'content-type: application/json' \
  -d '{"data": {...valid input...}}'
# → before fix: 500 {"error":"keyValidator._parse is not a function"}
# → after fix:  200 {...tool result...}
```

## Notes / follow-ups (not required for this fix)

- `this.originalTool.inputSchema = ...` still mutates a (potentially) shared `originalTool` reference. After this fix it's safe (the new value is version-neutral), but it's a smell worth cleaning up later — `CoreToolBuilder` should not be mutating its input.
- This is the same class of bug pattern as #16782 and #16783 (framework-controlled state silently grafted onto user schemas) — worth a sweep for any other call sites that splice `import { z } from 'zod/v4'` schemas into user-provided schemas.

## Changeset

Patch bump for `@mastra/core`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

The app crashed because adding hidden helper fields mixed two incompatible versions of a schema library. Now the builder converts any input schema to a neutral JSON Schema, injects the helper fields there, and converts back so tools using either schema version (or raw JSON) won't break.

## Changes

### Core Fix: JSON Schema Normalization for Override Injection
- Refactored CoreToolBuilder (packages/core/src/tools/tool-builder/builder.ts) to stop unconditionally using Zod v4 .extend() for injecting framework-controlled fields.
- New behavior:
  1. Detects true Zod v4 object schemas and keeps the previous .extend() path for those exact cases.
  2. For Zod v3, raw JSON Schema inputs, or other wrapper cases: normalizes the tool's input schema to the project's StandardSchema, converts it to JSON Schema (io: 'input'), injects override properties into the JSON Schema properties, then converts back to a StandardSchema (resulting in a JsonSchemaWrapper) and assigns it to originalTool.inputSchema.
- Injected, version-neutral properties:
  - _background (when backgroundTaskEnabled) — uses existing backgroundOverrideJsonSchema shape.
  - suspendedToolRunId and resumeData (for resumable tools via autoResumeSuspendedTools or IDs prefixed with agent-/workflow-).
- The JsonSchemaWrapper preserves original runtime validation when possible by stripping injected keys before delegating to the original ~standard.validate and merging injected values back afterwards; otherwise it falls back to JSON Schema validation.
- Removed dead local imports/usages related to the prior Zod v4 override and isZodObject in the file; backgroundOverrideZodSchema remains exported for external consumers.
- Tightened types on the JSON-schema injection path (properties typed as Record<string, JSONSchema7Definition>).
- Note: originalTool.inputSchema is still mutated in-place by CoreToolBuilder (flagged as a smell for future cleanup).

### Tests and Changeset
- Added Vitest regression tests (packages/core/src/tools/tool-builder/background-override-injection.test.ts) covering:
  - Zod v3 regression that previously crashed during execution.
  - Zod v4 compatibility (unchanged behavior for v4 objects).
  - Raw JSON Schema wrapper behavior.
  - Resumable-tool injection for agent-/workflow- prefixed IDs.
  - Non-injection case ensuring no unintended changes.
- Changeset (.changeset/grumpy-planes-count.md): patch bump for `@mastra/core` describing the fix.

## Verification
- Reproduced the crash and confirmed the fix in smoke tests:
  - Forced zod@3.25.76: previously failing tool-execution tests now pass.
  - Forced zod@4.4.3: existing passing tests remain green.
- Regression test asserts the resulting JSON Schema contains user properties plus _background, suspendedToolRunId, and resumeData when applicable.

## Impact
- Prevents runtime TypeError from mixing Zod v3 and v4 internals (e.g., keyValidator._parse is not a function).
- Makes framework-injected fields version-neutral and ensures consistent behavior across Zod v3, Zod v4, and JSON Schema input schemas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->