### PR TITLE
fix(playground): stabilize agent-profile Models and Integrations loading states

### DIFF
--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/integrations-loading.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/integrations-loading.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { AgentBuilderEditFormValues } from '../../../../schemas';
+import { Integrations } from '../integrations';
+
+const BASE_URL = 'http://localhost:4111';
+
+vi.mock('@/domains/agent-builder/contexts/edit-page-context', () => ({
+  useEditPage: () => ({ canPublishToChannel: false }),
+}));
+
+vi.mock('@/domains/agents/hooks/use-channels', () => ({
+  useChannelPlatforms: () => ({ data: undefined, isLoading: true }),
+  useChannelInstallations: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('@/domains/agent-builder/hooks/use-publish-and-connect-channel', () => ({
+  usePublishAndConnectChannel: () => ({
+    requestPublishAndConnect: () => {},
+    dialog: null,
+    channelDialog: null,
+  }),
+}));
+
+const Harness = ({ children }: { children: ReactNode }) => {
+  const methods = useForm<AgentBuilderEditFormValues>({
+    defaultValues: { name: '', instructions: '', visibility: 'private' } as AgentBuilderEditFormValues,
+  });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <TooltipProvider>
+            <FormProvider {...methods}>{children}</FormProvider>
+          </TooltipProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+const installRadixDomShims = () => {
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+  if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+  if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    class StubResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+  }
+};
+
+describe('Integrations loading state', () => {
+  beforeAll(() => {
+    installRadixDomShims();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a structural skeleton that reserves the heading + card footprint', () => {
+    const { getByTestId, queryByTestId, container } = render(
+      <Harness>
+        <Integrations agentId="agent-1" />
+      </Harness>,
+    );
+
+    const skeleton = getByTestId('integrations-detail-picker-loading');
+    expect(skeleton).toBeTruthy();
+    // The loaded picker testid must NOT be present while data is loading.
+    expect(queryByTestId('integrations-detail-picker')).toBeNull();
+
+    // Lock in that the card footprint is reserved with the same `w-48`
+    // width as the real `IntegrationCard`, so the panel doesn't reflow
+    // when channel platforms resolve.
+    const cardWidthRegex = /(^|\s)w-48(\s|$)/;
+    const hasCardSizedChild = Array.from(container.querySelectorAll('*')).some(el => cardWidthRegex.test(el.className));
+    expect(hasCardSizedChild).toBe(true);
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/models-loading.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/models-loading.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AgentColorProvider } from '../../../../contexts/agent-color-context';
+import type { AgentBuilderEditFormValues } from '../../../../schemas';
+import { Models } from '../models';
+
+vi.mock('@/domains/builder', () => ({
+  useBuilderModelPolicy: () => ({ active: false, pickerVisible: true }),
+  useBuilderFilteredProviders: (providers: unknown) => providers,
+  useBuilderFilteredModels: (models: unknown) => models,
+}));
+
+vi.mock('@/domains/llm', () => ({
+  cleanProviderId: (provider: string) => provider,
+  ProviderLogo: ({ providerId }: { providerId: string }) => <span data-testid={`provider-logo-${providerId}`} />,
+  useAllModels: () => [],
+  useLLMProviders: () => ({
+    isLoading: true,
+    data: undefined,
+  }),
+}));
+
+const FormHarness = ({ children }: { children: ReactNode }) => {
+  const methods = useForm<AgentBuilderEditFormValues>({
+    defaultValues: {
+      name: '',
+      model: { provider: '', name: '' },
+    } as AgentBuilderEditFormValues,
+  });
+  return (
+    <FormProvider {...methods}>
+      <AgentColorProvider>{children}</AgentColorProvider>
+    </FormProvider>
+  );
+};
+
+describe('Models loading state', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a structural skeleton that mirrors the loaded grid template', () => {
+    const { getByTestId, queryByTestId } = render(
+      <FormHarness>
+        <Models />
+      </FormHarness>,
+    );
+
+    const skeleton = getByTestId('model-card-picker-loading');
+    expect(skeleton).toBeTruthy();
+    // The loaded picker testid must NOT be present while data is loading.
+    expect(queryByTestId('model-card-picker')).toBeNull();
+    // Lock in the structural grid contract so a regression to the old
+    // `<Skeleton className="h-40 w-full" />` block can't slip back in.
+    expect(skeleton.className).toContain('grid-rows-[auto_auto_minmax(0,1fr)]');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/integrations.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/integrations.tsx
@@ -1,4 +1,4 @@
-import { StatusBadge, Txt } from '@mastra/playground-ui';
+import { Skeleton, StatusBadge, Txt } from '@mastra/playground-ui';
 import { useEditPage } from '@/domains/agent-builder/contexts/edit-page-context';
 import { usePublishAndConnectChannel } from '@/domains/agent-builder/hooks/use-publish-and-connect-channel';
 import { PlatformIcon } from '@/domains/agents/components/agent-channels/platform-icons';
@@ -19,7 +19,40 @@ export const Integrations = ({ agentId, editable = true }: IntegrationsProps) =>
   const { canPublishToChannel } = useEditPage();
   const { requestPublishAndConnect, dialog, channelDialog } = usePublishAndConnectChannel(agentId);
 
-  if (isLoading) return null;
+  if (isLoading) {
+    return (
+      <div
+        className="flex h-full min-h-0 items-center justify-center px-6 py-8"
+        data-testid="integrations-detail-picker-loading"
+      >
+        <div className="flex w-full max-w-[48rem] flex-col items-center gap-6 text-center">
+          <div className="flex flex-col items-center gap-2">
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-4 w-80" />
+          </div>
+
+          <div className="flex flex-wrap items-stretch justify-center gap-4">
+            <div className="flex w-48 flex-col items-center gap-3 rounded-xl border border-border1 bg-surface3 px-4 py-6">
+              <Skeleton className="size-14 rounded-xl" />
+              <div className="flex flex-col items-center gap-1">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+              <Skeleton className="h-badge-default w-20 rounded-full" />
+            </div>
+            <div className="flex w-48 flex-col items-center gap-3 rounded-xl border border-border1 bg-surface3 px-4 py-6">
+              <Skeleton className="size-14 rounded-xl" />
+              <div className="flex flex-col items-center gap-1">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+              <Skeleton className="h-badge-default w-20 rounded-full" />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (platforms.length === 0) {
     return (

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/models.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/models.tsx
@@ -75,8 +75,7 @@ const ModelPicker = ({ disabled = false }: ModelPickerProps) => {
       .sort((a, b) => a.providerName.localeCompare(b.providerName));
   }, [policyAllowedModels]);
 
-  const isProviderChecked = (providerId: string) =>
-    selectedProviders === null || selectedProviders.has(providerId);
+  const isProviderChecked = (providerId: string) => selectedProviders === null || selectedProviders.has(providerId);
 
   const handleToggleProvider = (providerId: string) => {
     setSelectedProviders(prev => {
@@ -92,7 +91,40 @@ const ModelPicker = ({ disabled = false }: ModelPickerProps) => {
   };
 
   if (isLoading) {
-    return <Skeleton className="h-40 w-full" />;
+    return (
+      <div className="h-full overflow-y-auto">
+        <div
+          className="grid h-full min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] gap-4 px-6 overflow-y-auto"
+          data-testid="model-card-picker-loading"
+        >
+          <div className="shrink-0 max-w-[30ch]">
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+
+          <div className="flex flex-wrap gap-2 shrink-0">
+            <Skeleton className="h-badge-default w-20 rounded-full" />
+            <Skeleton className="h-badge-default w-24 rounded-full" />
+            <Skeleton className="h-badge-default w-20 rounded-full" />
+            <Skeleton className="h-badge-default w-28 rounded-full" />
+            <Skeleton className="h-badge-default w-24 rounded-full" />
+          </div>
+
+          <div className="flex min-h-0 flex-col gap-6 overflow-y-auto">
+            <div className="flex flex-col gap-3">
+              <Skeleton className="h-4 w-24" />
+              <div className="grid grid-cols-1 content-start gap-2 lg:gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                <Skeleton className="h-20 rounded-lg" />
+                <Skeleton className="h-20 rounded-lg" />
+                <Skeleton className="h-20 rounded-lg" />
+                <Skeleton className="h-20 rounded-lg" />
+                <Skeleton className="h-20 rounded-lg" />
+                <Skeleton className="h-20 rounded-lg" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   const provider = cleanProviderId(model?.provider ?? '');


### PR DESCRIPTION
## Summary

The agent-profile **Models** and **Integrations** tabs reflowed when their data arrived because their loading footprints did not match the loaded layout:

- **Models** rendered a single `h-40 w-full` skeleton while `useLLMProviders` loaded, then popped the search bar, provider filter row, and model card grid into existence.
- **Integrations** returned `null` while `useChannelPlatforms` loaded, then popped the centered heading + row of integration cards in from nothing.

This change replaces both loading branches with structural skeletons that mirror the loaded layout — same outer grid template, same fixed-width cards, same badge footprint — so the panel area is reserved before data lands and content slots into place without reflow.

## Changes

- `models.tsx` — loading state now reserves the search bar (`max-w-[30ch]`), a wrap row of provider-pill skeletons, and a 1/2/3-column grid of card skeletons under the same `grid-rows-[auto_auto_minmax(0,1fr)]` container. Exposed via `data-testid="model-card-picker-loading"`.
- `integrations.tsx` — loading state now renders a centered `max-w-[48rem]` column with title/description skeletons and a wrapping row of `w-48` card skeletons that mirror the real `IntegrationCard`. Exposed via `data-testid="integrations-detail-picker-loading"`.
- Added two sibling vitest unit tests that override the relevant data hooks with `isLoading: true` and lock in the structural contract (grid template / `w-48` card width) so regressions are caught.

## Test plan

- `pnpm --filter ./packages/playground build` — passes.
- `npx tsc --noEmit -p tsconfig.build.json` in `packages/playground` — clean.
- `npx vitest run` against `agent-profile/__tests__` — 10 files, 54 tests pass (including the 2 new tests).
- `eslint --no-warn-ignored` on the four touched files — clean.
- Manual: under throttled network, switching between Models and Integrations tabs no longer reflows the panel when data resolves.

Scope is intentionally limited to the `packages/playground` agent-builder Models/Integrations tabs and their colocated vitest coverage; no changeset and no E2E coverage in this PR.

🤖 Generated with [Mastra Code](https://mastra.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->