### PR TITLE
feat(playground-ui): migrate hover cards to Base UI

### DIFF
--- a/.changeset/tall-hounds-grin.md
+++ b/.changeset/tall-hounds-grin.md
@@ -2,7 +2,7 @@
 '@mastra/playground-ui': minor
 ---
 
-Added a reusable `HoverCard` component (`HoverCard`, `HoverCardTrigger`, `HoverCardContent`) built on Base UI. The trace timeline and key-value list hover cards now share this single component instead of inlining the markup, and it is exported for general use.
+Added a reusable `HoverCard` component (`HoverCard`, `HoverCardTrigger`, `HoverCardContent`) built on Base UI. You can now use these exported components to add hover card interactions anywhere in your UI.
 
 ```tsx
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@mastra/playground-ui';

--- a/.changeset/tall-hounds-grin.md
+++ b/.changeset/tall-hounds-grin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved the hover cards used in the trace timeline and key-value lists by migrating them to Base UI for more reliable positioning. This is an internal change with no API differences for consumers.

--- a/.changeset/tall-hounds-grin.md
+++ b/.changeset/tall-hounds-grin.md
@@ -1,5 +1,14 @@
 ---
-'@mastra/playground-ui': patch
+'@mastra/playground-ui': minor
 ---
 
-Improved the hover cards used in the trace timeline and key-value lists by migrating them to Base UI for more reliable positioning. This is an internal change with no API differences for consumers.
+Added a reusable `HoverCard` component (`HoverCard`, `HoverCardTrigger`, `HoverCardContent`) built on Base UI. The trace timeline and key-value list hover cards now share this single component instead of inlining the markup, and it is exported for general use.
+
+```tsx
+import { HoverCard, HoverCardTrigger, HoverCardContent } from '@mastra/playground-ui';
+
+<HoverCard>
+  <HoverCardTrigger>Weather Agent</HoverCardTrigger>
+  <HoverCardContent>Answers questions about current conditions and forecasts.</HoverCardContent>
+</HoverCard>;
+```

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -75,7 +75,6 @@
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
-    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/packages/playground-ui/src/domains/traces/components/timeline-timing-col.tsx
+++ b/packages/playground-ui/src/domains/traces/components/timeline-timing-col.tsx
@@ -1,4 +1,4 @@
-import * as HoverCard from '@radix-ui/react-hover-card';
+import { PreviewCard } from '@base-ui/react/preview-card';
 import { format } from 'date-fns/format';
 import type { UISpan } from '../types';
 import { DataKeysAndValues } from '@/ds/components/DataKeysAndValues';
@@ -32,8 +32,9 @@ export function TimelineTimingCol({
   const percentageSpanStartTime = overallLatency && Math.floor((spanStartTimeShift / overallLatency) * 100);
 
   return (
-    <HoverCard.Root openDelay={250}>
-      <HoverCard.Trigger
+    <PreviewCard.Root>
+      <PreviewCard.Trigger
+        delay={250}
         className={cn(
           'h-8 p-1 grid grid-cols-[1fr_auto] gap-2 items-center cursor-help pr-2 rounded-r-md',
           chartWidth === 'wide' ? 'min-w-72' : 'min-w-32',
@@ -58,31 +59,29 @@ export function TimelineTimingCol({
         </div>
 
         <div className={cn('flex justify-end text-neutral3 text-ui-xs')}>{(span.latency / 1000).toFixed(3)}&nbsp;s</div>
-      </HoverCard.Trigger>
-      <HoverCard.Portal>
-        <HoverCard.Content
-          className="z-50 w-auto max-w-100 rounded-md bg-surface4 p-2 px-4 pr-6 text-ui-sm text-neutral5 border border-border1"
-          sideOffset={5}
-          side="top"
-        >
-          <div className={cn('text-ui-sm flex items-center gap-2 mb-2 mt-1')}>Span Timing</div>
-          <DataKeysAndValues>
-            <DataKeysAndValues.Key>Latency</DataKeysAndValues.Key>
-            <DataKeysAndValues.Value>{span.latency} ms</DataKeysAndValues.Value>
-            <DataKeysAndValues.Key>Started at</DataKeysAndValues.Key>
-            <DataKeysAndValues.Value>
-              {span.startTime ? format(new Date(span.startTime), 'hh:mm:ss:SSS a') : '-'}
-            </DataKeysAndValues.Value>
-            <DataKeysAndValues.Key>Ended at</DataKeysAndValues.Key>
-            <DataKeysAndValues.Value>
-              {span.endTime ? format(new Date(span.endTime), 'hh:mm:ss:SSS a') : '-'}
-            </DataKeysAndValues.Value>
-            <DataKeysAndValues.Key>Start Shift</DataKeysAndValues.Key>
-            <DataKeysAndValues.Value>{spanStartTimeShift}ms</DataKeysAndValues.Value>
-          </DataKeysAndValues>
-          <HoverCard.Arrow className="fill-surface5" />
-        </HoverCard.Content>
-      </HoverCard.Portal>
-    </HoverCard.Root>
+      </PreviewCard.Trigger>
+      <PreviewCard.Portal>
+        <PreviewCard.Positioner sideOffset={5} side="top" className="z-50">
+          <PreviewCard.Popup className="w-auto max-w-100 rounded-md bg-surface4 p-2 px-4 pr-6 text-ui-sm text-neutral5 border border-border1">
+            <div className={cn('text-ui-sm flex items-center gap-2 mb-2 mt-1')}>Span Timing</div>
+            <DataKeysAndValues>
+              <DataKeysAndValues.Key>Latency</DataKeysAndValues.Key>
+              <DataKeysAndValues.Value>{span.latency} ms</DataKeysAndValues.Value>
+              <DataKeysAndValues.Key>Started at</DataKeysAndValues.Key>
+              <DataKeysAndValues.Value>
+                {span.startTime ? format(new Date(span.startTime), 'hh:mm:ss:SSS a') : '-'}
+              </DataKeysAndValues.Value>
+              <DataKeysAndValues.Key>Ended at</DataKeysAndValues.Key>
+              <DataKeysAndValues.Value>
+                {span.endTime ? format(new Date(span.endTime), 'hh:mm:ss:SSS a') : '-'}
+              </DataKeysAndValues.Value>
+              <DataKeysAndValues.Key>Start Shift</DataKeysAndValues.Key>
+              <DataKeysAndValues.Value>{spanStartTimeShift}ms</DataKeysAndValues.Value>
+            </DataKeysAndValues>
+            <PreviewCard.Arrow className="fill-surface5" />
+          </PreviewCard.Popup>
+        </PreviewCard.Positioner>
+      </PreviewCard.Portal>
+    </PreviewCard.Root>
   );
 }

--- a/packages/playground-ui/src/domains/traces/components/timeline-timing-col.tsx
+++ b/packages/playground-ui/src/domains/traces/components/timeline-timing-col.tsx
@@ -1,7 +1,7 @@
-import { PreviewCard } from '@base-ui/react/preview-card';
 import { format } from 'date-fns/format';
 import type { UISpan } from '../types';
 import { DataKeysAndValues } from '@/ds/components/DataKeysAndValues';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/ds/components/HoverCard';
 import { cn } from '@/lib/utils';
 
 type TimelineTimingColProps = {
@@ -32,9 +32,8 @@ export function TimelineTimingCol({
   const percentageSpanStartTime = overallLatency && Math.floor((spanStartTimeShift / overallLatency) * 100);
 
   return (
-    <PreviewCard.Root>
-      <PreviewCard.Trigger
-        delay={250}
+    <HoverCard>
+      <HoverCardTrigger
         className={cn(
           'h-8 p-1 grid grid-cols-[1fr_auto] gap-2 items-center cursor-help pr-2 rounded-r-md',
           chartWidth === 'wide' ? 'min-w-72' : 'min-w-32',
@@ -59,29 +58,24 @@ export function TimelineTimingCol({
         </div>
 
         <div className={cn('flex justify-end text-neutral3 text-ui-xs')}>{(span.latency / 1000).toFixed(3)}&nbsp;s</div>
-      </PreviewCard.Trigger>
-      <PreviewCard.Portal>
-        <PreviewCard.Positioner sideOffset={5} side="top" className="z-50">
-          <PreviewCard.Popup className="w-auto max-w-100 rounded-md bg-surface4 p-2 px-4 pr-6 text-ui-sm text-neutral5 border border-border1">
-            <div className={cn('text-ui-sm flex items-center gap-2 mb-2 mt-1')}>Span Timing</div>
-            <DataKeysAndValues>
-              <DataKeysAndValues.Key>Latency</DataKeysAndValues.Key>
-              <DataKeysAndValues.Value>{span.latency} ms</DataKeysAndValues.Value>
-              <DataKeysAndValues.Key>Started at</DataKeysAndValues.Key>
-              <DataKeysAndValues.Value>
-                {span.startTime ? format(new Date(span.startTime), 'hh:mm:ss:SSS a') : '-'}
-              </DataKeysAndValues.Value>
-              <DataKeysAndValues.Key>Ended at</DataKeysAndValues.Key>
-              <DataKeysAndValues.Value>
-                {span.endTime ? format(new Date(span.endTime), 'hh:mm:ss:SSS a') : '-'}
-              </DataKeysAndValues.Value>
-              <DataKeysAndValues.Key>Start Shift</DataKeysAndValues.Key>
-              <DataKeysAndValues.Value>{spanStartTimeShift}ms</DataKeysAndValues.Value>
-            </DataKeysAndValues>
-            <PreviewCard.Arrow className="fill-surface5" />
-          </PreviewCard.Popup>
-        </PreviewCard.Positioner>
-      </PreviewCard.Portal>
-    </PreviewCard.Root>
+      </HoverCardTrigger>
+      <HoverCardContent className="bg-surface4 pr-6">
+        <div className={cn('text-ui-sm flex items-center gap-2 mb-2 mt-1')}>Span Timing</div>
+        <DataKeysAndValues>
+          <DataKeysAndValues.Key>Latency</DataKeysAndValues.Key>
+          <DataKeysAndValues.Value>{span.latency} ms</DataKeysAndValues.Value>
+          <DataKeysAndValues.Key>Started at</DataKeysAndValues.Key>
+          <DataKeysAndValues.Value>
+            {span.startTime ? format(new Date(span.startTime), 'hh:mm:ss:SSS a') : '-'}
+          </DataKeysAndValues.Value>
+          <DataKeysAndValues.Key>Ended at</DataKeysAndValues.Key>
+          <DataKeysAndValues.Value>
+            {span.endTime ? format(new Date(span.endTime), 'hh:mm:ss:SSS a') : '-'}
+          </DataKeysAndValues.Value>
+          <DataKeysAndValues.Key>Start Shift</DataKeysAndValues.Key>
+          <DataKeysAndValues.Value>{spanStartTimeShift}ms</DataKeysAndValues.Value>
+        </DataKeysAndValues>
+      </HoverCardContent>
+    </HoverCard>
   );
 }

--- a/packages/playground-ui/src/ds/components/HoverCard/hover-card.stories.tsx
+++ b/packages/playground-ui/src/ds/components/HoverCard/hover-card.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { HoverCard, HoverCardTrigger, HoverCardContent } from './hover-card';
+
+const meta: Meta<typeof HoverCard> = {
+  title: 'Elements/HoverCard',
+  component: HoverCard,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof HoverCard>;
+
+export const Default: Story = {
+  render: () => (
+    <HoverCard>
+      <HoverCardTrigger className="cursor-help text-ui-md text-neutral6 underline">Hover me</HoverCardTrigger>
+      <HoverCardContent>This content appears when the trigger is hovered or focused.</HoverCardContent>
+    </HoverCard>
+  ),
+};
+
+export const WithRichContent: Story = {
+  render: () => (
+    <HoverCard>
+      <HoverCardTrigger className="cursor-help text-ui-md text-neutral6 underline">Weather Agent</HoverCardTrigger>
+      <HoverCardContent className="text-left">
+        <div className="text-ui-sm text-neutral6">Weather Agent</div>
+        <p className="mt-1 text-ui-xs text-neutral4">
+          Answers questions about current conditions and forecasts using a weather tool.
+        </p>
+      </HoverCardContent>
+    </HoverCard>
+  ),
+};
+
+export const BottomNoArrow: Story = {
+  render: () => (
+    <HoverCard>
+      <HoverCardTrigger className="cursor-help text-ui-md text-neutral6 underline">Open below</HoverCardTrigger>
+      <HoverCardContent side="bottom" showArrow={false}>
+        Positioned below the trigger, without an arrow.
+      </HoverCardContent>
+    </HoverCard>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/HoverCard/hover-card.test.tsx
+++ b/packages/playground-ui/src/ds/components/HoverCard/hover-card.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { HoverCard, HoverCardContent, HoverCardTrigger } from './hover-card';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('HoverCard', () => {
+  it('renders the trigger', () => {
+    render(
+      <HoverCard>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardContent>Card content</HoverCardContent>
+      </HoverCard>,
+    );
+
+    expect(screen.getByText('Hover me')).toBeTruthy();
+  });
+
+  it('keeps the content unmounted while closed', () => {
+    render(
+      <HoverCard>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardContent>Card content</HoverCardContent>
+      </HoverCard>,
+    );
+
+    expect(screen.queryByText('Card content')).toBeNull();
+  });
+
+  it('renders the content when open', () => {
+    render(
+      <HoverCard defaultOpen>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardContent>Card content</HoverCardContent>
+      </HoverCard>,
+    );
+
+    expect(screen.getByText('Card content')).toBeTruthy();
+  });
+
+  it('forwards className to the content popup', () => {
+    render(
+      <HoverCard defaultOpen>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardContent className="custom-content">Card content</HoverCardContent>
+      </HoverCard>,
+    );
+
+    expect(screen.getByText('Card content').classList.contains('custom-content')).toBe(true);
+  });
+
+  it('projects the trigger onto an existing element via render', () => {
+    render(
+      <HoverCard>
+        <HoverCardTrigger render={<button type="button">Custom trigger</button>} />
+        <HoverCardContent>Card content</HoverCardContent>
+      </HoverCard>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Custom trigger' })).toBeTruthy();
+  });
+});

--- a/packages/playground-ui/src/ds/components/HoverCard/hover-card.tsx
+++ b/packages/playground-ui/src/ds/components/HoverCard/hover-card.tsx
@@ -53,7 +53,9 @@ const HoverCardContent = React.forwardRef<HTMLDivElement, HoverCardContentProps>
         <PreviewCardPrimitive.Popup
           ref={ref}
           className={cn(
-            'w-auto max-w-100 rounded-md border border-border1 bg-surface5 p-2 px-4 text-ui-sm text-neutral5',
+            'w-auto max-w-100 rounded-md border border-border1 bg-surface5 p-2 px-4 text-ui-sm text-neutral5 origin-[var(--transform-origin)]',
+            'data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95',
+            'data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1',
             className,
           )}
           {...props}

--- a/packages/playground-ui/src/ds/components/HoverCard/hover-card.tsx
+++ b/packages/playground-ui/src/ds/components/HoverCard/hover-card.tsx
@@ -1,0 +1,70 @@
+import { PreviewCard as PreviewCardPrimitive } from '@base-ui/react/preview-card';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * HoverCard — a floating card that reveals extra content when its trigger is
+ * hovered or focused. Built on Base UI's `PreviewCard`
+ * (`@base-ui/react/preview-card`); the `HoverCard` name matches the Radix
+ * component this replaced and the common term for the pattern.
+ *
+ * Compose it as `HoverCard` > (`HoverCardTrigger` + `HoverCardContent`).
+ */
+const HoverCard = PreviewCardPrimitive.Root;
+
+export type HoverCardTriggerProps = Omit<PreviewCardPrimitive.Trigger.Props, 'className'> & {
+  className?: string;
+};
+
+/**
+ * The element that opens the card on hover/focus. Renders an `<a>` by default;
+ * pass `render` to project the behavior onto an existing element.
+ *
+ * `delay` defaults to 250ms to preserve the previous Radix `openDelay`
+ * behavior — Base UI's own default is 600ms.
+ */
+const HoverCardTrigger = React.forwardRef<HTMLAnchorElement, HoverCardTriggerProps>(
+  ({ className, delay = 250, ...props }, ref) => (
+    <PreviewCardPrimitive.Trigger ref={ref} delay={delay} className={className} {...props} />
+  ),
+);
+HoverCardTrigger.displayName = 'HoverCardTrigger';
+
+export type HoverCardContentProps = Omit<PreviewCardPrimitive.Popup.Props, 'className'> & {
+  className?: string;
+  side?: PreviewCardPrimitive.Positioner.Props['side'];
+  align?: PreviewCardPrimitive.Positioner.Props['align'];
+  sideOffset?: PreviewCardPrimitive.Positioner.Props['sideOffset'];
+  /** Optional portal container, forwarded to `PreviewCard.Portal`. */
+  container?: HTMLElement | null;
+  /** Whether to render the small arrow pointing at the trigger. */
+  showArrow?: boolean;
+};
+
+/**
+ * The floating card body. Wraps Base UI's `Portal` / `Positioner` / `Popup`
+ * (and an optional `Arrow`) so consumers only deal with a single element.
+ */
+const HoverCardContent = React.forwardRef<HTMLDivElement, HoverCardContentProps>(
+  ({ className, children, side = 'top', align, sideOffset = 5, container, showArrow = true, ...props }, ref) => (
+    <PreviewCardPrimitive.Portal container={container ?? undefined}>
+      <PreviewCardPrimitive.Positioner side={side} align={align} sideOffset={sideOffset} className="z-50">
+        <PreviewCardPrimitive.Popup
+          ref={ref}
+          className={cn(
+            'w-auto max-w-100 rounded-md border border-border1 bg-surface5 p-2 px-4 text-ui-sm text-neutral5',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+          {showArrow && <PreviewCardPrimitive.Arrow className="fill-surface5" />}
+        </PreviewCardPrimitive.Popup>
+      </PreviewCardPrimitive.Positioner>
+    </PreviewCardPrimitive.Portal>
+  ),
+);
+HoverCardContent.displayName = 'HoverCardContent';
+
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/packages/playground-ui/src/ds/components/HoverCard/index.ts
+++ b/packages/playground-ui/src/ds/components/HoverCard/index.ts
@@ -1,0 +1,1 @@
+export * from './hover-card';

--- a/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.stories.tsx
@@ -76,6 +76,41 @@ const complexData = [
   },
 ];
 
+const dataWithDescriptions = [
+  {
+    key: 'tools',
+    label: 'Tools',
+    value: [
+      {
+        id: '1',
+        name: 'Web Search',
+        path: '/tools/web-search',
+        description: 'Searches the web and returns ranked results for a query.',
+      },
+      {
+        id: '2',
+        name: 'File System',
+        path: '/tools/file-system',
+        description: 'Reads and writes files in the local workspace.',
+      },
+    ],
+    icon: <BrainIcon />,
+  },
+  {
+    key: 'agents',
+    label: 'Agents',
+    value: [
+      {
+        id: '1',
+        name: 'Research Agent',
+        path: '/agents/research',
+        description: 'Gathers and summarizes information from multiple sources.',
+      },
+    ],
+    icon: <UserIcon />,
+  },
+];
+
 const emptyData = [
   {
     key: 'tools',
@@ -100,6 +135,16 @@ export const Default: Story = {
 export const WithLinks: Story = {
   args: {
     data: complexData,
+  },
+};
+
+/**
+ * Relation items that carry a `description` render inside a hover card
+ * (`@base-ui/react/preview-card`). Hover a linked value to reveal it.
+ */
+export const WithRelationHoverCards: Story = {
+  args: {
+    data: dataWithDescriptions,
   },
 };
 

--- a/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
+++ b/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
@@ -1,4 +1,4 @@
-import * as HoverCard from '@radix-ui/react-hover-card';
+import { PreviewCard } from '@base-ui/react/preview-card';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { ChevronRightIcon } from 'lucide-react';
 import React from 'react';
@@ -118,19 +118,20 @@ type RelationWrapperProps = {
 
 function RelationWrapper({ description, children }: RelationWrapperProps) {
   return description ? (
-    <HoverCard.Root openDelay={250}>
-      <HoverCard.Trigger asChild>{children}</HoverCard.Trigger>
-      <HoverCard.Portal>
-        <HoverCard.Content
-          className="z-50 w-auto max-w-60 rounded-md bg-surface5 p-2 px-4 text-ui-sm text-neutral5 text-center"
-          sideOffset={5}
-          side="top"
-        >
-          {description}
-          <HoverCard.Arrow className="fill-surface5" />
-        </HoverCard.Content>
-      </HoverCard.Portal>
-    </HoverCard.Root>
+    <PreviewCard.Root>
+      <PreviewCard.Trigger
+        delay={250}
+        render={React.isValidElement(children) ? (children as React.ReactElement) : undefined}
+      />
+      <PreviewCard.Portal>
+        <PreviewCard.Positioner sideOffset={5} side="top" className="z-50">
+          <PreviewCard.Popup className="w-auto max-w-60 rounded-md bg-surface5 p-2 px-4 text-ui-sm text-neutral5 text-center">
+            {description}
+            <PreviewCard.Arrow className="fill-surface5" />
+          </PreviewCard.Popup>
+        </PreviewCard.Positioner>
+      </PreviewCard.Portal>
+    </PreviewCard.Root>
   ) : (
     children
   );

--- a/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
+++ b/packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
@@ -1,7 +1,7 @@
-import { PreviewCard } from '@base-ui/react/preview-card';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { ChevronRightIcon } from 'lucide-react';
 import React from 'react';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/ds/components/HoverCard';
 import type { LinkComponent } from '@/ds/types/link-component';
 import { cn } from '@/lib/utils';
 
@@ -118,20 +118,10 @@ type RelationWrapperProps = {
 
 function RelationWrapper({ description, children }: RelationWrapperProps) {
   return description ? (
-    <PreviewCard.Root>
-      <PreviewCard.Trigger
-        delay={250}
-        render={React.isValidElement(children) ? (children as React.ReactElement) : undefined}
-      />
-      <PreviewCard.Portal>
-        <PreviewCard.Positioner sideOffset={5} side="top" className="z-50">
-          <PreviewCard.Popup className="w-auto max-w-60 rounded-md bg-surface5 p-2 px-4 text-ui-sm text-neutral5 text-center">
-            {description}
-            <PreviewCard.Arrow className="fill-surface5" />
-          </PreviewCard.Popup>
-        </PreviewCard.Positioner>
-      </PreviewCard.Portal>
-    </PreviewCard.Root>
+    <HoverCard>
+      <HoverCardTrigger render={React.isValidElement(children) ? (children as React.ReactElement) : undefined} />
+      <HoverCardContent className="max-w-60 text-center">{description}</HoverCardContent>
+    </HoverCard>
   ) : (
     children
   );

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -30,6 +30,7 @@ export * from './ds/components/DropdownMenu';
 export * from './ds/components/Entry';
 export * from './ds/components/EntityHeader';
 export * from './ds/components/FormFieldBlocks';
+export * from './ds/components/HoverCard';
 export * from './ds/components/Input';
 export * from './ds/components/InputGroup';
 export * from './ds/components/Kbd';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4465,9 +4465,6 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-hover-card':
-        specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
## Summary

- Adds a reusable `HoverCard` component (`HoverCard`, `HoverCardTrigger`, `HoverCardContent`) in `packages/playground-ui/src/ds/components/HoverCard`, built on `@base-ui/react/preview-card`.
- Migrates the hover cards in the trace timeline (`timeline-timing-col.tsx`) and the key-value list relation wrapper (`key-value-list.tsx`) from `@radix-ui/react-hover-card` to consume the new component instead of inlining the markup.
- Drops `@radix-ui/react-hover-card` from `packages/playground-ui` dependencies.

## Notes

- `HoverCardContent` wraps Base UI's `Portal` / `Positioner` / `Popup` (and an optional `Arrow`) so consumers deal with a single element.
- `HoverCardTrigger` defaults `delay` to 250ms to preserve the previous Radix `openDelay` behaviour (Base UI's own default is 600ms). It renders an `<a>` by default; pass `render` to project onto an existing element.
- `key-value-list.tsx` keeps its existing `@radix-ui/react-visually-hidden` import unchanged; the `VisuallyHidden` migration is tracked separately.
- Adds `hover-card.test.tsx` and `hover-card.stories.tsx` (a standalone `Elements/HoverCard` story), plus a `KeyValueList` story exercising the relation hover card.

## Test plan

- [x] `pnpm build` (tsc + vite) in `packages/playground-ui`
- [x] `pnpm test HoverCard` (5 passed)
- [x] `pnpm build-storybook`
- [x] `eslint` + `prettier --check` on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR replaces small hover popups in the playground UI that used Radix with a shared HoverCard built on Base UI so tooltips keep working the same but use Base UI building blocks.

## Overview

Adds a reusable HoverCard suite (HoverCard, HoverCardTrigger, HoverCardContent) implemented on `@base-ui/react/preview-card` and migrates existing hover-card usages in playground-ui from `@radix-ui/react-hover-card` to the new component. HoverCardContent wraps Portal/Positioner/Popup (and an optional Arrow) so consumers use a single element; HoverCardTrigger defaults the open delay to 250ms to preserve prior timing and supports a render prop for projecting onto an existing element. No public API breaking changes for playground-ui consumers. The HoverCardContent also gains enter/exit motion (fade/zoom/slide) to match existing Popover animations.

## Changes

- Dependencies
  - Removed `@radix-ui/react-hover-card` from packages/playground-ui/package.json.
  - Kept `@radix-ui/react-visually-hidden` (VisuallyHidden migration tracked separately).

- New / updated DS component
  - packages/playground-ui/src/ds/components/HoverCard/hover-card.tsx
    - Adds HoverCard (alias for PreviewCard.Root), HoverCardTrigger (forwardRef, default delay 250ms, supports render prop), and HoverCardContent (Portal + Positioner + Popup, optional container and optional arrow). Includes enter/exit animations for open/close.
  - packages/playground-ui/src/ds/components/HoverCard/index.ts
    - Re-exports the HoverCard module.
  - packages/playground-ui/src/index.ts
    - Re-exports HoverCard in the package public surface.
  - Added Storybook stories and unit tests:
    - hover-card.stories.tsx
    - hover-card.test.tsx

- Component migrations
  - packages/playground-ui/src/domains/traces/components/timeline-timing-col.tsx
    - Replaced Radix hover-card usage with the new HoverCard components; preserved tooltip content and formatting (Span Timing, Latency, Started at, Ended at, Start Shift) and adapted styling to the new component.
  - packages/playground-ui/src/ds/components/KeyValueList/key-value-list.tsx
    - RelationWrapper now uses HoverCard/HoverCardTrigger/HoverCardContent; when children is a valid React element, HoverCardTrigger uses the render prop to project onto it. The file still imports Radix VisuallyHidden.

- Stories & tests
  - Added KeyValueList story WithRelationHoverCards to demonstrate descriptions in hover cards.
  - Added HoverCard stories (Default, WithRichContent, BottomNoArrow) and tests verifying trigger rendering, mount/unmount behavior, className forwarding, and custom trigger support.

- Changeset
  - .changeset/tall-hounds-grin.md: bumps `@mastra/playground-ui` (minor) and documents the new HoverCard component and migration.

## Migration notes / API adaptations

- Radix Root/Portal/Content → Base UI Portal / Positioner / Popup: HoverCardContent consolidates these.
- Radix Root.openDelay → PreviewCard.Trigger.delay: HoverCardTrigger defaults to 250ms to match previous behavior.
- Radix asChild → PreviewCard.Trigger.render prop: HoverCardTrigger exposes render for in-place projection.
- Consumers should observe equivalent hover behaviour with Base UI primitives and added open/close motion.

## Test plan

- pnpm build (tsc + vite) in packages/playground-ui
- pnpm test HoverCard (tests added; all passed in PR)
- pnpm build-storybook
- eslint and prettier checks on changed files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->