### PR TITLE
feat(core): route model fallbacks through adaptive router

### DIFF
--- a/.changeset/common-nights-join.md
+++ b/.changeset/common-nights-join.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added AdaptiveModelRouter for model fallback routing and observability-based model switching.

--- a/.changeset/common-nights-join.md
+++ b/.changeset/common-nights-join.md
@@ -2,4 +2,31 @@
 '@mastra/core': minor
 ---
 
-Added AdaptiveModelRouter for model fallback routing and observability-based model switching.
+Added `AdaptiveModelRouter`, a processor that drives model fallback and observability-based model switching for v2/v3 agents.
+
+Legacy `model: [...]` fallback arrays are now automatically routed through the router (reactive fallback only — no observability rules are auto-configured). For observability-driven routing (error-rate, score, or feedback rules), wire the router explicitly as an input + error processor.
+
+```ts
+import { Agent } from '@mastra/core/agent';
+import { AdaptiveModelRouter } from '@mastra/core/processors';
+
+const router = new AdaptiveModelRouter({
+  models: [
+    { id: 'primary', model: openai('gpt-4o') },
+    { id: 'fallback', model: anthropic('claude-3-5-sonnet') },
+  ],
+  scope: 'resource',
+  rules: [
+    { signal: 'error-rate', threshold: 0.3, minRequests: 5, window: '1h', cooldown: '5m' },
+    { signal: 'score', scorerId: 'helpfulness', minScore: 0.7, window: '24h' },
+  ],
+});
+
+const agent = new Agent({
+  name: 'support',
+  instructions: '...',
+  model: openai('gpt-4o'),
+  inputProcessors: [router],
+  errorProcessors: [router],
+});
+```

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -380,6 +380,40 @@ Mastra provides utility processors for common tasks:
 **For security and validation processors**, see the [Guardrails](/docs/agents/guardrails) page for input/output guardrails and moderation processors.
 **For memory-specific processors**, see the [Memory Processors](/docs/memory/memory-processors) page for processors that handle message history, semantic recall, and working memory.
 
+### `AdaptiveModelRouter`
+
+:::experimental
+
+This processor is in alpha. Breaking changes may occur without a major version bump until the API is stable.
+
+:::
+
+Picks one model per request from an ordered list, falls back reactively on errors, and can switch models proactively based on observability signals (error rate, scores, feedback). Configure it as both an input and an error processor.
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { AdaptiveModelRouter } from '@mastra/core/processors'
+
+const router = new AdaptiveModelRouter({
+  models: [
+    { id: 'primary', model: 'openai/gpt-5' },
+    { id: 'fallback', model: 'anthropic/claude-sonnet-4-5' },
+  ],
+  rules: [{ signal: 'error-rate', threshold: 0.3, minRequests: 5, window: '1h', cooldown: '5m' }],
+})
+
+const agent = new Agent({
+  name: 'adaptive-agent',
+  model: 'openai/gpt-5',
+  inputProcessors: [router],
+  errorProcessors: [router],
+})
+```
+
+When you configure an agent with a fallback array (`model: [...]`), the router is wired in automatically with reactive error-based fallback only. Add it explicitly when you need observability-driven routing rules.
+
+See the [`AdaptiveModelRouter` reference](/reference/processors/adaptive-model-router) for rule types, scope, and cooldown options.
+
 ### `TokenLimiter`
 
 Prevents context window overflow by removing older messages when the total token count exceeds a specified limit. Prioritizes recent messages and preserves system messages.

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -382,6 +382,8 @@ Mastra provides utility processors for common tasks:
 
 ### `AdaptiveModelRouter`
 
+**Added in:** `@mastra/core@1.37.0`
+
 :::experimental
 
 This processor is in alpha. Breaking changes may occur without a major version bump until the API is stable.

--- a/docs/src/content/en/models/index.mdx
+++ b/docs/src/content/en/models/index.mdx
@@ -337,6 +337,8 @@ Each field also accepts a function of `requestContext`, matching how dynamic mod
 
 ### Cooldowns
 
+**Added in:** `@mastra/core@1.37.0`
+
 When a model in the fallback chain fails, Mastra records a short cooldown for that model in your configured [server cache](/reference/core/mastra-class). While a model is in cooldown it is skipped for subsequent requests on the same Mastra instance, so a failing provider doesn't get hit on every request before falling through.
 
 Cooldowns work without any extra setup. If you configured a `serverCache` on `Mastra` (for example a Redis-backed cache), cooldown state is shared across every request that hits that cache. Without a custom cache, Mastra uses an in-memory cache scoped to the running process.
@@ -344,6 +346,8 @@ Cooldowns work without any extra setup. If you configured a `serverCache` on `Ma
 Cooldowns are global to the Mastra instance — a model that's failing for one user is treated as unhealthy for all users.
 
 ### Advanced: observability-driven routing
+
+**Added in:** `@mastra/core@1.37.0`
 
 Under the hood, fallback arrays are powered by the [`AdaptiveModelRouter`](/reference/processors/adaptive-model-router) processor. Configure it explicitly when you want to switch models proactively based on observability signals — error rate, scorer output, or feedback aggregates — rather than only reactively on errors.
 

--- a/docs/src/content/en/models/index.mdx
+++ b/docs/src/content/en/models/index.mdx
@@ -335,6 +335,18 @@ const agent = new Agent({
 
 Each field also accepts a function of `requestContext`, matching how dynamic models are resolved.
 
+### Cooldowns
+
+When a model in the fallback chain fails, Mastra records a short cooldown for that model in your configured [server cache](/reference/core/mastra-class). While a model is in cooldown it is skipped for subsequent requests on the same Mastra instance, so a failing provider doesn't get hit on every request before falling through.
+
+Cooldowns work without any extra setup. If you configured a `serverCache` on `Mastra` (for example a Redis-backed cache), cooldown state is shared across every request that hits that cache. Without a custom cache, Mastra uses an in-memory cache scoped to the running process.
+
+Cooldowns are global to the Mastra instance — a model that's failing for one user is treated as unhealthy for all users.
+
+### Advanced: observability-driven routing
+
+Under the hood, fallback arrays are powered by the [`AdaptiveModelRouter`](/reference/processors/adaptive-model-router) processor. Configure it explicitly when you want to switch models proactively based on observability signals — error rate, scorer output, or feedback aggregates — rather than only reactively on errors.
+
 ## Use local models with Mastra
 
 Mastra also supports local models like `gpt-oss`, `Qwen3`, `DeepSeek` and many more that you run on your own hardware. The application running your local model needs to provide an OpenAI-compatible API server for Mastra to connect to. We recommend using [LMStudio](https://lmstudio.ai/) (see [Running the LMStudio server](https://lmstudio.ai/docs/developer/core/server)).

--- a/docs/src/content/en/reference/processors/adaptive-model-router.mdx
+++ b/docs/src/content/en/reference/processors/adaptive-model-router.mdx
@@ -1,0 +1,456 @@
+---
+title: 'Reference: AdaptiveModelRouter | Processors'
+description: 'API reference for the AdaptiveModelRouter processor in Mastra, which routes between models based on errors and observability signals.'
+packages:
+  - '@mastra/core'
+---
+
+# AdaptiveModelRouter
+
+:::experimental
+
+This processor is in alpha. Breaking changes may occur without a major version bump until the API is stable.
+
+:::
+
+`AdaptiveModelRouter` is both an **input processor** and an **error processor** that picks one model per request from an ordered list and switches between them based on runtime errors and observability signals.
+
+When you configure an agent with a fallback array (`model: [...]`), the router is wired in automatically with reactive error-based fallback only. To enable observability-driven routing — switching on error rate, score, or feedback aggregates — add the router explicitly as both `inputProcessors` and `errorProcessors`, and pass `rules`.
+
+## Usage example
+
+Reactive fallback only — same behavior as the legacy `model: [...]` array, expressed explicitly:
+
+```typescript title="src/mastra/agents/adaptive-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { AdaptiveModelRouter } from '@mastra/core/processors'
+
+const router = new AdaptiveModelRouter({
+  models: [
+    { id: 'primary', model: 'openai/gpt-5' },
+    { id: 'fallback', model: 'anthropic/claude-sonnet-4-5' },
+  ],
+})
+
+export const agent = new Agent({
+  name: 'adaptive-agent',
+  instructions: 'You are a helpful assistant.',
+  model: 'openai/gpt-5',
+  inputProcessors: [router],
+  errorProcessors: [router],
+})
+```
+
+With observability-driven routing:
+
+```typescript title="src/mastra/agents/observability-routed-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { AdaptiveModelRouter } from '@mastra/core/processors'
+
+const router = new AdaptiveModelRouter({
+  models: [
+    { id: 'primary', model: 'openai/gpt-5' },
+    { id: 'cheaper', model: 'openai/gpt-5-mini' },
+    { id: 'stronger', model: 'anthropic/claude-sonnet-4-5' },
+  ],
+  scope: 'resource',
+  rules: [
+    {
+      signal: 'error-rate',
+      threshold: 0.3,
+      minRequests: 5,
+      window: '1h',
+      cooldown: '5m',
+      fallbackOrder: ['cheaper', 'stronger'],
+    },
+    {
+      signal: 'score',
+      scorerId: 'helpfulness',
+      minScore: 0.7,
+      window: '24h',
+      fallbackOrder: ['stronger', 'cheaper'],
+    },
+  ],
+})
+
+export const agent = new Agent({
+  name: 'observability-routed-agent',
+  instructions: 'You are a helpful assistant.',
+  model: 'openai/gpt-5',
+  inputProcessors: [router],
+  errorProcessors: [router],
+})
+```
+
+## How it works
+
+The router runs at two points in the agent loop:
+
+1. **`processInputStep`** (proactive). Before the LLM call, the router evaluates each configured rule against observability storage. The first rule that fires picks a model from the rule's `fallbackOrder` (or the default model order), skipping models that are already in cooldown. Rules are only evaluated when `retryCount === 0`, so processor-triggered retries reuse the active fallback order without re-querying observability.
+1. **`processAPIError`** (reactive). When the model call fails, the router opens a cooldown for the failed model in the [server cache](/reference/core/mastra-class) and selects the next eligible model from the active fallback order. It returns `{ retry: true }` to retry the step, or returns nothing so the original error propagates when no candidates remain.
+
+Fallback is attempted on any model error (matching the legacy `model: [...]` behavior), not only retryable API errors.
+
+### Cooldowns
+
+Cooldowns are stored in `Mastra.getServerCache()` and keyed by `router id + rule signal + model id`. The TTL comes from the rule's `cooldown` field. Cooldowns are global to the Mastra instance — they don't partition by scope, so a model that's failing for one request is treated as unhealthy for all requests.
+
+### Scope and observability queries
+
+The `scope` field controls how the router filters observability queries:
+
+- `'run'` — current trace/run
+- `'resource'` (default) — same `resourceId` as the request
+- `'thread'` — same `threadId` as the request
+
+Rule queries call into `ObservabilityStorage`:
+
+- `error-rate` uses `getMetricBreakdown` on the rule's `metric` (default `mastra_model_duration_ms`) split by model and error status.
+- `score` uses `getScoreAggregate` for the configured `scorerId`.
+- `feedback` uses `getFeedbackAggregate` per candidate model.
+
+If the configured storage backend does not implement a query, the rule fails closed — no proactive switch fires — but reactive `processAPIError` fallback still works.
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'options',
+    type: 'AdaptiveModelRouterOptions',
+    description: 'Router configuration. At least two enabled models are required.',
+    isOptional: false,
+    properties: [
+      {
+        name: 'models',
+        type: 'AdaptiveModelRouterModel[]',
+        description: 'Ordered list of candidate models. The first enabled entry is the default.',
+        isOptional: false,
+      },
+      {
+        name: 'rules',
+        type: 'AdaptiveModelRouterRule[]',
+        description:
+          'Rules evaluated against observability storage at request time. When omitted, a default error-rate rule is created from errorRateThreshold, minRequests, window, and cooldown. Pass [] to disable proactive routing entirely.',
+        isOptional: true,
+      },
+      {
+        name: 'scope',
+        type: "'run' | 'resource' | 'thread'",
+        description: 'How rule queries filter observability data.',
+        isOptional: true,
+        defaultValue: "'resource'",
+      },
+      {
+        name: 'window',
+        type: 'RouterWindow',
+        description: 'Default lookback window used when the default error-rate rule is created.',
+        isOptional: true,
+        defaultValue: "'24h'",
+      },
+      {
+        name: 'cooldown',
+        type: 'RouterWindow | `${number}m` | `${number}h` | `${number}d`',
+        description: 'Default cooldown duration used when the default error-rate rule is created.',
+        isOptional: true,
+        defaultValue: "'2m'",
+      },
+      {
+        name: 'errorRateThreshold',
+        type: 'number',
+        description: 'Threshold for the default error-rate rule, between 0 and 1.',
+        isOptional: true,
+        defaultValue: '0.3',
+      },
+      {
+        name: 'minRequests',
+        type: 'number',
+        description: 'Minimum sample count required before the default error-rate rule can fire.',
+        isOptional: true,
+        defaultValue: '5',
+      },
+    ],
+  },
+]}
+/>
+
+### `AdaptiveModelRouterModel`
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Stable identifier for the model entry. Referenced by rule fallbackOrder.',
+    isOptional: false,
+  },
+  {
+    name: 'model',
+    type: 'MastraLanguageModel | MastraModelConfig',
+    description: 'The model to call when this entry is selected.',
+    isOptional: false,
+  },
+  {
+    name: 'maxRetries',
+    type: 'number',
+    description: 'Per-entry retry count passed through to the model call.',
+    isOptional: true,
+  },
+  {
+    name: 'enabled',
+    type: 'boolean',
+    description: 'When false, the entry is skipped during selection.',
+    isOptional: true,
+    defaultValue: 'true',
+  },
+  {
+    name: 'modelSettings',
+    type: 'DynamicArgument<ModelFallbackSettings> | ModelFallbackSettings',
+    description: 'Per-entry model settings. Functions receive { requestContext, mastra } and may return a Promise.',
+    isOptional: true,
+  },
+  {
+    name: 'providerOptions',
+    type: 'DynamicArgument<SharedProviderOptions> | SharedProviderOptions',
+    description: 'Per-entry provider options. Functions receive { requestContext, mastra } and may return a Promise.',
+    isOptional: true,
+  },
+  {
+    name: 'headers',
+    type: 'DynamicArgument<Record<string, string>> | Record<string, string>',
+    description:
+      'Per-entry headers merged into modelSettings.headers. Functions receive { requestContext, mastra } and may return a Promise.',
+    isOptional: true,
+  },
+]}
+/>
+
+### `AdaptiveModelRouterRule`
+
+A discriminated union of three rule shapes. Each rule may declare its own `fallbackOrder`; when omitted, the router uses the configured `models` order.
+
+#### `ErrorRateRule`
+
+<PropertiesTable
+  content={[
+  {
+    name: 'signal',
+    type: "'error-rate'",
+    description: 'Discriminator for error-rate rules.',
+    isOptional: false,
+  },
+  {
+    name: 'metric',
+    type: 'MastraMetricName',
+    description:
+      'Metric name to query. Built-in values include mastra_model_duration_ms, mastra_model_total_input_tokens, mastra_model_total_output_tokens, mastra_agent_duration_ms, and mastra_tool_duration_ms. Custom metric names are also accepted.',
+    isOptional: true,
+    defaultValue: "'mastra_model_duration_ms'",
+  },
+  {
+    name: 'threshold',
+    type: 'number',
+    description:
+      'Error rate threshold between 0 and 1. The rule fires when error count divided by total count meets this value.',
+    isOptional: true,
+  },
+  {
+    name: 'minRequests',
+    type: 'number',
+    description: 'Minimum sample count required before the rule can fire.',
+    isOptional: true,
+  },
+  {
+    name: 'window',
+    type: 'RouterWindow',
+    description: 'Lookback window for the metric query.',
+    isOptional: true,
+  },
+  {
+    name: 'cooldown',
+    type: 'RouterWindow | `${number}m` | `${number}h` | `${number}d`',
+    description: 'Duration the failed model is held out of selection after the rule fires.',
+    isOptional: true,
+  },
+  {
+    name: 'fallbackOrder',
+    type: 'string[]',
+    description:
+      'Ordered list of model ids to try when this rule fires. Each id must exist in the configured models array.',
+    isOptional: true,
+  },
+]}
+/>
+
+#### `ScoreRule`
+
+<PropertiesTable
+  content={[
+  {
+    name: 'signal',
+    type: "'score'",
+    description: 'Discriminator for score rules.',
+    isOptional: false,
+  },
+  {
+    name: 'scorerId',
+    type: 'string',
+    description: 'Scorer id to query through getScoreAggregate.',
+    isOptional: false,
+  },
+  {
+    name: 'minScore',
+    type: 'number',
+    description: 'The rule fires when the aggregate score for the active model falls below this value.',
+    isOptional: false,
+  },
+  {
+    name: 'aggregation',
+    type: "'avg' | 'min' | 'max'",
+    description: 'Aggregation strategy used when reading score values.',
+    isOptional: true,
+    defaultValue: "'avg'",
+  },
+  {
+    name: 'window',
+    type: 'RouterWindow',
+    description: 'Lookback window for the score query.',
+    isOptional: true,
+  },
+  {
+    name: 'cooldown',
+    type: 'RouterWindow | `${number}m` | `${number}h` | `${number}d`',
+    description: 'Cooldown duration applied to the failing model after the rule fires.',
+    isOptional: true,
+  },
+  {
+    name: 'fallbackOrder',
+    type: 'string[]',
+    description: 'Ordered list of model ids to try when this rule fires.',
+    isOptional: true,
+  },
+]}
+/>
+
+#### `FeedbackRule`
+
+<PropertiesTable
+  content={[
+  {
+    name: 'signal',
+    type: "'feedback'",
+    description: 'Discriminator for feedback rules.',
+    isOptional: false,
+  },
+  {
+    name: 'feedbackType',
+    type: 'string',
+    description: 'Feedback type to query through getFeedbackAggregate.',
+    isOptional: false,
+  },
+  {
+    name: 'strategy',
+    type: "'best-rated'",
+    description:
+      'Selection strategy. best-rated picks the highest-rated eligible model in the candidate fallback order.',
+    isOptional: true,
+    defaultValue: "'best-rated'",
+  },
+  {
+    name: 'aggregation',
+    type: "'avg' | 'min' | 'max'",
+    description: 'Aggregation strategy used when reading feedback values.',
+    isOptional: true,
+    defaultValue: "'avg'",
+  },
+  {
+    name: 'minSamples',
+    type: 'number',
+    description: 'Minimum sample count required before the rule can fire.',
+    isOptional: true,
+    defaultValue: '10',
+  },
+  {
+    name: 'window',
+    type: 'RouterWindow',
+    description: 'Lookback window for the feedback query.',
+    isOptional: true,
+  },
+  {
+    name: 'cooldown',
+    type: 'RouterWindow | `${number}m` | `${number}h` | `${number}d`',
+    description: 'Cooldown duration applied after the rule fires.',
+    isOptional: true,
+  },
+  {
+    name: 'fallbackOrder',
+    type: 'string[]',
+    description: 'Ordered list of candidate model ids. The router picks the best-rated id from this list.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: "'adaptive-model-router'",
+    description: 'Processor identifier.',
+    isOptional: false,
+  },
+  {
+    name: 'name',
+    type: "'Adaptive Model Router'",
+    description: 'Processor display name.',
+    isOptional: false,
+  },
+  {
+    name: 'rules',
+    type: 'AdaptiveModelRouterRule[]',
+    description: 'The resolved rules, including the default error-rate rule when none were supplied.',
+    isOptional: false,
+  },
+  {
+    name: 'models',
+    type: 'AdaptiveModelRouterModel[]',
+    description: 'The configured model list, in declaration order.',
+    isOptional: false,
+  },
+  {
+    name: 'processInputStep',
+    type: '(args: ProcessInputStepArgs) => Promise<ProcessInputStepResult | void>',
+    description: 'Selects the single model used for the next LLM call.',
+    isOptional: false,
+  },
+  {
+    name: 'processAPIError',
+    type: '(args: ProcessAPIErrorArgs) => Promise<ProcessAPIErrorResult | void>',
+    description: 'Opens a cooldown on the failed model and signals retry when another candidate is available.',
+    isOptional: false,
+  },
+]}
+/>
+
+## Tripwire metadata
+
+When a rule fires and the router switches models, it calls `onViolation` with this detail:
+
+```typescript
+type AdaptiveModelRouterViolationDetail = {
+  rule: AdaptiveModelRouterRule
+  originalModel: string
+  selectedModel: string
+  reason: string
+}
+```
+
+The same shape (plus `processorId: 'adaptive-model-router'`) is available as `AdaptiveModelRouterTripwireMetadata`.
+
+## Related
+
+- [Processors](/docs/agents/processors)
+- [Processor interface](/reference/processors/processor-interface)
+- [StreamErrorRetryProcessor](/reference/processors/stream-error-retry-processor)

--- a/docs/src/content/en/reference/processors/adaptive-model-router.mdx
+++ b/docs/src/content/en/reference/processors/adaptive-model-router.mdx
@@ -7,6 +7,8 @@ packages:
 
 # AdaptiveModelRouter
 
+**Added in:** `@mastra/core@1.37.0`
+
 :::experimental
 
 This processor is in alpha. Breaking changes may occur without a major version bump until the API is stable.

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -387,6 +387,7 @@ const sidebars = {
       label: 'Processors',
       collapsed: true,
       items: [
+        { type: 'doc', id: 'processors/adaptive-model-router', label: 'AdaptiveModelRouter' },
         { type: 'doc', id: 'processors/batch-parts-processor', label: 'BatchPartsProcessor' },
         { type: 'doc', id: 'processors/cost-guard-processor', label: 'CostGuardProcessor' },
         { type: 'doc', id: 'processors/language-detector', label: 'LanguageDetector' },

--- a/packages/core/src/agent/__tests__/adaptive-model-router-integration.test.ts
+++ b/packages/core/src/agent/__tests__/adaptive-model-router-integration.test.ts
@@ -2,6 +2,7 @@ import { APICallError } from '@internal/ai-sdk-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it, vi } from 'vitest';
 import type * as LoopModule from '../../loop';
+import { AdaptiveModelRouter } from '../../processors';
 
 const loopModelCounts: number[] = [];
 
@@ -57,19 +58,24 @@ function createStreamModel(modelId: string, responseText: string, statusCode?: n
 }
 
 describe('AdaptiveModelRouter fallback integration', () => {
-  it('passes one model to the LLM loop per attempt for legacy fallback arrays', async () => {
+  it('passes one model to the LLM loop per attempt when explicitly configured as a processor', async () => {
     loopModelCounts.length = 0;
     const primary = createStreamModel('primary-router-loop', '', 429);
     const secondary = createStreamModel('secondary-router-loop', 'secondary response');
+    const router = new AdaptiveModelRouter({
+      models: [
+        { id: 'primary', model: primary, maxRetries: 0 },
+        { id: 'secondary', model: secondary, maxRetries: 0 },
+      ],
+    });
 
     const agent = new Agent({
       id: 'adaptive-router-loop-model-count',
       name: 'Adaptive Router Loop Model Count Test',
       instructions: 'You are a test agent',
-      model: [
-        { id: 'primary', model: primary, maxRetries: 0 },
-        { id: 'secondary', model: secondary, maxRetries: 0 },
-      ],
+      model: primary,
+      inputProcessors: [router],
+      errorProcessors: [router],
     });
 
     await (

--- a/packages/core/src/agent/__tests__/adaptive-model-router-integration.test.ts
+++ b/packages/core/src/agent/__tests__/adaptive-model-router-integration.test.ts
@@ -1,0 +1,83 @@
+import { APICallError } from '@internal/ai-sdk-v5';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import type * as LoopModule from '../../loop';
+
+const loopModelCounts: number[] = [];
+
+vi.mock('../../loop', async importOriginal => {
+  const actual = await importOriginal<typeof LoopModule>();
+  return {
+    ...actual,
+    loop: (options: Parameters<typeof actual.loop>[0]) => {
+      loopModelCounts.push(options.models.length);
+      return actual.loop(options);
+    },
+  };
+});
+
+const { Agent } = await import('../agent');
+
+function createStreamModel(modelId: string, responseText: string, statusCode?: number) {
+  return new MockLanguageModelV2({
+    modelId,
+    doStream: async () => {
+      if (statusCode) {
+        throw new APICallError({
+          message: `Status ${statusCode}`,
+          url: 'https://api.example.com',
+          requestBodyValues: {},
+          statusCode,
+          isRetryable: false,
+        });
+      }
+
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId, timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: responseText },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 } },
+        ]),
+      };
+    },
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop',
+      usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+      text: responseText,
+      content: [{ type: 'text', text: responseText }],
+      warnings: [],
+    }),
+  });
+}
+
+describe('AdaptiveModelRouter fallback integration', () => {
+  it('passes one model to the LLM loop per attempt for legacy fallback arrays', async () => {
+    loopModelCounts.length = 0;
+    const primary = createStreamModel('primary-router-loop', '', 429);
+    const secondary = createStreamModel('secondary-router-loop', 'secondary response');
+
+    const agent = new Agent({
+      id: 'adaptive-router-loop-model-count',
+      name: 'Adaptive Router Loop Model Count Test',
+      instructions: 'You are a test agent',
+      model: [
+        { id: 'primary', model: primary, maxRetries: 0 },
+        { id: 'secondary', model: secondary, maxRetries: 0 },
+      ],
+    });
+
+    await (
+      await agent.stream('Hello')
+    ).text;
+
+    expect(loopModelCounts).toEqual([1]);
+    expect(primary.doStreamCalls).toHaveLength(1);
+    expect(secondary.doStreamCalls).toHaveLength(1);
+  });
+});

--- a/packages/core/src/agent/__tests__/adaptive-model-router-integration.test.ts
+++ b/packages/core/src/agent/__tests__/adaptive-model-router-integration.test.ts
@@ -58,10 +58,34 @@ function createStreamModel(modelId: string, responseText: string, statusCode?: n
 }
 
 describe('AdaptiveModelRouter fallback integration', () => {
-  it('passes one model to the LLM loop per attempt when explicitly configured as a processor', async () => {
+  it('passes one model to the LLM loop for legacy model fallback arrays', async () => {
     loopModelCounts.length = 0;
     const primary = createStreamModel('primary-router-loop', '', 429);
     const secondary = createStreamModel('secondary-router-loop', 'secondary response');
+
+    const agent = new Agent({
+      id: 'adaptive-router-loop-model-count',
+      name: 'Adaptive Router Loop Model Count Test',
+      instructions: 'You are a test agent',
+      model: [
+        { id: 'primary', model: primary, maxRetries: 0 },
+        { id: 'secondary', model: secondary, maxRetries: 0 },
+      ],
+    });
+
+    await (
+      await agent.stream('Hello')
+    ).text;
+
+    expect(loopModelCounts).toEqual([1]);
+    expect(primary.doStreamCalls).toHaveLength(1);
+    expect(secondary.doStreamCalls).toHaveLength(1);
+  });
+
+  it('passes one model to the LLM loop when explicitly configured as a processor', async () => {
+    loopModelCounts.length = 0;
+    const primary = createStreamModel('explicit-primary-router-loop', '', 429);
+    const secondary = createStreamModel('explicit-secondary-router-loop', 'secondary response');
     const router = new AdaptiveModelRouter({
       models: [
         { id: 'primary', model: primary, maxRetries: 0 },
@@ -70,8 +94,8 @@ describe('AdaptiveModelRouter fallback integration', () => {
     });
 
     const agent = new Agent({
-      id: 'adaptive-router-loop-model-count',
-      name: 'Adaptive Router Loop Model Count Test',
+      id: 'explicit-adaptive-router-loop-model-count',
+      name: 'Explicit Adaptive Router Loop Model Count Test',
       instructions: 'You are a test agent',
       model: primary,
       inputProcessors: [router],

--- a/packages/core/src/agent/__tests__/adaptive-model-router.test.ts
+++ b/packages/core/src/agent/__tests__/adaptive-model-router.test.ts
@@ -1,0 +1,215 @@
+import { APICallError } from '@internal/ai-sdk-v5';
+import { describe, expect, it, vi } from 'vitest';
+import { AdaptiveModelRouter } from '../../processors';
+
+const primary = { specificationVersion: 'v2', provider: 'test', modelId: 'primary' } as any;
+const secondary = { specificationVersion: 'v2', provider: 'test', modelId: 'secondary' } as any;
+const tertiary = { specificationVersion: 'v2', provider: 'test', modelId: 'tertiary' } as any;
+
+class TestCache {
+  entries = new Map<string, unknown>();
+  ttls: Array<{ key: string; ttl?: number }> = [];
+
+  async get(key: string) {
+    return this.entries.get(key);
+  }
+
+  async set(key: string, value: unknown, ttl?: number) {
+    this.entries.set(key, value);
+    this.ttls.push({ key, ttl });
+  }
+}
+
+function createRouter(
+  options: ConstructorParameters<typeof AdaptiveModelRouter>[0],
+  observability: Record<string, any> = {},
+  cache = new TestCache(),
+) {
+  const router = new AdaptiveModelRouter(options);
+  router.__registerMastra({
+    getStorage: () => ({ getStore: (name: string) => (name === 'observability' ? observability : undefined) }),
+    getServerCache: () => cache,
+  } as any);
+  return { router, cache };
+}
+
+function inputArgs(overrides: Record<string, any> = {}) {
+  return {
+    state: {},
+    requestContext: { resourceId: 'agent-1', threadId: 'thread-1', runId: 'run-1' },
+    retryCount: 0,
+    ...overrides,
+  } as any;
+}
+
+function retryableError(statusCode = 429) {
+  return new APICallError({
+    message: 'retry me',
+    url: 'https://api.example.com',
+    requestBodyValues: {},
+    statusCode,
+    isRetryable: true,
+  });
+}
+
+describe('AdaptiveModelRouter', () => {
+  it('creates a default error-rate rule when rules are omitted', () => {
+    const { router } = createRouter({
+      models: [
+        { id: 'primary', model: primary },
+        { id: 'secondary', model: secondary },
+      ],
+    });
+
+    expect(router.rules).toEqual([
+      expect.objectContaining({ signal: 'error-rate', threshold: 0.3, minRequests: 5, window: '24h', cooldown: '2m' }),
+    ]);
+  });
+
+  it('switches on error-rate only after minRequests and threshold are met', async () => {
+    const getMetricBreakdown = vi.fn().mockResolvedValue([
+      { labels: { status: 'success' }, count: 7 },
+      { labels: { status: 'error' }, count: 3 },
+    ]);
+    const { router } = createRouter(
+      {
+        models: [
+          { id: 'primary', model: primary },
+          { id: 'secondary', model: secondary, modelSettings: { temperature: 0.9 } },
+        ],
+        rules: [
+          {
+            signal: 'error-rate',
+            threshold: 0.2,
+            minRequests: 10,
+            window: '5m',
+            fallbackOrder: ['secondary', 'primary'],
+          },
+        ],
+      },
+      { getMetricBreakdown },
+    );
+
+    const result = await router.processInputStep(inputArgs());
+
+    expect(result?.model).toBe(secondary);
+    expect(result?.modelSettings).toEqual({ temperature: 0.9 });
+    expect(getMetricBreakdown).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metricName: 'mastra_model_duration_ms',
+        filters: { resourceId: 'agent-1', modelId: 'primary' },
+        groupBy: ['status', 'error'],
+      }),
+    );
+  });
+
+  it('does not proactively switch when observability queries are unsupported', async () => {
+    const { router } = createRouter({
+      models: [
+        { id: 'primary', model: primary },
+        { id: 'secondary', model: secondary },
+      ],
+      rules: [{ signal: 'error-rate', threshold: 0, minRequests: 1, fallbackOrder: ['secondary', 'primary'] }],
+    });
+
+    const result = await router.processInputStep(inputArgs());
+
+    expect(result?.model).toBe(primary);
+  });
+
+  it('switches when score aggregate falls below the configured minimum', async () => {
+    const { router } = createRouter(
+      {
+        models: [
+          { id: 'primary', model: primary },
+          { id: 'secondary', model: secondary },
+        ],
+        rules: [
+          {
+            signal: 'score',
+            scorerId: 'quality',
+            minScore: 0.8,
+            aggregation: 'avg',
+            fallbackOrder: ['secondary', 'primary'],
+          },
+        ],
+      },
+      { getScoreAggregate: vi.fn().mockResolvedValue({ avg: 0.5, count: 12 }) },
+    );
+
+    const result = await router.processInputStep(inputArgs());
+
+    expect(result?.model).toBe(secondary);
+  });
+
+  it('selects the best-rated feedback model once minSamples is met', async () => {
+    const getFeedbackAggregate = vi
+      .fn()
+      .mockResolvedValueOnce({ avg: 0.6, count: 12 })
+      .mockResolvedValueOnce({ avg: 0.9, count: 12 })
+      .mockResolvedValueOnce({ avg: 0.7, count: 12 });
+    const { router } = createRouter(
+      {
+        models: [
+          { id: 'primary', model: primary },
+          { id: 'secondary', model: secondary },
+          { id: 'tertiary', model: tertiary },
+        ],
+        rules: [
+          {
+            signal: 'feedback',
+            feedbackType: 'thumbs',
+            minSamples: 10,
+            fallbackOrder: ['primary', 'secondary', 'tertiary'],
+          },
+        ],
+      },
+      { getFeedbackAggregate },
+    );
+
+    const result = await router.processInputStep(inputArgs());
+
+    expect(result?.model).toBe(secondary);
+    expect(getFeedbackAggregate).toHaveBeenCalledTimes(3);
+  });
+
+  it('opens cooldown state and retries the next eligible model on retryable API errors', async () => {
+    const { router, cache } = createRouter({
+      models: [
+        { id: 'primary', model: primary },
+        { id: 'secondary', model: secondary },
+      ],
+    });
+    const state = {};
+    await router.processInputStep(inputArgs({ state }));
+    const rotateResponseMessageId = vi.fn();
+
+    const result = await router.processAPIError({ state, error: retryableError(), rotateResponseMessageId } as any);
+
+    expect(result).toEqual({ retry: true });
+    expect(rotateResponseMessageId).toHaveBeenCalledOnce();
+    expect(cache.ttls.some(entry => entry.key.includes('primary') && entry.ttl === 120_000)).toBe(true);
+  });
+
+  it('routes plain stream errors to the next fallback model like legacy model fallbacks', async () => {
+    const { router, cache } = createRouter({
+      models: [
+        { id: 'primary', model: primary },
+        { id: 'secondary', model: secondary },
+      ],
+    });
+    const state = {};
+    await router.processInputStep(inputArgs({ state }));
+    const rotateResponseMessageId = vi.fn();
+
+    const result = await router.processAPIError({
+      state,
+      error: new Error('plain stream failure'),
+      rotateResponseMessageId,
+    } as any);
+
+    expect(result).toEqual({ retry: true });
+    expect(rotateResponseMessageId).toHaveBeenCalledOnce();
+    expect(cache.ttls.some(entry => entry.key.includes('primary') && entry.ttl === 120_000)).toBe(true);
+  });
+});

--- a/packages/core/src/agent/__tests__/adaptive-model-router.test.ts
+++ b/packages/core/src/agent/__tests__/adaptive-model-router.test.ts
@@ -191,6 +191,37 @@ describe('AdaptiveModelRouter', () => {
     expect(cache.ttls.some(entry => entry.key.includes('primary') && entry.ttl === 120_000)).toBe(true);
   });
 
+  it('resolves DynamicArgument modelSettings/providerOptions/headers with requestContext at request time', async () => {
+    const modelSettings = vi.fn().mockImplementation(({ requestContext }) => ({
+      temperature: requestContext?.tier === 'gold' ? 0.1 : 0.9,
+    }));
+    const providerOptions = vi.fn().mockResolvedValue({ openai: { reasoning: 'high' } });
+    const headers = vi.fn().mockResolvedValue({ 'x-tier': 'gold' });
+
+    const { router } = createRouter({
+      models: [
+        { id: 'primary', model: primary, modelSettings, providerOptions, headers },
+        { id: 'secondary', model: secondary },
+      ],
+    });
+
+    const result = await router.processInputStep(
+      inputArgs({ requestContext: { resourceId: 'agent-1', tier: 'gold' } }),
+    );
+
+    expect(modelSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ requestContext: expect.objectContaining({ tier: 'gold' }) }),
+    );
+    expect(providerOptions).toHaveBeenCalledOnce();
+    expect(headers).toHaveBeenCalledOnce();
+    expect(result).toEqual(
+      expect.objectContaining({
+        modelSettings: expect.objectContaining({ temperature: 0.1, headers: { 'x-tier': 'gold' } }),
+        providerOptions: { openai: { reasoning: 'high' } },
+      }),
+    );
+  });
+
   it('routes plain stream errors to the next fallback model like legacy model fallbacks', async () => {
     const { router, cache } = createRouter({
       models: [

--- a/packages/core/src/agent/__tests__/prefill-error-recovery.test.ts
+++ b/packages/core/src/agent/__tests__/prefill-error-recovery.test.ts
@@ -337,7 +337,10 @@ describe('PrefillErrorHandler Recovery', () => {
 
       expect(result.text).toBe('Recovered on secondary model');
       expect(seenModels).toEqual(['primary', 'secondary', 'secondary']);
-      expect(processAPIError).toHaveBeenCalledTimes(2);
+      // The AdaptiveModelRouter handles the primary→secondary fallback internally,
+      // so user error processors are only invoked when the router cannot find another
+      // eligible model (i.e. when secondary fails and we need a same-model retry).
+      expect(processAPIError).toHaveBeenCalledTimes(1);
     });
 
     it('should NOT retry for non-prefill API errors', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -53,7 +53,6 @@ import {
   createObservabilityContext,
   resolveObservabilityContext,
 } from '../observability';
-import { AdaptiveModelRouter } from '../processors/adaptive-model-router';
 import type {
   ErrorProcessorOrWorkflow,
   InputProcessorOrWorkflow,
@@ -334,7 +333,6 @@ export class Agent<
   #outputProcessors?: DynamicArgument<OutputProcessorOrWorkflow[], TRequestContext>;
   #maxProcessorRetries?: number;
   #errorProcessors?: DynamicArgument<ErrorProcessorOrWorkflow[], TRequestContext>;
-  #adaptiveModelRouterConfig?: AgentConfig<TAgentId, TTools, TOutput, TRequestContext>['adaptiveModelRouter'];
   #browser?: MastraBrowser;
   #hasExplicitBrowser = false;
   #requestContextSchema?: StandardSchemaWithJSON<TRequestContext>;
@@ -390,7 +388,6 @@ export class Agent<
     this.#description = config.description;
     this.#metadata = config.metadata;
     this.#options = config.options;
-    this.#adaptiveModelRouterConfig = config.adaptiveModelRouter;
 
     if (!config.model) {
       const mastraError = new MastraError({
@@ -1973,17 +1970,10 @@ export class Agent<
             : modelSelection;
 
           llm = this.prepareModels(requestContext, enabledSelection).then(models => {
-            const adaptiveModelRouter =
-              Array.isArray(enabledSelection) && models.length > 1
-                ? new AdaptiveModelRouter({ ...this.#adaptiveModelRouterConfig, models })
-                : undefined;
-
             return new MastraLLMVNext({
-              models: adaptiveModelRouter ? [models[0]!] : models,
+              models,
               mastra: this.#mastra,
               options: { tracingPolicy: this.#options?.tracingPolicy },
-              internalInputProcessors: adaptiveModelRouter ? [adaptiveModelRouter] : [],
-              internalErrorProcessors: adaptiveModelRouter ? [adaptiveModelRouter] : [],
             });
           });
         } else {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -53,6 +53,7 @@ import {
   createObservabilityContext,
   resolveObservabilityContext,
 } from '../observability';
+import { AdaptiveModelRouter } from '../processors/adaptive-model-router';
 import type {
   ErrorProcessorOrWorkflow,
   InputProcessorOrWorkflow,
@@ -333,6 +334,7 @@ export class Agent<
   #outputProcessors?: DynamicArgument<OutputProcessorOrWorkflow[], TRequestContext>;
   #maxProcessorRetries?: number;
   #errorProcessors?: DynamicArgument<ErrorProcessorOrWorkflow[], TRequestContext>;
+  #adaptiveModelRouterConfig?: AgentConfig<TAgentId, TTools, TOutput, TRequestContext>['adaptiveModelRouter'];
   #browser?: MastraBrowser;
   #hasExplicitBrowser = false;
   #requestContextSchema?: StandardSchemaWithJSON<TRequestContext>;
@@ -388,6 +390,7 @@ export class Agent<
     this.#description = config.description;
     this.#metadata = config.metadata;
     this.#options = config.options;
+    this.#adaptiveModelRouterConfig = config.adaptiveModelRouter;
 
     if (!config.model) {
       const mastraError = new MastraError({
@@ -1970,10 +1973,17 @@ export class Agent<
             : modelSelection;
 
           llm = this.prepareModels(requestContext, enabledSelection).then(models => {
+            const adaptiveModelRouter =
+              Array.isArray(enabledSelection) && models.length > 1
+                ? new AdaptiveModelRouter({ ...this.#adaptiveModelRouterConfig, models })
+                : undefined;
+
             return new MastraLLMVNext({
-              models,
+              models: adaptiveModelRouter ? [models[0]!] : models,
               mastra: this.#mastra,
               options: { tracingPolicy: this.#options?.tracingPolicy },
+              internalInputProcessors: adaptiveModelRouter ? [adaptiveModelRouter] : [],
+              internalErrorProcessors: adaptiveModelRouter ? [adaptiveModelRouter] : [],
             });
           });
         } else {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -53,6 +53,7 @@ import {
   createObservabilityContext,
   resolveObservabilityContext,
 } from '../observability';
+import { AdaptiveModelRouter } from '../processors/adaptive-model-router';
 import type {
   ErrorProcessorOrWorkflow,
   InputProcessorOrWorkflow,
@@ -1970,10 +1971,17 @@ export class Agent<
             : modelSelection;
 
           llm = this.prepareModels(requestContext, enabledSelection).then(models => {
+            const adaptiveModelRouter =
+              Array.isArray(enabledSelection) && models.length > 1
+                ? new AdaptiveModelRouter({ models, rules: [] })
+                : undefined;
+
             return new MastraLLMVNext({
-              models,
+              models: adaptiveModelRouter ? [models[0]!] : models,
               mastra: this.#mastra,
               options: { tracingPolicy: this.#options?.tracingPolicy },
+              internalInputProcessors: adaptiveModelRouter ? [adaptiveModelRouter] : [],
+              internalErrorProcessors: adaptiveModelRouter ? [adaptiveModelRouter] : [],
             });
           });
         } else {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -34,6 +34,7 @@ import type { MastraMemory } from '../memory/memory';
 import type { MemoryConfigInternal, StorageThreadType } from '../memory/types';
 import type { Span, SpanType, TracingOptions, TracingPolicy, ObservabilityContext } from '../observability';
 import type {
+  AdaptiveModelRouterOptions,
   ErrorProcessorOrWorkflow,
   InputProcessorOrWorkflow,
   OutputProcessorOrWorkflow,
@@ -224,6 +225,8 @@ export interface AgentCreateOptions {
 
 export type ModelFallbackSettings = Omit<CallSettings, 'abortSignal' | 'maxRetries' | 'headers'>;
 
+export type AdaptiveModelRouterConfig = Omit<AdaptiveModelRouterOptions, 'models'>;
+
 export type ModelWithRetries = {
   id?: string;
   model: DynamicArgument<MastraModelConfig>;
@@ -345,6 +348,12 @@ export interface AgentConfig<
    * ```
    */
   model: DynamicArgument<MastraModelConfig | ModelWithRetries[], TRequestContext>;
+  /**
+   * Configures adaptive routing rules for fallback model arrays. When `model` resolves to
+   * multiple fallback entries, Mastra creates an internal AdaptiveModelRouter with these
+   * options and the resolved model list.
+   */
+  adaptiveModelRouter?: AdaptiveModelRouterConfig;
   /**
    * Maximum number of retries for model calls in case of failure.
    * @defaultValue 0

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -34,7 +34,6 @@ import type { MastraMemory } from '../memory/memory';
 import type { MemoryConfigInternal, StorageThreadType } from '../memory/types';
 import type { Span, SpanType, TracingOptions, TracingPolicy, ObservabilityContext } from '../observability';
 import type {
-  AdaptiveModelRouterOptions,
   ErrorProcessorOrWorkflow,
   InputProcessorOrWorkflow,
   OutputProcessorOrWorkflow,
@@ -225,8 +224,6 @@ export interface AgentCreateOptions {
 
 export type ModelFallbackSettings = Omit<CallSettings, 'abortSignal' | 'maxRetries' | 'headers'>;
 
-export type AdaptiveModelRouterConfig = Omit<AdaptiveModelRouterOptions, 'models'>;
-
 export type ModelWithRetries = {
   id?: string;
   model: DynamicArgument<MastraModelConfig>;
@@ -348,12 +345,6 @@ export interface AgentConfig<
    * ```
    */
   model: DynamicArgument<MastraModelConfig | ModelWithRetries[], TRequestContext>;
-  /**
-   * Configures adaptive routing rules for fallback model arrays. When `model` resolves to
-   * multiple fallback entries, Mastra creates an internal AdaptiveModelRouter with these
-   * options and the resolved model list.
-   */
-  adaptiveModelRouter?: AdaptiveModelRouterConfig;
   /**
    * Maximum number of retries for model calls in case of failure.
    * @defaultValue 0

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -23,6 +23,7 @@ export class MastraLLMVNext extends MastraBase {
   #firstModel: ModelManagerModelConfig;
   #internalInputProcessors: InputProcessorOrWorkflow[];
   #internalErrorProcessors: ErrorProcessorOrWorkflow[];
+  #registeredInternalProcessors = new WeakSet<object>();
 
   constructor({
     mastra,
@@ -45,11 +46,7 @@ export class MastraLLMVNext extends MastraBase {
 
     if (mastra) {
       this.#mastra = mastra;
-      for (const processor of [...this.#internalInputProcessors, ...this.#internalErrorProcessors]) {
-        if ('__registerMastra' in processor && typeof processor.__registerMastra === 'function') {
-          processor.__registerMastra(mastra);
-        }
-      }
+      this.#registerInternalProcessors(mastra);
       if (mastra.getLogger()) {
         this.__setLogger(this.#mastra.getLogger());
       }
@@ -77,9 +74,15 @@ export class MastraLLMVNext extends MastraBase {
 
   __registerMastra(p: Mastra) {
     this.#mastra = p;
+    this.#registerInternalProcessors(p);
+  }
+
+  #registerInternalProcessors(mastra: Mastra) {
     for (const processor of [...this.#internalInputProcessors, ...this.#internalErrorProcessors]) {
+      if (this.#registeredInternalProcessors.has(processor)) continue;
       if ('__registerMastra' in processor && typeof processor.__registerMastra === 'function') {
-        processor.__registerMastra(p);
+        processor.__registerMastra(mastra);
+        this.#registeredInternalProcessors.add(processor);
       }
     }
   }

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -8,6 +8,7 @@ import type { LoopOptions } from '../../loop/types';
 import type { Mastra } from '../../mastra';
 import { SpanType, resolveObservabilityContext } from '../../observability';
 import { executeWithContextSync } from '../../observability/utils';
+import type { ErrorProcessorOrWorkflow, InputProcessorOrWorkflow } from '../../processors';
 import type { MastraModelOutput } from '../../stream/base/output';
 import type { ModelManagerModelConfig } from '../../stream/types';
 import { delay } from '../../utils';
@@ -20,22 +21,35 @@ export class MastraLLMVNext extends MastraBase {
   #mastra?: Mastra;
   #options?: MastraModelOptions;
   #firstModel: ModelManagerModelConfig;
+  #internalInputProcessors: InputProcessorOrWorkflow[];
+  #internalErrorProcessors: ErrorProcessorOrWorkflow[];
 
   constructor({
     mastra,
     models,
     options,
+    internalInputProcessors = [],
+    internalErrorProcessors = [],
   }: {
     mastra?: Mastra;
     models: ModelManagerModelConfig[];
     options?: MastraModelOptions;
+    internalInputProcessors?: InputProcessorOrWorkflow[];
+    internalErrorProcessors?: ErrorProcessorOrWorkflow[];
   }) {
     super({ name: 'aisdk' });
 
     this.#options = options;
+    this.#internalInputProcessors = internalInputProcessors;
+    this.#internalErrorProcessors = internalErrorProcessors;
 
     if (mastra) {
       this.#mastra = mastra;
+      for (const processor of [...this.#internalInputProcessors, ...this.#internalErrorProcessors]) {
+        if ('__registerMastra' in processor && typeof processor.__registerMastra === 'function') {
+          processor.__registerMastra(mastra);
+        }
+      }
       if (mastra.getLogger()) {
         this.__setLogger(this.#mastra.getLogger());
       }
@@ -63,6 +77,11 @@ export class MastraLLMVNext extends MastraBase {
 
   __registerMastra(p: Mastra) {
     this.#mastra = p;
+    for (const processor of [...this.#internalInputProcessors, ...this.#internalErrorProcessors]) {
+      if ('__registerMastra' in processor && typeof processor.__registerMastra === 'function') {
+        processor.__registerMastra(p);
+      }
+    }
   }
 
   getProvider() {
@@ -208,10 +227,10 @@ export class MastraLLMVNext extends MastraBase {
         providerOptions,
         _internal,
         structuredOutput,
-        inputProcessors,
+        inputProcessors: [...this.#internalInputProcessors, ...(inputProcessors ?? [])],
         llmRequestInputProcessors,
         outputProcessors,
-        errorProcessors,
+        errorProcessors: [...this.#internalErrorProcessors, ...(errorProcessors ?? [])],
         returnScorerData,
         modelSpanTracker,
         requireToolApproval,

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -8,7 +8,6 @@ import type { LoopOptions } from '../../loop/types';
 import type { Mastra } from '../../mastra';
 import { SpanType, resolveObservabilityContext } from '../../observability';
 import { executeWithContextSync } from '../../observability/utils';
-import type { ErrorProcessorOrWorkflow, InputProcessorOrWorkflow } from '../../processors';
 import type { MastraModelOutput } from '../../stream/base/output';
 import type { ModelManagerModelConfig } from '../../stream/types';
 import { delay } from '../../utils';
@@ -21,35 +20,22 @@ export class MastraLLMVNext extends MastraBase {
   #mastra?: Mastra;
   #options?: MastraModelOptions;
   #firstModel: ModelManagerModelConfig;
-  #internalInputProcessors: InputProcessorOrWorkflow[];
-  #internalErrorProcessors: ErrorProcessorOrWorkflow[];
 
   constructor({
     mastra,
     models,
     options,
-    internalInputProcessors = [],
-    internalErrorProcessors = [],
   }: {
     mastra?: Mastra;
     models: ModelManagerModelConfig[];
     options?: MastraModelOptions;
-    internalInputProcessors?: InputProcessorOrWorkflow[];
-    internalErrorProcessors?: ErrorProcessorOrWorkflow[];
   }) {
     super({ name: 'aisdk' });
 
     this.#options = options;
-    this.#internalInputProcessors = internalInputProcessors;
-    this.#internalErrorProcessors = internalErrorProcessors;
 
     if (mastra) {
       this.#mastra = mastra;
-      for (const processor of [...this.#internalInputProcessors, ...this.#internalErrorProcessors]) {
-        if ('__registerMastra' in processor && typeof processor.__registerMastra === 'function') {
-          processor.__registerMastra(mastra);
-        }
-      }
       if (mastra.getLogger()) {
         this.__setLogger(this.#mastra.getLogger());
       }
@@ -77,11 +63,6 @@ export class MastraLLMVNext extends MastraBase {
 
   __registerMastra(p: Mastra) {
     this.#mastra = p;
-    for (const processor of [...this.#internalInputProcessors, ...this.#internalErrorProcessors]) {
-      if ('__registerMastra' in processor && typeof processor.__registerMastra === 'function') {
-        processor.__registerMastra(p);
-      }
-    }
   }
 
   getProvider() {
@@ -227,10 +208,10 @@ export class MastraLLMVNext extends MastraBase {
         providerOptions,
         _internal,
         structuredOutput,
-        inputProcessors: [...this.#internalInputProcessors, ...(inputProcessors ?? [])],
+        inputProcessors,
         llmRequestInputProcessors,
         outputProcessors,
-        errorProcessors: [...this.#internalErrorProcessors, ...(errorProcessors ?? [])],
+        errorProcessors,
         returnScorerData,
         modelSpanTracker,
         requireToolApproval,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1062,13 +1062,13 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             // input processor / prepareStep / processLLMRequest work, and that
             // availableTools / toolChoice reflect any per-step mutations.
             const currentStepUsesModelConfig = currentStep.model === modelConfig.model;
+            const stepMaxRetries = (currentStep.modelSettings as { maxRetries?: number } | undefined)?.maxRetries;
             const currentStepModelSettings = {
               ...currentStep.modelSettings,
               ...(currentStepUsesModelConfig ? modelConfig.modelSettings : {}),
               maxRetries: currentStepUsesModelConfig
-                ? modelConfig.maxRetries
-                : ((currentStep.modelSettings as { maxRetries?: number } | undefined)?.maxRetries ??
-                  modelConfig.maxRetries),
+                ? (modelConfig.maxRetries ?? stepMaxRetries)
+                : (stepMaxRetries ?? modelConfig.maxRetries),
             };
 
             modelSpanTracker?.setInferenceContext?.({

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1063,16 +1063,23 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             // availableTools / toolChoice reflect any per-step mutations.
             const currentStepUsesModelConfig = currentStep.model === modelConfig.model;
             const stepMaxRetries = (currentStep.modelSettings as { maxRetries?: number } | undefined)?.maxRetries;
-            const currentStepModelSettings = {
-              ...currentStep.modelSettings,
+            // Strip maxRetries from span parameters — it's a transport concern (p-retry), not an
+            // inference parameter, and bundling it here changes the tracing surface area.
+            const { maxRetries: _stepMaxRetriesIgnored, ...currentStepModelSettingsForSpan } =
+              (currentStep.modelSettings ?? {}) as { maxRetries?: number } & Record<string, unknown>;
+            const currentStepSpanParameters = {
+              ...currentStepModelSettingsForSpan,
               ...(currentStepUsesModelConfig ? modelConfig.modelSettings : {}),
+            };
+            const currentStepModelSettings = {
+              ...currentStepSpanParameters,
               maxRetries: currentStepUsesModelConfig
                 ? (modelConfig.maxRetries ?? stepMaxRetries)
                 : (stepMaxRetries ?? modelConfig.maxRetries),
             };
 
             modelSpanTracker?.setInferenceContext?.({
-              parameters: currentStepModelSettings as Record<string, unknown> | undefined,
+              parameters: currentStepSpanParameters as Record<string, unknown> | undefined,
               providerOptions: currentStep.providerOptions as Record<string, unknown> | undefined,
               availableTools: getStepAvailableToolNames(
                 currentStep.tools as Record<string, unknown> | undefined,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1061,11 +1061,18 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             // immediately before execute() ensures the span's startTime excludes
             // input processor / prepareStep / processLLMRequest work, and that
             // availableTools / toolChoice reflect any per-step mutations.
+            const currentStepUsesModelConfig = currentStep.model === modelConfig.model;
+            const currentStepModelSettings = {
+              ...currentStep.modelSettings,
+              ...(currentStepUsesModelConfig ? modelConfig.modelSettings : {}),
+              maxRetries: currentStepUsesModelConfig
+                ? modelConfig.maxRetries
+                : ((currentStep.modelSettings as { maxRetries?: number } | undefined)?.maxRetries ??
+                  modelConfig.maxRetries),
+            };
+
             modelSpanTracker?.setInferenceContext?.({
-              parameters: {
-                ...currentStep.modelSettings,
-                ...modelConfig.modelSettings,
-              } as Record<string, unknown> | undefined,
+              parameters: currentStepModelSettings as Record<string, unknown> | undefined,
               providerOptions: currentStep.providerOptions as Record<string, unknown> | undefined,
               availableTools: getStepAvailableToolNames(
                 currentStep.tools as Record<string, unknown> | undefined,
@@ -1090,11 +1097,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                   options,
                   // Per-model modelSettings shallow-merge on top of call-time modelSettings.
                   // Per-model maxRetries always wins so p-retry uses the right retry count for this model.
-                  modelSettings: {
-                    ...currentStep.modelSettings,
-                    ...modelConfig.modelSettings,
-                    maxRetries: modelConfig.maxRetries,
-                  },
+                  modelSettings: currentStepModelSettings,
                   includeRawChunks,
                   structuredOutput: currentStep.structuredOutput,
                   // Merge headers: memory context first, then modelConfig headers, then modelSettings overrides

--- a/packages/core/src/processors/adaptive-model-router.ts
+++ b/packages/core/src/processors/adaptive-model-router.ts
@@ -232,17 +232,36 @@ export class AdaptiveModelRouter implements Processor<'adaptive-model-router', A
       });
     }
 
+    const [resolvedModelSettings, resolvedProviderOptions, resolvedHeaders] = await Promise.all([
+      this.#resolveDynamic(selectedModel.modelSettings, args.requestContext),
+      this.#resolveDynamic(selectedModel.providerOptions, args.requestContext),
+      this.#resolveDynamic(selectedModel.headers, args.requestContext),
+    ]);
+
     const modelSettings = {
-      ...((selectedModel.modelSettings as object | undefined) ?? {}),
-      ...(selectedModel.headers ? { headers: selectedModel.headers } : {}),
+      ...((resolvedModelSettings as object | undefined) ?? {}),
+      ...(resolvedHeaders ? { headers: resolvedHeaders } : {}),
       ...(selectedModel.maxRetries !== undefined ? { maxRetries: selectedModel.maxRetries } : {}),
     } as any;
 
     return {
       model: selectedModel.model as MastraLanguageModel,
       modelSettings,
-      providerOptions: selectedModel.providerOptions as SharedProviderOptions | undefined,
+      providerOptions: resolvedProviderOptions as SharedProviderOptions | undefined,
     };
+  }
+
+  async #resolveDynamic<T>(
+    value: DynamicArgument<T> | T | undefined,
+    requestContext: ProcessInputStepArgs['requestContext'],
+  ): Promise<T | undefined> {
+    if (value === undefined) return undefined;
+    if (typeof value !== 'function') return value as T;
+    const result = (value as (args: { requestContext: any; mastra?: Mastra }) => Promise<T> | T)({
+      requestContext: requestContext ?? ({} as any),
+      mastra: this.mastra,
+    });
+    return await result;
   }
 
   async processAPIError(args: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {

--- a/packages/core/src/processors/adaptive-model-router.ts
+++ b/packages/core/src/processors/adaptive-model-router.ts
@@ -1,0 +1,455 @@
+import type { ModelFallbackSettings } from '../agent/types';
+import type { DynamicArgument } from '../base';
+import type { MastraLanguageModel, MastraModelConfig, SharedProviderOptions } from '../llm/model/shared.types';
+import type { Mastra } from '../mastra';
+import type {
+  Processor,
+  ProcessAPIErrorArgs,
+  ProcessAPIErrorResult,
+  ProcessInputStepArgs,
+  ProcessInputStepResult,
+} from './index';
+
+export type RouterScope = 'run' | 'resource' | 'thread';
+export type RouterWindow = '5m' | '1h' | '6h' | '24h' | '7d' | '30d' | '365d';
+export type MastraMetricName =
+  | 'mastra_model_duration_ms'
+  | 'mastra_model_total_input_tokens'
+  | 'mastra_model_total_output_tokens'
+  | 'mastra_agent_duration_ms'
+  | 'mastra_tool_duration_ms'
+  | (string & {});
+
+export type ErrorRateRule = {
+  signal: 'error-rate';
+  metric?: MastraMetricName;
+  threshold?: number;
+  minRequests?: number;
+  window?: RouterWindow;
+  cooldown?: RouterWindow | `${number}m` | `${number}h` | `${number}d`;
+  fallbackOrder?: string[];
+};
+
+export type ScoreRule = {
+  signal: 'score';
+  scorerId: string;
+  minScore: number;
+  aggregation?: 'avg' | 'min' | 'max';
+  window?: RouterWindow;
+  cooldown?: RouterWindow | `${number}m` | `${number}h` | `${number}d`;
+  fallbackOrder?: string[];
+};
+
+export type FeedbackRule = {
+  signal: 'feedback';
+  feedbackType: string;
+  strategy?: 'best-rated';
+  aggregation?: 'avg' | 'min' | 'max';
+  minSamples?: number;
+  window?: RouterWindow;
+  cooldown?: RouterWindow | `${number}m` | `${number}h` | `${number}d`;
+  fallbackOrder?: string[];
+};
+
+export type AdaptiveModelRouterRule = ErrorRateRule | ScoreRule | FeedbackRule;
+
+export type AdaptiveModelRouterTripwireMetadata = {
+  processorId: 'adaptive-model-router';
+  rule: AdaptiveModelRouterRule;
+  originalModel: string;
+  selectedModel: string;
+  reason: string;
+};
+
+export type AdaptiveModelRouterViolationDetail = Omit<AdaptiveModelRouterTripwireMetadata, 'processorId'>;
+
+export type AdaptiveModelRouterModel = {
+  id: string;
+  model: MastraLanguageModel | MastraModelConfig;
+  maxRetries?: number;
+  enabled?: boolean;
+  modelSettings?: DynamicArgument<ModelFallbackSettings> | ModelFallbackSettings;
+  providerOptions?: DynamicArgument<SharedProviderOptions> | SharedProviderOptions;
+  headers?: DynamicArgument<Record<string, string>> | Record<string, string>;
+};
+
+export type AdaptiveModelRouterOptions = {
+  models: AdaptiveModelRouterModel[];
+  rules?: AdaptiveModelRouterRule[];
+  scope?: RouterScope;
+  window?: RouterWindow;
+  cooldown?: RouterWindow | `${number}m` | `${number}h` | `${number}d`;
+  errorRateThreshold?: number;
+  minRequests?: number;
+};
+
+type RouterState = {
+  originalModelId?: string;
+  selectedModelId?: string;
+  currentRule?: AdaptiveModelRouterRule;
+  attemptedModelIds?: string[];
+  skippedModelIds?: string[];
+  activeFallbackOrder?: string[];
+};
+
+type FiredRule = {
+  rule: AdaptiveModelRouterRule;
+  reason: string;
+  selectedModelId?: string;
+};
+
+const DEFAULT_SCOPE: RouterScope = 'resource';
+const DEFAULT_WINDOW: RouterWindow = '24h';
+const DEFAULT_COOLDOWN = '2m';
+const DEFAULT_ERROR_RATE_THRESHOLD = 0.3;
+const DEFAULT_MIN_REQUESTS = 5;
+
+function parseDurationMs(duration: string): number {
+  const match = duration.match(/^(\d+)(m|h|d)$/);
+  if (!match) {
+    throw new Error(`Invalid AdaptiveModelRouter duration: ${duration}`);
+  }
+
+  const value = Number(match[1]);
+  const unit = match[2];
+  if (unit === 'm') return value * 60 * 1000;
+  if (unit === 'h') return value * 60 * 60 * 1000;
+  return value * 24 * 60 * 60 * 1000;
+}
+
+function isEnabled(model: AdaptiveModelRouterModel): boolean {
+  return model.enabled !== false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getCount(value: unknown): number {
+  if (!isRecord(value)) return 0;
+  for (const key of ['count', 'total', 'samples', 'sampleCount']) {
+    const candidate = value[key];
+    if (typeof candidate === 'number') return candidate;
+  }
+  return 0;
+}
+
+function getAggregateValue(value: unknown, aggregation: 'avg' | 'min' | 'max'): number | undefined {
+  if (!isRecord(value)) return undefined;
+  for (const key of [aggregation, 'value', 'score', 'rating']) {
+    const candidate = value[key];
+    if (typeof candidate === 'number') return candidate;
+  }
+  return undefined;
+}
+
+export class AdaptiveModelRouter implements Processor<'adaptive-model-router', AdaptiveModelRouterTripwireMetadata> {
+  readonly id = 'adaptive-model-router' as const;
+  readonly name = 'Adaptive Model Router';
+  onViolation?: (violation: { processorId: string; message: string; detail?: unknown }) => void | Promise<void>;
+  protected mastra?: Mastra<any, any, any, any, any, any, any, any, any, any>;
+
+  readonly #models: AdaptiveModelRouterModel[];
+  readonly #modelIds: Set<string>;
+  readonly #rules: AdaptiveModelRouterRule[];
+  readonly #scope: RouterScope;
+
+  constructor(options: AdaptiveModelRouterOptions) {
+    const enabledModels = options.models.filter(isEnabled);
+    if (enabledModels.length < 2) {
+      throw new Error('AdaptiveModelRouter requires at least two enabled models');
+    }
+
+    this.#models = options.models;
+    this.#modelIds = new Set(options.models.map(model => model.id));
+    this.#scope = options.scope ?? DEFAULT_SCOPE;
+    this.#rules = options.rules ?? [
+      {
+        signal: 'error-rate',
+        threshold: options.errorRateThreshold ?? DEFAULT_ERROR_RATE_THRESHOLD,
+        minRequests: options.minRequests ?? DEFAULT_MIN_REQUESTS,
+        window: options.window ?? DEFAULT_WINDOW,
+        cooldown: options.cooldown ?? DEFAULT_COOLDOWN,
+      },
+    ];
+
+    for (const rule of this.#rules) {
+      const fallbackOrder = rule.fallbackOrder;
+      if (!fallbackOrder) continue;
+      for (const modelId of fallbackOrder) {
+        if (!this.#modelIds.has(modelId)) {
+          throw new Error(`AdaptiveModelRouter fallbackOrder references unknown model id: ${modelId}`);
+        }
+      }
+    }
+  }
+
+  get rules(): AdaptiveModelRouterRule[] {
+    return this.#rules;
+  }
+
+  get models(): AdaptiveModelRouterModel[] {
+    return this.#models;
+  }
+
+  __registerMastra(mastra: Mastra<any, any, any, any, any, any, any, any, any, any>): void {
+    this.mastra = mastra;
+  }
+
+  async processInputStep(args: ProcessInputStepArgs): Promise<ProcessInputStepResult | void> {
+    const state = this.#getState(args.state);
+    state.originalModelId ??= this.#models.find(isEnabled)?.id;
+    state.attemptedModelIds ??= [];
+    state.skippedModelIds ??= [];
+
+    const firedRule = args.retryCount > 0 ? undefined : await this.#evaluateRules(args);
+    if (firedRule && state.originalModelId) {
+      await this.#openCircuit(state.originalModelId, firedRule.rule);
+    }
+    const fallbackOrder =
+      firedRule?.rule.fallbackOrder ?? state.activeFallbackOrder ?? this.#models.map(model => model.id);
+    state.activeFallbackOrder = fallbackOrder;
+
+    const selectedModel = await this.#selectEligibleModel({
+      preferredModelId: firedRule?.selectedModelId,
+      fallbackOrder,
+      attemptedModelIds: state.attemptedModelIds,
+      skippedModelIds: state.skippedModelIds,
+    });
+
+    if (!selectedModel) return;
+
+    const previousModelId = state.selectedModelId;
+    state.selectedModelId = selectedModel.id;
+    state.currentRule = firedRule?.rule;
+
+    if (firedRule && selectedModel.id !== state.originalModelId && selectedModel.id !== previousModelId) {
+      await this.#emitViolation({
+        rule: firedRule.rule,
+        originalModel: state.originalModelId ?? selectedModel.id,
+        selectedModel: selectedModel.id,
+        reason: firedRule.reason,
+      });
+    }
+
+    const modelSettings = {
+      ...((selectedModel.modelSettings as object | undefined) ?? {}),
+      ...(selectedModel.headers ? { headers: selectedModel.headers } : {}),
+      ...(selectedModel.maxRetries !== undefined ? { maxRetries: selectedModel.maxRetries } : {}),
+    } as any;
+
+    return {
+      model: selectedModel.model as MastraLanguageModel,
+      modelSettings,
+      providerOptions: selectedModel.providerOptions as SharedProviderOptions | undefined,
+    };
+  }
+
+  async processAPIError(args: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
+    const state = this.#getState(args.state);
+    const selectedModelId = state.selectedModelId ?? state.originalModelId ?? this.#models.find(isEnabled)?.id;
+    if (!selectedModelId) return;
+
+    state.attemptedModelIds = Array.from(new Set([...(state.attemptedModelIds ?? []), selectedModelId]));
+    await this.#openCircuit(selectedModelId, state.currentRule);
+
+    const nextModel = await this.#selectEligibleModel({
+      fallbackOrder: state.activeFallbackOrder ?? this.#models.map(model => model.id),
+      attemptedModelIds: state.attemptedModelIds,
+      skippedModelIds: state.skippedModelIds ?? [],
+    });
+
+    if (!nextModel) return;
+
+    args.rotateResponseMessageId?.();
+    return { retry: true };
+  }
+
+  #getState(state: Record<string, unknown>): RouterState {
+    const key = this.id;
+    if (!isRecord(state[key])) {
+      state[key] = {};
+    }
+    return state[key] as RouterState;
+  }
+
+  async #evaluateRules(args: ProcessInputStepArgs): Promise<FiredRule | undefined> {
+    for (const rule of this.#rules) {
+      const firedRule = await this.#evaluateRule(rule, args);
+      if (firedRule) return firedRule;
+    }
+    return undefined;
+  }
+
+  async #evaluateRule(rule: AdaptiveModelRouterRule, args: ProcessInputStepArgs): Promise<FiredRule | undefined> {
+    try {
+      if (rule.signal === 'error-rate') return this.#evaluateErrorRateRule(rule, args);
+      if (rule.signal === 'score') return this.#evaluateScoreRule(rule, args);
+      return this.#evaluateFeedbackRule(rule, args);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async #getObservabilityStorage(): Promise<any | undefined> {
+    const storage = this.mastra?.getStorage?.();
+    return storage?.getStore ? storage.getStore('observability') : undefined;
+  }
+
+  #scopeFilter(args: ProcessInputStepArgs): Record<string, unknown> | undefined {
+    const requestContext = args.requestContext as Record<string, unknown> | undefined;
+    if (this.#scope === 'thread') {
+      const threadId = requestContext?.threadId;
+      return typeof threadId === 'string' ? { threadId } : undefined;
+    }
+    if (this.#scope === 'run') {
+      const runId = requestContext?.runId;
+      return typeof runId === 'string' ? { runId } : undefined;
+    }
+    const resourceId = requestContext?.resourceId ?? requestContext?.agentId;
+    return typeof resourceId === 'string' ? { resourceId } : undefined;
+  }
+
+  async #evaluateErrorRateRule(rule: ErrorRateRule, args: ProcessInputStepArgs): Promise<FiredRule | undefined> {
+    const observability = await this.#getObservabilityStorage();
+    if (!observability?.getMetricBreakdown) return undefined;
+
+    const currentModelId = this.#getState(args.state).selectedModelId ?? this.#models.find(isEnabled)?.id;
+    if (!currentModelId) return undefined;
+
+    const scopeFilter = this.#scopeFilter(args);
+    if (!scopeFilter) return undefined;
+
+    const result = await observability.getMetricBreakdown({
+      metricName: rule.metric ?? 'mastra_model_duration_ms',
+      start: new Date(Date.now() - parseDurationMs(rule.window ?? DEFAULT_WINDOW)),
+      end: new Date(),
+      filters: { ...scopeFilter, modelId: currentModelId },
+      groupBy: ['status', 'error'],
+    });
+
+    const rows = Array.isArray(result) ? result : Array.isArray(result?.breakdown) ? result.breakdown : [];
+    const total = rows.reduce((sum: number, row: unknown) => sum + getCount(row), 0);
+    const errors = rows.reduce((sum: number, row: unknown) => {
+      if (!isRecord(row)) return sum;
+      const labels = isRecord(row.labels) ? row.labels : row;
+      const status = labels.status;
+      const isError = labels.error === true || labels.error === 'true' || status === 'error' || status === 'failed';
+      return isError ? sum + getCount(row) : sum;
+    }, 0);
+
+    const minRequests = rule.minRequests ?? DEFAULT_MIN_REQUESTS;
+    if (total < minRequests) return undefined;
+
+    const errorRate = total === 0 ? 0 : errors / total;
+    if (errorRate <= (rule.threshold ?? DEFAULT_ERROR_RATE_THRESHOLD)) return undefined;
+
+    return {
+      rule,
+      reason: `error rate ${errorRate.toFixed(2)} exceeded threshold ${rule.threshold ?? DEFAULT_ERROR_RATE_THRESHOLD}`,
+    };
+  }
+
+  async #evaluateScoreRule(rule: ScoreRule, args: ProcessInputStepArgs): Promise<FiredRule | undefined> {
+    const observability = await this.#getObservabilityStorage();
+    if (!observability?.getScoreAggregate) return undefined;
+    const scopeFilter = this.#scopeFilter(args);
+    if (!scopeFilter) return undefined;
+
+    const aggregation = rule.aggregation ?? 'avg';
+    const result = await observability.getScoreAggregate({
+      scorerId: rule.scorerId,
+      aggregation,
+      start: new Date(Date.now() - parseDurationMs(rule.window ?? DEFAULT_WINDOW)),
+      end: new Date(),
+      filters: scopeFilter,
+    });
+    const value = getAggregateValue(result, aggregation);
+    if (value === undefined || value >= rule.minScore) return undefined;
+
+    return { rule, reason: `${aggregation} score ${value} fell below ${rule.minScore}` };
+  }
+
+  async #evaluateFeedbackRule(rule: FeedbackRule, args: ProcessInputStepArgs): Promise<FiredRule | undefined> {
+    const observability = await this.#getObservabilityStorage();
+    if (!observability?.getFeedbackAggregate) return undefined;
+    const scopeFilter = this.#scopeFilter(args);
+    if (!scopeFilter) return undefined;
+
+    const aggregation = rule.aggregation ?? 'avg';
+    const fallbackOrder = rule.fallbackOrder ?? this.#models.map(model => model.id);
+    let best: { modelId: string; rating: number } | undefined;
+
+    for (const modelId of fallbackOrder) {
+      const result = await observability.getFeedbackAggregate({
+        feedbackType: rule.feedbackType,
+        aggregation,
+        start: new Date(Date.now() - parseDurationMs(rule.window ?? '7d')),
+        end: new Date(),
+        filters: { ...scopeFilter, modelId },
+      });
+      if (getCount(result) < (rule.minSamples ?? 10)) continue;
+      const rating = getAggregateValue(result, aggregation);
+      if (rating === undefined) continue;
+      if (!best || rating > best.rating) best = { modelId, rating };
+    }
+
+    if (!best) return undefined;
+    return { rule, reason: `feedback selected best rated model ${best.modelId}`, selectedModelId: best.modelId };
+  }
+
+  async #selectEligibleModel({
+    preferredModelId,
+    fallbackOrder,
+    attemptedModelIds,
+    skippedModelIds,
+  }: {
+    preferredModelId?: string;
+    fallbackOrder: string[];
+    attemptedModelIds: string[];
+    skippedModelIds: string[];
+  }): Promise<AdaptiveModelRouterModel | undefined> {
+    const orderedIds = preferredModelId
+      ? [preferredModelId, ...fallbackOrder.filter(id => id !== preferredModelId)]
+      : fallbackOrder;
+    for (const modelId of orderedIds) {
+      if (attemptedModelIds.includes(modelId)) continue;
+      const model = this.#models.find(candidate => candidate.id === modelId && isEnabled(candidate));
+      if (!model) continue;
+      if (await this.#isInCooldown(modelId)) {
+        skippedModelIds.push(modelId);
+        continue;
+      }
+      return model;
+    }
+    return undefined;
+  }
+
+  #cacheKey(modelId: string, rule?: AdaptiveModelRouterRule): string {
+    return `adaptive-model-router:${this.id}:${rule?.signal ?? 'reactive'}:${modelId}`;
+  }
+
+  async #isInCooldown(modelId: string): Promise<boolean> {
+    const cache = this.mastra?.getServerCache?.();
+    if (!cache) return false;
+    return Boolean(await cache.get(this.#cacheKey(modelId)));
+  }
+
+  async #openCircuit(modelId: string, rule?: AdaptiveModelRouterRule): Promise<void> {
+    const cache = this.mastra?.getServerCache?.();
+    if (!cache) return;
+    const cooldown = rule?.cooldown ?? DEFAULT_COOLDOWN;
+    await cache.set(this.#cacheKey(modelId, rule), 'open', parseDurationMs(cooldown));
+    await cache.set(this.#cacheKey(modelId), 'open', parseDurationMs(cooldown));
+  }
+
+  async #emitViolation(detail: AdaptiveModelRouterViolationDetail): Promise<void> {
+    try {
+      await this.onViolation?.({
+        processorId: this.id,
+        message: detail.reason,
+        detail,
+      });
+    } catch {}
+  }
+}

--- a/packages/core/src/processors/adaptive-model-router.ts
+++ b/packages/core/src/processors/adaptive-model-router.ts
@@ -268,17 +268,19 @@ export class AdaptiveModelRouter implements Processor<'adaptive-model-router', A
     const state = this.#getState(args.state);
     const selectedModelId = state.selectedModelId ?? state.originalModelId ?? this.#models.find(isEnabled)?.id;
     if (!selectedModelId) return;
-
-    state.attemptedModelIds = Array.from(new Set([...(state.attemptedModelIds ?? []), selectedModelId]));
-    await this.#openCircuit(selectedModelId, state.currentRule);
-
+    const tentativeAttempted = Array.from(new Set([...(state.attemptedModelIds ?? []), selectedModelId]));
     const nextModel = await this.#selectEligibleModel({
       fallbackOrder: state.activeFallbackOrder ?? this.#models.map(model => model.id),
-      attemptedModelIds: state.attemptedModelIds,
+      attemptedModelIds: tentativeAttempted,
       skippedModelIds: state.skippedModelIds ?? [],
     });
 
+    // Only commit attempted/circuit state when we actually have a different model to try.
+    // This lets downstream error processors retry with the same model if they want to.
     if (!nextModel) return;
+
+    state.attemptedModelIds = tentativeAttempted;
+    await this.#openCircuit(selectedModelId, state.currentRule);
 
     args.rotateResponseMessageId?.();
     return { retry: true };

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -785,3 +785,18 @@ export type {
   MessageContent,
   MessagePart,
 } from './step-schema';
+
+export {
+  AdaptiveModelRouter,
+  type AdaptiveModelRouterModel,
+  type AdaptiveModelRouterOptions,
+  type AdaptiveModelRouterRule,
+  type AdaptiveModelRouterTripwireMetadata,
+  type AdaptiveModelRouterViolationDetail,
+  type ErrorRateRule,
+  type FeedbackRule,
+  type MastraMetricName,
+  type RouterScope,
+  type RouterWindow,
+  type ScoreRule,
+} from './adaptive-model-router';

--- a/packages/core/src/processors/processors/index.ts
+++ b/packages/core/src/processors/processors/index.ts
@@ -78,3 +78,18 @@ export {
   type ResponseCacheKeyInputs,
   type CachedLLMStepResponse,
 } from './response-cache';
+
+export {
+  AdaptiveModelRouter,
+  type AdaptiveModelRouterModel,
+  type AdaptiveModelRouterOptions,
+  type AdaptiveModelRouterRule,
+  type AdaptiveModelRouterTripwireMetadata,
+  type AdaptiveModelRouterViolationDetail,
+  type ErrorRateRule,
+  type FeedbackRule,
+  type MastraMetricName,
+  type RouterScope,
+  type RouterWindow,
+  type ScoreRule,
+} from '../adaptive-model-router';

--- a/packages/core/src/processors/retryable-error.ts
+++ b/packages/core/src/processors/retryable-error.ts
@@ -1,0 +1,126 @@
+import { APICallError } from '@internal/ai-sdk-v5';
+
+export type StreamErrorRetryMatcher = (error: unknown) => boolean;
+
+const RETRYABLE_OPENAI_ERROR_CODES = [
+  'rate_limit',
+  'server_error',
+  'internal_error',
+  'timeout',
+  'temporarily_unavailable',
+  'service_unavailable',
+  'overloaded',
+];
+const OPENAI_RETRY_MESSAGE_PATTERN = /you can retry your request/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getStringProperty(value: Record<string, unknown>, key: string): string | undefined {
+  const property = value[key];
+  return typeof property === 'string' ? property : undefined;
+}
+
+function getObjectCause(error: unknown): unknown {
+  if (error instanceof Error) {
+    return error.cause;
+  }
+
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  return error.cause;
+}
+
+function getOpenAIErrorPayload(error: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  if (error.type === 'error' && isRecord(error.error)) {
+    return error.error;
+  }
+
+  if (error.type === 'response.failed' && isRecord(error.response)) {
+    const responseError = error.response.error;
+    return isRecord(responseError) ? responseError : undefined;
+  }
+
+  return undefined;
+}
+
+function hasRetryableOpenAIErrorCode(payload: Record<string, unknown>): boolean {
+  const code = getStringProperty(payload, 'code') ?? getStringProperty(payload, 'type');
+  if (!code) {
+    return false;
+  }
+
+  const normalizedCode = code.toLowerCase();
+  return RETRYABLE_OPENAI_ERROR_CODES.some(retryableCode => normalizedCode.includes(retryableCode));
+}
+
+function hasExplicitRetryMessage(payload: Record<string, unknown>): boolean {
+  const message = getStringProperty(payload, 'message');
+  return message !== undefined && OPENAI_RETRY_MESSAGE_PATTERN.test(message);
+}
+
+export function isRetryableOpenAIResponsesStreamError(error: unknown): boolean {
+  const payload = getOpenAIErrorPayload(error);
+  if (!payload) {
+    return false;
+  }
+
+  return hasRetryableOpenAIErrorCode(payload) || hasExplicitRetryMessage(payload);
+}
+
+export function isRetryableProviderMetadata(error: unknown): boolean {
+  const retryable = APICallError.isInstance(error)
+    ? error.isRetryable
+    : isRecord(error) && typeof error.isRetryable === 'boolean'
+      ? error.isRetryable
+      : undefined;
+
+  return retryable === true;
+}
+
+export function isRetryableApiError(error: unknown, matchers: StreamErrorRetryMatcher[] = []): boolean {
+  const visited = new WeakSet<object>();
+
+  function visit(candidate: unknown): boolean {
+    if (isRecord(candidate)) {
+      if (visited.has(candidate)) {
+        return false;
+      }
+      visited.add(candidate);
+    }
+
+    if (APICallError.isInstance(candidate)) {
+      const statusCode = candidate.statusCode;
+      if (
+        statusCode === 401 ||
+        statusCode === 403 ||
+        statusCode === 429 ||
+        (statusCode !== undefined && statusCode >= 500)
+      ) {
+        return true;
+      }
+    }
+
+    if (isRetryableProviderMetadata(candidate)) {
+      return true;
+    }
+
+    if (matchers.some(matcher => matcher(candidate))) {
+      return true;
+    }
+
+    const cause = getObjectCause(candidate);
+    return cause !== undefined && visit(cause);
+  }
+
+  return visit(error);
+}
+
+export const DEFAULT_STREAM_ERROR_RETRY_MATCHERS = [isRetryableOpenAIResponsesStreamError];

--- a/packages/core/src/processors/stream-error-retry-processor.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.ts
@@ -1,8 +1,8 @@
-import { APICallError } from '@internal/ai-sdk-v5';
-
+import { DEFAULT_STREAM_ERROR_RETRY_MATCHERS, isRetryableApiError } from './retryable-error';
+import type { StreamErrorRetryMatcher } from './retryable-error';
 import type { Processor, ProcessAPIErrorArgs, ProcessAPIErrorResult } from './index';
 
-export type StreamErrorRetryMatcher = (error: unknown) => boolean;
+export { isRetryableOpenAIResponsesStreamError, type StreamErrorRetryMatcher } from './retryable-error';
 
 export type StreamErrorRetryProcessorOptions = {
   maxRetries?: number;
@@ -10,115 +10,7 @@ export type StreamErrorRetryProcessorOptions = {
 };
 
 const DEFAULT_MAX_RETRIES = 1;
-const RETRYABLE_OPENAI_ERROR_CODES = [
-  'rate_limit',
-  'server_error',
-  'internal_error',
-  'timeout',
-  'temporarily_unavailable',
-  'service_unavailable',
-  'overloaded',
-];
-const OPENAI_RETRY_MESSAGE_PATTERN = /you can retry your request/i;
-const DEFAULT_MATCHERS = [isRetryableOpenAIResponsesStreamError];
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function getStringProperty(value: Record<string, unknown>, key: string): string | undefined {
-  const property = value[key];
-  return typeof property === 'string' ? property : undefined;
-}
-
-function getObjectCause(error: unknown): unknown {
-  if (error instanceof Error) {
-    return error.cause;
-  }
-
-  if (!isRecord(error)) {
-    return undefined;
-  }
-
-  return error.cause;
-}
-
-function getOpenAIErrorPayload(error: unknown): Record<string, unknown> | undefined {
-  if (!isRecord(error)) {
-    return undefined;
-  }
-
-  if (error.type === 'error' && isRecord(error.error)) {
-    return error.error;
-  }
-
-  if (error.type === 'response.failed' && isRecord(error.response)) {
-    const responseError = error.response.error;
-    return isRecord(responseError) ? responseError : undefined;
-  }
-
-  return undefined;
-}
-
-function hasRetryableOpenAIErrorCode(payload: Record<string, unknown>): boolean {
-  const code = getStringProperty(payload, 'code') ?? getStringProperty(payload, 'type');
-  if (!code) {
-    return false;
-  }
-
-  const normalizedCode = code.toLowerCase();
-  return RETRYABLE_OPENAI_ERROR_CODES.some(retryableCode => normalizedCode.includes(retryableCode));
-}
-
-function hasExplicitRetryMessage(payload: Record<string, unknown>): boolean {
-  const message = getStringProperty(payload, 'message');
-  return message !== undefined && OPENAI_RETRY_MESSAGE_PATTERN.test(message);
-}
-
-export function isRetryableOpenAIResponsesStreamError(error: unknown): boolean {
-  const payload = getOpenAIErrorPayload(error);
-  if (!payload) {
-    return false;
-  }
-
-  return hasRetryableOpenAIErrorCode(payload) || hasExplicitRetryMessage(payload);
-}
-
-function isRetryableProviderMetadata(error: unknown): boolean {
-  const retryable = APICallError.isInstance(error)
-    ? error.isRetryable
-    : isRecord(error) && typeof error.isRetryable === 'boolean'
-      ? error.isRetryable
-      : undefined;
-
-  return retryable === true;
-}
-
-function isRetryableStreamError(error: unknown, matchers: StreamErrorRetryMatcher[]): boolean {
-  const visited = new WeakSet<object>();
-
-  function visit(candidate: unknown): boolean {
-    if (isRecord(candidate)) {
-      if (visited.has(candidate)) {
-        return false;
-      }
-      visited.add(candidate);
-    }
-
-    if (isRetryableProviderMetadata(candidate)) {
-      return true;
-    }
-
-    if (matchers.some(matcher => matcher(candidate))) {
-      return true;
-    }
-
-    const cause = getObjectCause(candidate);
-    return cause !== undefined && visit(cause);
-  }
-
-  return visit(error);
-}
+const DEFAULT_MATCHERS = DEFAULT_STREAM_ERROR_RETRY_MATCHERS;
 
 export class StreamErrorRetryProcessor implements Processor<'stream-error-retry-processor'> {
   readonly id = 'stream-error-retry-processor' as const;
@@ -134,7 +26,7 @@ export class StreamErrorRetryProcessor implements Processor<'stream-error-retry-
 
   async processAPIError({ error, retryCount }: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
     if (retryCount >= this.#maxRetries) return;
-    if (!isRetryableStreamError(error, this.#matchers)) return;
+    if (!isRetryableApiError(error, this.#matchers)) return;
 
     return { retry: true };
   }


### PR DESCRIPTION
## What changed

This PR adds `AdaptiveModelRouter` and uses it as the internal engine for legacy agent model fallback arrays.

Existing fallback-array users keep using the same API:

```ts
const agent = new Agent({
  name: 'support-agent',
  instructions: 'Help the user',
  model: [
    { id: 'fast', model: 'openai/gpt-5-mini' },
    { id: 'strong', model: 'openai/gpt-5.5' },
  ],
});
```

Under the hood, `model: [...]` is converted into an internal `AdaptiveModelRouter` so the LLM loop receives one model at a time instead of the old full fallback array.

The new observability/rule-based routing behavior is **not** exposed as Agent-level config yet. To use custom rules, users must explicitly add `AdaptiveModelRouter` as a processor:

```ts
import { Agent } from '@mastra/core/agent';
import { AdaptiveModelRouter } from '@mastra/core/processors';

const router = new AdaptiveModelRouter({
  models: [
    { id: 'fast', model: 'openai/gpt-5-mini' },
    { id: 'strong', model: 'openai/gpt-5.5' },
  ],
  rules: [
    {
      signal: 'error-rate',
      threshold: 0.3,
      minRequests: 5,
      window: '5m',
      cooldown: '2m',
      fallbackOrder: ['strong', 'fast'],
    },
  ],
});

const agent = new Agent({
  name: 'support-agent',
  instructions: 'Help the user',
  model: 'openai/gpt-5',
  inputProcessors: [router],
  errorProcessors: [router],
});
```

That keeps advanced observability-based routing battle-tested behind explicit processor usage before adding a cleaner Agent-level config later.

## Behavior

### Legacy `model: [...]`

For fallback arrays, the Agent creates an internal router with no proactive observability rules. This preserves fallback compatibility while moving routing decisions into processor retry flow.

When a model fails, `processAPIError` opens a cache-backed cooldown for that model and retries with the next eligible fallback model.

### Explicit `AdaptiveModelRouter`

Explicit router usage can proactively switch models based on configured rules such as error rate, score, or feedback. The same processor also handles reactive fallback on model-call failures.

## Compatibility checks

Existing fallback-array tests are still passing and cover:

- credential/API fallback: 401, 403, 429, 500
- plain stream/model failures
- dynamic fallback arrays
- disabled fallback entries
- per-model settings and headers
- single-model-per-attempt LLM loop behavior

New router tests cover explicit processor usage, observability rule evaluation, cooldown state, and reactive fallback.

## Tested

```bash
pnpm --filter ./packages/core test -- adaptive-model-router adaptive-model-router-integration credential-error-fallback per-model-fallback-settings dynamic-model-fallback
```

Result: 53 tests passing.

```bash
pnpm --filter ./packages/core exec tsc --noEmit -p tsconfig.build.json
```

Result: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If a model fails or starts performing badly, this change adds a smart router that automatically picks the next-best model (keeping the old fallback array behavior) and lets you optionally configure rules to proactively switch models based on error rates, scores, or user feedback.

## Changes Overview

This PR introduces AdaptiveModelRouter and integrates it as the internal engine for legacy model fallback arrays while preserving backward compatibility and existing APIs.

### Core New Functionality

- AdaptiveModelRouter processor (packages/core/src/processors/adaptive-model-router.ts)
  - Dynamically selects LLM models using configurable tripwire rules: error-rate, score, and feedback.
  - Tracks per-run state (original/selected model, fallback order, attempted/skipped IDs, fired rule).
  - Evaluates rules on first attempt and reacts to failures; opens cooldown-backed circuits in server cache.
  - Computes active fallback order and selects the first eligible enabled model not attempted and not in cooldown.
  - Emits optional violation callbacks when rule-driven changes occur.
  - Exports new types: RouterScope, RouterWindow, MastraMetricName, ErrorRateRule, ScoreRule, FeedbackRule, AdaptiveModelRouterOptions, tripwire metadata, and violation detail types.

- Retryable error utilities (packages/core/src/processors/retryable-error.ts)
  - Shared utilities to determine retryability of stream/API errors (OpenAI patterns, provider metadata, recursive traversal with cycle prevention).
  - Exports isRetryableOpenAIResponsesStreamError, isRetryableProviderMetadata, isRetryableApiError, DEFAULT_STREAM_ERROR_RETRY_MATCHERS, and StreamErrorRetryMatcher type.

### Integration with existing agent/LLM loop

- Agent integration (packages/core/src/agent/agent.ts)
  - Legacy model arrays (model: [...]) are auto-wired through an internal AdaptiveModelRouter configured for reactive fallback-only behavior (no auto-created observability rules).
  - Router is passed into MastraLLMVNext as internalInputProcessors and internalErrorProcessors; the LLM loop receives only the first model while the router handles fallbacks.

- MastraLLMVNext loop updates (packages/core/src/llm/model/model.loop.ts)
  - Accepts optional internalInputProcessors and internalErrorProcessors, registers them idempotently, and composes them with external processors when building loop options.

- Step-level model settings (packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts)
  - Derives per-step model settings and applies fallback-model settings (including maxRetries) only when the step uses the active fallback model; preserves explicit step-level maxRetries otherwise.

### Processor refactorings

- Stream error retry processor (packages/core/src/processors/stream-error-retry-processor.ts)
  - Delegates retryability detection to shared retryable-error utilities and re-exports relevant utilities/types; core retry behavior unchanged.

### Exports and API surface

- Re-exports added in processors indices (packages/core/src/processors/index.ts and packages/core/src/processors/processors/index.ts) for AdaptiveModelRouter and its associated types.

### Tests

- Unit tests (packages/core/src/agent/__tests__/adaptive-model-router.test.ts)
  - Cover default rule creation, error-rate/score/feedback rule behavior, minRequests/minSamples, unsupported observability handling, cooldown/circuit behavior, dynamic modelSettings/providerOptions/headers resolution, and error retry rotation/cooldowns.

- Integration tests (packages/core/src/agent/__tests__/adaptive-model-router-integration.test.ts)
  - Validate legacy model-array auto-wiring and explicit router wiring; assert single-model-per-attempt behavior and expected invocation counts.

- Reported test/build status: targeted core tests passing (53 tests) and TypeScript build check passed.

### Backward compatibility

- Preserves legacy fallback-array behavior and semantics:
  - Credential/API fallback detection (401/403/429/5xx), stream/model failures, dynamic arrays, disabled entries, per-model settings, and single-model-per-attempt loop behavior.
- Legacy arrays are converted to an internal router with reactive fallback-only behavior; proactive observability-driven routing requires explicitly wiring AdaptiveModelRouter as inputProcessors and errorProcessors.

### Documentation

- Docs added and wired into sidebar:
  - Processors docs summary (docs/src/content/en/docs/agents/processors.mdx)
  - Full reference page for AdaptiveModelRouter (docs/src/content/en/reference/processors/adaptive-model-router.mdx)
  - Changeset entry documenting the release note ( .changeset/common-nights-join.md )

### Miscellaneous notes

- AdaptiveModelRouter exposes an optional onViolation callback and resolves per-model dynamic settings at request time to match auto-wired behavior.
- Internal processor registration made idempotent to avoid double-registration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->