### PR TITLE
feat(sentry): emit gen_ai.conversation.id to support Sentry Conversations

### DIFF
--- a/.changeset/tame-zoos-clean.md
+++ b/.changeset/tame-zoos-clean.md
@@ -1,0 +1,14 @@
+---
+'@mastra/sentry': minor
+---
+
+Added the `gen_ai.conversation.id` span attribute to the Sentry exporter, sourced from `metadata.threadId`. Spans from the same chat thread now group together in Sentry's Conversations view (part of AI Agent Monitoring).
+
+```typescript
+const agent = mastra.getAgent('chat');
+
+// Pass threadId as before — the Sentry exporter now emits it as gen_ai.conversation.id
+await agent.generate('Hello', {
+  memory: { thread: 'thread-123', resource: 'user-1' },
+});
+```

--- a/docs/src/content/en/reference/observability/tracing/exporters/sentry.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/sentry.mdx
@@ -195,6 +195,7 @@ The exporter sets these standard OpenTelemetry attributes:
 
 - `sentry.origin`: `auto.ai.mastra` (identifies spans from Mastra)
 - `ai.span.type`: Mastra span type
+- `gen_ai.conversation.id`: Chat thread identifier, set from `metadata.threadId` to group spans in Sentry's Conversations view
 
 **MODEL\_GENERATION spans:**
 

--- a/observability/sentry/README.md
+++ b/observability/sentry/README.md
@@ -115,6 +115,7 @@ const mastra = new Mastra({
 
 - `sentry.origin`: `auto.ai.mastra` (identifies spans from Mastra)
 - `ai.span.type`: Mastra span type (e.g., `model_generation`, `tool_call`)
+- `gen_ai.conversation.id`: Chat thread identifier, set from `metadata.threadId` (groups spans in Sentry's Conversations view)
 
 **For `MODEL_GENERATION` and `MODEL_STEP` spans:**
 

--- a/observability/sentry/src/tracing.test.ts
+++ b/observability/sentry/src/tracing.test.ts
@@ -583,6 +583,51 @@ describe('SentryExporter', () => {
       );
     });
 
+    it('should set gen_ai.conversation.id from threadId', async () => {
+      const span = createMockSpan({
+        id: 'span-with-thread',
+        name: 'test',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+        metadata: {
+          threadId: 'thread-789',
+        },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: span,
+      });
+
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'gen_ai.conversation.id': 'thread-789',
+        }),
+      );
+    });
+
+    it('should not set gen_ai.conversation.id when threadId is absent', async () => {
+      const span = createMockSpan({
+        id: 'span-no-thread',
+        name: 'test',
+        type: SpanType.AGENT_RUN,
+        isRoot: true,
+        attributes: {},
+        metadata: {
+          userId: 'user-123',
+        },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: span,
+      });
+
+      const call = mockSpan.setAttributes.mock.calls[0][0];
+      expect(call).not.toHaveProperty('gen_ai.conversation.id');
+    });
+
     it('should not include langfuse metadata', async () => {
       const span = createMockSpan({
         id: 'span-with-langfuse',

--- a/observability/sentry/src/tracing.ts
+++ b/observability/sentry/src/tracing.ts
@@ -57,6 +57,7 @@ const ATTRIBUTE_KEYS = {
   GEN_AI_RESPONSE_STREAMING: 'gen_ai.response.streaming',
   GEN_AI_RESPONSE_TOOL_CALLS: 'gen_ai.response.tool_calls',
   GEN_AI_RESPONSE_TEXT: 'gen_ai.response.text',
+  GEN_AI_CONVERSATION_ID: 'gen_ai.conversation.id',
   GEN_AI_COMPLETION_START_TIME: 'gen_ai.completion_start_time',
   GEN_AI_TOOL_CALL_ID: 'gen_ai.tool.call.id',
   TOOL_SUCCESS: 'tool.success',
@@ -353,6 +354,7 @@ export class SentryExporter extends BaseExporter {
     }
 
     this.setAttributeIfDefined(attributes, ATTRIBUTE_KEYS.TAGS, span.tags?.join(','));
+    this.setAttributeIfDefined(attributes, ATTRIBUTE_KEYS.GEN_AI_CONVERSATION_ID, span.metadata?.threadId);
 
     this.addInputOutputAttributes(attributes, span);
 


### PR DESCRIPTION
## Description

The `@mastra/sentry` exporter now emits the `gen_ai.conversation.id` span attribute, sourced from `metadata.threadId`. This lets Sentry's **Conversations** view (part of AI Agent Monitoring, beta) group all spans from the same chat thread. Previously this never worked for Mastra: `Sentry.setConversationId()` only sets the value on the isolation scope, and because Mastra builds Sentry spans through its own OTel-to-Sentry conversion path, the scope value never reached Mastra-generated spans.

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/53a681f8-ad63-43b0-9228-4e9f4edef61b" />


- Added `GEN_AI_CONVERSATION_ID: 'gen_ai.conversation.id'` to `ATTRIBUTE_KEYS`
- Emit it from `span.metadata?.threadId` in `buildSpanAttributes()` via the existing `setAttributeIfDefined` helper, so it applies to every span type (agent run, model generation, tool call) — Sentry requires all spans in a conversation to share the same value
- Implements **option #2** from the issue (reuse existing `threadId`), mirroring how `@mastra/langfuse` maps `threadId` to `session.id`. No new public config field
- Added tests covering the attribute being set from `threadId` and absent when `threadId` is missing
- Documented the attribute in the package README and reference docs

## Verification

Tested live against a real Sentry project with a 3-turn agent conversation using a fixed `threadId`. All 9 spans carried `gen_ai.conversation.id` and the turns grouped into a single entry in Sentry's AI Conversations view.

> Screenshot: AI Conversations grouped view for `thread-demo-001` (add image here)

## Related Issue(s)

Fixes #16883

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
