### PR TITLE
chore: refine critique and debugging instructions

### DIFF
--- a/.claude/skills/debugging-difficult-bugs/SKILL.md
+++ b/.claude/skills/debugging-difficult-bugs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging-difficult-bugs
-description: Use early when debugging a medium or hard bug, especially when tests alone may not reveal the real runtime failure. Trigger this before extended TDD iteration when a bug involves runtime state, ordering, persistence, streaming, UI/manual reproduction, or when a red test may not fully model the issue.
+description: Use early when debugging a medium or hard bug, especially when tests alone may not reveal the real runtime failure. Trigger this before extended TDD iteration when a bug involves runtime state, ordering, persistence, streaming, concurrency, UI/manual reproduction, external services, or when a red or newly passing test may not model the real issue. Skip only when the root cause is already directly proven by a stack trace or deterministic test that exercises the real runtime path.
 ---
 
 # Debugging Difficult Bugs
@@ -22,6 +22,8 @@ Use this workflow near the start of debugging when any of these are true:
 
 Do **not** keep iterating only on tests if you do not understand the runtime behavior.
 
+Skip this workflow only when the root cause is already directly proven by a stack trace or by a deterministic failing test that exercises the real runtime path. If you are tempted to make a second speculative fix, use this workflow.
+
 ## Required Approach
 
 1. **State the uncertainty**
@@ -29,7 +31,8 @@ Do **not** keep iterating only on tests if you do not understand the runtime beh
    - Identify the real code path that must be observed.
 
 2. **Add temporary unconditional instrumentation**
-   - Add logs throughout the suspected code flow.
+   - Add minimal but sufficient logs through the suspected code flow.
+   - Log boundaries, meaningful branch decisions, state transitions, async ordering points, return values, and caught errors; do not log every line.
    - Logs must be unconditional: do **not** gate them behind an env var, debug flag, or log level.
    - Each log point must append one JSON object per line to a `.jsonl` file in the current working directory.
    - Include enough context to reconstruct the path: event name, timestamp, relevant ids, input shape, state transitions, branch decisions, return values, and caught errors.
@@ -47,6 +50,8 @@ Do **not** keep iterating only on tests if you do not understand the runtime beh
 
 5. **Clean up instrumentation**
    - Remove all temporary unconditional logs after root cause is understood and the fix is verified.
+   - Remove debug imports, helper functions, generated `.jsonl` files, and any other temporary artifacts.
+   - Check the final diff for instrumentation remnants.
    - Do not leave debug files, log helpers, or noisy runtime logging in the final diff unless the user explicitly asks.
 
 6. **Keep or improve tests**
@@ -123,6 +128,8 @@ Avoid logging:
 - Large payloads that make the log unreadable.
 - Binary data or full model responses unless the bug requires it.
 
+Treat debug logs as potentially sensitive. Do not ask the user to paste them into public issues, PRs, or shared channels unless they have reviewed/redacted them first.
+
 If sensitive data might appear, log redacted summaries:
 
 ```ts
@@ -147,7 +154,7 @@ After I inspect that log, I’ll remove the instrumentation and make the actual 
 
 If multiple processes have different working directories, either:
 
-- log the absolute `process.cwd()` at startup, or
+- log the absolute `process.cwd()`, process role, and pid at startup, or
 - write distinct files like `debug-server-flow.jsonl`, `debug-worker-flow.jsonl`, and `debug-client-flow.jsonl`.
 
 ## Analysis Checklist

--- a/.mastracode/commands/critique-pr.md
+++ b/.mastracode/commands/critique-pr.md
@@ -9,7 +9,7 @@ goal: true
 Use the GH CLI to analyze and summarize a pull request for the current repository.
 The current branch should be checked out in the same branch as the PR but you will need to verify that first.
 
-RUN gh pr view --json title,body,commits,files,labels,assignees,reviews,comments,checksStatus
+RUN gh pr view --json title,body,commits,files,labels,assignees,reviews,comments,statusCheckRollup
 
 ## Review Process
 

--- a/.mastracode/commands/critique-pr.md
+++ b/.mastracode/commands/critique-pr.md
@@ -17,16 +17,18 @@ RUN gh pr view --json title,body,commits,files,labels,assignees,reviews,comments
 ### Stage 2: Analyze the Code
 
 1. List all changed files using `gh pr diff`
-2. Create a PR_SUMMARY.md file in the project root with sections for:
+2. Create a .pr-review/PR_SUMMARY.md file with sections for:
    - **Overview**: What this PR accomplishes
    - **How It Works**: Technical explanation of the implementation
    - **Key Changes**: File-by-file breakdown with links (use format: `path/to/file.ts:line`)
    - **Architecture Impact**: How this fits into the overall system
    - **Dependencies**: Any new dependencies or APIs introduced
-   - **Testing**: What tests cover these changes
+   - **Testing**: What tests cover these changes, what validation you ran, and whether dependencies were installed and affected packages were built first
    - **Potential Concerns**: Any risks or areas that need attention
 
-3. For each significant file change:
+3. Before running tests, check whether dependencies are installed. If dependencies are missing, stale, or package manifests / lockfiles changed, run the project install command first. For this repo, prefer `pnpm i` unless local instructions say otherwise.
+4. Build affected packages before relying on tests that consume their compiled outputs. Prefer narrow package/workspace build commands over repo-wide builds.
+5. For each significant file change:
    - Understand the context and purpose
    - Explain the logic flow and implementation details
    - Note how it connects to other parts of the codebase
@@ -43,11 +45,12 @@ RUN gh pr view --json title,body,commits,files,labels,assignees,reviews,comments
 
 ### Stage 4: Present to User
 
-1. Complete the PR_SUMMARY.md with a comprehensive explanation
+1. Complete .pr-review/PR_SUMMARY.md with a comprehensive explanation
 2. Use clear, technical language to explain how the code works
 3. Include helpful diagrams or examples if complex logic is involved
 4. Link to specific files and line numbers for easy navigation
 5. Highlight any interesting design decisions or trade-offs
+6. Draft a PR review comment for the user, ask what changes they want, and make clear that posting it is optional. Do not post it unless the user explicitly asks you to post the current draft.
 
 ## Summary Structure Example
 
@@ -85,6 +88,8 @@ How these changes fit into and affect the overall system architecture.
 
 ## Testing
 
+- Ran `pnpm i` because the lockfile changed
+- Built affected package with `pnpm --filter ./packages/auth build`
 - Unit tests in `tests/auth.test.ts`
 - Integration tests in `tests/integration/auth.spec.ts`
 - All existing tests still pass
@@ -99,7 +104,9 @@ After you've finished and written the .md file, give the user a TLDR containing 
 
 ## Posting a PR Review Comment (Optional)
 
-Offer to post a PR review comment if the user wants one. First align on the contents of the review comment, then follow this guidance for posting:
+Draft a PR review comment proactively, but the user decides whether it gets posted. Ask what changes the user wants to the draft, whether they want to post it, or whether they do not want to post anything. If the user asks for changes, re-draft the full comment and ask again. Do not post unless the user explicitly asks you to post the current draft.
+
+If the user decides to post the review comment, first align on the contents of the review comment, then follow this guidance for posting:
 
 GitHub has separate rate-limit buckets for GraphQL and REST. Some `gh pr` commands use GraphQL, so they can fail with a GraphQL rate-limit error even when REST API calls still have quota. When that happens, use the REST issues comments API instead:
 

--- a/.mastracode/commands/critique-pr.md
+++ b/.mastracode/commands/critique-pr.md
@@ -9,10 +9,11 @@ RUN gh pr view --json title,body,commits,files,labels,assignees,reviews,comments
 
 ### Stage 1: Understand the Context
 
-1. Read the PR title and description carefully
-2. Check linked issues (if any) using `gh issue view`
-3. Review the commit history to understand the progression of changes
-4. Note any labels, assignees, and check status
+1. Verify the checked-out branch matches the PR head branch before reviewing
+2. Read the PR title and description carefully
+3. Check linked issues (if any) using `gh issue view`
+4. Review the commit history to understand the progression of changes
+5. Note any labels, assignees, and check status
 
 ### Stage 2: Analyze the Code
 
@@ -24,16 +25,17 @@ RUN gh pr view --json title,body,commits,files,labels,assignees,reviews,comments
    - **Architecture Impact**: How this fits into the overall system
    - **Dependencies**: Any new dependencies or APIs introduced
    - **Testing**: What tests cover these changes, what validation you ran, and whether dependencies were installed and affected packages were built first
-   - **Potential Concerns**: Any risks or areas that need attention
+   - **Potential Concerns**: Confirmed issues, speculative risks, or areas that need attention
 
 3. Before running tests, check whether dependencies are installed. If dependencies are missing, stale, or package manifests / lockfiles changed, run the project install command first. For this repo, prefer `pnpm i` unless local instructions say otherwise.
 4. Build affected packages before relying on tests that consume their compiled outputs. Prefer narrow package/workspace build commands over repo-wide builds.
-5. For each significant file change:
+5. Do not claim a test, build, or check passed unless you ran it or verified the matching CI check.
+6. For each significant file change:
    - Understand the context and purpose
    - Explain the logic flow and implementation details
    - Note how it connects to other parts of the codebase
    - Identify any patterns or conventions used
-   - Link to specific lines for important code sections
+   - Link to specific lines for important code sections only after confirming the line numbers
 
 ### Stage 3: Deep Dive
 
@@ -41,7 +43,8 @@ RUN gh pr view --json title,body,commits,files,labels,assignees,reviews,comments
 2. Understand the data flow and transformations
 3. Check how edge cases are handled
 4. Verify integration points with existing code
-5. Document your understanding in the summary file
+5. After reviewing the code, verify the PR title and description match the actual diff; call out mismatches
+6. Document your understanding in the summary file
 
 ### Stage 4: Present to User
 
@@ -96,8 +99,8 @@ How these changes fit into and affect the overall system architecture.
 
 ## Potential Concerns
 
-- Performance impact of additional middleware
-- Migration needed for existing tokens
+- Confirmed issue: old tokens fail immediately after deploy
+- Speculative risk: performance impact of additional middleware
 ```
 
 After you've finished and written the .md file, give the user a TLDR containing the most important points. After the TLDR explain concisely your main concerns, and just note that you don't have any concerns if you don't.

--- a/.mastracode/commands/critique-pr.md
+++ b/.mastracode/commands/critique-pr.md
@@ -44,7 +44,8 @@ RUN gh pr view --json title,body,commits,files,labels,assignees,reviews,comments
 3. Check how edge cases are handled
 4. Verify integration points with existing code
 5. After reviewing the code, verify the PR title and description match the actual diff; call out mismatches
-6. Document your understanding in the summary file
+6. Check whether the changes require a changeset, docs updates, package-local AGENTS.md instructions, or other repository PR requirements, and call out any missing required items
+7. Document your understanding in the summary file
 
 ### Stage 4: Present to User
 

--- a/.mastracode/commands/critique-pr.md
+++ b/.mastracode/commands/critique-pr.md
@@ -1,3 +1,9 @@
+---
+name: critique-pr
+description: Analyze, critique, summarize, and draft an optional review comment for the current pull request
+goal: true
+---
+
 # Review Pull Request
 
 Use the GH CLI to analyze and summarize a pull request for the current repository.


### PR DESCRIPTION
This tightens up a couple of local agent instructions after noticing some rough edges while using them.

## /critique-pr

The critique PR command now writes its summary into `.pr-review/PR_SUMMARY.md` instead of the repo root, makes the review comment draft proactive but still clearly optional/user-controlled, and reminds agents to install deps and build affected packages before trusting test results. It also adds a few guardrails around branch verification, matching the PR description to the reviewed diff, confirmed-vs-speculative concerns, validation claims, and line-number references.

Before, an agent could jump straight to tests and say something passed without first making sure deps were installed or package outputs were built:

```text
- Unit tests in `tests/auth.test.ts`
- All existing tests still pass
```

After, the command nudges it to capture the actual validation path:

```text
- Ran `pnpm i` because the lockfile changed
- Built affected package with `pnpm --filter ./packages/auth build`
- Unit tests in `tests/auth.test.ts`
```

## debugging-difficult-bugs skill

The difficult-bug debugging skill was already working well, but I noticed agents could activate it and then decide not to follow it because the trigger criteria were a little loose. This clarifies when it should be used or skipped, keeps JSONL instrumentation focused instead of noisy, and adds cleanup/sensitive-log reminders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR tightens automated review and debugging helpers so reviews are more careful and reproducible (summary file moved into a dedicated folder, exact build/test commands recorded) and the debugging skill runs only when clearly needed, logs minimally and temporarily, and cleans up sensitive traces.

---

## Changes

### Debugging Difficult Bugs Skill
- Clarified trigger criteria: run this skill only for medium/hard bugs where the failure is not already proven by a direct stack trace or a deterministic failing test on the real runtime path.
- Required approach narrowed: add temporary, unconditional instrumentation limited to minimal, sufficient JSONL logs (append-only, one JSON object per line) focused on meaningful branch/state points on the real runtime path.
- Reduced noisy instrumentation: discourage broad/permanent logging; keep JSONL focused and minimal.
- Multi-process guidance: additionally log process role and pid (or use distinct files per role) to disambiguate traces.
- Stronger cleanup and safety: remove debug imports/helpers, generated .jsonl files, and other instrumentation remnants; check diffs to avoid leaving artifacts; warn that debug logs may be sensitive and require review/redaction before sharing.

### PR Critique Command
- Command metadata: added YAML front-matter (name, description, goal) for running as a goal.
- Branch verification & diff checks: Stage 1 now requires confirming the checked-out branch matches the PR head commit and explicitly list changed files (gh pr diff) before analysis.
- Review summary location: write review summary to .pr-review/PR_SUMMARY.md instead of repository root.
- Validation steps & reproducibility: require recording exact validation commands (examples: pnpm i, pnpm --filter ./packages/auth build) and prefer running installs/builds and building affected packages before trusting test results; only claim tests/builds/checks passed if actually run/verified (or cite CI evidence).
- Analysis guardrails: distinguish confirmed vs. speculative concerns, validate claims and any line-number references, and ensure PR description matches the reviewed diff.
- Review comment behavior: proactively draft a PR review comment but treat posting as explicitly optional and user-controlled; include an iteration/redraft loop when the user requests changes.
- Repository-specific checks: prompt reviewers to verify repo conventions (changesets, docs, package-local instructions, etc.) and call out missing required items.

### Other
- Fix for critique status check: switched the gh pr view field used to read PR status from checksStatus to statusCheckRollup so the goal-enabled critique command reads the correct status information.

---

## Impact

Increases trust and safety of automated reviews by enforcing branch/build verification and precise validation steps, avoids overconfident assertions about tests/builds, reduces noisy or permanent debugging instrumentation, and protects potentially sensitive debug data while keeping reviewer actions user-controlled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->