### PR TITLE
fix(core): recover streamed tool-call args via sanitize + repair

### DIFF
--- a/.changeset/recover-streaming-end-args.md
+++ b/.changeset/recover-streaming-end-args.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': patch
+---
+
+fix(core): recover streamed tool-call args via sanitize + repair instead of silently dropping to `{}`
+
+`MastraModelOutput`'s `tool-call-input-streaming-end` handler joined accumulated `tool-call-delta` text and called `JSON.parse` directly. On failure it fell through to `args: {}` — the synthetic `tool-call` chunk then carried empty args even when the original deltas were recoverable.
+
+This is the same shape as the bug fixed on the consolidated `tool-call` path in #13400 (`sanitizeToolCallInput` for `<|...|>` token tails) and the `tryRepairJson` recovery path used in the same `aisdk/v5/transform.ts` site. The streaming-end synth path now mirrors that flow:
+
+1. Sanitize the joined delta string (strips LLM token tails like `<|call|>`).
+2. `JSON.parse` the sanitized string.
+3. On parse failure, attempt JSON repair (`tryRepairJson`) and use the repaired value if successful.
+4. Only fall through to `args: {}` (with a `console.error`) when none of the above recovers a value.
+
+Affected providers include OpenAI-compatible passthroughs (Vercel AI Gateway → DeepSeek, OpenRouter, Novita) that emit tool args as multiple delta chunks plus an LLM token tail. Without this fix, downstream `execute()` callbacks received empty args, schema validation rejected them, and the agent loop either fell into a recovery path or escalated the run.

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -376,6 +376,114 @@ describe('MastraModelOutput', () => {
       expect(toolCalls.length).toBeGreaterThan(0);
       expect(toolCalls[0].payload.args).toEqual({ query: 'SELECT 1' });
     });
+
+    // Regression: see fix on the consolidated tool-call path in
+    // aisdk/v5/transform.ts (PR #13400). The streaming-end synthesis
+    // path used the same JSON.parse-then-fall-through-to-{} shape but
+    // never adopted the sanitize + repair flow. Providers that emit
+    // args as multiple deltas plus an LLM token tail (e.g.
+    // `…}<|call|>`) silently lost args before this fix.
+    it('recovers args via sanitize when streamed deltas end with an LLM token tail', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      const toolCallId = 'tool-sanitize';
+
+      const stream = createChunkStream([
+        {
+          type: 'tool-call-input-streaming-start',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId, toolName: 'my-tool' },
+        },
+        // Two deltas whose join is valid JSON followed by an LLM token.
+        // Bare JSON.parse on the joined string throws; sanitize strips
+        // the `<|call|>` tail and the parse succeeds.
+        {
+          type: 'tool-call-delta',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId, argsTextDelta: '{"query":"SELECT 1"}' },
+        },
+        {
+          type: 'tool-call-delta',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId, argsTextDelta: '\t<|call|>' },
+        },
+        {
+          type: 'tool-call-input-streaming-end',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId },
+        },
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+
+      const toolCalls = await output.toolCalls;
+
+      expect(toolCalls.length).toBeGreaterThan(0);
+      expect(toolCalls[0].payload.args).toEqual({ query: 'SELECT 1' });
+    });
+
+    // Regression: when the joined delta string is malformed JSON the
+    // repair path (tryRepairJson) recovers it rather than silently
+    // dropping args. Mirrors the behaviour added by PR #13400 on the
+    // consolidated tool-call path.
+    it('recovers args via JSON repair when streamed deltas form malformed JSON', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      const toolCallId = 'tool-repair';
+
+      const stream = createChunkStream([
+        {
+          type: 'tool-call-input-streaming-start',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId, toolName: 'my-tool' },
+        },
+        // Trailing comma — invalid JSON, but tryRepairJson recovers it.
+        {
+          type: 'tool-call-delta',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId, argsTextDelta: '{"path":"a.md","mode":"edit",}' },
+        },
+        {
+          type: 'tool-call-input-streaming-end',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId },
+        },
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+
+      const toolCalls = await output.toolCalls;
+
+      expect(toolCalls.length).toBeGreaterThan(0);
+      expect(toolCalls[0].payload.args).toEqual({ path: 'a.md', mode: 'edit' });
+    });
   });
 
   describe('usage raw passthrough', () => {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -14,6 +14,7 @@ import { ProcessorState, ProcessorRunner } from '../../processors/runner';
 import type { WorkflowRunStatus } from '../../workflows';
 import { DelayedPromise, consumeStream } from '../aisdk/v5/compat';
 import type { ConsumeStreamOptions } from '../aisdk/v5/compat';
+import { sanitizeToolCallInput, tryRepairJson } from '../aisdk/v5/transform';
 import type {
   ChunkType,
   LanguageModelUsage,
@@ -471,11 +472,29 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               const deltaParts = self.#toolCallArgsDeltas[toolCallId];
               let args: Record<string, unknown> = {};
               if (deltaParts?.length) {
-                try {
-                  const merged = deltaParts.join('');
-                  args = typeof merged === 'string' && merged.length > 0 ? JSON.parse(merged) : {};
-                } catch {
-                  args = {};
+                // Mirror the recovery flow used on the consolidated tool-call
+                // path in `aisdk/v5/transform.ts` (PR #13400): sanitize LLM
+                // tokens before JSON.parse, then attempt JSON repair on
+                // parse failure before falling through to empty args.
+                // Without this, providers that emit args as multiple
+                // delta chunks (Vercel AI Gateway → DeepSeek, OpenRouter,
+                // some OpenAI-compatible passthroughs) silently lose
+                // recoverable args on JSON.parse failure, leading to a
+                // synthetic tool-call with `args: {}` that downstream
+                // schema validation can only treat as a no-arg call.
+                const merged = deltaParts.join('');
+                const sanitized = sanitizeToolCallInput(merged);
+                if (sanitized) {
+                  try {
+                    args = JSON.parse(sanitized);
+                  } catch {
+                    const repaired = tryRepairJson(sanitized);
+                    if (repaired) {
+                      args = repaired;
+                    } else {
+                      console.error('Error converting streamed tool-call args to JSON', { input: merged });
+                    }
+                  }
                 }
               }
               delete self.#toolCallStreamingMeta[toolCallId];


### PR DESCRIPTION
## Summary

Fixes #14179

`MastraModelOutput`'s `tool-call-input-streaming-end` handler joined accumulated `tool-call-delta` text and called `JSON.parse` directly. On parse failure it silently fell through to `args: {}` — the synthetic `tool-call` chunk then carried empty args even when the original deltas were recoverable.

This is the same shape as the bug fixed on the consolidated `tool-call` path in #13400 (sanitize `<|...|>` token tails) plus the `tryRepairJson` recovery path used at the same site in `packages/core/src/stream/aisdk/v5/transform.ts`. #14179 was closed when #13400 landed, but only the consolidated-tool-call path adopted the new recovery flow; the streaming-end synth path retained the silent-`{}` shape. This PR completes the fix on the second site.

## Recovery flow (mirror of `transform.ts`)

1. Sanitize the joined delta string via `sanitizeToolCallInput` (strips LLM token tails like `<|call|>`).
2. `JSON.parse` the sanitized string.
3. On parse failure, attempt JSON repair (`tryRepairJson`); use the repaired value if successful.
4. Only fall through to `args: {}` (with a `console.error`) when none of the above recovers a value.

## What changed

| File | Change |
|---|---|
| `packages/core/src/stream/base/output.ts` | Import sanitize+repair helpers; replace silent fall-through with the 4-step recovery flow at the `tool-call-input-streaming-end` case |
| `packages/core/src/stream/base/output.test.ts` | Two regression tests — sanitize-tail recovery and JSON-repair recovery — using the same chunk-stream helpers the existing streaming-end tests use |
| `.changeset/recover-streaming-end-args.md` | Patch-level changeset entry for `@mastra/core` |

## Affected providers in the wild

OpenAI-compatible passthroughs that emit tool args as multiple delta chunks plus an LLM token tail or briefly-parsable mid-stream JSON. Observed in production on Vercel AI Gateway → DeepSeek; reporters on #14179 hit it on OpenRouter and direct Anthropic.

Symptom on the consuming side: `execute()` callback receives empty args, the tool's schema validation rejects, and the agent loop either falls into a recovery turn or escalates the run.

## Notes

- No public API change.
- Behaviour change is only on the previously-silently-failing path — callers that already received correct args continue to receive them unchanged.
- `console.error` on the final fall-through matches `transform.ts`'s behaviour on the same recovery exhaustion.

## Test plan

- [x] Two new regression tests in `output.test.ts` cover the sanitize and repair recovery paths
- [x] Existing streaming-end tests (including the synthetic-with-empty-args merging test) untouched
- [ ] Reviewer: confirm CI green on the full `packages/core` suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When AI services send back tool commands in pieces (like a package arriving in multiple boxes), the code tries to put them back together. If the pieces don't quite fit together properly, instead of giving up, this PR teaches the code to try fixing the pieces in different ways—like scrubbing off extra wrapper text or patching small formatting mistakes—before finally admitting defeat and using an empty toolbox.

## Overview

This PR fixes a silent failure in `MastraModelOutput`'s handler for streaming tool-call arguments. Previously, when tool-call arguments arrived as multiple delta chunks and required recovery (due to LLM token tails or briefly-malformed intermediate JSON), the handler would directly attempt `JSON.parse` and, on failure, silently fall through to `args: {}` with no indication of the problem. This manifested as synthetic tool-call chunks with empty arguments even when recovery was possible.

The fix implements a 4-step recovery flow that mirrors logic already present in `packages/core/src/stream/aisdk/v5/transform.ts`:

1. **Sanitize** the joined delta string via `sanitizeToolCallInput` to remove LLM token tails (e.g., `<|call|>`).
2. **Attempt `JSON.parse`** on the sanitized string.
3. **On parse failure, attempt JSON repair** using `tryRepairJson` and use the repaired value if successful.
4. **Fall back to `args: {}`** (and log `console.error`) only when all recovery steps fail.

## Changes

**packages/core/src/stream/base/output.ts**
- Added imports for `sanitizeToolCallInput` and `tryRepairJson`
- Replaced the direct `JSON.parse` call in the `tool-call-input-streaming-end` handler with the 4-step recovery flow
- Logs an error when recovery fails (matching existing behavior in transform.ts)

**packages/core/src/stream/base/output.test.ts**
- Added two regression tests:
  - One covering recovery via sanitization when an LLM token tail is present
  - One covering recovery via JSON repair for malformed JSON with trailing commas
- Both tests construct streaming sequences with `tool-call-input-streaming-start`, multiple `tool-call-delta` chunks, and `tool-call-input-streaming-end`, verifying that `args` are correctly populated in the resulting tool-call chunk

**.changeset/recover-streaming-end-args.md**
- Patch-level changeset for `@mastra/core` documenting the fix

## Impact

- **Scope**: Affects OpenAI-compatible passthroughs (particularly Vercel AI Gateway routing to DeepSeek, OpenRouter, Anthropic) that emit tool arguments across multiple delta chunks with LLM token tails or briefly-malformed intermediate JSON
- **API**: No public API changes; behavior change is isolated to the previously-silent failure path
- **Compatibility**: Successful existing flows remain unchanged; only previously-lost arguments are now recovered
- **Observability**: Adds `console.error` logging on final recovery failure, improving debugging visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->