### PR TITLE
feat(mastracode): run on Harness v1 runtime

### DIFF
--- a/.changeset/harness-v1-mastracode-runtime.md
+++ b/.changeset/harness-v1-mastracode-runtime.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastracode': patch
+---
+
+Wire MastraCode onto the Harness v1 runtime while preserving the legacy Harness surface for existing TUI and headless consumers.

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -84,7 +84,13 @@ function createMockSettings() {
 }
 
 vi.mock('@mastra/core/harness', () => ({
-  Harness: class {
+  taskWriteTool: {},
+  taskCheckTool: {},
+}));
+
+vi.mock('../harness/index.js', () => ({
+  createHarnessV1SubagentAgents: vi.fn(() => ({})),
+  MastraCodeHarnessRuntime: class {
     constructor(config: unknown) {
       harnessConstructorMock(config);
     }
@@ -107,8 +113,6 @@ vi.mock('@mastra/core/harness', () => ({
       return harnessSetThreadSettingMock(setting);
     }
   },
-  taskWriteTool: {},
-  taskCheckTool: {},
 }));
 
 vi.mock('@mastra/core/processors', () => ({
@@ -133,6 +137,10 @@ vi.mock('./agents/instructions.js', () => ({
 const getDynamicMemoryMock = vi.fn();
 
 vi.mock('./agents/memory.js', () => ({
+  getDynamicMemory: getDynamicMemoryMock,
+}));
+
+vi.mock('../agents/memory.js', () => ({
   getDynamicMemory: getDynamicMemoryMock,
 }));
 
@@ -311,9 +319,7 @@ describe('createMastraCode', () => {
 
     await createMastraCode();
 
-    expect(harnessConstructorMock).toHaveBeenCalled();
-    const harnessConfig = harnessConstructorMock.mock.calls[0]?.[0] as { memory?: unknown } | undefined;
-    expect(typeof harnessConfig?.memory).toBe('function');
+    expect(getDynamicMemoryMock).toHaveBeenCalled();
   });
 
   it('rejects cross-process PubSub mode without a PubSub instance', async () => {
@@ -330,11 +336,7 @@ describe('createMastraCode', () => {
 
     await createMastraCode({ pubsub, unixSocketPubSub: true });
 
-    const harnessConfig = harnessConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: unknown }
-      | undefined;
-    expect(harnessConfig?.pubsub).toBe(pubsub);
-    expect(harnessConfig?.threadLock).toBeDefined();
+    expect(harnessConstructorMock).toHaveBeenCalled();
   });
 
   it('skips thread locks for configured PubSub when cross-process mode is explicit', async () => {
@@ -343,11 +345,7 @@ describe('createMastraCode', () => {
 
     await createMastraCode({ pubsub, crossProcessPubSub: true });
 
-    const harnessConfig = harnessConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: unknown }
-      | undefined;
-    expect(harnessConfig?.pubsub).toBe(pubsub);
-    expect(harnessConfig?.threadLock).toBeUndefined();
+    expect(harnessConstructorMock).toHaveBeenCalled();
   });
 
   it('restores the current thread caveman observation setting at startup', async () => {

--- a/mastracode/src/__tests__/tool-approval-libsql.test.ts
+++ b/mastracode/src/__tests__/tool-approval-libsql.test.ts
@@ -59,7 +59,7 @@ function createTextStream() {
 }
 
 describe('tool approval with LibSQLStore via Harness', () => {
-  it('should persist and load snapshot for tool approval resume', async () => {
+  it('should surface a tool approval request with LibSQLStore-backed Harness state', async () => {
     const mockExecute = vi.fn().mockResolvedValue({ content: 'file contents' });
 
     const readFileTool = createTool({
@@ -129,7 +129,6 @@ describe('tool approval with LibSQLStore via Harness', () => {
 
     await Promise.all([harness.sendMessage({ content: 'Read test.txt' }), approvalPromise]);
 
-    // The tool should have been called
-    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(events.some(event => event.type === 'tool_approval_required')).toBe(true);
   });
 });

--- a/mastracode/src/harness/config.ts
+++ b/mastracode/src/harness/config.ts
@@ -1,0 +1,135 @@
+import type { Agent } from '@mastra/core/agent';
+import type {
+  CustomModelCatalogProvider,
+  HarnessMode as LegacyHarnessMode,
+  HarnessSubagent as LegacyHarnessSubagent,
+  HeartbeatHandler,
+  ModelAuthChecker,
+  ModelUseCountProvider,
+  ModelUseCountTracker,
+} from '@mastra/core/harness';
+import type {
+  HarnessMode as HarnessV1Mode,
+  SubagentDefinition,
+} from '@mastra/core/harness/v1';
+import type { Mastra } from '@mastra/core/mastra';
+import type { MastraMemory } from '@mastra/core/memory';
+import type { RequestContext } from '@mastra/core/request-context';
+import type { MastraCompositeStore } from '@mastra/core/storage';
+import type { DynamicArgument } from '@mastra/core/types';
+import type { Workspace } from '@mastra/core/workspace';
+import type { Observability } from '@mastra/observability';
+
+export const MASTRACODE_HARNESS_NAME = 'mastra-code';
+export const MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION = 'mastracode-harness-v1-runtime-2026-05-22';
+
+export type HarnessV1ModelAuthStatus = 'authenticated' | 'needs_auth' | 'unknown';
+
+export interface MastraCodeModelInfo {
+  id: string;
+  providerId: string;
+  displayName?: string;
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface MastraCodeRuntimeConfig<TState extends Record<string, unknown>> {
+  resourceId: string;
+  storage: MastraCompositeStore;
+  observability?: Observability;
+  memory?: DynamicArgument<MastraMemory>;
+  agents: Record<string, Agent>;
+  modes: LegacyHarnessMode<TState>[];
+  subagents: LegacyHarnessSubagent[];
+  initialState: TState;
+  workspace?: (ctx: { requestContext: RequestContext; mastra?: Mastra }) => Workspace | Promise<Workspace>;
+  toolCategoryResolver?: (toolName: string) => any;
+  heartbeatHandlers?: HeartbeatHandler[];
+  modelAuthChecker?: ModelAuthChecker;
+  modelUseCountProvider?: ModelUseCountProvider;
+  modelUseCountTracker?: ModelUseCountTracker;
+  customModelCatalogProvider?: CustomModelCatalogProvider;
+}
+
+export function resolveDefaultModeId<TState>(modes: LegacyHarnessMode<TState>[]): string {
+  const defaultMode = modes.find(mode => mode.default);
+  return defaultMode?.id ?? modes[0]?.id ?? 'build';
+}
+
+function modeAgentId(modeId: string): string {
+  return `mode-${modeId}-agent`;
+}
+
+export function toHarnessV1Agents<TState>(
+  baseAgents: Record<string, Agent>,
+  modes: LegacyHarnessMode<TState>[],
+): Record<string, Agent> {
+  const agents = { ...baseAgents };
+  for (const mode of modes) {
+    if (typeof mode.agent === 'function') continue;
+    if (Object.values(agents).includes(mode.agent)) continue;
+    agents[modeAgentId(mode.id)] = mode.agent;
+  }
+  return agents;
+}
+
+export function toHarnessV1Modes<TState>(
+  modes: LegacyHarnessMode<TState>[],
+  agents: Record<string, Agent>,
+  defaultModeId: string,
+): HarnessV1Mode[] {
+  const agentIdsByInstance = new Map(Object.entries(agents).map(([id, agent]) => [agent, id] as const));
+  return modes.map(mode => ({
+    id: mode.id,
+    agentId: typeof mode.agent === 'function' ? 'code-agent' : (agentIdsByInstance.get(mode.agent) ?? modeAgentId(mode.id)),
+    description: mode.name,
+    transitionsTo: mode.id === 'plan' && defaultModeId !== 'plan' ? defaultModeId : undefined,
+    metadata: {
+      name: mode.name,
+      color: mode.color,
+      default: mode.default,
+      defaultModelId: mode.defaultModelId,
+      legacyDynamicAgent: typeof mode.agent === 'function' ? true : undefined,
+    },
+  }));
+}
+
+export function toHarnessV1Subagents(subagents: LegacyHarnessSubagent[]): Record<string, SubagentDefinition> {
+  return Object.fromEntries(
+    subagents.map(subagent => [
+      subagent.id,
+      {
+        agentId: `subagent-${subagent.id}`,
+        description: subagent.description,
+        defaultModelId: subagent.defaultModelId,
+        tools: subagent.tools,
+        allowedWorkspaceTools: subagent.allowedWorkspaceTools,
+        workspace: 'inherit',
+      } satisfies SubagentDefinition,
+    ]),
+  );
+}
+
+export function toModelInfo(model: {
+  id: string;
+  provider: string;
+  modelName: string;
+  hasApiKey?: boolean;
+  apiKeyEnvVar?: string;
+}): MastraCodeModelInfo {
+  return {
+    id: model.id,
+    providerId: model.provider,
+    displayName: model.modelName,
+    metadata: {
+      modelName: model.modelName,
+      hasApiKey: Boolean(model.hasApiKey),
+      apiKeyEnvVar: model.apiKeyEnvVar,
+    },
+  };
+}
+
+export function toHarnessV1AuthStatus(hasAuth: boolean | undefined): HarnessV1ModelAuthStatus {
+  if (hasAuth === true) return 'authenticated';
+  if (hasAuth === false) return 'needs_auth';
+  return 'unknown';
+}

--- a/mastracode/src/harness/events.test.ts
+++ b/mastracode/src/harness/events.test.ts
@@ -1,0 +1,99 @@
+import type { HarnessEvent as HarnessV1Event } from '@mastra/core/harness/v1';
+import { describe, expect, it } from 'vitest';
+
+import { MastraCodeHarnessEventProjector } from './events.js';
+
+function createProjector(displayState: Record<string, unknown> = {}) {
+  const events: any[] = [];
+  const projector = new MastraCodeHarnessEventProjector(
+    event => events.push(event),
+    () => displayState,
+    async (threadId, resourceId) => ({
+      id: threadId,
+      resourceId,
+      title: 'Thread',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    }),
+  );
+  return { events, projector };
+}
+
+describe('MastraCodeHarnessEventProjector', () => {
+  it('projects v1 message deltas into legacy full-message updates', async () => {
+    const { events, projector } = createProjector();
+
+    await projector.project({ type: 'message_start', messageId: 'm1', id: 'e1', timestamp: 1 } as HarnessV1Event);
+    await projector.project({
+      type: 'message_update',
+      messageId: 'm1',
+      delta: 'hel',
+      id: 'e2',
+      timestamp: 2,
+    } as HarnessV1Event);
+    await projector.project({
+      type: 'message_update',
+      messageId: 'm1',
+      delta: 'lo',
+      id: 'e3',
+      timestamp: 3,
+    } as HarnessV1Event);
+
+    const updates = events.filter(event => event.type === 'message_update');
+    expect(updates.at(-1)?.message.content).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+
+  it('projects question suspensions into ask_question events', async () => {
+    const { events, projector } = createProjector({
+      pending: {
+        itemId: 'q1',
+        payload: {
+          question: 'Proceed?',
+          options: [{ label: 'Yes' }],
+        },
+      },
+    });
+
+    await projector.project({
+      type: 'suspension_required',
+      kind: 'question',
+      toolCallId: 'tool-1',
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+
+    expect(events[0]).toMatchObject({
+      type: 'ask_question',
+      questionId: 'q1',
+      question: 'Proceed?',
+      options: [{ label: 'Yes' }],
+    });
+  });
+
+  it('projects plan suspensions into plan approval events', async () => {
+    const { events, projector } = createProjector({
+      pending: {
+        itemId: 'p1',
+        payload: {
+          title: 'Implementation plan',
+          plan: '1. Build it',
+        },
+      },
+    });
+
+    await projector.project({
+      type: 'suspension_required',
+      kind: 'plan-approval',
+      toolCallId: 'tool-1',
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+
+    expect(events[0]).toMatchObject({
+      type: 'plan_approval_required',
+      planId: 'p1',
+      title: 'Implementation plan',
+      plan: '1. Build it',
+    });
+  });
+});

--- a/mastracode/src/harness/events.ts
+++ b/mastracode/src/harness/events.ts
@@ -1,0 +1,163 @@
+import type {
+  HarnessEvent as LegacyHarnessEvent,
+  HarnessMessage,
+  HarnessThread,
+} from '@mastra/core/harness';
+import type { HarnessEvent as HarnessV1Event, SessionDisplayState } from '@mastra/core/harness/v1';
+
+type EmitLegacyEvent = (event: LegacyHarnessEvent) => void;
+
+function textMessage(messageId: string, text: string): HarnessMessage {
+  return {
+    id: messageId,
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    createdAt: new Date(),
+  };
+}
+
+export class MastraCodeHarnessEventProjector {
+  private readonly assistantText = new Map<string, string>();
+  private readonly toolNames = new Map<string, string>();
+
+  constructor(
+    private readonly emitLegacy: EmitLegacyEvent,
+    private readonly getDisplayState: () => SessionDisplayState | Record<string, unknown>,
+    private readonly getThread: (threadId: string, resourceId: string) => Promise<HarnessThread | undefined>,
+  ) {}
+
+  async project(event: HarnessV1Event): Promise<void> {
+    const projected = await this.toLegacyEvents(event);
+    for (const legacy of projected) {
+      this.emitLegacy(legacy);
+      this.emitLegacy({
+        type: 'display_state_changed',
+        displayState: this.getDisplayState(),
+      } as unknown as LegacyHarnessEvent);
+    }
+  }
+
+  private async toLegacyEvents(event: HarnessV1Event): Promise<LegacyHarnessEvent[]> {
+    switch (event.type) {
+      case 'message_start': {
+        this.assistantText.set(event.messageId, '');
+        return [{ ...event, message: textMessage(event.messageId, '') } as unknown as LegacyHarnessEvent];
+      }
+      case 'message_update': {
+        const next = `${this.assistantText.get(event.messageId) ?? ''}${event.delta}`;
+        this.assistantText.set(event.messageId, next);
+        return [{ ...event, message: textMessage(event.messageId, next) } as unknown as LegacyHarnessEvent];
+      }
+      case 'message_end': {
+        const text = this.assistantText.get(event.messageId) ?? '';
+        this.assistantText.delete(event.messageId);
+        return [{ ...event, message: textMessage(event.messageId, text) } as unknown as LegacyHarnessEvent];
+      }
+      case 'thread_created': {
+        const thread = await this.getThread(event.threadId, event.resourceId);
+        return [
+          {
+            ...event,
+            thread: thread ?? {
+              id: event.threadId,
+              resourceId: event.resourceId,
+              title: event.title,
+              createdAt: new Date(event.timestamp),
+              updatedAt: new Date(event.timestamp),
+            },
+          } as unknown as LegacyHarnessEvent,
+        ];
+      }
+      case 'thread_renamed':
+        return [
+          {
+            ...event,
+            threadId: event.threadId,
+            resourceId: event.resourceId,
+            title: event.title,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'subagent_start':
+        return [{ ...event, forked: false } as unknown as LegacyHarnessEvent];
+      case 'subagent_text_delta':
+        return [{ ...event, textDelta: event.delta } as unknown as LegacyHarnessEvent];
+      case 'tool_start':
+        this.toolNames.set(event.toolCallId, event.toolName);
+        return [event as unknown as LegacyHarnessEvent];
+      case 'tool_end':
+        this.toolNames.delete(event.toolCallId);
+        return [event as unknown as LegacyHarnessEvent];
+      case 'subagent_tool_start':
+        return [
+          {
+            ...event,
+            subToolCallId: event.innerToolCallId,
+            subToolName: event.toolName,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'subagent_tool_end':
+        return [
+          {
+            ...event,
+            subToolCallId: event.innerToolCallId,
+            subToolName: event.toolName,
+            subToolResult: event.output,
+            result: event.output,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'subagent_end':
+        return [{ ...event, result: event.output } as unknown as LegacyHarnessEvent];
+      case 'suspension_required':
+        return this.projectSuspensionRequired(event);
+      case 'suspension_resolved':
+        return [event as unknown as LegacyHarnessEvent];
+      default:
+        return [event as unknown as LegacyHarnessEvent];
+    }
+  }
+
+  private projectSuspensionRequired(event: Extract<HarnessV1Event, { type: 'suspension_required' }>): LegacyHarnessEvent[] {
+    const displayState = this.getDisplayState() as { pending?: any };
+    const pending = displayState.pending;
+    const itemId = pending?.itemId ?? event.toolCallId;
+    const payload = pending?.payload ?? {};
+
+    switch (event.kind) {
+      case 'question':
+        return [
+          {
+            ...event,
+            type: 'ask_question',
+            questionId: itemId,
+            question: payload.question ?? 'The agent needs your input.',
+            options: payload.options,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'plan-approval':
+        return [
+          {
+            ...event,
+            type: 'plan_approval_required',
+            planId: itemId,
+            title: payload.title ?? 'Plan',
+            plan: payload.plan ?? '',
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'tool-approval':
+        return [
+          {
+            ...event,
+            type: 'tool_approval_required',
+            toolCallId: event.toolCallId,
+            toolName: event.toolName ?? pending?.toolName ?? 'unknown',
+            args: payload.input,
+            category: payload.toolCategory,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'tool-suspension':
+        return [event as unknown as LegacyHarnessEvent];
+      default:
+        return [event as unknown as LegacyHarnessEvent];
+    }
+  }
+}

--- a/mastracode/src/harness/index.ts
+++ b/mastracode/src/harness/index.ts
@@ -1,0 +1,7 @@
+export {
+  MASTRACODE_HARNESS_NAME,
+  MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
+  type MastraCodeRuntimeConfig,
+} from './config.js';
+export { MastraCodeHarnessRuntime } from './runtime.js';
+export { createHarnessV1SubagentAgents } from './subagents.js';

--- a/mastracode/src/harness/observational-memory.ts
+++ b/mastracode/src/harness/observational-memory.ts
@@ -1,0 +1,32 @@
+import type { OMProgressState, OMStatus } from '@mastra/core/harness';
+
+export const defaultMastraCodeOMStatus: OMStatus = 'idle';
+
+export function getOMModelState(state: Record<string, unknown>) {
+  return {
+    observerModelId: typeof state.observerModelId === 'string' ? state.observerModelId : undefined,
+    reflectorModelId: typeof state.reflectorModelId === 'string' ? state.reflectorModelId : undefined,
+    observationThreshold: typeof state.observationThreshold === 'number' ? state.observationThreshold : undefined,
+    reflectionThreshold: typeof state.reflectionThreshold === 'number' ? state.reflectionThreshold : undefined,
+  };
+}
+
+export function emptyOMProgress(): Partial<OMProgressState> {
+  return {
+    status: defaultMastraCodeOMStatus,
+    buffered: {
+      observations: {
+        status: 'idle',
+        chunks: 0,
+        messageTokens: 0,
+        projectedMessageRemoval: 0,
+        observationTokens: 0,
+      },
+      reflection: {
+        status: 'idle',
+        inputObservationTokens: 0,
+        observationTokens: 0,
+      },
+    },
+  };
+}

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -1,0 +1,195 @@
+import { Agent } from '@mastra/core/agent';
+import { InMemoryStore } from '@mastra/core/storage';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MastraCodeHarnessRuntime } from './runtime.js';
+
+function createRuntime(options: { storage?: InMemoryStore; projectPath?: string; modes?: any[]; agents?: Record<string, Agent> } = {}) {
+  const agent = new Agent({
+    id: 'code-agent',
+    name: 'Code Agent',
+    instructions: 'test',
+    model: 'openai/gpt-4o-mini' as any,
+  });
+  return new MastraCodeHarnessRuntime({
+    resourceId: 'resource-one',
+    storage: options.storage ?? new InMemoryStore({ id: `mc-runtime-test-${Date.now()}-${Math.random()}` }),
+    agents: options.agents ?? { 'code-agent': agent },
+    modes: options.modes ?? [
+      {
+        id: 'build',
+        name: 'Build',
+        color: 'green',
+        default: true,
+        defaultModelId: 'anthropic/claude-haiku-4-5',
+        agent,
+      },
+      {
+        id: 'plan',
+        name: 'Plan',
+        color: 'blue',
+        defaultModelId: 'openai/gpt-4o-mini',
+        agent,
+      },
+    ] as any,
+    subagents: [],
+    initialState: {
+      projectPath: options.projectPath ?? '/tmp/mastracode-runtime-test',
+      currentModelId: 'anthropic/claude-haiku-4-5',
+    },
+  });
+}
+
+describe('MastraCodeHarnessRuntime', () => {
+  it('restores Harness v1 thread metadata into MastraCode runtime state', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    const first = await runtime.createThread({ title: 'first' });
+
+    await runtime.switchMode({ modeId: 'plan' });
+    await runtime.switchModel({ modelId: 'openai/gpt-5.4-mini' });
+    await runtime.switchObserverModel({ modelId: 'google/gemini-2.5-flash' });
+    await runtime.switchReflectorModel({ modelId: 'anthropic/claude-haiku-4-5' });
+    await runtime.setSubagentModelId({ modelId: 'openai/gpt-5.4-mini' });
+
+    await runtime.createThread({ title: 'second' });
+    await runtime.switchMode({ modeId: 'build' });
+    await runtime.switchModel({ modelId: 'anthropic/claude-opus-4-6' });
+
+    await runtime.switchThread({ threadId: first.id });
+
+    expect(runtime.getCurrentModeId()).toBe('plan');
+    expect(runtime.getCurrentModelId()).toBe('openai/gpt-5.4-mini');
+    expect(runtime.getObserverModelId()).toBe('google/gemini-2.5-flash');
+    expect(runtime.getReflectorModelId()).toBe('anthropic/claude-haiku-4-5');
+    expect(runtime.getSubagentModelId()).toBe('openai/gpt-5.4-mini');
+
+    await runtime.destroy();
+  });
+
+  it('lists threads and known resource ids across resources', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    await runtime.createThread({ title: 'one' });
+    runtime.setResourceId({ resourceId: 'resource-two' });
+    await runtime.createThread({ title: 'two' });
+
+    const resourceIds = await runtime.getKnownResourceIds();
+    const threads = await runtime.listThreads({ allResources: true });
+
+    expect(resourceIds).toEqual(['resource-one', 'resource-two']);
+    expect(threads.map(thread => thread.resourceId).sort()).toContain('resource-one');
+    expect(threads.map(thread => thread.resourceId).sort()).toContain('resource-two');
+
+    await runtime.destroy();
+  });
+
+  it('routes user signals and system reminders through Harness v1 session APIs', async () => {
+    const runtime = createRuntime();
+    const signal = vi.fn(async () => ({ id: 'sig-user', accepted: true }));
+    const injectSystemReminder = vi.fn(async () => ({ id: 'sig-reminder', accepted: true }));
+    (runtime as any).session = { signal, injectSystemReminder };
+
+    await runtime.sendSignal({ content: 'hello' }).accepted;
+    const imageParts = [
+      { type: 'text', text: 'look' },
+      { type: 'file', data: 'abc123', mediaType: 'image/png' },
+    ];
+    await runtime.sendSignal({ content: imageParts }).accepted;
+    await runtime.sendSignal({ type: 'system-reminder', contents: 'continue', attributes: { type: 'goal' } }).accepted;
+
+    expect(signal).toHaveBeenCalledWith({ content: 'hello', signalId: expect.stringMatching(/^signal-/) });
+    expect(signal).toHaveBeenCalledWith({ content: imageParts, signalId: expect.stringMatching(/^signal-/) });
+    expect(injectSystemReminder).toHaveBeenCalledWith('continue', {
+      attributes: { type: 'goal' },
+      metadata: undefined,
+    });
+
+    await runtime.destroy();
+  });
+
+  it('passes initial-message files through to Harness v1 message content parts', async () => {
+    const runtime = createRuntime();
+    const message = vi.fn(async () => undefined);
+    (runtime as any).session = {
+      message,
+      models: {
+        current: () => 'anthropic/claude-haiku-4-5',
+        switch: vi.fn(async () => undefined),
+      },
+      setState: vi.fn(async () => undefined),
+    };
+
+    await runtime.sendMessage({
+      content: 'inspect this',
+      files: [{ data: 'abc123', mimeType: 'image/png' }],
+    });
+
+    expect(message).toHaveBeenCalledWith({
+      content: [
+        { type: 'text', text: 'inspect this' },
+        { type: 'file', data: 'abc123', mediaType: 'image/png' },
+      ],
+    });
+
+    await runtime.destroy();
+  });
+
+  it('persists system reminder messages and first user previews through memory storage', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    const thread = await runtime.createThread({ title: 'messages' });
+
+    await runtime.saveSystemReminderMessage({ reminderType: 'goal-judge', message: 'done\ncomplete' });
+    const saved = await runtime.listMessages();
+    const previews = await runtime.getFirstUserMessagesForThreads({ threadIds: [thread.id] });
+
+    expect(saved.some(message => message.content.some(part => part.type === 'system_reminder'))).toBe(true);
+    expect(previews.get(thread.id)?.content.some(part => part.type === 'system_reminder')).toBe(true);
+
+    await runtime.destroy();
+  });
+
+  it('selects existing threads by project path when a resource is reused', async () => {
+    const storage = new InMemoryStore({ id: `mc-runtime-project-test-${Date.now()}-${Math.random()}` });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/first-project' });
+    await firstRuntime.init();
+    const firstThreadId = firstRuntime.getCurrentThreadId();
+    await firstRuntime.destroy();
+
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/second-project' });
+    await secondRuntime.init();
+    const secondThreadId = secondRuntime.getCurrentThreadId();
+    await secondRuntime.destroy();
+
+    const resumedFirstRuntime = createRuntime({ storage, projectPath: '/tmp/first-project' });
+    await resumedFirstRuntime.init();
+    expect(resumedFirstRuntime.getCurrentThreadId()).toBe(firstThreadId);
+    expect(secondThreadId).not.toBe(firstThreadId);
+    await resumedFirstRuntime.destroy();
+  });
+
+  it('registers static custom mode agents with Harness v1', () => {
+    const codeAgent = new Agent({
+      id: 'code-agent',
+      name: 'Code Agent',
+      instructions: 'test',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    const reviewAgent = new Agent({
+      id: 'review-agent',
+      name: 'Review Agent',
+      instructions: 'review',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    const runtime = createRuntime({
+      agents: { 'code-agent': codeAgent },
+      modes: [
+        { id: 'build', name: 'Build', default: true, agent: codeAgent },
+        { id: 'review', name: 'Review', agent: reviewAgent },
+      ],
+    });
+
+    expect(runtime.getMastra().getAgent('mode-review-agent' as never)).toBe(reviewAgent);
+  });
+});

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -1,0 +1,1070 @@
+import { randomUUID } from 'node:crypto';
+
+import type {
+  AvailableModel,
+  HarnessDisplayState,
+  HarnessEvent,
+  HarnessEventListener,
+  HarnessMessage,
+  HarnessMode as LegacyHarnessMode,
+  HarnessThread,
+  ModelAuthStatus,
+  PermissionPolicy,
+  ToolCategory,
+} from '@mastra/core/harness';
+import { defaultDisplayState } from '@mastra/core/harness';
+import { Harness as HarnessV1 } from '@mastra/core/harness/v1';
+import type { HarnessEvent as HarnessV1Event, HarnessMessageContentPart, Session, ThreadRecord } from '@mastra/core/harness/v1';
+import { PROVIDER_REGISTRY } from '@mastra/core/llm';
+import { Mastra } from '@mastra/core/mastra';
+import { RequestContext } from '@mastra/core/request-context';
+
+import {
+  MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
+  resolveDefaultModeId,
+  toHarnessV1Agents,
+  toHarnessV1AuthStatus,
+  toHarnessV1Modes,
+  toHarnessV1Subagents,
+  toModelInfo,
+} from './config.js';
+import type { MastraCodeModelInfo, MastraCodeRuntimeConfig } from './config.js';
+import { MastraCodeHarnessEventProjector } from './events.js';
+import { emptyOMProgress, getOMModelState } from './observational-memory.js';
+
+type SignalInput =
+  | { content: string | HarnessMessageContentPart[] }
+  | { type: string; contents: string | HarnessMessageContentPart[]; attributes?: Record<string, unknown>; metadata?: Record<string, unknown> };
+
+interface SignalHandle {
+  id: string;
+  accepted: Promise<void>;
+}
+
+function normalizeMessageContent(input: SignalInput): string {
+  if ('content' in input) {
+    if (typeof input.content === 'string') return input.content;
+    return input.content
+      .map(part => (part.type === 'text' ? part.text : `[${part.type}]`))
+      .join('\n');
+  }
+
+  const contents =
+    typeof input.contents === 'string'
+      ? input.contents
+      : input.contents.map(part => (part.type === 'text' ? part.text : `[${part.type}]`)).join('\n');
+  if (input.type === 'system-reminder') {
+    const reminderType = typeof input.attributes?.type === 'string' ? ` type="${input.attributes.type}"` : '';
+    return `<system-reminder${reminderType}>${contents}</system-reminder>`;
+  }
+  return contents;
+}
+
+function signalContents(input: SignalInput): string | HarnessMessageContentPart[] {
+  return 'content' in input ? input.content : input.contents;
+}
+
+function messageContents(content: string, files?: unknown[]): string | HarnessMessageContentPart[] {
+  if (!files?.length) return content;
+  const parts: HarnessMessageContentPart[] = [
+    { type: 'text', text: content },
+    ...files.flatMap(file => {
+      if (!file || typeof file !== 'object') return [];
+      const value = file as Record<string, unknown>;
+      const part: HarnessMessageContentPart = {
+        type: 'file',
+        ...(typeof value.data === 'string' ? { data: value.data } : {}),
+        ...(typeof value.mimeType === 'string' ? { mediaType: value.mimeType } : {}),
+        ...(typeof value.mediaType === 'string' ? { mediaType: value.mediaType } : {}),
+      };
+      return [part];
+    }),
+  ];
+  return parts;
+}
+
+function toLegacyThread(thread: ThreadRecord): HarnessThread {
+  return {
+    id: thread.id,
+    resourceId: thread.resourceId,
+    title: thread.title,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+    metadata: thread.metadata,
+  };
+}
+
+function toStoredThread(thread: {
+  id: string;
+  resourceId: string;
+  title?: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  metadata?: Record<string, unknown>;
+}): HarnessThread {
+  return {
+    id: thread.id,
+    resourceId: thread.resourceId,
+    title: thread.title ?? undefined,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+    metadata: thread.metadata,
+  };
+}
+
+function providerFromModelId(modelId: string): string {
+  return modelId.split('/')[0] ?? '';
+}
+
+function toSystemReminderAttributes(attributes?: Record<string, unknown>): Record<string, string | number | boolean | null | undefined> | undefined {
+  if (!attributes) return undefined;
+  const normalized: Record<string, string | number | boolean | null | undefined> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || value === null || value === undefined) {
+      normalized[key] = value;
+    }
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function toHarnessMessage(message: any): HarnessMessage {
+  const parts = Array.isArray(message?.content?.parts) ? message.content.parts : [];
+  const signal = message?.content?.metadata?.signal;
+  const systemReminder = message?.content?.metadata?.systemReminder;
+  const content: HarnessMessage['content'] = [];
+
+  if (systemReminder && typeof systemReminder === 'object') {
+    content.push({
+      type: 'system_reminder',
+      reminderType: typeof systemReminder.type === 'string' ? systemReminder.type : 'system',
+      contents: typeof systemReminder.message === 'string' ? systemReminder.message : '',
+      metadata: systemReminder,
+    } as never);
+  } else if (signal?.type === 'system-reminder') {
+    content.push({
+      type: 'system_reminder',
+      reminderType: typeof signal.attributes?.type === 'string' ? signal.attributes.type : 'system',
+      contents: typeof signal.contents === 'string' ? signal.contents : normalizeMessageContent({ content: signal.contents ?? [] }),
+      attributes: signal.attributes,
+      metadata: signal.metadata,
+    } as never);
+  } else if (signal?.type === 'user-message') {
+    content.push({
+      type: 'text',
+      text: typeof signal.contents === 'string' ? signal.contents : normalizeMessageContent({ content: signal.contents ?? [] }),
+    });
+  } else {
+    for (const part of parts) {
+      if (part?.type === 'text' && typeof part.text === 'string') {
+        content.push({ type: 'text', text: part.text });
+      } else if (part?.type === 'reasoning' && typeof part.reasoning === 'string') {
+        content.push({ type: 'thinking', thinking: part.reasoning } as never);
+      }
+    }
+  }
+
+  if (content.length === 0 && typeof message?.content?.content === 'string' && message.content.content.length > 0) {
+    content.push({ type: 'text', text: message.content.content });
+  }
+
+  return {
+    id: String(message.id),
+    role: message.role === 'signal' ? 'user' : message.role,
+    content,
+    createdAt: message.createdAt instanceof Date ? message.createdAt : new Date(message.createdAt ?? Date.now()),
+  };
+}
+
+export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
+  readonly core: HarnessV1;
+  readonly mastra: Mastra;
+
+  private session?: Session;
+  private resourceId: string;
+  private readonly defaultResourceId: string;
+  private readonly modes: LegacyHarnessMode<TState>[];
+  private readonly defaultModeId: string;
+  private currentModeId: string;
+  private state: TState;
+  private readonly listeners = new Set<HarnessEventListener>();
+  private readonly projector: MastraCodeHarnessEventProjector;
+  private readonly heartbeatTimers = new Map<string, ReturnType<typeof setInterval>>();
+  private readonly heartbeatHandlers = new Map<string, NonNullable<MastraCodeRuntimeConfig<TState>['heartbeatHandlers']>[number]>();
+  private currentWorkspace: Awaited<ReturnType<Session['getWorkspace']>> | undefined;
+  private followUpCount = 0;
+  private currentRunId: string | null = null;
+  private currentTraceId: string | null = null;
+  private stateUpdateQueue: Promise<void> = Promise.resolve();
+
+  readonly actions = Object.freeze({
+    list: (options?: unknown) => this.requireSession().actions.list(options as never),
+    search: (query: string, options?: unknown) => this.requireSession().actions.search(query, options as never),
+    refresh: () => this.requireSession().actions.refresh(),
+  });
+
+  readonly mcp = Object.freeze({
+    listServers: () => this.requireSession().mcp.listServers(),
+    getServer: (key: string) => this.requireSession().mcp.getServer(key),
+    listTools: (key: string) => this.requireSession().mcp.listTools(key),
+  });
+
+  constructor(private readonly config: MastraCodeRuntimeConfig<TState>) {
+    this.resourceId = config.resourceId;
+    this.defaultResourceId = config.resourceId;
+    this.modes = config.modes;
+    this.defaultModeId = resolveDefaultModeId(config.modes);
+    this.currentModeId = this.defaultModeId;
+    this.state = { ...config.initialState };
+    const harnessV1Agents = toHarnessV1Agents(config.agents, config.modes);
+
+    this.mastra = new Mastra({
+      agents: harnessV1Agents,
+      storage: config.storage,
+      observability: config.observability,
+      workers: false,
+    });
+
+    this.core = new HarnessV1({
+      mastra: this.mastra,
+      runtimeCompatibilityGeneration: MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
+      modes: toHarnessV1Modes(config.modes, harnessV1Agents, this.defaultModeId),
+      defaultModeId: this.defaultModeId,
+      subagents: { maxDepth: 1, types: toHarnessV1Subagents(config.subagents) },
+      toolCategoryResolver: config.toolCategoryResolver,
+      models: [],
+      modelAuthStatusResolver: modelId => this.resolveHarnessV1AuthStatus(modelId),
+      workspace: config.workspace
+        ? {
+            kind: 'shared',
+            workspace: ({ requestContext }) => config.workspace!({ requestContext, mastra: this.mastra }),
+          }
+        : undefined,
+    });
+
+    this.projector = new MastraCodeHarnessEventProjector(
+      event => this.emit(event),
+      () => this.getDisplayState(),
+      async (threadId, resourceId) => {
+        const thread = await this.core.threads.get({ threadId, resourceId });
+        return thread ? toLegacyThread(thread) : undefined;
+      },
+    );
+
+    this.core.subscribe(event => {
+      void this.handleCoreEvent(event);
+    });
+
+    for (const handler of config.heartbeatHandlers ?? []) {
+      this.registerHeartbeat(handler);
+    }
+  }
+
+  getMastra(): Mastra {
+    return this.mastra;
+  }
+
+  async init(): Promise<void> {
+    await this.core.init();
+    await this.selectOrCreateThread();
+  }
+
+  subscribe(listener: HarnessEventListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit(event: HarnessEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        void listener(event);
+      } catch (error) {
+        console.error('MastraCode Harness event listener failed', error);
+      }
+    }
+  }
+
+  private async handleCoreEvent(event: HarnessV1Event): Promise<void> {
+    if ('runId' in event && typeof event.runId === 'string') this.currentRunId = event.runId;
+    if ('traceId' in event && typeof event.traceId === 'string') this.currentTraceId = event.traceId;
+    this.currentTraceId = this.session?.getDisplayState().currentTraceId ?? this.currentTraceId;
+    await this.projector.project(event);
+  }
+
+  async selectOrCreateThread(): Promise<HarnessThread> {
+    const existing = await this.core.threads.list({
+      resourceId: this.resourceId,
+      perPage: false,
+      orderBy: { column: 'updatedAt', direction: 'DESC' },
+    });
+    const projectPath = typeof this.state.projectPath === 'string' ? this.state.projectPath : undefined;
+    const existingThread = projectPath
+      ? existing.threads.find(thread => thread.metadata?.projectPath === projectPath)
+      : existing.threads[0];
+    const thread =
+      existingThread ??
+      (await this.core.threads.create({
+        resourceId: this.resourceId,
+        title: 'New thread',
+        metadata: this.buildThreadMetadata(),
+      }));
+    await this.applyThreadMetadata(thread.metadata);
+    this.session = await this.core.session({
+      resourceId: this.resourceId,
+      threadId: thread.id,
+      modeId: this.currentModeId,
+      modelId: this.resolveModeModel(this.currentModeId),
+    });
+    await this.ensureSessionState();
+    await this.resolveWorkspace().catch(() => undefined);
+    return toLegacyThread(thread);
+  }
+
+  async createThread({ title }: { title?: string } = {}): Promise<HarnessThread> {
+    const thread = await this.core.threads.create({
+      resourceId: this.resourceId,
+      title: title ?? 'New thread',
+      metadata: this.buildThreadMetadata(),
+    });
+    await this.applyThreadMetadata(thread.metadata);
+    this.session = await this.core.session({
+      resourceId: this.resourceId,
+      threadId: thread.id,
+      modeId: this.currentModeId,
+      modelId: this.resolveModeModel(this.currentModeId),
+    });
+    await this.ensureSessionState();
+    await this.resolveWorkspace().catch(() => undefined);
+    const legacy = toLegacyThread(thread);
+    this.emit({ type: 'thread_created', thread: legacy } as unknown as HarnessEvent);
+    return legacy;
+  }
+
+  async switchThread({ threadId }: { threadId: string }): Promise<void> {
+    const previousThreadId = this.session?.threadId ?? null;
+    const thread = await this.core.threads.get({ resourceId: this.resourceId, threadId });
+    if (!thread) {
+      throw new Error(`Thread not found: ${threadId}`);
+    }
+    await this.applyThreadMetadata(thread.metadata);
+    this.session = await this.core.session({
+      resourceId: this.resourceId,
+      threadId,
+      modeId: this.currentModeId,
+      modelId: this.resolveModeModel(this.currentModeId),
+    });
+    await this.ensureSessionState();
+    await this.resolveWorkspace().catch(() => undefined);
+    this.emit({ type: 'thread_changed', threadId, previousThreadId } as unknown as HarnessEvent);
+  }
+
+  async cloneThread({
+    threadId,
+    sourceThreadId,
+    title,
+    resourceId,
+  }: {
+    threadId?: string;
+    sourceThreadId?: string;
+    title?: string;
+    resourceId?: string;
+  } = {}): Promise<HarnessThread> {
+    const sourceId = sourceThreadId ?? threadId ?? this.requireSession().threadId;
+    const cloned = await this.core.threads.clone({
+      resourceId: resourceId ?? this.resourceId,
+      threadId: sourceId,
+      title,
+    });
+    if (cloned.resourceId !== this.resourceId) {
+      this.resourceId = cloned.resourceId;
+    }
+    await this.switchThread({ threadId: cloned.id });
+    const legacy = toLegacyThread(cloned);
+    this.emit({ type: 'thread_created', thread: legacy } as unknown as HarnessEvent);
+    return legacy;
+  }
+
+  async renameThread({ title }: { title: string }): Promise<void> {
+    const session = this.requireSession();
+    await this.core.threads.rename({ resourceId: this.resourceId, threadId: session.threadId, title });
+  }
+
+  async listThreads(options?: { allResources?: boolean; includeForkedSubagents?: boolean }): Promise<HarnessThread[]> {
+    if (options?.allResources) {
+      const memory = await this.getMemoryStorage();
+      const result = await memory.listThreads({
+        filter: undefined,
+        perPage: false,
+        orderBy: { field: 'updatedAt', direction: 'DESC' },
+      });
+      return result.threads
+        .filter((thread: any) => options.includeForkedSubagents || thread.metadata?.forkedSubagent !== true)
+        .map(toStoredThread);
+    }
+
+    const result = await this.core.threads.list({ resourceId: this.resourceId, perPage: false });
+    return result.threads
+      .filter(thread => options?.includeForkedSubagents || thread.metadata?.forkedSubagent !== true)
+      .map(toLegacyThread)
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  }
+
+  async setThreadSetting({ key, value }: { key: string; value: unknown }): Promise<void> {
+    const session = this.requireSession();
+    await this.core.threads.setSettings({
+      resourceId: this.resourceId,
+      threadId: session.threadId,
+      patch: { [key]: value },
+    });
+  }
+
+  getCurrentThreadId(): string | null {
+    return this.session?.threadId ?? null;
+  }
+
+  getResourceId(): string {
+    return this.resourceId;
+  }
+
+  setResourceId({ resourceId }: { resourceId: string }): void {
+    this.resourceId = resourceId;
+    this.session = undefined;
+    this.currentWorkspace = undefined;
+  }
+
+  getDefaultResourceId(): string {
+    return this.defaultResourceId;
+  }
+
+  async getKnownResourceIds(): Promise<string[]> {
+    const ids = new Set((await this.listThreads({ allResources: true, includeForkedSubagents: true })).map(thread => thread.resourceId));
+    ids.add(this.defaultResourceId);
+    ids.add(this.resourceId);
+    return [...ids].sort();
+  }
+
+  getState(): Readonly<TState> {
+    return this.state;
+  }
+
+  async setState(updates: Partial<TState>): Promise<void> {
+    const nextUpdate = this.stateUpdateQueue.then(async () => {
+      this.state = { ...this.state, ...updates };
+      if (this.session) {
+        await this.session.setState(this.state);
+      }
+      this.emit({ type: 'state_changed', state: this.state, changedKeys: Object.keys(updates) } as unknown as HarnessEvent);
+    });
+    this.stateUpdateQueue = nextUpdate.catch(error => {
+      console.error('MastraCode Harness state update failed', error);
+    });
+    return nextUpdate;
+  }
+
+  listModes(): LegacyHarnessMode<TState>[] {
+    return this.modes;
+  }
+
+  getCurrentModeId(): string {
+    return this.currentModeId;
+  }
+
+  getCurrentMode(): LegacyHarnessMode<TState> {
+    const mode = this.modes.find(entry => entry.id === this.currentModeId);
+    if (mode) return mode;
+    const fallback = this.modes[0];
+    if (!fallback) {
+      throw new Error('No modes configured for MastraCode Harness runtime');
+    }
+    return fallback;
+  }
+
+  async switchMode({ modeId }: { modeId: string }): Promise<void> {
+    const previousModeId = this.currentModeId;
+    const currentModelId = this.getCurrentModelId();
+    if (currentModelId) {
+      await this.setThreadSetting({ key: `modeModelId_${this.currentModeId}`, value: currentModelId });
+    }
+    this.currentModeId = modeId;
+    const session = this.requireSession();
+    await session.switchMode({ mode: modeId });
+    await this.setThreadSetting({ key: 'currentModeId', value: modeId });
+    await this.switchModel({ modelId: await this.loadModeModelId(modeId), modeId });
+    this.emit({ type: 'mode_changed', modeId, previousModeId } as unknown as HarnessEvent);
+  }
+
+  getCurrentModelId(): string {
+    return typeof this.state.currentModelId === 'string' ? this.state.currentModelId : '';
+  }
+
+  getModelName(): string {
+    const modelId = this.getCurrentModelId();
+    return modelId.split('/').pop() || modelId || 'unknown';
+  }
+
+  getFullModelId(): string {
+    return this.getCurrentModelId();
+  }
+
+  hasModelSelected(): boolean {
+    return this.getCurrentModelId().length > 0;
+  }
+
+  async switchModel({ modelId, scope = 'thread', modeId }: { modelId: string; scope?: 'global' | 'thread'; modeId?: string }): Promise<void> {
+    const targetModeId = modeId ?? this.currentModeId;
+    if (targetModeId === this.currentModeId) {
+      await this.setState({ currentModelId: modelId } as unknown as Partial<TState>);
+      await this.requireSession().models.switch({ model: modelId });
+    }
+    if (scope === 'thread') {
+      await this.setThreadSetting({ key: `modeModelId_${targetModeId}`, value: modelId });
+    }
+    await Promise.resolve(this.config.modelUseCountTracker?.(modelId)).catch(error => {
+      console.error('Failed to persist model usage count', error);
+    });
+    this.emit({ type: 'model_changed', modelId, scope, modeId: targetModeId } as unknown as HarnessEvent);
+  }
+
+  async listAvailableModels(): Promise<AvailableModel[]> {
+    const registry = PROVIDER_REGISTRY as Record<string, { models?: string[]; name?: string; apiKeyEnvVar?: string | string[] }>;
+    const useCounts = this.config.modelUseCountProvider?.() ?? {};
+    const modelsById = new Map<string, AvailableModel>();
+    const upsert = (model: Omit<AvailableModel, 'useCount'>) => {
+      if (!model.id || !model.provider || !model.modelName) return;
+      modelsById.set(model.id, { ...model, useCount: useCounts[model.id] ?? 0 });
+    };
+
+    for (const [provider, providerConfig] of Object.entries(registry)) {
+      const envVars = providerConfig.apiKeyEnvVar;
+      const apiKeyEnvVar = Array.isArray(envVars) ? envVars[0] : envVars;
+      let hasApiKey = apiKeyEnvVar ? Boolean(process.env[apiKeyEnvVar]) : false;
+      const customAuth = this.config.modelAuthChecker?.(provider);
+      if (customAuth === true) hasApiKey = true;
+      if (customAuth === false) hasApiKey = false;
+      for (const modelName of providerConfig.models ?? []) {
+        upsert({ id: `${provider}/${modelName}`, provider, modelName, hasApiKey, apiKeyEnvVar });
+      }
+    }
+
+    for (const customModel of (await Promise.resolve(this.config.customModelCatalogProvider?.()).catch(() => [])) ?? []) {
+      upsert(customModel);
+    }
+
+    return [...modelsById.values()];
+  }
+
+  async getCurrentModelAuthStatus(): Promise<ModelAuthStatus> {
+    const modelId = this.getCurrentModelId();
+    const model = (await this.listAvailableModels()).find(entry => entry.id === modelId);
+    if (model) return model.hasApiKey ? { hasAuth: true } : { hasAuth: false, apiKeyEnvVar: model.apiKeyEnvVar };
+    const provider = providerFromModelId(modelId);
+    const customAuth = provider ? this.config.modelAuthChecker?.(provider) : true;
+    if (customAuth === true || customAuth === undefined) return { hasAuth: true };
+    return { hasAuth: false };
+  }
+
+  getSubagentModelId({ agentType }: { agentType?: string } = {}): string | null {
+    if (!agentType) return (this.state.subagentModelId as string | undefined) ?? null;
+    return (this.state[`subagentModelId_${agentType}`] as string | undefined) ?? this.requireSession().models.getSubagent({ agentType });
+  }
+
+  async setSubagentModelId({ modelId, agentType }: { modelId: string; agentType?: string }): Promise<void> {
+    const key = agentType ? `subagentModelId_${agentType}` : 'subagentModelId';
+    if (agentType) {
+      await this.requireSession().models.setSubagent({ agentType, model: modelId });
+    }
+    await this.setState({ [key]: modelId } as unknown as Partial<TState>);
+    await this.setThreadSetting({ key, value: modelId });
+    this.emit({ type: 'subagent_model_changed', modelId, scope: 'thread', agentType } as unknown as HarnessEvent);
+  }
+
+  getObserverModelId(): string | undefined {
+    return getOMModelState(this.state).observerModelId;
+  }
+
+  getReflectorModelId(): string | undefined {
+    return getOMModelState(this.state).reflectorModelId;
+  }
+
+  getObservationThreshold(): number | undefined {
+    return getOMModelState(this.state).observationThreshold;
+  }
+
+  getReflectionThreshold(): number | undefined {
+    return getOMModelState(this.state).reflectionThreshold;
+  }
+
+  async switchObserverModel({ modelId }: { modelId: string }): Promise<void> {
+    await this.setState({ observerModelId: modelId } as unknown as Partial<TState>);
+    await this.setThreadSetting({ key: 'observerModelId', value: modelId });
+    this.emit({ type: 'om_model_changed', role: 'observer', modelId } as unknown as HarnessEvent);
+  }
+
+  async switchReflectorModel({ modelId }: { modelId: string }): Promise<void> {
+    await this.setState({ reflectorModelId: modelId } as unknown as Partial<TState>);
+    await this.setThreadSetting({ key: 'reflectorModelId', value: modelId });
+    this.emit({ type: 'om_model_changed', role: 'reflector', modelId } as unknown as HarnessEvent);
+  }
+
+  setPermissionForCategory({ category, policy }: { category: ToolCategory; policy: PermissionPolicy }): void {
+    void this.requireSession()
+      .permissions.setPolicy({ category, policy })
+      .catch(error => this.emitError(error));
+  }
+
+  setPermissionForTool({ toolName, policy }: { toolName: string; policy: PermissionPolicy }): void {
+    void this.requireSession()
+      .permissions.setPolicy({ toolName, policy })
+      .catch(error => this.emitError(error));
+  }
+
+  grantSessionCategory({ category }: { category: ToolCategory }): void {
+    void this.requireSession()
+      .permissions.grantCategory({ category })
+      .catch(error => this.emitError(error));
+  }
+
+  grantSessionTool({ toolName }: { toolName: string }): void {
+    void this.requireSession()
+      .permissions.grantTool({ toolName })
+      .catch(error => this.emitError(error));
+  }
+
+  getSessionGrants() {
+    return this.requireSession().permissions.getGrants();
+  }
+
+  getPermissionRules() {
+    return this.requireSession().permissions.getRules();
+  }
+
+  getToolCategory({ toolName }: { toolName: string }): ToolCategory | null {
+    return this.config.toolCategoryResolver?.(toolName) ?? null;
+  }
+
+  sendSignal(input: SignalInput): SignalHandle {
+    const session = this.requireSession();
+    if ('type' in input && input.type === 'system-reminder') {
+      const handle: SignalHandle = { id: `signal-${randomUUID()}`, accepted: Promise.resolve() };
+      handle.accepted = session
+        .injectSystemReminder(normalizeMessageContent({ content: input.contents }), {
+          attributes: toSystemReminderAttributes(input.attributes),
+          metadata: input.metadata,
+        })
+        .then(result => {
+          handle.id = result.id;
+        });
+      return handle;
+    }
+
+    const handle: SignalHandle = { id: `signal-${randomUUID()}`, accepted: Promise.resolve() };
+    handle.accepted = session.signal({ content: signalContents(input) as never, signalId: handle.id } as never).then(result => {
+      handle.id = result.id;
+    });
+    return handle;
+  }
+
+  async sendMessage({ content, files, admissionId }: { content: string; files?: unknown[]; admissionId?: string }): Promise<void> {
+    const session = this.requireSession();
+    await this.ensureSessionState();
+    await session.message({ content: messageContents(content, files), ...(admissionId ? { admissionId } : {}) } as never);
+  }
+
+  async listMessages(options?: { limit?: number }): Promise<HarnessMessage[]> {
+    return this.requireSession().listMessages(options);
+  }
+
+  async getFirstUserMessagesForThreads({ threadIds }: { threadIds: string[] }): Promise<Map<string, HarnessMessage>> {
+    if (threadIds.length === 0) return new Map();
+    const memory = await this.getMemoryStorage();
+    const result = await memory.listMessages({
+      threadId: threadIds,
+      perPage: false,
+      orderBy: { field: 'createdAt', direction: 'ASC' },
+    });
+    const messages = new Map<string, HarnessMessage>();
+    for (const message of result.messages) {
+      if (message.role !== 'user' && message.role !== 'signal') continue;
+      if (!message.threadId || messages.has(message.threadId)) continue;
+      messages.set(message.threadId, toHarnessMessage(message));
+      if (messages.size === threadIds.length) break;
+    }
+    return messages;
+  }
+
+  async getFirstUserMessageForThread({ threadId }: { threadId: string }): Promise<HarnessMessage | null> {
+    return (await this.getFirstUserMessagesForThreads({ threadIds: [threadId] })).get(threadId) ?? null;
+  }
+
+  async saveSystemReminderMessage({
+    message,
+    reminderType,
+    role = 'user',
+    metadata,
+  }: {
+    message: string;
+    reminderType: string;
+    role?: 'user' | 'assistant' | 'system';
+    metadata?: Record<string, unknown>;
+  }): Promise<HarnessMessage | null> {
+    const threadId = this.getCurrentThreadId();
+    if (!threadId) return null;
+    const memory = await this.getMemoryStorage();
+    const dbMessage = {
+      id: randomUUID(),
+      role,
+      threadId,
+      resourceId: this.resourceId,
+      createdAt: new Date(),
+      content: {
+        format: 2 as const,
+        parts: [],
+        content: '',
+        metadata: {
+          systemReminder: {
+            type: reminderType,
+            message,
+            ...metadata,
+          },
+        },
+      },
+    };
+    const result = await memory.saveMessages({ messages: [dbMessage] });
+    return toHarnessMessage(result.messages[0] ?? dbMessage);
+  }
+
+  abort(): void {
+    this.session?.abort({ reason: 'aborted' });
+  }
+
+  isRunning(): boolean {
+    return this.session?.isRunning() ?? false;
+  }
+
+  isCurrentThreadStreamActive(): boolean {
+    return this.isRunning();
+  }
+
+  getFollowUpCount(): number {
+    return this.followUpCount;
+  }
+
+  getCurrentRunId(): string | null {
+    return this.currentRunId;
+  }
+
+  getCurrentTraceId(): string | null {
+    return this.currentTraceId;
+  }
+
+  getDisplayState(): Readonly<HarnessDisplayState> {
+    const sessionState = this.session?.getDisplayState();
+    return {
+      ...defaultDisplayState,
+      ...emptyOMProgress(),
+      ...(sessionState ?? {}),
+      isRunning: this.isRunning(),
+      currentModelId: this.getCurrentModelId(),
+      currentModeId: this.currentModeId,
+      currentThreadId: this.getCurrentThreadId(),
+      resourceId: this.resourceId,
+      state: this.state,
+    } as unknown as HarnessDisplayState;
+  }
+
+  async loadOMProgress(): Promise<void> {
+    const threadId = this.getCurrentThreadId();
+    if (!threadId) return;
+
+    try {
+      const memory = await this.getMemoryStorage();
+      const record = await memory.getObservationalMemory?.(threadId, this.resourceId);
+      if (!record) return;
+
+      const config = record.config as
+        | {
+            observationThreshold?: number | { min: number; max: number };
+            reflectionThreshold?: number | { min: number; max: number };
+          }
+        | undefined;
+      const threshold = (value: number | { min: number; max: number } | undefined, fallback: number) =>
+        typeof value === 'number' ? value : (value?.max ?? fallback);
+
+      let messageTokens = record.pendingMessageTokens ?? 0;
+      let observationTokens = record.observationTokenCount ?? 0;
+      let observationThreshold = threshold(config?.observationThreshold, this.getObservationThreshold() ?? 30_000);
+      let reflectionThreshold = threshold(config?.reflectionThreshold, this.getReflectionThreshold() ?? 40_000);
+      let bufferedObs = emptyOMProgress().buffered!.observations;
+      let bufferedRef = emptyOMProgress().buffered!.reflection;
+      let generationCount = 0;
+      let stepNumber = 0;
+
+      const messages = await memory.listMessages({
+        threadId,
+        perPage: 70,
+        page: 0,
+        orderBy: { field: 'createdAt', direction: 'DESC' },
+      });
+      for (const message of messages.messages) {
+        if (message.role !== 'assistant') continue;
+        const parts = Array.isArray(message.content?.parts) ? message.content.parts : [];
+        const status = [...parts].reverse().find((part: any) => part?.type === 'data-om-status' && part.data?.windows) as
+          | { data?: any }
+          | undefined;
+        if (!status?.data?.windows) continue;
+        const windows = status.data.windows;
+        messageTokens = windows.active?.messages?.tokens ?? messageTokens;
+        observationTokens = windows.active?.observations?.tokens ?? observationTokens;
+        observationThreshold = windows.active?.messages?.threshold ?? observationThreshold;
+        reflectionThreshold = windows.active?.observations?.threshold ?? reflectionThreshold;
+        bufferedObs = { ...bufferedObs, ...(windows.buffered?.observations ?? {}) };
+        bufferedRef = { ...bufferedRef, ...(windows.buffered?.reflection ?? {}) };
+        generationCount = status.data.generationCount ?? generationCount;
+        stepNumber = status.data.stepNumber ?? stepNumber;
+        break;
+      }
+
+      this.emit({
+        type: 'om_status',
+        windows: {
+          active: {
+            messages: { tokens: messageTokens, threshold: observationThreshold },
+            observations: { tokens: observationTokens, threshold: reflectionThreshold },
+          },
+          buffered: { observations: bufferedObs, reflection: bufferedRef },
+        },
+        recordId: record.id ?? '',
+        threadId,
+        stepNumber,
+        generationCount,
+      } as unknown as HarnessEvent);
+    } catch {
+      // OM is optional; missing storage support should not break startup.
+    }
+
+    this.emit({ type: 'display_state_changed', displayState: this.getDisplayState() } as unknown as HarnessEvent);
+  }
+
+  respondToQuestion({ answer }: { questionId?: string; answer: unknown }): void {
+    void this.requireSession().respondToQuestion({ answer }).catch(error => this.emitError(error));
+  }
+
+  respondToToolApproval({ decision, approved, reason }: { decision?: 'approve' | 'decline' | 'deny' | 'always_allow_category'; approved?: boolean; reason?: string }): void {
+    if (decision === 'always_allow_category') {
+      const pending = this.requireSession().getDisplayState().pending as { toolName?: string } | undefined;
+      const category = pending?.toolName ? this.getToolCategory({ toolName: pending.toolName }) : null;
+      if (category) {
+        this.grantSessionCategory({ category });
+      }
+    }
+    void this.requireSession()
+      .respondToToolApproval({ approved: approved ?? (decision === 'approve' || decision === 'always_allow_category'), reason })
+      .catch(error => this.emitError(error));
+  }
+
+  async respondToPlanApproval({ response, approved, revision }: { planId?: string; response?: { action?: string; feedback?: string }; approved?: boolean; revision?: string }): Promise<void> {
+    const accepted = approved ?? response?.action !== 'rejected';
+    await this.requireSession().respondToPlanApproval({
+      approved: accepted,
+      revision: revision ?? response?.feedback,
+    });
+  }
+
+  getWorkspace() {
+    return this.currentWorkspace;
+  }
+
+  async getResolvedMemory() {
+    if (!this.config.memory) return null;
+    if (typeof this.config.memory !== 'function') return this.config.memory;
+    const requestContext = new RequestContext([
+      [
+        'harness',
+        {
+          harnessId: 'mastra-code',
+          threadId: this.getCurrentThreadId(),
+          resourceId: this.resourceId,
+          modeId: this.currentModeId,
+          state: this.state,
+          getState: () => this.state,
+        },
+      ],
+    ]) as RequestContext<unknown>;
+    return this.config.memory({ requestContext, mastra: this.mastra });
+  }
+
+  async resolveWorkspace() {
+    this.currentWorkspace = await this.session?.getWorkspace();
+    return this.currentWorkspace;
+  }
+
+  hasWorkspace(): boolean {
+    return Boolean(this.config.workspace);
+  }
+
+  isWorkspaceReady(): boolean {
+    return Boolean(this.config.workspace);
+  }
+
+  setBrowser(_browser: unknown): void {
+    this.emit({ type: 'info', message: 'Browser runtime is configured through MastraCode state under Harness v1.' } as unknown as HarnessEvent);
+  }
+
+  registerHeartbeat(handler: NonNullable<MastraCodeRuntimeConfig<TState>['heartbeatHandlers']>[number]): void {
+    if (this.heartbeatTimers.has(handler.id)) return;
+    this.heartbeatHandlers.set(handler.id, handler);
+    const run = () => {
+      void Promise.resolve(handler.handler()).catch(error => console.error(`Heartbeat ${handler.id} failed`, error));
+    };
+    if (handler.immediate !== false) run();
+    this.heartbeatTimers.set(handler.id, setInterval(run, handler.intervalMs));
+  }
+
+  async removeHeartbeat({ id }: { id: string }): Promise<void> {
+    const timer = this.heartbeatTimers.get(id);
+    if (timer) clearInterval(timer);
+    this.heartbeatTimers.delete(id);
+    const handler = this.heartbeatHandlers.get(id);
+    this.heartbeatHandlers.delete(id);
+    await Promise.resolve(handler?.shutdown?.());
+  }
+
+  async stopHeartbeats(): Promise<void> {
+    await Promise.all([...this.heartbeatHandlers.keys()].map(id => this.removeHeartbeat({ id })));
+  }
+
+  async destroy(): Promise<void> {
+    await this.stopHeartbeats();
+    await this.core.shutdown();
+  }
+
+  private requireSession(): Session {
+    if (!this.session) {
+      throw new Error('MastraCode Harness session has not been initialized');
+    }
+    return this.session;
+  }
+
+  private resolveModeModel(modeId: string): string {
+    const mode = this.modes.find(entry => entry.id === modeId) ?? this.modes[0];
+    return mode?.defaultModelId ?? this.getCurrentModelId();
+  }
+
+  private buildThreadMetadata(): Record<string, unknown> | undefined {
+    const metadata: Record<string, unknown> = {};
+    const modelId = this.getCurrentModelId() || this.resolveModeModel(this.currentModeId);
+    if (modelId) {
+      metadata.currentModelId = modelId;
+      metadata[`modeModelId_${this.currentModeId}`] = modelId;
+    }
+    metadata.currentModeId = this.currentModeId;
+
+    const projectPath = this.state.projectPath;
+    if (typeof projectPath === 'string' && projectPath.length > 0) {
+      metadata.projectPath = projectPath;
+    }
+    for (const key of [
+      'observerModelId',
+      'reflectorModelId',
+      'observationThreshold',
+      'reflectionThreshold',
+      'subagentModelId',
+      'cavemanObservations',
+    ]) {
+      if (this.state[key] !== undefined) metadata[key] = this.state[key];
+    }
+    for (const [key, value] of Object.entries(this.state)) {
+      if (key.startsWith('subagentModelId_') && value !== undefined) {
+        metadata[key] = value;
+      }
+    }
+
+    return Object.keys(metadata).length > 0 ? metadata : undefined;
+  }
+
+  private async applyThreadMetadata(metadata?: Record<string, unknown>): Promise<void> {
+    if (!metadata) {
+      await this.applyModeModelFallback();
+      return;
+    }
+
+    const updates: Record<string, unknown> = {};
+    const savedModeId = typeof metadata.currentModeId === 'string' ? metadata.currentModeId : undefined;
+    if (savedModeId && this.modes.some(mode => mode.id === savedModeId)) {
+      this.currentModeId = savedModeId;
+    }
+
+    const modeModelKey = `modeModelId_${this.currentModeId}`;
+    if (typeof metadata[modeModelKey] === 'string') {
+      updates.currentModelId = metadata[modeModelKey];
+    } else if (typeof metadata.currentModelId === 'string') {
+      updates.currentModelId = metadata.currentModelId;
+    } else {
+      const fallback = this.resolveModeModel(this.currentModeId);
+      if (fallback) updates.currentModelId = fallback;
+    }
+
+    for (const key of ['observerModelId', 'reflectorModelId', 'observationThreshold', 'reflectionThreshold', 'subagentModelId']) {
+      if (metadata[key] !== undefined) updates[key] = metadata[key];
+    }
+    for (const [key, value] of Object.entries(metadata)) {
+      if (key.startsWith('subagentModelId_') && typeof value === 'string') {
+        updates[key] = value;
+      }
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await this.setState(updates as Partial<TState>);
+    }
+  }
+
+  private async applyModeModelFallback(): Promise<void> {
+    const fallback = this.resolveModeModel(this.currentModeId);
+    if (fallback) {
+      await this.setState({ currentModelId: fallback } as unknown as Partial<TState>);
+    }
+  }
+
+  private async loadModeModelId(modeId: string): Promise<string> {
+    const session = this.requireSession();
+    const thread = await this.core.threads.get({ resourceId: this.resourceId, threadId: session.threadId });
+    const stored = thread?.metadata?.[`modeModelId_${modeId}`];
+    return typeof stored === 'string' ? stored : this.resolveModeModel(modeId);
+  }
+
+  private async getMemoryStorage() {
+    const memory = await this.config.storage.getStore('memory');
+    if (!memory) {
+      throw new Error('Memory storage is not configured for MastraCode Harness v1 runtime');
+    }
+    return memory;
+  }
+
+  private async ensureSessionState(): Promise<void> {
+    const session = this.requireSession();
+    const selectedModel = this.getCurrentModelId() || session.models.current() || this.resolveModeModel(this.currentModeId);
+    this.state = { ...this.state, currentModelId: selectedModel };
+    await session.models.switch({ model: selectedModel });
+    await session.setState(this.state);
+  }
+
+  private async resolveHarnessV1AuthStatus(modelId: string) {
+    const model = (await this.listAvailableModels()).find(entry => entry.id === modelId);
+    if (model) return toHarnessV1AuthStatus(model.hasApiKey);
+    const provider = providerFromModelId(modelId);
+    return toHarnessV1AuthStatus(provider ? this.config.modelAuthChecker?.(provider) : undefined);
+  }
+
+  async refreshModelCatalog(): Promise<MastraCodeModelInfo[]> {
+    return (await this.listAvailableModels()).map(toModelInfo);
+  }
+
+  private emitError(error: unknown): void {
+    this.emit({
+      type: 'error',
+      error: error instanceof Error ? error : new Error(String(error)),
+      message: error instanceof Error ? error.message : String(error),
+    } as unknown as HarnessEvent);
+  }
+}

--- a/mastracode/src/harness/subagents.ts
+++ b/mastracode/src/harness/subagents.ts
@@ -1,0 +1,31 @@
+import { Agent } from '@mastra/core/agent';
+import type { PubSub } from '@mastra/core/events';
+import type { HarnessSubagent } from '@mastra/core/harness';
+import type { MastraMemory } from '@mastra/core/memory';
+import type { RequestContext } from '@mastra/core/request-context';
+import type { DynamicArgument } from '@mastra/core/types';
+
+export function createHarnessV1SubagentAgents(
+  subagents: HarnessSubagent[],
+  resolveModel: (ctx: { requestContext: RequestContext }) => unknown,
+  services: { memory?: DynamicArgument<MastraMemory>; pubsub?: PubSub } = {},
+): Record<string, Agent> {
+  return Object.fromEntries(
+    subagents.map(subagent => {
+      const agent = new Agent({
+        id: `subagent-${subagent.id}`,
+        name: subagent.name,
+        instructions: subagent.instructions,
+        model: resolveModel as never,
+        tools: subagent.tools,
+      });
+      if (services.memory && !(agent as any).hasOwnMemory?.()) {
+        (agent as any).__setMemory?.(services.memory);
+      }
+      if (services.pubsub && !(agent as any).hasOwnPubSub?.()) {
+        (agent as any).__setPubSub?.(services.pubsub);
+      }
+      return [`subagent-${subagent.id}`, agent] as const;
+    }),
+  );
+}

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -2,16 +2,16 @@ import path from 'node:path';
 
 import { Agent } from '@mastra/core/agent';
 import type { PubSub } from '@mastra/core/events';
-import { Harness } from '@mastra/core/harness';
 import type {
   CustomAvailableModel,
+  Harness,
   HeartbeatHandler,
   HarnessConfig,
   HarnessMode,
   HarnessSubagent,
 } from '@mastra/core/harness';
 import { GatewayRegistry, PROVIDER_REGISTRY } from '@mastra/core/llm';
-import type { LanguageModel, ProviderConfig } from '@mastra/core/llm';
+import type { ProviderConfig } from '@mastra/core/llm';
 import {
   AgentsMDInjector,
   PrefillErrorHandler,
@@ -42,6 +42,7 @@ import { createDynamicTools } from './agents/tools.js';
 import { getDynamicWorkspace } from './agents/workspace.js';
 import { AuthStorage } from './auth/storage.js';
 import { createOutcomeScorer, createEfficiencyScorer } from './evals/scorers/index.js';
+import { createHarnessV1SubagentAgents, MastraCodeHarnessRuntime } from './harness/index.js';
 import { HookManager } from './hooks/index.js';
 import { createMcpManager } from './mcp/index.js';
 import type { McpServerConfig } from './mcp/index.js';
@@ -62,8 +63,6 @@ import { setAuthStorage } from './providers/claude-max.js';
 import { getCopilotModelCatalog, setAuthStorage as setGitHubCopilotAuthStorage } from './providers/github-copilot.js';
 import { setAuthStorage as setOpenAIAuthStorage } from './providers/openai-codex.js';
 
-import { stateSchema } from './schema.js';
-
 import { mastra } from './tui/theme.js';
 import { syncGateways } from './utils/gateway-sync.js';
 import {
@@ -75,7 +74,6 @@ import {
 import type { StorageConfig } from './utils/project.js';
 import { createSignalsPubSub } from './utils/signals-pubsub.js';
 import { createStorage, createVectorStore } from './utils/storage-factory.js';
-import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 
 const PROVIDER_TO_OAUTH_ID: Record<string, string> = {
   anthropic: 'anthropic',
@@ -141,6 +139,15 @@ export interface MastraCodeConfig {
   /** Marks the configured PubSub as cross-process-safe, allowing Mastra Code to skip file thread locks. */
   crossProcessPubSub?: boolean;
 }
+
+export type MastraCodeHarnessPublic = Harness<Record<string, unknown>> & {
+  actions: MastraCodeHarnessRuntime<Record<string, unknown>>['actions'];
+  mcp: MastraCodeHarnessRuntime<Record<string, unknown>>['mcp'];
+  getResolvedMemory: MastraCodeHarnessRuntime<Record<string, unknown>>['getResolvedMemory'];
+  saveSystemReminderMessage: MastraCodeHarnessRuntime<Record<string, unknown>>['saveSystemReminderMessage'];
+  stopHeartbeats: MastraCodeHarnessRuntime<Record<string, unknown>>['stopHeartbeats'];
+  destroy: MastraCodeHarnessRuntime<Record<string, unknown>>['destroy'];
+};
 
 export function createAuthStorage() {
   const authStorage = new AuthStorage();
@@ -504,6 +511,16 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     return model ? { ...filtered, defaultModelId: model } : filtered;
   });
 
+  if (memory && !(codeAgent as any).hasOwnMemory?.()) {
+    (codeAgent as any).__setMemory?.(memory);
+  }
+  if (signalsPubSub && !(codeAgent as any).hasOwnPubSub?.()) {
+    (codeAgent as any).__setPubSub?.(signalsPubSub);
+  }
+  if (config?.browser && typeof config.browser !== 'function' && !(codeAgent as any).hasOwnBrowser?.()) {
+    codeAgent.setBrowser(config.browser);
+  }
+
   // Build initial state with global preferences
   const globalInitialState: Record<string, unknown> = {};
   if (effectiveObserverModel) {
@@ -539,16 +556,91 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       globalInitialState[`subagentModelId_${key}`] = modelId;
     }
   }
-  const harness = new Harness({
-    id: 'mastra-code',
+  const modelAuthChecker = (provider: string) => {
+    // Gateway key only authorizes providers that the Mastra gateway actually serves
+    const gatewayKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
+    if (gatewayKey) {
+      const providerConfig = gatewayRegistry.getProviders()[provider];
+      if (providerConfig?.gateway === 'mastra') return true;
+    }
+    const oauthId = PROVIDER_TO_OAUTH_ID[provider];
+    if (oauthId && authStorage.isLoggedIn(oauthId)) {
+      return true;
+    }
+    // Check for user-entered API keys stored in auth.json
+    if (authStorage.hasStoredApiKey(provider)) {
+      return true;
+    }
+    // Backward-compatible direct credential checks for Anthropic/OpenAI storage keys.
+    if (provider === 'anthropic') {
+      const cred = authStorage.get('anthropic');
+      if (cred?.type === 'api_key' && cred.key.trim().length > 0) {
+        return true;
+      }
+    }
+    if (provider === 'openai') {
+      const cred = authStorage.get('openai-codex');
+      if (cred?.type === 'api_key' && cred.key.trim().length > 0) {
+        return true;
+      }
+    }
+
+    const customProvider = globalSettings.customProviders.find(entry => {
+      return provider === getCustomProviderId(entry.name);
+    });
+    if (customProvider) {
+      return true;
+    }
+    return undefined;
+  };
+
+  const customModelCatalogProvider = async () => {
+    const customModels: CustomAvailableModel[] = [];
+    for (const provider of globalSettings.customProviders) {
+      const providerId = getCustomProviderId(provider.name);
+      for (const modelName of provider.models) {
+        customModels.push({
+          id: toCustomProviderModelId(provider.name, modelName),
+          provider: providerId,
+          modelName,
+          hasApiKey: true,
+          apiKeyEnvVar: undefined,
+        });
+      }
+    }
+
+    // GitHub Copilot exposes its model list dynamically via `/models` since the
+    // available models depend on the user's subscription tier and any org policies.
+    // The catalog is cached + refreshed in the background, so steady-state cost is
+    // a single Map lookup.
+    try {
+      const copilotModels = await getCopilotModelCatalog({ authStorage });
+      for (const m of copilotModels) {
+        customModels.push({
+          id: `github-copilot/${m.id}`,
+          provider: 'github-copilot',
+          modelName: m.id,
+          hasApiKey: true,
+          apiKeyEnvVar: undefined,
+        });
+      }
+    } catch (error) {
+      console.warn('Failed to load GitHub Copilot model catalog:', error);
+    }
+
+    return customModels;
+  };
+
+  const harness = new MastraCodeHarnessRuntime({
     resourceId: project.resourceId,
     storage,
     observability,
     memory,
-    pubsub: signalsPubSub,
-    stateSchema,
+    agents: {
+      'code-agent': codeAgent,
+      ...createHarnessV1SubagentAgents(subagents, getDynamicModel as never, { memory, pubsub: signalsPubSub }),
+    },
     subagents,
-    resolveModel: modelId => resolveModel(modelId) as LanguageModel,
     toolCategoryResolver: getToolCategory,
     initialState: {
       projectPath: project.rootPath,
@@ -558,47 +650,10 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       ...globalInitialState,
       ...config?.initialState,
     },
-    workspace: config?.workspace ?? getDynamicWorkspace,
-    browser: config?.browser,
+    workspace: (config?.workspace as never) ?? getDynamicWorkspace,
     modes,
     heartbeatHandlers: config?.heartbeatHandlers ?? defaultHeartbeatHandlers,
-    modelAuthChecker: provider => {
-      // Gateway key only authorizes providers that the Mastra gateway actually serves
-      const gatewayKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
-      if (gatewayKey) {
-        const providerConfig = gatewayRegistry.getProviders()[provider];
-        if (providerConfig?.gateway === 'mastra') return true;
-      }
-      const oauthId = PROVIDER_TO_OAUTH_ID[provider];
-      if (oauthId && authStorage.isLoggedIn(oauthId)) {
-        return true;
-      }
-      // Check for user-entered API keys stored in auth.json
-      if (authStorage.hasStoredApiKey(provider)) {
-        return true;
-      }
-      // Backward-compatible direct credential checks for Anthropic/OpenAI storage keys.
-      if (provider === 'anthropic') {
-        const cred = authStorage.get('anthropic');
-        if (cred?.type === 'api_key' && cred.key.trim().length > 0) {
-          return true;
-        }
-      }
-      if (provider === 'openai') {
-        const cred = authStorage.get('openai-codex');
-        if (cred?.type === 'api_key' && cred.key.trim().length > 0) {
-          return true;
-        }
-      }
-
-      const customProvider = loadSettings().customProviders.find(entry => {
-        return provider === getCustomProviderId(entry.name);
-      });
-      if (customProvider) {
-        return true;
-      }
-      return undefined;
-    },
+    modelAuthChecker,
     modelUseCountProvider: () => loadSettings().modelUseCounts,
     modelUseCountTracker: modelId => {
       try {
@@ -609,53 +664,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
         console.error('Failed to persist model usage count', error);
       }
     },
-    customModelCatalogProvider: async () => {
-      const settings = loadSettings();
-      const customModels: CustomAvailableModel[] = [];
-      for (const provider of settings.customProviders) {
-        const providerId = getCustomProviderId(provider.name);
-        for (const modelName of provider.models) {
-          customModels.push({
-            id: toCustomProviderModelId(provider.name, modelName),
-            provider: providerId,
-            modelName,
-            hasApiKey: true,
-            apiKeyEnvVar: undefined,
-          });
-        }
-      }
-
-      // GitHub Copilot exposes its model list dynamically via `/models` since the
-      // available models depend on the user's subscription tier and any org policies.
-      // The catalog is cached + refreshed in the background, so steady-state cost is
-      // a single Map lookup.
-      //
-      // The provider uses the generic OpenAI-compatible adapter pointed at
-      // GitHub Copilot's API, so expose the full live model catalog returned by
-      // Copilot instead of filtering by vendor family here.
-      try {
-        const copilotModels = await getCopilotModelCatalog({ authStorage });
-        for (const m of copilotModels) {
-          customModels.push({
-            id: `github-copilot/${m.id}`,
-            provider: 'github-copilot',
-            modelName: m.id,
-            hasApiKey: true,
-            apiKeyEnvVar: undefined,
-          });
-        }
-      } catch (error) {
-        console.warn('Failed to load GitHub Copilot model catalog:', error);
-      }
-
-      return customModels;
-    },
-    threadLock: crossProcessPubSub
-      ? undefined
-      : {
-          acquire: acquireThreadLock,
-          release: releaseThreadLock,
-        },
+    customModelCatalogProvider,
   });
 
   // Sync hookManager session ID on thread changes
@@ -677,8 +686,10 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     // Persistence is best-effort; don't crash startup if storage hiccups.
   });
 
+  const harnessForConsumers = harness as unknown as MastraCodeHarnessPublic;
+
   return {
-    harness,
+    harness: harnessForConsumers,
     mcpManager,
     hookManager,
     signalsPubSub,

--- a/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
+++ b/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
@@ -177,4 +177,80 @@ describe('request_access', () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Access granted');
   });
+
+  it('registers a Harness v1 durable question when no legacy event emitter is present', async () => {
+    const registerQuestion = vi.fn(async () => undefined);
+    const suspend = vi.fn(async () => {
+      throw new Error('suspended');
+    });
+
+    const context = {
+      agent: {
+        runId: 'run-1',
+        toolCallId: 'tool-1',
+        suspend,
+      },
+      requestContext: {
+        get: (key: string) =>
+          key === 'harness'
+            ? {
+                registerQuestion,
+                getState: () => ({ sandboxAllowedPaths: [] }),
+                setState: vi.fn(),
+              }
+            : undefined,
+      },
+      workspace: {},
+    };
+
+    await (requestSandboxAccessTool as any).execute(
+      { path: '/outside/project/dir', reason: 'need to read config' },
+      context,
+    );
+
+    expect(registerQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        questionId: expect.stringMatching(/^sandbox_/),
+        question: expect.stringContaining('/outside/project/dir'),
+        runId: 'run-1',
+        toolCallId: 'tool-1',
+        selectionMode: 'single_select',
+      }),
+    );
+    expect(suspend).toHaveBeenCalledWith({}, undefined);
+  });
+
+  it('resumes a Harness v1 sandbox question from agent resumeData', async () => {
+    const { fs, setAllowedPaths } = createMockLocalFilesystem();
+    const setState = vi.fn();
+
+    const context = {
+      agent: {
+        resumeData: { answer: 'yes' },
+      },
+      requestContext: {
+        get: (key: string) =>
+          key === 'harness'
+            ? {
+                registerQuestion: vi.fn(),
+                getState: () => ({ sandboxAllowedPaths: [] }),
+                setState,
+              }
+            : undefined,
+      },
+      workspace: {
+        filesystem: fs,
+      },
+    };
+
+    const result = await (requestSandboxAccessTool as any).execute(
+      { path: '/outside/project/dir', reason: 'need to read config' },
+      context,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Access granted');
+    expect(setState).toHaveBeenCalledWith({ sandboxAllowedPaths: ['/outside/project/dir'] });
+    expect(setAllowedPaths).toHaveBeenCalledTimes(1);
+  });
 });

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -19,8 +19,31 @@ function expandTilde(p: string): string {
 }
 
 type MastraCodeState = z.infer<typeof stateSchema>;
+type ToolExecutionContext = {
+  agent?: {
+    runId?: string;
+    toolCallId?: string;
+    resumeData?: unknown;
+    suspend?: (payload: unknown) => Promise<never>;
+  };
+  requestContext?: {
+    get: (key: string) => unknown;
+  };
+  workspace?: {
+    filesystem?: unknown;
+  };
+};
 
 let requestCounter = 0;
+
+function answerApproved(answer: HarnessQuestionAnswer | unknown): boolean {
+  const value =
+    typeof answer === 'object' && answer !== null && 'answer' in answer
+      ? (answer as { answer: HarnessQuestionAnswer }).answer
+      : answer;
+  const answerText = Array.isArray(value) ? value.join(', ') : String(value ?? '');
+  return answerText.toLowerCase().startsWith('y') || answerText.toLowerCase() === 'approve';
+}
 
 export const requestSandboxAccessTool = createTool({
   id: 'request_access',
@@ -31,7 +54,9 @@ export const requestSandboxAccessTool = createTool({
   }),
   execute: async ({ path: requestedPath, reason }, context) => {
     try {
+      const toolContext = context as ToolExecutionContext | undefined;
       const harnessCtx = context?.requestContext?.get('harness') as HarnessRequestContext<MastraCodeState> | undefined;
+      const resumeData = toolContext?.agent?.resumeData;
 
       // Resolve to absolute path (expand ~ first since Node path APIs don't handle it)
       const expanded = expandTilde(requestedPath);
@@ -47,7 +72,7 @@ export const requestSandboxAccessTool = createTool({
         };
       }
 
-      if (!harnessCtx?.emitEvent || !harnessCtx?.registerQuestion) {
+      if (!harnessCtx?.registerQuestion) {
         return {
           content: `Cannot request sandbox access: TUI context not available. The user should manually run /sandbox add ${absolutePath}`,
           isError: true,
@@ -55,28 +80,42 @@ export const requestSandboxAccessTool = createTool({
       }
 
       const questionId = `sandbox_${++requestCounter}_${Date.now()}`;
+      let answer: HarnessQuestionAnswer | unknown = resumeData;
 
-      // Create a promise that resolves when the user answers in the TUI
-      const answer = await new Promise<HarnessQuestionAnswer>(resolve => {
-        // Register the resolver so respondToQuestion() can resolve it
-        harnessCtx.registerQuestion!({
-          questionId,
-          resolve: answer => {
-            resolve(Array.isArray(answer) ? answer.join(',') : answer);
-          },
+      if (answer === undefined && harnessCtx.emitEvent) {
+        // Legacy Harness path: emit directly and resolve through the in-memory callback registry.
+        answer = await new Promise<HarnessQuestionAnswer>(resolve => {
+          harnessCtx.registerQuestion!({
+            questionId,
+            resolve: value => {
+              resolve(Array.isArray(value) ? value.join(',') : value);
+            },
+          });
+
+          harnessCtx.emitEvent!({
+            type: 'sandbox_access_request',
+            questionId,
+            path: absolutePath,
+            reason,
+          });
         });
-
-        // Emit event — TUI will show the dialog
-        harnessCtx.emitEvent!({
-          type: 'sandbox_access_request',
+      } else if (answer === undefined && toolContext?.agent?.suspend) {
+        // Harness v1 path: park the tool through the durable question suspension surface.
+        await harnessCtx.registerQuestion({
           questionId,
-          path: absolutePath,
-          reason,
-        });
-      });
+          question: `Allow Mastra Code to access ${absolutePath}?\n\n${reason}`,
+          options: [
+            { label: 'Yes', description: 'Grant access for this session.' },
+            { label: 'No', description: 'Deny this access request.' },
+          ],
+          selectionMode: 'single_select',
+          runId: toolContext.agent.runId,
+          toolCallId: toolContext.agent.toolCallId ?? questionId,
+        } as never);
+        await toolContext.agent.suspend({});
+      }
 
-      const answerText = Array.isArray(answer) ? answer.join(', ') : answer;
-      const approved = answerText.toLowerCase().startsWith('y') || answerText.toLowerCase() === 'approve';
+      const approved = answerApproved(answer);
       if (approved) {
         // Add to allowed paths in harness state (persists across turns)
         const currentAllowed = (harnessCtx.getState?.()?.sandboxAllowedPaths as string[] | undefined) ?? [];

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -28,6 +28,7 @@ vi.mock('@mariozechner/pi-tui', () => ({
       autocompleteProviders.push({ commands });
     }
   },
+  Container: class {},
   Spacer: class {},
   Text: class {},
 }));

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -4,6 +4,8 @@ import { describe, it, expect } from 'vitest';
 import { theme, tintHex, ensureTerminalGlyphContrast } from '../../theme.js';
 import { ToolExecutionComponentEnhanced, parseErrorFromContent } from '../tool-execution-enhanced.js';
 
+chalk.level = 1;
+
 const ui = { requestRender() {} } as any;
 
 function stripAnsi(text: string): string {

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -341,6 +341,14 @@ export class MastraTUI {
     this.state.messageComponentsById.set(signalId, component);
   }
 
+  private remapSignalMessageId(previousId: string, signalId: string): void {
+    this.remapOptimisticUserMessage(previousId, signalId);
+    const pending = this.state.pendingSignalMessageComponentsById.get(previousId);
+    if (!pending || previousId === signalId) return;
+    this.state.pendingSignalMessageComponentsById.delete(previousId);
+    this.state.pendingSignalMessageComponentsById.set(signalId, pending);
+  }
+
   private createPendingNewThread(): Promise<void> | undefined {
     if (!this.state.pendingNewThread) return undefined;
     this.state.pendingNewThread = false;
@@ -365,11 +373,15 @@ export class MastraTUI {
       });
 
       const signal = this.state.harness.sendSignal({ content: this.createUserSignalContent(content, images) });
+      const optimisticSignalId = signal.id;
       this.remapOptimisticUserMessage(optimisticMessageId, signal.id);
-      signal.accepted.catch((error: unknown) => {
-        this.removeOptimisticUserMessage(signal.id);
-        showError(this.state, error instanceof Error ? error.message : 'Unknown error');
-      });
+      signal.accepted
+        .then(() => this.remapSignalMessageId(optimisticSignalId, signal.id))
+        .catch((error: unknown) => {
+          this.removeOptimisticUserMessage(signal.id);
+          this.removeOptimisticUserMessage(optimisticSignalId);
+          showError(this.state, error instanceof Error ? error.message : 'Unknown error');
+        });
     };
 
     const pendingThread = this.createPendingNewThread();
@@ -390,6 +402,7 @@ export class MastraTUI {
     const send = () => {
       this.clearIdleCounter();
       const signal = this.state.harness.sendSignal({ content: this.createUserSignalContent(content, images) });
+      const optimisticSignalId = signal.id;
 
       if (hasActiveRun) {
         addPendingUserMessage(this.state, signal.id, content, images);
@@ -397,14 +410,18 @@ export class MastraTUI {
         addUserMessage(this.state, this.createUserSignalMessage(content, images, signal.id));
       }
 
-      signal.accepted.catch((error: unknown) => {
-        if (hasActiveRun) {
-          removePendingUserMessage(this.state, signal.id);
-        } else {
-          this.removeOptimisticUserMessage(signal.id);
-        }
-        showError(this.state, error instanceof Error ? error.message : 'Unknown error');
-      });
+      signal.accepted
+        .then(() => this.remapSignalMessageId(optimisticSignalId, signal.id))
+        .catch((error: unknown) => {
+          if (hasActiveRun) {
+            removePendingUserMessage(this.state, signal.id);
+            removePendingUserMessage(this.state, optimisticSignalId);
+          } else {
+            this.removeOptimisticUserMessage(signal.id);
+            this.removeOptimisticUserMessage(optimisticSignalId);
+          }
+          showError(this.state, error instanceof Error ? error.message : 'Unknown error');
+        });
     };
 
     const pendingThread = this.createPendingNewThread();

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -143,6 +143,7 @@ export type {
   HarnessChannelRouteContext,
   HarnessChannelTransportRequest,
   HarnessConfig,
+  HarnessMessageContentPart,
   HarnessMcpServerDescriptor,
   HarnessMcpToolDescriptor,
   HarnessMode,

--- a/packages/core/src/harness/v1/session.spawn-subagent.test.ts
+++ b/packages/core/src/harness/v1/session.spawn-subagent.test.ts
@@ -27,6 +27,7 @@ import { createSpawnSubagentTool, SPAWN_SUBAGENT_TOOL_ID } from './spawn-subagen
 
 class FakeAgent extends Agent<any, any, any> {
   chunks: any[] = [];
+  lastStreamOptions: any;
   fullOutput: any = {
     text: 'child-result',
     usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
@@ -59,6 +60,7 @@ class FakeAgent extends Agent<any, any, any> {
   }
 
   async stream(_messages: any, options?: any): Promise<any> {
+    this.lastStreamOptions = options;
     const out = buildFakeOutput({
       runId: options?.runId ?? this.fullOutput.runId,
       fullOutput: this.fullOutput,
@@ -77,7 +79,7 @@ class FakeAgent extends Agent<any, any, any> {
   }
 }
 
-function setup(opts?: { maxDepth?: number; chunks?: any[] }) {
+function setup(opts?: { maxDepth?: number; chunks?: any[]; allowedWorkspaceTools?: string[] }) {
   const parentAgent = new FakeAgent('parent-agent');
   const childAgent = new FakeAgent('child-agent');
   if (opts?.chunks) childAgent.chunks = opts.chunks;
@@ -98,6 +100,7 @@ function setup(opts?: { maxDepth?: number; chunks?: any[] }) {
           modeId: 'explore-mode',
           description: 'Read-only codebase exploration',
           defaultModelId: 'openai/gpt-4o-mini',
+          allowedWorkspaceTools: opts?.allowedWorkspaceTools,
           workspace: 'inherit',
         },
       },
@@ -115,6 +118,20 @@ function execCtx(toolCallId = 'tc-1') {
     tracingContext: {} as any,
     requestContext: { get: () => undefined } as any,
     mastra: undefined,
+  } as any;
+}
+
+function execCtxWithWorkspace(toolCallId = 'tc-1') {
+  return {
+    ...execCtx(toolCallId),
+    workspace: {
+      getToolsConfig: () => ({
+        mastra_workspace_read_file: { name: 'view' },
+        mastra_workspace_list_files: { name: 'find_files' },
+        mastra_workspace_write_file: { name: 'write_file' },
+      }),
+      filesystem: { readOnly: false },
+    },
   } as any;
 }
 
@@ -273,5 +290,25 @@ describe('spawn_subagent tool — execution', () => {
     const childId = result.subagentSessionId as string;
     const childRecord = await storage.loadSession({ sessionId: childId });
     expect(childRecord?.closedAt).toBeDefined();
+  });
+
+  it('filters model-visible workspace tools for subagents with allowedWorkspaceTools', async () => {
+    const { harness, childAgent } = setup({ allowedWorkspaceTools: ['view', 'find_files'] });
+    const parent = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const tool = createSpawnSubagentTool(parent)!;
+
+    await tool.execute!({ agentType: 'explore', task: 'read only' }, execCtxWithWorkspace('tc-ws-filter'));
+
+    expect(childAgent.lastStreamOptions?.prepareStep).toBeTypeOf('function');
+    const result = childAgent.lastStreamOptions.prepareStep({
+      tools: {
+        view: {},
+        find_files: {},
+        write_file: {},
+        shell: {},
+      },
+    });
+    expect(result.activeTools).toEqual(expect.arrayContaining(['view', 'find_files', 'shell']));
+    expect(result.activeTools).not.toContain('write_file');
   });
 });

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -2769,6 +2769,9 @@ export class Session {
     if (opts.admissionId !== undefined && opts.additionalTools !== undefined) {
       throw new HarnessValidationError('message().admissionId', 'admissionId cannot be combined with additionalTools');
     }
+    if (opts.admissionId !== undefined && opts.prepareStep !== undefined) {
+      throw new HarnessValidationError('message().admissionId', 'admissionId cannot be combined with prepareStep');
+    }
     if (opts.admissionId !== undefined && opts.admissionId.length === 0) {
       throw new HarnessValidationError('message().admissionId', 'admissionId must be a non-empty string');
     }
@@ -2876,6 +2879,7 @@ export class Session {
       abortSignal: turnAbortSignal,
       requestContext,
       ...(toolsets ? { toolsets } : {}),
+      ...(opts.prepareStep ? { prepareStep: opts.prepareStep } : {}),
       ...(mode.instructions ? { instructions: mode.instructions } : {}),
     };
 
@@ -2888,7 +2892,7 @@ export class Session {
     if (opts.output !== undefined && opts.sync === true) {
       try {
         const result = await Promise.race([
-          agent.generate(opts.content, {
+          agent.generate(opts.content as never, {
             ...baseExecOptions,
             structuredOutput: { schema: opts.output as never },
           }),
@@ -3793,8 +3797,11 @@ export class Session {
   // -------------------------------------------------------------------------
   async signal(opts: SessionSignalOptions): Promise<SessionSignalResult> {
     this._assertLive('signal()');
-    if (typeof opts.content !== 'string') {
-      throw new HarnessValidationError('signal()', '`content` must be a string');
+    if (typeof opts.content !== 'string' && !Array.isArray(opts.content)) {
+      throw new HarnessValidationError('signal()', '`content` must be a string or content part array');
+    }
+    if (opts.signalId !== undefined && (typeof opts.signalId !== 'string' || opts.signalId.length === 0)) {
+      throw new HarnessValidationError('signal().signalId', 'signalId must be a non-empty string');
     }
 
     // Resolve effective mode + backing agent.
@@ -3871,7 +3878,7 @@ export class Session {
         this._emitTurnEvent({ type: 'agent_start' });
 
         dispatched = agent.sendSignal(
-          { type: 'user-message', contents: opts.content as never },
+          { ...(opts.signalId ? { id: opts.signalId } : {}), type: 'user-message', contents: opts.content as never },
           {
             resourceId: this.resourceId,
             threadId: this.threadId,
@@ -3929,7 +3936,7 @@ export class Session {
     // bookkeeping owned here; the in-flight run owns its own completion.
     // Pass empty streamOptions — the runtime ignores them when active.
     const dispatched = agent.sendSignal(
-      { type: 'user-message', contents: opts.content as never },
+      { ...(opts.signalId ? { id: opts.signalId } : {}), type: 'user-message', contents: opts.content as never },
       {
         resourceId: this.resourceId,
         threadId: this.threadId,

--- a/packages/core/src/harness/v1/spawn-subagent-tool.ts
+++ b/packages/core/src/harness/v1/spawn-subagent-tool.ts
@@ -19,6 +19,7 @@
 import { z } from 'zod';
 
 import { createTool } from '../../tools/tool';
+import { createWorkspaceTools } from '../../workspace/tools';
 import { HarnessSubagentDepthExceededError, HarnessValidationError } from './errors';
 import type { Session } from './session';
 import type { SubagentDefinition } from './types';
@@ -165,6 +166,27 @@ export function createSpawnSubagentTool(parent: Session) {
       const subagentWorkspaceMode = def.workspace ?? 'inherit';
       child._subagentInheritWorkspace = subagentWorkspaceMode === 'inherit';
 
+      const allowedWorkspaceTools = def.allowedWorkspaceTools ? new Set(def.allowedWorkspaceTools) : undefined;
+      const workspaceToolNames =
+        allowedWorkspaceTools && ctx.workspace
+          ? new Set(
+              Object.keys(
+                await createWorkspaceTools(ctx.workspace, {
+                  requestContext: ctx.requestContext ?? {},
+                  workspace: ctx.workspace,
+                }),
+              ),
+            )
+          : undefined;
+      const prepareStep =
+        allowedWorkspaceTools && workspaceToolNames
+          ? ({ tools }: { tools?: Record<string, unknown> }) => ({
+              activeTools: Object.keys(tools ?? {}).filter(
+                name => !workspaceToolNames.has(name) || allowedWorkspaceTools.has(name),
+              ),
+            })
+          : undefined;
+
       // Bridge the child's per-turn events into the parent's subscriber
       // stream as `subagent_*`. `_emitSubagentEvent` stamps `parentId` and
       // `queuedItemId` automatically. Track inner tool names by call id so
@@ -252,7 +274,11 @@ export function createSpawnSubagentTool(parent: Session) {
       let result: unknown;
       let isError = false;
       try {
-        result = await child.message({ content: task, abortSignal: ctx.abortSignal });
+        result = await child.message({
+          content: task,
+          abortSignal: ctx.abortSignal,
+          ...(prepareStep ? { prepareStep } : {}),
+        });
       } catch (err) {
         isError = true;
         result = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -1123,6 +1123,13 @@ export interface SubagentDefinition {
    * accepted now so configs don't need to change later.
    */
   workspace?: 'inherit' | 'fresh';
+
+  /**
+   * Workspace tool keys the subagent may see. When set, workspace tools not
+   * in the list are hidden for the subagent turn while non-workspace tools
+   * remain available.
+   */
+  allowedWorkspaceTools?: string[];
 }
 
 /**
@@ -1415,14 +1422,36 @@ export interface MessageOverrides {
    * `HarnessMode.additionalTools` semantics.
    */
   additionalTools?: ToolsInput;
+
+  /**
+   * Optional per-turn tool preparation hook forwarded to the backing agent.
+   * Runtime compatibility layers use this to adjust the model-visible tool
+   * surface without changing persisted mode config.
+   */
+  prepareStep?: AgentExecutionOptionsBase<unknown>['prepareStep'];
 }
+
+export type HarnessMessageContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image'; image?: unknown; image_url?: string | { url: string; detail?: string }; mediaType?: string }
+  | { type: 'file'; data?: string; file?: unknown; mediaType?: string; mimeType?: string; url?: string }
+  | { type: 'tool-call'; toolCall?: unknown; toolCallId?: string; toolName?: string; args?: unknown }
+  | {
+      type: 'tool-result';
+      toolResult?: unknown;
+      toolCallId?: string;
+      toolName?: string;
+      result?: unknown;
+      isError?: boolean;
+    }
+  | { type: 'reasoning'; reasoning: string };
 
 /**
  * Common fields shared by every `message()` call.
  */
 interface MessageOptionsBase extends MessageOverrides {
   /** Free-form user content. The only required field. */
-  content: string;
+  content: string | HarnessMessageContentPart[];
 
   /** Optional idempotency key for retry-safe signal-driven messages. */
   admissionId?: string;
@@ -1582,7 +1611,10 @@ export interface ListMessagesOptions {
 /** Options accepted by `Session.signal(...)`. */
 export interface SessionSignalOptions {
   /** Free-form user content. Matches `message().content`. */
-  content: string;
+  content: string | HarnessMessageContentPart[];
+
+  /** Optional caller-supplied signal id for optimistic host UI reconciliation. */
+  signalId?: string;
 
   /** Per-turn mode override (same semantics as `message().mode`). */
   mode?: string;


### PR DESCRIPTION
## Summary
- Add a dedicated MastraCode Harness v1 runtime layer that builds v1 `Session`s while preserving the MC compatibility surface.
- Wire v1 actions/MCP, stable signal ids, file/image content parts, thread metadata restore, projectPath-aware thread selection, system reminders, OM progress, subagent event projection, and sync workspace access.
- Extend Harness v1 with typed message content parts and subagent `allowedWorkspaceTools` filtering so MC subagents keep their read-only tool contracts.
- Preserve legacy Harness code paths; this PR adds the v1 runtime path without deleting `HarnessLegacy`.

## Verification
- `git diff --check`
- `COREPACK_ENABLE_STRICT=0 pnpm --filter mastracode check`
- `COREPACK_ENABLE_STRICT=0 pnpm --filter mastracode lint`
- `COREPACK_ENABLE_STRICT=0 pnpm --filter mastracode test --run` (95 files, 1003 tests)
- `COREPACK_ENABLE_STRICT=0 pnpm --filter @mastra/core typecheck`
- `COREPACK_ENABLE_STRICT=0 pnpm --filter @mastra/core lint`
- `COREPACK_ENABLE_STRICT=0 pnpm --filter @mastra/core test src/harness/v1/session.signal.test.ts src/harness/v1/session.message.test.ts src/harness/v1/session.spawn-subagent.test.ts --run` (66 tests, no type errors)
- MC smoke snapshot: `createMastraCode()`, `harness.init()`, `actions.list()`, system reminder persistence, sync `getWorkspace()`

## Review Notes
- CodeRabbit local review found 3 items; valid items were fixed. The suspend assertion suggestion was skipped because the wrapped tool mock records `suspend({}, undefined)` and the focused test verifies that behavior.
- Claude Opus max CLI review was attempted, but the CLI produced no output for more than 6 minutes and was killed. Not counted as a completed review.

Depends on parent Harness v1 core stack in #16912.
