### PR TITLE
fix(server): restore agent-builder permissions in generated catalog

### DIFF
--- a/.changeset/restore-agent-builder-permissions.md
+++ b/.changeset/restore-agent-builder-permissions.md
@@ -1,0 +1,6 @@
+---
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Restore `agent-builder:*` permissions in the generated permission catalog. The FGA route policy coverage refactor (#16651) regenerated `permissions.generated.ts` from `SERVER_ROUTES`, but `AGENT_BUILDER_ROUTES` is intentionally excluded from that array (deferred-import for Cloudflare Workers compatibility, see #16499). As a result `agent-builder:read`, `agent-builder:write`, `agent-builder:execute`, and `agent-builder:*` were silently dropped from `PERMISSION_PATTERNS`, breaking typed `RoleMapping` configs that reference them. The permission generator now also walks `AGENT_BUILDER_ROUTES` so the catalog matches runtime FGA behavior, without changing the lazy-loading guarantee.

--- a/packages/core/src/auth/ee/interfaces/permissions.generated.ts
+++ b/packages/core/src/auth/ee/interfaces/permissions.generated.ts
@@ -13,12 +13,15 @@
  */
 export const RESOURCES = [
   'a2a',
+  'agent-builder',
   'agents',
+  'auth',
   'background-tasks',
   'channels',
   'datasets',
   'embedders',
   'experiments',
+  'infrastructure',
   'logs',
   'mcp',
   'memory',
@@ -86,8 +89,12 @@ export const PERMISSION_PATTERNS = {
   '*:write': '*:write',
   /** Full access to agent-to-agent communication */
   'a2a:*': 'a2a:*',
+  /** Full access to agent builder */
+  'agent-builder:*': 'agent-builder:*',
   /** Full access to agents */
   'agents:*': 'agents:*',
+  /** Full access to auth */
+  'auth:*': 'auth:*',
   /** Full access to background tasks */
   'background-tasks:*': 'background-tasks:*',
   /** Full access to channels */
@@ -98,6 +105,8 @@ export const PERMISSION_PATTERNS = {
   'embedders:*': 'embedders:*',
   /** Full access to experiments */
   'experiments:*': 'experiments:*',
+  /** Full access to infrastructure */
+  'infrastructure:*': 'infrastructure:*',
   /** Full access to logs */
   'logs:*': 'logs:*',
   /** Full access to MCP servers */
@@ -144,6 +153,12 @@ export const PERMISSION_PATTERNS = {
   'a2a:read': 'a2a:read',
   /** Create and modify agent-to-agent communication */
   'a2a:write': 'a2a:write',
+  /** Execute agent builder */
+  'agent-builder:execute': 'agent-builder:execute',
+  /** View agent builder */
+  'agent-builder:read': 'agent-builder:read',
+  /** Create and modify agent builder */
+  'agent-builder:write': 'agent-builder:write',
   /** Create agents */
   'agents:create': 'agents:create',
   /** Delete agents */
@@ -154,6 +169,8 @@ export const PERMISSION_PATTERNS = {
   'agents:read': 'agents:read',
   /** Create and modify agents */
   'agents:write': 'agents:write',
+  /** View auth */
+  'auth:read': 'auth:read',
   /** View background tasks */
   'background-tasks:read': 'background-tasks:read',
   /** View channels */
@@ -172,6 +189,8 @@ export const PERMISSION_PATTERNS = {
   'embedders:read': 'embedders:read',
   /** View experiments */
   'experiments:read': 'experiments:read',
+  /** View infrastructure */
+  'infrastructure:read': 'infrastructure:read',
   /** View logs */
   'logs:read': 'logs:read',
   /** Execute MCP servers */
@@ -316,11 +335,15 @@ export type PermissionPattern = keyof typeof PERMISSION_PATTERNS;
 export const PERMISSIONS = [
   'a2a:read',
   'a2a:write',
+  'agent-builder:execute',
+  'agent-builder:read',
+  'agent-builder:write',
   'agents:create',
   'agents:delete',
   'agents:execute',
   'agents:read',
   'agents:write',
+  'auth:read',
   'background-tasks:read',
   'channels:read',
   'channels:write',
@@ -330,6 +353,7 @@ export const PERMISSIONS = [
   'datasets:write',
   'embedders:read',
   'experiments:read',
+  'infrastructure:read',
   'logs:read',
   'mcp:execute',
   'mcp:read',
@@ -405,6 +429,12 @@ export const MastraFGAPermissions = {
   A2A_READ: 'a2a:read',
   /** Create and modify agent-to-agent communication */
   A2A_WRITE: 'a2a:write',
+  /** Execute agent builder */
+  AGENT_BUILDER_EXECUTE: 'agent-builder:execute',
+  /** View agent builder */
+  AGENT_BUILDER_READ: 'agent-builder:read',
+  /** Create and modify agent builder */
+  AGENT_BUILDER_WRITE: 'agent-builder:write',
   /** Create agents */
   AGENTS_CREATE: 'agents:create',
   /** Delete agents */
@@ -415,6 +445,8 @@ export const MastraFGAPermissions = {
   AGENTS_READ: 'agents:read',
   /** Create and modify agents */
   AGENTS_WRITE: 'agents:write',
+  /** View auth */
+  AUTH_READ: 'auth:read',
   /** View background tasks */
   BACKGROUND_TASKS_READ: 'background-tasks:read',
   /** View channels */
@@ -433,6 +465,8 @@ export const MastraFGAPermissions = {
   EMBEDDERS_READ: 'embedders:read',
   /** View experiments */
   EXPERIMENTS_READ: 'experiments:read',
+  /** View infrastructure */
+  INFRASTRUCTURE_READ: 'infrastructure:read',
   /** View logs */
   LOGS_READ: 'logs:read',
   /** Execute MCP servers */

--- a/packages/server/scripts/permission-generator.ts
+++ b/packages/server/scripts/permission-generator.ts
@@ -10,6 +10,7 @@
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { AGENT_BUILDER_ROUTES } from '../src/server/server-adapter/routes/agent-builder.js';
 import { SERVER_ROUTES } from '../src/server/server-adapter/routes/index.js';
 import { getEffectivePermission } from '../src/server/server-adapter/routes/permissions.js';
 
@@ -119,7 +120,14 @@ export function derivePermissionData(): PermissionData {
   const actionSet = new Set<string>();
   const permissionSet = new Set<string>();
 
-  for (const route of SERVER_ROUTES) {
+  // AGENT_BUILDER_ROUTES are intentionally excluded from SERVER_ROUTES so the
+  // routes barrel does not eagerly import @mastra/agent-builder (Cloudflare
+  // Workers compat — see agent-builder-loading.test.ts). They are still
+  // protected at runtime by `agent-builder:*` permissions, so include them
+  // here when deriving the permission catalog.
+  const routesForPermissions = [...SERVER_ROUTES, ...AGENT_BUILDER_ROUTES];
+
+  for (const route of routesForPermissions) {
     const permission = getEffectivePermission(route);
     if (permission) {
       const perms = Array.isArray(permission) ? permission : [permission];


### PR DESCRIPTION
## Summary

The `agent-builder:read`, `agent-builder:write`, `agent-builder:execute`, and `agent-builder:*` permissions silently dropped out of `packages/core/src/auth/ee/interfaces/permissions.generated.ts`, which made typed `RoleMapping` configs that reference them fail at compile time. Runtime FGA still works (it derives the permission from path/method), so this is a **type-only regression**.

## Root cause

#16651 (FGA route policy coverage) regenerated the permission catalog from `SERVER_ROUTES`. `AGENT_BUILDER_ROUTES` is deliberately *not* spread into `SERVER_ROUTES` so that importing the routes barrel does not eagerly load `@mastra/agent-builder` (Cloudflare Workers compat from #16499 — see `agent-builder-loading.test.ts`).

The generator therefore never saw agent-builder routes.

## Fix

`packages/server/scripts/permission-generator.ts` now walks `AGENT_BUILDER_ROUTES` in addition to `SERVER_ROUTES` when deriving the permission catalog. The runtime `SERVER_ROUTES` array is unchanged, so the lazy-load guarantee is preserved.

## Test plan

- `pnpm --filter @mastra/server generate:permissions` — regenerates with `agent-builder:*` restored
- `pnpm --filter @mastra/server test` — all 1585 tests pass, including `agent-builder-loading.test.ts` which asserts `SERVER_ROUTES` still does not contain `/agent-builder` paths
- Manual: `RoleMapping` configs in example apps that reference `'agent-builder:*'` now typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

The permission system lost track of "agent-builder" permissions when generating type definitions—making TypeScript angry even though the runtime still worked. The fix was to update the permission generator to also look at agent-builder routes (in addition to the main routes) when creating the type definitions, without changing how those routes are lazily loaded.

---

## Summary of Changes

This PR restores `agent-builder` permissions (`agent-builder:read`, `agent-builder:write`, `agent-builder:execute`, and `agent-builder:*`) to the generated permission catalog.

### Problem

Commit `#16651` regenerated the permission catalog from `SERVER_ROUTES`, but `AGENT_BUILDER_ROUTES` is deliberately omitted from `SERVER_ROUTES` to preserve lazy-loading behavior (avoiding eager imports of `@mastra/agent-builder` for Cloudflare Workers compatibility). This caused the generator to silently drop agent-builder permissions from `PERMISSION_PATTERNS`, breaking TypeScript type-checking for `TypedRoleMapping` configs that referenced those permissions. Runtime FGA continued to derive them correctly from path/method, so this was a type-only regression.

### Solution

Updated `packages/server/scripts/permission-generator.ts` to walk both `SERVER_ROUTES` and `AGENT_BUILDER_ROUTES` when deriving the permission catalog. This restores agent-builder permissions to the generated types without changing the lazy-loading guarantee (SERVER_ROUTES itself remains unchanged).

### Files Modified

- **packages/core/src/auth/ee/interfaces/permissions.generated.ts** — Restored agent-builder permissions (plus auth and infrastructure) to `RESOURCES`, `PERMISSION_PATTERNS`, `PERMISSIONS`, and `MastraFGAPermissions`
- **packages/server/scripts/permission-generator.ts** — Now imports and includes `AGENT_BUILDER_ROUTES` in permission derivation
- **.changeset/restore-agent-builder-permissions.md** — Changeset documentation

### Testing & Verification

- All 1585 server tests pass
- `agent-builder-loading.test.ts` verifies `SERVER_ROUTES` still excludes `/agent-builder` paths
- Developers regenerate permissions via `pnpm --filter `@mastra/server` generate:permissions`
- `TypedRoleMapping` configs referencing `agent-builder:*` now typecheck correctly

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->