### PR TITLE
fix(core): remove stale createdAt to fix agent response ordering (fixes #16893)

### DIFF
--- a/.changeset/fix-agent-response-ordering.md
+++ b/.changeset/fix-agent-response-ordering.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+fix(core): remove stale createdAt to fix agent response ordering (fixes #16893)

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1377,7 +1377,6 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               messageId: currentStep.messageId,
               responseModelMetadata: buildResponseModelMetadata(runState, currentStep.model),
               tools: currentStep.tools,
-              createdAt: currentStep.createdAt,
             });
             for (const msg of builtMessages) {
               messageList.add(msg, 'response');


### PR DESCRIPTION
Closes #16893

## Summary
This PR fixes a P1 regression where agent response messages were incorrectly timestamped with the step's start time, causing mis-ordering in the conversation history and leading to duplicate tool calls.

### Changes
File: packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
Removed the explicit createdAt: currentStep.createdAt argument from the buildMessagesFromChunks call, allowing it to use the default new Date() value at the time of message construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an AI agent responds to messages, those response messages were being timestamped with the time the step *started* rather than when the response was actually built. This caused the responses to appear earlier in the conversation history than they should, leading to duplicate tool calls. This PR fixes it by letting response messages get a fresh timestamp when they're created.

## Summary

This PR addresses a P1 regression in `@mastra/core` 1.35.0+ where assistant/agent response messages were being assigned stale timestamps, causing message ordering issues in multi-turn agent loops.

### Root Cause

The `buildMessagesFromChunks` function has a `createdAt` parameter that defaults to `new Date()` (current time when called). However, the function was being explicitly passed `createdAt: currentStep.createdAt`, which is the timestamp from when the step *started*. This caused response messages to be backdated to the step's creation time rather than receiving a fresh timestamp at message construction.

In parallel, the `MessageList.generateCreatedAt` logic inflates input message timestamps (using `lastCreatedAt + 1`) to maintain ordering, which could exceed the outdated step timestamp, causing response messages to sort *before* later input messages and become buried mid-conversation history.

### The Fix

The change is minimal but impactful: remove the explicit `createdAt: currentStep.createdAt` argument from the `buildMessagesFromChunks` call in `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`. This allows the function to use its default `createdAt = new Date()`, ensuring response messages receive a build-time timestamp that properly sorts after preceding input messages.

### Impact

- **Fixes message ordering**: Assistant response messages are now correctly positioned after the input messages they respond to
- **Eliminates duplicate tool calls**: Proper conversation history ordering prevents the LLM from re-issuing tool calls it already made
- **Restores 1.34.0 behavior**: Removes the regression introduced in 1.35.0+

### Changes

**File**: `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`
- Removed `createdAt: currentStep.createdAt` from the `buildMessagesFromChunks` call
- Now passes only `messageId`, `responseModelMetadata` (from `runState`), and `tools` (from `currentStep`)

**File**: `.changeset/fix-agent-response-ordering.md`
- Added changeset documenting the patch release fix

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16953?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->