### PR TITLE
fix(mcp): close transport on connection close to prevent SSE leaks (fixes #16693)

### DIFF
--- a/.changeset/fix-mcp-sse-leak.md
+++ b/.changeset/fix-mcp-sse-leak.md
@@ -1,0 +1,5 @@
+---
+"@mastra/mcp": patch
+---
+
+fix(mcp): close transport on connection close to prevent SSE leaks (fixes #16693)

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -500,6 +500,17 @@ export class InternalMastraMCPClient extends MastraBase {
         this.client.onclose = () => {
           this.log('debug', `MCP server connection closed`);
           this.isConnected = null;
+
+          // Cleanup transport on server-initiated close to prevent SSE leaks (fixes #16693)
+          if (this.transport) {
+            this.transport.close().catch(e => {
+              this.log('debug', 'Error closing transport on connection close (ignored)', {
+                error: e instanceof Error ? e.message : String(e),
+              });
+            });
+            this.transport = undefined;
+          }
+
           if (typeof originalOnClose === 'function') {
             originalOnClose();
           }


### PR DESCRIPTION
Closes #16693

## Summary
This PR fixes an SSE transport resource leak in the MCP client by properly closing the transport when the server initiates connection closure.

### Changes
File: packages/mcp/src/client/client.ts
Modified the this.client.onclose disconnect handler in the InternalMastraMCPClient.connect() method to:
1. Explicitly call this.transport.close() when the transport exists
2. Catch and log any errors that occur during transport closure
3. Clear the this.transport reference
4. Preserve the original behavior of resetting this.isConnected to null
5. Call any pre-existing onclose handler if one was defined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR fixes a resource leak where the MCP client wasn't properly cleaning up connections when the server closed them. Think of it like leaving a door open after someone tells you to shut it — the client would keep trying to reconnect through the old door instead of closing it, which wasted server resources and caused the server to accumulate thousands of unused sessions. The fix makes sure the client properly closes and cleans up the old connection when the server tells it to close.

## Changes

**packages/mcp/src/client/client.ts**

Modified the `this.client.onclose` disconnect handler in `InternalMastraMCPClient.connect()` to:
- Explicitly call `this.transport.close()` when the transport exists
- Catch and log any errors thrown during transport closure
- Clear the `this.transport` reference after closing
- Preserve the existing behavior of resetting `this.isConnected` to `null`
- Still invoke any pre-existing `onclose` handler if defined

This ensures that orphaned EventSource instances don't remain in a CONNECTING state with an active retry loop, preventing the repeated SSE connections that were leaking server sessions.

**Changelog**

Added a Changesets entry for `@mastra/mcp` marking a patch release documenting the fix for the SSE transport resource leak (fixes `#16693`).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->