### PR TITLE
refactor(playground): migrate ExperimentResultsList to DataList

### DIFF
--- a/.changeset/experiment-results-list-update.md
+++ b/.changeset/experiment-results-list-update.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Improved the Experiment Results list (Experiments → Experiment → Results tab) with the condensed layout shared by Traces, Logs, Scores, Dataset Items, Skills, Span Feedback, Dataset Experiments, and Dataset Review. 

--- a/packages/playground/src/domains/experiments/components/experiment-page-content.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-page-content.tsx
@@ -219,12 +219,12 @@ export function ExperimentPageContent({
 
   const resultsListColumns = useMemo(
     () => [
-      { name: 'itemId', label: 'Item ID', size: '5rem' },
-      { name: 'status', label: 'Status', size: '3rem' },
-      { name: 'input', label: 'Input', size: '1fr' },
-      ...(!featuredResultId ? scorerIds.map(id => ({ name: id, label: id, size: '1fr' })) : []),
+      { name: 'itemId', label: 'Item ID', size: '7rem' },
+      { name: 'status', label: 'Status', size: '5rem' },
+      { name: 'input', label: 'Input', size: 'minmax(15rem,1fr)' },
+      ...scorerIds.map(id => ({ name: id, label: id, size: '12rem' })),
     ],
-    [featuredResultId, scorerIds],
+    [scorerIds],
   );
 
   return (
@@ -273,7 +273,7 @@ export function ExperimentPageContent({
               onResultClick={handleResultClick}
               columns={resultsListColumns}
               scoresByItemId={scoresByExperimentId}
-              scorerIds={!featuredResultId ? scorerIds : undefined}
+              scorerIds={scorerIds}
               setEndOfListElement={setEndOfListElement}
               isFetchingNextPage={isFetchingNextPage}
               hasNextPage={hasNextPage}

--- a/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
@@ -71,7 +71,11 @@ export function ExperimentResultsList({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div className="flex items-center justify-center w-10 relative bg-transparent h-full">
-                        <div className={cn('w-2 h-2 rounded-full', hasError ? 'bg-red-700' : 'bg-green-600')} />
+                        <div
+                          role="img"
+                          aria-label={hasError ? 'Error' : 'Success'}
+                          className={cn('w-2 h-2 rounded-full', hasError ? 'bg-red-700' : 'bg-green-600')}
+                        />
                       </div>
                     </TooltipTrigger>
                     <TooltipContent>{hasError ? 'Error' : 'Success'}</TooltipContent>

--- a/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
@@ -1,5 +1,5 @@
 import type { ClientScoreRowData, DatasetExperimentResult } from '@mastra/client-js';
-import { Checkbox, EntityList, Spinner, Tooltip, TooltipContent, TooltipTrigger, Txt, cn } from '@mastra/playground-ui';
+import { DataList, DataListSkeleton, Tooltip, TooltipContent, TooltipTrigger, cn } from '@mastra/playground-ui';
 
 export type ExperimentResultsListProps = {
   results: DatasetExperimentResult[];
@@ -34,105 +34,99 @@ export function ExperimentResultsList({
   onToggleSelect,
 }: ExperimentResultsListProps) {
   const hasSelection = Boolean(selectedIds && onToggleSelect);
-  const gridColumns = (hasSelection ? '2rem ' : '') + columns.map(c => c.size).join(' ');
-
-  const headerCells = (
-    <>
-      {hasSelection && <EntityList.TopCell>&nbsp;</EntityList.TopCell>}
-      {columns.map(col => (
-        <EntityList.TopCell key={col.name}>{col.label}</EntityList.TopCell>
-      ))}
-    </>
-  );
+  const gridColumns = [hasSelection ? 'auto' : '', ...columns.map(c => c.size)].filter(Boolean).join(' ');
+  const hasInputColumn = columns.some(col => col.name === 'input');
 
   if (isLoading) {
-    return (
-      <EntityList columns={gridColumns}>
-        <EntityList.Top>{headerCells}</EntityList.Top>
-        <div className="flex items-center justify-center py-20 col-span-full">
-          <Spinner />
-        </div>
-      </EntityList>
-    );
-  }
-
-  if (results.length === 0) {
-    return (
-      <EntityList columns={gridColumns}>
-        <EntityList.Top>{headerCells}</EntityList.Top>
-        <EntityList.NoMatch message="No results yet" />
-      </EntityList>
-    );
+    return <DataListSkeleton columns={gridColumns} />;
   }
 
   return (
-    <EntityList columns={gridColumns}>
-      <EntityList.Top>{headerCells}</EntityList.Top>
+    <DataList columns={gridColumns} className="min-w-0">
+      <DataList.Top hasLeadingCell={hasSelection}>
+        {hasSelection && <DataList.TopCell>&nbsp;</DataList.TopCell>}
+        {hasSelection ? (
+          <DataList.TopCells colStart={2}>
+            {columns.map(col => (
+              <DataList.TopCell key={col.name}>{col.label}</DataList.TopCell>
+            ))}
+          </DataList.TopCells>
+        ) : (
+          columns.map(col => <DataList.TopCell key={col.name}>{col.label}</DataList.TopCell>)
+        )}
+      </DataList.Top>
 
-      <EntityList.Rows>
-        {results.map(result => {
-          const hasError = Boolean(result.error);
-          const isSelected = result.id === featuredResultId;
-          const isChecked = selectedIds?.has(result.id) ?? false;
+      {results.length === 0 ? (
+        <DataList.NoMatch message="No results yet" />
+      ) : (
+        <>
+          {results.map(result => {
+            const hasError = Boolean(result.error);
+            const isFeatured = result.id === featuredResultId;
 
-          return (
-            <EntityList.Row key={result.id} onClick={() => onResultClick(result.id)} selected={isSelected}>
-              {hasSelection && (
-                <EntityList.Cell>
-                  <Checkbox
-                    checked={isChecked}
-                    onCheckedChange={() => onToggleSelect?.(result.id)}
-                    onClick={e => e.stopPropagation()}
-                    aria-label={`Select result ${result.itemId}`}
-                  />
-                </EntityList.Cell>
-              )}
-              <EntityList.TextCell>
-                <span className="truncate block font-mono">{result.itemId}</span>
-              </EntityList.TextCell>
-              <EntityList.Cell>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="flex items-center justify-center w-10 relative bg-transparent h-full">
-                      <div className={cn('w-2 h-2 rounded-full', hasError ? 'bg-red-700' : 'bg-green-600')} />
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>{hasError ? 'Error' : 'Success'}</TooltipContent>
-                </Tooltip>
-              </EntityList.Cell>
+            const rowCells = (
+              <>
+                <DataList.IdCell id={result.itemId} />
+                <DataList.Cell height="compact">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="flex items-center justify-center w-10 relative bg-transparent h-full">
+                        <div className={cn('w-2 h-2 rounded-full', hasError ? 'bg-red-700' : 'bg-green-600')} />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>{hasError ? 'Error' : 'Success'}</TooltipContent>
+                  </Tooltip>
+                </DataList.Cell>
 
-              {columns.some(col => col.name === 'input') && (
-                <EntityList.TextCell>
-                  <span className="truncate block font-mono">{truncate(formatValue(result.input), 200)}</span>
-                </EntityList.TextCell>
-              )}
-              {scorerIds?.map(scorerId => {
-                const scores = scoresByItemId?.[result.itemId];
-                const score = scores?.find(s => s.scorerId === scorerId);
-                return (
-                  <EntityList.TextCell key={scorerId}>
-                    <span className="font-mono">{score != null ? score.score.toFixed(3) : '-'}</span>
-                  </EntityList.TextCell>
-                );
-              })}
-            </EntityList.Row>
-          );
-        })}
+                {hasInputColumn && <DataList.MonoCell>{truncate(formatValue(result.input), 200)}</DataList.MonoCell>}
 
-        <div ref={setEndOfListElement} className="h-1 col-span-full">
-          {isFetchingNextPage && (
-            <div className="flex justify-center py-4">
-              <Spinner />
-            </div>
-          )}
-          {!hasNextPage && results.length > 0 && (
-            <Txt variant="ui-xs" className="text-icon3 text-center py-4 block">
-              All results loaded
-            </Txt>
-          )}
-        </div>
-      </EntityList.Rows>
-    </EntityList>
+                {scorerIds?.map(scorerId => {
+                  const scores = scoresByItemId?.[result.itemId];
+                  const score = scores?.find(s => s.scorerId === scorerId);
+                  return (
+                    <DataList.Cell key={scorerId} height="compact" className="font-mono text-neutral3 text-ui-smd">
+                      {score != null ? score.score.toFixed(3) : '-'}
+                    </DataList.Cell>
+                  );
+                })}
+              </>
+            );
+
+            if (!hasSelection) {
+              return (
+                <DataList.RowButton key={result.id} featured={isFeatured} onClick={() => onResultClick(result.id)}>
+                  {rowCells}
+                </DataList.RowButton>
+              );
+            }
+
+            return (
+              <DataList.Row key={result.id}>
+                <DataList.SelectCell
+                  checked={selectedIds!.has(result.id)}
+                  onToggle={() => onToggleSelect!(result.id)}
+                  aria-label={`Select result ${result.itemId}`}
+                />
+                <DataList.RowButton
+                  flushLeft
+                  colStart={2}
+                  featured={isFeatured}
+                  onClick={() => onResultClick(result.id)}
+                >
+                  {rowCells}
+                </DataList.RowButton>
+              </DataList.Row>
+            );
+          })}
+
+          <DataList.NextPageLoading
+            isLoading={isFetchingNextPage}
+            hasMore={hasNextPage}
+            setEndOfListElement={setEndOfListElement}
+          />
+        </>
+      )}
+    </DataList>
   );
 }
 


### PR DESCRIPTION
## Summary

Migrate the **Experiment Results list** (Experiments → Experiment → Results tab) from \`EntityList\` to \`DataList\`, matching the condensed layout used across Traces, Logs, Scores, Dataset Items, Skills, Span Feedback, Dataset Experiments, and Dataset Review.

### Layout

- All columns (Item ID, Status, Input + scorer columns) now render in both detail-panel-open and -closed states — no more conditional column hiding.
- Input column uses \`minmax(15rem,1fr)\` so it doesn't collapse when the detail panel narrows the list.
- \`className="min-w-0"\` on the DataList lets the grid shrink inside its flex parent so horizontal scroll engages.
- Item ID column now uses \`DataList.IdCell\` (compact mono short-id), matching the convention from \`DatasetExperimentsList\`.
- Loading state uses \`DataListSkeleton\` (matches \`SpanScoresList\`).

### Behavior

- Click-to-feature, infinite scroll, loading and empty states are unchanged.
- The "All results loaded" footer text is dropped in favor of the shared \`DataList.NextPageLoading\` primitive, matching the other lists.

## Test plan

- [ ] Open an experiment with results — list renders condensed.
- [ ] Click a row → detail panel opens; list narrows and scrolls horizontally; all scorer columns remain visible.
- [ ] Scroll to the bottom → infinite-scroll sentinel fetches the next page (loading text appears).
- [ ] Empty experiment → "No results yet" still shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR swaps the experiment results list to use the same compact table component as other lists across the app so rows take up less space and the UI is more consistent. It keeps the same features (click-to-feature, infinite scroll, loading/empty states) but improves layout and scrolling when a detail panel is open.

## Overview

Migrates the Experiment Results list (Experiments → Experiment → Results tab) from EntityList to DataList to provide a condensed, consistent layout used by Traces, Logs, Scores, Dataset Items, Skills, Span Feedback, Dataset Experiments, and Dataset Review.

## Key Changes

- Replaced EntityList/Spinner/Txt usage with the DataList suite (DataList, DataList.Row/RowButton, DataList.SelectCell, DataList.IdCell, DataListSkeleton, DataList.NoMatch, DataList.NextPageLoading).
- All columns (Item ID, Status, Input, and per-scorer columns) always render regardless of detail-panel open/closed state; removed conditional column hiding.
- Input column uses CSS grid track minmax(15rem, 1fr) to avoid collapsing when the detail panel narrows the list.
- Added className="min-w-0" on the DataList so the grid can shrink inside its flex parent and enable horizontal scrolling to keep scorer columns visible.
- Item ID column now uses DataList.IdCell (compact monospace short-id), matching DatasetExperimentsList.
- Loading state now renders DataListSkeleton; empty state uses DataList.NoMatch.
- Pagination/footer UI replaced: removed inline spinner and “All results loaded” text and now uses DataList.NextPageLoading driven by isFetchingNextPage, hasNextPage, and setEndOfListElement.

## Behavioral & Implementation Notes

- Rows render as DataList.RowButton when selection is disabled, or as a selectable DataList.Row with DataList.SelectCell and a row button when selection is enabled.
- Success/error indicator preserved via tooltip-based indicator in each row.
- Click-to-feature, infinite scroll, loading, and empty behaviors remain unchanged from the previous implementation.
- ExperimentPageContent now always includes scorer columns for each scorerId, memoization for columns depends only on scorerIds, and ExperimentResultsList always receives scorerIds (no conditional undefined).

## Test Plan

- Confirm condensed rendering for experiment results matches other DataList-based views.
- Open a row to ensure the detail panel narrows the list and horizontal scroll keeps scorer (right-side) columns visible.
- Scroll to bottom to verify infinite-scroll fetch and NextPageLoading behavior.
- Confirm "No results yet" displays for empty experiments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->