### PR TITLE
fix(otel-exporter): pin otel exporter deps to ^0.218.0 to fix protobu…

### DIFF
--- a/observability/otel-exporter/package.json
+++ b/observability/otel-exporter/package.json
@@ -43,13 +43,13 @@
   },
   "optionalDependencies": {
     "@grpc/grpc-js": "^1.14.3",
-    "@opentelemetry/exporter-logs-otlp-grpc": "^0.215.0",
-    "@opentelemetry/exporter-logs-otlp-http": "^0.215.0",
-    "@opentelemetry/exporter-logs-otlp-proto": "^0.215.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.215.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.215.0",
-    "@opentelemetry/exporter-zipkin": "^2.7.0"
+    "@opentelemetry/exporter-logs-otlp-grpc": "^0.218.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.218.0",
+    "@opentelemetry/exporter-zipkin": "^2.8.0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",
@@ -66,13 +66,13 @@
   "peerDependencies": {
     "@grpc/grpc-js": "^1.13.4",
     "@mastra/core": ">=1.16.0-0 <2.0.0-0",
-    "@opentelemetry/exporter-logs-otlp-grpc": "^0.215.0",
-    "@opentelemetry/exporter-logs-otlp-http": "^0.215.0",
-    "@opentelemetry/exporter-logs-otlp-proto": "^0.215.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.215.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.215.0",
-    "@opentelemetry/exporter-zipkin": "^2.6.0"
+    "@opentelemetry/exporter-logs-otlp-grpc": "^0.218.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.218.0",
+    "@opentelemetry/exporter-zipkin": "^2.8.0"
   },
   "peerDependenciesMeta": {
     "@grpc/grpc-js": {


### PR DESCRIPTION
…fjs CVEs

Upgrades @opentelemetry/exporter-*-otlp-* optionalDependencies from ^0.215.0 to ^0.218.0, and peerDependencies to match.

These newer exporter versions pull in @opentelemetry/sdk-node >=0.218.0, which carries patched protobufjs (resolves GHSA-66ff-xgx4-vchm and 5 other advisories).

Fixes #16965

## Description

### Problem

`@mastra/observability@1.12.0` and `@mastra/otel-exporter@1.1.0` resolve `@opentelemetry/sdk-node` to the `0.209.0 – 0.217.0` range. That range pulls in `protobufjs` versions affected by **6 published GitHub Security Advisories**:

- GHSA-66ff-xgx4-vchm — Code injection via `toObject()` defaults
- GHSA-2pr8-phx7-x9h3 — DoS from crafted field names
- GHSA-fx83-v9x8-x52w — Prototype injection in constructors
- GHSA-75px-5xx7-5xc7 — Code generation gadget after prototype pollution
- GHSA-jvwf-75h9-cwgg — Process-wide DoS via unsafe option paths
- GHSA-685m-2w69-288q — DoS via unbounded protobuf recursion

Every Mastra consumer running `npm audit` (or any CI gate built on it) sees these advisories and may block the build.

### Solution

Upgrade all `@opentelemetry/exporter-*-otlp-*` optional dependencies from `^0.215.0` → `^0.218.0`, and `@opentelemetry/exporter-zipkin` from `^2.7.0` → `^2.8.0`.

`@opentelemetry/sdk-node@0.218.0` (the current `latest` dist-tag) already carries patched `protobufjs` versions, so the vulnerable range is no longer reachable.

### Impact

- `npm audit` comes back clean for all Mastra TS/JS consumers
- No runtime behavior change — only dependency resolution is affected
- Follows semver `^` ranges, so all `>=0.218.0 <0.219.0` releases are eligible (safe)

### Verification

```bash
npm install
npm audit --omit=dev | grep -i protobuf || echo "No protobufjs advisories found"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes security vulnerabilities in Mastra's OpenTelemetry package by upgrading dependency versions. The older versions of the OpenTelemetry exporter packages were pulling in a vulnerable version of a library called protobufjs, which had multiple security issues. Upgrading to newer OpenTelemetry exporter versions ensures users get the patched, secure version of protobufjs automatically.

---

## Changes

Updated `@opentelemetry/exporter-*` package versions in `observability/otel-exporter/package.json`:

**optionalDependencies:**
- `@opentelemetry/exporter-logs-otlp-grpc`, `@opentelemetry/exporter-logs-otlp-http`, `@opentelemetry/exporter-logs-otlp-proto`, `@opentelemetry/exporter-trace-otlp-grpc`, `@opentelemetry/exporter-trace-otlp-http`, `@opentelemetry/exporter-trace-otlp-proto`: upgraded from `^0.215.0` → `^0.218.0`
- `@opentelemetry/exporter-zipkin`: upgraded from `^2.6.0` → `^2.8.0` (or `^2.7.0` depending on previous baseline)

**peerDependencies:**
- All the same exporter packages updated to match the optionalDependencies versions above

## Security Impact

These newer OpenTelemetry exporter versions resolve to `@opentelemetry/sdk-node >=0.218.0`, which bundles patched protobufjs versions that address six published GitHub Security Advisories (GHSA):
- GHSA-66ff-xgx4-vchm and 5 others covering code injection, prototype injection, denial-of-service, unsafe option path handling, unbounded recursion, and UTF-8 decoding issues.

The upgrade makes `npm audit --omit=dev` clean for Mastra TypeScript/JavaScript consumers and resolves CI and audit gate failures related to these protobufjs vulnerabilities.

## Fixed Issue

Fixes `#16965`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->