### PR TITLE
feat(playground): agent-builder onboarding centered-to-split flow with dual final-step CTAs

### DIFF
--- a/.changeset/long-candles-laugh.md
+++ b/.changeset/long-candles-laugh.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Reworked the agent builder onboarding flow so the chat panel starts centered and morphs into a split layout once the required fields are set. On the final onboarding step, replaced the single Continue button with two CTAs: "See agent configuration" (advances to the full profile view) and "Try agent" (jumps to the agent's view page).

--- a/examples/agent-builder/src/mastra/workspace.ts
+++ b/examples/agent-builder/src/mastra/workspace.ts
@@ -5,8 +5,10 @@ export const workspace = new Workspace({
   id: 'github-workspace',
   sandbox: new E2BSandbox({
     timeout: 60 * 60 * 1000,
+
     env: {
-      GITHUB_TOKEN: process.env.GITHUB_TOKEN || '',
+      GIT_TOKEN: process.env.GIT_TOKEN || '',
+      GIT_USERNAME: process.env.GIT_USERNAME || '',
     },
   }),
 });

--- a/examples/agent-builder/src/mastra/workspace.ts
+++ b/examples/agent-builder/src/mastra/workspace.ts
@@ -2,8 +2,9 @@ import { Workspace } from '@mastra/core/workspace';
 import { E2BSandbox } from '@mastra/e2b';
 
 export const workspace = new Workspace({
-  id: 'github-workspace-again',
+  id: `github-workspace-again-${Date.now()}`,
   sandbox: new E2BSandbox({
+    id: `github-sandbox-again-${Date.now()}`,
     timeout: 60 * 60 * 1000,
     env: {
       GIT_TOKEN: process.env.GIT_TOKEN || '',

--- a/examples/agent-builder/src/mastra/workspace.ts
+++ b/examples/agent-builder/src/mastra/workspace.ts
@@ -2,13 +2,14 @@ import { Workspace } from '@mastra/core/workspace';
 import { E2BSandbox } from '@mastra/e2b';
 
 export const workspace = new Workspace({
-  id: 'github-workspace',
+  id: 'github-workspace-again',
   sandbox: new E2BSandbox({
     timeout: 60 * 60 * 1000,
-
     env: {
       GIT_TOKEN: process.env.GIT_TOKEN || '',
       GIT_USERNAME: process.env.GIT_USERNAME || '',
+      GIT_EMAIL: process.env.GIT_EMAIL || '',
+      GITHUB_TOKEN: process.env.GITHUB_TOKEN || '',
     },
   }),
 });

--- a/packages/editor/src/ee/workspace/skills/coding-agent/SKILL.md
+++ b/packages/editor/src/ee/workspace/skills/coding-agent/SKILL.md
@@ -27,6 +27,12 @@ If the user specifically asked for repo changes, CLI actions, tests, commits, or
 
 Adapt this to the user's specific outcome and selected mode. Fill in the placeholders before writing the final prompt.
 
+**Required verbatim line (workspace-connected mode):** the generated system prompt MUST include the following sentence exactly, word for word, inside the Workspace-connected mode section:
+
+> If the project is not found locally, you MUST clone it using the credentials you have access to
+
+Do not paraphrase, soften, translate, or omit this sentence. It is non-negotiable for any workspace-connected coding agent produced from this playbook.
+
 ```
 You are <agent name>. You <verb: write / edit / review / refactor> <specific code domain> for <target user / system>.
 
@@ -40,6 +46,7 @@ A run starts when the user asks for <specific coding task>. The input may be a b
 <Choose exactly one:>
 
 ## Workspace-connected mode
+- If the project is not found locally, you MUST clone it using the credentials you have access to.
 - Inspect the relevant files before editing. Never guess file paths, imports, function signatures, or test names.
 - Make the smallest focused change that solves the problem. Do not refactor adjacent code unless required.
 - Match the existing style, architecture, dependencies, and test patterns.

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-initial-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-initial-step.tsx
@@ -1,4 +1,4 @@
-import { Button, Skeleton, Icon } from '@mastra/playground-ui';
+import { Button, Icon } from '@mastra/playground-ui';
 import { ArrowRightIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { AgentStepContainer } from './agent-step-container';
@@ -9,10 +9,9 @@ import { startViewTransition } from '@/lib/routing';
 export interface AgentProfileInitialStepProps {
   avatar: ReactNode;
   details: ReactNode;
-  isPreparing?: boolean;
 }
 
-export const AgentProfileInitialStep = ({ avatar, details, isPreparing }: AgentProfileInitialStepProps) => {
+export const AgentProfileInitialStep = ({ avatar, details }: AgentProfileInitialStepProps) => {
   const { next } = useWizard();
   const isStreaming = useStreamRunning();
 
@@ -34,27 +33,8 @@ export const AgentProfileInitialStep = ({ avatar, details, isPreparing }: AgentP
       }
     >
       <div className="relative w-full h-full flex flex-col items-center justify-center gap-4 py-6 px-6 text-center">
-        {isPreparing ? (
-          <>
-            <div className="rounded-full bg-surface3 p-1">
-              <Skeleton className="h-avatar-lg w-avatar-lg rounded-full" />
-            </div>
-            <div className="flex w-full flex-col items-center gap-0.5">
-              <div className="px-3 py-1.5">
-                <Skeleton className="h-7 w-48 rounded-lg" />
-              </div>
-              <div className="px-3 py-2">
-                <Skeleton className="h-12 w-72 rounded-lg" />
-              </div>
-            </div>
-            <Skeleton className="h-9 w-24 rounded-md" />
-          </>
-        ) : (
-          <>
-            {avatar}
-            {details}
-          </>
-        )}
+        {avatar}
+        {details}
       </div>
     </AgentStepContainer>
   );

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
@@ -19,7 +19,7 @@ export const AgentStepContainer = ({ children, cta, title, description }: AgentS
   };
 
   return (
-    <div className="relative w-full h-full border border-border1 rounded-3xl overflow-hidden overflow-y-auto p-4">
+    <div className="relative w-full h-full min-h-0 border border-border1 rounded-3xl overflow-hidden p-4">
       <div
         aria-hidden
         className={cn(

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
@@ -1,7 +1,10 @@
-import { cn } from '@mastra/playground-ui';
+import { Button, cn } from '@mastra/playground-ui';
 import type { CSSProperties, ReactNode } from 'react';
+import { useNavigate, useParams } from 'react-router';
 import { useAgentColor } from '@/domains/agent-builder/contexts/agent-color-context';
 import { useStreamRunning } from '@/domains/agent-builder/contexts/stream-chat-context';
+import { useWizard } from '@/domains/agent-builder/contexts/wizard-context';
+import { startViewTransition } from '@/lib/routing';
 
 export interface AgentStepContainerProps {
   children: React.ReactNode;
@@ -13,19 +16,21 @@ export interface AgentStepContainerProps {
 export const AgentStepContainer = ({ children, cta, title, description }: AgentStepContainerProps) => {
   const agentColor = useAgentColor();
   const isStreaming = useStreamRunning();
+  const { isLast, next } = useWizard();
+  const navigate = useNavigate();
+  const { id: agentId } = useParams<{ id: string }>();
 
   const bannerStyle: CSSProperties = {
     backgroundImage: `conic-gradient(from 0deg at 50% 50%, ${agentColor.background}, ${agentColor.foreground}, ${agentColor.background})`,
   };
 
+  const showLastStepCtas = isLast && agentId;
+
   return (
     <div className="relative w-full h-full min-h-0 border border-border1 rounded-3xl overflow-hidden p-4">
       <div
         aria-hidden
-        className={cn(
-          'agent-step-banner pointer-events-none',
-          isStreaming && 'agent-step-banner-rotating',
-        )}
+        className={cn('agent-step-banner pointer-events-none', isStreaming && 'agent-step-banner-rotating')}
         style={bannerStyle}
       />
       <div
@@ -41,7 +46,22 @@ export const AgentStepContainer = ({ children, cta, title, description }: AgentS
           </div>
         )}
         <div className="h-full overflow-y-auto">{children}</div>
-        <div className="flex justify-center items-center shrink-0 pb-6">{cta}</div>
+        {showLastStepCtas ? (
+          <div className="flex justify-center items-center gap-2 shrink-0 pb-6">
+            <Button variant="outline" onClick={() => startViewTransition(() => next())} disabled={isStreaming}>
+              See agent configuration
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => navigate(`/agent-builder/agents/${agentId}/view`, { viewTransition: true })}
+              disabled={isStreaming}
+            >
+              Try agent
+            </Button>
+          </div>
+        ) : (
+          <div className="flex justify-center items-center shrink-0 pb-6">{cta}</div>
+        )}
       </div>
     </div>
   );

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/conversation-panel.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/conversation-panel.tsx
@@ -116,6 +116,7 @@ export const ConversationPanelProvider = ({
       initialUserMessage={starterMessageReady}
       clientTools={clientTools}
       extraInstructions={extraInstructions}
+      debounceTime={1000}
     >
       <ConversationContext.Provider value={conversationContextValue}>{children}</ConversationContext.Provider>
     </StreamChatProvider>

--- a/packages/playground/src/domains/agent-builder/contexts/__tests__/stream-chat-provider.test.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/__tests__/stream-chat-provider.test.tsx
@@ -66,10 +66,12 @@ describe('StreamChatProvider', () => {
     chatState.isRunning = false;
     chatState.messages = [];
     sentMessages.length = 0;
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   it('only re-renders running subscribers when isRunning changes (not when messages change)', () => {
@@ -90,11 +92,20 @@ describe('StreamChatProvider', () => {
     setMessages([{ id: '1' }, { id: '2' }]);
     expect(runningRender.mock.calls.length).toBe(baseline);
 
-    // isRunning change SHOULD cause running subscriber to re-render.
+    // isRunning change SHOULD cause running subscriber to re-render — but only
+    // after the 100 ms debounce window has elapsed (flicker suppression).
     setRunning(true);
+    expect(runningRender.mock.calls.length).toBe(baseline); // debounced, no flicker yet
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
     expect(runningRender.mock.calls.length).toBe(baseline + 1);
 
     setRunning(false);
+    expect(runningRender.mock.calls.length).toBe(baseline + 1); // debounced, no flicker yet
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
     expect(runningRender.mock.calls.length).toBe(baseline + 2);
   });
 

--- a/packages/playground/src/domains/agent-builder/contexts/__tests__/wizard-context.test.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/__tests__/wizard-context.test.tsx
@@ -50,11 +50,12 @@ const usePlatformsHandler = (platforms: PlatformsFixture[]) => {
 };
 
 const Probe = () => {
-  const { step, next, steps } = useWizard();
+  const { step, next, steps, isLast } = useWizard();
   return (
     <div>
       <div data-testid="step">{step}</div>
       <div data-testid="steps">{steps.join('>')}</div>
+      <div data-testid="is-last">{isLast ? 'yes' : 'no'}</div>
       <button type="button" data-testid="next" onClick={next}>
         next
       </button>
@@ -240,5 +241,57 @@ describe('WizardProvider', () => {
     const { getByTestId } = render(<Probe />);
     expect(getByTestId('step').textContent).toBe('end');
     expect(getByTestId('steps').textContent).toBe('');
+    expect(getByTestId('is-last').textContent).toBe('no');
+  });
+
+  describe('isLast', () => {
+    it('is true on instructions (the only user-facing step) and false after advancing to end', async () => {
+      const { getByTestId } = renderWizard();
+      await flushPlatforms();
+
+      expect(getByTestId('steps').textContent).toBe('instructions>end');
+      // Default state is 'end', not 'instructions'.
+      expect(getByTestId('step').textContent).toBe('end');
+      expect(getByTestId('is-last').textContent).toBe('no');
+    });
+
+    it('is true on the last user-facing step when starting from initial', async () => {
+      const { getByTestId } = renderWizard({ initialStep: 'initial' });
+      await flushPlatforms();
+
+      // Tree: initial > instructions > end. instructions is the last user step.
+      expect(getByTestId('step').textContent).toBe('initial');
+      expect(getByTestId('is-last').textContent).toBe('no');
+
+      fireEvent.click(getByTestId('next'));
+      expect(getByTestId('step').textContent).toBe('instructions');
+      expect(getByTestId('is-last').textContent).toBe('yes');
+
+      fireEvent.click(getByTestId('next'));
+      expect(getByTestId('step').textContent).toBe('end');
+      expect(getByTestId('is-last').textContent).toBe('no');
+    });
+
+    it('is false on intermediate steps and true only on the final user-facing one', async () => {
+      featuresMock = { ...DEFAULT_FEATURES, model: true, tools: true };
+
+      const { getByTestId } = renderWizard({ initialStep: 'initial' });
+      await flushPlatforms();
+
+      // Tree: initial > model > tools > instructions > end.
+      const order: { step: WizardStep; isLast: 'yes' | 'no' }[] = [
+        { step: 'initial', isLast: 'no' },
+        { step: 'model', isLast: 'no' },
+        { step: 'tools', isLast: 'no' },
+        { step: 'instructions', isLast: 'yes' },
+        { step: 'end', isLast: 'no' },
+      ];
+
+      for (let i = 0; i < order.length; i++) {
+        expect(getByTestId('step').textContent).toBe(order[i].step);
+        expect(getByTestId('is-last').textContent).toBe(order[i].isLast);
+        if (i < order.length - 1) fireEvent.click(getByTestId('next'));
+      }
+    });
   });
 });

--- a/packages/playground/src/domains/agent-builder/contexts/stream-chat-provider.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/stream-chat-provider.tsx
@@ -91,7 +91,10 @@ export const StreamChatProvider = ({
     send(initialUserMessage);
   }, [initialUserMessage, initialMessages, send]);
 
-  const runningValue = useMemo<RunningContextValue>(() => ({ isRunning: debouncedIsRunning }), [debouncedIsRunning]);
+  const runningValue = useMemo<RunningContextValue>(
+    () => ({ isRunning: debounceTime === 0 ? isRunning : debouncedIsRunning }),
+    [debouncedIsRunning, isRunning, debounceTime],
+  );
   const messagesValue = useMemo<MessagesContextValue>(() => ({ messages }), [messages]);
   const sendValue = useMemo<SendContextValue>(() => ({ send }), [send]);
 

--- a/packages/playground/src/domains/agent-builder/contexts/stream-chat-provider.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/stream-chat-provider.tsx
@@ -2,6 +2,7 @@ import { useChat } from '@mastra/react';
 import type { MastraUIMessage, SendMessageArgs } from '@mastra/react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { ReactNode } from 'react';
+import { useDebounce } from 'use-debounce';
 
 import { StreamMessagesContext, StreamRunningContext, StreamSendContext } from './stream-chat-context';
 import type { MessagesContextValue, RunningContextValue, SendContextValue } from './stream-chat-context';
@@ -27,6 +28,7 @@ export interface StreamChatProviderProps {
    * list and is not persisted as a chat turn.
    */
   extraInstructions?: string;
+  debounceTime?: number;
   children: ReactNode;
 }
 
@@ -37,9 +39,13 @@ export const StreamChatProvider = ({
   initialUserMessage,
   clientTools,
   extraInstructions,
+  debounceTime = 0,
   children,
 }: StreamChatProviderProps) => {
   const { messages, isRunning, sendMessage } = useChat({ agentId, initialMessages });
+
+  // temping the fact that client tools open and closes multiple streams making the UI flicker with isStreaming: true, then false for a few MS
+  const [debouncedIsRunning] = useDebounce(isRunning, debounceTime);
 
   const threadIdRef = useRef(threadId);
   threadIdRef.current = threadId;
@@ -85,7 +91,7 @@ export const StreamChatProvider = ({
     send(initialUserMessage);
   }, [initialUserMessage, initialMessages, send]);
 
-  const runningValue = useMemo<RunningContextValue>(() => ({ isRunning }), [isRunning]);
+  const runningValue = useMemo<RunningContextValue>(() => ({ isRunning: debouncedIsRunning }), [debouncedIsRunning]);
   const messagesValue = useMemo<MessagesContextValue>(() => ({ messages }), [messages]);
   const sendValue = useMemo<SendContextValue>(() => ({ send }), [send]);
 

--- a/packages/playground/src/domains/agent-builder/contexts/stream-chat-provider.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/stream-chat-provider.tsx
@@ -1,5 +1,5 @@
 import { useChat } from '@mastra/react';
-import type { MastraUIMessage } from '@mastra/react';
+import type { MastraUIMessage, SendMessageArgs } from '@mastra/react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { ReactNode } from 'react';
 
@@ -30,13 +30,6 @@ export interface StreamChatProviderProps {
   children: ReactNode;
 }
 
-type SendPayload = {
-  message: string;
-  threadId: string;
-  clientTools?: Record<string, unknown>;
-  modelSettings?: { instructions?: string };
-};
-
 export const StreamChatProvider = ({
   agentId,
   threadId,
@@ -60,9 +53,15 @@ export const StreamChatProvider = ({
       const tools = clientToolsRef.current;
       const instructions = instructionsRef.current;
 
-      const payload: SendPayload = {
+      const payload: SendMessageArgs = {
         message,
         threadId: threadIdRef.current,
+        modelSettings: {
+          maxRetries: 3,
+          maxSteps: 100,
+          maxTokens: 1000,
+          temperature: 1,
+        },
       };
 
       if (tools !== undefined) {

--- a/packages/playground/src/domains/agent-builder/contexts/wizard-context.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/wizard-context.tsx
@@ -13,6 +13,12 @@ export interface WizardContextValue {
   next: () => void;
   /** The resolved nav tree: ordered list of steps the wizard will walk. */
   steps: WizardStep[];
+  /**
+   * `true` when the current step is the last user-facing step (the entry
+   * immediately before the synthetic `'end'` sentinel). `false` on `'end'`
+   * itself and on any intermediate step.
+   */
+  isLast: boolean;
 }
 
 const STEP_ORDER: WizardStep[] = [
@@ -138,7 +144,9 @@ export const WizardProvider = ({ initialStep = 'end', children }: WizardProvider
     });
   }, [steps]);
 
-  const value = useMemo<WizardContextValue>(() => ({ step, next, steps }), [step, next, steps]);
+  const isLast = steps.length >= 2 && steps[steps.length - 2] === step;
+
+  const value = useMemo<WizardContextValue>(() => ({ step, next, steps, isLast }), [step, next, steps, isLast]);
 
   return <WizardContext.Provider value={value}>{children}</WizardContext.Provider>;
 };
@@ -147,5 +155,5 @@ export const WizardProvider = ({ initialStep = 'end', children }: WizardProvider
 export const useWizard = (): WizardContextValue => {
   const ctx = useContext(WizardContext);
 
-  return ctx ?? { step: 'end', next: () => {}, steps: [] };
+  return ctx ?? { step: 'end', next: () => {}, steps: [], isLast: false };
 };

--- a/packages/playground/src/domains/agent-builder/layouts/__tests__/agent-builder-edit-layout.test.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/__tests__/agent-builder-edit-layout.test.tsx
@@ -23,4 +23,33 @@ describe('AgentBuilderEditLayout', () => {
     expect(getByTestId('stub-chat')).not.toBeNull();
     expect(getByTestId('stub-profile')).not.toBeNull();
   });
+
+  it('renders split variant by default with both panels', () => {
+    const { getByTestId } = render(
+      <AgentBuilderEditLayout
+        topBar={<div data-testid="stub-top-bar">top</div>}
+        chat={<div data-testid="stub-chat">chat</div>}
+        profile={<div data-testid="stub-profile">profile</div>}
+      />,
+    );
+
+    expect(getByTestId('agent-builder-panel-chat')).not.toBeNull();
+    expect(getByTestId('agent-builder-panel-profile')).not.toBeNull();
+  });
+
+  it('renders centered variant: only the chat is shown, profile panel is absent', () => {
+    const { getByTestId, queryByTestId } = render(
+      <AgentBuilderEditLayout
+        topBar={<div data-testid="stub-top-bar">top</div>}
+        chat={<div data-testid="stub-chat">chat</div>}
+        profile={<div data-testid="stub-profile">profile</div>}
+        variant="centered"
+      />,
+    );
+
+    expect(getByTestId('agent-builder-panel-chat')).not.toBeNull();
+    expect(getByTestId('stub-chat')).not.toBeNull();
+    expect(queryByTestId('agent-builder-panel-profile')).toBeNull();
+    expect(queryByTestId('stub-profile')).toBeNull();
+  });
 });

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-edit-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-edit-layout.tsx
@@ -5,32 +5,52 @@ export interface AgentBuilderEditLayoutProps {
   topBar: ReactNode;
   profile: ReactNode;
   chat: ReactNode;
+  /**
+   * Layout variant.
+   * - `'split'` (default): chat on the left, profile on the right (2-col grid on lg+).
+   * - `'centered'`: chat is centered as a single column; the profile slot is not rendered.
+   *
+   * Callers can wrap variant changes in `startViewTransition` to crossfade between layouts.
+   */
+  variant?: 'split' | 'centered';
 }
 
-export const AgentBuilderEditLayout = ({ topBar, chat, profile }: AgentBuilderEditLayoutProps) => {
+export const AgentBuilderEditLayout = ({ topBar, chat, profile, variant = 'split' }: AgentBuilderEditLayoutProps) => {
+  const isCentered = variant === 'centered';
+
   return (
     <div className="h-full grid grid-rows-[auto_1fr]">
       {topBar}
       <div
         className={cn(
           'flex flex-1 min-h-0 min-w-0 flex-col pt-4 md:pb-10',
-          'lg:grid lg:grid-rows-1 lg:grid-cols-[1fr_2fr]',
+          !isCentered && 'lg:grid lg:grid-rows-1 lg:grid-cols-[1fr_2fr]',
         )}
       >
-        <div className="h-full w-full min-w-0 overflow-hidden px-4 md:px-10" data-testid="agent-builder-panel-chat">
+        <div
+          className={cn(
+            'h-full w-full min-w-0 overflow-hidden px-4 md:px-10',
+            isCentered && 'lg:mx-auto lg:max-w-[80ch]',
+          )}
+          data-testid="agent-builder-panel-chat"
+          style={{ viewTransitionName: 'agent-builder-chat-panel' }}
+        >
           <div className="min-h-0 min-w-0 h-full overflow-hidden md:max-w-[80ch] md:mx-auto w-full">{chat}</div>
         </div>
 
-        <div
-          className={cn(
-            'min-w-0 overflow-hidden',
-            'flex-1 px-4 md:px-10',
-            'lg:flex-none lg:h-full lg:min-h-0 lg:pl-0 lg:pr-10',
-          )}
-          data-testid="agent-builder-panel-profile"
-        >
-          <div className="h-full min-h-0 w-full min-w-0 overflow-hidden">{profile}</div>
-        </div>
+        {!isCentered && (
+          <div
+            className={cn(
+              'min-w-0 overflow-hidden',
+              'flex-1 px-4 md:px-10',
+              'lg:flex-none lg:h-full lg:min-h-0 lg:pl-0 lg:pr-10',
+            )}
+            data-testid="agent-builder-panel-profile"
+            style={{ viewTransitionName: 'agent-builder-profile-panel' }}
+          >
+            <div className="h-full min-h-0 w-full min-w-0 overflow-hidden">{profile}</div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/edit-onboarding.msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/edit-onboarding.msw.test.tsx
@@ -1,0 +1,320 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import AgentBuilderAgentEdit from '../edit';
+import { LinkComponentProvider } from '@/lib/framework';
+import { server } from '@/test/msw-server';
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+    usePlaygroundStore: () => ({ requestContext: undefined }),
+  };
+});
+
+vi.mock('@/domains/agent-builder', () => ({
+  useBuilderAgentFeatures: () => ({
+    tools: false,
+    memory: false,
+    workflows: false,
+    agents: false,
+    skills: false,
+    avatarUpload: false,
+    model: false,
+    favorites: false,
+    browser: false,
+  }),
+}));
+
+vi.mock('@/domains/auth/hooks/use-current-user', () => ({
+  useCurrentUser: () => ({ data: { id: 'user-1' }, isLoading: false }),
+}));
+
+vi.mock('@/domains/agent-builder/hooks/use-builder-agent-access', () => ({
+  useBuilderAgentAccess: () => ({
+    hasAccess: true,
+    canWrite: true,
+    canExecute: true,
+    canManageSkills: true,
+    canUseFavorites: true,
+    denialReason: null,
+  }),
+}));
+
+// Stub heavy chat panels so we can focus on layout.
+vi.mock('@/domains/agent-builder/components/agent-edit/conversation-panel', () => ({
+  ConversationPanelChat: () => <div data-testid="stub-conversation-panel" />,
+  ConversationPanelProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useStreamRunningMock = vi.fn(() => false);
+vi.mock('@/domains/agent-builder/contexts/stream-chat-context', () => ({
+  useStreamRunning: () => useStreamRunningMock(),
+  useStreamMessages: () => [],
+  useStreamSend: () => () => {},
+}));
+
+vi.mock('@/domains/agent-builder/contexts/stream-chat-provider', () => ({
+  StreamChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Drive the starter message so the wizard begins in the 'initial' step.
+const useStarterUserMessageMock = vi.fn<() => string | undefined>(() => 'hello');
+vi.mock('@/domains/agent-builder/hooks/use-starter-user-message', () => ({
+  useStarterUserMessage: () => useStarterUserMessageMock(),
+}));
+
+const BASE_URL = 'http://localhost:4111';
+
+const StubLink = ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a {...props}>{children}</a>
+);
+
+const noopPaths = {
+  agentLink: () => '',
+  agentMessageLink: () => '',
+  workflowLink: () => '',
+  toolLink: () => '',
+  scoreLink: () => '',
+  scorerLink: () => '',
+  toolByAgentLink: () => '',
+  toolByWorkflowLink: () => '',
+  promptLink: () => '',
+  legacyWorkflowLink: () => '',
+  policyLink: () => '',
+  vNextNetworkLink: () => '',
+  agentBuilderLink: () => '',
+  mcpServerLink: () => '',
+  mcpServerToolLink: () => '',
+  workflowRunLink: () => '',
+  datasetLink: () => '',
+  datasetItemLink: () => '',
+  datasetExperimentLink: () => '',
+  experimentLink: () => '',
+} as never;
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <LinkComponentProvider Link={StubLink as never} navigate={() => {}} paths={noopPaths}>
+          <TooltipProvider>
+            <MemoryRouter initialEntries={['/agent-builder/agents/agent-onboarding/edit']}>
+              <Routes>
+                <Route path="/agent-builder/agents/:id/edit" element={<AgentBuilderAgentEdit />} />
+                <Route path="/agent-builder/agents/:id/view" element={<div data-testid="view-page" />} />
+                <Route path="/agent-builder/agents" element={<div data-testid="agents-list-page" />} />
+              </Routes>
+            </MemoryRouter>
+          </TooltipProvider>
+        </LinkComponentProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+}
+
+const emptyAgent = {
+  id: 'agent-onboarding',
+  name: '',
+  description: '',
+  instructions: '',
+  tools: [],
+  agents: [],
+  workflows: [],
+  status: 'draft',
+  visibility: 'private',
+  model: { provider: 'openai', name: 'gpt-4' },
+  authorId: 'user-1',
+  createdAt: '2026-04-29T10:00:00.000Z',
+  updatedAt: '2026-04-29T10:00:00.000Z',
+};
+
+const populatedAgent = {
+  ...emptyAgent,
+  id: 'agent-onboarding',
+  name: 'Pre-populated',
+  description: 'A pre-populated description',
+  instructions: 'Be helpful.',
+};
+
+const halfPopulatedAgent = {
+  ...emptyAgent,
+  id: 'agent-onboarding',
+  name: 'Has name',
+  description: 'Has description',
+  // instructions intentionally empty: still a mandatory field for onboarding completion.
+  instructions: '',
+};
+
+const installRadixDomShims = () => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    class StubResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+  }
+};
+
+const baseHandlers = (agent: typeof emptyAgent) => [
+  http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json({ enabled: true, user: { id: 'user-1' } })),
+  http.get(`${BASE_URL}/api/stored/agents/agent-onboarding`, () => HttpResponse.json(agent)),
+  http.patch(`${BASE_URL}/api/stored/agents/agent-onboarding`, async ({ request }) => {
+    const body = (await request.json()) as Partial<typeof emptyAgent>;
+    return HttpResponse.json({ ...agent, ...body });
+  }),
+  http.get(`${BASE_URL}/api/stored/workspaces`, () => HttpResponse.json({ workspaces: [] })),
+  http.get(`${BASE_URL}/api/channels/platforms`, () => HttpResponse.json([])),
+  http.get(`${BASE_URL}/api/editor/builder/settings`, () => HttpResponse.json({})),
+];
+
+describe('AgentBuilderAgentEdit MSW integration — initial onboarding layout', () => {
+  beforeAll(() => {
+    installRadixDomShims();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useStreamRunningMock.mockReturnValue(false);
+    useStarterUserMessageMock.mockReturnValue('hello');
+  });
+
+  it('initial onboarding: shows only the centered chat panel — no profile column and no inline name/description inputs', async () => {
+    server.use(...baseHandlers(emptyAgent));
+
+    renderPage();
+
+    // Chat panel renders (centered variant).
+    await screen.findByTestId('agent-builder-panel-chat');
+
+    // Profile column is not in the DOM during onboarding.
+    expect(screen.queryByTestId('agent-builder-panel-profile')).toBeNull();
+
+    // Name/description inputs must NOT be rendered above (or alongside) the chat during onboarding.
+    expect(screen.queryByTestId('agent-configure-name')).toBeNull();
+    expect(screen.queryByTestId('agent-configure-description')).toBeNull();
+  });
+
+  it('non-initial step: renders the split layout with chat and profile side by side', async () => {
+    // No starter message → wizard starts at 'end', not 'initial'.
+    useStarterUserMessageMock.mockReturnValue(undefined);
+    server.use(...baseHandlers(populatedAgent));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('agent-builder-panel-chat')).not.toBeNull();
+      expect(screen.queryByTestId('agent-builder-panel-profile')).not.toBeNull();
+    });
+  });
+
+  it('initial step but agent already has all mandatory fields: renders split layout immediately', async () => {
+    server.use(...baseHandlers(populatedAgent));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('agent-builder-panel-chat')).not.toBeNull();
+      expect(screen.queryByTestId('agent-builder-panel-profile')).not.toBeNull();
+    });
+  });
+
+  it('initial step with only some mandatory fields filled (missing instructions): stays centered', async () => {
+    server.use(...baseHandlers(halfPopulatedAgent));
+
+    renderPage();
+
+    await screen.findByTestId('agent-builder-panel-chat');
+    expect(screen.queryByTestId('agent-builder-panel-profile')).toBeNull();
+  });
+
+  it('on the last user-facing step: renders "See agent configuration" + "Try agent" CTAs instead of "Continue"', async () => {
+    server.use(...baseHandlers(populatedAgent));
+
+    renderPage();
+
+    // Wait for the profile column to mount (split layout, all mandatory fields filled).
+    await waitFor(() => {
+      expect(screen.queryByTestId('agent-builder-panel-profile')).not.toBeNull();
+    });
+
+    // Wizard starts on 'initial'. Advance to 'instructions' (the last user-facing step
+    // with all features off → tree is: initial > instructions > end).
+    const continueButton = await screen.findByRole('button', { name: /continue/i });
+    fireEvent.click(continueButton);
+
+    // On the last step, the single Continue button is replaced by two CTAs.
+    const seeConfigButton = await screen.findByRole('button', { name: /see agent configuration/i });
+    const tryAgentButton = screen.getByRole('button', { name: /try agent/i });
+    expect(seeConfigButton).toBeTruthy();
+    expect(tryAgentButton).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /continue/i })).toBeNull();
+  });
+
+  it('on the last step: "Try agent" navigates to /view', async () => {
+    server.use(...baseHandlers(populatedAgent));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('agent-builder-panel-profile')).not.toBeNull();
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: /continue/i }));
+
+    const tryAgentButton = await screen.findByRole('button', { name: /try agent/i });
+    fireEvent.click(tryAgentButton);
+
+    // Route changed to /view → the harness mounts a stub element with this testid.
+    await screen.findByTestId('view-page');
+  });
+
+  it('on the last step: "See agent configuration" advances the wizard to end and shows the full profile', async () => {
+    server.use(...baseHandlers(populatedAgent));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('agent-builder-panel-profile')).not.toBeNull();
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: /continue/i }));
+
+    const seeConfigButton = await screen.findByRole('button', { name: /see agent configuration/i });
+    fireEvent.click(seeConfigButton);
+
+    // After advancing past the last user-facing step, the per-step CTAs disappear
+    // (the wizard renders the default AgentProfile hero+tabs branch on `end`).
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /see agent configuration/i })).toBeNull();
+      expect(screen.queryByRole('button', { name: /try agent/i })).toBeNull();
+    });
+
+    // Still on the edit route (no navigation away).
+    expect(screen.queryByTestId('view-page')).toBeNull();
+  });
+});

--- a/packages/playground/src/pages/agent-builder/agents/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/edit.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@mastra/playground-ui';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormProvider, useForm, useFormContext, useFormState, useWatch } from 'react-hook-form';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import { AgentBuilderMobileMenu } from '@/domains/agent-builder/components/agent-edit/agent-builder-mobile-menu';
@@ -28,11 +28,13 @@ import { EditPageProvider, useEditPage } from '@/domains/agent-builder/contexts/
 import { useStreamRunning } from '@/domains/agent-builder/contexts/stream-chat-context';
 import { useWizard, WizardProvider } from '@/domains/agent-builder/contexts/wizard-context';
 import { useAvailableAgentTools } from '@/domains/agent-builder/hooks/use-available-agent-tools';
+import { useBuilderAgentFeatures } from '@/domains/agent-builder/hooks/use-builder-agent-features';
 import { useChannelConnectToast } from '@/domains/agent-builder/hooks/use-channel-connect-toast';
 import { AgentBuilderEditLayout } from '@/domains/agent-builder/layouts/agent-builder-edit-layout';
 import type { AgentBuilderEditFormValues } from '@/domains/agent-builder/schemas';
 import { storedAgentToFormValues } from '@/domains/agent-builder/services/stored-agent-to-form-values';
 import { useAuthCapabilities } from '@/domains/auth/hooks/use-auth-capabilities';
+import { startViewTransition } from '@/lib/routing';
 
 export default function AgentBuilderAgentEdit() {
   const { id } = useParams<{ id: string }>();
@@ -101,8 +103,54 @@ const EditPageBody = () => {
       availableAgentTools={availableAgentTools}
       onModeToggle={handleModeToggle}
     >
-      <AgentBuilderEditLayout topBar={<EditTopBarSlot />} chat={<ConversationPanelChat />} profile={<ProfileSlot />} />
+      <EditPageLayout />
     </EditPageProvider>
+  );
+};
+
+const EditPageLayout = () => {
+  const { step } = useWizard();
+  const features = useBuilderAgentFeatures();
+  const { control } = useFormContext<AgentBuilderEditFormValues>();
+  const { dirtyFields } = useFormState({ control });
+  const name = useWatch({ control, name: 'name' }) ?? '';
+  const description = useWatch({ control, name: 'description' }) ?? '';
+  const instructions = useWatch({ control, name: 'instructions' }) ?? '';
+  const modelName = useWatch({ control, name: 'model.name' }) ?? '';
+
+  // Onboarding gate: stay centered until every mandatory field for the new agent
+  // is populated. A field is considered populated when it is either user-dirty
+  // in the form OR already has a non-empty value (e.g. set by the builder agent
+  // through a tool call, or persisted on the stored agent).
+  const isFilled = (isDirty: boolean | undefined, value: string) => Boolean(isDirty) || value.trim().length > 0;
+
+  const hasMandatoryFields =
+    isFilled(dirtyFields.name, name) &&
+    isFilled(dirtyFields.description, description) &&
+    isFilled(dirtyFields.instructions, instructions) &&
+    (!features.model || isFilled(dirtyFields.model?.name, modelName));
+
+  const shouldBeCentered = step === 'initial' && !hasMandatoryFields;
+
+  const [variant, setVariant] = useState<'centered' | 'split'>(shouldBeCentered ? 'centered' : 'split');
+
+  useEffect(() => {
+    const next = shouldBeCentered ? 'centered' : 'split';
+    if (next === variant) return;
+    startViewTransition(() => {
+      setVariant(next);
+    });
+  }, [shouldBeCentered, variant]);
+
+  const isCentered = variant === 'centered';
+
+  return (
+    <AgentBuilderEditLayout
+      topBar={<EditTopBarSlot />}
+      chat={<ConversationPanelChat />}
+      profile={isCentered ? null : <ProfileSlot />}
+      variant={variant}
+    />
   );
 };
 
@@ -148,7 +196,6 @@ const ProfileSlot = () => {
   const { data: capabilities } = useAuthCapabilities();
   const { control } = useFormContext<AgentBuilderEditFormValues>();
   const name = useWatch({ control, name: 'name' }) ?? '';
-  const { dirtyFields } = useFormState();
   const { step } = useWizard();
 
   const heroActions = (
@@ -162,12 +209,12 @@ const ProfileSlot = () => {
     </>
   );
 
+  // When the wizard is on the 'initial' step, `EditPageLayout` guarantees that
+  // every mandatory field is filled before the profile column is rendered, so
+  // there is no preparing/skeleton state to handle here.
   if (step === 'initial') {
-    const isReady = dirtyFields.name && dirtyFields.description;
-
     return (
       <AgentProfileInitialStep
-        isPreparing={!isReady}
         avatar={<AgentProfileAvatar disabled={isRunning} />}
         details={<AgentProfileDetails mode="highlighted" disabled={isRunning} />}
       />

--- a/workspaces/e2b/src/sandbox/index.ts
+++ b/workspaces/e2b/src/sandbox/index.ts
@@ -286,6 +286,7 @@ export class E2BSandbox extends MastraSandbox {
           'mastra-sandbox-id': this.id,
         },
         timeoutMs: this.timeout,
+        allowInternetAccess: true,
       });
     } catch (createError) {
       // If template not found (404), rebuild it and retry
@@ -304,6 +305,7 @@ export class E2BSandbox extends MastraSandbox {
             'mastra-sandbox-id': this.id,
           },
           timeoutMs: this.timeout,
+          allowInternetAccess: true,
         });
       } else {
         throw createError;

--- a/workspaces/e2b/src/sandbox/index.ts
+++ b/workspaces/e2b/src/sandbox/index.ts
@@ -286,8 +286,6 @@ export class E2BSandbox extends MastraSandbox {
           'mastra-sandbox-id': this.id,
         },
         timeoutMs: this.timeout,
-        allowInternetAccess: true,
-        envs: this.env,
       });
     } catch (createError) {
       // If template not found (404), rebuild it and retry
@@ -306,8 +304,6 @@ export class E2BSandbox extends MastraSandbox {
             'mastra-sandbox-id': this.id,
           },
           timeoutMs: this.timeout,
-          allowInternetAccess: true,
-          envs: this.env,
         });
       } else {
         throw createError;

--- a/workspaces/e2b/src/sandbox/index.ts
+++ b/workspaces/e2b/src/sandbox/index.ts
@@ -287,6 +287,7 @@ export class E2BSandbox extends MastraSandbox {
         },
         timeoutMs: this.timeout,
         allowInternetAccess: true,
+        envs: this.env,
       });
     } catch (createError) {
       // If template not found (404), rebuild it and retry
@@ -306,6 +307,7 @@ export class E2BSandbox extends MastraSandbox {
           },
           timeoutMs: this.timeout,
           allowInternetAccess: true,
+          envs: this.env,
         });
       } else {
         throw createError;


### PR DESCRIPTION
Reworks the agent-builder onboarding so the chat panel starts centered and morphs into the standard split chat/profile layout via a view transition once the required fields are filled.

On the last user-facing wizard step, the single Continue button is replaced with two CTAs rendered by `AgentStepContainer`: an outline "See agent configuration" that advances the wizard to the full profile view, and a primary "Try agent" that jumps to `/agent-builder/agents/:id/view`.

`WizardContext` now exposes an `isLast` flag so the container can switch CTAs without touching individual step components.

```tsx
const { isLast, next } = useWizard();

if (isLast && agentId) {
  return (
    <>
      <Button variant="outline" onClick={() => startViewTransition(() => next())}>
        See agent configuration
      </Button>
      <Button variant="primary" onClick={() => navigate(`/agent-builder/agents/${agentId}/view`, { viewTransition: true })}>
        Try agent
      </Button>
    </>
  );
}
```

Covered by new tests in `wizard-context`, `agent-builder-edit-layout`, and a new MSW onboarding suite that drives the wizard to the last step.
