### PR TITLE
fix(core): preserve stream memory persistence for subscribers

### DIFF
--- a/.changeset/quick-animals-beam.md
+++ b/.changeset/quick-animals-beam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed thread stream subscriptions so streamed agent responses are saved to memory while still supporting multiple subscribers.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -1116,6 +1116,56 @@ describe('Agent signals', () => {
     },
   );
 
+  it.runIf(process.platform !== 'win32')(
+    'broadcasts to a remote subscriber without a same-runtime subscriber',
+    async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'mastra-agent-remote-only-'));
+      const ownerPubSub = new UnixSocketPubSub(join(tempDir, 'signals.sock'));
+      const followerPubSub = new UnixSocketPubSub(join(tempDir, 'signals.sock'));
+      const ownerRuntime = new AgentThreadStreamRuntime();
+      const followerRuntime = new AgentThreadStreamRuntime();
+      const owner = { id: 'remote-only-agent' } as Agent<any, any, any, any>;
+      const follower = { id: 'remote-only-agent' } as Agent<any, any, any, any>;
+      const runId = 'remote-only-run';
+      let finishRun!: () => void;
+      const output = {
+        runId,
+        status: 'running',
+        fullStream: (async function* () {
+          yield { type: 'text-delta', runId, payload: { text: 'remote only response' } };
+          yield { type: 'finish', runId, payload: {} };
+        })(),
+        _waitUntilFinished: () => new Promise<void>(resolve => (finishRun = resolve)),
+      } as any;
+
+      try {
+        const followerSubscription = await followerRuntime.subscribeToThread(
+          follower,
+          { resourceId: 'remote-only-resource', threadId: 'remote-only-thread' },
+          followerPubSub,
+        );
+        const followerRun = readNextRun(followerSubscription.stream[Symbol.asyncIterator]());
+
+        ownerRuntime.registerRun(
+          owner,
+          output,
+          { runId, memory: { resource: 'remote-only-resource', thread: 'remote-only-thread' } } as any,
+          ownerPubSub,
+        );
+
+        await expect(withTimeout(followerRun, 'Timed out waiting for remote-only subscriber')).resolves.toMatchObject({
+          value: { runId, text: 'remote only response' },
+          done: false,
+        });
+        finishRun();
+        followerSubscription.unsubscribe();
+      } finally {
+        await Promise.allSettled([ownerPubSub.close(), followerPubSub.close()]);
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it('supports cross-instance thread subscriptions through an injected PubSub without Mastra', async () => {
     const pubsub = new EventEmitterPubSub();
     const runner = new Agent({

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -137,8 +137,6 @@ export class AgentThreadStreamRuntime {
 
   #withBroadcastStream<OUTPUT>(output: MastraModelOutput<OUTPUT>, pubsub: PubSub | undefined, key: string) {
     const runtime = this;
-    const source = output.fullStream as ReadableStream<unknown> | undefined;
-    if (!source) return { output };
 
     const parts: unknown[] = [];
     const waiters = new Set<() => void>();
@@ -152,21 +150,24 @@ export class AgentThreadStreamRuntime {
       for (const waiter of pending) waiter();
     };
 
+    const emitPart = (part: unknown) => {
+      parts.push(part);
+      runtime.#publish(pubsub, key, {
+        type: 'stream-part',
+        runId: output.runId,
+        part,
+        sourceId: runtime.#getSourceId(),
+      });
+      wake();
+    };
+
     const start = () => {
       if (started) return;
       started = true;
       void (async () => {
         try {
-          const emitPart = (part: unknown) => {
-            parts.push(part);
-            runtime.#publish(pubsub, key, {
-              type: 'stream-part',
-              runId: output.runId,
-              part,
-              sourceId: runtime.#getSourceId(),
-            });
-            wake();
-          };
+          const source = output.fullStream as ReadableStream<unknown> | undefined;
+          if (!source) return;
 
           if (typeof source.getReader === 'function') {
             const reader = source.getReader();
@@ -234,11 +235,6 @@ export class AgentThreadStreamRuntime {
       });
     };
 
-    Object.defineProperty(output, 'fullStream', {
-      configurable: true,
-      enumerable: true,
-      value: createStream(),
-    });
     return { output, createSubscriberStream: createStream };
   }
 

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -150,9 +150,9 @@ export class AgentThreadStreamRuntime {
       for (const waiter of pending) waiter();
     };
 
-    const emitPart = (part: unknown) => {
+    const emitPart = async (part: unknown) => {
       parts.push(part);
-      runtime.#publish(pubsub, key, {
+      await runtime.#publishAndWait(pubsub, key, {
         type: 'stream-part',
         runId: output.runId,
         part,
@@ -175,14 +175,14 @@ export class AgentThreadStreamRuntime {
               while (true) {
                 const { value: part, done: streamDone } = await reader.read();
                 if (streamDone) break;
-                emitPart(part);
+                await emitPart(part);
               }
             } finally {
               reader.releaseLock();
             }
           } else {
             for await (const part of source as any) {
-              emitPart(part);
+              await emitPart(part);
             }
           }
         } catch (caught) {
@@ -235,7 +235,7 @@ export class AgentThreadStreamRuntime {
       });
     };
 
-    return { output, createSubscriberStream: createStream };
+    return { output, createSubscriberStream: createStream, startBroadcast: start };
   }
 
   #getThreadTarget(options?: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext }) {
@@ -363,7 +363,11 @@ export class AgentThreadStreamRuntime {
 
     const state = this.#getState(pubsub);
     const key = this.#threadKey(resourceId, threadId);
-    const { output: outputForSubscribers, createSubscriberStream } = this.#withBroadcastStream(output, pubsub, key);
+    const {
+      output: outputForSubscribers,
+      createSubscriberStream,
+      startBroadcast,
+    } = this.#withBroadcastStream(output, pubsub, key);
     const record: AgentThreadRunRecord<OUTPUT> = {
       agent,
       output: outputForSubscribers,
@@ -377,7 +381,8 @@ export class AgentThreadStreamRuntime {
     state.threadRunsById.set(output.runId, record);
     state.threadKeysByRunId.set(output.runId, key);
     state.activeThreadRunIds.set(key, output.runId);
-    this.#publish(pubsub, key, { type: 'run-registered', runId: output.runId });
+    const registered = this.#publishAndWait(pubsub, key, { type: 'run-registered', runId: output.runId });
+    void registered.then(startBroadcast, startBroadcast);
     this.#watchThreadRunCompletion(state, pubsub, key, record);
   }
 


### PR DESCRIPTION
This fixes thread stream subscriptions so watching a run no longer replaces or eagerly consumes the agent output stream.

Before: registering a streamed run could swap out `fullStream`, which meant normal stream finish handling and memory persistence could be skipped.

After: subscriber replay streams are created lazily, so multiple subscribers still work while the native stream path saves streamed responses to memory.

Verified with the focused core stream, memory, save/error, agent signal suites, and `pnpm --filter ./packages/core check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Instead of swapping out the main output pipe when someone watches a run (which could steal the responses), this change gives watchers a separate, lazy view of the same stream so the original stream keeps saving data to memory while multiple subscribers can still read it.

## Technical Details

### Changes

- Preserve native output stream and memory persistence:
  - Removed the runtime mutation that overwrote `output.fullStream` via `Object.defineProperty`.
  - `#withBroadcastStream` no longer replaces or eagerly consumes the native stream; it now returns a lazy `createSubscriberStream` and a `startBroadcast` function.
  - Emission of stream parts was lifted out of the `start()` closure and `emitPart` now awaits `#publishAndWait` when publishing `stream-part` events, while still buffering parts and waking subscriber waiters.
  - `registerRun` wiring updated to use the destructured return values from `#withBroadcastStream`; `startBroadcast` is only triggered after the `run-registered` publish resolves, and `publishAndWait` is used for `run-registered` events (start still runs even if publish rejects).

- Remote subscriber behavior:
  - The broadcast loop is started after run registration so remote subscribers (e.g., via Unix-socket PubSub) receive stream parts even when no same-runtime subscriber exists, without replacing the native stream.

### Files Modified

- .changeset/quick-animals-beam.md — changeset for patch release of `@mastra/core`.
- packages/core/src/agent/thread-stream-runtime.ts — refactor to preserve native stream, add lazy subscriber streams, publish-and-wait behavior, and separate broadcast starter (+/- changes).
- packages/core/src/agent/__tests__/agent-signals.test.ts — added a UnixSocketPubSub-based test (non-Windows guarded) ensuring a remote subscriber receives run broadcast when no same-runtime subscriber is present.

### Verification

- Focused core stream, memory, save/error, and agent signal test suites were run.
- Confirmed with pnpm --filter ./packages/core check.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->