### PR TITLE
fix(core): preserve TRequestContext generic in workflow.parallel()

### DIFF
--- a/.changeset/forty-chefs-care.md
+++ b/.changeset/forty-chefs-care.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed type error when using `parallel()` with steps that declare a `requestContextSchema`. The `parallel()` method was dropping the workflow's request-context generic when validating each step, which produced a misleading "Expected Step with state schema that is a subset of workflow state" error for steps with a typed request context. Fixes #16975.

--- a/.changeset/forty-chefs-care.md
+++ b/.changeset/forty-chefs-care.md
@@ -2,4 +2,7 @@
 '@mastra/core': patch
 ---
 
-Fixed type error when using `parallel()` with steps that declare a `requestContextSchema`. The `parallel()` method was dropping the workflow's request-context generic when validating each step, which produced a misleading "Expected Step with state schema that is a subset of workflow state" error for steps with a typed request context. Fixes #16975.
+Fixed `workflow.parallel()` type-checking for steps that declare `requestContextSchema`.
+Steps with matching request context now type-check correctly.
+Steps with mismatched request context still fail with a type error.
+Fixes #16975.

--- a/packages/core/src/workflows/workflow-schema-types.test-d.ts
+++ b/packages/core/src/workflows/workflow-schema-types.test-d.ts
@@ -491,4 +491,62 @@ describe('Workflow schema type inference', () => {
       workflow.dountil(step, async ({ inputData }) => inputData.value >= 10);
     });
   });
+
+  // Regression: https://github.com/mastra-ai/mastra/issues/16975
+  // parallel() dropped the TRequestContext generic on the step parameter,
+  // causing typed requestContextSchema steps to be rejected with a misleading
+  // "Expected Step with state schema that is a subset of workflow state" error.
+  describe('requestContextSchema inference in parallel', () => {
+    const requestContextSchema = z.object({
+      userId: z.string(),
+    });
+
+    it('parallel should accept steps whose requestContextSchema matches the workflow', () => {
+      const stepA = createStep({
+        id: 'step-a',
+        inputSchema: z.object({ name: z.string() }),
+        outputSchema: z.object({ a: z.string() }),
+        requestContextSchema,
+        execute: async ({ inputData }) => ({ a: inputData.name }),
+      });
+
+      const stepB = createStep({
+        id: 'step-b',
+        inputSchema: z.object({ name: z.string() }),
+        outputSchema: z.object({ b: z.string() }),
+        requestContextSchema,
+        execute: async () => ({ b: 'step-b' }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'repro',
+        inputSchema: z.object({ name: z.string() }),
+        outputSchema: z.object({ result: z.string() }),
+        requestContextSchema,
+      });
+
+      const chained = workflow.parallel([stepA, stepB]);
+      expectTypeOf(chained).not.toBeNever();
+    });
+
+    it('parallel should reject a step whose requestContextSchema does not match the workflow', () => {
+      const step = createStep({
+        id: 'bad-ctx',
+        inputSchema: z.object({ name: z.string() }),
+        outputSchema: z.object({ a: z.string() }),
+        requestContextSchema: z.object({ otherProp: z.boolean() }),
+        execute: async ({ inputData }) => ({ a: inputData.name }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'parallel-mismatch',
+        inputSchema: z.object({ name: z.string() }),
+        outputSchema: z.object({ result: z.string() }),
+        requestContextSchema,
+      });
+
+      // @ts-expect-error - step's requestContextSchema does not match the workflow's
+      workflow.parallel([step]);
+    });
+  });
 });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2079,9 +2079,21 @@ export class Workflow<
         infer O,
         any, // Don't infer TResume - causes issues with heterogeneous tuples
         any, // Don't infer TSuspend - causes issues with heterogeneous tuples
-        TEngineType
+        TEngineType,
+        infer TStepRC
       >
-        ? Step<string, SubsetOf<S, TState>, TPrevSchema, O, any, any, TEngineType>
+        ? Step<
+            string,
+            SubsetOf<S, TState>,
+            TPrevSchema,
+            O,
+            any,
+            any,
+            TEngineType,
+            // Allow steps that don't declare a requestContextSchema (TStepRC=unknown) or that
+            // declare one matching the workflow's TRequestContext. Mismatched schemas error.
+            unknown extends TStepRC ? unknown : TRequestContext
+          >
         : `Error: Expected Step with state schema that is a subset of workflow state`;
     },
   ) {


### PR DESCRIPTION
Fixes #16975.

`workflow.parallel()` was dropping the workflow's `TRequestContext` generic when validating each step, so any step with a `requestContextSchema` got rejected with a misleading "Expected Step with state schema that is a subset of workflow state" error. Same shape of bug as #15989 (which fixed the loop helpers); this applies the same fix to `parallel()`.

Before:

```ts
const step = createStep({
  id: 'step-a',
  inputSchema: z.object({ name: z.string() }),
  outputSchema: z.object({ a: z.string() }),
  requestContextSchema: z.object({ userId: z.string() }),
  execute: async ({ inputData }) => ({ a: inputData.name }),
});

workflow.parallel([step]);
// ts(2322): Type 'Step<..., { userId: string }>' is not assignable to type
// '"Error: Expected Step with state schema that is a subset of workflow state"'
```

After: typechecks cleanly. Steps without a `requestContextSchema` still work, mismatched schemas still error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

TypeScript was "forgetting" a small piece of type information for steps run in parallel, which made correct steps get rejected. This PR ensures that the request-context type is kept through parallel() so valid steps type-check and invalid ones still error.

## Summary

This PR fixes a TypeScript typing bug in workflow.parallel() where the per-step conditional type only passed 7 of Step's 8 generic parameters, causing the TRequestContext generic to default to unknown. As a result, steps that declare a requestContextSchema could be incorrectly rejected with a misleading "Expected Step with state schema that is a subset of workflow state" error. The fix threads each step's request-context schema (TStepRC) through the conditional and maps it to the workflow's TRequestContext via unknown extends TStepRC ? unknown : TRequestContext, preserving request-context inference while keeping real schema-subset checks and errors. Fixes `#16975`.

## Changes

packages/core/src/workflows/workflow.ts
- Updated Workflow.parallel(...) typing to infer each step's request-context schema (TStepRC) and include it in the per-step conditional Step<... , TRequestContext> mapping.
- Return tuple element typing now conditionally resolves per-step request-context to the workflow's TRequestContext when compatible.

packages/core/src/workflows/workflow-schema-types.test-d.ts
- Added regression tests verifying parallel() preserves requestContextSchema inference:
  - Accepts steps whose requestContextSchema matches the workflow's request context.
  - Rejects steps with mismatched requestContextSchema (using `@ts-expect-error`).

.changeset/forty-chefs-care.md
- Added changeset entry documenting the patch for `@mastra/core` referencing issue `#16975`.

## Impact

Steps that declare a requestContextSchema are now correctly accepted by workflow.parallel() when compatible with the workflow's request context; steps without a requestContextSchema continue to behave as before, and genuine mismatches still produce type errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->