### PR TITLE
fix(playground-ui): make default-height PageLayout pages scroll on short viewports

### DIFF
--- a/.changeset/fruity-cougars-raise.md
+++ b/.changeset/fruity-cougars-raise.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed Studio Settings page (and other default-height `PageLayout` pages) clipping their content with no scrollbar on viewports shorter than the form. Users on short laptop screens (under ~991px tall) could not reach the Save button under the Mastra Connection headers form, making it impossible to apply changes. Default-height `PageLayout` pages now grow with their content and scroll through the studio chrome wrapper; `height="full"` pages (Logs, Traces, Metrics, etc.) are unchanged.

--- a/packages/playground-ui/src/ds/components/PageLayout/page-layout-root.tsx
+++ b/packages/playground-ui/src/ds/components/PageLayout/page-layout-root.tsx
@@ -18,10 +18,10 @@ export function PageLayoutRoot({
   return (
     <main
       className={cn(
-        'w-full h-full grid grid-rows-[auto_auto] p-6 content-start overflow-y-auto',
+        'w-full grid grid-rows-[auto_auto] p-6 content-start',
         {
           'max-w-screen-lg mx-auto pt-8': width === 'narrow',
-          'grid-rows-[auto_1fr]': height === 'full',
+          'h-full grid-rows-[auto_1fr] overflow-y-auto': height === 'full',
         },
         className,
         //   'LAYOUT_ROOT border border-dashed border-orange-400',


### PR DESCRIPTION
## Description

The Studio `/settings` page (and any other `PageLayout` page using the default `height`) clipped its content with no scrollbar when the viewport was shorter than the content (≈< 991px tall). On short viewports users couldn't reach form controls like the **Save** button under the Mastra Connection headers form, making it impossible to apply changes.

## Before
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/814e3f10-4d40-4adc-9190-758d3e36d622" />

## After
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/3262c332-a149-46cc-b0a9-0a9aef7396a3" />

## Related Issue(s)

Fixes #16996

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Settings page and similar pages were getting cut off at the bottom when your browser window was too short, so you couldn't scroll down to see the Save button. This fix removes conflicting scroll behaviors that were preventing the page from scrolling properly, letting the outer browser window handle scrolling instead of the page itself trying to do it.

## Changes

### Changeset
- Added changeset for `@mastra/playground-ui` with `patch` release documenting the UI fix

### PageLayout Component Updates
- **PageLayoutRoot (`page-layout-root.tsx`)**: 
  - Removed `h-full` and `overflow-y-auto` from the base `<main>` element classes
  - These properties are now conditionally applied only when `height="full"` is explicitly set (along with `grid-rows-[auto_1fr]`)
  - Preserves sticky-top and internal scrolling behavior for full-height pages (Logs, Traces, Metrics)
  - Default-height pages now grow naturally with content and rely on the outer chrome wrapper for scrolling

## Impact

- **Fixed Pages**: Settings, Resources, Agents, Workflows, Tools, and other default-height PageLayout pages now properly scroll on viewports shorter than ~991px
- **Unaffected Pages**: Full-height pages maintain existing behavior with internal scrolling
- **API Compatibility**: No breaking changes; all existing PageLayout usages remain compatible

## Related Issue
Fixes `#16996` (Mastra Studio /settings not scrollable on short viewports)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/16999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->