### PR TITLE
fix(mastracode): wrap long ask_user option labels to prevent TUI crash

### DIFF
--- a/.changeset/smart-loops-jog.md
+++ b/.changeset/smart-loops-jog.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fix Mastra Code TUI crash when ask_user option labels are wider than the terminal — long labels now wrap inside the bordered box, matching how question text already wraps. Reported in #17002.

--- a/mastracode/src/tui/components/__tests__/ask-question-inline-long-labels.test.ts
+++ b/mastracode/src/tui/components/__tests__/ask-question-inline-long-labels.test.ts
@@ -1,0 +1,131 @@
+import { visibleWidth } from '@mariozechner/pi-tui';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock pi-tui — the real components touch the terminal at construction time.
+// Width/wrap helpers (visibleWidth, wrapTextWithAnsi) come from `actual` so the
+// wrap path under test executes the real logic.
+vi.mock('@mariozechner/pi-tui', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  class StubInput {
+    onSubmit?: (value: string) => void;
+    focused = false;
+    handleInput(_data: string): void {}
+    render(_width: number): string[] {
+      return [''];
+    }
+  }
+  class StubBox {
+    children: unknown[] = [];
+    addChild(c: unknown): void {
+      this.children.push(c);
+    }
+    invalidate(): void {}
+  }
+  class StubContainer extends StubBox {}
+  class StubText {
+    constructor(_text: string, _x: number, _y: number) {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  class StubSpacer {
+    constructor(_height: number) {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  class StubSelectList {
+    onSelect?: (item: unknown) => void;
+    onCancel?: () => void;
+    constructor(
+      public items: unknown[],
+      _h: number,
+      _theme: unknown,
+    ) {}
+    handleInput(_data: string): void {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  return {
+    ...actual,
+    Input: StubInput,
+    Box: StubBox,
+    Container: StubContainer,
+    Text: StubText,
+    Spacer: StubSpacer,
+    SelectList: StubSelectList,
+    getKeybindings: () => ({ matches: () => false }),
+    matchesKey: (_data: string, _key: string) => false,
+  };
+});
+
+vi.mock('../multiline-input.js', () => {
+  class StubMultilineInput {
+    onSubmit?: (value: string) => void;
+    onEscape?: () => void;
+    allowEmptySubmit = false;
+    focused = false;
+    constructor(_tui: unknown, _theme: unknown) {}
+    handleInput(_data: string): void {}
+    render(): string[] {
+      return [''];
+    }
+    getText(): string {
+      return '';
+    }
+    setText(_text: string): void {}
+  }
+  return { MultilineInput: StubMultilineInput };
+});
+
+import { AskQuestionInlineComponent } from '../ask-question-inline.js';
+
+const TERMINAL_WIDTH = 80;
+const LONG_LABEL =
+  'Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua';
+
+function maxLineWidth(lines: string[]): number {
+  return lines.reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
+}
+
+describe('AskQuestionInlineComponent long-label wrapping (issue #17002)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('wraps long option labels in streaming state without overflowing the bordered box', () => {
+    const component = AskQuestionInlineComponent.createStreaming();
+    component.updateArgs({
+      question: 'Pick one',
+      options: [{ label: LONG_LABEL }],
+    });
+    const box = (component as any).borderedBox;
+    const lines = box.render(TERMINAL_WIDTH) as string[];
+    expect(maxLineWidth(lines)).toBeLessThanOrEqual(TERMINAL_WIDTH);
+  });
+
+  it('wraps long answered selected/unselected labels without overflowing', () => {
+    const component = AskQuestionInlineComponent.fromHistory(
+      'Pick one',
+      [{ label: LONG_LABEL }, { label: 'Short' }],
+      LONG_LABEL,
+      false,
+    );
+    const box = (component as any).borderedBox;
+    const lines = box.render(TERMINAL_WIDTH) as string[];
+    expect(maxLineWidth(lines)).toBeLessThanOrEqual(TERMINAL_WIDTH);
+  });
+
+  it('wraps long labels in answered cancelled state without overflowing', () => {
+    const component = AskQuestionInlineComponent.fromHistory(
+      'Pick one',
+      [{ label: LONG_LABEL }],
+      '',
+      true,
+    );
+    const box = (component as any).borderedBox;
+    const lines = box.render(TERMINAL_WIDTH) as string[];
+    expect(maxLineWidth(lines)).toBeLessThanOrEqual(TERMINAL_WIDTH);
+  });
+});

--- a/mastracode/src/tui/components/__tests__/ask-question-inline-long-labels.test.ts
+++ b/mastracode/src/tui/components/__tests__/ask-question-inline-long-labels.test.ts
@@ -118,12 +118,7 @@ describe('AskQuestionInlineComponent long-label wrapping (issue #17002)', () => 
   });
 
   it('wraps long labels in answered cancelled state without overflowing', () => {
-    const component = AskQuestionInlineComponent.fromHistory(
-      'Pick one',
-      [{ label: LONG_LABEL }],
-      '',
-      true,
-    );
+    const component = AskQuestionInlineComponent.fromHistory('Pick one', [{ label: LONG_LABEL }], '', true);
     const box = (component as any).borderedBox;
     const lines = box.render(TERMINAL_WIDTH) as string[];
     expect(maxLineWidth(lines)).toBeLessThanOrEqual(TERMINAL_WIDTH);

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -150,37 +150,49 @@ class AskQuestionBorderedBox {
     // Empty separator
     addLine('', 0);
 
+    // Wrap a labelled option line so long labels don't overflow the bordered box.
+    // Mirrors the free-text answered branch below: first wrapped line keeps the
+    // styled prefix (icon/spaces), continuation lines indent 3 spaces.
+    const continuationPrefix = '   ';
+    const addWrappedOptionLine = (prefix: string, label: string, style: (s: string) => string) => {
+      const prefixVis = visibleWidth(prefix);
+      const wrapped = wrapTextWithAnsi(label, Math.max(1, innerWidth - prefixVis));
+      wrapped.forEach((line, index) => {
+        const linePrefix = index === 0 ? prefix : continuationPrefix;
+        const content = `${linePrefix}${style(line)}`;
+        addLine(content, visibleWidth(linePrefix) + visibleWidth(line));
+      });
+    };
+
     if (this.streaming) {
       // Streaming: show option labels as they arrive (dimmed, no interactivity)
+      const dim = (s: string) => theme.fg('dim', s);
       for (const item of this.items) {
-        const line = theme.fg('dim', `   ${item.label}`);
-        addLine(line, visibleWidth(line));
+        addWrappedOptionLine(continuationPrefix, item.label, dim);
       }
       // Waiting indicator
       const waiting = theme.fg('dim', '…');
       addLine(waiting, visibleWidth(waiting));
     } else if (this.answered && this.items.length > 0) {
       // Render frozen item list
+      const dim = (s: string) => theme.fg('dim', s);
       if (this.cancelled) {
         // All items dimmed, cancelled notice
         for (const item of this.items) {
-          const line = theme.fg('dim', `   ${item.label}`);
-          addLine(line, visibleWidth(line));
+          addWrappedOptionLine(continuationPrefix, item.label, dim);
         }
         const cancelLine = `${theme.fg('error', '✗')}  ${theme.fg('dim', '(cancelled)')}`;
         addLine(cancelLine, visibleWidth(cancelLine));
       } else {
         // ✓/✗ on selected, dimmed unselected
+        const text = (s: string) => theme.fg('text', s);
         for (const item of this.items) {
           const isSelected = item.label === this.selectedValue;
           if (isSelected) {
             const icon = this.answerIsNegative ? theme.fg('error', '✗') : theme.fg('success', '✓');
-            const label = theme.fg('text', item.label);
-            const line = `${icon}  ${label}`;
-            addLine(line, visibleWidth(line));
+            addWrappedOptionLine(`${icon}  `, item.label, text);
           } else {
-            const line = theme.fg('dim', `   ${item.label}`);
-            addLine(line, visibleWidth(line));
+            addWrappedOptionLine(continuationPrefix, item.label, dim);
           }
         }
       }


### PR DESCRIPTION
## Description

Long `ask_user` option labels were rendered without wrapping inside the bordered question box, producing lines wider than the terminal that pi-tui's post-render width check threw on, killing the TUI and the conversation. Option labels now wrap the same way question text and free-text answers already do.

## Before 
<img width="662" height="622" alt="image" src="https://github.com/user-attachments/assets/2f4433b7-bdde-4f9b-b2b1-57af954b1a31" />

## After
<img width="662" height="276" alt="image" src="https://github.com/user-attachments/assets/1081e747-0192-4f7a-bb64-5ea25c69bc20" />

## Related Issue(s)

Fixes #17002

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

When the chatbot showed very long answer choices, it tried to draw them all on one line and crashed the screen. This PR makes long choices break into multiple lines so everything fits and the chatbot no longer crashes.

---

## Summary

Fixes a TUI crash in Mastra Code where long `ask_user` option labels rendered past the terminal width and triggered a fatal pi-tui width check. Option labels now wrap inside the bordered question box (matching question text behavior) so rendered lines never exceed the terminal width.

### Changes

- mastracode/src/tui/components/ask-question-inline.ts
  - Added a local helper AskQuestionBorderedBox._render(): addWrappedOptionLine(prefix, label, style) that wraps labels to innerWidth − 3, preserves the styled prefix on the first line (✓ / ✗ / three spaces) and indents continuation lines by 3 spaces.
  - Applied the helper to four rendering paths: streaming, answered-selected, answered-unselected, and answered-cancelled.
  - No change required for the interactive SelectList path (it already truncates).

- mastracode/src/tui/components/__tests__/ask-question-inline-long-labels.test.ts
  - Added a vitest asserting visibleWidth(line) ≤ terminalWidth (80) for streaming, answered (selected/unselected), and cancelled branches. The test reproduces the previous failure when the fix is reverted.

- .changeset/smart-loops-jog.md
  - Patch release note documenting the bugfix.

### Impact

- Fixes issue `#17002`.
- Prevents "Rendered line exceeds terminal width" fatal errors caused by long option labels.
- Ensures option labels wrap consistently with question text and preserves prefix styling/indentation for wrapped lines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17005?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->