### PR TITLE
fix(core): infer createTool inputData type from inputSchema without annotation

### DIFF
--- a/.changeset/fix-createtool-inputdata-inference.md
+++ b/.changeset/fix-createtool-inputdata-inference.md
@@ -1,0 +1,30 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `createTool` so that the `execute` callback's `inputData` parameter is properly inferred from `inputSchema` without requiring an explicit type annotation.
+
+Previously, TypeScript could not resolve the contextual type for `inputData` because `InferSchema<TInputSchema>` is a deferred conditional type — evaluated while `TInputSchema` itself is still being inferred from the object literal. This caused `inputData` to silently fall back to `any`, losing all type safety inside the callback body.
+
+**Before:**
+```ts
+const tool = createTool({
+  inputSchema: z.object({ name: z.string() }),
+  execute: async (inputData) => {
+    inputData.this_does_not_exist; // no TS error — inputData was `any`
+  },
+});
+```
+
+**After:**
+```ts
+const tool = createTool({
+  inputSchema: z.object({ name: z.string() }),
+  execute: async (inputData) => {
+    inputData.this_does_not_exist; // TS error: Property does not exist
+    inputData.name; // string ✓
+  },
+});
+```
+
+The fix adds an overload for `createTool` where `inputSchema: PublicSchema<TIn>` binds `TIn` as a concrete type parameter, giving TypeScript a non-deferred type to use when contextually typing `execute`.

--- a/packages/core/src/tools/createtool-types.test.ts
+++ b/packages/core/src/tools/createtool-types.test.ts
@@ -174,6 +174,41 @@ describe('createTool type improvements', () => {
     expect(output.result).toBe(8);
     expect(output.operation).toBe('add');
   });
+
+  it('should accept a function for requireApproval and type the predicate input', () => {
+    const tool = createTool({
+      id: 'conditional-approval',
+      description: 'Tool with conditional approval',
+      inputSchema: z.object({
+        isDryRun: z.boolean(),
+        target: z.string(),
+      }),
+      requireApproval: async ({ isDryRun, target }) => {
+        // TypeScript should infer these from inputSchema
+        expectTypeOf(isDryRun).toEqualTypeOf<boolean>();
+        expectTypeOf(target).toEqualTypeOf<string>();
+        return !isDryRun;
+      },
+      execute: async () => ({ ok: true }),
+    });
+
+    expect(tool.requireApproval).toBeDefined();
+    expect(typeof tool.requireApproval).toBe('function');
+  });
+
+  it('should infer inputData type without explicit annotation (issue #16528)', () => {
+    const tool = createTool({
+      id: 'infer-test',
+      description: 'issue #16528 regression guard',
+      inputSchema: z.object({ name: z.string(), count: z.number() }),
+      execute: async inputData => {
+        expectTypeOf(inputData).toEqualTypeOf<{ name: string; count: number }>();
+        return { ok: true };
+      },
+    });
+
+    expect(tool).toBeDefined();
+  });
 });
 
 /**

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -512,6 +512,34 @@ type CreateToolOpts<
   suspendSchema?: TSuspendSchema;
   resumeSchema?: TResumeSchema;
 };
+
+// Overload: when inputSchema is provided, bind TIn directly from PublicSchema<TIn> so
+// TypeScript can contextually type execute's inputData without deferred conditional types.
+export function createTool<
+  TId extends string = string,
+  TIn = unknown,
+  TOut = unknown,
+  TSuspend = unknown,
+  TResume = unknown,
+  TRequestContext extends Record<string, any> | unknown = unknown,
+  TContext extends ToolExecutionContext<TSuspend, TResume, TRequestContext> = ToolExecutionContext<
+    TSuspend,
+    TResume,
+    TRequestContext
+  >,
+>(
+  opts: Omit<
+    ToolAction<TIn, TOut, TSuspend, TResume, TContext, TId, TRequestContext>,
+    'inputSchema' | 'outputSchema' | 'suspendSchema' | 'resumeSchema'
+  > & {
+    inputSchema: PublicSchema<TIn>;
+    outputSchema?: PublicSchema<TOut>;
+    suspendSchema?: PublicSchema<TSuspend>;
+    resumeSchema?: PublicSchema<TResume>;
+  },
+): Tool<TIn, TOut, TSuspend, TResume, TContext, TId, TRequestContext>;
+
+// Fallback: no inputSchema (or explicitly typed generics via TInputSchema).
 export function createTool<
   TId extends string = string,
   TInputSchema extends SchemaLike = undefined,
@@ -531,6 +559,8 @@ export function createTool<
   TContext,
   TId,
   TRequestContext
-> {
+>;
+
+export function createTool(opts: any): any {
   return new Tool(opts);
 }


### PR DESCRIPTION
## Problem

When `createTool` is called with an `inputSchema`, the `inputData` parameter of the `execute` callback is typed as `any` instead of the schema's output type. This silently defeats TypeScript's type safety inside the callback body:

```ts
createTool({
  inputSchema: z.object({ name: z.string() }),
  execute: async (inputData) => {
    inputData.this_does_not_exist; // no TS error — inputData is `any`
  },
});
```

Closes #16528.

## Root Cause

TypeScript cannot resolve `InferSchema<TInputSchema>` as a contextual type for `execute`'s `inputData` parameter when both `inputSchema` and `execute` are inferred simultaneously within the same object literal. Since `TInputSchema` is still a free type variable when TypeScript processes `execute`, the conditional type `InferSchema<TInputSchema>` is deferred — causing `inputData` to fall back to `any`.

## Solution

Added an overload for `createTool` where `inputSchema: PublicSchema<TIn>` binds `TIn` as a concrete (non-deferred) type parameter. TypeScript can then contextually type `execute`'s `inputData` as `TIn` directly, without going through a deferred conditional type chain.

The fallback overload (no `inputSchema`) remains unchanged.

## Testing

Added a regression test in `createtool-types.test.ts` (issue #16528 guard) that uses `expectTypeOf(inputData).toEqualTypeOf<{ name: string; count: number }>()` to verify the type is resolved correctly, not `any`.

```ts
// After fix — inputData is properly typed:
createTool({
  inputSchema: z.object({ name: z.string() }),
  execute: async (inputData) => {
    inputData.this_does_not_exist; // TS error: Property does not exist ✓
    inputData.name;                // string ✓
  },
});
```

All existing tool tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you create a tool and tell TypeScript what kind of input data it should accept (using a schema), TypeScript was forgetting that information and saying the input could be anything. This PR fixes that by adding a special instruction for TypeScript so it remembers the input shape and can catch when you try to use fields that don't exist.

## Overview

This PR fixes TypeScript type inference for `createTool` so that when an `inputSchema` is provided, the `execute` callback's `inputData` parameter is automatically inferred as the schema's type instead of defaulting to `any`. This restores TypeScript safety and prevents invalid property access on the input data.

## Problem

Previously, when calling `createTool` with an `inputSchema`, the `inputData` parameter in the `execute` callback was typed as `any`, losing all TypeScript safety. This meant invalid properties like `inputData.this_does_not_exist` would not produce a compile-time error.

**Root cause:** TypeScript could not resolve the inferred type (`InferSchema<TInputSchema>`) as a contextual type for the `execute` parameter when both `inputSchema` and `execute` were being inferred simultaneously in the same object literal, causing the type to fall back to `any`.

## Solution

Added a new overload for `createTool` where `inputSchema: PublicSchema<TIn>` binds `TIn` as a concrete type parameter. This allows TypeScript to contextually type the `execute` callback's `inputData` parameter as `TIn` directly, without relying on deferred conditional type resolution.

The existing fallback overload (for cases without `inputSchema`) remains unchanged.

## Changes

**packages/core/src/tools/tool.ts**
- Added a new `createTool` overload with signature binding `inputSchema: PublicSchema<TIn>` to provide concrete type information for contextual typing of the `execute` callback

**packages/core/src/tools/createtool-types.test.ts**
- Added regression test for issue `#16528` verifying that `inputData` type is correctly inferred from `inputSchema` without explicit annotation
- Added test case for `requireApproval` parameter type inference

**.changeset/fix-createtool-inputdata-inference.md**
- Changeset documenting the fix with before/after TypeScript examples showing that invalid properties now produce compile-time errors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->