### PR TITLE
feat(agent): allow workflows to define explicit toolId for agent

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4721,6 +4721,8 @@ export class Agent<
     const workflows = await this.listWorkflows({ requestContext });
     if (Object.keys(workflows).length > 0) {
       for (const [workflowName, workflow] of Object.entries(workflows)) {
+        const toolName = workflow.options?.toolId || `workflow-${workflowName}`;
+
         // Build input/output schemas as JSONSchema7 to avoid Zod composition issues
         // when workflow schemas are StandardSchemaWithJSON wrappers (e.g. from storage)
         const inputDataJsonSchema: JSONSchema7 = workflow.inputSchema
@@ -4769,7 +4771,7 @@ export class Agent<
         };
 
         const toolObj = createTool({
-          id: `workflow-${workflowName}`,
+          id: toolName,
           description: workflow.description || `Workflow: ${workflowName}`,
           inputSchema: extendedInputSchema,
           outputSchema,
@@ -4933,7 +4935,7 @@ export class Agent<
         });
 
         const options: ToolOptions = {
-          name: `workflow-${workflowName}`,
+          name: toolName,
           runId,
           threadId,
           resourceId,
@@ -4948,7 +4950,7 @@ export class Agent<
           tracingPolicy: this.#options?.tracingPolicy,
         };
 
-        convertedWorkflowTools[`workflow-${workflowName}`] = makeCoreTool(
+        convertedWorkflowTools[toolName] = makeCoreTool(
           toolObj,
           options,
           undefined,

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -479,6 +479,12 @@ export interface WorkflowOptions {
    * Errors thrown in this callback are caught and logged, not propagated.
    */
   onError?: (errorInfo: WorkflowErrorCallbackInfo) => Promise<void> | void;
+
+  /**
+   * Explicit model-facing tool ID used when this workflow is exposed as a tool on an agent.
+   * If set, the agent uses this value as the tool name instead of the default `workflow-${registrationKey}`.
+   */
+  toolId?: string;
 }
 
 export type WorkflowInfo = {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1709,6 +1709,7 @@ export class Workflow<
       onFinish: options.onFinish,
       onError: options.onError,
       sharePubsub: options.sharePubsub,
+      toolId: options.toolId,
     };
 
     if (!executionEngine) {


### PR DESCRIPTION
#### description

- Allow workflows attached to agents to define an explicit model-facing tool ID via options.toolId. When set, the agent uses this value as the tool name instead of the default workflow-${registrationKey}. If omitted, existing behavior is preserved.

#### Related issue(s)
Fixes #17001

#### Type of change
- New feature (non-breaking change that adds functionality)

#### Checklist

-  I have linked the related issue(s) in the description above
-  I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Workflows attached to agents now get to choose what name they're called by the AI model. Instead of always getting an auto-generated name like "workflow-myWorkflow123", they can specify their own name (like "send-email" or "check-inventory") to be clearer and more stable across different parts of the system.

## Changes

### Overview

This PR adds support for workflows to explicitly define their model-facing tool ID via a new optional `options.toolId` parameter. When provided, the agent uses this exact name as the tool identifier instead of the auto-generated `workflow-${registrationKey}` format. If omitted, the existing behavior is preserved for backwards compatibility.

### Core Changes

**WorkflowOptions Type (`packages/core/src/workflows/types.ts`)**
- Added optional `toolId?: string` field to the `WorkflowOptions` export
- Documented as the explicit model-facing tool ID used when the workflow is exposed as a tool on an agent

**Workflow Constructor (`packages/core/src/workflows/workflow.ts`)**
- Updated the private `#options` object to include `toolId: options.toolId`
- Preserves the option alongside existing configuration like `validateInputs`, `shouldPersistSnapshot`, `tracingPolicy`, and lifecycle hooks

**Agent Tool Resolution (`packages/core/src/agent/agent.ts`)**
- Modified `listWorkflowTools()` to derive `toolName` from `workflow.options?.toolId` 
- Falls back to the existing `workflow-${workflowName}` format when `toolId` is not specified
- Applies the resolved `toolName` consistently across:
  - Tool creation via `createTool({ id })`
  - Tool options naming
  - Workflow tool registration keys

### Backwards Compatibility

The implementation maintains full backwards compatibility by defaulting to the existing `workflow-${workflowName}` naming scheme when `toolId` is not provided. Existing workflows will continue to function without any modifications.

### Benefits

- **Stable naming**: Tool names are no longer coupled to internal JavaScript registration keys
- **Descriptive identifiers**: Workflows can use meaningful names that clearly describe their purpose
- **Multi-agent systems**: Consistent tool naming across different agents in complex deployments
- **Convention compliance**: Supports naming conventions required by specific AI models or integration standards

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->