### PR TITLE
fix(ci): exclude audited tinyexec from pnpm trust-policy check

### DIFF
--- a/e2e-tests/type-check/prepare.js
+++ b/e2e-tests/type-check/prepare.js
@@ -17,7 +17,14 @@ export async function setupTemplate(pathToStoreFiles, pkgManager) {
   await mkdir(newPath, { recursive: true });
   await cp(templatePath, newPath, { recursive: true });
 
-  const installArgs = pkgManager === 'pnpm' ? ['install', '--config.minimum-release-age=0'] : ['install'];
+  // tinyexec 1.2.x switched to npm's staged-publishes workflow
+  // (tinylibs/tinyexec#129, #130), which drops the trusted-publisher
+  // metadata on npm. Audited as a benign maintainer-driven hardening,
+  // not a takeover. Remove once upstream restores trusted-publisher.
+  const installArgs =
+    pkgManager === 'pnpm'
+      ? ['install', '--config.minimum-release-age=0', '--config.trust-policy-exclude=tinyexec@*']
+      : ['install'];
 
   console.log('Directory:', newPath);
   console.log('Installing dependencies...');


### PR DESCRIPTION
## Summary

The `E2E Type check` job has been failing on every PR since 2026-05-23 with:

```
ERR_PNPM_TRUST_DOWNGRADE  High-risk trust downgrade for "tinyexec@1.2.2" (possible package takeover)
This error happened while installing the dependencies of vitest@4.1.7
```

This PR scopes the bypass to `tinyexec` specifically, after a manual audit confirmed the alert is a false positive.

## Audit of tinyexec 1.1.2 → 1.2.2

| Version | Published | Publisher (npm `_npmUser`) |
|---|---|---|
| 1.1.2 | 2026-04-29 | `GitHub Actions <npm-oidc-no-reply@github.com>` (trusted publisher / OIDC) |
| 1.2.0 | 2026-05-23 | `43081j <43081james@gmail.com>` (maintainer, manual) |
| 1.2.1 | 2026-05-23 | `43081j <43081james@gmail.com>` |
| 1.2.2 | 2026-05-23 | `43081j <43081james@gmail.com>` |

`43081j` is the sole listed maintainer of `tinyexec` and the owner of the `tinylibs/tinyexec` repo (James Garbutt), unchanged across all versions.

The publisher field change is explained by two deliberate workflow changes merged by the maintainer:

- [tinylibs/tinyexec#129](https://github.com/tinylibs/tinyexec/pull/129) — `chore: setup funding / publish env` — adds `environment: WORLD` to the npm-publish workflow (GitHub Actions manual approval gate).
- [tinylibs/tinyexec#130](https://github.com/tinylibs/tinyexec/pull/130) — `chore: enable staged publishes` — switches `npm publish` to `npm stage publish` (npm's staged-publishes feature; the final promotion to the registry is done manually rather than from CI, which drops the OIDC trusted-publisher attestation).

The code diff `1.1.2..1.2.2` is benign: refactor (inline parse), additional normalize/env/throw tests, a `nodePath` flag, dependabot bumps, shebang fix. No suspicious changes.

**Conclusion:** the npm trust-evidence "downgrade" is a benign side effect of the maintainer hardening the publish pipeline (adding manual approval gates). It is not a takeover.

pnpm upstream explicitly recommends `trustPolicyExclude` for audited false positives ([pnpm/pnpm#10622 comment](https://github.com/pnpm/pnpm/issues/10622#issuecomment-by-kopach)):

> "If a package was published with NPM provenance enabled, any later versions that disable this will trigger `ERR_PNPM_TRUST_DOWNGRADE`. This is the purpose of `trustPolicy: no-downgrade`. Use `trustPolicyExclude` if you have **manually** verified that the published package is valid and conforms to the source code to bypass this."

## Change

One-line change in `e2e-tests/type-check/prepare.js`: add `--config.trust-policy-exclude=tinyexec@*` next to the existing `--config.minimum-release-age=0` flag, with an inline comment linking the audit and the removal condition.

```js
// tinyexec 1.2.x switched to npm's staged-publishes workflow
// (tinylibs/tinyexec#129, #130), which drops the trusted-publisher
// metadata on npm. Audited as a benign maintainer-driven hardening,
// not a takeover. Remove once upstream restores trusted-publisher.
const installArgs =
  pkgManager === 'pnpm'
    ? ['install', '--config.minimum-release-age=0', '--config.trust-policy-exclude=tinyexec@*']
    : ['install'];
```

## Why this scope

- **Surgical, not blanket.** Excludes only `tinyexec`. Any other supply-chain regression (a real takeover in vitest / zod / @ai-sdk/openai / any other transitive) still trips `no-downgrade` and blocks CI.
- **Continues an established pattern.** `prepare.js` already passes `--config.minimum-release-age=0` (`46f9565ee5` — "stabilize PR CI fixtures") to bypass the release-age gate for the same reason: hermetic E2E fixture in a tmpdir against a local Verdaccio registry.
- **Workspace defense unchanged.** `pnpm-workspace.yaml` keeps `trustPolicy: no-downgrade`, `trustPolicyIgnoreAfter: 43200`, and `blockExoticSubdeps: true`. Only the throwaway fixture install opts out for `tinyexec`.
- **No test is muted.** `trust-policy` is install-time only. After install, `pnpm vitest run` executes the type-check assertions against the published `@mastra/core` and `@mastra/client-js` packages exactly as before.
- **Self-cleaning.** Workspace `trustPolicyIgnoreAfter: 43200` (30 days) would auto-resolve this around 2026-06-22 for workspace installs but does not apply to the fixture install in a tmpdir. The inline comment documents the condition for removing the exclusion.

## Scope

Only `e2e-tests/type-check` is currently failing — the 5 other `prepare.js` scripts (`monorepo`, `deployers`, `no-bundling`, `commonjs`, `bundler-analysis.test.ts`) are green and are not touched. They can adopt the same flag if they hit the same case later.

## Test plan

- [ ] `E2E Type check` job passes on this PR
- [ ] Other E2E jobs (monorepo, deployers, no-bundling, commonjs, kitchen-sink, create-mastra) remain green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A test job keeps breaking because it thinks one of the tools it's using (called tinyexec) might be fake or compromised. But we checked the tool and it's actually fine—just some internal changes by the original author. So we're telling the system "don't worry about this one, we verified it's safe."

## Changes Summary

**File Modified:** `e2e-tests/type-check/prepare.js`

The `setupTemplate` function's `pnpm` installation command now includes an additional flag `--config.trust-policy-exclude=tinyexec@*` alongside the existing `--config.minimum-release-age=0` flag.

**Before:**
```
pnpm install --config.minimum-release-age=0
```

**After:**
```
pnpm install --config.minimum-release-age=0 --config.trust-policy-exclude=tinyexec@*
```

An inline comment was added documenting the rationale for this exclusion and the manual audit findings.

## Context

The E2E Type check job began failing on 2026-05-23 with `ERR_PNPM_TRUST_DOWNGRADE` for tinyexec@1.2.2 (pulled as a transitive dependency via vitest@4.1.7). The package lost trusted-publisher metadata when the maintainer (43081j / James Garbutt) switched to a staged publish workflow with manual approval gates. A manual code audit of versions 1.1.2 → 1.2.2 found only benign changes (refactoring, test updates, flags, and dependabot fixes), confirming no supply chain compromise occurred. This is a false positive triggered by pnpm's strict `no-downgrade` trust policy.

## Rationale

The fix follows pnpm's upstream recommendation for handling manually verified false positives by using `trustPolicyExclude`. The exclusion is:
- **Surgical:** scoped to tinyexec only
- **Temporary:** applies only to the throwaway fixture install in the E2E test
- **Non-invasive:** workspace-level trustPolicy settings remain unchanged; other trust protections (minimum-release-age, blockExoticSubdeps) are preserved

## Impact

- Changes only affect the E2E Type check job's temporary fixture installation
- No test code muted; only install-time behavior modified
- Workspace security posture otherwise unchanged

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->