### PR TITLE
fix(voice-google-gemini-live): route tool Zod schemas through GoogleSchemaCompatLayer

### DIFF
--- a/.changeset/shaky-singers-teach.md
+++ b/.changeset/shaky-singers-teach.md
@@ -1,0 +1,7 @@
+---
+'@mastra/voice-google-gemini-live': patch
+---
+
+Tools registered via `voice.addTools(...)` with rich Zod schemas now reach Gemini Live with a faithful schema. The package routes Zod through `@mastra/schema-compat`'s `applyCompatLayer` + `GoogleSchemaCompatLayer` — the in-repo Google pipeline — so the tool parameters land in the OpenAPI 3.0 shape Gemini Live's setup validator accepts.
+
+Fixes #17020.

--- a/.changeset/wide-cities-jog.md
+++ b/.changeset/wide-cities-jog.md
@@ -1,0 +1,15 @@
+---
+'@mastra/voice-google-gemini-live': patch
+---
+
+**Fixed** Gemini Live sessions now connect successfully when using native-audio models. Previously the connection failed during session setup.
+
+**Fixed** tools are now invoked correctly. Previously tool calls were silently ignored even when tools were registered during setup.
+
+**Fixed** tool results of any shape (arrays, primitives, objects) are now accepted. Previously, non-object tool return values caused sessions to close unexpectedly.
+
+**Fixed** the `speaker` option is now honored when passed at the `VoiceConfig` root alongside `realtimeConfig`, not only when passed in the flat config shape.
+
+**Changed** default model from `gemini-2.0-flash-exp` (shut down 2025-12-09) to `gemini-3.1-flash-live-preview` (Google's current Live API quickstart model). If you weren't explicitly setting `model`, your sessions will start connecting again.
+
+Fixes #17018.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6807,6 +6807,9 @@ importers:
       '@google/genai':
         specifier: ^1.45.0
         version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(bufferutil@4.1.0)
+      '@mastra/schema-compat':
+        specifier: workspace:*
+        version: link:../../packages/schema-compat
       google-auth-library:
         specifier: ^10.6.1
         version: 10.6.2
@@ -6853,9 +6856,6 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
-      zod-to-json-schema:
-        specifier: ^3.25.1
-        version: 3.25.1(zod@4.4.3)
 
   voice/inworld:
     dependencies:

--- a/voice/google-gemini-live-api/package.json
+++ b/voice/google-gemini-live-api/package.json
@@ -33,6 +33,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@google/genai": "^1.45.0",
+    "@mastra/schema-compat": "workspace:*",
     "google-auth-library": "^10.6.1",
     "ws": "^8.20.0"
   },
@@ -49,8 +50,7 @@
     "tsx": "^4.21.0",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "zod": "catalog:",
-    "zod-to-json-schema": "^3.25.1"
+    "zod": "catalog:"
   },
   "peerDependencies": {
     "@mastra/core": ">=1.0.0-0 <2.0.0-0"

--- a/voice/google-gemini-live-api/src/index.test.ts
+++ b/voice/google-gemini-live-api/src/index.test.ts
@@ -1,5 +1,6 @@
 import { PassThrough } from 'node:stream';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
 import { GeminiLiveVoice } from './index';
 
 // Mock WebSocket
@@ -45,15 +46,6 @@ vi.mock('google-auth-library', () => {
 
   return { GoogleAuth: MockGoogleAuth };
 });
-
-// Mock zod-to-json-schema
-vi.mock('zod-to-json-schema', () => ({
-  zodToJsonSchema: vi.fn().mockImplementation(() => ({
-    type: 'object',
-    properties: {},
-    $schema: 'http://json-schema.org/draft-07/schema#',
-  })),
-}));
 
 describe('GeminiLiveVoice', () => {
   let voice: GeminiLiveVoice;
@@ -1111,6 +1103,96 @@ describe('GeminiLiveVoice', () => {
       expect(usage.outputTokens).toBe(2);
       expect(usage.totalTokens).toBe(3);
       expect(['audio', 'text', 'video']).toContain(usage.modality);
+    });
+  });
+
+  describe('Zod schema → JSON Schema for tool parameters', () => {
+    async function captureToolParameters(zodSchema: unknown): Promise<any> {
+      const v = new GeminiLiveVoice({ apiKey: 'k' });
+      v.addTools({
+        probe: {
+          id: 'probe',
+          description: 'probe tool',
+          inputSchema: zodSchema,
+          execute: vi.fn() as any,
+        },
+      });
+
+      vi.spyOn((v as any).connectionManager, 'waitForOpen').mockResolvedValue(undefined as any);
+      (v as any).waitForSessionCreated = vi.fn().mockResolvedValue(undefined);
+
+      await v.connect();
+
+      const wsSent = ((v as any).connectionManager.getWebSocket() as any).send as any;
+      const payloads = wsSent.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const setupMsg = payloads.find((p: any) => p.setup);
+      const toolEntry = setupMsg.setup.tools?.[0];
+      // The wire shape (camelCase `functionDeclarations` vs snake_case `function_declarations`) is
+      // tracked separately in #17018; pick whichever container the current setup builder produced.
+      const declarations = toolEntry?.functionDeclarations ?? toolEntry?.function_declarations;
+      return declarations?.[0]?.parameters;
+    }
+
+    it('converts ZodUnion to a real JSON Schema (not the empty fallback)', async () => {
+      const params = await captureToolParameters(z.object({ value: z.union([z.string(), z.number()]) }));
+      const value = params.properties.value;
+      // The old hand-rolled converter dropped unions to `{ type: 'object', properties: {} }`.
+      // zod-to-json now emits a union via `anyOf` / `oneOf`. We don't pin the exact keyword —
+      // both forms describe "string or number" faithfully and are what we care about.
+      const branches = value.anyOf ?? value.oneOf;
+      expect(branches).toBeDefined();
+      expect(branches.map((b: any) => b.type).sort()).toEqual(['number', 'string']);
+    });
+
+    it('converts ZodLiteral to a const-style JSON Schema', async () => {
+      const params = await captureToolParameters(z.object({ mode: z.literal('strict') }));
+      const mode = params.properties.mode;
+      // Faithful conversion preserves the literal value via `const` or single-element `enum`.
+      const literalValue =
+        mode.const ?? (Array.isArray(mode.enum) && mode.enum.length === 1 ? mode.enum[0] : undefined);
+      expect(literalValue).toBe('strict');
+    });
+
+    it('converts ZodDiscriminatedUnion (tagged union) to a branched JSON Schema', async () => {
+      const params = await captureToolParameters(
+        z.object({
+          event: z.discriminatedUnion('kind', [
+            z.object({ kind: z.literal('click'), x: z.number() }),
+            z.object({ kind: z.literal('hover'), seconds: z.number() }),
+          ]),
+        }),
+      );
+      const event = params.properties.event;
+      const branches = event.anyOf ?? event.oneOf;
+      expect(branches).toBeDefined();
+      expect(branches).toHaveLength(2);
+      // Each branch must be an object with its discriminator + its own payload field — i.e. the
+      // type information actually survived the conversion.
+      for (const branch of branches) {
+        expect(branch.type).toBe('object');
+        expect(Object.keys(branch.properties)).toContain('kind');
+      }
+    });
+
+    it('converts a nullable field to a faithful nullable JSON Schema', async () => {
+      const params = await captureToolParameters(z.object({ note: z.string().nullable() }));
+      const note = params.properties.note;
+      // Accept any faithful encoding (anyOf [string, null]; `type: ['string','null']`; or `nullable: true`).
+      const acceptableNullable =
+        (Array.isArray(note.type) && note.type.includes('null')) ||
+        note.nullable === true ||
+        (Array.isArray(note.anyOf) && note.anyOf.some((b: any) => b.type === 'null'));
+      expect(acceptableNullable).toBe(true);
+    });
+
+    it('passes through a tool that already supplies a JSON Schema in inputSchema unchanged', async () => {
+      const jsonSchema = {
+        type: 'object',
+        properties: { q: { type: 'string' } },
+        required: ['q'],
+      };
+      const params = await captureToolParameters(jsonSchema);
+      expect(params).toEqual(jsonSchema);
     });
   });
 });

--- a/voice/google-gemini-live-api/src/index.test.ts
+++ b/voice/google-gemini-live-api/src/index.test.ts
@@ -812,7 +812,251 @@ describe('GeminiLiveVoice', () => {
       const setupMsg = payloads.find((p: any) => p.setup);
       expect(setupMsg).toBeDefined();
       expect(setupMsg.setup.model).toBe('models/gemini-2.0-flash-exp');
-      expect(setupMsg.setup.systemInstruction.parts[0].text).toBe('You are test');
+      expect(setupMsg.setup.system_instruction.parts[0].text).toBe('You are test');
+    });
+
+    it('connect() should default model to gemini-3.1-flash-live-preview when none is supplied', async () => {
+      const v = new GeminiLiveVoice({ apiKey: 'k' });
+
+      vi.spyOn((v as any).connectionManager, 'waitForOpen').mockResolvedValue(undefined as any);
+      (v as any).waitForSessionCreated = vi.fn().mockResolvedValue(undefined);
+
+      await v.connect();
+
+      const wsSent = ((v as any).connectionManager.getWebSocket() as any).send as any;
+      const payloads = wsSent.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const setupMsg = payloads.find((p: any) => p.setup);
+      expect(setupMsg.setup.model).toBe('models/gemini-3.1-flash-live-preview');
+    });
+
+    it('connect() should always emit generation_config.response_modalities: ["AUDIO"]', async () => {
+      const v = new GeminiLiveVoice({ apiKey: 'k' });
+
+      vi.spyOn((v as any).connectionManager, 'waitForOpen').mockResolvedValue(undefined as any);
+      (v as any).waitForSessionCreated = vi.fn().mockResolvedValue(undefined);
+
+      await v.connect();
+
+      const wsSent = ((v as any).connectionManager.getWebSocket() as any).send as any;
+      const payloads = wsSent.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const setupMsg = payloads.find((p: any) => p.setup);
+      expect(setupMsg.setup.generation_config).toBeDefined();
+      expect(setupMsg.setup.generation_config.response_modalities).toEqual(['AUDIO']);
+    });
+
+    it('connect() should include speech_config.voice_config.prebuilt_voice_config.voice_name when speaker is set', async () => {
+      const v = new GeminiLiveVoice({ apiKey: 'k', speaker: 'Puck' });
+
+      vi.spyOn((v as any).connectionManager, 'waitForOpen').mockResolvedValue(undefined as any);
+      (v as any).waitForSessionCreated = vi.fn().mockResolvedValue(undefined);
+
+      await v.connect();
+
+      const wsSent = ((v as any).connectionManager.getWebSocket() as any).send as any;
+      const payloads = wsSent.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const setupMsg = payloads.find((p: any) => p.setup);
+      expect(setupMsg.setup.generation_config.speech_config.voice_config.prebuilt_voice_config.voice_name).toBe('Puck');
+    });
+
+    it('connect() should pick up apiKey and model placed on realtimeConfig root (not inside options)', async () => {
+      const v = new GeminiLiveVoice({
+        realtimeConfig: {
+          model: 'gemini-3.1-flash-live-preview',
+          apiKey: 'root-key',
+          // intentionally no `options.apiKey` — caller relies on the root field
+        },
+      });
+
+      vi.spyOn((v as any).connectionManager, 'waitForOpen').mockResolvedValue(undefined as any);
+      (v as any).waitForSessionCreated = vi.fn().mockResolvedValue(undefined);
+
+      await v.connect();
+
+      const wsSent = ((v as any).connectionManager.getWebSocket() as any).send as any;
+      const payloads = wsSent.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const setupMsg = payloads.find((p: any) => p.setup);
+      expect(setupMsg.setup.model).toBe('models/gemini-3.1-flash-live-preview');
+      expect((v as any).options.apiKey).toBe('root-key');
+    });
+
+    it('connect() should honor a VoiceConfig-root speaker passed alongside realtimeConfig', async () => {
+      const v = new GeminiLiveVoice({
+        speaker: 'Charon',
+        realtimeConfig: {
+          model: 'gemini-3.1-flash-live-preview',
+          apiKey: 'k',
+          options: { apiKey: 'k' },
+        },
+      });
+
+      vi.spyOn((v as any).connectionManager, 'waitForOpen').mockResolvedValue(undefined as any);
+      (v as any).waitForSessionCreated = vi.fn().mockResolvedValue(undefined);
+
+      await v.connect();
+
+      const wsSent = ((v as any).connectionManager.getWebSocket() as any).send as any;
+      const payloads = wsSent.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const setupMsg = payloads.find((p: any) => p.setup);
+      expect(setupMsg.setup.generation_config.speech_config.voice_config.prebuilt_voice_config.voice_name).toBe(
+        'Charon',
+      );
+    });
+
+    it('connect() should emit tools as a single function_declarations container holding every tool', async () => {
+      const v = new GeminiLiveVoice({
+        apiKey: 'k',
+        tools: [
+          { name: 'first', description: 'a', parameters: { type: 'object', properties: {} } },
+          { name: 'second', description: 'b', parameters: { type: 'object', properties: {} } },
+        ],
+      });
+
+      vi.spyOn((v as any).connectionManager, 'waitForOpen').mockResolvedValue(undefined as any);
+      (v as any).waitForSessionCreated = vi.fn().mockResolvedValue(undefined);
+
+      await v.connect();
+
+      const wsSent = ((v as any).connectionManager.getWebSocket() as any).send as any;
+      const payloads = wsSent.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const setupMsg = payloads.find((p: any) => p.setup);
+      expect(setupMsg.setup.tools).toHaveLength(1);
+      expect(setupMsg.setup.tools[0].function_declarations).toHaveLength(2);
+      expect(setupMsg.setup.tools[0].function_declarations.map((d: any) => d.name)).toEqual(['first', 'second']);
+    });
+
+    it('updateSessionConfig({ tools }) should merge config.tools with addTools() registrations into one container', async () => {
+      // Mirror sendInitialConfig: both tool sources contribute. Previously updateSessionConfig
+      // dropped config.tools entirely whenever any `addTools()` registrations existed.
+      voice.addTools({
+        registered: {
+          id: 'registered',
+          description: 'r',
+          parameters: { type: 'object', properties: {} },
+          execute: vi.fn() as any,
+        },
+      });
+
+      setTimeout(() => {
+        (voice as any).eventManager.getEventEmitter().emit('session.updated', { ok: true } as any);
+      }, 10);
+
+      await voice.updateSessionConfig({
+        tools: [{ name: 'fromConfig', description: 'c', parameters: { type: 'object', properties: {} } }],
+      });
+
+      const calls = mockWs.send.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const updateMsg = calls.find((p: any) => p.session?.tools !== undefined);
+      expect(updateMsg.session.tools).toHaveLength(1);
+      const names = updateMsg.session.tools[0].function_declarations.map((d: any) => d.name);
+      expect(names).toContain('fromConfig');
+      expect(names).toContain('registered');
+    });
+
+    it('updateSessionConfig({ tools }) should emit the same single-container function_declarations shape as setup', async () => {
+      // Mid-session updateSessionConfig must not regress to the one-container-per-tool shape; Gemini
+      // accepts that shape at the wire but suppresses tool_call frames, silently breaking tool routing.
+      setTimeout(() => {
+        (voice as any).eventManager.getEventEmitter().emit('session.updated', { ok: true } as any);
+      }, 10);
+
+      await voice.updateSessionConfig({
+        tools: [
+          { name: 'alpha', description: 'a', parameters: { type: 'object', properties: {} } },
+          { name: 'beta', description: 'b', parameters: { type: 'object', properties: {} } },
+        ],
+      });
+
+      const calls = mockWs.send.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const updateMsg = calls.find((p: any) => p.session?.tools !== undefined);
+      expect(updateMsg).toBeDefined();
+      expect(updateMsg.session.tools).toHaveLength(1);
+      expect(updateMsg.session.tools[0].function_declarations).toHaveLength(2);
+      expect(updateMsg.session.tools[0].function_declarations.map((d: any) => d.name)).toEqual(['alpha', 'beta']);
+    });
+
+    it('should wrap array tool results in { result } so the Gemini Live `response` proto field stays a struct', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(['hit-1', 'hit-2']);
+      voice.addTools({
+        searchTool: { id: 'searchTool', description: 'd', inputSchema: {}, execute: mockExecute as any },
+      });
+
+      await (voice as any).handleGeminiMessage({
+        toolCall: { name: 'searchTool', args: {}, id: 'id-array' },
+      });
+
+      const payloads = mockWs.send.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const toolResult = payloads.find((p: any) => p.toolResponse);
+      expect(toolResult.toolResponse.functionResponses[0].name).toBe('searchTool');
+      expect(toolResult.toolResponse.functionResponses[0].response).toEqual({ result: ['hit-1', 'hit-2'] });
+    });
+
+    it('should wrap non-plain-object tool results (Date, Map, Set, Error, class instances) in { result }', async () => {
+      // Bare Map/Set/Date/Error/class instances JSON.stringify to `{}` or non-struct shapes; the
+      // proto `response` field is a struct, so we must wrap to keep tool data on the wire.
+      class Custom {
+        constructor(public value: number) {}
+      }
+      const cases: Array<{ id: string; toolName: string; result: unknown }> = [
+        { id: 'id-map', toolName: 'mapTool', result: new Map([['k', 'v']]) },
+        { id: 'id-set', toolName: 'setTool', result: new Set([1, 2]) },
+        { id: 'id-date', toolName: 'dateTool', result: new Date('2026-01-01T00:00:00Z') },
+        { id: 'id-class', toolName: 'classTool', result: new Custom(42) },
+      ];
+
+      for (const c of cases) {
+        voice.addTools({
+          [c.toolName]: {
+            id: c.toolName,
+            description: 'd',
+            inputSchema: {},
+            execute: vi.fn().mockResolvedValue(c.result) as any,
+          },
+        });
+        await (voice as any).handleGeminiMessage({ toolCall: { name: c.toolName, args: {}, id: c.id } });
+      }
+
+      const payloads = mockWs.send.mock.calls.map((call: any[]) => JSON.parse(call[0]));
+      for (const c of cases) {
+        const toolResult = payloads.find((p: any) => p.toolResponse?.functionResponses?.[0]?.id === c.id);
+        expect(toolResult, `payload for ${c.toolName}`).toBeDefined();
+        const response = toolResult.toolResponse.functionResponses[0].response;
+        // Every non-plain-object result must be wrapped — the wire field is always an object with `result` key.
+        expect(response).toHaveProperty('result');
+      }
+    });
+
+    it('should pass plain-object tool results through unwrapped', async () => {
+      const mockExecute = vi.fn().mockResolvedValue({ temperature: 72, conditions: 'sunny' });
+      voice.addTools({
+        weatherTool: { id: 'weatherTool', description: 'd', inputSchema: {}, execute: mockExecute as any },
+      });
+
+      await (voice as any).handleGeminiMessage({
+        toolCall: { name: 'weatherTool', args: {}, id: 'id-plain' },
+      });
+
+      const payloads = mockWs.send.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const toolResult = payloads.find((p: any) => p.toolResponse);
+      expect(toolResult.toolResponse.functionResponses[0].response).toEqual({ temperature: 72, conditions: 'sunny' });
+    });
+
+    it('updateSessionConfig({ tools: [] }) should clear tools even when addTools() registry is non-empty', async () => {
+      // Explicit-clear intent: caller passes an empty `config.tools` array to remove all tools
+      // mid-session. Without this honor, addTools() registrations would silently survive.
+      voice.addTools({
+        sticky: { id: 'sticky', description: 'd', inputSchema: {}, execute: vi.fn() as any },
+      });
+
+      setTimeout(() => {
+        (voice as any).eventManager.getEventEmitter().emit('session.updated', { ok: true } as any);
+      }, 10);
+
+      await voice.updateSessionConfig({ tools: [] });
+
+      const calls = mockWs.send.mock.calls.map((c: any[]) => JSON.parse(c[0]));
+      const updateMsg = calls.find((p: any) => p.session?.tools !== undefined);
+      expect(updateMsg).toBeDefined();
+      expect(updateMsg.session.tools).toEqual([]);
     });
 
     it('speak() should send per-turn session.update before content (language, modalities, voice)', async () => {
@@ -851,6 +1095,7 @@ describe('GeminiLiveVoice', () => {
       expect(toolResult).toBeDefined();
       expect(toolResult.toolResponse.functionResponses).toBeDefined();
       expect(toolResult.toolResponse.functionResponses[0].id).toBe('id-1');
+      expect(toolResult.toolResponse.functionResponses[0].name).toBe('testTool');
       expect(toolResult.toolResponse.functionResponses[0].response).toEqual({ result: 'ok' });
     });
 

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { ToolsInput } from '@mastra/core/agent';
 import { MastraVoice } from '@mastra/core/voice';
 import type { VoiceEventType, VoiceConfig } from '@mastra/core/voice';
+import { applyCompatLayer, GoogleSchemaCompatLayer } from '@mastra/schema-compat';
 import type { WebSocket as WSType } from 'ws';
 import { WebSocket } from 'ws';
 import { AudioStreamManager, ConnectionManager, ContextManager, AuthManager, EventManager } from './managers';
@@ -2005,12 +2006,29 @@ export class GeminiLiveVoice extends MastraVoice<
     }
 
     if (registeredTools && Object.keys(registeredTools).length > 0) {
+      const compatLayers = [
+        new GoogleSchemaCompatLayer({
+          provider: 'google',
+          modelId: this.options.model ?? DEFAULT_MODEL,
+          supportsStructuredOutputs: false,
+        }),
+      ];
+
       for (const [toolName, tool] of Object.entries(registeredTools)) {
         try {
           let parameters: unknown;
           if ('inputSchema' in tool && tool.inputSchema) {
             if (typeof tool.inputSchema === 'object' && 'safeParse' in tool.inputSchema) {
-              parameters = this.convertZodSchemaToJsonSchema(tool.inputSchema);
+              // Route Zod schemas through the in-repo Google compat pipeline. Per #17060,
+              // `GoogleSchemaCompatLayer` emits OpenAPI 3.0 Schema Object output that the
+              // Gemini Live setup validator accepts directly — no extra post-processing
+              // needed in this package.
+              const aiSdkSchema = applyCompatLayer({
+                schema: tool.inputSchema as any,
+                compatLayers,
+                mode: 'aiSdkSchema',
+              });
+              parameters = aiSdkSchema.jsonSchema;
             } else {
               parameters = tool.inputSchema;
             }
@@ -2032,106 +2050,6 @@ export class GeminiLiveVoice extends MastraVoice<
     }
 
     return declarations;
-  }
-
-  /**
-   * Convert Zod schema to JSON Schema for tool parameters
-   * @private
-   */
-  private convertZodSchemaToJsonSchema(schema: any): unknown {
-    try {
-      // Try to use the schema's toJSON method if available
-      if (typeof schema.toJSON === 'function') {
-        return schema.toJSON();
-      }
-
-      // Try to use the schema's _def property if available (Zod internal)
-      if (schema._def) {
-        return this.convertZodDefToJsonSchema(schema._def);
-      }
-
-      // If it's already a plain object, return as is
-      if (typeof schema === 'object' && !schema.safeParse) {
-        return schema;
-      }
-
-      // Default fallback
-      return {
-        type: 'object',
-        properties: {},
-        description: schema.description || '',
-      };
-    } catch (error) {
-      this.log('Failed to convert Zod schema to JSON schema', { error, schema });
-      return {
-        type: 'object',
-        properties: {},
-        description: 'Schema conversion failed',
-      };
-    }
-  }
-
-  /**
-   * Convert Zod definition to JSON Schema
-   * @private
-   */
-  private convertZodDefToJsonSchema(def: any): unknown {
-    switch (def.typeName) {
-      case 'ZodString':
-        return {
-          type: 'string',
-          description: def.description || '',
-        };
-      case 'ZodNumber':
-        return {
-          type: 'number',
-          description: def.description || '',
-        };
-      case 'ZodBoolean':
-        return {
-          type: 'boolean',
-          description: def.description || '',
-        };
-      case 'ZodArray':
-        return {
-          type: 'array',
-          items: this.convertZodDefToJsonSchema(def.type._def),
-          description: def.description || '',
-        };
-      case 'ZodObject':
-        const properties: Record<string, unknown> = {};
-        const required: string[] = [];
-
-        for (const [key, value] of Object.entries(def.shape())) {
-          properties[key] = this.convertZodDefToJsonSchema((value as any)._def);
-          if ((value as any)._def.typeName === 'ZodOptional') {
-            // Optional field, don't add to required
-          } else {
-            required.push(key);
-          }
-        }
-
-        return {
-          type: 'object',
-          properties,
-          required: required.length > 0 ? required : undefined,
-          description: def.description || '',
-        };
-      case 'ZodOptional':
-        return this.convertZodDefToJsonSchema(def.innerType._def);
-      case 'ZodEnum':
-        return {
-          type: 'string',
-          enum: def.values,
-          description: def.description || '',
-        };
-      default:
-        return {
-          type: 'object',
-          properties: {},
-          description: def.description || '',
-        };
-    }
   }
 
   /**

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -26,8 +26,17 @@ type GeminiEventName = Extract<keyof GeminiLiveEventMap, string>;
 /**
  * Default configuration values
  */
-const DEFAULT_MODEL: GeminiVoiceModel = 'gemini-2.0-flash-exp';
+const DEFAULT_MODEL: GeminiVoiceModel = 'gemini-3.1-flash-live-preview';
 const DEFAULT_VOICE: GeminiVoiceName = 'Puck';
+
+// Treats only plain objects (own prototype chain ends at `Object.prototype` or `null`) as
+// proto-struct compatible — `Date`, `Map`, `Set`, `Error`, `RegExp`, and class instances all
+// JSON-serialize to `{}` if forwarded bare and need wrapping for Gemini Live's `response` field.
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
 
 /**
  * Helper class for consistent error handling
@@ -162,8 +171,25 @@ export class GeminiLiveVoice extends MastraVoice<
     const normalizedConfig = GeminiLiveVoice.normalizeConfig(config);
     super(normalizedConfig);
 
-    // Extract options from realtimeConfig
-    this.options = normalizedConfig.realtimeConfig?.options || {};
+    // Seed `this.options` from `realtimeConfig`. Fields on the `realtimeConfig` root
+    // (`model`, `apiKey`, `vertexAI`, `project`, etc.) and on the inner `options` object both
+    // belong in the flat `GeminiLiveVoiceConfig` shape this class reads from; merge with the
+    // explicit inner `options` last so caller intent on the inner object wins on collisions.
+    const realtimeConfig = normalizedConfig.realtimeConfig;
+    if (realtimeConfig) {
+      const { options: innerOptions, ...realtimeConfigRoot } = realtimeConfig;
+      this.options = { ...(realtimeConfigRoot as Partial<GeminiLiveVoiceConfig>), ...(innerOptions || {}) };
+    } else {
+      this.options = {};
+    }
+
+    // `speaker` lives at the `VoiceConfig` root, sibling to `realtimeConfig` — not inside it.
+    // Propagate explicitly so `new GeminiLiveVoice({ speaker: 'Puck', realtimeConfig: { ... } })`
+    // honors the caller's voice. Reading from `normalizedConfig.speaker` would pin `DEFAULT_VOICE`
+    // whenever the flat-config branch normalized without an explicit speaker, so use the raw `config`.
+    if ('realtimeConfig' in config && config.speaker && !this.options.speaker) {
+      this.options.speaker = config.speaker as GeminiVoiceName;
+    }
 
     // Validate API key
     const apiKey = this.options.apiKey;
@@ -866,76 +892,23 @@ export class GeminiLiveVoice extends MastraVoice<
         this.log('Updating instructions');
       }
 
-      // Update tools if provided
-      if (config.tools !== undefined) {
+      // Mirror `sendInitialConfig`: flatten both tool sources — the explicit `config.tools` arg
+      // and the `addTools()` registry — into a single `function_declarations` container so the
+      // model receives every available tool. The multi-container shape previously emitted here
+      // was accepted by Gemini at setup but suppressed tool_call frames mid-session, reintroducing #17018.
+      const hasRegisteredTools = !!this.tools && Object.keys(this.tools).length > 0;
+      // `config.tools: []` is the explicit-clear signal; honor it even when the `addTools()`
+      // registry is non-empty, otherwise the caller has no way to remove all tools mid-session.
+      const isExplicitClear = Array.isArray(config.tools) && config.tools.length === 0;
+      if (config.tools !== undefined || hasRegisteredTools) {
         hasUpdates = true;
-        if (config.tools.length > 0) {
-          updateMessage.session.tools = config.tools.map((tool: GeminiToolConfig) => ({
-            function_declarations: [
-              {
-                name: tool.name,
-                description: tool.description,
-                parameters: tool.parameters,
-              },
-            ],
-          }));
+        const declarations = isExplicitClear ? [] : this.buildToolDeclarations(config.tools, this.tools);
+        if (declarations.length > 0) {
+          updateMessage.session.tools = [{ function_declarations: declarations }];
         } else {
-          // Clear tools if empty array provided
           updateMessage.session.tools = [];
         }
-
-        this.log('Updating tools:', config.tools.length, 'tools');
-      }
-
-      // Also check for tools from addTools method
-      if (this.tools && Object.keys(this.tools).length > 0) {
-        hasUpdates = true;
-        const allTools: Array<{
-          function_declarations: Array<{
-            name: string;
-            description?: string;
-            parameters?: unknown;
-          }>;
-        }> = [];
-
-        for (const [toolName, tool] of Object.entries(this.tools)) {
-          try {
-            let parameters: unknown;
-
-            // Handle different tool formats
-            if ('inputSchema' in tool && tool.inputSchema) {
-              // Convert Zod schema to JSON schema if needed
-              if (typeof tool.inputSchema === 'object' && 'safeParse' in tool.inputSchema) {
-                // This is a Zod schema - we need to convert it
-                parameters = this.convertZodSchemaToJsonSchema(tool.inputSchema);
-              } else {
-                parameters = tool.inputSchema;
-              }
-            } else if ('parameters' in tool && tool.parameters) {
-              parameters = tool.parameters;
-            } else {
-              // Default empty object if no schema found
-              parameters = { type: 'object', properties: {} };
-            }
-
-            allTools.push({
-              function_declarations: [
-                {
-                  name: toolName,
-                  description: tool.description || `Tool: ${toolName}`,
-                  parameters,
-                },
-              ],
-            });
-          } catch (error) {
-            this.log('Failed to process tool for session update', { toolName, error });
-          }
-        }
-
-        if (allTools.length > 0) {
-          updateMessage.session.tools = allTools;
-          this.log('Updating tools from addTools method:', allTools.length, 'tools');
-        }
+        this.log('Updating tools:', declarations.length, 'tools');
       }
 
       // Update session configuration if provided
@@ -1594,13 +1567,21 @@ export class GeminiLiveVoice extends MastraVoice<
         result = { error: 'Tool has no execute function' };
       }
 
+      // Gemini Live's `response` proto field is a struct, not repeating. Tools returning arrays
+      // or primitives close the session with `1007 Unknown name "response": Proto field is not
+      // repeating`. Wrap everything except plain objects in `{ result }` so the field is always a
+      // struct — `Date`, `Map`, `Set`, `Error`, and class instances all serialize as `{}` if sent
+      // bare (their own enumerable properties are empty), losing the tool's data silently.
+      const responsePayload = isPlainObject(result) ? result : { result };
+
       // Send tool result back to Gemini Live API
       const toolResultMessage = {
         toolResponse: {
           functionResponses: [
             {
               id: toolId,
-              response: result,
+              name: toolName,
+              response: responsePayload,
             },
           ],
         },
@@ -1618,6 +1599,7 @@ export class GeminiLiveVoice extends MastraVoice<
           functionResponses: [
             {
               id: toolId,
+              name: toolName,
               response: { error: errorMessage },
             },
           ],
@@ -1733,32 +1715,35 @@ export class GeminiLiveVoice extends MastraVoice<
       throw new Error('WebSocket not connected');
     }
 
-    // Live API format - based on the official documentation
+    // Live API setup message. Keys must be snake_case to match Gemini Live's wire format —
+    // camelCase keys cause native-audio models to reject the setup with
+    // `1007 Cannot extract voices from a non-audio request`. Matches the `UpdateMessage` shape
+    // already used by this package's `session.update` path.
     interface LiveGenerateContentSetup {
       model?: string;
-      generationConfig?: {
+      generation_config?: {
         temperature?: number;
-        topK?: number;
-        topP?: number;
-        maxOutputTokens?: number;
-        stopSequences?: string[];
-        candidateCount?: number;
-        responseModalities?: string[];
-        speechConfig?: {
-          voiceConfig?: {
-            prebuiltVoiceConfig?: {
-              voiceName?: string;
+        top_k?: number;
+        top_p?: number;
+        max_output_tokens?: number;
+        stop_sequences?: string[];
+        candidate_count?: number;
+        response_modalities?: ('AUDIO' | 'TEXT')[];
+        speech_config?: {
+          voice_config?: {
+            prebuilt_voice_config?: {
+              voice_name?: string;
             };
           };
         };
       };
-      systemInstruction?: {
+      system_instruction?: {
         parts: Array<{
           text: string;
         }>;
       };
       tools?: Array<{
-        functionDeclarations: Array<{
+        function_declarations: Array<{
           name: string;
           description?: string;
           parameters?: unknown;
@@ -1766,85 +1751,49 @@ export class GeminiLiveVoice extends MastraVoice<
       }>;
     }
 
+    // Native-audio models require `response_modalities: ["AUDIO"]` at setup time. This is a voice
+    // library, so AUDIO is the only sensible session-level default; callers needing a TEXT-only
+    // turn can override per-turn via `GeminiLiveVoiceOptions.responseModalities` on `speak()`.
+    const generationConfig: NonNullable<LiveGenerateContentSetup['generation_config']> = {
+      response_modalities: ['AUDIO'],
+    };
+
+    // Only attach `voice_config` when the caller supplied a `speaker`. Omitting the field lets
+    // Gemini Live pick its server-side default and avoids pinning a Mastra-side preference.
+    if (this.options.speaker) {
+      generationConfig.speech_config = {
+        voice_config: {
+          prebuilt_voice_config: {
+            voice_name: this.options.speaker,
+          },
+        },
+      };
+    }
+
     // Build the Live API setup message
     const setupMessage: { setup: LiveGenerateContentSetup } = {
       setup: {
         model: this.resolveModelIdentifier(),
+        generation_config: generationConfig,
       },
     };
 
     // Add system instructions if provided
     if (this.options.instructions) {
-      setupMessage.setup.systemInstruction = {
+      setupMessage.setup.system_instruction = {
         parts: [{ text: this.options.instructions }],
       };
     }
 
-    // Collect tools from both options and addTools method
-    const allTools: Array<{
-      functionDeclarations: Array<{
-        name: string;
-        description?: string;
-        parameters?: unknown;
-      }>;
-    }> = [];
+    // Gemini Live expects a single `tools` entry whose `function_declarations` array holds every
+    // tool. The previous shape (one entry per tool, camelCase `functionDeclarations`) was accepted
+    // at setup but the model never emitted tool_call frames back to the client.
+    const functionDeclarations = this.buildToolDeclarations(this.options.tools, this.tools);
 
-    // Add tools from options (GeminiToolConfig[])
-    if (this.options.tools && this.options.tools.length > 0) {
-      for (const tool of this.options.tools) {
-        allTools.push({
-          functionDeclarations: [
-            {
-              name: tool.name,
-              description: tool.description,
-              parameters: tool.parameters,
-            },
-          ],
-        });
-      }
-    }
-
-    // Add tools from addTools method (ToolsInput)
-    if (this.tools && Object.keys(this.tools).length > 0) {
-      for (const [toolName, tool] of Object.entries(this.tools)) {
-        try {
-          let parameters: unknown;
-
-          // Handle different tool formats
-          if ('inputSchema' in tool && tool.inputSchema) {
-            // Convert Zod schema to JSON schema if needed
-            if (typeof tool.inputSchema === 'object' && 'safeParse' in tool.inputSchema) {
-              // This is a Zod schema - we need to convert it
-              parameters = this.convertZodSchemaToJsonSchema(tool.inputSchema);
-            } else {
-              parameters = tool.inputSchema;
-            }
-          } else if ('parameters' in tool && tool.parameters) {
-            parameters = tool.parameters;
-          } else {
-            // Default empty object if no schema found
-            parameters = { type: 'object', properties: {} };
-          }
-
-          allTools.push({
-            functionDeclarations: [
-              {
-                name: toolName,
-                description: tool.description || `Tool: ${toolName}`,
-                parameters,
-              },
-            ],
-          });
-        } catch (error) {
-          this.log('Failed to process tool', { toolName, error });
-        }
-      }
-    }
-
-    // Add tools to setup message if any exist
-    if (allTools.length > 0) {
-      setupMessage.setup.tools = allTools;
-      this.log('Including tools in setup message', { toolCount: allTools.length });
+    // Emit tools as a single container with all declarations
+    if (functionDeclarations.length > 0) {
+      setupMessage.setup.tools = [{ function_declarations: functionDeclarations }];
+      this.log('Including tools in setup message', { toolCount: functionDeclarations.length });
     }
 
     this.log('Sending Live API setup message:', setupMessage);
@@ -2030,6 +1979,59 @@ export class GeminiLiveVoice extends MastraVoice<
     if (this.debug) {
       console.info(`[GeminiLiveVoice] ${message}`, ...args);
     }
+  }
+
+  /**
+   * Flatten both tool sources (constructor `tools` option and runtime `addTools()` registry) into
+   * the single declaration array Gemini Live expects inside `tools[0].function_declarations`.
+   * Used by both `sendInitialConfig()` and `updateSessionConfig()` so mid-session tool updates
+   * stay on the same shape as setup-time tools.
+   * @private
+   */
+  private buildToolDeclarations(
+    configTools: GeminiToolConfig[] | undefined,
+    registeredTools: ToolsInput | undefined,
+  ): Array<{ name: string; description?: string; parameters?: unknown }> {
+    const declarations: Array<{ name: string; description?: string; parameters?: unknown }> = [];
+
+    if (configTools && configTools.length > 0) {
+      for (const tool of configTools) {
+        declarations.push({
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+        });
+      }
+    }
+
+    if (registeredTools && Object.keys(registeredTools).length > 0) {
+      for (const [toolName, tool] of Object.entries(registeredTools)) {
+        try {
+          let parameters: unknown;
+          if ('inputSchema' in tool && tool.inputSchema) {
+            if (typeof tool.inputSchema === 'object' && 'safeParse' in tool.inputSchema) {
+              parameters = this.convertZodSchemaToJsonSchema(tool.inputSchema);
+            } else {
+              parameters = tool.inputSchema;
+            }
+          } else if ('parameters' in tool && tool.parameters) {
+            parameters = tool.parameters;
+          } else {
+            parameters = { type: 'object', properties: {} };
+          }
+
+          declarations.push({
+            name: toolName,
+            description: tool.description || `Tool: ${toolName}`,
+            parameters,
+          });
+        } catch (error) {
+          this.log('Failed to process tool', { toolName, error });
+        }
+      }
+    }
+
+    return declarations;
   }
 
   /**

--- a/voice/google-gemini-live-api/src/types.ts
+++ b/voice/google-gemini-live-api/src/types.ts
@@ -6,6 +6,7 @@
  * Available Gemini Live API models
  */
 export type GeminiVoiceModel =
+  | 'gemini-3.1-flash-live-preview'
   /** @deprecated Shut down on 2025-12-09. */
   | 'gemini-2.0-flash-exp'
   /** @deprecated Shut down on 2025-11-14. */


### PR DESCRIPTION
## Description

`@mastra/voice-google-gemini-live` shipped a hand-rolled `convertZodSchemaToJsonSchema` /
`convertZodDefToJsonSchema` (~95 lines) that only understood a hardcoded short list of Zod 3
types — `ZodString`, `ZodNumber`, `ZodBoolean`, `ZodArray`, `ZodObject`, `ZodOptional`,
`ZodEnum` — and dropped every other Zod type to an empty `{ type: 'object', properties: {} }`
fallback. Tools registered via `voice.addTools(...)` with common patterns (`z.union`,
`z.discriminatedUnion`, `z.literal`, `.nullable()`, `z.record`, `z.tuple`, `z.date`,
`.refine()`, `.default()`, `z.lazy()`) reached Gemini Live with no schema, so the model got no
signal about tool arguments and returned empty args. The converter also read `def.typeName`
(a Zod 3 internal), so every Zod 4 schema fell through too.

This PR routes tool Zod schemas through `@mastra/schema-compat`'s `applyCompatLayer` +
`GoogleSchemaCompatLayer` — the in-repo Google pipeline the rest of the monorepo uses. It
covers the full Zod 3/4 surface and emits the **OpenAPI 3.0 Schema Object** shape Gemini
Live's setup validator requires (`tools[].function_declarations[].parameters` is OpenAPI 3.0
per `@google/genai`'s `Schema` typedef, not JSON Schema 2020-12), so no Live-specific
post-processing is needed in this package.

**Merge order — top of a four-PR chain:**
1. **#17052** — patches a Zod v4 `z.record()` crash in schema-compat's standard-schema adapter (pre-processing prerequisite for `applyCompatLayer`).
2. **#17060** — aligns `GoogleSchemaCompatLayer` output with the OpenAPI 3.0 Schema Object (fixes #17057; post-processing).
3. **#17019** — native-audio setup + tool wire shape (fixes #17018).
4. **#17023** (this PR) — the Zod-routing fix.

Held as **draft** until #17052, #17060, and #17019 merge. This branch currently carries
#17019's native-audio commit as its base; once #17019 lands in `main` and this branch is
rebased, that commit drops out and the diff narrows to the pure Zod-routing change.

Side effects:
- Added `@mastra/schema-compat` as a dependency; removed the dead `zod-to-json-schema` devDependency (declared, never imported).
- Removed the stale `vi.mock('zod-to-json-schema', ...)` block in `index.test.ts` that masked the bug.
- Added a `Zod schema → JSON Schema for tool parameters` describe block in `index.test.ts`.

## Related issue(s)

Fixes #17020.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable) — N/A: no public API surface or behavior contract changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR — will address as feedback arrives.
