### PR TITLE
fix(core): treat reserved runs as active in subscribeToThread

### DIFF
--- a/.changeset/tender-bars-stick.md
+++ b/.changeset/tender-bars-stick.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a race in Harness `sendMessage` where a phantom `agent_end: 'complete'` event could fire before any chunks arrived. Subscribers that closed on the first `agent_end` (for example UIs running on Cloudflare Workers / Durable Objects) lost every text-delta, message, and tool event the agent produced.
+
+The cause was `AgentThreadStreamRuntime.subscribeToThread`'s `activeRunId()` returning `null` during the gap between `sendSignal` reserving a runId and `registerRun` populating the stream record, which made `waitForCurrentThreadStreamIdle()` exit immediately and `sendMessage` emit a synthetic `agent_end`. The subscriber now treats both a reserved-but-not-yet-registered local run and an active remote run as live, matching `sendSignal`'s own behavior.

--- a/.changeset/tender-bars-stick.md
+++ b/.changeset/tender-bars-stick.md
@@ -2,6 +2,6 @@
 '@mastra/core': patch
 ---
 
-Fixed a race in Harness `sendMessage` where a phantom `agent_end: 'complete'` event could fire before any chunks arrived. Subscribers that closed on the first `agent_end` (for example UIs running on Cloudflare Workers / Durable Objects) lost every text-delta, message, and tool event the agent produced.
+Fixed a race in Harness `sendMessage` where a phantom `agent_end: 'complete'` event could fire before any chunks arrived. Subscribers, such as apps running on Cloudflare Workers or Durable Objects, will no longer miss text deltas, messages, or tool events when an agent run completes.
 
 The cause was `AgentThreadStreamRuntime.subscribeToThread`'s `activeRunId()` returning `null` during the gap between `sendSignal` reserving a runId and `registerRun` populating the stream record, which made `waitForCurrentThreadStreamIdle()` exit immediately and `sendMessage` emit a synthetic `agent_end`. The subscriber now treats both a reserved-but-not-yet-registered local run and an active remote run as live, matching `sendSignal`'s own behavior.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -871,6 +871,34 @@ describe('Agent signals', () => {
     expect(result).toEqual(expect.objectContaining({ accepted: true }));
   });
 
+  it('reports the reserved runId as active before registerRun populates the stream record', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const threadId = 'reservation-gap-thread';
+    const resourceId = 'reservation-gap-user';
+
+    // agent.stream is awaited inside the idle-wake path before registerRun fires. Returning
+    // a never-resolving promise pins the runtime in the gap where sendSignal has reserved
+    // activeThreadRunIds + threadKeysByRunId but threadRunsById is still empty.
+    const agent = {
+      id: 'reservation-gap-agent',
+      stream: () => new Promise(() => {}),
+    } as unknown as Agent<any, any, any, any>;
+
+    const subscription = await runtime.subscribeToThread(agent, { threadId, resourceId });
+    expect(subscription.activeRunId()).toBeNull();
+
+    const result = runtime.sendSignal(agent, createSignal({ type: 'user-message', contents: 'hello' }), {
+      resourceId,
+      threadId,
+      ifIdle: { streamOptions: { memory: { resource: resourceId, thread: threadId } } as any },
+    });
+
+    expect(result.accepted).toBe(true);
+    expect(subscription.activeRunId()).toBe(result.runId);
+
+    subscription.unsubscribe();
+  });
+
   it('persists an idle signal without waking the agent when idle behavior is persist', async () => {
     let streamCount = 0;
     const memory = new MockMemory();

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -575,7 +575,10 @@ export class AgentThreadStreamRuntime {
       const runId = state.activeThreadRunIds.get(key);
       if (!runId) return null;
       const record = state.threadRunsById.get(runId);
-      if (!record) return state.threadKeysByRunId.get(runId) === key ? null : runId;
+      // No record yet means either a remote run (record never lives locally) or a local run
+      // that sendSignal has reserved but has not yet registered via registerRun. Both are
+      // in flight from the subscriber's perspective; treat them as active.
+      if (!record) return runId;
       return record.output.status === 'running' ? runId : null;
     };
 

--- a/packages/core/src/harness/tracing-propagation.test.ts
+++ b/packages/core/src/harness/tracing-propagation.test.ts
@@ -13,24 +13,36 @@ function createAgent() {
   });
 }
 
-/**
- * Create a mock stream response that processStream can consume without errors.
- */
-function createMockStreamResponse() {
+function createMockStreamResponse(runId: string) {
   const chunks: any[] = [
-    { type: 'text-start', payload: { id: 'msg-1' } },
-    { type: 'text-delta', payload: { id: 'msg-1', text: 'Hello' } },
-    { type: 'text-end', payload: { id: 'msg-1' } },
-    { type: 'step-end', payload: {} },
-    { type: 'finish', payload: {} },
+    { type: 'start', runId },
+    { type: 'text-start', runId, payload: { id: 'msg-1' } },
+    { type: 'text-delta', runId, payload: { id: 'msg-1', text: 'Hello' } },
+    { type: 'text-end', runId, payload: { id: 'msg-1' } },
+    {
+      type: 'finish',
+      runId,
+      payload: { usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 }, finishReason: 'stop' },
+    },
   ];
 
+  let finish!: () => void;
+  const finished = new Promise<void>(resolve => {
+    finish = resolve;
+  });
+  const fullStream = new ReadableStream({
+    start(controller) {
+      for (const part of chunks) controller.enqueue(part);
+      controller.close();
+      finish();
+    },
+  });
+
   return {
-    fullStream: (async function* () {
-      for (const chunk of chunks) {
-        yield chunk;
-      }
-    })(),
+    runId,
+    status: 'running' as const,
+    fullStream,
+    _waitUntilFinished: () => finished,
   };
 }
 
@@ -48,10 +60,12 @@ describe('Harness tracing propagation', () => {
       modes: [{ id: 'default', name: 'Default', default: true, agent }],
     });
 
-    // Spy on agent.stream to capture the options it receives
-    streamSpy = vi.spyOn(agent, 'stream').mockResolvedValue(createMockStreamResponse() as any);
+    streamSpy = vi.spyOn(agent, 'stream').mockImplementation(async (_signal: any, options: any) => {
+      const response = createMockStreamResponse(options?.runId ?? 'mock-run-id');
+      agentThreadStreamRuntime.registerRun(agent, response as any, options);
+      return response as any;
+    });
 
-    // Set up a thread so sendMessage doesn't try to create one via storage
     (harness as any).currentThreadId = 'test-thread-123';
   });
 


### PR DESCRIPTION
## Description

Fixes a race in `Harness.sendMessage` where a phantom `agent_end: 'complete'` event could fire before any chunks arrived. UIs that close on the first `agent_end` (notably Cloudflare Workers / Durable Objects) lost every text-delta, message, and tool event the agent produced.

- `AgentThreadStreamRuntime.subscribeToThread`'s `activeRunId()` now returns the reserved runId when no stream record exists yet, instead of returning `null` for local reservations. This matches `sendSignal`'s own treatment of reserved-but-not-yet-registered runs (`thread-stream-runtime.ts:799-803`) and preserves the remote-pubsub-active path added in #16665.
- `Harness.waitForCurrentThreadStreamIdle()` now correctly waits for the run to actually be idle, so the fallback emit in `sendMessage` only fires as the intended safety net — not during the reservation gap.
- Added a regression test in `agent-signals.test.ts` that pins the runtime in the reservation gap (mock `agent.stream` returns a never-resolving promise) and asserts `activeRunId()` returns the reserved runId. Verified the test fails without the fix.
- Updated `harness/tracing-propagation.test.ts` so its mock `agent.stream` drives the run lifecycle via `registerRun` and a finishing `ReadableStream`. The tests were previously passing only because of the bug; assertion shapes are unchanged.

## Related Issue(s)

Fixes #16998

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Imagine you order a package online. The system marks your order as "reserved" but hasn't actually started delivery yet. Previously, the system could say "delivery complete" too early; this PR makes the system treat reserved orders as "in progress" until the delivery actually happens.

## Overview

Fixes a race in Harness.sendMessage where a phantom `agent_end: 'complete'` could be emitted before any message chunks arrived, causing subscribers that close on the first `agent_end` to miss subsequent text-delta, message, and tool events. The root cause was a timing window between `sendSignal` reserving a `runId` and `registerRun` creating the stream record: during that gap `activeRunId()` could return `null`, letting `waitForCurrentThreadStreamIdle()` exit early and triggering a synthetic `agent_end`.

## Changes

- Core runtime fix (packages/core/src/agent/thread-stream-runtime.ts):
  - AgentThreadStreamRuntime.subscribeToThread: `activeRunId()` now returns the reserved runId when `state.activeThreadRunIds` points to a run but `threadRunsById` has no record yet, treating reserved-but-not-yet-registered local runs as active (instead of `null`). This preserves the remote-pubsub-active path and aligns with `sendSignal` behavior.

- Harness idle wait (packages/core/src/...):
  - Harness.waitForCurrentThreadStreamIdle(): now correctly waits for the run to actually become idle so the synthetic `agent_end` emitted in `sendMessage` remains a safety net and doesn't fire during the reservation gap.

- Tests:
  - Added regression test (packages/core/src/agent/__tests__/agent-signals.test.ts) that pins the runtime in the reservation gap (mock `agent.stream` returns a never-resolving promise) and asserts `subscription.activeRunId()` returns the reserved runId.
  - Updated harness/tracing-propagation.test.ts to use a run-id-aware mock stream that registers runs and emits structured start/finish events, ensuring the mock stream lifecycle matches runtime expectations. The new test fails before the fix and passes after.

- Release notes:
  - changeset ( .changeset/tender-bars-stick.md ) documenting the patch to `@mastra/core`.

Fixes `#16998`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->