### PR TITLE
feat(observability): emit drop events for auth-cooldown drops in cloud/platform exporters

### DIFF
--- a/.changeset/brave-bears-smile.md
+++ b/.changeset/brave-bears-smile.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add `'auth-cooldown'` to `ObservabilityDropReason` so observability exporters can report events dropped while an authentication failure cooldown is active.

--- a/.changeset/tall-tables-help.md
+++ b/.changeset/tall-tables-help.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Cloud and Mastra Platform exporters now emit `ObservabilityDropEvent`s (with `reason: 'auth-cooldown'`) when events are dropped during an authentication-failure cooldown. Consumers wired to the observability bus's `emitDropEvent` callback (see PR #16111) can now observe these drops per signal (tracing, log, metric, score, feedback) instead of having them silently discarded.

--- a/observability/mastra/src/exporters/base.ts
+++ b/observability/mastra/src/exporters/base.ts
@@ -7,6 +7,7 @@
  * - Graceful shutdown lifecycle
  */
 
+import { MastraError } from '@mastra/core/error';
 import { ConsoleLogger, LogLevel } from '@mastra/core/logger';
 import type { IMastraLogger } from '@mastra/core/logger';
 import type {
@@ -14,6 +15,9 @@ import type {
   ObservabilityExporter,
   InitExporterOptions,
   CustomSpanFormatter,
+  ObservabilityDropEvent,
+  ObservabilityDropReason,
+  ObservabilityDropSignal,
 } from '@mastra/core/observability';
 
 /**
@@ -94,9 +98,67 @@ export abstract class BaseExporter implements ObservabilityExporter {
   /** Whether this exporter is disabled */
   #disabled: boolean = false;
 
+  /** Callback used to publish ObservabilityDropEvent to the bus (set via init). */
+  #emitDropEvent?: (event: ObservabilityDropEvent) => void;
+
   /** Public getter for disabled state */
   get isDisabled(): boolean {
     return this.#disabled;
+  }
+
+  /**
+   * Capture the optional `emitDropEvent` callback from {@link InitExporterOptions}.
+   * Subclasses that override `init` should call this (or `super.init(options)`)
+   * so that {@link emitDrop} can forward drop events to the observability bus.
+   */
+  protected captureDropEventEmitter(options: InitExporterOptions): void {
+    this.#emitDropEvent = options.emitDropEvent;
+  }
+
+  /**
+   * Sanitize an error before including it in an {@link ObservabilityDropEvent}.
+   */
+  protected sanitizeDropError(error: unknown): ObservabilityDropEvent['error'] {
+    if (error instanceof MastraError) {
+      return {
+        id: error.id,
+        domain: String(error.domain),
+        message: error.message,
+      };
+    }
+
+    if (error instanceof Error) {
+      return { message: error.message };
+    }
+
+    return { message: String(error) };
+  }
+
+  /**
+   * Emit a structured drop event for `count` events of `signal` that the
+   * exporter pipeline could not deliver. No-op when `count` is 0 or when no
+   * `emitDropEvent` callback was captured.
+   */
+  protected emitDrop(
+    signal: ObservabilityDropSignal,
+    reason: ObservabilityDropReason,
+    count: number,
+    error?: unknown,
+  ): void {
+    if (count === 0) return;
+    if (!this.#emitDropEvent) return;
+
+    const dropEvent: ObservabilityDropEvent = {
+      type: 'drop',
+      signal,
+      reason,
+      count,
+      timestamp: new Date(),
+      exporterName: this.name,
+      ...(error === undefined ? {} : { error: this.sanitizeDropError(error) }),
+    };
+
+    this.#emitDropEvent(dropEvent);
   }
 
   /**
@@ -108,6 +170,16 @@ export abstract class BaseExporter implements ObservabilityExporter {
     const logLevel = this.resolveLogLevel(config.logLevel);
     // Use constructor name as fallback since this.name isn't set yet (subclass initializes it)
     this.logger = config.logger ?? new ConsoleLogger({ level: logLevel, name: this.constructor.name });
+  }
+
+  /**
+   * Default initialization hook. Captures the optional `emitDropEvent`
+   * callback so {@link emitDrop} can publish drop events to the bus.
+   * Subclasses that override `init` should call `super.init(options)` (or
+   * {@link captureDropEventEmitter}) to preserve this behavior.
+   */
+  async init(options: InitExporterOptions): Promise<void> {
+    this.captureDropEventEmitter(options);
   }
 
   /**
@@ -218,11 +290,6 @@ export abstract class BaseExporter implements ObservabilityExporter {
    * This method is called by exportTracingEvent after checking if the exporter is disabled.
    */
   protected abstract _exportTracingEvent(event: TracingEvent): Promise<void>;
-
-  /**
-   * Optional initialization hook called after Mastra is fully configured
-   */
-  init?(_options: InitExporterOptions): void;
 
   /**
    * Optional method to add scores to traces

--- a/observability/mastra/src/exporters/cloud.test.ts
+++ b/observability/mastra/src/exporters/cloud.test.ts
@@ -1876,4 +1876,106 @@ describe('CloudExporter', () => {
       expect(loggerInfoSpy).toHaveBeenCalledWith('CloudExporter shutdown complete');
     });
   });
+
+  describe('emitDropEvent integration', () => {
+    const mockSpan = getMockSpan({
+      id: 'span-drop',
+      name: 'drop-span',
+      type: SpanType.AGENT_RUN,
+      isEvent: false,
+      traceId: 'trace-drop',
+    });
+
+    async function makeExporterWithEmitDropEvent() {
+      const emitDropEvent = vi.fn();
+      const cooldownExporter = new CloudExporter({
+        accessToken: testJWT,
+        endpoint: 'http://localhost:3000',
+      });
+      // Call init directly to capture emitDropEvent — production wiring is via
+      // ObservabilityInstance, which we don't exercise in this unit test.
+      await cooldownExporter.init({ emitDropEvent } as any);
+      return { cooldownExporter, emitDropEvent };
+    }
+
+    it('emits per-signal drop events with reason "auth-cooldown" while in cooldown', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const { cooldownExporter, emitDropEvent } = await makeExporterWithEmitDropEvent();
+
+      try {
+        // 1) Trip the cooldown with a single failing flush.
+        mockAuthFailure(401);
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await (cooldownExporter as any).flush();
+
+        // The failed batch itself must emit a drop event for the tracing signal.
+        expect(emitDropEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'drop',
+            signal: 'tracing',
+            reason: 'auth-cooldown',
+            count: 1,
+            exporterName: 'mastra-cloud-observability-exporter',
+          }),
+        );
+        emitDropEvent.mockClear();
+
+        // 2) Subsequent per-signal events while cooling down should each emit a drop.
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+        await cooldownExporter.onMetricEvent(getMockMetricEvent());
+        await cooldownExporter.onScoreEvent(getMockScoreEvent());
+        await cooldownExporter.onFeedbackEvent(getMockFeedbackEvent());
+
+        const signals = emitDropEvent.mock.calls.map(call => (call[0] as any).signal);
+        expect(signals).toEqual(['tracing', 'log', 'metric', 'score', 'feedback']);
+        for (const call of emitDropEvent.mock.calls) {
+          expect(call[0]).toMatchObject({
+            type: 'drop',
+            reason: 'auth-cooldown',
+            count: 1,
+            exporterName: 'mastra-cloud-observability-exporter',
+          });
+        }
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+        await cooldownExporter.shutdown();
+      }
+    });
+
+    it('emits one drop per buffered signal when flush short-circuits during cooldown', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const { cooldownExporter, emitDropEvent } = await makeExporterWithEmitDropEvent();
+
+      try {
+        // Pre-seed the cooldown by setting cooldownUntilMs directly so the
+        // first flush short-circuits without us also exercising the recordFailure
+        // path again.
+        (cooldownExporter as any).authFailureCooldown.cooldownUntilMs = 5_000_000;
+
+        // Per-signal handlers themselves drop while in cooldown, so each call
+        // emits an immediate drop event and never touches the buffer.
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+        await cooldownExporter.onMetricEvent(getMockMetricEvent());
+
+        expect((cooldownExporter as any).buffer.totalSize).toBe(0);
+        expect(emitDropEvent).toHaveBeenCalledTimes(3);
+        expect(emitDropEvent.mock.calls.map(call => (call[0] as any).signal)).toEqual(['log', 'log', 'metric']);
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+        await cooldownExporter.shutdown();
+      }
+    });
+  });
 });

--- a/observability/mastra/src/exporters/cloud.ts
+++ b/observability/mastra/src/exporters/cloud.ts
@@ -36,6 +36,14 @@ export interface CloudExporterConfig extends BaseExporterConfig {
 
 type CloudSignal = 'traces' | 'logs' | 'metrics' | 'scores' | 'feedback';
 
+const CLOUD_SIGNAL_TO_DROP_SIGNAL: Record<CloudSignal, 'tracing' | 'log' | 'metric' | 'score' | 'feedback'> = {
+  traces: 'tracing',
+  logs: 'log',
+  metrics: 'metric',
+  scores: 'score',
+  feedback: 'feedback',
+};
+
 const SIGNAL_PUBLISH_SUFFIXES: Record<CloudSignal, string> = {
   traces: '/spans/publish',
   logs: '/logs/publish',
@@ -316,6 +324,7 @@ export class CloudExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      this.emitDrop('tracing', 'auth-cooldown', 1);
       return;
     }
 
@@ -330,6 +339,7 @@ export class CloudExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      this.emitDrop('log', 'auth-cooldown', 1);
       return;
     }
 
@@ -343,6 +353,7 @@ export class CloudExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      this.emitDrop('metric', 'auth-cooldown', 1);
       return;
     }
 
@@ -356,6 +367,7 @@ export class CloudExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      this.emitDrop('score', 'auth-cooldown', 1);
       return;
     }
 
@@ -369,6 +381,7 @@ export class CloudExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      this.emitDrop('feedback', 'auth-cooldown', 1);
       return;
     }
 
@@ -518,6 +531,7 @@ export class CloudExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventsIfCoolingDown(this.buffer.totalSize)) {
+      this.emitBufferDrops('auth-cooldown');
       this.resetBuffer();
       return;
     }
@@ -563,12 +577,28 @@ export class CloudExporter extends BaseExporter {
       return;
     }
 
+    const signalCounts: Record<CloudSignal, number> = {
+      traces: spansCopy.length,
+      logs: logsCopy.length,
+      metrics: metricsCopy.length,
+      scores: scoresCopy.length,
+      feedback: feedbackCopy.length,
+    };
+
     if (authFailure?.authFailureStatus !== undefined) {
+      const droppedBatchSize = failedSignals.reduce((sum, signal) => sum + signalCounts[signal], 0);
       this.authFailureCooldown.recordFailure({
         status: authFailure.authFailureStatus,
         failedSignals,
-        droppedBatchSize: batchSize,
+        droppedBatchSize,
       });
+      for (const signal of failedSignals) {
+        this.emitDrop(CLOUD_SIGNAL_TO_DROP_SIGNAL[signal], 'auth-cooldown', signalCounts[signal]);
+      }
+    } else {
+      for (const signal of failedSignals) {
+        this.emitDrop(CLOUD_SIGNAL_TO_DROP_SIGNAL[signal], 'retry-exhausted', signalCounts[signal]);
+      }
     }
 
     this.logger.warn('Batch flush completed with dropped signal batches', {
@@ -637,6 +667,23 @@ export class CloudExporter extends BaseExporter {
       this.logger.trackException(mastraError);
       this.logger.error('Batch upload failed after all retries, dropping batch', mastraError);
       return { signal, succeeded: false };
+    }
+  }
+
+  /** Emit one `ObservabilityDropEvent` per non-empty signal in the buffer. */
+  private emitBufferDrops(reason: 'auth-cooldown' | 'retry-exhausted'): void {
+    const counts: Array<[CloudSignal, number]> = [
+      ['traces', this.buffer.spans.length],
+      ['logs', this.buffer.logs.length],
+      ['metrics', this.buffer.metrics.length],
+      ['scores', this.buffer.scores.length],
+      ['feedback', this.buffer.feedback.length],
+    ];
+
+    for (const [signal, count] of counts) {
+      if (count > 0) {
+        this.emitDrop(CLOUD_SIGNAL_TO_DROP_SIGNAL[signal], reason, count);
+      }
     }
   }
 

--- a/observability/mastra/src/exporters/default.ts
+++ b/observability/mastra/src/exporters/default.ts
@@ -227,7 +227,7 @@ export class DefaultExporter extends BaseExporter {
     }
   }
 
-  private sanitizeDropError(error: unknown): ObservabilityDropEvent['error'] {
+  protected override sanitizeDropError(error: unknown): ObservabilityDropEvent['error'] {
     if (error instanceof MastraError) {
       return {
         id: error.id,
@@ -243,7 +243,7 @@ export class DefaultExporter extends BaseExporter {
     return { message: String(error) };
   }
 
-  private emitDrop(
+  protected override emitDrop(
     signal: ObservabilityDropSignal,
     reason: ObservabilityDropReason,
     count: number,

--- a/observability/mastra/src/exporters/mastra-platform.test.ts
+++ b/observability/mastra/src/exporters/mastra-platform.test.ts
@@ -2052,4 +2052,105 @@ describe('MastraPlatformExporter', () => {
       expect(loggerInfoSpy).toHaveBeenCalledWith('MastraPlatformExporter shutdown complete');
     });
   });
+
+  describe('emitDropEvent integration', () => {
+    const mockSpan = getMockSpan({
+      id: 'span-drop',
+      name: 'drop-span',
+      type: SpanType.AGENT_RUN,
+      isEvent: false,
+      traceId: 'trace-drop',
+    });
+
+    async function makeExporterWithEmitDropEvent() {
+      const emitDropEvent = vi.fn();
+      const cooldownExporter = new MastraPlatformExporter({
+        accessToken: testJWT,
+        endpoint: 'http://localhost:3000',
+      });
+      // Call init directly to capture emitDropEvent — production wiring is via
+      // ObservabilityInstance, which we don't exercise in this unit test.
+      await cooldownExporter.init({ emitDropEvent } as any);
+      return { cooldownExporter, emitDropEvent };
+    }
+
+    it('emits per-signal drop events with reason "auth-cooldown" while in cooldown', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const { cooldownExporter, emitDropEvent } = await makeExporterWithEmitDropEvent();
+
+      try {
+        // 1) Trip the cooldown with a single failing flush.
+        mockAuthFailure(401);
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await (cooldownExporter as any).flush();
+
+        // The failed batch itself must emit a drop event for the tracing signal.
+        expect(emitDropEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'drop',
+            signal: 'tracing',
+            reason: 'auth-cooldown',
+            count: 1,
+            exporterName: 'mastra-platform-exporter',
+          }),
+        );
+        emitDropEvent.mockClear();
+
+        // 2) Subsequent per-signal events while cooling down should each emit a drop.
+        await cooldownExporter.exportTracingEvent({
+          type: TracingEventType.SPAN_ENDED,
+          exportedSpan: mockSpan,
+        });
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+        await cooldownExporter.onMetricEvent(getMockMetricEvent());
+        await cooldownExporter.onScoreEvent(getMockScoreEvent());
+        await cooldownExporter.onFeedbackEvent(getMockFeedbackEvent());
+
+        const signals = emitDropEvent.mock.calls.map(call => (call[0] as any).signal);
+        expect(signals).toEqual(['tracing', 'log', 'metric', 'score', 'feedback']);
+        for (const call of emitDropEvent.mock.calls) {
+          expect(call[0]).toMatchObject({
+            type: 'drop',
+            reason: 'auth-cooldown',
+            count: 1,
+            exporterName: 'mastra-platform-exporter',
+          });
+        }
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+        await cooldownExporter.shutdown();
+      }
+    });
+
+    it('emits one drop per buffered signal when flush short-circuits during cooldown', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const { cooldownExporter, emitDropEvent } = await makeExporterWithEmitDropEvent();
+
+      try {
+        // Pre-seed the cooldown so the first flush short-circuits without
+        // exercising the recordFailure path again.
+        (cooldownExporter as any).authFailureCooldown.cooldownUntilMs = 5_000_000;
+
+        // Per-signal handlers themselves drop while in cooldown, so each call
+        // emits an immediate drop event and never touches the buffer.
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+        await cooldownExporter.onLogEvent(getMockLogEvent());
+        await cooldownExporter.onMetricEvent(getMockMetricEvent());
+
+        expect((cooldownExporter as any).buffer.totalSize).toBe(0);
+        expect(emitDropEvent).toHaveBeenCalledTimes(3);
+        expect(emitDropEvent.mock.calls.map(call => (call[0] as any).signal)).toEqual(['log', 'log', 'metric']);
+      } finally {
+        nowSpy.mockRestore();
+        randomSpy.mockRestore();
+        await cooldownExporter.shutdown();
+      }
+    });
+  });
 });

--- a/observability/mastra/src/exporters/mastra-platform.ts
+++ b/observability/mastra/src/exporters/mastra-platform.ts
@@ -30,6 +30,14 @@ export interface MastraPlatformExporterConfig extends BaseExporterConfig {
 
 type PlatformSignal = 'traces' | 'logs' | 'metrics' | 'scores' | 'feedback';
 
+const PLATFORM_SIGNAL_TO_DROP_SIGNAL: Record<PlatformSignal, 'tracing' | 'log' | 'metric' | 'score' | 'feedback'> = {
+  traces: 'tracing',
+  logs: 'log',
+  metrics: 'metric',
+  scores: 'score',
+  feedback: 'feedback',
+};
+
 const SIGNAL_PUBLISH_SUFFIXES: Record<PlatformSignal, string> = {
   traces: '/spans/publish',
   logs: '/logs/publish',
@@ -309,6 +317,7 @@ export class MastraPlatformExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      this.emitDrop('tracing', 'auth-cooldown', 1);
       return;
     }
 
@@ -323,6 +332,7 @@ export class MastraPlatformExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      this.emitDrop('log', 'auth-cooldown', 1);
       return;
     }
 
@@ -336,6 +346,7 @@ export class MastraPlatformExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      this.emitDrop('metric', 'auth-cooldown', 1);
       return;
     }
 
@@ -349,6 +360,7 @@ export class MastraPlatformExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      this.emitDrop('score', 'auth-cooldown', 1);
       return;
     }
 
@@ -362,6 +374,7 @@ export class MastraPlatformExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventIfCoolingDown()) {
+      this.emitDrop('feedback', 'auth-cooldown', 1);
       return;
     }
 
@@ -508,6 +521,7 @@ export class MastraPlatformExporter extends BaseExporter {
     }
 
     if (this.authFailureCooldown.dropEventsIfCoolingDown(this.buffer.totalSize)) {
+      this.emitBufferDrops('auth-cooldown');
       this.resetBuffer();
       return;
     }
@@ -552,12 +566,28 @@ export class MastraPlatformExporter extends BaseExporter {
       return;
     }
 
+    const signalCounts: Record<PlatformSignal, number> = {
+      traces: spansCopy.length,
+      logs: logsCopy.length,
+      metrics: metricsCopy.length,
+      scores: scoresCopy.length,
+      feedback: feedbackCopy.length,
+    };
+
     if (authFailure?.authFailureStatus !== undefined) {
+      const droppedBatchSize = failedSignals.reduce((sum, signal) => sum + signalCounts[signal], 0);
       this.authFailureCooldown.recordFailure({
         status: authFailure.authFailureStatus,
         failedSignals,
-        droppedBatchSize: batchSize,
+        droppedBatchSize,
       });
+      for (const signal of failedSignals) {
+        this.emitDrop(PLATFORM_SIGNAL_TO_DROP_SIGNAL[signal], 'auth-cooldown', signalCounts[signal]);
+      }
+    } else {
+      for (const signal of failedSignals) {
+        this.emitDrop(PLATFORM_SIGNAL_TO_DROP_SIGNAL[signal], 'retry-exhausted', signalCounts[signal]);
+      }
     }
 
     this.logger.warn('Batch flush completed with dropped signal batches', {
@@ -626,6 +656,23 @@ export class MastraPlatformExporter extends BaseExporter {
       this.logger.trackException(mastraError);
       this.logger.error('Batch upload failed after all retries, dropping batch', mastraError);
       return { signal, succeeded: false };
+    }
+  }
+
+  /** Emit one `ObservabilityDropEvent` per non-empty signal in the buffer. */
+  private emitBufferDrops(reason: 'auth-cooldown' | 'retry-exhausted'): void {
+    const counts: Array<[PlatformSignal, number]> = [
+      ['traces', this.buffer.spans.length],
+      ['logs', this.buffer.logs.length],
+      ['metrics', this.buffer.metrics.length],
+      ['scores', this.buffer.scores.length],
+      ['feedback', this.buffer.feedback.length],
+    ];
+
+    for (const [signal, count] of counts) {
+      if (count > 0) {
+        this.emitDrop(PLATFORM_SIGNAL_TO_DROP_SIGNAL[signal], reason, count);
+      }
     }
   }
 

--- a/observability/mastra/src/exporters/mastra-storage.ts
+++ b/observability/mastra/src/exporters/mastra-storage.ts
@@ -216,7 +216,7 @@ export class MastraStorageExporter extends BaseExporter {
     }
   }
 
-  private sanitizeDropError(error: unknown): ObservabilityDropEvent['error'] {
+  protected override sanitizeDropError(error: unknown): ObservabilityDropEvent['error'] {
     if (error instanceof MastraError) {
       return {
         id: error.id,
@@ -232,7 +232,7 @@ export class MastraStorageExporter extends BaseExporter {
     return { message: String(error) };
   }
 
-  private emitDrop(
+  protected override emitDrop(
     signal: ObservabilityDropSignal,
     reason: ObservabilityDropReason,
     count: number,

--- a/packages/core/src/observability/types/core.ts
+++ b/packages/core/src/observability/types/core.ts
@@ -166,7 +166,7 @@ export type ObservabilityEvent = TracingEvent | LogEvent | MetricEvent | ScoreEv
 export type ObservabilityDropSignal = 'tracing' | 'log' | 'metric' | 'score' | 'feedback';
 
 /** Reason an observability event was dropped by the exporter pipeline. */
-export type ObservabilityDropReason = 'unsupported-storage' | 'retry-exhausted';
+export type ObservabilityDropReason = 'unsupported-storage' | 'retry-exhausted' | 'auth-cooldown';
 
 /** Sanitized error details for observability drop events. */
 export interface ObservabilityDropError {


### PR DESCRIPTION
## Summary

Implements Eric's suggestion from [PR #16743](https://github.com/mastra-ai/mastra/pull/16743): route events dropped during the auth-failure cooldown introduced in that PR through the observability bus's existing `emitDropEvent` callback mechanism (added in [PR #16111](https://github.com/mastra-ai/mastra/pull/16111)).

Before this change, when `CloudExporter` or `MastraPlatformExporter` hit an auth failure (401/403) and entered cooldown, every subsequent event — including the user's own logs — was silently discarded. Drop handlers registered on the bus had no way to observe these losses. Now they do, with per-signal accurate counts and `reason: 'auth-cooldown'`.

## What changed

- **`@mastra/core`**: added `'auth-cooldown'` to `ObservabilityDropReason`.
- **`@mastra/observability`**:
  - Lifted `emitDrop()` and `sanitizeDropError()` into `BaseExporter` as protected helpers, and added an `init()` capture for the `emitDropEvent` callback. `DefaultExporter` / `MastraStorageExporter` keep their existing `storageName`-aware overrides.
  - Wired `emitDrop()` into `CloudExporter` and `MastraPlatformExporter` at three drop sites:
    1. Per-signal handlers (`exportTracingEvent`, `onLogEvent`, `onMetricEvent`, `onScoreEvent`, `onFeedbackEvent`) when an individual event is dropped due to active cooldown.
    2. `flushBuffer()` cooldown short-circuit (whole buffered batch).
    3. Auth-failure path inside `flushBuffer()` (per failed signal).
  - Replaced the aggregate `droppedBatchSize` reporting with per-signal counts (addresses CodeRabbit feedback on PR #16743).

## Test plan

- `observability/mastra/src/exporters/cloud.test.ts`: +2 `emitDropEvent integration` tests — 70 tests pass.
- `observability/mastra/src/exporters/mastra-platform.test.ts`: +2 mirrored tests — 76 tests pass.
- Full `@mastra/observability` suite: 919 passed / 2 skipped.
- `tsc --noEmit` clean for both `observability/mastra` and `packages/core`.

## Changesets

- `.changeset/brave-bears-smile.md` — `@mastra/core` (patch)
- `.changeset/tall-tables-help.md` — `@mastra/observability` (patch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When your authentication fails and the system has to temporarily pause, events get dropped silently. This PR makes the system announce these dropped events to the monitoring system so they can be tracked and reported instead of disappearing without a trace.

## Overview

This PR implements observability for authentication-cooldown drops in the Cloud and Mastra Platform exporters. When events are dropped due to an active auth-failure cooldown, the system now emits structured drop events through the observability bus so downstream consumers can observe and track these losses.

## Changes

### Core Types
- Added `'auth-cooldown'` as a new drop reason to `ObservabilityDropReason` in `packages/core/src/observability/types/core.ts`

### Base Infrastructure
- `BaseExporter` now provides a concrete `async init()` method that captures the `emitDropEvent` callback from `InitExporterOptions`
- Added three new `protected` helper methods to `BaseExporter`:
  - `captureDropEventEmitter()`: stores the drop event callback
  - `sanitizeDropError()`: cleanses unknown errors for safe emission
  - `emitDrop()`: emits structured drop events with signal/reason/count/timestamp/exporterName metadata

### Exporter Implementations
- `DefaultExporter` and `MastraStorageExporter` now expose `sanitizeDropError()` and `emitDrop()` as `protected override` methods to align with the base-class interface

- **CloudExporter**:
  - Added `CLOUD_SIGNAL_TO_DROP_SIGNAL` mapping to translate internal signal names to drop-event signal names
  - Per-signal handlers (`onTracingEvent`, `onLogEvent`, etc.) now emit drop events when `dropEventIfCoolingDown()` is triggered
  - `flushBuffer()` emits per-signal drop events when the cooldown short-circuit activates
  - Auth-failure path now computes `droppedBatchSize` from only the failed signals' record counts and emits per-signal `auth-cooldown` drops instead of aggregate drops
  - Non-auth failures emit per-signal `retry-exhausted` drops

- **MastraPlatformExporter**:
  - Per-signal handlers emit `auth-cooldown` drops before returning
  - `flushBuffer()` emits per-signal drop events via new `emitBufferDrops('auth-cooldown')` helper when cooldown short-circuits
  - Post-upload failure handling computes per-signal record counts and emits appropriate drop events (`auth-cooldown` for auth failures, `retry-exhausted` for others)

### Test Coverage
- Added 2 emitDropEvent integration tests to `cloud.test.ts` covering:
  - Auth-failure flush triggering per-signal drops with `reason: 'auth-cooldown'`
  - Pre-cooled cooldown causing per-signal handlers to emit immediate drops without buffering
- Added 2 mirrored integration tests to `mastra-platform.test.ts` with identical coverage
- Full test suite: 919 passed / 2 skipped in `@mastra/observability`; tsc validation clean for both affected packages

### Changesets
- `@mastra/core`: Patch bump documenting `auth-cooldown` addition to `ObservabilityDropReason`
- `@mastra/observability`: Patch bump documenting Cloud and Mastra Platform exporters now emitting drop events for auth-cooldown drops with per-signal granularity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->