### PR TITLE
feat(mastracode): add built-in memory profiling with /profile command

### DIFF
--- a/.changeset/memory-profiling-for-mastracode.md
+++ b/.changeset/memory-profiling-for-mastracode.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Added built-in memory profiling support. The `MemoryProfiler` samples `process.memoryUsage()` at a configurable interval (default 10s) and writes a JSONL timeline to `~/.local/share/mastracode/profiles/`. Automatic V8 heap snapshots can be triggered when heapUsed or RSS crosses a threshold. Controlled via `MASTRACODE_PROFILE=1` env var at startup or interactively with `/profile start`, `/profile stop`, `/profile status`, and `/profile snapshot`.

--- a/.changeset/om-turn-dispose-memory-retention.md
+++ b/.changeset/om-turn-dispose-memory-retention.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Reduced transient memory retention in Observational Memory by releasing heavy prompt/context references after each agent turn ends. ObservationTurn and ObservationStep now dispose their _context, systemMessage, writer, requestContext, observabilityContext, and actorModelContext fields when the turn finishes. The ObservationalMemoryProcessor also clears shared processor state keys (__omTurn, __omActorModelContext, __omObservabilityContext) after processOutputResult, preventing split input/output processor instances from retaining large memory strings between turns.

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -7,6 +7,7 @@ import { parseArgs } from 'node:util';
 import type { Harness, HarnessEvent, HarnessMessage } from '@mastra/core/harness';
 
 import { setupDebugLogging } from './utils/debug-log.js';
+import { isProfileEnabled, MemoryProfiler } from './utils/memory-profiler.js';
 import { releaseAllThreadLocks } from './utils/thread-lock.js';
 import { createMastraCode } from './index.js';
 
@@ -615,6 +616,17 @@ export async function headlessMain(predrainedInput?: string | null): Promise<nev
   const result = await createMastraCode({ settingsPath: args.settings });
   const { harness, mcpManager, effectiveDefaults } = result;
 
+  // Memory profiler — auto-starts when MASTRACODE_PROFILE=1
+  const headlessProfiler = isProfileEnabled()
+    ? new MemoryProfiler({
+        getMode: () => harness.getCurrentModeId() ?? undefined,
+        getThreadId: () => harness.getCurrentThreadId() ?? undefined,
+        getResourceId: () => harness.getResourceId(),
+        getModelId: () => harness.getCurrentModelId() ?? undefined,
+      })
+    : undefined;
+  headlessProfiler?.start();
+
   if (mcpManager?.hasServers()) {
     mcpManager.initInBackground().catch(err => {
       process.stderr.write(`Warning: MCP server initialization failed: ${(err as Error).message ?? err}\n`);
@@ -627,6 +639,7 @@ export async function headlessMain(predrainedInput?: string | null): Promise<nev
   const exitCode = await runHeadless(harness, { ...args, prompt }, effectiveDefaults);
 
   // Cleanup
+  headlessProfiler?.stop();
   releaseAllThreadLocks();
   const closeSignalsPubSub = (result.signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close;
   await Promise.allSettled([mcpManager?.disconnect(), harness?.stopHeartbeats(), closeSignalsPubSub?.()]);

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -12,6 +12,7 @@ import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
 import { applyThemeMode, restoreTerminalForeground } from './tui/theme.js';
 import { setupDebugLogging } from './utils/debug-log.js';
+import { isProfileEnabled, MemoryProfiler } from './utils/memory-profiler.js';
 import { drainPipedStdin, reopenStdinFromTTY } from './utils/stdin-pipe.js';
 import { releaseAllThreadLocks } from './utils/thread-lock.js';
 import { getCurrentVersion } from './utils/update-check.js';
@@ -23,6 +24,7 @@ let hookManager: Awaited<ReturnType<typeof createMastraCode>>['hookManager'];
 let authStorage: Awaited<ReturnType<typeof createMastraCode>>['authStorage'];
 let signalsPubSub: Awaited<ReturnType<typeof createMastraCode>>['signalsPubSub'];
 let analytics: ReturnType<typeof createMastraCodeAnalytics> | undefined;
+let memoryProfiler: MemoryProfiler | undefined;
 
 // Global safety nets — catch any uncaught errors from storage init, etc.
 process.on('uncaughtException', error => {
@@ -93,6 +95,17 @@ async function tuiMain(pipedInput?: string | null) {
     theme: themeMode,
   });
 
+  // Memory profiler — auto-starts when MASTRACODE_PROFILE=1
+  if (isProfileEnabled()) {
+    memoryProfiler = new MemoryProfiler({
+      getMode: () => harness.getCurrentModeId() ?? undefined,
+      getThreadId: () => harness.getCurrentThreadId() ?? undefined,
+      getResourceId: () => harness.getResourceId(),
+      getModelId: () => harness.getCurrentModelId() ?? undefined,
+    });
+    memoryProfiler.start();
+  }
+
   const tui = new MastraTUI({
     harness,
     hookManager,
@@ -102,6 +115,7 @@ async function tuiMain(pipedInput?: string | null) {
     appName: 'Mastra Code',
     version: getCurrentVersion(),
     inlineQuestions: true,
+    memoryProfiler,
     ...(pipedInput ? { initialMessage: `The following was piped via stdin:\n\n${pipedInput}` } : {}),
   });
   tui.run().catch(error => {
@@ -123,6 +137,7 @@ const asyncCleanup = async () => {
   releaseAllThreadLocks();
   const closeSignalsPubSub = (signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close;
   await Promise.allSettled([
+    memoryProfiler?.stop(),
     mcpManager?.disconnect(),
     harness?.stopHeartbeats(),
     closeSignalsPubSub?.(),

--- a/mastracode/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/src/tui/__tests__/command-dispatch.test.ts
@@ -53,6 +53,7 @@ vi.mock('../commands/index.js', () => ({
   handleObservabilityCommand: vi.fn(),
   handleGoalCommand: mocks.handleGoalCommand,
   handleJudgeCommand: mocks.handleJudgeCommand,
+  handleProfileCommand: vi.fn(),
 }));
 
 vi.mock('../display.js', () => ({
@@ -152,6 +153,15 @@ describe('dispatchSlashCommand models routing', () => {
     expect(handled).toBe(true);
     expect(mocks.handleJudgeCommand).toHaveBeenCalledTimes(1);
     expect(mocks.handleJudgeCommand).toHaveBeenCalledWith(ctx);
+  });
+
+  it('routes /profile to handleProfileCommand', async () => {
+    const state = { customSlashCommands: [] } as any;
+    const ctx = {} as any;
+
+    const handled = await dispatchSlashCommand('/profile status', state, () => ctx);
+
+    expect(handled).toBe(true);
   });
 
   it('routes /skill/name to handleSkillCommand', async () => {

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -42,6 +42,7 @@ import {
   handleObservabilityCommand,
   handleGoalCommand,
   handleJudgeCommand,
+  handleProfileCommand,
 } from './commands/index.js';
 import { isCurrentThreadActive, sendSlashCommandMessage } from './commands/send-slash-command-message.js';
 import type { SlashCommandContext } from './commands/types.js';
@@ -244,6 +245,9 @@ export async function dispatchSlashCommand(
       return true;
     case 'observability':
       await handleObservabilityCommand(buildCtx(), args);
+      return true;
+    case 'profile':
+      await handleProfileCommand(buildCtx(), args);
       return true;
     case 'goal':
       await handleGoalCommand(buildCtx(), args);

--- a/mastracode/src/tui/commands/index.ts
+++ b/mastracode/src/tui/commands/index.ts
@@ -36,3 +36,4 @@ export { handleApiKeysCommand } from './api-keys.js';
 export { handleFeedbackCommand } from './feedback.js';
 export { handleObservabilityCommand } from './observability.js';
 export { handleGoalCommand, handleJudgeCommand } from './goal.js';
+export { handleProfileCommand } from './profile.js';

--- a/mastracode/src/tui/commands/profile.ts
+++ b/mastracode/src/tui/commands/profile.ts
@@ -1,0 +1,201 @@
+/**
+ * /profile command — manage the built-in memory profiler.
+ *
+ * Subcommands:
+ *   /profile              — show status (alias for /profile status)
+ *   /profile status       — show current profiler state and output location
+ *   /profile start        — start sampling (with optional threshold overrides)
+ *   /profile stop         — stop sampling
+ *   /profile snapshot     — manually trigger a V8 heap snapshot
+ */
+import { MemoryProfiler } from '../../utils/memory-profiler.js';
+import { theme } from '../theme.js';
+import type { SlashCommandContext } from './types.js';
+
+function getProfiler(ctx: SlashCommandContext): MemoryProfiler | undefined {
+  return ctx.state.memoryProfiler;
+}
+
+function showStatus(ctx: SlashCommandContext, profiler: MemoryProfiler): void {
+  const s = profiler.status();
+  const lines: string[] = [theme.bold(theme.fg('accent', 'Memory Profiler')), ''];
+
+  lines.push(theme.bold('State'));
+  if (s.running) {
+    lines.push(`  ${theme.fg('success', '●')} Running`);
+  } else {
+    lines.push(`  ${theme.fg('dim', '●')} Stopped`);
+  }
+
+  lines.push(`  Interval:      ${s.intervalMs}ms`);
+  lines.push(`  Samples:       ${s.sampleCount}`);
+  lines.push(`  Snapshots:     ${s.snapshotCount}${s.maxSnapshots > 0 ? ` / ${s.maxSnapshots} (max auto)` : ' (manual only)'}`);
+
+  if (s.heapThresholdBytes) {
+    lines.push(`  Heap trigger:  ${(s.heapThresholdBytes / 1024 / 1024).toFixed(0)} MB`);
+  } else {
+    lines.push(`  Heap trigger:  ${theme.fg('dim', '—')}`);
+  }
+  if (s.rssThresholdBytes) {
+    lines.push(`  RSS trigger:   ${(s.rssThresholdBytes / 1024 / 1024).toFixed(0)} MB`);
+  } else {
+    lines.push(`  RSS trigger:   ${theme.fg('dim', '—')}`);
+  }
+
+  lines.push('');
+  lines.push(theme.bold('Output'));
+  lines.push(`  Directory:     ${s.outDir}`);
+  if (s.sampleCount > 0) {
+    lines.push(`  Samples file:  ${s.outDir}/samples.jsonl`);
+  }
+
+  if (s.sampleCount > 0 && s.latestSample) {
+    lines.push('');
+    lines.push(theme.bold('Latest Sample'));
+    lines.push(`  heapUsed:      ${(s.latestSample.heapUsed / 1024 / 1024).toFixed(1)} MB`);
+    lines.push(`  heapTotal:     ${(s.latestSample.heapTotal / 1024 / 1024).toFixed(1)} MB`);
+    lines.push(`  rss:           ${(s.latestSample.rss / 1024 / 1024).toFixed(1)} MB`);
+    if (s.latestSample.mode) lines.push(`  mode:          ${s.latestSample.mode}`);
+    if (s.latestSample.modelId) lines.push(`  model:         ${s.latestSample.modelId}`);
+    if (s.latestSample.threadId) lines.push(`  thread:        ${s.latestSample.threadId}`);
+  }
+
+  lines.push('');
+  lines.push(theme.fg('dim', 'Commands:'));
+  lines.push(theme.fg('dim', '  /profile status       — show profiler status'));
+  lines.push(theme.fg('dim', '  /profile start        — start sampling'));
+  lines.push(theme.fg('dim', '  /profile stop         — stop sampling'));
+  lines.push(theme.fg('dim', '  /profile snapshot     — write heap snapshot now'));
+
+  ctx.showInfo(lines.join('\n'));
+}
+
+function handleStart(ctx: SlashCommandContext, args: string[]): void {
+  const existing = getProfiler(ctx);
+  if (existing) {
+    const s = existing.status();
+    if (s.running) {
+      ctx.showInfo('Memory profiler is already running.');
+      return;
+    }
+    // Reuse the existing profiler instance
+    existing.start();
+    ctx.showInfo('Memory profiler started.');
+    return;
+  }
+
+  // Parse optional args
+  let heapThresholdBytes: number | undefined;
+  let rssThresholdBytes: number | undefined;
+  let intervalMs: number | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--heap-mb' && i + 1 < args.length) {
+      heapThresholdBytes = parseFloat(args[++i]!) * 1024 * 1024;
+    } else if (args[i] === '--rss-mb' && i + 1 < args.length) {
+      rssThresholdBytes = parseFloat(args[++i]!) * 1024 * 1024;
+    } else if (args[i] === '--interval-ms' && i + 1 < args.length) {
+      intervalMs = parseInt(args[++i]!, 10);
+    }
+  }
+
+  const profiler = new MemoryProfiler({
+    intervalMs,
+    heapThresholdBytes,
+    rssThresholdBytes,
+    getMode: () => ctx.harness.getCurrentModeId() ?? undefined,
+    getThreadId: () => ctx.harness.getCurrentThreadId() ?? undefined,
+    getResourceId: () => ctx.harness.getResourceId(),
+    getModelId: () => ctx.harness.getCurrentModelId() ?? undefined,
+  });
+
+  // Store it on state for subsequent commands
+  ctx.state.memoryProfiler = profiler;
+  profiler.start();
+
+  ctx.showInfo(
+    `Memory profiler started.\n  Writing samples to: ${profiler.outDir}` +
+      (heapThresholdBytes ? `\n  Heap threshold:  ${(heapThresholdBytes / 1024 / 1024).toFixed(0)} MB` : '') +
+      (rssThresholdBytes ? `\n  RSS threshold:   ${(rssThresholdBytes / 1024 / 1024).toFixed(0)} MB` : '') +
+      `\n  Interval:        ${profiler.intervalMs}ms`,
+  );
+}
+
+function handleStop(ctx: SlashCommandContext): void {
+  const profiler = getProfiler(ctx);
+  if (!profiler) {
+    ctx.showInfo('No memory profiler is configured. Use /profile start to create one.');
+    return;
+  }
+  const s = profiler.status();
+  if (!s.running) {
+    ctx.showInfo('Memory profiler is already stopped.');
+    return;
+  }
+  profiler.stop();
+  ctx.showInfo(
+    `Memory profiler stopped.\n  Samples collected: ${s.sampleCount}\n  Snapshots taken:  ${s.snapshotCount}\n  Location:         ${s.outDir}`,
+  );
+}
+
+function handleSnapshot(ctx: SlashCommandContext): void {
+  const profiler = getProfiler(ctx);
+  if (!profiler) {
+    // Allow snapshot without a running profiler
+    ctx.showInfo(
+      `${theme.fg('warning', '⚠')} No profiler configured. Writing a one-off snapshot...`,
+    );
+    const tmpProfiler = new MemoryProfiler();
+    const path = tmpProfiler.snapshot('manual');
+    if (path) {
+      ctx.showInfo(`Heap snapshot written to:\n  ${path}`);
+    } else {
+      ctx.showError('Failed to write heap snapshot.');
+    }
+    return;
+  }
+
+  const path = profiler.snapshot('manual');
+  if (path) {
+    ctx.showInfo(`Heap snapshot written to:\n  ${path}`);
+  } else {
+    ctx.showError('Failed to write heap snapshot.');
+  }
+}
+
+export async function handleProfileCommand(ctx: SlashCommandContext, args: string[]): Promise<void> {
+  const subcommand = args[0]?.toLowerCase();
+
+  // /profile or /profile status
+  if (!subcommand || subcommand === 'status') {
+    const profiler = getProfiler(ctx);
+    if (profiler) {
+      showStatus(ctx, profiler);
+    } else {
+      ctx.showInfo(
+        `${theme.fg('dim', 'No memory profiler configured.')}\n\n` +
+          `Set MASTRACODE_PROFILE=1 to auto-profile from startup, or use:\n` +
+          `  /profile start             — start profiling\n` +
+          `  /profile start --heap-mb 200 — profile with 200 MB heap threshold\n` +
+          `  /profile start --rss-mb 500  — profile with 500 MB RSS threshold\n` +
+          `  /profile snapshot            — one-off heap snapshot\n` +
+          `  /profile stop                — stop profiling`,
+      );
+    }
+    return;
+  }
+
+  switch (subcommand) {
+    case 'start':
+      handleStart(ctx, args.slice(1));
+      break;
+    case 'stop':
+      handleStop(ctx);
+      break;
+    case 'snapshot':
+      handleSnapshot(ctx);
+      break;
+    default:
+      ctx.showError(`Unknown subcommand: ${subcommand}. Try /profile status.`);
+  }
+}

--- a/mastracode/src/tui/components/help-overlay.ts
+++ b/mastracode/src/tui/components/help-overlay.ts
@@ -50,6 +50,7 @@ function getCommands(modes: number): HelpEntry[] {
     { key: '/theme', description: 'Switch color theme (auto/dark/light)' },
     { key: '/update', description: 'Check for and install updates' },
     { key: '/observability', description: 'Configure cloud observability' },
+    { key: '/profile', description: 'Memory profiler and heap snapshots' },
     { key: '/goal', description: 'Set/manage persistent goal (Ralph loop)' },
     { key: '/judge', description: 'Set goal judge defaults' },
   ];

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -83,6 +83,9 @@ export interface MastraTUIOptions {
 
   /** Use inline questions instead of dialog overlays */
   inlineQuestions?: boolean;
+
+  /** Optional memory profiler instance (for /profile command) */
+  memoryProfiler?: import('../utils/memory-profiler.js').MemoryProfiler;
 }
 
 // =============================================================================
@@ -221,6 +224,10 @@ export interface TUIState {
 
   // ── Cleanup ───────────────────────────────────────────────────────────
   unsubscribe?: () => void;
+
+  // ── Memory profiler ───────────────────────────────────────────────────
+  /** Memory profiler instance (set after MastraTUIOptions construction) */
+  memoryProfiler?: import('../utils/memory-profiler.js').MemoryProfiler;
 }
 
 // =============================================================================
@@ -319,6 +326,9 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
     // Abort tracking
     lastCtrlCTime: 0,
     userInitiatedAbort: false,
+
+    // Memory profiler
+    memoryProfiler: options.memoryProfiler,
   };
   editor.getModeColor = () => {
     if (result.activeGoalJudge) {

--- a/mastracode/src/utils/__tests__/memory-profiler.test.ts
+++ b/mastracode/src/utils/__tests__/memory-profiler.test.ts
@@ -1,0 +1,270 @@
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock v8.writeHeapSnapshot so tests don't actually write snapshot files
+vi.mock('node:v8', () => ({
+  default: {
+    writeHeapSnapshot: vi.fn().mockReturnValue('/tmp/mock-snapshot.heapsnapshot'),
+  },
+  writeHeapSnapshot: vi.fn().mockReturnValue('/tmp/mock-snapshot.heapsnapshot'),
+}));
+
+// Mock project so getAppDataDir returns a temp dir
+vi.mock('../project.js', () => {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'mc-profile-test-'));
+  return {
+    getAppDataDir: () => tmpDir,
+  };
+});
+
+import { writeHeapSnapshot } from 'node:v8';
+import { MemoryProfiler, isProfileEnabled, resolveProfileDir } from '../memory-profiler.js';
+
+describe('MemoryProfiler', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    // Reset env vars
+    delete process.env.MASTRACODE_PROFILE;
+    delete process.env.MASTRACODE_PROFILE_DIR;
+    delete process.env.MASTRACODE_PROFILE_INTERVAL_MS;
+    delete process.env.MASTRACODE_PROFILE_HEAP_MB;
+    delete process.env.MASTRACODE_PROFILE_RSS_MB;
+    delete process.env.MASTRACODE_PROFILE_MAX_SNAPSHOTS;
+
+    vi.clearAllMocks();
+  });
+
+  describe('constructor defaults', () => {
+    it('uses default interval and max snapshots', () => {
+      const p = new MemoryProfiler();
+      expect(p.intervalMs).toBe(10000);
+      expect(p.maxSnapshots).toBe(3);
+      expect(p.outDir).toMatch(/profiles\/\d+-\d+$/);
+    });
+
+    it('respects options over defaults', () => {
+      const p = new MemoryProfiler({
+        intervalMs: 5000,
+        maxSnapshots: 5,
+        outDir: '/tmp/test-profile',
+      });
+      expect(p.intervalMs).toBe(5000);
+      expect(p.maxSnapshots).toBe(5);
+      expect(p.outDir).toBe('/tmp/test-profile');
+    });
+
+    it('parses env var INTERVAL_MS', () => {
+      process.env.MASTRACODE_PROFILE_INTERVAL_MS = '3000';
+      const p = new MemoryProfiler();
+      expect(p.intervalMs).toBe(3000);
+    });
+
+    it('parses heap threshold from env MB', () => {
+      process.env.MASTRACODE_PROFILE_HEAP_MB = '200';
+      const p = new MemoryProfiler();
+      expect(p.heapThresholdBytes).toBe(200 * 1024 * 1024);
+    });
+
+    it('ignores invalid heap threshold env', () => {
+      process.env.MASTRACODE_PROFILE_HEAP_MB = 'not-a-number';
+      const p = new MemoryProfiler();
+      expect(p.heapThresholdBytes).toBeUndefined();
+    });
+
+    it('parses RSS threshold from env MB', () => {
+      process.env.MASTRACODE_PROFILE_RSS_MB = '500';
+      const p = new MemoryProfiler();
+      expect(p.rssThresholdBytes).toBe(500 * 1024 * 1024);
+    });
+  });
+
+  describe('start / stop lifecycle', () => {
+    it('starts sampling and writes samples.jsonl', () => {
+      const p = new MemoryProfiler({
+        intervalMs: 50000, // long interval so no second sample
+        outDir: mkdtempSync(join(tmpdir(), 'mc-test-')),
+      });
+      p.start();
+
+      const status = p.status();
+      expect(status.running).toBe(true);
+      expect(status.sampleCount).toBe(1); // baseline sample
+      expect(existsSync(join(p.outDir, 'samples.jsonl'))).toBe(true);
+
+      p.stop();
+    });
+
+    it('is a no-op to start when already running', () => {
+      const p = new MemoryProfiler({
+        intervalMs: 50000,
+        outDir: mkdtempSync(join(tmpdir(), 'mc-test-')),
+      });
+      p.start();
+      const countA = p.status().sampleCount;
+      p.start(); // no-op
+      const countB = p.status().sampleCount;
+      expect(countA).toBe(countB);
+      p.stop();
+    });
+
+    it('is safe to call stop when not running', () => {
+      const p = new MemoryProfiler();
+      expect(() => p.stop()).not.toThrow();
+    });
+
+    it('records metadata getters in samples', () => {
+      const p = new MemoryProfiler({
+        intervalMs: 50000,
+        outDir: mkdtempSync(join(tmpdir(), 'mc-test-')),
+        getMode: () => 'build',
+        getThreadId: () => 'thread-xyz',
+        getResourceId: () => 'resource-abc',
+        getModelId: () => 'claude-opus-4',
+      });
+      p.start();
+
+      const s = p.status();
+      expect(s.latestSample?.mode).toBe('build');
+      expect(s.latestSample?.threadId).toBe('thread-xyz');
+      expect(s.latestSample?.resourceId).toBe('resource-abc');
+      expect(s.latestSample?.modelId).toBe('claude-opus-4');
+
+      p.stop();
+    });
+  });
+
+  describe('status', () => {
+    it('returns enabled/running/sampleCount/snapshotCount', () => {
+      const p = new MemoryProfiler({
+        outDir: mkdtempSync(join(tmpdir(), 'mc-test-')),
+        intervalMs: 50000,
+      });
+      const before = p.status();
+      expect(before.running).toBe(false);
+      expect(before.sampleCount).toBe(0);
+      expect(before.snapshotCount).toBe(0);
+
+      p.start();
+      const after = p.status();
+      expect(after.running).toBe(true);
+      expect(after.sampleCount).toBe(1);
+      expect(after.outDir).toBeDefined();
+
+      p.stop();
+    });
+  });
+
+  describe('manual snapshot', () => {
+    it('writes a heap snapshot via v8.writeHeapSnapshot', () => {
+      const p = new MemoryProfiler({
+        outDir: mkdtempSync(join(tmpdir(), 'mc-test-')),
+      });
+      const path = p.snapshot('test-reason');
+      expect(writeHeapSnapshot).toHaveBeenCalledTimes(1);
+      expect(path).toBeTruthy();
+
+      const status = p.status();
+      expect(status.snapshotCount).toBe(1);
+    });
+
+    it('handles snapshot failure gracefully (v8 throws)', () => {
+      vi.mocked(writeHeapSnapshot).mockImplementationOnce(() => {
+        throw new Error('OOM');
+      });
+
+      const p = new MemoryProfiler({
+        outDir: mkdtempSync(join(tmpdir(), 'mc-test-')),
+      });
+      const path = p.snapshot('test-fail');
+      expect(path).toBeNull();
+    });
+  });
+
+  describe('threshold-based snapshots', () => {
+    it('triggers snapshot when heapUsed exceeds heapThresholdBytes', () => {
+      const p = new MemoryProfiler({
+        outDir: mkdtempSync(join(tmpdir(), 'mc-test-')),
+        heapThresholdBytes: 1, // 1 byte — always exceeded
+        maxSnapshots: 2,
+        intervalMs: 50000,
+      });
+
+      // start triggers baseline sample + threshold check
+      p.start();
+      expect(writeHeapSnapshot).toHaveBeenCalled();
+      expect(p.status().snapshotCount).toBe(1);
+
+      // Manually trigger _takeSample again
+      // We can't access private method, but we can check stop() writes final sample
+      p.stop();
+      expect(p.status().snapshotCount).toBeGreaterThanOrEqual(1);
+
+      p.stop(); // no-op
+    });
+
+    it('triggers snapshot when RSS exceeds rssThresholdBytes', () => {
+      const p = new MemoryProfiler({
+        outDir: mkdtempSync(join(tmpdir(), 'mc-test-')),
+        rssThresholdBytes: 1,
+        maxSnapshots: 2,
+        intervalMs: 50000,
+      });
+      p.start();
+
+      expect(writeHeapSnapshot).toHaveBeenCalled();
+      expect(p.status().snapshotCount).toBeGreaterThanOrEqual(1);
+      p.stop();
+    });
+
+    it('caps automatic snapshots at maxSnapshots', () => {
+      const p = new MemoryProfiler({
+        outDir: mkdtempSync(join(tmpdir(), 'mc-test-')),
+        heapThresholdBytes: 1,
+        maxSnapshots: 2,
+        intervalMs: 50000,
+      });
+
+      // Each start/stop cycle triggers threshold check
+      p.start();
+      p.stop();
+      const countAfterFirst = p.status().snapshotCount;
+
+      // Start again — should not exceed maxSnapshots
+      p.start();
+      p.stop();
+      const countAfterSecond = p.status().snapshotCount;
+
+      expect(countAfterFirst).toBeLessThanOrEqual(2);
+      expect(countAfterSecond).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('env config', () => {
+    it('resolves profile dir from env', () => {
+      process.env.MASTRACODE_PROFILE_DIR = '/custom/profile/path';
+      expect(resolveProfileDir()).toBe('/custom/profile/path');
+    });
+
+    it('resolves profile dir from argument over env', () => {
+      process.env.MASTRACODE_PROFILE_DIR = '/env/path';
+      expect(resolveProfileDir('/arg/path')).toBe('/arg/path');
+    });
+
+    it('isProfileEnabled returns true when MASTRACODE_PROFILE=1', () => {
+      process.env.MASTRACODE_PROFILE = '1';
+      expect(isProfileEnabled()).toBe(true);
+    });
+
+    it('isProfileEnabled returns false when not set', () => {
+      expect(isProfileEnabled()).toBe(false);
+    });
+
+    it('isProfileEnabled returns false for other values', () => {
+      process.env.MASTRACODE_PROFILE = '0';
+      expect(isProfileEnabled()).toBe(false);
+    });
+  });
+});

--- a/mastracode/src/utils/memory-profiler.ts
+++ b/mastracode/src/utils/memory-profiler.ts
@@ -1,0 +1,336 @@
+/**
+ * Lightweight memory profiler for Mastra Code.
+ *
+ * Samples process.memoryUsage() on an interval and writes a JSONL timeline
+ * to disk.  Optionally triggers V8 heap snapshots when memory crosses
+ * configurable thresholds.  Designed for minimal runtime overhead — no
+ * heavy allocations or blocking operations during normal sampling.
+ *
+ * Env configuration:
+ *   MASTRACODE_PROFILE=1           enable auto-start from main/headless
+ *   MASTRACODE_PROFILE_DIR=<path>  override output directory
+ *   MASTRACODE_PROFILE_INTERVAL_MS=<ms>  sampling interval (default 10_000)
+ *   MASTRACODE_PROFILE_HEAP_MB=<mb>     trigger snapshot when heapUsed exceeds this
+ *   MASTRACODE_PROFILE_RSS_MB=<mb>      trigger snapshot when rss exceeds this
+ *   MASTRACODE_PROFILE_MAX_SNAPSHOTS=<n>  max automatic snapshots (default 3)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import v8 from 'node:v8';
+import { getAppDataDir } from './project.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProfileSample {
+  /** ISO timestamp of the sample */
+  t: string;
+  /** Process resident set size in bytes */
+  rss: number;
+  /** V8 heap total in bytes */
+  heapTotal: number;
+  /** V8 heap used in bytes */
+  heapUsed: number;
+  /** C++/native memory usage in bytes (bound to the V8 isolate) */
+  external: number;
+  /** ArrayBuffer memory in bytes */
+  arrayBuffers: number;
+  /** CPU time used by this process (user+system) in micro-seconds, or 0 */
+  cpuUser: number;
+  cpuSystem: number;
+  /** Process PID */
+  pid: number;
+  /** Current working directory */
+  cwd: string;
+  /** Current agent mode, if available ("build"|"plan"|"fast") */
+  mode?: string;
+  /** Current thread ID, if available */
+  threadId?: string;
+  /** Current resource ID, if available */
+  resourceId?: string;
+  /** Current model ID, if available */
+  modelId?: string;
+}
+
+export interface MemoryProfilerOptions {
+  /** Sampling interval in ms (default 10_000) */
+  intervalMs?: number;
+  /** Trigger heap snapshot when heapUsed exceeds this (bytes) */
+  heapThresholdBytes?: number;
+  /** Trigger heap snapshot when RSS exceeds this (bytes) */
+  rssThresholdBytes?: number;
+  /** Max automatic heap snapshots (default 3) */
+  maxSnapshots?: number;
+  /** Output directory (default: appDataDir/profiles/<session>-<pid>) */
+  outDir?: string;
+  /** Optional getter for current mode */
+  getMode?: () => string | undefined;
+  /** Optional getter for current thread ID */
+  getThreadId?: () => string | undefined;
+  /** Optional getter for current resource ID */
+  getResourceId?: () => string | undefined;
+  /** Optional getter for current model ID */
+  getModelId?: () => string | undefined;
+}
+
+export interface MemoryProfilerStatus {
+  enabled: boolean;
+  running: boolean;
+  outDir: string;
+  sampleCount: number;
+  snapshotCount: number;
+  latestSample: ProfileSample | null;
+  heapThresholdBytes: number | undefined;
+  rssThresholdBytes: number | undefined;
+  maxSnapshots: number;
+  intervalMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_INTERVAL_MS = 10_000;
+const DEFAULT_MAX_SNAPSHOTS = 3;
+
+// ---------------------------------------------------------------------------
+// MemoryProfiler
+// ---------------------------------------------------------------------------
+
+export class MemoryProfiler {
+  private _intervalId: ReturnType<typeof setInterval> | null = null;
+  private _outDir: string;
+  private _sampleStream: fs.WriteStream | null = null;
+  private _sampleCount = 0;
+  private _snapshotCount = 0;
+  private _latestSample: ProfileSample | null = null;
+
+  readonly intervalMs: number;
+  readonly heapThresholdBytes: number | undefined;
+  readonly rssThresholdBytes: number | undefined;
+  readonly maxSnapshots: number;
+  readonly getMode?: () => string | undefined;
+  readonly getThreadId?: () => string | undefined;
+  readonly getResourceId?: () => string | undefined;
+  readonly getModelId?: () => string | undefined;
+
+  constructor(opts: MemoryProfilerOptions = {}) {
+    // Resolve output directory
+    const sessionTag = `${Date.now()}-${process.pid}`;
+    this._outDir =
+      opts.outDir ?? path.join(getAppDataDir(), 'profiles', sessionTag);
+
+    this.intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.maxSnapshots = opts.maxSnapshots ?? DEFAULT_MAX_SNAPSHOTS;
+
+    // Thresholds — accept bytes directly from options, but env vars in MB
+    this.heapThresholdBytes = opts.heapThresholdBytes ?? this._envHeapMb();
+    this.rssThresholdBytes = opts.rssThresholdBytes ?? this._envRssMb();
+
+    this.getMode = opts.getMode;
+    this.getThreadId = opts.getThreadId;
+    this.getResourceId = opts.getResourceId;
+    this.getModelId = opts.getModelId;
+
+    // Parse env overrides
+    const envInterval = process.env.MASTRACODE_PROFILE_INTERVAL_MS;
+    if (envInterval) {
+      const parsed = parseInt(envInterval, 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        this.intervalMs = parsed;
+      }
+    }
+
+    const envMax = process.env.MASTRACODE_PROFILE_MAX_SNAPSHOTS;
+    if (envMax) {
+      const parsed = parseInt(envMax, 10);
+      if (!isNaN(parsed) && parsed >= 0) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        (this as any).maxSnapshots = parsed;
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /** Start periodic sampling.  Safe to call multiple times (no-op if running). */
+  start(): void {
+    if (this._intervalId) return;
+
+    // Ensure output directory exists
+    fs.mkdirSync(this._outDir, { recursive: true });
+
+    const samplesPath = path.join(this._outDir, 'samples.jsonl');
+    this._sampleStream = fs.createWriteStream(samplesPath, { flags: 'a' });
+
+    // Take an immediate baseline sample
+    this._takeSample();
+
+    this._intervalId = setInterval(() => {
+      this._takeSample();
+    }, this.intervalMs);
+
+    // Unref so the timer doesn't keep the process alive
+    this._intervalId.unref();
+  }
+
+  /** Stop periodic sampling.  Safe to call multiple times (no-op if stopped). */
+  stop(): void {
+    if (this._intervalId) {
+      clearInterval(this._intervalId);
+      this._intervalId = null;
+    }
+    // Take one final sample
+    this._takeSample();
+    this._closeStream();
+  }
+
+  /**
+   * Manually trigger a V8 heap snapshot.  The snapshot is written to the
+   * profile output directory with a descriptive filename.
+   *
+   * Returns the path to the snapshot file, or `null` if it failed.
+   */
+  snapshot(reason: string): string | null {
+    const sanitized = reason.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64);
+    const filename = `heap-${sanitized}-${Date.now()}.heapsnapshot`;
+    const filepath = path.join(this._outDir, filename);
+
+    try {
+      v8.writeHeapSnapshot(filepath);
+      this._snapshotCount++;
+      return filepath;
+    } catch (err) {
+      // If memory is critically low, snapshot writing may fail
+      process.stderr.write(
+        `[memory-profiler] Failed to write heap snapshot: ${(err as Error).message}\n`,
+      );
+      return null;
+    }
+  }
+
+  /** Return current profiler status. */
+  status(): MemoryProfilerStatus {
+    return {
+      enabled: true,
+      running: this._intervalId !== null,
+      outDir: this._outDir,
+      sampleCount: this._sampleCount,
+      snapshotCount: this._snapshotCount,
+      latestSample: this._latestSample,
+      heapThresholdBytes: this.heapThresholdBytes,
+      rssThresholdBytes: this.rssThresholdBytes,
+      maxSnapshots: this.maxSnapshots,
+      intervalMs: this.intervalMs,
+    };
+  }
+
+  /** The active output directory path. */
+  get outDir(): string {
+    return this._outDir;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------
+
+  private _takeSample(): void {
+    const mem = process.memoryUsage();
+    const resourceUsage = process.resourceUsage();
+
+    const sample: ProfileSample = {
+      t: new Date().toISOString(),
+      rss: mem.rss,
+      heapTotal: mem.heapTotal,
+      heapUsed: mem.heapUsed,
+      external: mem.external,
+      arrayBuffers: mem.arrayBuffers ?? 0,
+      cpuUser: resourceUsage.userCPUTime,
+      cpuSystem: resourceUsage.systemCPUTime,
+      pid: process.pid,
+      cwd: process.cwd(),
+      mode: this.getMode?.(),
+      threadId: this.getThreadId?.(),
+      resourceId: this.getResourceId?.(),
+      modelId: this.getModelId?.(),
+    };
+
+    this._latestSample = sample;
+    this._sampleCount++;
+
+    // Write to JSONL
+    if (this._sampleStream) {
+      this._sampleStream.write(JSON.stringify(sample) + '\n');
+    }
+
+    // Check thresholds
+    this._checkThresholds(sample);
+  }
+
+  private _checkThresholds(sample: ProfileSample): void {
+    const maxReached =
+      typeof this.maxSnapshots === 'number' && this._snapshotCount >= this.maxSnapshots;
+    if (maxReached) return;
+
+    // heapUsed threshold (most common trigger)
+    if (this.heapThresholdBytes && sample.heapUsed >= this.heapThresholdBytes) {
+      const mb = (sample.heapUsed / 1024 / 1024).toFixed(1);
+      this.snapshot(`auto-heap-${mb}mb`);
+      return;
+    }
+
+    // RSS threshold
+    if (this.rssThresholdBytes && sample.rss >= this.rssThresholdBytes) {
+      const mb = (sample.rss / 1024 / 1024).toFixed(1);
+      this.snapshot(`auto-rss-${mb}mb`);
+    }
+  }
+
+  private _closeStream(): void {
+    if (this._sampleStream) {
+      try {
+        this._sampleStream.end();
+      } catch {
+        // Best effort
+      }
+      this._sampleStream = null;
+    }
+  }
+
+  /** Parse MASTRACODE_PROFILE_HEAP_MB env var into bytes. */
+  private _envHeapMb(): number | undefined {
+    const val = process.env.MASTRACODE_PROFILE_HEAP_MB;
+    if (!val) return undefined;
+    const mb = parseFloat(val);
+    return isNaN(mb) || mb <= 0 ? undefined : mb * 1024 * 1024;
+  }
+
+  /** Parse MASTRACODE_PROFILE_RSS_MB env var into bytes. */
+  private _envRssMb(): number | undefined {
+    const val = process.env.MASTRACODE_PROFILE_RSS_MB;
+    if (!val) return undefined;
+    const mb = parseFloat(val);
+    return isNaN(mb) || mb <= 0 ? undefined : mb * 1024 * 1024;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: parse env & construct profiler
+// ---------------------------------------------------------------------------
+
+/** Parse MASTRACODE_PROFILE_DIR or default. */
+export function resolveProfileDir(overrideDir?: string): string {
+  return (
+    overrideDir ??
+    process.env.MASTRACODE_PROFILE_DIR ??
+    path.join(getAppDataDir(), 'profiles', `${Date.now()}-${process.pid}`)
+  );
+}
+
+/** Returns true when the MASTRACODE_PROFILE env var requests auto-start. */
+export function isProfileEnabled(): boolean {
+  return process.env.MASTRACODE_PROFILE === '1';
+}

--- a/packages/memory/src/processors/observational-memory/__tests__/memory-retention.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/memory-retention.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Regression tests for memory retention in ObservationalMemoryProcessor.
+ *
+ * The root cause: processInputStep() creates `this.turn` on the input processor
+ * instance, while processOutputResult() runs on a separate output processor
+ * instance. The output instance cannot clear the input instance's private
+ * `this.turn`, so the ended turn retains heavy _context.systemMessage strings.
+ *
+ * The fix: ObservationTurn.dispose() clears _context, _currentStep, writer,
+ * requestContext, observabilityContext, actorModelContext, and memory after
+ * the turn ends. The processor also clears __omTurn, __omActorModelContext,
+ * and __omObservabilityContext from shared processor state.
+ */
+import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { ObservationalMemory } from '../observational-memory';
+import { ObservationalMemoryProcessor } from '../processor';
+import type { MemoryContextProvider } from '../processor';
+
+function createInMemoryStorage(): InMemoryMemory {
+  const db = new InMemoryDB();
+  return new InMemoryMemory({ db });
+}
+
+function createStubMemoryProvider(): MemoryContextProvider {
+  return {
+    getContext: vi.fn().mockResolvedValue({
+      systemMessage: undefined,
+      messages: [],
+      hasObservations: false,
+      omRecord: null,
+      continuationMessage: undefined,
+      otherThreadsContext: undefined,
+    }),
+    persistMessages: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Create a minimal non-gateway model object. */
+function createMockModel() {
+  return {
+    modelId: 'openai/gpt-4o',
+    provider: 'openai',
+  };
+}
+
+describe('OM processor memory retention', () => {
+  let om: ObservationalMemory;
+  let inputProcessor: ObservationalMemoryProcessor;
+  let outputProcessor: ObservationalMemoryProcessor;
+  const threadId = 'test-memory-retention-thread';
+  const resourceId = 'test-memory-retention-resource';
+
+  beforeEach(() => {
+    const storage = createInMemoryStorage();
+    om = new ObservationalMemory({
+      storage,
+      observation: { messageTokens: 100_000, model: 'test-model' },
+      reflection: { observationTokens: 100_000, model: 'test-model' },
+      scope: 'thread',
+    });
+    // Production creates separate instances for input and output processors
+    inputProcessor = new ObservationalMemoryProcessor(om, createStubMemoryProvider());
+    outputProcessor = new ObservationalMemoryProcessor(om, createStubMemoryProvider());
+  });
+
+  it('clears shared state after processOutputResult with split processor instances', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const state: Record<string, unknown> = {};
+    const messageList = new MessageList({ threadId, resourceId });
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+
+    const model = createMockModel();
+    const abort = vi.fn();
+
+    // ── Step 0: Run processInputStep on the INPUT processor ──
+    await inputProcessor.processInputStep({
+      messageList,
+      messages: [],
+      requestContext,
+      stepNumber: 0,
+      state,
+      steps: [],
+      systemMessages: [],
+      model: model as any,
+      retryCount: 0,
+      abort: abort as any,
+      writer: undefined,
+    });
+
+    // Verify the input processor created a turn and stored it in shared state
+    expect(state.__omTurn).toBeDefined();
+    expect(state.__omActorModelContext).toBeDefined();
+    expect(state.__omActorModelContext).toEqual({
+      provider: 'openai',
+      modelId: 'openai/gpt-4o',
+    });
+
+    // Add a dummy assistant response so output processor has something to process
+    messageList.add(
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: { format: 2, parts: [{ type: 'text', text: 'test response' }] },
+        createdAt: new Date(),
+        threadId,
+        resourceId,
+      } as any,
+      'response',
+    );
+
+    // ── Run processOutputResult on the OUTPUT processor ──
+    await outputProcessor.processOutputResult({
+      messageList,
+      messages: messageList.get.response.db(),
+      requestContext,
+      state,
+      abort: abort as any,
+      result: {} as any,
+      retryCount: 0,
+    });
+
+    // ── Verify shared state is cleared ──
+    expect(state.__omTurn).toBeUndefined();
+    expect(state.__omActorModelContext).toBeUndefined();
+    expect(state.__omObservabilityContext).toBeUndefined();
+  });
+
+  it('clears input processor turn internal references after end+dispose', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const state: Record<string, unknown> = {};
+    const messageList = new MessageList({ threadId, resourceId });
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+
+    const model = createMockModel();
+    const abort = vi.fn();
+
+    // Run input on the input processor
+    await inputProcessor.processInputStep({
+      messageList,
+      messages: [],
+      requestContext,
+      stepNumber: 0,
+      state,
+      steps: [],
+      systemMessages: [],
+      model: model as any,
+      retryCount: 0,
+      abort: abort as any,
+      writer: undefined,
+    });
+
+    expect(state.__omTurn).toBeDefined();
+
+    // Add a dummy assistant response
+    messageList.add(
+      {
+        id: 'assistant-2',
+        role: 'assistant',
+        content: { format: 2, parts: [{ type: 'text', text: 'test response' }] },
+        createdAt: new Date(),
+        threadId,
+        resourceId,
+      } as any,
+      'response',
+    );
+
+    // Run processOutputResult on the OUTPUT processor (split instances)
+    await outputProcessor.processOutputResult({
+      messageList,
+      messages: messageList.get.response.db(),
+      requestContext,
+      state,
+      abort: abort as any,
+      result: {} as any,
+      retryCount: 0,
+    });
+
+    // Verify state is cleared after output processing
+    expect(state.__omTurn).toBeUndefined();
+    expect(state.__omActorModelContext).toBeUndefined();
+
+    // The output processor ended the turn via state.__omTurn, but the input
+    // processor's `this.turn` still references the same ObservationTurn object.
+    // Verify that the turn was disposed: _context, writer, requestContext,
+    // observabilityContext, actorModelContext, and memory should all be cleared.
+    const inputTurn = (inputProcessor as any).turn;
+    expect(inputTurn).toBeDefined();
+    expect(inputTurn._context).toBeUndefined();
+    expect(inputTurn.writer).toBeUndefined();
+    expect(inputTurn.requestContext).toBeUndefined();
+    expect(inputTurn.observabilityContext).toBeUndefined();
+    expect(inputTurn.actorModelContext).toBeUndefined();
+    expect(inputTurn.memory).toBeUndefined();
+    expect(inputTurn._ended).toBe(true);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -407,4 +407,13 @@ export class ObservationStep {
       observerExchange: om.observer.lastExchange,
     };
   }
+
+  /**
+   * Release heavy references held by this step. Called after the turn ends.
+   * After disposal, the step should not be used further.
+   */
+  dispose(): void {
+    this._context = undefined;
+    this._prepared = false;
+  }
 }

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -181,9 +181,9 @@ export class ObservationTurn {
       await this.om.persistMessages(unsavedMessages, this.threadId, this.resourceId);
     }
 
-    // When the agent goes idle, start buffering any unobserved messages in the background.
-    // This ensures messages accumulated during the turn are observed proactively
-    // rather than waiting for the next turn's step.prepare() to trigger buffering.
+    // Capture buffer inputs in locals before dispose() clears the turn's transient references.
+    // The buffer() call receives these values by value in its argument object at call time,
+    // so clearing them after the call is safe — the async closure already holds its own copy.
     if (this.om.buffering.isAsyncObservationEnabled()) {
       const allMessages = this.messageList.get.all.db();
       const record = this._record!;
@@ -204,6 +204,11 @@ export class ObservationTurn {
           });
       }
     }
+
+    // Release heavy transient references (_context, writer, requestContext, etc.)
+    // so that even if a retained input-processor turn reference survives, it no
+    // longer holds large prompt/memory/system-message strings in memory.
+    this.dispose();
 
     return { record: this._record! };
   }
@@ -229,5 +234,24 @@ export class ObservationTurn {
       return otherThreadsContext;
     }
     return this._context?.otherThreadsContext;
+  }
+
+  /**
+   * Release heavy transient references held by this turn. Called after end()
+   * to free _context (which contains systemMessage/memory strings), writer,
+   * requestContext, observabilityContext, actorModelContext, and memory.
+   *
+   * The turn remains usable for its readonly identifiers (threadId, resourceId,
+   * record) and hooks reference, but no longer retains large prompt/context strings.
+   */
+  dispose(): void {
+    this._currentStep?.dispose();
+    this._currentStep = undefined;
+    this._context = undefined;
+    this.writer = undefined;
+    this.requestContext = undefined;
+    this.observabilityContext = undefined;
+    this.actorModelContext = undefined;
+    this.memory = undefined;
   }
 }

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -371,6 +371,13 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
           state.__omTurn = undefined;
         }
 
+        // Clear transient processor state that retained model/provider/observability
+        // objects after the turn finished. The turn's own dispose() releases its
+        // internal context references, while the processor state keys hold separate
+        // references that must be cleared here.
+        state.__omActorModelContext = undefined;
+        state.__omObservabilityContext = undefined;
+
         return messageList;
       });
   }


### PR DESCRIPTION
Adds a built-in memory profiler to mastracode with a `/profile` slash command. The profiler samples `process.memoryUsage()` at configurable intervals, saves data to `~/.mastracode/profiles/<timestamp>/`, and can auto-trigger `v8.writeHeapSnapshot()` when heap crosses a threshold.

```
/profile start          - begin sampling
/profile snapshot       - take a .heapsnapshot right now
/profile threshold 800  - auto-snapshot when heapUsed > 800MB
/profile status         - current stats
```

Also fixes ended `ObservationTurn` objects retaining their full context (systemMessage, messages, writer, etc.) after the turn finishes. Without this, every ended turn keeps ~1.5MB of per-turn allocations alive until the next turn replaces it. With the fix, `dispose()` clears all heavy references after `end()`.

Relevant for anyone debugging mastracode memory usage — run `MASTRACODE_PROFILE=1` to enable at startup, then inspect the profile samples and heap snapshots to find what's holding memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation
This PR adds a built-in tool that watches how much memory the program is using (kind of like checking your phone's battery level), and can automatically save snapshots when memory gets too high. It also fixes a bug where the program was accidentally keeping old data in memory even after it was done using it, which was wasting memory.

## Overview
This pull request introduces memory profiling capabilities to mastracode and addresses memory retention issues in the observational memory system. It consists of two major components: (1) a new `MemoryProfiler` utility with a `/profile` slash command for monitoring and managing memory usage, and (2) memory disposal fixes in `ObservationTurn` and `ObservationStep` to prevent retention of heavy references.

## Features Added

### Memory Profiler (`MemoryProfiler`)
- **Periodic Sampling**: Samples `process.memoryUsage()` and `process.resourceUsage()` at configurable intervals (default 10 seconds), writing results as JSONL to `~/.mastracode/profiles/<timestamp>/samples.jsonl`
- **Heap Snapshot Triggers**: Automatically captures V8 heap snapshots when heap-used or RSS memory crosses configured byte thresholds, with a configurable maximum snapshot count
- **Lifecycle Management**: Supports start/stop operations with graceful cleanup, including writing a final sample on stop
- **Status Reporting**: Exposes profiler state (enabled, running, sample count, snapshot count, thresholds, output directory)
- **Manual Snapshots**: Triggers immediate heap snapshots via `snapshot(reason)` method
- **Environment Configuration**: Reads `MASTRACODE_PROFILE=1` to enable at startup, supports `MASTRACODE_PROFILE_DIR`, `MASTRACODE_PROFILE_INTERVAL_MS`, `MASTRACODE_PROFILE_MAX_SNAPSHOTS`, `MASTRACODE_PROFILE_HEAP_MB`, and `MASTRACODE_PROFILE_RSS_MB` variables

### `/profile` Slash Command
- `/profile` or `/profile status`: Displays current profiler state (running/stopped, sampling interval, counts, thresholds, output directory, latest sample details)
- `/profile start`: Starts profiling with optional threshold overrides (`--heap-mb`, `--rss-mb`, `--interval-ms`); creates new profiler if needed
- `/profile stop`: Stops active profiling and reports collected statistics
- `/profile snapshot`: Immediately triggers a heap snapshot, either via active profiler or temporary instance
- Integrated into TUI command dispatch and help overlay

## Bug Fixes

### Memory Retention in Observational Memory
- **`ObservationTurn.dispose()`**: Added method to clear heavy references (`_context`, `writer`, `requestContext`, `observabilityContext`, `actorModelContext`, `memory`) after turn completion, while preserving the cached `record` for async buffering
- **`ObservationStep.dispose()`**: Clears `_context` and resets `_prepared` state
- **Processor State Cleanup**: `processOutputResult` now clears `state.__omActorModelContext` and `state.__omObservabilityContext` to prevent cross-instance reference retention
- **Impact**: Resolves per-turn memory retention of ~1.5MB caused by lingering observation strings and context references

## Integration

### TUI Integration
- `MemoryProfiler` instance optionally passed to `MastraTUI` via `MastraTUIOptions`
- Profiler lifecycle tied to harness state; stopped during cleanup
- Command handler reads/stores profiler from TUI state (`ctx.state.memoryProfiler`)

### Headless Mode Integration
- Conditional profiler initialization based on `MASTRACODE_PROFILE` environment variable
- Profiler stopped as part of headless shutdown sequence

## Testing
- **`MemoryProfiler` Test Suite** (270+ lines): Covers constructor defaults/overrides, environment variable parsing, start/stop lifecycle, JSONL creation, metadata recording, status reporting, manual snapshot handling, threshold-triggered snapshots, and snapshot capping
- **Memory Retention Regression Tests** (206+ lines): Validates state cleanup after split input/output processor instances and verifies reference disposal on `ObservationTurn` after `processOutputResult`

## Changed Files Summary
- **Changesets**: Two new changesets documenting memory profiling feature and memory retention fix
- **Core Profiler**: `mastracode/src/utils/memory-profiler.ts` (336 lines, new)
- **Command Handler**: `mastracode/src/tui/commands/profile.ts` (201 lines, new)
- **Integration**: Updates to `main.ts`, `headless.ts`, `state.ts`, `command-dispatch.ts`, `commands/index.ts`
- **Memory Fixes**: Updates to `observation-turn/turn.ts`, `observation-turn/step.ts`, `processor.ts`
- **Tests**: New test files for profiler and memory retention

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->