### PR TITLE
fix: preserve unresolved slash command references and update pr-triage command

### DIFF
--- a/.changeset/bright-kings-punch.md
+++ b/.changeset/bright-kings-punch.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed custom slash commands so unresolved @ references remain literal instead of rendering read errors.

--- a/.mastracode/commands/pr-triage.md
+++ b/.mastracode/commands/pr-triage.md
@@ -1,28 +1,34 @@
 ---
 name: pr-triage
-description: Find Mastra PRs related to my expertise, sort them by merge/close potential, and pair-review them one at a time
+description: Find Mastra PRs involving me first, sort them by merge/close potential, and pair-review them one at a time
 goal: true
 ---
-Mastra has many open PRs. We want to merge or close as many as possible, but only focus on PRs that are related to my areas of expertise.
+Mastra has many open PRs. We want to merge or close as many as possible, starting with PRs where I am already involved, then falling back to PRs related to my areas of expertise.
 
 Do this:
 
-1. Look through git history in this repo and build a concise understanding of the areas I have worked on and am likely qualified to review.
-2. Look through every open PR before stopping. Do not begin pair review until all open PRs have been inspected and categorized.
-3. Create a markdown tracking file listing every open PR by relevance:
+1. Build the primary candidate queue from open PRs involving me, oldest-updated first. Use GitHub search semantics equivalent to:
+   - Browser URL: `https://github.com/mastra-ai/mastra/pulls?q=is%3Aopen+is%3Apr+involves%3A%40me+sort%3Aupdated-asc`
+   - Preferred CLI: `gh search prs --repo mastra-ai/mastra --state open --involves @me --sort updated --order asc --limit 100 --json number,title,author,url,updatedAt,isDraft,labels`
+   - Repo-local alternative: `gh pr list --state open --search 'involves:@me sort:updated-asc' --limit 100 --json number,title,author,url,updatedAt,isDraft,labels,reviewDecision,mergeStateStatus,statusCheckRollup`
+2. If the involving-me queue is exhausted or clearly too small, look through git history in this repo and build a concise understanding of the areas I have worked on and am likely qualified to review.
+3. Then inspect the remaining open PRs by expertise relevance before stopping. Do not begin pair review on fallback PRs until open PRs have been inspected and categorized.
+4. Create or update a markdown tracking file listing PRs by priority:
+   - Involves me — primary queue, sorted oldest-updated first unless I provide a different priority
    - Definitely related to my expertise
    - Maybe related / needs my judgment
    - Probably not related
-4. In the tracking file, clearly mark PRs where I am explicitly tagged as a reviewer because those are higher-priority review candidates.
-5. Within each section, sort PRs in this order:
+5. In the tracking file, clearly mark why each PR involves me when available: author, assignee, reviewer/review-requested, commenter, mentioned, or existing review.
+6. Within the fallback expertise sections, sort PRs in this order:
    - PRs where I am explicitly tagged as a reviewer
    - PRs with no reviewers tagged
    - PRs where reviewers are tagged, but I am not one of them
    Within each reviewer bucket, sort so easy merges or easy closes appear first.
-6. After the full tracking file is ready, present the best first candidates and pair-review them with me one at a time, updating the list as we go through to add status/notes, until the list is empty.
-7. For each PR in the pair-review sequence, start with a concise TL;DR that explains the issue/change, whether it needs more work or looks close to done, and any other short helpful context for deciding what to do next.
-8. After the TL;DR for each PR, stop and ask me what action to take. Do not submit a review, request changes, approve, merge, close, comment, or mark a GitHub action as taken until I explicitly choose that action.
-9. When pair-reviewing the first PR, ask whether I want you to open each PR in my browser with the GitHub CLI (`gh pr view <number> --web`). Ask this preference only once, then respect the answer for each PR in the pair-review sequence.
+7. Present the best first candidates and pair-review them with me one at a time, updating the list as we go through to add status/notes, until the list is empty.
+8. For each PR in the pair-review sequence, start with a concise TL;DR that explains the issue/change, whether it needs more work or looks close to done, and any other short helpful context for deciding what to do next.
+9. After the TL;DR for each PR, stop and ask me what action to take. Do not submit a review, request changes, approve, merge, close, comment, or mark a GitHub action as taken until I explicitly choose that action.
+10. When pair-reviewing the first PR, ask whether I want you to open each PR in my browser with the GitHub CLI (`gh pr view <number> --web`). Ask this preference only once, then respect the answer for each PR in the pair-review sequence.
+11. If I give standing guidance during triage, apply it to later PRs. Current defaults from prior triage: open PRs in browser when reviewing, skip workflow PRs unless I override, skip PRs already approved, and skip PRs where Tyler or someone else already requested changes unless I explicitly ask to revisit.
 
 If I provide extra guidance, use it as additional selection criteria:
 

--- a/mastracode/src/utils/__tests__/slash-command-processor.test.ts
+++ b/mastracode/src/utils/__tests__/slash-command-processor.test.ts
@@ -4,8 +4,8 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { processSlashCommand } from '../slash-command-processor.js';
 import type { SlashCommandMetadata } from '../slash-command-loader.js';
+import { processSlashCommand } from '../slash-command-processor.js';
 
 const createCommand = (template: string): SlashCommandMetadata => ({
   name: 'test',

--- a/mastracode/src/utils/__tests__/slash-command-processor.test.ts
+++ b/mastracode/src/utils/__tests__/slash-command-processor.test.ts
@@ -1,0 +1,38 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { processSlashCommand } from '../slash-command-processor.js';
+import type { SlashCommandMetadata } from '../slash-command-loader.js';
+
+const createCommand = (template: string): SlashCommandMetadata => ({
+  name: 'test',
+  description: 'Test command',
+  template,
+  sourcePath: '/tmp/test.md',
+});
+
+describe('slash command processor', () => {
+  it('replaces file references that resolve on disk', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastracode-command-processor-'));
+    await writeFile(join(dir, 'context.md'), 'File context');
+
+    const result = await processSlashCommand(createCommand('Read @context.md'), [], dir);
+
+    expect(result).toBe('Read File context');
+  });
+
+  it('leaves @ references intact when they do not resolve to files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastracode-command-processor-'));
+
+    const result = await processSlashCommand(
+      createCommand('gh search prs --involves @me --search "involves:@me sort:updated-asc"'),
+      [],
+      dir,
+    );
+
+    expect(result).toBe('gh search prs --involves @me --search "involves:@me sort:updated-asc"');
+  });
+});

--- a/mastracode/src/utils/slash-command-processor.ts
+++ b/mastracode/src/utils/slash-command-processor.ts
@@ -101,9 +101,8 @@ async function replaceFileReferences(template: string, workingDir: string): Prom
       const fullPath = path.resolve(workingDir, filePath!);
       const content = await fs.readFile(fullPath, 'utf-8');
       result = result.replace(fullMatch, content);
-    } catch (error) {
-      console.error(`Error reading file "${filePath}":`, error);
-      result = result.replace(fullMatch, `[Error: Could not read "${filePath}"]`);
+    } catch {
+      // Leave literal @mentions/search qualifiers such as @me intact when they do not resolve to files.
     }
   }
 


### PR DESCRIPTION
This fixes custom slash commands treating unresolved `@...` text as broken file references. That came up with GitHub search qualifiers like `@me`, where the PR triage command rendered `[Error: Could not read "me"]` instead of preserving the query.

Before:

```sh
gh search prs --involves @me
# rendered as: gh search prs --involves [Error: Could not read "me"]
```

After:

```sh
gh search prs --involves @me
# stays literal when `@me` is not a file
```

I also updated the PR triage command to start with PRs involving Tyler, oldest updated first, and then fall back to the previous expertise-based flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Slash commands were mistakenly trying to open things like `@me` as files and showing errors; now they keep those `@` mentions as-is. The PR triage workflow now prioritizes PRs that involve you first, then falls back to expertise-based ordering.

## Changes

### Bug fix: preserve unresolved `@` references in slash commands
- replaceFileReferences now suppresses file-read failures and leaves literal `@` mentions unchanged when they don't resolve to files (so `gh search prs --involves `@me`` stays `gh search prs --involves `@me`` instead of showing an error).
- Added tests verifying: existing `@file` references are replaced with file contents when present, and unresolved `@` references remain literal.

Files:
- mastracode/src/utils/slash-command-processor.ts — suppress file-read failures and preserve unresolved `@` mentions
- mastracode/src/utils/__tests__/slash-command-processor.test.ts — new tests covering both resolved and unresolved `@` references

### PR triage command update
- Changes the triage workflow to a two-stage selection: primary queue of open PRs involving the user (oldest-updated first), then fallback to expertise-based buckets (definitely/maybe/probably not related).
- Adds explicit steps to create/update a markdown tracking file with an “Involves me” primary section and fallback expertise sections; preserves reviewer-priority bucketing and sorting within fallback sections.
- Enforces stricter guidance to not submit/mark actions until the user explicitly chooses; documents how to mark why a PR involves the user and retains defaults for browser workflow, skipping already-approved PRs, and skipping PRs with prior requested changes unless overridden.

File:
- .mastracode/commands/pr-triage.md — updated workflow and operational details

### Changeset
- .changeset/bright-kings-punch.md — documents the patch-level fix to mastracode

### Commit notes
- One commit: "fix(mastracode): satisfy slash command test import order" (adjusts test import order for linting)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->