### PR TITLE
fix(core): use `extends object` for structured output detection in AgentExecutionOptions

### DIFF
--- a/.changeset/three-ravens-cross.md
+++ b/.changeset/three-ravens-cross.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `AgentExecutionOptions` to use `extends object` instead of `extends {}` for structured output detection. The `{}` condition resolves differently under `strictNullChecks: false`, causing `undefined` (the default `TOutput`) to be treated as a concrete output type and making `structuredOutput` required in `defaultOptions`. Using `extends object` correctly excludes `undefined` and `unknown` from requiring structured output in both strict and non-strict projects.

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -406,7 +406,7 @@ export type NetworkOptions<OUTPUT = undefined> = {
    * const result = await stream.object;
    * ```
    */
-  structuredOutput?: PublicStructuredOutputOptions<OUTPUT extends {} ? OUTPUT : never>;
+  structuredOutput?: PublicStructuredOutputOptions<OUTPUT extends object ? OUTPUT : never>;
 
   /** Callback fired after each LLM step within a sub-agent execution */
   onStepFinish?: LoopConfig<OUTPUT>['onStepFinish'];
@@ -608,14 +608,14 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
  * Use this type for public method signatures.
  */
 export type PublicAgentExecutionOptions<OUTPUT = unknown> = AgentExecutionOptionsBase<OUTPUT> &
-  (OUTPUT extends {} ? { structuredOutput: PublicStructuredOutputOptions<OUTPUT> } : { structuredOutput?: never });
+  (OUTPUT extends object ? { structuredOutput: PublicStructuredOutputOptions<OUTPUT> } : { structuredOutput?: never });
 
 /**
  * Internal agent execution options that require StandardSchemaWithJSON.
  * Use this type internally after converting from PublicSchema.
  */
 export type AgentExecutionOptions<OUTPUT = unknown> = AgentExecutionOptionsBase<OUTPUT> &
-  (OUTPUT extends {} ? { structuredOutput: StructuredOutputOptions<OUTPUT> } : { structuredOutput?: never });
+  (OUTPUT extends object ? { structuredOutput: StructuredOutputOptions<OUTPUT> } : { structuredOutput?: never });
 
 export type InnerAgentExecutionOptions<OUTPUT = unknown> = AgentExecutionOptionsBase<OUTPUT> & {
   outputWriter?: OutputWriter;
@@ -629,4 +629,4 @@ export type InnerAgentExecutionOptions<OUTPUT = unknown> = AgentExecutionOptions
     snapshot: any;
   };
   toolCallId?: string;
-} & (OUTPUT extends {} ? { structuredOutput: StructuredOutputOptions<OUTPUT> } : { structuredOutput?: never });
+} & (OUTPUT extends object ? { structuredOutput: StructuredOutputOptions<OUTPUT> } : { structuredOutput?: never });


### PR DESCRIPTION
## Problem

`AgentExecutionOptions<undefined>` (the default when no `TOutput` generic is provided) compiles incorrectly under `strictNullChecks: false`.

The conditional `OUTPUT extends {}` resolves differently across TypeScript modes:
- **`strictNullChecks: true`**: `undefined extends {}` → `false` → `structuredOutput` is optional ✓
- **`strictNullChecks: false`**: `undefined extends {}` → `true` → `structuredOutput` becomes **required** ✗

Since `Agent<TOutput = undefined>` uses `undefined` as the default, this causes a TS2322 error for any project with non-strict settings:

```ts
// Fails under strictNullChecks: false
new Agent({
  name: 'my-agent',
  instructions: '...',
  model: myModel,
  defaultOptions: { maxSteps: 50 }, // TS2322: missing required 'structuredOutput'
});
```

Closes #16732

## Solution

Replace `OUTPUT extends {}` with `OUTPUT extends object` in the four locations within `AgentExecutionOptions`, `PublicAgentExecutionOptions`, `InnerAgentExecutionOptions`, and `NetworkOptions`.

`{}` includes `null` and `undefined` under `strictNullChecks: false`, while `object` consistently excludes all primitives and `undefined`/`null` in both strict and non-strict modes.

| Type | `extends {}` (strict=false) | `extends object` |
|------|---------------------------|-----------------|
| `undefined` | ✅ true (broken) | ❌ false (correct) |
| `null` | ✅ true (broken) | ❌ false (correct) |
| `string` | ✅ true | ❌ false |
| `{ text: string }` | ✅ true | ✅ true |
| `unknown` | ❌ false | ❌ false |

## Testing

This is a pure TypeScript type change — no runtime behavior is affected. The fix can be verified by creating a `tsconfig.json` with `"strictNullChecks": false` and checking that `new Agent({ defaultOptions: { maxSteps: 50 } })` compiles without errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

TypeScript has different "strictness" modes. In less-strict mode, a code check (`OUTPUT extends {}`) was incorrectly telling TypeScript that every agent needs to provide a `structuredOutput` configuration, even when it shouldn't. The fix changes that check to (`OUTPUT extends object`) so it works correctly whether you're in strict or less-strict mode, letting developers use agents without explicitly providing this optional setting.

---

## Changes

### Type System Fix for AgentExecutionOptions

Changed the structured output detection logic in `AgentExecutionOptions`, `PublicAgentExecutionOptions`, and `NetworkOptions` types from using `OUTPUT extends {}` to `OUTPUT extends object`. This ensures that the optional nature of `structuredOutput` is correctly preserved across TypeScript compilation modes, particularly when `strictNullChecks` is disabled.

The root issue: Under `strictNullChecks: false`, the condition `undefined extends {}` evaluates to `true`, incorrectly making `structuredOutput` a required property for agents without explicit output types. The `object` type constraint consistently excludes primitives, `undefined`, and `null` across all TypeScript modes, fixing this behavior.

### Files Modified

- **packages/core/src/agent/agent.types.ts**: Updated conditional type logic in `NetworkOptions<OUTPUT>`, `PublicAgentExecutionOptions<OUTPUT>`, and `AgentExecutionOptions<OUTPUT>` to use `OUTPUT extends object` for determining `structuredOutput` requirement.
- **.changeset/three-ravens-cross.md**: Added changeset entry documenting the patch fix to `@mastra/core`.

### Impact

This is a purely type-level fix with no runtime impact. Untyped agents (using the default `undefined` for `OUTPUT`) now correctly treat `structuredOutput` as optional regardless of TypeScript strictness settings. This resolves compilation errors when using common patterns like `{ defaultOptions: { maxSteps: 50 } }` in projects with `strictNullChecks: false`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17033?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->