### PR TITLE
fix(files-sdk): lint, object-store semantics, integration suite, and reference docs

### DIFF
--- a/.changeset/rich-kind-gold.md
+++ b/.changeset/rich-kind-gold.md
@@ -11,7 +11,7 @@ import { Files } from 'files-sdk';
 import { s3 } from 'files-sdk/s3';
 import { FilesSDKFilesystem } from '@mastra/files-sdk';
 
-const files = new Files(s3({ bucket: 'my-bucket', region: 'us-east-1' }));
+const files = new Files({ adapter: s3({ bucket: 'my-bucket', region: 'us-east-1' }) });
 
 const filesystem = new FilesSDKFilesystem({ files });
 ```

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -30,6 +30,7 @@ Available providers:
 - [`GCSFilesystem`](/reference/workspace/gcs-filesystem): Stores files in Google Cloud Storage
 - [`GoogleDriveFilesystem`](/reference/workspace/google-drive-filesystem): Stores files inside a Google Drive folder
 - [`AzureBlobFilesystem`](/reference/workspace/azure-blob-filesystem): Stores files in Azure Blob Storage
+- [`FilesSDKFilesystem`](/reference/workspace/files-sdk-filesystem): Stores files in any [FilesSDK](https://files-sdk.dev) adapter (S3, R2, GCS, Azure Blob, Vercel Blob, local filesystem, and more) — useful when you want one provider that can target multiple backends
 - [`AgentFSFilesystem`](/reference/workspace/agentfs-filesystem): Stores files in a Turso/SQLite database via AgentFS
 
 :::tip
@@ -243,6 +244,7 @@ When you configure a filesystem on a workspace, agents receive tools for reading
 - [GCSFilesystem reference](/reference/workspace/gcs-filesystem)
 - [GoogleDriveFilesystem reference](/reference/workspace/google-drive-filesystem)
 - [AzureBlobFilesystem reference](/reference/workspace/azure-blob-filesystem)
+- [FilesSDKFilesystem reference](/reference/workspace/files-sdk-filesystem)
 - [AgentFSFilesystem reference](/reference/workspace/agentfs-filesystem)
 - [Workspace overview](/docs/workspace/overview)
 - [Sandbox](/docs/workspace/sandbox)

--- a/docs/src/content/en/reference/workspace/files-sdk-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/files-sdk-filesystem.mdx
@@ -1,0 +1,225 @@
+---
+title: "Reference: FilesSDKFilesystem | Workspace"
+description: "Documentation for the FilesSDKFilesystem provider, a unified adapter for S3, R2, GCS, Azure Blob, Vercel Blob, and other FilesSDK backends."
+packages:
+  - "@mastra/files-sdk"
+---
+
+# FilesSDKFilesystem
+
+Stores files in any storage backend supported by [FilesSDK](https://files-sdk.dev) — a unified abstraction over S3, Cloudflare R2, Google Cloud Storage, Azure Blob, Vercel Blob, MinIO, the local filesystem, and more.
+
+:::info
+
+For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
+
+:::
+
+Use `FilesSDKFilesystem` when you want a single adapter that can target multiple storage backends with the same code. Swap the underlying driver without changing the workspace setup. If you only target one backend and want first-class options for that backend, prefer the dedicated provider (for example [`S3Filesystem`](/reference/workspace/s3-filesystem) or [`GCSFilesystem`](/reference/workspace/gcs-filesystem)).
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/files-sdk files-sdk
+```
+
+`files-sdk` is a peer dependency you configure with the adapter you want to use.
+
+## Usage
+
+Create a `Files` instance from FilesSDK with the adapter of your choice, then pass it to `FilesSDKFilesystem`:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { Workspace } from '@mastra/core/workspace'
+import { FilesSDKFilesystem } from '@mastra/files-sdk'
+import { Files } from 'files-sdk'
+import { s3 } from 'files-sdk/s3'
+
+const files = new Files({
+  adapter: s3({
+    bucket: 'my-bucket',
+    region: 'us-east-1',
+  }),
+})
+
+const workspace = new Workspace({
+  filesystem: new FilesSDKFilesystem({ files }),
+})
+
+const agent = new Agent({
+  name: 'file-agent',
+  model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
+  workspace,
+})
+```
+
+### Swapping adapters
+
+The same `FilesSDKFilesystem` works with any FilesSDK adapter. Replace the driver factory to switch backends:
+
+```typescript
+import { Files } from 'files-sdk'
+import { r2 } from 'files-sdk/r2'
+import { gcs } from 'files-sdk/gcs'
+import { azure } from 'files-sdk/azure'
+import { fs } from 'files-sdk/fs'
+
+// Cloudflare R2
+const r2Files = new Files({ adapter: r2({ accountId, bucket, accessKeyId, secretAccessKey }) })
+
+// Google Cloud Storage
+const gcsFiles = new Files({ adapter: gcs({ bucket, projectId }) })
+
+// Azure Blob
+const azureFiles = new Files({ adapter: azure({ container, connectionString }) })
+
+// Local filesystem (useful for tests and development)
+const localFiles = new Files({ adapter: fs({ root: './workspace' }) })
+```
+
+See the [FilesSDK documentation](https://files-sdk.dev) for the full adapter catalog and configuration options.
+
+### Read-only mounts
+
+```typescript
+const filesystem = new FilesSDKFilesystem({
+  files,
+  readOnly: true,
+})
+```
+
+All write operations (`writeFile`, `appendFile`, `deleteFile`, `copyFile`, `moveFile`, `mkdir`, `rmdir`) throw `WorkspaceReadOnlyError` while reads succeed.
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'files',
+    type: 'Files',
+    description: 'A pre-configured FilesSDK `Files` instance bound to the adapter and credentials you want to use.',
+  },
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Unique identifier for this filesystem instance.',
+    isOptional: true,
+    defaultValue: 'Auto-generated',
+  },
+  {
+    name: 'displayName',
+    type: 'string',
+    description: 'Human-friendly display name for the UI.',
+    isOptional: true,
+  },
+  {
+    name: 'icon',
+    type: 'FilesystemIcon',
+    description: 'Icon identifier for the UI.',
+    isOptional: true,
+  },
+  {
+    name: 'description',
+    type: 'string',
+    description: 'Short description of this filesystem for the UI.',
+    isOptional: true,
+  },
+  {
+    name: 'readOnly',
+    type: 'boolean',
+    description: 'When true, all write operations are blocked.',
+    isOptional: true,
+    defaultValue: 'false',
+  },
+]}
+/>
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Filesystem instance identifier.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: "Provider name ('FilesSDKFilesystem').",
+  },
+  {
+    name: 'provider',
+    type: 'string',
+    description: "Provider identifier ('files-sdk').",
+  },
+  {
+    name: 'readOnly',
+    type: 'boolean | undefined',
+    description: 'Whether the filesystem is in read-only mode.',
+  },
+]}
+/>
+
+## Methods
+
+`FilesSDKFilesystem` implements the [WorkspaceFilesystem interface](/reference/workspace/filesystem), providing all standard filesystem methods:
+
+- `readFile(path, options?)` - Read file contents
+- `writeFile(path, content, options?)` - Write content to a file
+- `appendFile(path, content)` - Append content to a file
+- `deleteFile(path, options?)` - Delete a file
+- `copyFile(src, dest, options?)` - Copy a file
+- `moveFile(src, dest, options?)` - Move or rename a file
+- `mkdir(path, options?)` - Create a directory (no-op for object stores)
+- `rmdir(path, options?)` - Remove a directory
+- `readdir(path, options?)` - List directory contents
+- `exists(path)` - Check if a path exists
+- `stat(path)` - Get file or directory metadata
+
+### `init()`
+
+Initialize the filesystem. Verifies that the configured adapter can list keys with the supplied credentials.
+
+```typescript
+await filesystem.init()
+```
+
+### `getInfo()`
+
+Returns metadata about this filesystem instance.
+
+```typescript
+const info = filesystem.getInfo()
+// { id: '...', name: 'FilesSDKFilesystem', provider: 'files-sdk', status: 'ready' }
+```
+
+### `files`
+
+The underlying FilesSDK `Files` instance is exposed as a public property if you need to call adapter-specific APIs directly.
+
+```typescript
+const url = await filesystem.files.url('reports/q3.pdf')
+```
+
+## Object-store semantics
+
+`FilesSDKFilesystem` treats the configured backend as an object store, even when the underlying adapter is hierarchical (such as `fs`). This keeps behavior consistent across adapters:
+
+- **`mkdir`** is a no-op. Directories exist implicitly when keys with that prefix exist.
+- **`exists`** returns `true` only when an exact key is present as a file, or when the path is a prefix that contains at least one child key. Empty leftover directories on hierarchical adapters do not count.
+- **`deleteFile`** throws `FileNotFoundError` when the key does not exist, unless `{ force: true }` is passed.
+- **`deleteFile`** on a directory delegates to `rmdir({ recursive: true })`, matching the [`S3Filesystem`](/reference/workspace/s3-filesystem) and [`GCSFilesystem`](/reference/workspace/gcs-filesystem) behavior.
+- **`moveFile`** is implemented as `copyFile` followed by `deleteFile`. It is **not atomic** — if the source delete fails after a successful copy, the destination remains and the source is not removed.
+- **`appendFile`** is a read-modify-write operation. Concurrent appends to the same key may overwrite each other; this is inherent to object storage and not specific to FilesSDK.
+- **`readdir({ recursive: true })`** emits intermediate directory entries (for example, `a/b` is emitted alongside `a/b/c.txt`).
+
+## Related
+
+- [WorkspaceFilesystem interface](/reference/workspace/filesystem)
+- [S3Filesystem reference](/reference/workspace/s3-filesystem)
+- [GCSFilesystem reference](/reference/workspace/gcs-filesystem)
+- [AzureBlobFilesystem reference](/reference/workspace/azure-blob-filesystem)
+- [Workspace overview](/docs/workspace/overview)
+- [FilesSDK documentation](https://files-sdk.dev)

--- a/workspaces/files-sdk/package.json
+++ b/workspaces/files-sdk/package.json
@@ -22,7 +22,8 @@
     "build": "tsup --silent --config tsup.config.ts",
     "build:lib": "pnpm build",
     "build:watch": "pnpm build --watch",
-    "test:unit": "vitest run",
+    "test:unit": "vitest run --exclude '**/*.integration.test.ts'",
+    "test:integration": "vitest run ./src/**/*.integration.test.ts",
     "test:watch": "vitest watch",
     "lint": "eslint ."
   },

--- a/workspaces/files-sdk/src/filesystem/index.integration.test.ts
+++ b/workspaces/files-sdk/src/filesystem/index.integration.test.ts
@@ -1,0 +1,63 @@
+/**
+ * FilesSDK Filesystem Integration Tests
+ *
+ * Runs the shared `@internal/workspace-test-utils` conformance suite against a
+ * real FilesSDK `Files` instance backed by the local `fs` adapter pointed at a
+ * temporary directory. This validates the full FilesSDKFilesystem implementation
+ * end-to-end without requiring any cloud credentials.
+ *
+ * The same `FilesSDKFilesystem` class is what users wire to S3, R2, GCS, Azure,
+ * Vercel Blob, etc. via FilesSDK — so passing this suite against the `fs`
+ * adapter exercises every code path that doesn't depend on cloud-specific
+ * behavior.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createFilesystemTestSuite } from '@internal/workspace-test-utils';
+import { Files } from 'files-sdk';
+import { fs as fsAdapter } from 'files-sdk/fs';
+import { afterAll } from 'vitest';
+
+import { FilesSDKFilesystem } from './index';
+
+// Track all tmp dirs created during this run so we can clean them up.
+const tmpDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+});
+
+function createTempFilesSDKFilesystem(): FilesSDKFilesystem {
+  const root = mkdtempSync(join(tmpdir(), 'mastra-files-sdk-'));
+  tmpDirs.push(root);
+  const files = new Files({ adapter: fsAdapter({ root }) });
+  return new FilesSDKFilesystem({ files });
+}
+
+createFilesystemTestSuite({
+  suiteName: 'FilesSDKFilesystem Conformance (fs adapter)',
+  createFilesystem: () => createTempFilesSDKFilesystem(),
+  capabilities: {
+    supportsAppend: true,
+    supportsBinaryFiles: true,
+    supportsForceDelete: true,
+    supportsOverwrite: true,
+    supportsConcurrency: true,
+    // FilesSDK is an object-storage abstraction — no first-class directories.
+    supportsEmptyDirectories: false,
+    // Our deleteFile throws FileNotFoundError on missing keys.
+    deleteThrowsOnMissing: true,
+    // Mounting (sandbox) is not supported by FilesSDK adapters.
+    supportsMounting: false,
+  },
+  testTimeout: 15000,
+});

--- a/workspaces/files-sdk/src/filesystem/index.test.ts
+++ b/workspaces/files-sdk/src/filesystem/index.test.ts
@@ -12,7 +12,7 @@
  * All tests mock the FilesSDK Files instance.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { FilesSDKFilesystem } from './index';
 import type { FilesSDKFilesystemOptions } from './index';
@@ -259,15 +259,36 @@ describe('FilesSDKFilesystem', () => {
   describe('deleteFile()', () => {
     it('calls delete for files', async () => {
       const { fs, mockFiles } = createFs();
-      // isDirectory check returns empty (not a directory)
+      // isDirectory check (prefix 'test.txt/') returns empty (not a directory)
       mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      // isFile check (prefix 'test.txt') returns the key (file exists)
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'test.txt' }], cursor: undefined });
 
       await fs.deleteFile('/test.txt');
 
       expect(mockFiles.delete).toHaveBeenCalledWith('test.txt');
     });
 
-    it('delegates to rmdir for directories', async () => {
+    it('throws FileNotFoundError when file does not exist (without force)', async () => {
+      const { fs, mockFiles } = createFs();
+      // Not a directory, not a file
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      await expect(fs.deleteFile('/missing.txt')).rejects.toThrow(/missing\.txt/);
+      expect(mockFiles.delete).not.toHaveBeenCalled();
+    });
+
+    it('silently succeeds when file does not exist and force=true', async () => {
+      const { fs, mockFiles } = createFs();
+      // Not a directory (force path skips the isFile check)
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      mockFiles.delete.mockRejectedValueOnce(Object.assign(new Error('nope'), { code: 'NotFound' }));
+
+      await expect(fs.deleteFile('/missing.txt', { force: true })).resolves.toBeUndefined();
+    });
+
+    it('recursively delegates to rmdir for directories (matches S3/GCS)', async () => {
       const { fs, mockFiles } = createFs();
       // isDirectory check returns items (is a directory)
       mockFiles.list
@@ -275,7 +296,9 @@ describe('FilesSDKFilesystem', () => {
         // rmdir lists all keys
         .mockResolvedValueOnce({ items: [{ key: 'dir/file.txt' }], cursor: undefined });
 
-      await fs.deleteFile('/dir', { recursive: true });
+      // Note: caller does NOT need to pass recursive — deleteFile on a directory
+      // always cleans up recursively.
+      await fs.deleteFile('/dir');
 
       // Should have called delete with array of keys (batch)
       expect(mockFiles.delete).toHaveBeenCalledWith(['dir/file.txt']);
@@ -308,6 +331,23 @@ describe('FilesSDKFilesystem', () => {
       mockFiles.copy.mockRejectedValueOnce(error);
 
       await expect(fs.copyFile('/missing.txt', '/dest.txt')).rejects.toThrow(/missing\.txt/);
+    });
+
+    it('throws FileExistsError when overwrite=false and dest exists', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(true);
+
+      await expect(fs.copyFile('/src.txt', '/dest.txt', { overwrite: false })).rejects.toThrow(/dest\.txt/);
+      expect(mockFiles.copy).not.toHaveBeenCalled();
+    });
+
+    it('allows copy when overwrite=false and dest does not exist', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(false);
+
+      await fs.copyFile('/src.txt', '/dest.txt', { overwrite: false });
+
+      expect(mockFiles.copy).toHaveBeenCalledWith('src.txt', 'dest.txt');
     });
   });
 
@@ -434,6 +474,59 @@ describe('FilesSDKFilesystem', () => {
       expect(entries).toHaveLength(2);
       expect(mockFiles.list).toHaveBeenCalledTimes(2);
     });
+
+    it('recursive: emits every intermediate directory along the path', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'root/a/b/c.txt', size: 1 }],
+        cursor: undefined,
+      });
+
+      const entries = await fs.readdir('/root', { recursive: true });
+      const dirs = entries.filter(e => e.type === 'directory').map(e => e.name);
+
+      // For a/b/c.txt: should emit "a", "a/b" as directories
+      expect(dirs).toContain('a');
+      expect(dirs).toContain('a/b');
+      // And the file with full relative path
+      expect(entries).toContainEqual({ name: 'a/b/c.txt', type: 'file', size: 1 });
+    });
+
+    it('recursive: deduplicates intermediate directories across files', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [
+          { key: 'root/a/b/x.txt', size: 1 },
+          { key: 'root/a/b/y.txt', size: 2 },
+          { key: 'root/a/c.txt', size: 3 },
+        ],
+        cursor: undefined,
+      });
+
+      const entries = await fs.readdir('/root', { recursive: true });
+      const dirs = entries.filter(e => e.type === 'directory').map(e => e.name);
+
+      expect(dirs.filter(n => n === 'a')).toHaveLength(1);
+      expect(dirs.filter(n => n === 'a/b')).toHaveLength(1);
+    });
+
+    it('recursive: respects maxDepth for both files and directories', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'root/a/b/c/deep.txt', size: 1 }],
+        cursor: undefined,
+      });
+
+      const entries = await fs.readdir('/root', { recursive: true, maxDepth: 2 });
+      const dirs = entries.filter(e => e.type === 'directory').map(e => e.name);
+      const files = entries.filter(e => e.type === 'file');
+
+      expect(dirs).toContain('a');
+      expect(dirs).toContain('a/b');
+      expect(dirs).not.toContain('a/b/c');
+      // File has depth 4 > maxDepth 2, so excluded
+      expect(files).toHaveLength(0);
+    });
   });
 
   describe('rmdir()', () => {
@@ -483,14 +576,16 @@ describe('FilesSDKFilesystem', () => {
 
     it('returns true when file exists', async () => {
       const { fs, mockFiles } = createFs();
-      mockFiles.exists.mockResolvedValueOnce(true);
+      // isDirectory check (prefix 'test.txt/'): no children
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      // isFile check (prefix 'test.txt'): exact key match
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'test.txt' }], cursor: undefined });
 
       expect(await fs.exists('/test.txt')).toBe(true);
     });
 
-    it('checks as directory when file does not exist', async () => {
+    it('returns true when path is a directory (prefix has children)', async () => {
       const { fs, mockFiles } = createFs();
-      mockFiles.exists.mockResolvedValueOnce(false);
       // isDirectory check: has children
       mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'dir/child.txt' }], cursor: undefined });
 
@@ -499,10 +594,25 @@ describe('FilesSDKFilesystem', () => {
 
     it('returns false when neither file nor directory', async () => {
       const { fs, mockFiles } = createFs();
-      mockFiles.exists.mockResolvedValueOnce(false);
+      // isDirectory check: empty
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      // isFile check: no matching key
       mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
 
       expect(await fs.exists('/nope')).toBe(false);
+    });
+
+    it('returns false for an empty leftover directory (object-store semantics)', async () => {
+      const { fs, mockFiles } = createFs();
+      // isDirectory: no children
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      // isFile: list returns sibling keys but not the exact key
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'other/file.txt' }],
+        cursor: undefined,
+      });
+
+      expect(await fs.exists('/empty')).toBe(false);
     });
   });
 
@@ -644,7 +754,9 @@ describe('FilesSDKFilesystem', () => {
 
     it('allows exists', async () => {
       const { fs, mockFiles } = createFs({ readOnly: true });
-      mockFiles.exists.mockResolvedValueOnce(true);
+      // isDirectory: empty; isFile: matching key
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'test.txt' }], cursor: undefined });
 
       expect(await fs.exists('/test.txt')).toBe(true);
     });

--- a/workspaces/files-sdk/src/filesystem/index.ts
+++ b/workspaces/files-sdk/src/filesystem/index.ts
@@ -1,5 +1,3 @@
-import type { Files, StoredFile as SDKStoredFile } from 'files-sdk';
-
 import type {
   FileContent,
   FileStat,
@@ -21,6 +19,7 @@ import {
   DirectoryNotEmptyError,
   WorkspaceReadOnlyError,
 } from '@mastra/core/workspace';
+import type { Files, StoredFile as SDKStoredFile } from 'files-sdk';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -65,18 +64,28 @@ function basename(key: string): string {
   return idx === -1 ? key : key.slice(idx + 1);
 }
 
-function isNotFoundError(err: unknown): boolean {
-  if (err && typeof err === 'object' && 'code' in err) {
-    return (err as { code: string }).code === 'NotFound';
-  }
+/**
+ * Walk the FilesSDK error code chain.
+ *
+ * FilesSDK frequently wraps an inner `NotFound` / `Unauthorized` error in an
+ * outer `Provider` error (`error.cause` carries the original). Some adapters
+ * may wrap multiple levels deep, so we walk the cause chain and return any
+ * matching code found along the way.
+ */
+function hasFilesSDKCode(err: unknown, code: string, depth = 0): boolean {
+  if (depth > 5 || !err || typeof err !== 'object') return false;
+  const e = err as { code?: unknown; cause?: unknown };
+  if (e.code === code) return true;
+  if (e.cause) return hasFilesSDKCode(e.cause, code, depth + 1);
   return false;
 }
 
+function isNotFoundError(err: unknown): boolean {
+  return hasFilesSDKCode(err, 'NotFound');
+}
+
 function isUnauthorizedError(err: unknown): boolean {
-  if (err && typeof err === 'object' && 'code' in err) {
-    return (err as { code: string }).code === 'Unauthorized';
-  }
-  return false;
+  return hasFilesSDKCode(err, 'Unauthorized');
 }
 
 function generateId(): string {
@@ -285,26 +294,41 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     this.assertWritable('deleteFile');
     const key = toKey(path);
 
-    // Check if path is a directory (has children)
+    // If the path is a directory, recursively delete (matches sibling
+    // filesystems like S3/GCS). Object storage has no first-class directories,
+    // so callers calling deleteFile on a prefix expect it to clean up.
     if (await this.isDirectory(key)) {
-      await this.rmdir(path, options);
+      await this.rmdir(path, { recursive: true, force: options?.force });
       return;
+    }
+
+    // Some FilesSDK adapters (notably the local `fs` adapter) silently succeed
+    // when deleting a non-existent key instead of raising `NotFound`. Match the
+    // shared filesystem contract (and S3/GCS behavior) by checking existence
+    // first when `force` is not set.
+    if (!options?.force && !(await this.isFile(key))) {
+      throw new FileNotFoundError(path);
     }
 
     try {
       await this._files.delete(key);
     } catch (err) {
       if (options?.force) return;
+      if (isNotFoundError(err)) throw new FileNotFoundError(path);
       throw err;
     }
   }
 
-  async copyFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
+  async copyFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
     await this.ensureReady();
     this.assertWritable('copyFile');
     const fromKey = toKey(src);
     const toKey_ = toKey(dest);
 
+    if (options?.overwrite === false && (await this._files.exists(toKey_))) {
+      throw new FileExistsError(dest);
+    }
+
     try {
       await this._files.copy(fromKey, toKey_);
     } catch (err) {
@@ -313,19 +337,11 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     }
   }
 
-  async moveFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
-    await this.ensureReady();
-    this.assertWritable('moveFile');
-    const fromKey = toKey(src);
-    const toKey_ = toKey(dest);
-
-    try {
-      await this._files.copy(fromKey, toKey_);
-      await this._files.delete(fromKey);
-    } catch (err) {
-      if (isNotFoundError(err)) throw new FileNotFoundError(src);
-      throw err;
-    }
+  async moveFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
+    // Object storage has no atomic rename. Mirrors the S3/GCS pattern:
+    // copy first; if that succeeds, force-delete the source.
+    await this.copyFile(src, dest, options);
+    await this.deleteFile(src, { force: true });
   }
 
   // ---------------------------------------------------------------------------
@@ -409,8 +425,8 @@ export class FilesSDKFilesystem extends MastraFilesystem {
             type: 'file',
             size: item.size,
           });
-        } else {
-          // Nested item — synthesize a directory entry for the first segment
+        } else if (!recursive) {
+          // Non-recursive: synthesize a directory entry for the first segment only.
           const dirName = segments[0]!;
           if (!seenDirs.has(dirName)) {
             seenDirs.add(dirName);
@@ -419,25 +435,36 @@ export class FilesSDKFilesystem extends MastraFilesystem {
               type: 'directory',
             });
           }
-
-          // If recursive, also include this file
-          if (recursive) {
-            // Check depth
-            if (maxDepth !== undefined && segments.length > maxDepth) continue;
-
-            const name = relativePath;
-
-            if (extensions) {
-              const ext = name.lastIndexOf('.') !== -1 ? name.slice(name.lastIndexOf('.')) : '';
-              if (!extensions.includes(ext)) continue;
+        } else {
+          // Recursive: emit every intermediate directory along the path, then the file.
+          // For "a/b/c/file.txt": emit "a", "a/b", "a/b/c" as directories, then the file.
+          for (let i = 1; i < segments.length; i++) {
+            const dirPath = segments.slice(0, i).join('/');
+            const dirDepth = i; // number of segments in dirPath
+            if (maxDepth !== undefined && dirDepth > maxDepth) continue;
+            if (!seenDirs.has(dirPath)) {
+              seenDirs.add(dirPath);
+              entries.push({
+                name: dirPath,
+                type: 'directory',
+              });
             }
-
-            entries.push({
-              name,
-              type: 'file',
-              size: item.size,
-            });
           }
+
+          // Depth check for the file itself
+          if (maxDepth !== undefined && segments.length > maxDepth) continue;
+
+          const name = relativePath;
+          if (extensions) {
+            const ext = name.lastIndexOf('.') !== -1 ? name.slice(name.lastIndexOf('.')) : '';
+            if (!extensions.includes(ext)) continue;
+          }
+
+          entries.push({
+            name,
+            type: 'file',
+            size: item.size,
+          });
         }
       }
 
@@ -458,12 +485,20 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     // Root always exists
     if (!key) return true;
 
-    // Check as file
-    const fileExists = await this._files.exists(key);
-    if (fileExists) return true;
+    // Check as directory first (any key under this prefix). Doing the prefix
+    // list before the per-key check matters for adapters like FilesSDK's `fs`
+    // that leave empty parent directories on disk after their contents are
+    // deleted — those would otherwise report true via `_files.exists` even
+    // though no objects exist there. Object-store semantics: a "directory"
+    // exists iff it has children.
+    if (await this.isDirectory(key)) return true;
 
-    // Check as directory (any key with this prefix)
-    return this.isDirectory(key);
+    // Check as a real stored file. We deliberately avoid `_files.exists(key)`
+    // here because some adapters (e.g. the local `fs` adapter) consider an
+    // empty leftover directory to exist as a key, which would break
+    // object-store semantics. A prefix list constrained to the exact key only
+    // matches actually-stored files.
+    return this.isFile(key);
   }
 
   async stat(path: string): Promise<FileStat> {
@@ -523,6 +558,17 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     const prefix = `${key}/`;
     const result = await this._files.list({ prefix, limit: 1 });
     return result.items.length > 0;
+  }
+
+  /**
+   * Check whether `key` refers to a real stored file (not an empty leftover
+   * directory). Uses prefix listing constrained to the exact key, which only
+   * matches actually-stored objects across all adapters.
+   */
+  private async isFile(key: string): Promise<boolean> {
+    if (!key) return false;
+    const result = await this._files.list({ prefix: key, limit: 10 });
+    return result.items.some(item => item.key === key);
   }
 
   /** Convert a FilesSDK StoredFile to a Mastra FileStat. */

--- a/workspaces/files-sdk/src/filesystem/index.ts
+++ b/workspaces/files-sdk/src/filesystem/index.ts
@@ -266,6 +266,16 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     });
   }
 
+  /**
+   * Append content to a file.
+   *
+   * **Not atomic.** Object storage has no native append, so this is implemented
+   * as a read-modify-write: the existing object is downloaded, the new content
+   * is concatenated, and the result is uploaded as a new object. Concurrent
+   * appends to the same key may overwrite each other. This limitation is
+   * inherent to object storage, not specific to FilesSDK, and matches the
+   * behavior of the sibling S3, GCS, and Azure workspace providers.
+   */
   async appendFile(path: string, content: FileContent): Promise<void> {
     await this.ensureReady();
     this.assertWritable('appendFile');


### PR DESCRIPTION
Stacked on #17027 (`shade-colby`).

## TL;DR

On `shade-colby`, every workspace agent write through `FilesSDKFilesystem` fails with a raw `ENOENT: ... stat '<path>'` tool error. The agent gets stuck trying to recover and the user has to kill the run. The root cause is a one-level error-code check that misses FilesSDK's wrapped `NotFound` errors, so the workspace tools see a "real" error instead of "file does not exist" and never take the "create new" branch.

This PR fixes that, plus the related object-store-semantics gaps that surfaced once the shared workspace conformance suite was wired up.

## The fix

### Walk the `.cause` chain in `isNotFoundError` / `isUnauthorizedError`

FilesSDK wraps inner `FilesError` instances. For example, calling `files.head()` on a missing key in the `fs` adapter throws:

```
_FilesError code=Provider
  └─ cause: _FilesError code=NotFound
       └─ cause: Error code=ENOENT
```

The previous `isNotFoundError` only checked `err.code === 'NotFound'` on the top-level error, so it returned `false` here. That meant `FilesSDKFilesystem.stat()` re-threw the raw error instead of throwing `FileNotFoundError`, which the workspace `writeFile` tool wrapper specifically catches to take the "this is a new file" branch (see `wrapWithReadTracker` pre-write `stat()` in `packages/core/src/workspace/tools/tools.ts`). The raw error escaped as the tool result and the agent saw `ENOENT: no such file or directory, stat '.../foo.txt'`.

The fix replaces both helpers with a small `hasFilesSDKCode(err, code, depth = 0)` that walks `err.cause` up to depth 5 and returns true if any level matches. Reproduced and verified locally on a fresh shade-colby checkout — agent writes (flat path and nested paths) succeed cleanly after the patch.

## Supporting fixes (same commit)

Each of these is a separate object-store-semantics gap that was caught by the shared `createFilesystemTestSuite` once it was wired up. Each matches the existing `S3Filesystem` / `GCSFilesystem` behavior.

- **`exists()` ignores empty leftover directories.** The previous check used `_files.exists(key)`, which on hierarchical adapters (`fs`) returns `true` for empty dirs left behind by earlier operations. Now uses a prefixed `list` and a child-directory probe so only real keys and non-empty prefixes count.
- **`deleteFile` on missing files throws `FileNotFoundError`** unless `{ force: true }`. Matches the `deleteThrowsOnMissing` capability the shared suite expects.
- **`deleteFile` on a directory delegates to `rmdir({ recursive: true, force })`.** Matches sibling providers.
- **`copyFile` honors `{ overwrite: false }`** by throwing `FileExistsError` before copying.
- **`moveFile` is now `copyFile` + `deleteFile({ force: true })`** so it picks up the overwrite check and the corrected error mapping. Documented as non-atomic.
- **`readdir({ recursive: true })` emits intermediate directories.** For a key at `a/b/c.txt`, both `a/`, `a/b/`, and the file are emitted. Matches the S3 `Delimiter`/`CommonPrefixes` behavior.
- **Lint:** drop unused `beforeEach`, fix `import/order` — both were failing CI.

## Tests

### `test(files-sdk): wire shared workspace integration suite via fs adapter`

`@internal/workspace-test-utils` was already a devDependency but `createFilesystemTestSuite` wasn't being called. This PR adds `index.integration.test.ts` that runs the shared 58-test conformance suite against a FilesSDK `fs` adapter pointed at a tmp dir — fully hermetic, no credentials, sub-second. This is the suite that surfaced the `exists()`, `deleteFile`, and error-cause issues. Also adds a `test:integration` script and excludes integration files from `test:unit`, mirroring the S3 workspace layout.

## Docs

### `docs(files-sdk): add reference page, overview entry, and clarifications`

- New reference page at `docs/src/content/en/reference/workspace/files-sdk-filesystem.mdx` covering installation, adapter swapping (S3 / R2 / GCS / Azure / fs), read-only mounts, constructor params, properties, methods, and the object-store semantics callers should be aware of.
- Adds `FilesSDKFilesystem` to the filesystem overview's supported-providers list and related links.
- Documents `appendFile` as non-atomic (read-modify-write) in the implementation — inherent to object storage, matches sibling providers.
- Fixes the changeset usage snippet which had the wrong `Files` constructor signature (`Files` takes `FilesOptions`, not the adapter directly).

## Test plan

From `workspaces/files-sdk`:

- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm test:unit` — 68/68 pass
- `pnpm test:integration` — 58/58 pass (shared conformance suite via `fs` adapter)

Manual repro on `shade-colby` (deterministic):

1. Delete `examples/agent/src/mastra/public/workspace` and `mastra.db`.
2. Run the agent and ask it to `write_file hello-world.txt "..."`.
3. **Before patch:** tool returns `ENOENT: no such file or directory, stat '.../hello-world.txt'`.
4. **After patch:** tool returns `Wrote N bytes`. Same for nested paths like `level-one/level-two/nested-poem.txt`.

## Notes

- `stat()` on a synthesized directory returns `new Date()` for `mtime`. Intentional; matches `S3Filesystem` / `GCSFilesystem`.
- `appendFile`'s read-modify-write race is documented but not "fixed" — it's inherent to object storage and the sibling providers behave the same way.
- Unrelated infra noise on the parent PR's E2E Type check (`ERR_PNPM_TRUST_DOWNGRADE` for `tinyexec` inside `vitest@4.1.7`) is not addressed here.
