### PR TITLE
fix(memory): release OM turn references after end

### DIFF
--- a/.changeset/om-turn-dispose-memory-retention.md
+++ b/.changeset/om-turn-dispose-memory-retention.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Reduced transient memory retention in Observational Memory by releasing heavy prompt/context references after each agent turn ends. ObservationTurn and ObservationStep now dispose their _context, systemMessage, writer, requestContext, observabilityContext, and actorModelContext fields when the turn finishes. The ObservationalMemoryProcessor also clears shared processor state keys (__omTurn, __omActorModelContext, __omObservabilityContext) after processOutputResult, preventing split input/output processor instances from retaining large memory strings between turns.

--- a/packages/memory/src/processors/observational-memory/__tests__/memory-retention.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/memory-retention.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Regression tests for memory retention in ObservationalMemoryProcessor.
+ *
+ * The root cause: processInputStep() creates `this.turn` on the input processor
+ * instance, while processOutputResult() runs on a separate output processor
+ * instance. The output instance cannot clear the input instance's private
+ * `this.turn`, so the ended turn retains heavy _context.systemMessage strings.
+ *
+ * The fix: ObservationTurn.dispose() clears _context, _currentStep, writer,
+ * requestContext, observabilityContext, actorModelContext, and memory after
+ * the turn ends. The processor also clears __omTurn, __omActorModelContext,
+ * and __omObservabilityContext from shared processor state.
+ */
+import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { ObservationalMemory } from '../observational-memory';
+import { ObservationalMemoryProcessor } from '../processor';
+import type { MemoryContextProvider } from '../processor';
+
+function createInMemoryStorage(): InMemoryMemory {
+  const db = new InMemoryDB();
+  return new InMemoryMemory({ db });
+}
+
+function createStubMemoryProvider(): MemoryContextProvider {
+  return {
+    getContext: vi.fn().mockResolvedValue({
+      systemMessage: undefined,
+      messages: [],
+      hasObservations: false,
+      omRecord: null,
+      continuationMessage: undefined,
+      otherThreadsContext: undefined,
+    }),
+    persistMessages: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Create a minimal non-gateway model object. */
+function createMockModel() {
+  return {
+    modelId: 'openai/gpt-4o',
+    provider: 'openai',
+  };
+}
+
+describe('OM processor memory retention', () => {
+  let om: ObservationalMemory;
+  let inputProcessor: ObservationalMemoryProcessor;
+  let outputProcessor: ObservationalMemoryProcessor;
+  const threadId = 'test-memory-retention-thread';
+  const resourceId = 'test-memory-retention-resource';
+
+  beforeEach(() => {
+    const storage = createInMemoryStorage();
+    om = new ObservationalMemory({
+      storage,
+      observation: { messageTokens: 100_000, model: 'test-model' },
+      reflection: { observationTokens: 100_000, model: 'test-model' },
+      scope: 'thread',
+    });
+    // Production creates separate instances for input and output processors
+    inputProcessor = new ObservationalMemoryProcessor(om, createStubMemoryProvider());
+    outputProcessor = new ObservationalMemoryProcessor(om, createStubMemoryProvider());
+  });
+
+  it('clears shared state after processOutputResult with split processor instances', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const state: Record<string, unknown> = {};
+    const messageList = new MessageList({ threadId, resourceId });
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+
+    const model = createMockModel();
+    const abort = vi.fn();
+
+    // ── Step 0: Run processInputStep on the INPUT processor ──
+    await inputProcessor.processInputStep({
+      messageList,
+      messages: [],
+      requestContext,
+      stepNumber: 0,
+      state,
+      steps: [],
+      systemMessages: [],
+      model: model as any,
+      retryCount: 0,
+      abort: abort as any,
+      writer: undefined,
+    });
+
+    // Verify the input processor created a turn and stored it in shared state
+    expect(state.__omTurn).toBeDefined();
+    expect(state.__omActorModelContext).toBeDefined();
+    expect(state.__omActorModelContext).toEqual({
+      provider: 'openai',
+      modelId: 'openai/gpt-4o',
+    });
+
+    // Add a dummy assistant response so output processor has something to process
+    messageList.add(
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: { format: 2, parts: [{ type: 'text', text: 'test response' }] },
+        createdAt: new Date(),
+        threadId,
+        resourceId,
+      } as any,
+      'response',
+    );
+
+    // ── Run processOutputResult on the OUTPUT processor ──
+    await outputProcessor.processOutputResult({
+      messageList,
+      messages: messageList.get.response.db(),
+      requestContext,
+      state,
+      abort: abort as any,
+      result: {} as any,
+      retryCount: 0,
+    });
+
+    // ── Verify shared state is cleared ──
+    expect(state.__omTurn).toBeUndefined();
+    expect(state.__omActorModelContext).toBeUndefined();
+    expect(state.__omObservabilityContext).toBeUndefined();
+  });
+
+  it('clears input processor turn internal references after end+dispose', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const state: Record<string, unknown> = {};
+    const messageList = new MessageList({ threadId, resourceId });
+
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', { thread: { id: threadId }, resourceId });
+
+    const model = createMockModel();
+    const abort = vi.fn();
+
+    // Run input on the input processor
+    await inputProcessor.processInputStep({
+      messageList,
+      messages: [],
+      requestContext,
+      stepNumber: 0,
+      state,
+      steps: [],
+      systemMessages: [],
+      model: model as any,
+      retryCount: 0,
+      abort: abort as any,
+      writer: undefined,
+    });
+
+    expect(state.__omTurn).toBeDefined();
+
+    // Add a dummy assistant response
+    messageList.add(
+      {
+        id: 'assistant-2',
+        role: 'assistant',
+        content: { format: 2, parts: [{ type: 'text', text: 'test response' }] },
+        createdAt: new Date(),
+        threadId,
+        resourceId,
+      } as any,
+      'response',
+    );
+
+    // Run processOutputResult on the OUTPUT processor (split instances)
+    await outputProcessor.processOutputResult({
+      messageList,
+      messages: messageList.get.response.db(),
+      requestContext,
+      state,
+      abort: abort as any,
+      result: {} as any,
+      retryCount: 0,
+    });
+
+    // Verify state is cleared after output processing
+    expect(state.__omTurn).toBeUndefined();
+    expect(state.__omActorModelContext).toBeUndefined();
+
+    // The output processor ended the turn via state.__omTurn, but the input
+    // processor's `this.turn` still references the same ObservationTurn object.
+    // Verify that the turn was disposed: _context, writer, requestContext,
+    // observabilityContext, actorModelContext, and memory should all be cleared.
+    const inputTurn = (inputProcessor as any).turn;
+    expect(inputTurn).toBeDefined();
+    expect(inputTurn._context).toBeUndefined();
+    expect(inputTurn.writer).toBeUndefined();
+    expect(inputTurn.requestContext).toBeUndefined();
+    expect(inputTurn.observabilityContext).toBeUndefined();
+    expect(inputTurn.actorModelContext).toBeUndefined();
+    expect(inputTurn.memory).toBeUndefined();
+    expect(inputTurn._ended).toBe(true);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/observation-turn/step.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/step.ts
@@ -407,4 +407,13 @@ export class ObservationStep {
       observerExchange: om.observer.lastExchange,
     };
   }
+
+  /**
+   * Release heavy references held by this step. Called after the turn ends.
+   * After disposal, the step should not be used further.
+   */
+  dispose(): void {
+    this._context = undefined;
+    this._prepared = false;
+  }
 }

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -181,9 +181,9 @@ export class ObservationTurn {
       await this.om.persistMessages(unsavedMessages, this.threadId, this.resourceId);
     }
 
-    // When the agent goes idle, start buffering any unobserved messages in the background.
-    // This ensures messages accumulated during the turn are observed proactively
-    // rather than waiting for the next turn's step.prepare() to trigger buffering.
+    // Capture buffer inputs in locals before dispose() clears the turn's transient references.
+    // The buffer() call receives these values by value in its argument object at call time,
+    // so clearing them after the call is safe — the async closure already holds its own copy.
     if (this.om.buffering.isAsyncObservationEnabled()) {
       const allMessages = this.messageList.get.all.db();
       const record = this._record!;
@@ -204,6 +204,11 @@ export class ObservationTurn {
           });
       }
     }
+
+    // Release heavy transient references (_context, writer, requestContext, etc.)
+    // so that even if a retained input-processor turn reference survives, it no
+    // longer holds large prompt/memory/system-message strings in memory.
+    this.dispose();
 
     return { record: this._record! };
   }
@@ -229,5 +234,24 @@ export class ObservationTurn {
       return otherThreadsContext;
     }
     return this._context?.otherThreadsContext;
+  }
+
+  /**
+   * Release heavy transient references held by this turn. Called after end()
+   * to free _context (which contains systemMessage/memory strings), writer,
+   * requestContext, observabilityContext, actorModelContext, and memory.
+   *
+   * The turn remains usable for its readonly identifiers (threadId, resourceId,
+   * record) and hooks reference, but no longer retains large prompt/context strings.
+   */
+  dispose(): void {
+    this._currentStep?.dispose();
+    this._currentStep = undefined;
+    this._context = undefined;
+    this.writer = undefined;
+    this.requestContext = undefined;
+    this.observabilityContext = undefined;
+    this.actorModelContext = undefined;
+    this.memory = undefined;
   }
 }

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -371,6 +371,13 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
           state.__omTurn = undefined;
         }
 
+        // Clear transient processor state that retained model/provider/observability
+        // objects after the turn finished. The turn's own dispose() releases its
+        // internal context references, while the processor state keys hold separate
+        // references that must be cleared here.
+        state.__omActorModelContext = undefined;
+        state.__omObservabilityContext = undefined;
+
         return messageList;
       });
   }


### PR DESCRIPTION
Fixes a memory retention issue in observational memory where ended turns could keep large prompt/context strings alive after the agent response finished.

Before, an ended `ObservationTurn` could still retain its full context:

```ts
ObservationTurn -> _context -> systemMessage
ObservationTurn -> _currentStep -> _context -> systemMessage
```

After `end()`, the turn now captures the small values needed for buffering, then disposes heavy transient references:

```ts
await turn.end();
turn._context // undefined
turn._currentStep // undefined
turn.writer // undefined
```

This is especially useful in longer sessions where old turns can otherwise accumulate retained system prompts and processor context. The focused regression test covers split input/output processor instances sharing state, which is the path we saw in the heap snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an AI conversation turn ends, the system was holding onto large text like system prompts even though they were no longer needed. This PR cleans up and throws away that unnecessary data after each conversation turn finishes, so memory can be freed up and used elsewhere.

## Problem

The observational memory system was experiencing memory retention issues where ended `ObservationTurn` instances kept large prompt and context strings alive after the agent response was complete. In long sessions or when using split input/output processors, old turns could accumulate, retaining system prompts and processor context that should have been released. Heap snapshots showed that `ObservationTurn._context.systemMessage` strings (≈28MB) were persisting after turn end.

## Solution

The PR implements explicit cleanup of transient references after observation turns complete:

1. **ObservationTurn.dispose()**: Clears heavy transient references including `_currentStep`, `_context`, `writer`, `requestContext`, `observabilityContext`, `actorModelContext`, and `memory` while preserving readonly identifiers and cached records.

2. **ObservationStep.dispose()**: Releases context references held by steps by clearing `_context` and resetting the prepared state.

3. **Updated ObservationTurn.end()**: Now calls `dispose()` after async idle buffering is initiated. Buffering closures capture required buffer inputs by value at call time, making it safe to clear turn references immediately.

4. **ObservationalMemoryProcessor.processOutputResult()**: Clears additional shared processor state (`__omActorModelContext` and `__omObservabilityContext`) after the active observation turn ends, preventing retention of model/provider/observability references.

## Changes

- **Changeset**: Documents patch release for `@mastra/memory` with behavioral update on memory disposal
- **Regression tests**: Added comprehensive tests covering memory-retention cleanup for split input/output processor instances, verifying that shared state keys are removed and internal references are cleared
- **Core implementation**: Added `dispose()` methods to `ObservationTurn` and `ObservationStep`, modified `end()` logic to invoke disposal, and updated processor cleanup

## Impact

This change reduces memory footprint in long-running agent sessions and scenarios with split input/output processors by ensuring that large transient data structures are properly released and available for garbage collection after each turn completes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->