### PR TITLE
fix(core): extract intermediate type aliases in MastraMessagePart to avoid TS2589

### DIFF
--- a/packages/core/src/agent/message-list/state/types.ts
+++ b/packages/core/src/agent/message-list/state/types.ts
@@ -73,18 +73,22 @@ export type MastraSourceUrlPart = Omit<LegacySourcePart, 'providerMetadata'> & {
   createdAt?: number;
 };
 
+// Named intermediate types to avoid TS2589 (type instantiation excessively deep)
+// when MastraMessagePart is used in contexts with deep type inference (e.g. @hono/zod-openapi).
+type MastraStandardUIV4Part = Exclude<UIMessageV4['parts'][number], { type: 'tool-invocation' | 'source' | 'step-start' }>;
+type MastraStandardUIV4PartWithMetadata = PartWithProviderMetadata<MastraStandardUIV4Part>;
+type MastraDataUIPart = PartWithProviderMetadata<AIV5Type.DataUIPart<AIV5.UIDataTypes>>;
+
 // Canonical stored part type. It starts from the v4 UI part model and extends
 // it with provider metadata, AI SDK v5 data parts, and v6-only persisted parts
 // such as approval-aware tool invocations and source documents.
 export type MastraMessagePart =
-  | PartWithProviderMetadata<
-      Exclude<UIMessageV4['parts'][number], { type: 'tool-invocation' | 'source' | 'step-start' }>
-    >
+  | MastraStandardUIV4PartWithMetadata
   | MastraStepStartPart
   | MastraToolInvocationPart
   | MastraSourceUrlPart
   | MastraSourceDocumentPart
-  | PartWithProviderMetadata<AIV5Type.DataUIPart<AIV5.UIDataTypes>>;
+  | MastraDataUIPart;
 
 // V4-compatible part type (excludes DataUIPart which V4 doesn't support)
 export type UIMessageV4Part = UIMessageV4['parts'][number] & MastraPartExtensions;


### PR DESCRIPTION
Fixes #17047

## Summary

Extracts the two inline complex types inside `MastraMessagePart` into named intermediate type aliases to avoid TypeScript error TS2589 ("Type instantiation is excessively deep and possibly infinite") when `MastraMessagePart` is used in contexts with deep type inference such as `@hono/zod-openapi` route handlers.

**Root cause**: The `PartWithProviderMetadata<Exclude<UIMessageV4['parts'][number], ...>>` and `PartWithProviderMetadata<DataUIPart<UIDataTypes>>` expressions were inlined directly in the union. TypeScript re-instantiates these on every usage site, which when combined with `@hono/zod-openapi`'s deep response-type validation exceeds TypeScript's instantiation depth limit.

**Fix**: Naming the intermediate types allows TypeScript to cache the resolved type and reuse it, breaking the chain.

## Changes

`packages/core/src/agent/message-list/state/types.ts` — **+3 lines, ~3 lines changed** (no runtime change)

```typescript
// Added
type MastraStandardUIV4Part = Exclude<UIMessageV4['parts'][number], { type: 'tool-invocation' | 'source' | 'step-start' }>;
type MastraStandardUIV4PartWithMetadata = PartWithProviderMetadata<MastraStandardUIV4Part>;
type MastraDataUIPart = PartWithProviderMetadata<AIV5Type.DataUIPart<AIV5.UIDataTypes>>;

// MastraMessagePart now references named types instead of inline expressions
```

No runtime behavior changes. The exported type `MastraMessagePart` remains structurally identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a TypeScript error that happens when developers use a message type called `MastraMessagePart` with a library called `@hono/zod-openapi`. The fix breaks down a complex type definition into smaller, named pieces so TypeScript doesn't get confused while checking types—like organizing a complicated LEGO structure into smaller sub-assemblies that are easier to work with.

## Changes

**File Modified:** `packages/core/src/agent/message-list/state/types.ts`

The `MastraMessagePart` union type was refactored to extract three inline complex type expressions into named intermediate type aliases:

- `MastraStandardUIV4Part` — filters standard UI v4 parts
- `MastraStandardUIV4PartWithMetadata` — wraps the standard UI v4 parts with provider metadata
- `MastraDataUIPart` — wraps v5 DataUIPart with provider metadata

The resulting union membership remains structurally identical; these changes are purely organizational at the type level.

## Impact

- **Fixes TS2589 errors** — resolves "Type instantiation is excessively deep and possibly infinite" errors that occur in `@hono/zod-openapi` route handlers
- **Type caching** — TypeScript can now cache the resolved intermediate types, avoiding repeated deep re-instantiation
- **No runtime changes** — this is a type-only refactor with no behavioral impact
- **Low review effort** — minimal changes (~8 lines added, ~4 lines removed)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->