### PR TITLE
feat(mastracode): wrap long ask_user picker option labels with ↳ continuation

### DIFF
--- a/.changeset/breezy-pets-mix.md
+++ b/.changeset/breezy-pets-mix.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Mastra Code's `ask_user` interactive picker now wraps long option labels across multiple rows with a `↳` continuation marker, instead of truncating them at the box edge. Mirrors fzf's `--wrap` design: arrow keys still navigate item-to-item (not row-to-row), so picking remains predictable when options span multiple lines. Follow-up to the crash fix in #17005 — the picker UX gap noted by @Doddle-BE on #17002.

--- a/.changeset/breezy-pets-mix.md
+++ b/.changeset/breezy-pets-mix.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Mastra Code's `ask_user` interactive picker now wraps long option labels across multiple rows with a `↳` continuation marker, instead of truncating them at the box edge. Mirrors fzf's `--wrap` design: arrow keys still navigate item-to-item (not row-to-row), so picking remains predictable when options span multiple lines. Follow-up to the crash fix in #17005 — the picker UX gap noted by @Doddle-BE on #17002.
+Mastra Code's `ask_user` interactive picker now wraps long option labels across multiple rows with a `↳` continuation marker, instead of truncating them at the box edge. Arrow keys still navigate item-to-item (not row-to-row), so picking remains predictable when options span multiple lines.

--- a/mastracode/src/tui/components/__tests__/wrapping-select-list.test.ts
+++ b/mastracode/src/tui/components/__tests__/wrapping-select-list.test.ts
@@ -1,0 +1,141 @@
+import { visibleWidth } from '@mariozechner/pi-tui';
+import type { SelectListTheme } from '@mariozechner/pi-tui';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the keybindings helper so handleInput tests can simulate up/down/enter/esc
+// without depending on the real config. The mock recognises a small set of
+// sentinel strings the tests pass in directly.
+vi.mock('@mariozechner/pi-tui', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getKeybindings: () => ({
+      matches: (data: string, key: string) => data === `__${key}__`,
+    }),
+  };
+});
+
+import { WrappingSelectList } from '../wrapping-select-list.js';
+
+const theme: SelectListTheme = {
+  selectedPrefix: (s: string) => `[S]${s}`,
+  selectedText: (s: string) => `[S]${s}`,
+  description: (s: string) => `[D]${s}`,
+  scrollInfo: (s: string) => `[I]${s}`,
+  noMatch: (s: string) => `[N]${s}`,
+};
+
+const items = (...labels: string[]) => labels.map(label => ({ value: label, label }));
+
+describe('WrappingSelectList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders short labels as one row each with the correct prefix', () => {
+      const list = new WrappingSelectList(items('Alpha', 'Beta'), 5, theme);
+      const lines = list.render(40);
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toContain('[S]→ Alpha'); // first item is selected by default
+      expect(lines[1]).toContain('  Beta');
+      expect(lines[1]).not.toContain('[S]'); // unselected items are not themed
+    });
+
+    it('wraps long labels onto multiple rows with the ↳ continuation marker', () => {
+      const longLabel = 'Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor';
+      const list = new WrappingSelectList(items(longLabel), 5, theme);
+      list.setSelectedIndex(0);
+      const lines = list.render(20);
+      expect(lines.length).toBeGreaterThan(1);
+      expect(lines[0]).toContain('→ ');
+      lines.slice(1).forEach(row => expect(row).toContain('↳ '));
+    });
+
+    it('keeps every rendered row within the requested width', () => {
+      // Use a passthrough theme — the styled `theme` mock wraps with visible
+      // `[S]` chars to make styling observable, but production themes wrap
+      // with invisible ANSI escapes. Width checks need the production shape.
+      const passthrough: SelectListTheme = {
+        selectedPrefix: s => s,
+        selectedText: s => s,
+        description: s => s,
+        scrollInfo: s => s,
+        noMatch: s => s,
+      };
+      const longLabel = 'Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor';
+      const list = new WrappingSelectList(items(longLabel, 'Short'), 5, passthrough);
+      const lines = list.render(24);
+      lines.forEach(row => expect(visibleWidth(row)).toBeLessThanOrEqual(24));
+    });
+
+    it('themes every row of the selected item — including continuation rows', () => {
+      const longLabel = 'Lorem ipsum dolor sit amet consectetur adipiscing elit';
+      const list = new WrappingSelectList(items(longLabel), 5, theme);
+      list.setSelectedIndex(0);
+      const lines = list.render(20);
+      lines.forEach(row => expect(row).toContain('[S]'));
+    });
+
+    it('shows the noMatch message when filter eliminates every item', () => {
+      const list = new WrappingSelectList(items('Alpha', 'Beta'), 5, theme);
+      list.setFilter('zzz');
+      const lines = list.render(30);
+      expect(lines).toEqual([expect.stringContaining('[N]')]);
+    });
+
+    it('emits the scroll indicator when items exceed maxVisible', () => {
+      const list = new WrappingSelectList(items('a', 'b', 'c', 'd', 'e'), 2, theme);
+      const lines = list.render(20);
+      expect(lines.some(line => line.includes('[I]') && line.includes('1/5'))).toBe(true);
+    });
+  });
+
+  describe('navigation — arrow keys move item-to-item, not row-to-row', () => {
+    it('advances selectedIndex by one item on down arrow, regardless of label height', () => {
+      const longLabel = 'Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor';
+      const list = new WrappingSelectList(items(longLabel, 'Short'), 5, theme);
+      expect(list.getSelectedItem()?.value).toBe(longLabel);
+      list.handleInput('__tui.select.down__');
+      expect(list.getSelectedItem()?.value).toBe('Short');
+    });
+
+    it('wraps to the last item when up arrow is pressed at the first item', () => {
+      const list = new WrappingSelectList(items('a', 'b', 'c'), 5, theme);
+      list.handleInput('__tui.select.up__');
+      expect(list.getSelectedItem()?.value).toBe('c');
+    });
+
+    it('wraps to the first item when down arrow is pressed at the last item', () => {
+      const list = new WrappingSelectList(items('a', 'b'), 5, theme);
+      list.setSelectedIndex(1);
+      list.handleInput('__tui.select.down__');
+      expect(list.getSelectedItem()?.value).toBe('a');
+    });
+
+    it('fires onSelect with the highlighted item on enter', () => {
+      const list = new WrappingSelectList(items('a', 'b'), 5, theme);
+      list.setSelectedIndex(1);
+      const onSelect = vi.fn();
+      list.onSelect = onSelect;
+      list.handleInput('__tui.select.confirm__');
+      expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ value: 'b' }));
+    });
+
+    it('fires onCancel on escape', () => {
+      const list = new WrappingSelectList(items('a'), 5, theme);
+      const onCancel = vi.fn();
+      list.onCancel = onCancel;
+      list.handleInput('__tui.select.cancel__');
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+
+    it('fires onSelectionChange after up/down navigation', () => {
+      const list = new WrappingSelectList(items('a', 'b'), 5, theme);
+      const onSelectionChange = vi.fn();
+      list.onSelectionChange = onSelectionChange;
+      list.handleInput('__tui.select.down__');
+      expect(onSelectionChange).toHaveBeenCalledWith(expect.objectContaining({ value: 'b' }));
+    });
+  });
+});

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -16,7 +16,6 @@ import {
   Container,
   getKeybindings,
   Input,
-  SelectList,
   Spacer,
   visibleWidth,
   wrapTextWithAnsi,
@@ -24,6 +23,7 @@ import {
 import type { Focusable, SelectItem, TUI } from '@mariozechner/pi-tui';
 import { BOX_INDENT_STR, theme, getSelectListTheme, getEditorTheme } from '../theme.js';
 import { MultilineInput } from './multiline-input.js';
+import { WrappingSelectList } from './wrapping-select-list.js';
 
 export interface AskQuestionInlineOptions {
   question: string;
@@ -52,7 +52,7 @@ export interface AskQuestionInlineOptions {
  */
 class AskQuestionBorderedBox {
   questionLines: string[];
-  private selectList?: SelectList;
+  private selectList?: WrappingSelectList;
   private input?: Input | MultilineInput;
   private hintText: string;
   items: Array<{ label: string; description?: string }>;
@@ -67,7 +67,7 @@ class AskQuestionBorderedBox {
     questionLines: string[],
     hintText: string,
     items: Array<{ label: string; description?: string }>,
-    selectList?: SelectList,
+    selectList?: WrappingSelectList,
     input?: Input | MultilineInput,
     streaming?: boolean,
   ) {
@@ -83,7 +83,7 @@ class AskQuestionBorderedBox {
     this.selectList?.invalidate();
   }
 
-  setInteractive(selectList?: SelectList, input?: Input | MultilineInput, hintText?: string) {
+  setInteractive(selectList?: WrappingSelectList, input?: Input | MultilineInput, hintText?: string) {
     this.streaming = false;
     this.selectList = selectList;
     this.input = input;
@@ -242,7 +242,7 @@ class AskQuestionBorderedBox {
 
 export class AskQuestionInlineComponent extends Container implements Focusable {
   private borderedBox: AskQuestionBorderedBox;
-  private selectList?: SelectList;
+  private selectList?: WrappingSelectList;
   private input?: Input | MultilineInput;
   private tui?: TUI;
   private onSubmit?: (answer: string) => void;
@@ -422,18 +422,18 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
   private buildSelectMode(opts: Array<{ label: string; description?: string }>): void {
     const items: SelectItem[] = opts.map(opt => ({
       value: opt.label,
-      label: opt.description ? `  ${opt.label}  ${theme.fg('dim', opt.description)}` : `  ${opt.label}`,
+      label: opt.description ? `${opt.label}  ${theme.fg('dim', opt.description)}` : opt.label,
     }));
 
     // Append a "Custom response..." option so the user can type a free-text answer
     if (this.allowCustomResponse) {
       items.push({
         value: AskQuestionInlineComponent.CUSTOM_RESPONSE_VALUE,
-        label: `  ${theme.fg('dim', '✎ Custom response...')}`,
+        label: theme.fg('dim', '✎ Custom response...'),
       });
     }
 
-    this.selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
+    this.selectList = new WrappingSelectList(items, Math.min(items.length, 8), getSelectListTheme());
 
     this.selectList.onSelect = (item: SelectItem) => {
       if (item.value === AskQuestionInlineComponent.CUSTOM_RESPONSE_VALUE) {

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -12,14 +12,7 @@
  * 3. **Answered** — After the user responds, the box freezes with ✓/✗ icons.
  */
 
-import {
-  Container,
-  getKeybindings,
-  Input,
-  Spacer,
-  visibleWidth,
-  wrapTextWithAnsi,
-} from '@mariozechner/pi-tui';
+import { Container, getKeybindings, Input, Spacer, visibleWidth, wrapTextWithAnsi } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, TUI } from '@mariozechner/pi-tui';
 import { BOX_INDENT_STR, theme, getSelectListTheme, getEditorTheme } from '../theme.js';
 import { MultilineInput } from './multiline-input.js';

--- a/mastracode/src/tui/components/wrapping-select-list.ts
+++ b/mastracode/src/tui/components/wrapping-select-list.ts
@@ -1,13 +1,8 @@
 /**
  * Drop-in replacement for pi-tui's `SelectList` that wraps long item labels
  * across multiple terminal rows with a `↳ ` continuation marker instead of
- * truncating them. Mirrors fzf's `--wrap` design: continuation rows align with
- * the prefix column, and arrow keys still move item-to-item — not row-to-row —
- * so navigation stays predictable regardless of label length.
- *
- * Used by the `ask_user` interactive picker, where agent-generated option
- * labels (file paths, code snippets, sentence-form choices) can easily exceed
- * the terminal width.
+ * truncating them. Arrow keys move item-to-item — not row-to-row — so
+ * navigation stays predictable regardless of label height.
  */
 
 import { getKeybindings, wrapTextWithAnsi } from '@mariozechner/pi-tui';

--- a/mastracode/src/tui/components/wrapping-select-list.ts
+++ b/mastracode/src/tui/components/wrapping-select-list.ts
@@ -107,7 +107,9 @@ export class WrappingSelectList implements Component {
     return wrapped.map((chunk, index) => {
       const prefix = index === 0 ? (isSelected ? SELECTED_PREFIX : UNSELECTED_PREFIX) : CONTINUATION_PREFIX;
       const rendered = `${prefix}${chunk}`;
-      return isSelected ? this.theme.selectedText(rendered) : prefix === CONTINUATION_PREFIX ? this.theme.description(rendered) : rendered;
+      if (isSelected) return this.theme.selectedText(rendered);
+      if (prefix === CONTINUATION_PREFIX) return this.theme.description(rendered);
+      return rendered;
     });
   }
 

--- a/mastracode/src/tui/components/wrapping-select-list.ts
+++ b/mastracode/src/tui/components/wrapping-select-list.ts
@@ -1,0 +1,127 @@
+/**
+ * Drop-in replacement for pi-tui's `SelectList` that wraps long item labels
+ * across multiple terminal rows with a `↳ ` continuation marker instead of
+ * truncating them. Mirrors fzf's `--wrap` design: continuation rows align with
+ * the prefix column, and arrow keys still move item-to-item — not row-to-row —
+ * so navigation stays predictable regardless of label length.
+ *
+ * Used by the `ask_user` interactive picker, where agent-generated option
+ * labels (file paths, code snippets, sentence-form choices) can easily exceed
+ * the terminal width.
+ */
+
+import { getKeybindings, wrapTextWithAnsi } from '@mariozechner/pi-tui';
+import type { Component, SelectItem, SelectListTheme } from '@mariozechner/pi-tui';
+
+const SELECTED_PREFIX = '→ ';
+const UNSELECTED_PREFIX = '  ';
+const CONTINUATION_PREFIX = '↳ ';
+const PREFIX_WIDTH = 2;
+
+export class WrappingSelectList implements Component {
+  private items: SelectItem[];
+  private filteredItems: SelectItem[];
+  private selectedIndex = 0;
+  private maxVisible: number;
+  private theme: SelectListTheme;
+
+  onSelect?: (item: SelectItem) => void;
+  onCancel?: () => void;
+  onSelectionChange?: (item: SelectItem) => void;
+
+  constructor(items: SelectItem[], maxVisible: number, theme: SelectListTheme) {
+    this.items = items;
+    this.filteredItems = items;
+    this.maxVisible = maxVisible;
+    this.theme = theme;
+  }
+
+  setFilter(filter: string): void {
+    this.filteredItems = this.items.filter(item => item.value.toLowerCase().startsWith(filter.toLowerCase()));
+    this.selectedIndex = 0;
+  }
+
+  setSelectedIndex(index: number): void {
+    this.selectedIndex = Math.max(0, Math.min(index, this.filteredItems.length - 1));
+  }
+
+  invalidate(): void {}
+
+  getSelectedItem(): SelectItem | null {
+    return this.filteredItems[this.selectedIndex] ?? null;
+  }
+
+  render(width: number): string[] {
+    const lines: string[] = [];
+
+    if (this.filteredItems.length === 0) {
+      lines.push(this.theme.noMatch('  No matching items'));
+      return lines;
+    }
+
+    const startIndex = Math.max(
+      0,
+      Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), this.filteredItems.length - this.maxVisible),
+    );
+    const endIndex = Math.min(startIndex + this.maxVisible, this.filteredItems.length);
+
+    for (let i = startIndex; i < endIndex; i++) {
+      const item = this.filteredItems[i];
+      if (!item) continue;
+      const isSelected = i === this.selectedIndex;
+      for (const row of this.renderItem(item, isSelected, width)) {
+        lines.push(row);
+      }
+    }
+
+    if (startIndex > 0 || endIndex < this.filteredItems.length) {
+      lines.push(this.theme.scrollInfo(`  (${this.selectedIndex + 1}/${this.filteredItems.length})`));
+    }
+
+    return lines;
+  }
+
+  handleInput(keyData: string): void {
+    const kb = getKeybindings();
+
+    if (kb.matches(keyData, 'tui.select.up')) {
+      this.selectedIndex = this.selectedIndex === 0 ? this.filteredItems.length - 1 : this.selectedIndex - 1;
+      this.notifySelectionChange();
+    } else if (kb.matches(keyData, 'tui.select.down')) {
+      this.selectedIndex = this.selectedIndex === this.filteredItems.length - 1 ? 0 : this.selectedIndex + 1;
+      this.notifySelectionChange();
+    } else if (kb.matches(keyData, 'tui.select.confirm')) {
+      const selected = this.filteredItems[this.selectedIndex];
+      if (selected && this.onSelect) this.onSelect(selected);
+    } else if (kb.matches(keyData, 'tui.select.cancel')) {
+      this.onCancel?.();
+    }
+  }
+
+  private renderItem(item: SelectItem, isSelected: boolean, width: number): string[] {
+    const labelText = this.getDisplayValue(item);
+    const labelWidth = Math.max(1, width - PREFIX_WIDTH);
+    const wrapped = wrapTextWithAnsi(labelText, labelWidth);
+
+    if (wrapped.length === 0) {
+      const prefix = isSelected ? SELECTED_PREFIX : UNSELECTED_PREFIX;
+      const rendered = `${prefix}`;
+      return [isSelected ? this.theme.selectedText(rendered) : rendered];
+    }
+
+    return wrapped.map((chunk, index) => {
+      const prefix = index === 0 ? (isSelected ? SELECTED_PREFIX : UNSELECTED_PREFIX) : CONTINUATION_PREFIX;
+      const rendered = `${prefix}${chunk}`;
+      return isSelected ? this.theme.selectedText(rendered) : prefix === CONTINUATION_PREFIX ? this.theme.description(rendered) : rendered;
+    });
+  }
+
+  private getDisplayValue(item: SelectItem): string {
+    return item.label || item.value;
+  }
+
+  private notifySelectionChange(): void {
+    const selected = this.filteredItems[this.selectedIndex];
+    if (selected && this.onSelectionChange) this.onSelectionChange(selected);
+  }
+}


### PR DESCRIPTION
## Description

Follow-up to #17005. The `ask_user` interactive picker still rendered long option labels via pi-tui's `SelectList`, which truncates at the box edge so the user can't read the full option before choosing. This PR replaces the picker with a drop-in `WrappingSelectList` that wraps long labels across multiple rows with a `↳` continuation marker — mirroring `fzf`'s `--wrap` (v0.54.0+) design while keeping arrow-key navigation item-scoped so picking stays predictable.

## Before
<img width="1126" height="679" alt="WhatsApp Image 2026-05-26 at 12 25 27-2" src="https://github.com/user-attachments/assets/47036b36-0580-44e4-bd10-2184482897da" />

## After
<img width="1023" height="693" alt="WhatsApp Image 2026-05-26 at 12 20 46-2" src="https://github.com/user-attachments/assets/b06dcb1b-25ee-4feb-b666-e7e997ce111d" />

## Related Issue(s)

Fixes #17002 (follow-up to #17005; resolves the picker-UX gap @Doddle-BE raised in https://github.com/mastra-ai/mastra/issues/17002#issuecomment-4540098596)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes the ask_user menu so long option names no longer get cut off — they wrap onto extra lines and show a ↳ marker for continuation, while the arrow keys still move between whole items.

---

## What Changed

### New Component: WrappingSelectList
- Added mastracode/src/tui/components/wrapping-select-list.ts as a drop-in replacement for pi-tui's SelectList used by the ask_user picker.
- Wraps long item labels across multiple terminal rows instead of truncating them.
- Prepends continuation rows with "↳ " and uses "→ " for the selected item's first row; the selected styling is applied to all wrapped rows.
- Keeps navigation item-scoped (↑/↓ move by item index regardless of wrapped row count).
- Preserves the SelectList public surface: onSelect, onCancel, onSelectionChange, setFilter, setSelectedIndex, getSelectedItem, handleInput, render.
- Renders a window of maxVisible items, shows a scroll indicator when needed, and displays a no-match message when filtering removes all items.

### ask-question-inline.ts Update
- Replaced SelectList with WrappingSelectList in mastracode/src/tui/components/ask-question-inline.ts and adjusted option-label rendering so the widget owns its prefix column (removed baked-in 2-space padding).
- Appended descriptions are formatted with theme.fg('dim', ...) to produce dimmed continuation styling.

### Tests
- Added mastracode/src/tui/components/__tests__/wrapping-select-list.test.ts.
- Tests cover rendering, wrapping behavior and width constraints, continuation marker presence, selected-item styling across wrapped rows, noMatch/scroll branches, navigation semantics, Enter/Esc behavior, and selection-change events.

### Changeset
- .changeset/breezy-pets-mix.md updated with a patch-level UX note describing the wrapping fix for the ask_user picker.

---

## Scope
Changes are scoped to the ask_user picker in mastracode; other pi-tui SelectList usages are unchanged. This PR follows up on `#17005` and fixes `#17002`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->