### PR TITLE
feat(react): handle reasoning-start and reasoning-end stream chunks

### DIFF
--- a/.changeset/fruity-camels-marry.md
+++ b/.changeset/fruity-camels-marry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Added support for reasoning-start and reasoning-end stream chunks so reasoning blocks are opened and closed with provider metadata preserved.

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
@@ -1161,6 +1161,681 @@ describe('toUIMessage', () => {
     });
   });
 
+  describe('toUIMessage - reasoning-start chunk', () => {
+    const baseMetadata: MastraUIMessageMetadata = {
+      mode: 'stream',
+    };
+
+    const makeStartChunk = (providerMetadata?: any): ChunkType => ({
+      type: 'reasoning-start',
+      payload: {
+        id: 'reasoning-1',
+        ...(providerMetadata !== undefined ? { providerMetadata } : {}),
+      },
+      runId: 'run-123',
+      from: ChunkFrom.AGENT,
+    });
+
+    it('should create a new assistant message when the conversation is empty', () => {
+      const result = toUIMessage({
+        chunk: makeStartChunk({ model: { name: 'o1' } }),
+        conversation: [],
+        metadata: baseMetadata,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            text: '',
+            state: 'streaming',
+            providerMetadata: { model: { name: 'o1' } },
+          },
+        ],
+        metadata: baseMetadata,
+      });
+      expect(result[0].id).toMatch(/^reasoning-run-123/);
+    });
+
+    it('should create a new assistant message when the tail message is a user message', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'user-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'hi' }],
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeStartChunk({ model: { name: 'o1' } }),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(conversation[0]);
+      expect(result[1]).toMatchObject({
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            text: '',
+            state: 'streaming',
+            providerMetadata: { model: { name: 'o1' } },
+          },
+        ],
+        metadata: baseMetadata,
+      });
+      expect(result[1].id).toMatch(/^reasoning-run-123/);
+    });
+
+    it('should append a new empty streaming reasoning part to an existing assistant message', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'text',
+              text: 'Hello.',
+              state: 'streaming',
+              textId: 'text-1',
+            } as MastraExtendedTextPart,
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+      const originalParts = conversation[0].parts;
+
+      const result = toUIMessage({
+        chunk: makeStartChunk({ anthropic: { cacheControl: 'ephemeral' } }),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('msg-1');
+      expect(result[0].metadata).toEqual(baseMetadata);
+      expect(result[0].parts).toHaveLength(2);
+      expect(result[0].parts[0]).toEqual(originalParts[0]);
+      expect(result[0].parts[1]).toEqual({
+        type: 'reasoning',
+        text: '',
+        state: 'streaming',
+        providerMetadata: { anthropic: { cacheControl: 'ephemeral' } },
+      });
+
+      // immutability: input conversation arrays/parts are not mutated by reference
+      expect(conversation[0].parts).toBe(originalParts);
+      expect(conversation[0].parts).toHaveLength(1);
+      expect(result[0].parts).not.toBe(conversation[0].parts);
+    });
+
+    it('should always open a new reasoning part even when the previous part is already a reasoning part', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'First thought.',
+              state: 'done',
+            },
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeStartChunk({ model: { name: 'o1' } }),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].parts).toHaveLength(2);
+      expect(result[0].parts[0]).toMatchObject({
+        type: 'reasoning',
+        text: 'First thought.',
+        state: 'done',
+      });
+      expect(result[0].parts[1]).toEqual({
+        type: 'reasoning',
+        text: '',
+        state: 'streaming',
+        providerMetadata: { model: { name: 'o1' } },
+      });
+    });
+
+    it('should append a reasoning part after a dynamic-tool part preserving order', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'dynamic-tool',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { query: 'weather' },
+            },
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeStartChunk(),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].parts.map(part => part.type)).toEqual(['dynamic-tool', 'reasoning']);
+      expect(result[0].parts[1]).toEqual({
+        type: 'reasoning',
+        text: '',
+        state: 'streaming',
+        providerMetadata: undefined,
+      });
+    });
+
+    it('should produce a reasoning part with providerMetadata: undefined when payload has none', () => {
+      const result = toUIMessage({
+        chunk: makeStartChunk(),
+        conversation: [],
+        metadata: baseMetadata,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].parts).toHaveLength(1);
+      expect(result[0].parts[0]).toEqual({
+        type: 'reasoning',
+        text: '',
+        state: 'streaming',
+        providerMetadata: undefined,
+      });
+    });
+  });
+
+  describe('toUIMessage - reasoning-end chunk', () => {
+    const baseMetadata: MastraUIMessageMetadata = {
+      mode: 'stream',
+    };
+
+    const makeEndChunk = (providerMetadata?: any): ChunkType => ({
+      type: 'reasoning-end',
+      payload: {
+        id: 'reasoning-1',
+        ...(providerMetadata !== undefined ? { providerMetadata } : {}),
+      },
+      runId: 'run-123',
+      from: ChunkFrom.AGENT,
+    });
+
+    it('should return the conversation unchanged when the conversation is empty', () => {
+      const conversation: MastraUIMessage[] = [];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk({ model: { name: 'o1' } }),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result).toEqual(conversation);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should return the conversation unchanged when the tail message is a user message', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'user-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'hi' }],
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk({ model: { name: 'o1' } }),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result).toEqual(conversation);
+      // tail message is preserved by reference (not rewritten)
+      expect(result[0]).toBe(conversation[0]);
+    });
+
+    it('should return the conversation unchanged when the assistant message has no parts', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk(),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result).toEqual(conversation);
+      expect(result[0]).toBe(conversation[0]);
+    });
+
+    it('should return the conversation unchanged when no reasoning part exists', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'text',
+              text: 'Hello.',
+              state: 'streaming',
+              textId: 'text-1',
+            } as MastraExtendedTextPart,
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk(),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result).toEqual(conversation);
+      expect(result[0]).toBe(conversation[0]);
+    });
+
+    it('should return the conversation unchanged when all reasoning parts are already done', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'First thought.',
+              state: 'done',
+            },
+            {
+              type: 'reasoning',
+              text: 'Second thought.',
+              state: 'done',
+            },
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk({ model: { name: 'o1' } }),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result).toEqual(conversation);
+      expect(result[0]).toBe(conversation[0]);
+    });
+
+    it('should transition only the last streaming reasoning part to done (findLastIndex semantics)', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'First thought.',
+              state: 'streaming',
+            },
+            {
+              type: 'reasoning',
+              text: 'Second thought.',
+              state: 'streaming',
+            },
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk(),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].parts).toHaveLength(2);
+      expect(result[0].parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'First thought.',
+        state: 'streaming',
+      });
+      expect(result[0].parts[1]).toEqual({
+        type: 'reasoning',
+        text: 'Second thought.',
+        state: 'done',
+      });
+    });
+
+    it('should close the streaming reasoning part even when later parts follow it', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Thinking...',
+              state: 'streaming',
+              providerMetadata: { anthropic: { cacheControl: 'ephemeral' } },
+            },
+            {
+              type: 'text',
+              text: 'Answer in progress.',
+              state: 'streaming',
+              textId: 'text-1',
+            } as MastraExtendedTextPart,
+            {
+              type: 'dynamic-tool',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { query: 'weather' },
+            },
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk(),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].parts).toHaveLength(3);
+      expect(result[0].parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Thinking...',
+        state: 'done',
+        providerMetadata: { anthropic: { cacheControl: 'ephemeral' } },
+      });
+      // later parts unchanged
+      expect(result[0].parts[1]).toEqual(conversation[0].parts[1]);
+      expect(result[0].parts[2]).toEqual(conversation[0].parts[2]);
+    });
+
+    it('should write chunk providerMetadata through verbatim when the existing part has none', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Done thinking.',
+              state: 'streaming',
+            },
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk({ usage: { reasoningTokens: 42 } }),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Done thinking.',
+        state: 'done',
+        providerMetadata: { usage: { reasoningTokens: 42 } },
+      });
+    });
+
+    it('should preserve existing part providerMetadata when chunk has none', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Done thinking.',
+              state: 'streaming',
+              providerMetadata: { model: { name: 'o1' } },
+            },
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk(),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Done thinking.',
+        state: 'done',
+        providerMetadata: { model: { name: 'o1' } },
+      });
+    });
+
+    it('should override existing providerMetadata keys with chunk providerMetadata on collision', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Done thinking.',
+              state: 'streaming',
+              providerMetadata: { model: { name: 'o1' }, kept: { value: true } },
+            },
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk({ model: { name: 'o3' }, added: { extra: 'x' } }),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Done thinking.',
+        state: 'done',
+        providerMetadata: { model: { name: 'o3' }, kept: { value: true }, added: { extra: 'x' } },
+      });
+    });
+
+    it('should omit providerMetadata entirely when neither side provides any', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Done thinking.',
+              state: 'streaming',
+            },
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk(),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Done thinking.',
+        state: 'done',
+      });
+      expect(result[0].parts[0]).not.toHaveProperty('providerMetadata');
+    });
+
+    it('should preserve the accumulated text on the streaming reasoning part', () => {
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'A long chain of thought built up over multiple deltas.',
+              state: 'streaming',
+            },
+          ],
+          metadata: baseMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk(),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].parts[0]).toMatchObject({
+        type: 'reasoning',
+        text: 'A long chain of thought built up over multiple deltas.',
+        state: 'done',
+      });
+    });
+
+    it('should preserve the assistant message id and metadata', () => {
+      const customMetadata: MastraUIMessageMetadata = {
+        mode: 'stream',
+        status: 'warning',
+      };
+
+      const conversation: MastraUIMessage[] = [
+        {
+          id: 'msg-keep-me',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Hmm.',
+              state: 'streaming',
+            },
+          ],
+          metadata: customMetadata,
+        },
+      ];
+
+      const result = toUIMessage({
+        chunk: makeEndChunk(),
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(result[0].id).toBe('msg-keep-me');
+      expect(result[0].metadata).toEqual(customMetadata);
+    });
+  });
+
+  describe('toUIMessage - reasoning sequence (start -> delta -> end)', () => {
+    const baseMetadata: MastraUIMessageMetadata = {
+      mode: 'stream',
+    };
+
+    it('should produce a single coherent done reasoning part with accumulated text and merged metadata', () => {
+      let conversation: MastraUIMessage[] = [];
+
+      conversation = toUIMessage({
+        chunk: {
+          type: 'reasoning-start',
+          payload: {
+            id: 'reasoning-1',
+            providerMetadata: { model: { name: 'o1' } },
+          },
+          runId: 'run-123',
+          from: ChunkFrom.AGENT,
+        },
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      conversation = toUIMessage({
+        chunk: {
+          type: 'reasoning-delta',
+          payload: {
+            id: 'reasoning-1',
+            text: 'Let me think',
+          },
+          runId: 'run-123',
+          from: ChunkFrom.AGENT,
+        },
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      conversation = toUIMessage({
+        chunk: {
+          type: 'reasoning-delta',
+          payload: {
+            id: 'reasoning-1',
+            text: ' about this.',
+          },
+          runId: 'run-123',
+          from: ChunkFrom.AGENT,
+        },
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      conversation = toUIMessage({
+        chunk: {
+          type: 'reasoning-end',
+          payload: {
+            id: 'reasoning-1',
+            providerMetadata: { usage: { reasoningTokens: 7 } },
+          },
+          runId: 'run-123',
+          from: ChunkFrom.AGENT,
+        },
+        conversation,
+        metadata: baseMetadata,
+      });
+
+      expect(conversation).toHaveLength(1);
+      expect(conversation[0].role).toBe('assistant');
+      expect(conversation[0].parts).toHaveLength(1);
+      expect(conversation[0].parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Let me think about this.',
+        state: 'done',
+        providerMetadata: {
+          model: { name: 'o1' },
+          usage: { reasoningTokens: 7 },
+        },
+      });
+    });
+  });
+
   describe('toUIMessage - tool-call chunk', () => {
     const baseMetadata: MastraUIMessageMetadata = {
       mode: 'stream',

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts
@@ -484,6 +484,42 @@ export const toUIMessage = ({ chunk, conversation, metadata }: ToUIMessageArgs):
       ];
     }
 
+    case 'reasoning-start': {
+      const lastMessage = result[result.length - 1];
+      if (!lastMessage || lastMessage.role !== 'assistant') {
+        const newMessage: MastraUIMessage = {
+          id: `reasoning-${chunk.runId + Date.now()}`,
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: '',
+              state: 'streaming',
+              providerMetadata: chunk.payload.providerMetadata,
+            },
+          ],
+          metadata,
+        };
+        return [...result, newMessage];
+      }
+
+      const parts = [...lastMessage.parts];
+      parts.push({
+        type: 'reasoning',
+        text: '',
+        state: 'streaming',
+        providerMetadata: chunk.payload.providerMetadata,
+      });
+
+      return [
+        ...result.slice(0, -1),
+        {
+          ...lastMessage,
+          parts,
+        },
+      ];
+    }
+
     case 'reasoning-delta': {
       const lastMessage = result[result.length - 1];
       if (!lastMessage || lastMessage.role !== 'assistant') {
@@ -524,6 +560,45 @@ export const toUIMessage = ({ chunk, conversation, metadata }: ToUIMessageArgs):
           providerMetadata: chunk.payload.providerMetadata,
         });
       }
+
+      return [
+        ...result.slice(0, -1),
+        {
+          ...lastMessage,
+          parts,
+        },
+      ];
+    }
+
+    case 'reasoning-end': {
+      const lastMessage = result[result.length - 1];
+      if (!lastMessage || lastMessage.role !== 'assistant') return result;
+
+      const parts = [...lastMessage.parts];
+      const reasoningPartIndex = parts.findLastIndex(
+        part => part.type === 'reasoning' && (part as { state?: string }).state === 'streaming',
+      );
+
+      if (reasoningPartIndex === -1) return result;
+
+      const reasoningPart = parts[reasoningPartIndex];
+      if (reasoningPart.type !== 'reasoning') return result;
+
+      const existingMetadata = (reasoningPart as { providerMetadata?: any }).providerMetadata;
+      const endMetadata = chunk.payload.providerMetadata;
+
+      parts[reasoningPartIndex] = {
+        ...reasoningPart,
+        state: 'done',
+        ...(existingMetadata || endMetadata
+          ? {
+              providerMetadata: {
+                ...(existingMetadata ?? {}),
+                ...(endMetadata ?? {}),
+              },
+            }
+          : {}),
+      };
 
       return [
         ...result.slice(0, -1),


### PR DESCRIPTION
Adds handling for `reasoning-start` and `reasoning-end` stream chunks in `@mastra/react`'s `toUIMessage`, so reasoning blocks are properly opened and closed during streaming with provider metadata preserved.

`reasoning-start` opens a new empty reasoning part in `streaming` state (creating an assistant message if needed). `reasoning-end` finds the last streaming reasoning part and transitions it to `done`, merging existing part metadata with the chunk's `providerMetadata` (chunk keys win on collision). The conversation is returned unchanged when there's no streaming reasoning part to close.

```ts
// after
let conversation = []

conversation = toUIMessage({ chunk: { type: 'reasoning-start', payload: { providerMetadata: { model: { name: 'o1' } } }, runId, from: 'AGENT' }, conversation, metadata })
conversation = toUIMessage({ chunk: { type: 'reasoning-delta', payload: { text: 'Thinking...' }, runId, from: 'AGENT' }, conversation, metadata })
conversation = toUIMessage({ chunk: { type: 'reasoning-end', payload: { providerMetadata: { usage: { reasoningTokens: 7 } } }, runId, from: 'AGENT' }, conversation, metadata })

// → reasoning part: { state: 'done', text: 'Thinking...', providerMetadata: { model: { name: 'o1' }, usage: { reasoningTokens: 7 } } }
```

Test plan: 28 new vitest cases covering every code path of both handlers plus a full start → delta → end integration sequence. `pnpm --filter @mastra/react test:unit` passes (333/333).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine an AI is thinking through a problem step-by-step. This PR teaches a React component to properly track when the AI starts thinking (opening a "reasoning block"), what it thinks about (adding text), and when it finishes thinking (closing the block), while also remembering important details about where that thinking came from.

## Summary

This PR adds support for `reasoning-start` and `reasoning-end` stream chunks in `@mastra/react`'s `toUIMessage` function, enabling proper handling of reasoning blocks during AI streaming responses with metadata preservation.

### Implementation Changes

**`toUIMessage.ts`** (+75 lines)
- `reasoning-start` handler: Creates a new empty reasoning part with `state: 'streaming'` and the chunk's `providerMetadata`. If the conversation tail is not an assistant message, a new assistant message is created; otherwise, a fresh reasoning part is appended to the existing assistant message.
- `reasoning-end` handler: Locates the last streaming reasoning part using `findLastIndex` and transitions it to `state: 'done'`. Merges the existing part's metadata with the chunk's `providerMetadata`, with keys from the chunk taking precedence on collisions. Returns conversation unchanged if there is no assistant tail or no streaming reasoning part to close.
- Existing chunk handling (reasoning-delta, tool calls, files) remains unchanged.

### Test Coverage

**`toUIMessage.test.ts`** (+675 lines)
- 28 new Vitest cases covering all code paths for both handlers
- `reasoning-start` tests: Validates creation vs. appending behavior based on tail message role, ensures new reasoning parts are always opened (even after previous reasoning parts), and verifies immutability of parts arrays
- `reasoning-end` tests: Ensures conversation is unchanged when appropriate (empty conversation, tail is user, no reasoning parts, all parts already done), and verifies only the last streaming reasoning part transitions to done
- `providerMetadata` handling tests: Covers chunk metadata passthrough, omission when neither side provides it, preservation when chunk has none, key collision override behavior, and accumulated text preservation
- Integration test: Full lifecycle coverage of `reasoning-start` → multiple `reasoning-delta` updates → `reasoning-end` resulting in a single coherent `done` part with merged text and metadata
- Test suite passes: 333/333 tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->