### PR TITLE
chore(cli): drop --project-name in favor of [project-name] argument

### DIFF
--- a/.changeset/remove-create-project-name-flag.md
+++ b/.changeset/remove-create-project-name-flag.md
@@ -1,0 +1,6 @@
+---
+'mastra': major
+'create-mastra': major
+---
+
+Removed the deprecated `--project-name` flag from `mastra create` and `create-mastra`. Pass the project name as the positional argument instead, for example `mastra create my-app` or `npx create-mastra@latest my-app`.

--- a/docs/src/content/en/reference/cli/create-mastra.mdx
+++ b/docs/src/content/en/reference/cli/create-mastra.mdx
@@ -48,9 +48,10 @@ Instead of an interactive prompt you can also define these CLI flags.
     isOptional: true,
   },
   {
-    name: '--project-name',
+    name: '[project-name]',
     type: 'string',
-    description: 'Project name that will be used in package.json and as the project directory name',
+    description:
+      'Project name used in package.json and as the project directory name. Pass as the first argument, e.g. npx create-mastra@latest my-app',
     isOptional: true,
   },
   {

--- a/packages/cli/src/commands/actions/create-project.test.ts
+++ b/packages/cli/src/commands/actions/create-project.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createProject } from './create-project';
+
+const { mockCreate, mockTrackCommandExecution, mockTrackEvent } = vi.hoisted(() => ({
+  mockCreate: vi.fn(() => Promise.resolve()),
+  mockTrackCommandExecution: vi.fn(({ execution }: { execution: () => Promise<void> }) => execution()),
+  mockTrackEvent: vi.fn(),
+}));
+
+vi.mock('../create/create', () => ({
+  create: mockCreate,
+}));
+
+vi.mock('../..', () => ({
+  analytics: {
+    trackEvent: mockTrackEvent,
+    trackCommandExecution: mockTrackCommandExecution,
+  },
+}));
+
+describe('createProject', () => {
+  it('passes the positional project name to create with --default', async () => {
+    await createProject('my-app', { default: true });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectName: 'my-app',
+        components: ['agents', 'tools', 'workflows'],
+      }),
+    );
+  });
+
+  it('passes the positional project name to create without --default', async () => {
+    await createProject('my-app', {
+      components: ['agents'],
+      llm: 'openai',
+      dir: 'src/',
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectName: 'my-app',
+        directory: 'src/',
+        components: ['agents'],
+        llmProvider: 'openai',
+      }),
+    );
+  });
+
+  it('passes undefined when no positional project name is provided', async () => {
+    await createProject(undefined, { default: true });
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ projectName: undefined }));
+  });
+
+  it('records the positional project name in analytics args', async () => {
+    await createProject('my-app', { default: true });
+
+    expect(mockTrackCommandExecution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'create',
+        args: expect.objectContaining({ projectName: 'my-app' }),
+      }),
+    );
+  });
+});

--- a/packages/cli/src/commands/actions/create-project.ts
+++ b/packages/cli/src/commands/actions/create-project.ts
@@ -14,7 +14,6 @@ interface CreateProjectArgs {
   example?: boolean;
   timeout?: string | boolean;
   dir?: string;
-  projectName?: string;
   mcp?: Editor;
   skills?: string[];
   template?: string | boolean;
@@ -23,8 +22,6 @@ interface CreateProjectArgs {
 }
 
 export const createProject = async (projectNameArg: string | undefined, args: CreateProjectArgs) => {
-  // TODO(major): Remove args.projectName in favor of projectNameArg
-  const projectName = projectNameArg || args.projectName;
   if (args.observability !== undefined) {
     analytics.trackEvent('cli_observability_selected', {
       command: 'create',
@@ -36,7 +33,7 @@ export const createProject = async (projectNameArg: string | undefined, args: Cr
 
   await analytics.trackCommandExecution({
     command: 'create',
-    args: { ...args, projectName },
+    args: { ...args, projectName: projectNameArg },
     execution: async () => {
       const timeout = args?.timeout ? (args?.timeout === true ? 60000 : parseInt(args?.timeout, 10)) : undefined;
       if (args.default) {
@@ -60,7 +57,7 @@ export const createProject = async (projectNameArg: string | undefined, args: Cr
         addExample: args.example,
         llmApiKey: args.llmApiKey,
         timeout,
-        projectName,
+        projectName: projectNameArg,
         directory: args.dir,
         mcpServer: args.mcp,
         skills: args.skills,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -91,10 +91,6 @@ program
   .option('-t, --timeout [timeout]', 'Configurable timeout for package installation, defaults to 60000 ms')
   .option('-d, --dir <directory>', 'Target directory for Mastra source code (default: src/)')
   .option(
-    '-p, --project-name <string>',
-    'Project name that will be used in package.json and as the project directory name.',
-  )
-  .option(
     '-m, --mcp <editor>',
     'MCP Server for code editor (cursor, cursor-global, windsurf, vscode, antigravity)',
     parseMcp,

--- a/packages/create-mastra/src/index.ts
+++ b/packages/create-mastra/src/index.ts
@@ -36,10 +36,6 @@ program
   .name('create-mastra')
   .description('Create a new Mastra project')
   .argument('[project-name]', 'Directory name of the project')
-  .option(
-    '-p, --project-name <string>',
-    'Project name that will be used in package.json and as the project directory name.',
-  )
   .option('--default', 'Quick start with defaults (src, OpenAI, examples)')
   .option('-c, --components <components>', 'Comma-separated list of components (agents, tools, workflows, scorers)')
   .option('-l, --llm <model-provider>', 'Default model provider (openai, anthropic, groq, google, or cerebras)')
@@ -59,7 +55,7 @@ program
     analytics.trackCommandExecution({
       command: 'create',
       args: {
-        projectName: projectNameArg || args.projectName,
+        projectName: projectNameArg,
         components: args.components,
         llmProvider: args.llm,
         addExample: args.example,
@@ -68,8 +64,6 @@ program
         observability: args.observe,
       },
       execution: async () => {
-        // TODO(major): Remove args.projectName in favor of projectNameArg
-        const projectName = projectNameArg || args.projectName;
         const timeout = args?.timeout ? (args?.timeout === true ? 60000 : parseInt(args?.timeout, 10)) : undefined;
 
         if (args.default) {
@@ -79,7 +73,7 @@ program
             addExample: true,
             createVersionTag,
             timeout,
-            projectName,
+            projectName: projectNameArg,
             mcpServer: args.mcp,
             directory: 'src/',
             template: args.template,
@@ -96,7 +90,7 @@ program
           llmApiKey: args.llmApiKey,
           createVersionTag,
           timeout,
-          projectName,
+          projectName: projectNameArg,
           directory: args.dir,
           mcpServer: args.mcp,
           template: args.template,


### PR DESCRIPTION
## Description
Removes the deprecated `-p, --project-name` flag from project creation in favor of `[project-name]`. This resolves the `TODO(major)` to drop `args.projectName`.
- `mastra` CLI (`packages/cli/src/index.ts`): remove `-p, --project-name` from `mastra create`
- `createProject` (`packages/cli/src/commands/actions/create-project.ts`): use only `projectNameArg` and remove `projectName` from `CreateProjectArgs`
- `create-mastra` (`packages/create-mastra/src/index.ts`): remove `-p, --project-name`; pass `projectNameArg` through to `create()`

#### Tests passed:
<img width="631" height="237" alt="Screenshot 2026-05-26 165035" src="https://github.com/user-attachments/assets/c8920a30-ecf8-4258-a20d-9547ea386b4c" />

## Related issue(s)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes the old `-p, --project-name` flag from the CLI commands and replaces it with a simpler positional argument. Instead of typing `mastra create --project-name my-app`, you now just type `mastra create my-app` (the project name comes right after the command, no flag needed).

## Overview

This PR removes the deprecated `--project-name` flag from the `mastra create` and `create-mastra` commands, replacing it with a positional `[project-name]` argument. This is a breaking change that simplifies the CLI interface.

## Changes

**CLI Commands Updated:**
- `packages/cli/src/index.ts`: Removed `-p, --project-name` option from the `mastra create` command
- `packages/create-mastra/src/index.ts`: Removed `-p, --project-name` option and updated to use positional `[project-name]` argument

**Implementation Changes:**
- `packages/cli/src/commands/actions/create-project.ts`: 
  - Removed `projectName` field from `CreateProjectArgs` type
  - Updated to consistently use `projectNameArg` instead of the deprecated `projectName` field
  - Updated both the `--default` and non-default code paths to use the positional argument
  - Updated analytics tracking to reference the positional argument

**Documentation:**
- `docs/src/content/en/reference/cli/create-mastra.mdx`: Updated CLI reference documentation to reflect the new positional `[project-name]` argument format

**Testing:**
- `packages/cli/src/commands/actions/create-project.test.ts`: Added comprehensive test suite (4 tests) verifying:
  - Positional project name is passed correctly to `create()` with `--default` flag
  - Positional project name is passed correctly with other options
  - Undefined is passed when no positional name is provided
  - Analytics tracking correctly records the positional project name

**Changelog:**
- `.changeset/remove-create-project-name-flag.md`: Added Changeset entry marking this as a breaking change requiring major version bumps for both `mastra` and `create-mastra`

## Breaking Changes

The `--project-name` / `-p` flag has been removed. Users must now provide the project name as a positional argument instead (e.g., `mastra create my-app` or `npx create-mastra@latest my-app`).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->