### PR TITLE
fix(core,ci): isolate legacy sub-agent tool output

### DIFF
--- a/.changeset/sweet-doodles-clap.md
+++ b/.changeset/sweet-doodles-clap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix legacy agent tools so model-facing sub-agent results stay text-only by default while raw metadata remains available.

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -35,6 +35,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             .github/actions
+            package.json
             scripts/pr-issue-link
           sparse-checkout-cone-mode: false
 
@@ -81,6 +82,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             .github/actions
+            package.json
             scripts/pr-complexity
           sparse-checkout-cone-mode: false
 
@@ -126,6 +128,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             .github/actions
+            package.json
             scripts/pr-automation-comment
           sparse-checkout-cone-mode: false
 
@@ -168,6 +171,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             .github/actions
+            package.json
             scripts/pr-issue-link
           sparse-checkout-cone-mode: false
 

--- a/packages/core/__recordings__/core-src-agent-__tests__-tool-handling.e2e.json
+++ b/packages/core/__recordings__/core-src-agent-__tests__-tool-handling.e2e.json
@@ -208,7 +208,7 @@
       }
     },
     {
-      "hash": "e805b7bf457a5dc0",
+      "hash": "ee7f80b59dfaedef",
       "request": {
         "url": "https://api.openai.com/v1/chat/completions",
         "method": "POST",
@@ -241,7 +241,7 @@
             {
               "role": "tool",
               "tool_call_id": "call_PT0d286WNzsYZW8lnwi268G7",
-              "content": "{\"text\":\"Dummy response\"}"
+              "content": "[{\"type\":\"text\",\"text\":\"Dummy response\"}]"
             }
           ],
           "tools": [
@@ -539,7 +539,14 @@
                   "resumeData"
                 ],
                 "additionalProperties": false,
-                "x-optional": ["threadId", "resourceId", "instructions", "maxSteps", "suspendedToolRunId", "resumeData"]
+                "x-optional": [
+                  "threadId",
+                  "resourceId",
+                  "instructions",
+                  "maxSteps",
+                  "suspendedToolRunId",
+                  "resumeData"
+                ]
               },
               "strict": false
             }
@@ -711,7 +718,14 @@
                   "resumeData"
                 ],
                 "additionalProperties": false,
-                "x-optional": ["threadId", "resourceId", "instructions", "maxSteps", "suspendedToolRunId", "resumeData"]
+                "x-optional": [
+                  "threadId",
+                  "resourceId",
+                  "instructions",
+                  "maxSteps",
+                  "suspendedToolRunId",
+                  "resumeData"
+                ]
               },
               "strict": false
             }
@@ -857,7 +871,14 @@
                   "resumeData"
                 ],
                 "additionalProperties": false,
-                "x-optional": ["threadId", "resourceId", "instructions", "maxSteps", "suspendedToolRunId", "resumeData"]
+                "x-optional": [
+                  "threadId",
+                  "resourceId",
+                  "instructions",
+                  "maxSteps",
+                  "suspendedToolRunId",
+                  "resumeData"
+                ]
               },
               "strict": false
             }
@@ -1035,7 +1056,14 @@
                   "resumeData"
                 ],
                 "additionalProperties": false,
-                "x-optional": ["threadId", "resourceId", "instructions", "maxSteps", "suspendedToolRunId", "resumeData"]
+                "x-optional": [
+                  "threadId",
+                  "resourceId",
+                  "instructions",
+                  "maxSteps",
+                  "suspendedToolRunId",
+                  "resumeData"
+                ]
               },
               "strict": false
             }
@@ -1172,7 +1200,14 @@
                   "resumeData"
                 ],
                 "additionalProperties": false,
-                "x-optional": ["threadId", "resourceId", "instructions", "maxSteps", "suspendedToolRunId", "resumeData"]
+                "x-optional": [
+                  "threadId",
+                  "resourceId",
+                  "instructions",
+                  "maxSteps",
+                  "suspendedToolRunId",
+                  "resumeData"
+                ]
               }
             }
           ],
@@ -1343,7 +1378,14 @@
                   "resumeData"
                 ],
                 "additionalProperties": false,
-                "x-optional": ["threadId", "resourceId", "instructions", "maxSteps", "suspendedToolRunId", "resumeData"]
+                "x-optional": [
+                  "threadId",
+                  "resourceId",
+                  "instructions",
+                  "maxSteps",
+                  "suspendedToolRunId",
+                  "resumeData"
+                ]
               },
               "strict": false
             }
@@ -1489,7 +1531,14 @@
                   "resumeData"
                 ],
                 "additionalProperties": false,
-                "x-optional": ["threadId", "resourceId", "instructions", "maxSteps", "suspendedToolRunId", "resumeData"]
+                "x-optional": [
+                  "threadId",
+                  "resourceId",
+                  "instructions",
+                  "maxSteps",
+                  "suspendedToolRunId",
+                  "resumeData"
+                ]
               }
             }
           ],
@@ -1666,7 +1715,14 @@
                   "resumeData"
                 ],
                 "additionalProperties": false,
-                "x-optional": ["threadId", "resourceId", "instructions", "maxSteps", "suspendedToolRunId", "resumeData"]
+                "x-optional": [
+                  "threadId",
+                  "resourceId",
+                  "instructions",
+                  "maxSteps",
+                  "suspendedToolRunId",
+                  "resumeData"
+                ]
               },
               "strict": false
             }

--- a/packages/core/src/agent/__tests__/tool-handling.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/tool-handling.e2e.test.ts
@@ -6,7 +6,7 @@ import { getOpenAIModel, getSingleDummyResponseModel } from './mock-model';
 
 setupDummyApiKeys(getLLMTestMode(), ['openai']);
 
-const mock = createGatewayMock();
+const mock = createGatewayMock({ exactMatch: true });
 beforeAll(() => mock.start());
 afterAll(() => mock.saveAndStop());
 
@@ -57,18 +57,16 @@ function toolhandlingE2ETests(version: 'v1' | 'v2' | 'v3') {
           ? toolCalls.find((tc: any) => tc.toolName === 'agent-researchAgent')
           : toolCalls.find((tc: any) => tc.payload?.toolName === 'agent-researchAgent');
 
-      expect(version === 'v1' ? toolCalls[0]?.result : toolCalls[0]?.payload?.result).toStrictEqual({
-        ...(version === 'v1'
-          ? {}
-          : {
-              subAgentResourceId: expect.any(String),
-              subAgentThreadId: expect.any(String),
-              subAgentToolResults: expect.any(Array),
-            }),
+      expect(agentToolCall).toBeDefined();
+
+      const agentToolResult = version === 'v1' ? agentToolCall?.result : agentToolCall?.payload?.result;
+
+      expect(agentToolResult).toStrictEqual({
+        subAgentResourceId: expect.any(String),
+        subAgentThreadId: expect.any(String),
+        subAgentToolResults: expect.any(Array),
         text: 'Dummy response',
       });
-
-      expect(agentToolCall).toBeDefined();
     }, 50000);
   });
 }

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -218,6 +218,88 @@ export interface AgentLegacyCapabilities {
   ): Promise<void>;
 }
 
+type LegacyToolResultContent = ReturnType<NonNullable<Tool['experimental_toToolResultContent']>>;
+type LegacyToolWithModelOutput = CoreTool & Partial<Pick<Tool, 'experimental_toToolResultContent'>>;
+
+function stringifyLegacyToolContent(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    const json = JSON.stringify(value);
+    return json ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function normalizeLegacyToolResultContent(output: unknown): LegacyToolResultContent {
+  if (!output || typeof output !== 'object') {
+    return [{ type: 'text', text: stringifyLegacyToolContent(output) }];
+  }
+
+  const modelOutput = output as Record<string, unknown>;
+
+  if (modelOutput.type === 'text') {
+    return [{ type: 'text', text: stringifyLegacyToolContent(modelOutput.value ?? modelOutput.text ?? '') }];
+  }
+
+  if (modelOutput.type !== 'content' || !Array.isArray(modelOutput.value)) {
+    return [{ type: 'text', text: stringifyLegacyToolContent(output) }];
+  }
+
+  const parts = modelOutput.value.flatMap((part): LegacyToolResultContent => {
+    if (!part || typeof part !== 'object') {
+      return [{ type: 'text', text: stringifyLegacyToolContent(part) }];
+    }
+
+    const contentPart = part as Record<string, unknown>;
+    if (contentPart.type === 'text') {
+      return [{ type: 'text', text: stringifyLegacyToolContent(contentPart.text ?? '') }];
+    }
+
+    const mimeType =
+      typeof contentPart.mimeType === 'string'
+        ? contentPart.mimeType
+        : typeof contentPart.mediaType === 'string'
+          ? contentPart.mediaType
+          : undefined;
+    if (
+      typeof contentPart.data === 'string' &&
+      (contentPart.type === 'image' || (contentPart.type === 'media' && mimeType?.startsWith('image/')))
+    ) {
+      return [{ type: 'image', data: contentPart.data, ...(mimeType ? { mimeType } : {}) }];
+    }
+
+    return [{ type: 'text', text: stringifyLegacyToolContent(contentPart) }];
+  });
+
+  return parts.length > 0 ? parts : [{ type: 'text', text: '' }];
+}
+
+function applyLegacyToolModelOutput(tools: Record<string, CoreTool>): Record<string, CoreTool> {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, tool]) => {
+      const legacyTool = tool as LegacyToolWithModelOutput;
+      if (!legacyTool.toModelOutput || legacyTool.experimental_toToolResultContent) {
+        return [name, tool];
+      }
+
+      return [
+        name,
+        {
+          ...tool,
+          experimental_toToolResultContent: result => {
+            const modelOutput = legacyTool.toModelOutput?.(result);
+            return normalizeLegacyToolResultContent(modelOutput ?? result);
+          },
+        } satisfies LegacyToolWithModelOutput,
+      ];
+    }),
+  );
+}
+
 /**
  * Handler class for legacy Agent functionality (v1 models).
  * Encapsulates all legacy-specific streaming and generation logic.
@@ -302,19 +384,21 @@ export class AgentLegacyHandler {
 
         const threadId = thread?.id;
 
-        let convertedTools = await this.capabilities.convertTools({
-          toolsets,
-          clientTools,
-          threadId,
-          resourceId,
-          runId,
-          requestContext,
-          ...innerObservabilityContext,
-          writableStream,
-          methodType: methodType === 'generate' ? 'generateLegacy' : 'streamLegacy',
-          memoryConfig,
-          inputProcessors,
-        });
+        let convertedTools = applyLegacyToolModelOutput(
+          await this.capabilities.convertTools({
+            toolsets,
+            clientTools,
+            threadId,
+            resourceId,
+            runId,
+            requestContext,
+            ...innerObservabilityContext,
+            writableStream,
+            methodType: methodType === 'generate' ? 'generateLegacy' : 'streamLegacy',
+            memoryConfig,
+            inputProcessors,
+          }),
+        );
 
         let messageList = new MessageList({
           threadId,
@@ -349,7 +433,7 @@ export class AgentLegacyHandler {
               resourceId,
             });
             if (inputStepResult.tools) {
-              convertedTools = inputStepResult.tools;
+              convertedTools = applyLegacyToolModelOutput(inputStepResult.tools);
             }
             if (inputStepResult.tripwire) {
               return {
@@ -456,7 +540,7 @@ export class AgentLegacyHandler {
             resourceId,
           });
           if (inputStepResult.tools) {
-            convertedTools = inputStepResult.tools;
+            convertedTools = applyLegacyToolModelOutput(inputStepResult.tools);
           }
           if (inputStepResult.tripwire) {
             return {


### PR DESCRIPTION
## Summary
- bridge legacy v1 tool `toModelOutput` into the AI SDK v4 `experimental_toToolResultContent` path so supervisor model input stays text-only by default
- keep the raw sub-agent tool result shape available to callers, including `subAgentThreadId`, `subAgentResourceId`, and `subAgentToolResults`
- update the focused core E2E test and cassette so exact replay verifies both sides of that contract
- include root `package.json` in PR Triage sparse checkouts so `setup-pnpm-node` can read the pinned `packageManager` version

## Why
#15825 intentionally made the v1 raw sub-agent result richer, but the legacy v1 path was not applying the existing model-output projection before sending the tool result back to the supervisor model. This restores the split introduced by #15832: application-visible tool results can include sub-agent metadata, while model-facing tool output remains text-only unless a tool opts into something else.

The PR Triage failures seen on #17062 are separate from the core E2E failure. They happen before tests because the sparse checkout omitted root `package.json`, so `pnpm/action-setup@v4` could not infer the pnpm version. Adding `package.json` to those sparse checkouts keeps the existing shared setup action behavior and does not change the automation scripts.

## Checks
- `pnpm prettier --check .github/workflows/pr-triage.yml`
- `git diff --check`
- `node -p "require('./package.json').packageManager"`
- `CI=true LLM_TEST_MODE=replay pnpm vitest run packages/core/src/agent/__tests__/tool-handling.e2e.test.ts --project e2e:packages/core`
- previously on this branch: `CI=true pnpm vitest run packages/core/src/agent/__tests__/tool-handling.e2e.test.ts --project e2e:packages/core`
- previously on this branch: `pnpm --filter ./packages/core check`
- previously on this branch: `pnpm --filter ./packages/core lint`
- previously on this branch: `pnpm prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'`
- previously on this branch: `pnpm test:core`

CodeRabbit CLI local review could not run because this machine is not authenticated for CodeRabbit (`coderabbit auth login` required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

Think of this PR as a mailroom problem: when a sub-agent sends back a response with extra details (metadata), we want those details delivered to the person who asked for it, but NOT passed along in the next message to the supervisor. This PR fixes that by cleaning up the supervisor's message—removing the extra details so it only sees the essential text—while still preserving all those details for the original caller.

---

## Overview

This PR isolates how legacy AI SDK v1 tools handle sub-agent results to prevent metadata leakage. It separates the **raw tool result** (with all sub-agent metadata visible to callers) from the **model-facing output** (sanitized text-only content for the supervisor), ensuring backward compatibility with v1 tool consumers while maintaining clean supervisor context.

## Changes

### Core Implementation (packages/core/src/agent/agent-legacy.ts)
Added legacy tool result-content normalization to handle the `experimental_toToolResultContent` hook:
- Introduced helper functions to stringify legacy content and normalize model outputs into the standard `{ type: 'text' | 'image', ... }[]` format
- Added image/media handling and safe fallbacks for unexpected structures
- Updated the legacy agent tool conversion flow to automatically wrap converted tools with `applyLegacyToolModelOutput(...)` at two key points:
  1. After the initial `convertTools(...)` call
  2. After step 0 of `__runProcessInputStep(...)` returns updated tools

This ensures v1 tools receive and expose raw results (including sub-agent metadata like `subAgentThreadId`, `subAgentResourceId`, `subAgentToolResults`, and `usage`) while the supervisor model only sees the model-facing output with metadata stripped.

### Test Updates (packages/core/src/agent/__tests__/tool-handling.e2e.test.ts)
- Initialized the gateway mock with `exactMatch: true` for stricter test matching
- Enhanced the "agents as tools" assertion to explicitly verify that agent tool results contain the expected sub-agent identifiers and metadata fields
- Uses version-dependent paths to extract and assert the full agent tool result object

### Test Cassette Refresh (packages/core/__recordings__/core-src-agent-__tests__-tool-handling.e2e.json)
- Updated the recorded tool-call output to convert a single-object response form (`{"text":"Dummy response"}`) to the AI SDK v4 tool-result content array form (`[{"type":"text","text":"Dummy response"}]`)
- This reflects the application of `toModelOutput` and ensures sub-agent metadata no longer leaks into supervisor model requests
- Updated hash values and reformatted parameter arrays for consistency

### Build/Workflow Updates
- Updated `.github/workflows/pr-triage.yml` sparse-checkout lists in four jobs (`issue-link-nudge`, `complexity`, `summarize`, `close-stale-unlinked`) to include `package.json`
- Added a Changesets entry for `@mastra/core` documenting the patch-level fix

## Context
This PR addresses a regression introduced in PR `#15825`, which enriched v1 raw sub-agent result fields for caller visibility. However, those fields were inadvertently leaked into the supervisor model's next request because the legacy v1 path did not apply `toModelOutput`. This fix applies the necessary output transformation to maintain the surface separation: callers continue to receive full metadata while the model only sees sanitized, model-facing content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17066?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->