### PR TITLE
fix(mastracode): recover from stale Harness v1 session leases on startup

### DIFF
--- a/.changeset/cute-mails-brush.md
+++ b/.changeset/cute-mails-brush.md
@@ -1,0 +1,24 @@
+---
+'mastracode': patch
+---
+
+**Recover from stale Harness v1 session leases on startup.**
+
+A crashed or killed MastraCode process used to block the next launch with an opaque `HarnessSessionLockedError`. The runtime now waits out the stale lease automatically (up to 60s on startup, 2s mid-session) and emits status messages while it retries.
+
+After 5s of waiting, when stdin is a TTY, an interactive prompt offers `(W)ait / (F)orce-claim / (N)ew thread / (Q)uit`. The choice can also be set via environment variable for scripts, headless mode, or CI:
+
+```bash
+# Force-claim the foreign lease immediately on the next startup
+MASTRACODE_LEASE_RECOVERY=force-claim mastracode
+
+# Abandon the locked thread and start a new one
+MASTRACODE_LEASE_RECOVERY=new-thread mastracode
+
+# Fail fast with a recovery error instead of waiting
+MASTRACODE_LEASE_RECOVERY=quit mastracode
+```
+
+When recovery times out or the user quits, the runtime throws a new `MastraCodeSessionLeaseRecoveryError` (exported from `mastracode`) carrying the underlying `HarnessSessionLockedError` as its `cause`, plus `sessionId`, `currentOwnerId`, and `expiresAt` fields for downstream handlers.
+
+Also fixes a long-standing terminal-state bug surfaced by this scenario: after a crashed or `SIGKILL`'d MastraCode, the parent shell would stay stuck emitting raw CSI-u keypress sequences until manually `reset`. The CLI now restores pi-tui's keyboard mode (kitty progressive enhancement, modifyOtherKeys, bracketed paste) on `SIGINT`/`SIGTERM`/`SIGHUP`/`exit`/`uncaughtException`/`unhandledRejection`, and also emits the restore sequence once at launch so the next mastracode invocation cleans up after a prior ungraceful exit it couldn't trap.

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -212,6 +212,25 @@ Once saved, provider models appear in existing selectors like `/models` and `/su
 
 Custom providers are stored in `settings.json` in the same app data directory. If you save an API key, it is stored locally in plaintext, so use a machine/user profile you trust.
 
+### Recovering from a stale session lease
+
+If MastraCode crashes or is killed without a clean shutdown, the next launch can refuse to reopen the project's thread because the Harness v1 session lease for that thread is still held by the previous owner. The TUI now waits out the stale lease automatically (up to 60s) and emits status messages while it retries.
+
+If you know the other process is dead and do not want to wait, set the recovery action via environment variable:
+
+```bash
+# Force-claim the foreign lease immediately on the next startup
+MASTRACODE_LEASE_RECOVERY=force-claim mastracode
+
+# Abandon the current thread and start a fresh one
+MASTRACODE_LEASE_RECOVERY=new-thread mastracode
+
+# Fail fast with a recovery error instead of waiting
+MASTRACODE_LEASE_RECOVERY=quit mastracode
+```
+
+When stdin is a TTY and no env override is set, MastraCode also shows an interactive `(W)ait / (F)orce-claim / (N)ew thread / (Q)uit` prompt after 5 seconds of waiting.
+
 ### macOS sleep prevention
 
 On macOS, Mastra Code starts the built-in `caffeinate` utility while the agent is actively running, then stops it as soon as the run completes, errors, aborts, or the TUI exits. Idle sessions do not keep your machine awake.

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -112,6 +112,10 @@ vi.mock('@mastra/observability', () => ({
 
 vi.mock('../harness/index.js', () => ({
   createHarnessV1SubagentAgents: vi.fn(() => ({})),
+  defaultStdioLeaseRecoveryPrompt: vi.fn(() => undefined),
+  MastraCodeSessionLeaseRecoveryError: class extends Error {
+    readonly name = 'MastraCodeSessionLeaseRecoveryError';
+  },
   MastraCodeHarnessRuntime: class {
     constructor(config: unknown) {
       harnessConstructorMock(config);

--- a/mastracode/src/harness/config.ts
+++ b/mastracode/src/harness/config.ts
@@ -30,6 +30,23 @@ export interface MastraCodeModelInfo {
   metadata?: Readonly<Record<string, unknown>>;
 }
 
+export type LeaseRecoveryAction = 'wait' | 'force-claim' | 'new-thread' | 'quit';
+
+export interface LeaseRecoveryPromptInfo {
+  threadId: string;
+  sessionId: string;
+  currentOwnerId: string;
+  expiresAt: number;
+  secondsWaited: number;
+  /** When false, the `new-thread` action must not be offered. Set by callers
+   * that need to bind to a specific threadId (createThread, switchThread). */
+  allowNewThread: boolean;
+}
+
+export type LeaseRecoveryPromptHandler = (
+  info: LeaseRecoveryPromptInfo,
+) => LeaseRecoveryAction | Promise<LeaseRecoveryAction>;
+
 export interface MastraCodeRuntimeConfig<TState extends Record<string, unknown>> {
   resourceId: string;
   storage: MastraCompositeStore;
@@ -49,6 +66,7 @@ export interface MastraCodeRuntimeConfig<TState extends Record<string, unknown>>
   resolveModel?: (modelId: string) => unknown;
   disabledTools?: string[];
   browser?: DynamicArgument<MastraBrowser | undefined>;
+  leaseRecoveryPrompt?: LeaseRecoveryPromptHandler;
 }
 
 /**

--- a/mastracode/src/harness/index.ts
+++ b/mastracode/src/harness/index.ts
@@ -3,5 +3,11 @@ export {
   MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
   type MastraCodeRuntimeConfig,
 } from './config.js';
-export { MastraCodeHarnessRuntime } from './runtime.js';
+export { MastraCodeHarnessRuntime, MastraCodeSessionLeaseRecoveryError } from './runtime.js';
+export { defaultStdioLeaseRecoveryPrompt } from './lease-recovery-prompt.js';
+export type {
+  LeaseRecoveryAction,
+  LeaseRecoveryPromptHandler,
+  LeaseRecoveryPromptInfo,
+} from './config.js';
 export { createHarnessV1SubagentAgents } from './subagents.js';

--- a/mastracode/src/harness/lease-recovery-prompt.ts
+++ b/mastracode/src/harness/lease-recovery-prompt.ts
@@ -1,0 +1,62 @@
+import { createInterface } from 'node:readline';
+
+import type { LeaseRecoveryAction, LeaseRecoveryPromptHandler, LeaseRecoveryPromptInfo } from './config.js';
+
+/**
+ * Stdio-driven prompt invoked during `MastraCodeHarnessRuntime.init()` when a
+ * stale Harness v1 session lease is held by another process. The handler
+ * resolves to `wait` immediately when stdin is not a TTY so headless callers
+ * stay non-interactive without an explicit `MASTRACODE_LEASE_RECOVERY` value.
+ */
+export function defaultStdioLeaseRecoveryPrompt(): LeaseRecoveryPromptHandler {
+  return async (info: LeaseRecoveryPromptInfo): Promise<LeaseRecoveryAction> => {
+    // Re-check TTY state at invocation time so tests / embedders that flip
+    // `process.stdin.isTTY` after construction get the right behavior.
+    if (!process.stdin.isTTY) return 'wait';
+    const expires =
+      Number.isFinite(info.expiresAt) && info.expiresAt > 0
+        ? new Date(info.expiresAt).toLocaleTimeString()
+        : 'an unknown time';
+    const newThreadLine = info.allowNewThread
+      ? `  (N)ew thread — abandon this thread and start a new one (loses continuity with thread history)\n`
+      : '';
+    const choiceHint = info.allowNewThread ? '[W/f/n/q]' : '[W/f/q]';
+    process.stderr.write(
+      `\nA previous MastraCode Harness session lease for thread "${info.threadId}" is still held by another process (owner "${info.currentOwnerId}", expires at ${expires}). Waited ${info.secondsWaited}s.\n` +
+        `  (W)ait for the lease to expire (up to 60s total) — safe default\n` +
+        `  (F)orce-claim the lease — only safe if the other process is known dead\n` +
+        newThreadLine +
+        `  (Q)uit\n` +
+        `Tip: set MASTRACODE_LEASE_RECOVERY=force-claim|wait|new-thread|quit to skip this prompt next time.\n` +
+        `Choice ${choiceHint}: `,
+    );
+    const rl = createInterface({ input: process.stdin, output: process.stderr, terminal: false });
+    let closed = false;
+    rl.once('close', () => {
+      closed = true;
+    });
+    try {
+      for (;;) {
+        if (closed) return 'wait';
+        // `rl.question` never resolves if stdin closes mid-prompt (Ctrl+D,
+        // piped input ends); the `close` listener short-circuits to 'wait'
+        // via the loop guard above.
+        const answer = await new Promise<string>(resolve => {
+          rl.question('', resolve);
+          rl.once('close', () => resolve(''));
+        });
+        if (closed) return 'wait';
+        const normalized = answer.trim().toLowerCase();
+        if (normalized === '' || normalized === 'w' || normalized === 'wait') return 'wait';
+        if (normalized === 'f' || normalized === 'force' || normalized === 'force-claim') return 'force-claim';
+        if (info.allowNewThread && (normalized === 'n' || normalized === 'new' || normalized === 'new-thread')) {
+          return 'new-thread';
+        }
+        if (normalized === 'q' || normalized === 'quit') return 'quit';
+        process.stderr.write(`Please choose ${choiceHint.replace(/[\[\]]/g, '').toUpperCase()}: `);
+      }
+    } finally {
+      rl.close();
+    }
+  };
+}

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -1016,3 +1016,427 @@ describe('MastraCodeHarnessRuntime', () => {
     expect(runtime.getCurrentThreadId()).toBe(currentThreadId);
   });
 });
+
+// Structural type covering only the harness-storage methods the lease-recovery
+// tests exercise. Avoids `as any` while keeping the test self-contained.
+type TestHarnessStorage = {
+  loadSession: (opts: { harnessName: string; sessionId: string }) => Promise<{ ownerId?: string } | null>;
+  releaseSessionLease: (opts: { harnessName: string; sessionId: string; ownerId: string }) => Promise<void>;
+  acquireSessionLease: (opts: {
+    harnessName: string;
+    sessionId: string;
+    ownerId: string;
+    ttlMs: number;
+  }) => Promise<unknown>;
+};
+
+describe('MastraCodeHarnessRuntime — stale session lease recovery (MASTRA-4344)', () => {
+  it('waits out a stale foreign lease and adopts the previous session at startup', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const storage = new InMemoryStore({ id: 'mc-runtime-stale-lease-startup' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-stale-lease-startup' });
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-stale-lease-startup' });
+
+    try {
+      await firstRuntime.init();
+      const threadId = firstRuntime.getCurrentThreadId();
+      const sessionId = firstRuntime.getCurrentSessionId();
+      if (!threadId || !sessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: 'harness-foreign-owner',
+        ttlMs: 250,
+      });
+
+      const infoMessages: string[] = [];
+      secondRuntime.subscribe(event => {
+        if (event.type === 'info') infoMessages.push(event.message);
+      });
+
+      const initPromise = secondRuntime.init();
+      await vi.advanceTimersByTimeAsync(750);
+      await initPromise;
+
+      expect(secondRuntime.getCurrentThreadId()).toBe(threadId);
+      expect(secondRuntime.getCurrentSessionId()).toBe(sessionId);
+      expect(infoMessages.some(m => /lease|retrying/i.test(m))).toBe(true);
+      expect(infoMessages.some(m => /Recovered/i.test(m))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('throws MastraCodeSessionLeaseRecoveryError when the foreign lease outlasts the startup cap', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const storage = new InMemoryStore({ id: 'mc-runtime-stale-lease-timeout' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-live-lease' });
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-live-lease' });
+
+    try {
+      await firstRuntime.init();
+      const sessionId = firstRuntime.getCurrentSessionId();
+      if (!sessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: 'harness-still-running-owner',
+        ttlMs: 120_000,
+      });
+
+      const initPromise = secondRuntime.init().catch(err => err);
+      await vi.advanceTimersByTimeAsync(65_000);
+      const err = await initPromise;
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).name).toBe('MastraCodeSessionLeaseRecoveryError');
+      expect((err as { code: string }).code).toBe('mastracode.session_lease_recovery_failed');
+      expect((err as Error).message).toContain('Another MastraCode instance may still be running');
+      expect((err as { cause: { name?: string } }).cause?.name).toBe('HarnessSessionLockedError');
+      expect((err as { sessionId: string }).sessionId).toBe(sessionId);
+      expect((err as { currentOwnerId: string }).currentOwnerId).toBe('harness-still-running-owner');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('propagates non-locked errors from session() without retrying', async () => {
+    const runtime = createRuntime();
+    const sessionSpy = vi
+      .spyOn(runtime.core, 'session')
+      .mockRejectedValueOnce(new Error('storage offline'));
+
+    await expect(runtime.init()).rejects.toThrow('storage offline');
+    expect(sessionSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('adopts the existing session without waiting when the lease is reentrant for this process', async () => {
+    const storage = new InMemoryStore({ id: 'mc-runtime-reentrant-lease' });
+    const runtime = createRuntime({ storage, projectPath: '/tmp/mastracode-reentrant' });
+
+    const infoMessages: string[] = [];
+    runtime.subscribe(event => {
+      if (event.type === 'info') infoMessages.push(event.message);
+    });
+
+    await runtime.init();
+    const sessionId = runtime.getCurrentSessionId();
+
+    expect(sessionId).toBeDefined();
+    expect(infoMessages.some(m => /lease|retrying|Recovered/i.test(m))).toBe(false);
+  });
+
+  it('uses the short mid-session cap when re-binding a session lazily after the bound one is dropped', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const storage = new InMemoryStore({ id: 'mc-runtime-midsession-cap' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-midsession' });
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-midsession' });
+
+    try {
+      await firstRuntime.init();
+      const sessionId = firstRuntime.getCurrentSessionId();
+      if (!sessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: 'harness-still-running-owner',
+        ttlMs: 120_000,
+      });
+
+      const reboundPromise = secondRuntime
+        .selectOrCreateThread({ leaseRecoveryMode: 'midsession' })
+        .catch(err => err);
+      await vi.advanceTimersByTimeAsync(3_000);
+      const err = await reboundPromise;
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).name).toBe('MastraCodeSessionLeaseRecoveryError');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('honors MASTRACODE_LEASE_RECOVERY=force-claim across owner-change races', async () => {
+    const storage = new InMemoryStore({ id: 'mc-runtime-force-claim-race' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-force-claim' });
+
+    const restore = process.env.MASTRACODE_LEASE_RECOVERY;
+    process.env.MASTRACODE_LEASE_RECOVERY = 'force-claim';
+    try {
+      await firstRuntime.init();
+      const sessionId = firstRuntime.getCurrentSessionId();
+      if (!sessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: 'harness-still-running-owner',
+        ttlMs: 120_000,
+      });
+
+      const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-force-claim' });
+      const infoMessages: string[] = [];
+      secondRuntime.subscribe(event => {
+        if (event.type === 'info') infoMessages.push(event.message);
+      });
+      await secondRuntime.init();
+      expect(secondRuntime.getCurrentSessionId()).toBe(sessionId);
+      expect(infoMessages.some(m => /Released.*harness-still-running-owner/.test(m))).toBe(true);
+    } finally {
+      if (restore === undefined) {
+        delete process.env.MASTRACODE_LEASE_RECOVERY;
+      } else {
+        process.env.MASTRACODE_LEASE_RECOVERY = restore;
+      }
+    }
+  });
+
+  it('force-claims again across an owner-change race between release and retry', async () => {
+    const storage = new InMemoryStore({ id: 'mc-runtime-owner-change-race' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-owner-race' });
+
+    const restore = process.env.MASTRACODE_LEASE_RECOVERY;
+    process.env.MASTRACODE_LEASE_RECOVERY = 'force-claim';
+    try {
+      await firstRuntime.init();
+      const sessionId = firstRuntime.getCurrentSessionId();
+      if (!sessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: 'harness-owner-a',
+        ttlMs: 120_000,
+      });
+
+      const originalRelease = harnessStorage.releaseSessionLease.bind(harnessStorage);
+      let releaseCount = 0;
+      vi.spyOn(harnessStorage, 'releaseSessionLease').mockImplementation(async opts => {
+        await originalRelease(opts);
+        releaseCount += 1;
+        if (releaseCount === 1) {
+          // Racer process re-acquires the lease in the gap between our
+          // release and the next core.session() retry.
+          await harnessStorage.acquireSessionLease({
+            harnessName: MASTRACODE_HARNESS_NAME,
+            sessionId,
+            ownerId: 'harness-owner-b',
+            ttlMs: 120_000,
+          });
+        }
+      });
+
+      const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-owner-race' });
+      const infoMessages: string[] = [];
+      secondRuntime.subscribe(event => {
+        if (event.type === 'info') infoMessages.push(event.message);
+      });
+      await secondRuntime.init();
+
+      expect(secondRuntime.getCurrentSessionId()).toBe(sessionId);
+      expect(releaseCount).toBeGreaterThanOrEqual(2);
+      expect(infoMessages.some(m => /Released.*harness-owner-a/.test(m))).toBe(true);
+      expect(infoMessages.some(m => /Released.*harness-owner-b/.test(m))).toBe(true);
+    } finally {
+      if (restore === undefined) {
+        delete process.env.MASTRACODE_LEASE_RECOVERY;
+      } else {
+        process.env.MASTRACODE_LEASE_RECOVERY = restore;
+      }
+    }
+  });
+
+  it('honors MASTRACODE_LEASE_RECOVERY=new-thread at startup by creating a fresh thread', async () => {
+    const storage = new InMemoryStore({ id: 'mc-runtime-new-thread-startup' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-new-thread' });
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-new-thread' });
+
+    const restore = process.env.MASTRACODE_LEASE_RECOVERY;
+    process.env.MASTRACODE_LEASE_RECOVERY = 'new-thread';
+    try {
+      await firstRuntime.init();
+      const lockedThreadId = firstRuntime.getCurrentThreadId();
+      const lockedSessionId = firstRuntime.getCurrentSessionId();
+      if (!lockedThreadId || !lockedSessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+        ownerId: 'harness-still-running-owner',
+        ttlMs: 120_000,
+      });
+
+      await secondRuntime.init();
+      expect(secondRuntime.getCurrentThreadId()).not.toBe(lockedThreadId);
+      expect(secondRuntime.getCurrentSessionId()).not.toBe(lockedSessionId);
+    } finally {
+      if (restore === undefined) {
+        delete process.env.MASTRACODE_LEASE_RECOVERY;
+      } else {
+        process.env.MASTRACODE_LEASE_RECOVERY = restore;
+      }
+    }
+  });
+
+  it('warns and ignores an unrecognized MASTRACODE_LEASE_RECOVERY value', async () => {
+    const storage = new InMemoryStore({ id: 'mc-runtime-invalid-env' });
+    const runtime = createRuntime({ storage, projectPath: '/tmp/mastracode-invalid-env' });
+
+    const restore = process.env.MASTRACODE_LEASE_RECOVERY;
+    process.env.MASTRACODE_LEASE_RECOVERY = 'force';
+    const infoMessages: string[] = [];
+    runtime.subscribe(event => {
+      if (event.type === 'info') infoMessages.push(event.message);
+    });
+    try {
+      await runtime.init();
+      expect(runtime.getCurrentSessionId()).toBeDefined();
+      expect(infoMessages.some(m => /invalid MASTRACODE_LEASE_RECOVERY/i.test(m))).toBe(true);
+    } finally {
+      if (restore === undefined) {
+        delete process.env.MASTRACODE_LEASE_RECOVERY;
+      } else {
+        process.env.MASTRACODE_LEASE_RECOVERY = restore;
+      }
+    }
+  });
+
+  it('does not leak the new-thread sentinel when switchThread hits a stale foreign lease', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const storage = new InMemoryStore({ id: 'mc-runtime-switchthread-sentinel' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-switch-sentinel-a' });
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-switch-sentinel-b' });
+
+    try {
+      await firstRuntime.init();
+      const lockedThreadId = firstRuntime.getCurrentThreadId();
+      const lockedSessionId = firstRuntime.getCurrentSessionId();
+      if (!lockedThreadId || !lockedSessionId) throw new Error('expected first runtime to bind a session');
+
+      await secondRuntime.init();
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+        ownerId: 'harness-still-running-owner',
+        ttlMs: 120_000,
+      });
+
+      const restore = process.env.MASTRACODE_LEASE_RECOVERY;
+      process.env.MASTRACODE_LEASE_RECOVERY = 'new-thread';
+      try {
+        const switchPromise = secondRuntime.switchThread({ threadId: lockedThreadId }).catch(err => err);
+        await vi.advanceTimersByTimeAsync(65_000);
+        const err = await switchPromise;
+        // new-thread is not honored from switchThread (caller wants a SPECIFIC
+        // threadId); the env override down-converts to a clean recovery error
+        // instead of leaking MastraCodeLeaseRecoveryNewThreadError.
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).name).toBe('MastraCodeSessionLeaseRecoveryError');
+      } finally {
+        if (restore === undefined) {
+          delete process.env.MASTRACODE_LEASE_RECOVERY;
+        } else {
+          process.env.MASTRACODE_LEASE_RECOVERY = restore;
+        }
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -19,6 +19,7 @@ import type {
 import { convertStoredMessageToHarnessMessage, defaultDisplayState } from '@mastra/core/harness';
 import {
   Harness as HarnessV1,
+  HarnessSessionLockedError,
   getHarnessWorkspaceActionPathInput,
   isHarnessWorkspaceFileMutationTool,
 } from '@mastra/core/harness/v1';
@@ -48,7 +49,11 @@ import {
   toHarnessV1Subagents,
   toModelInfo,
 } from './config.js';
-import type { MastraCodeModelInfo, MastraCodeRuntimeConfig } from './config.js';
+import type {
+  LeaseRecoveryAction,
+  MastraCodeModelInfo,
+  MastraCodeRuntimeConfig,
+} from './config.js';
 import { MastraCodeHarnessEventProjector } from './events.js';
 import { emptyOMProgress, getOMModelState } from './observational-memory.js';
 
@@ -59,6 +64,76 @@ const HARNESS_SESSION_LIFECYCLE_ERROR_NAMES = new Set([
   'HarnessSessionClosingError',
   'HarnessSessionDeletedError',
 ]);
+
+const SESSION_LEASE_RECOVERY_STARTUP_WAIT_MS = 60_000;
+const SESSION_LEASE_RECOVERY_MIDSESSION_WAIT_MS = 2_000;
+const SESSION_LEASE_RETRY_GRACE_MS = 25;
+const SESSION_LEASE_RETRY_MIN_MS = 25;
+const SESSION_LEASE_RETRY_MAX_MS = 5_000;
+const SESSION_LEASE_PROMPT_THRESHOLD_MS = 5_000;
+// Prevent the interactive prompt from suspending the retry loop indefinitely:
+// if no answer arrives within this window, treat it as 'wait' so the runtime
+// keeps polling and can still acquire the lease automatically once expired.
+const SESSION_LEASE_PROMPT_RESPONSE_BUDGET_MS = 30_000;
+
+type LeaseRecoveryMode = 'startup' | 'midsession';
+
+class MastraCodeLeaseRecoveryNewThreadError extends Error {
+  readonly name = 'MastraCodeLeaseRecoveryNewThreadError';
+}
+
+/**
+ * Resolve the lease-recovery action override from `MASTRACODE_LEASE_RECOVERY`.
+ * Returns `{ action }` on a recognized value, `{ invalid }` when the env var
+ * is set to something unrecognized (so the caller can warn), or `{}` when
+ * unset.
+ */
+function resolveLeaseRecoveryEnvOverride(): { action?: LeaseRecoveryAction; invalid?: string } {
+  const raw = process.env.MASTRACODE_LEASE_RECOVERY?.trim().toLowerCase();
+  if (!raw) return {};
+  if (raw === 'wait' || raw === 'force-claim' || raw === 'new-thread' || raw === 'quit') return { action: raw };
+  return { invalid: raw };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function formatRetryDelay(ms: number): string {
+  if (ms < 1_000) return `${ms}ms`;
+  const seconds = ms / 1_000;
+  return `${seconds.toFixed(seconds >= 10 ? 0 : 1)}s`;
+}
+
+function sessionLeaseRetryDelayMs(error: HarnessSessionLockedError): number {
+  const expiresInMs =
+    Number.isFinite(error.expiresAt) && error.expiresAt > 0
+      ? error.expiresAt - Date.now()
+      : SESSION_LEASE_RETRY_MAX_MS;
+  return Math.min(
+    SESSION_LEASE_RETRY_MAX_MS,
+    Math.max(SESSION_LEASE_RETRY_MIN_MS, Math.ceil(expiresInMs + SESSION_LEASE_RETRY_GRACE_MS)),
+  );
+}
+
+export class MastraCodeSessionLeaseRecoveryError extends Error {
+  readonly name = 'MastraCodeSessionLeaseRecoveryError';
+  readonly code = 'mastracode.session_lease_recovery_failed';
+  constructor(
+    public readonly threadId: string,
+    public readonly sessionId: string,
+    public readonly currentOwnerId: string,
+    public readonly expiresAt: number,
+    options?: { cause?: unknown },
+  ) {
+    const expiresIso =
+      Number.isFinite(expiresAt) && expiresAt > 0 ? new Date(expiresAt).toISOString() : 'unknown';
+    super(
+      `MastraCode could not reopen thread "${threadId}" because its Harness v1 session "${sessionId}" is still locked by another process (owner "${currentOwnerId}", lease expires at ${expiresIso}). Another MastraCode instance may still be running. Quit the other instance or retry after the lease expires.`,
+      options,
+    );
+  }
+}
 type MastraCodeOMEvent = Extract<
   HarnessEvent,
   {
@@ -381,6 +456,10 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     };
   }
 
+  getCurrentSessionId(): string | undefined {
+    return this.session?.id;
+  }
+
   private emit(event: HarnessEvent): void {
     for (const listener of this.listeners) {
       try {
@@ -620,7 +699,9 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     }
   }
 
-  async selectOrCreateThread(): Promise<HarnessThread> {
+  async selectOrCreateThread(
+    options: { leaseRecoveryMode?: LeaseRecoveryMode } = {},
+  ): Promise<HarnessThread> {
     const existing = await this.core.threads.list({
       resourceId: this.resourceId,
       perPage: false,
@@ -630,7 +711,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     const existingThread = projectPath
       ? existing.threads.find(thread => thread.metadata?.projectPath === projectPath)
       : existing.threads[0];
-    const thread =
+    let thread =
       existingThread ??
       (await this.core.threads.create({
         resourceId: this.resourceId,
@@ -638,14 +719,22 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
         metadata: this.buildThreadMetadata(),
       }));
     await this.applyThreadMetadata(thread.metadata, { persist: false });
-    this.bindActiveSession(
-      await this.core.session({
+    try {
+      await this.bindSessionForThread(thread.id, options.leaseRecoveryMode ?? 'startup', {
+        allowNewThread: true,
+      });
+    } catch (error) {
+      if (!(error instanceof MastraCodeLeaseRecoveryNewThreadError)) throw error;
+      thread = await this.core.threads.create({
         resourceId: this.resourceId,
-        threadId: thread.id,
-        modeId: this.currentModeId,
-        modelId: this.resolveModeModel(this.currentModeId),
-      }),
-    );
+        title: 'New thread',
+        metadata: this.buildThreadMetadata(),
+      });
+      await this.applyThreadMetadata(thread.metadata, { persist: false });
+      await this.bindSessionForThread(thread.id, options.leaseRecoveryMode ?? 'startup', {
+        allowNewThread: false,
+      });
+    }
     await this.ensureSessionState();
     await this.syncSessionControls();
     await this.resolveWorkspace().catch(() => undefined);
@@ -659,14 +748,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       metadata: this.buildThreadMetadata(),
     });
     await this.applyThreadMetadata(thread.metadata, { persist: false });
-    this.bindActiveSession(
-      await this.core.session({
-        resourceId: this.resourceId,
-        threadId: thread.id,
-        modeId: this.currentModeId,
-        modelId: this.resolveModeModel(this.currentModeId),
-      }),
-    );
+    await this.bindSessionForThread(thread.id, 'startup');
     await this.ensureSessionState();
     await this.syncSessionControls();
     await this.resolveWorkspace().catch(() => undefined);
@@ -680,15 +762,19 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     if (!thread) {
       throw new Error(`Thread not found: ${threadId}`);
     }
+    // Snapshot mode/state so a bind failure (e.g. lease recovery timeout) does
+    // not leave the runtime with the target thread's metadata but the previous
+    // session still bound.
+    const previousModeId = this.currentModeId;
+    const previousState = { ...this.state };
     await this.applyThreadMetadata(thread.metadata, { persist: false });
-    this.bindActiveSession(
-      await this.core.session({
-        resourceId: this.resourceId,
-        threadId,
-        modeId: this.currentModeId,
-        modelId: this.resolveModeModel(this.currentModeId),
-      }),
-    );
+    try {
+      await this.bindSessionForThread(threadId, 'startup');
+    } catch (error) {
+      this.currentModeId = previousModeId;
+      this.state = previousState;
+      throw error;
+    }
     await this.ensureSessionState();
     await this.syncSessionControls();
     await this.resolveWorkspace().catch(() => undefined);
@@ -1603,7 +1689,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
 
   private async ensureSession(): Promise<Session> {
     if (!this.session) {
-      await this.selectOrCreateThread();
+      await this.selectOrCreateThread({ leaseRecoveryMode: 'midsession' });
     }
     return this.requireSession();
   }
@@ -1720,6 +1806,219 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       void this.handleCoreEvent(event).catch(error => {
         this.emitNonLifecycleError(error);
       });
+    });
+  }
+
+  private async bindSessionForThread(
+    threadId: string,
+    mode: LeaseRecoveryMode,
+    options: { allowNewThread?: boolean } = {},
+  ): Promise<void> {
+    this.bindActiveSession(await this.resolveThreadSessionWithLeaseRecovery(threadId, mode, options));
+  }
+
+  private async resolveThreadSessionWithLeaseRecovery(
+    threadId: string,
+    mode: LeaseRecoveryMode,
+    options: { allowNewThread?: boolean } = {},
+  ): Promise<Session> {
+    const allowNewThread = options.allowNewThread ?? false;
+    const maxWaitMs =
+      mode === 'startup'
+        ? SESSION_LEASE_RECOVERY_STARTUP_WAIT_MS
+        : SESSION_LEASE_RECOVERY_MIDSESSION_WAIT_MS;
+    const startedAt = Date.now();
+    let attempt = 0;
+    const envOverride = resolveLeaseRecoveryEnvOverride();
+    if (envOverride.invalid) {
+      this.emit({
+        type: 'info',
+        message: `Ignoring invalid MASTRACODE_LEASE_RECOVERY="${envOverride.invalid}"; expected wait|force-claim|new-thread|quit.`,
+      });
+    }
+    const envAction = envOverride.action;
+    const envQuit = envAction === 'quit';
+    const envNewThread = envAction === 'new-thread';
+    // `chosenPolicy === 'force-claim'` persists across owner changes so a race
+    // where another process re-acquires the lease between releaseSessionLease
+    // and the next core.session() does NOT silently downgrade the user's
+    // explicit force-claim choice back to wait-and-fail.
+    let chosenPolicy: 'force-claim' | undefined = envAction === 'force-claim' ? 'force-claim' : undefined;
+    // `MASTRACODE_LEASE_RECOVERY=wait` is an explicit "always wait, never prompt"
+    // policy. The prompt threshold is suppressed so the loop simply retries
+    // until maxWaitMs or successful acquisition.
+    let promptInvoked = envAction === 'wait' || mode !== 'startup' || !this.config.leaseRecoveryPrompt;
+    const promptHandler = mode === 'startup' ? this.config.leaseRecoveryPrompt : undefined;
+    let infoHintEmitted = false;
+
+    for (;;) {
+      try {
+        const session = await this.core.session({
+          resourceId: this.resourceId,
+          threadId,
+          modeId: this.currentModeId,
+          modelId: this.resolveModeModel(this.currentModeId),
+        });
+        if (attempt > 0) {
+          this.emit({
+            type: 'info',
+            message: 'Recovered the previous MastraCode Harness session after its stale lease expired.',
+          });
+        }
+        return session;
+      } catch (error) {
+        if (!(error instanceof HarnessSessionLockedError)) throw error;
+        attempt += 1;
+        const elapsedMs = Date.now() - startedAt;
+
+        if (envQuit) {
+          throw new MastraCodeSessionLeaseRecoveryError(
+            threadId,
+            error.sessionId,
+            error.currentOwnerId,
+            error.expiresAt,
+            { cause: error },
+          );
+        }
+        if (envNewThread) {
+          if (allowNewThread) throw new MastraCodeLeaseRecoveryNewThreadError();
+          // Caller (createThread/switchThread) needs a specific threadId and
+          // cannot honor the new-thread request — fail fast with a clean
+          // recovery error rather than the internal sentinel.
+          throw new MastraCodeSessionLeaseRecoveryError(
+            threadId,
+            error.sessionId,
+            error.currentOwnerId,
+            error.expiresAt,
+            { cause: error },
+          );
+        }
+
+        if (chosenPolicy === 'force-claim') {
+          try {
+            await this.forceReleaseForeignLease(error.sessionId, error.currentOwnerId);
+          } catch (releaseErr) {
+            throw new MastraCodeSessionLeaseRecoveryError(
+              threadId,
+              error.sessionId,
+              error.currentOwnerId,
+              error.expiresAt,
+              { cause: releaseErr },
+            );
+          }
+          this.emit({
+            type: 'info',
+            message: `Released the MastraCode Harness session lease previously owned by "${error.currentOwnerId}"; retrying acquisition.`,
+          });
+          continue;
+        }
+
+        if (!promptInvoked && mode === 'startup' && elapsedMs >= SESSION_LEASE_PROMPT_THRESHOLD_MS) {
+          promptInvoked = true;
+          // Race the prompt against a bounded response budget so a user who
+          // walks away from the terminal does NOT defeat the documented
+          // 60s automatic-wait guarantee. When the budget wins the loop
+          // resumes retrying as if 'wait' was chosen.
+          const rawAction: LeaseRecoveryAction = promptHandler
+            ? await Promise.race([
+                Promise.resolve(
+                  promptHandler({
+                    threadId,
+                    sessionId: error.sessionId,
+                    currentOwnerId: error.currentOwnerId,
+                    expiresAt: error.expiresAt,
+                    secondsWaited: Math.round(elapsedMs / 1000),
+                    allowNewThread,
+                  }),
+                ),
+                sleep(SESSION_LEASE_PROMPT_RESPONSE_BUDGET_MS).then<LeaseRecoveryAction>(() => 'wait'),
+              ])
+            : 'wait';
+          // Direct thread API callers (createThread / switchThread) cannot
+          // honor a new-thread choice — they must bind a specific threadId.
+          // Down-convert to quit so the caller sees a clean recovery error
+          // instead of the internal sentinel leaking out.
+          const action: LeaseRecoveryAction =
+            rawAction === 'new-thread' && !allowNewThread ? 'quit' : rawAction;
+          if (action === 'force-claim') {
+            chosenPolicy = 'force-claim';
+            try {
+              await this.forceReleaseForeignLease(error.sessionId, error.currentOwnerId);
+            } catch (releaseErr) {
+              throw new MastraCodeSessionLeaseRecoveryError(
+                threadId,
+                error.sessionId,
+                error.currentOwnerId,
+                error.expiresAt,
+                { cause: releaseErr },
+              );
+            }
+            this.emit({
+              type: 'info',
+              message: `Released the MastraCode Harness session lease previously owned by "${error.currentOwnerId}"; retrying acquisition.`,
+            });
+            continue;
+          }
+          if (action === 'new-thread') {
+            throw new MastraCodeLeaseRecoveryNewThreadError();
+          }
+          if (action === 'quit') {
+            throw new MastraCodeSessionLeaseRecoveryError(
+              threadId,
+              error.sessionId,
+              error.currentOwnerId,
+              error.expiresAt,
+              { cause: error },
+            );
+          }
+        }
+
+        const rawRetryDelayMs = sessionLeaseRetryDelayMs(error);
+        const remainingMs = maxWaitMs - elapsedMs;
+        if (remainingMs <= 0) {
+          throw new MastraCodeSessionLeaseRecoveryError(
+            threadId,
+            error.sessionId,
+            error.currentOwnerId,
+            error.expiresAt,
+            { cause: error },
+          );
+        }
+        // Cap the next sleep at the remaining budget so total wait never
+        // exceeds maxWaitMs by more than ~one storage round-trip.
+        const retryDelayMs = Math.min(rawRetryDelayMs, remainingMs);
+        const expiresLabel =
+          Number.isFinite(error.expiresAt) && error.expiresAt > 0
+            ? new Date(error.expiresAt).toLocaleTimeString()
+            : 'an unknown time';
+        // Show the env-var hint on the first wait message only; subsequent
+        // retries just say "still waiting" to avoid log spam.
+        const hint = infoHintEmitted
+          ? ''
+          : ' Set MASTRACODE_LEASE_RECOVERY=force-claim to take the lease immediately if the other process is known dead.';
+        infoHintEmitted = true;
+        this.emit({
+          type: 'info',
+          message: `A previous MastraCode Harness session lease is still held by another process until ${expiresLabel}; retrying in ${formatRetryDelay(retryDelayMs)}.${hint}`,
+        });
+        await sleep(retryDelayMs);
+      }
+    }
+  }
+
+  private async forceReleaseForeignLease(sessionId: string, ownerId: string): Promise<void> {
+    const harnessStorage = (await this.config.storage.getStore('harness')) as
+      | {
+          releaseSessionLease?: (opts: { harnessName: string; sessionId: string; ownerId: string }) => Promise<void>;
+        }
+      | undefined;
+    if (!harnessStorage || typeof harnessStorage.releaseSessionLease !== 'function') {
+      throw new Error('MastraCode Harness storage does not expose releaseSessionLease; cannot force-claim session lease.');
+    }
+    await harnessStorage.releaseSessionLease({
+      harnessName: MASTRACODE_HARNESS_NAME,
+      sessionId,
+      ownerId,
     });
   }
 

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -42,7 +42,8 @@ import { createDynamicTools } from './agents/tools.js';
 import { getDynamicWorkspace } from './agents/workspace.js';
 import { AuthStorage } from './auth/storage.js';
 import { createOutcomeScorer, createEfficiencyScorer } from './evals/scorers/index.js';
-import { createHarnessV1SubagentAgents, MastraCodeHarnessRuntime } from './harness/index.js';
+import { createHarnessV1SubagentAgents, defaultStdioLeaseRecoveryPrompt, MastraCodeHarnessRuntime } from './harness/index.js';
+import type { LeaseRecoveryPromptHandler } from './harness/index.js';
 import { HookManager } from './hooks/index.js';
 import { createMcpManager } from './mcp/index.js';
 import type { McpServerConfig } from './mcp/index.js';
@@ -138,7 +139,25 @@ export interface MastraCodeConfig {
   unixSocketPubSub?: boolean;
   /** Marks the configured PubSub as cross-process-safe, allowing Mastra Code to skip file thread locks. */
   crossProcessPubSub?: boolean;
+  /**
+   * Interactive prompt invoked during startup when a stale Harness v1 session
+   * lease is still held by another process. Defaults to a stdio readline
+   * prompt when stdin is a TTY (`(W)ait/(F)orce-claim/(N)ew thread/(Q)uit`).
+   * Set `MASTRACODE_LEASE_RECOVERY=wait|force-claim|new-thread|quit` to skip
+   * the prompt programmatically.
+   */
+  leaseRecoveryPrompt?: LeaseRecoveryPromptHandler;
 }
+
+export {
+  MastraCodeSessionLeaseRecoveryError,
+  defaultStdioLeaseRecoveryPrompt,
+} from './harness/index.js';
+export type {
+  LeaseRecoveryAction,
+  LeaseRecoveryPromptInfo,
+  LeaseRecoveryPromptHandler,
+} from './harness/index.js';
 
 export type MastraCodeHarnessPublic = Harness<Record<string, unknown>> & {
   actions: MastraCodeHarnessRuntime<Record<string, unknown>>['actions'];
@@ -670,6 +689,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     resolveModel,
     disabledTools: config?.disabledTools,
     browser: config?.browser,
+    leaseRecoveryPrompt: config?.leaseRecoveryPrompt ?? defaultStdioLeaseRecoveryPrompt(),
   });
 
   // Sync hookManager session ID on thread changes

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -23,16 +23,34 @@ let hookManager: Awaited<ReturnType<typeof createMastraCode>>['hookManager'];
 let authStorage: Awaited<ReturnType<typeof createMastraCode>>['authStorage'];
 let signalsPubSub: Awaited<ReturnType<typeof createMastraCode>>['signalsPubSub'];
 let analytics: ReturnType<typeof createMastraCodeAnalytics> | undefined;
+let activeTui: MastraTUI | undefined;
+
+// Reset extended terminal modes (bracketed paste, kitty progressive-enhancement
+// keyboard protocol, modifyOtherKeys) that pi-tui enables at startup. pi-tui
+// restores these via `TUI.stop()` on a clean exit, but a SIGKILL or unhandled
+// crash leaves the parent shell stuck — every subsequent keypress emits raw
+// CSI-u sequences. Calling this on every trappable exit path AND once at
+// launch time recovers cleanly from a previous ungraceful exit.
+function restoreTerminalKeyboardModes(): void {
+  if (!process.stdout.isTTY) return;
+  // \x1b[<u  — pop kitty kbd protocol layer
+  // \x1b[>4;0m — disable xterm modifyOtherKeys mode 2
+  // \x1b[?2004l — disable bracketed paste
+  // \x1b[?1l — leave cursor-key application mode
+  process.stdout.write('\x1b[<u\x1b[>4;0m\x1b[?2004l\x1b[?1l');
+}
 
 // Global safety nets — catch any uncaught errors from storage init, etc.
 process.on('uncaughtException', error => {
   // ERR_STREAM_DESTROYED is non-fatal — happens routinely when streams close
   // during shutdown, cancelled LLM requests, or LSP/subprocess exits (#13548, #13549)
   if (isStreamDestroyedError(error)) return;
+  restoreTerminalKeyboardModes();
   handleFatalError(error);
 });
 process.on('unhandledRejection', reason => {
   if (isStreamDestroyedError(reason)) return;
+  restoreTerminalKeyboardModes();
   handleFatalError(reason instanceof Error ? reason : new Error(String(reason)));
 });
 
@@ -104,6 +122,7 @@ async function tuiMain(pipedInput?: string | null) {
     inlineQuestions: true,
     ...(pipedInput ? { initialMessage: `The following was piped via stdin:\n\n${pipedInput}` } : {}),
   });
+  activeTui = tui;
   tui.run().catch(error => {
     handleFatalError(error);
   });
@@ -134,13 +153,23 @@ process.on('beforeExit', () => {
   void asyncCleanup();
 });
 process.on('exit', () => {
+  restoreTerminalKeyboardModes();
   restoreTerminalForeground();
   releaseAllThreadLocks();
 });
 process.on('SIGINT', () => {
+  activeTui?.stop();
+  restoreTerminalKeyboardModes();
   void asyncCleanup().finally(() => process.exit(0));
 });
 process.on('SIGTERM', () => {
+  activeTui?.stop();
+  restoreTerminalKeyboardModes();
+  void asyncCleanup().finally(() => process.exit(0));
+});
+process.on('SIGHUP', () => {
+  activeTui?.stop();
+  restoreTerminalKeyboardModes();
   void asyncCleanup().finally(() => process.exit(0));
 });
 
@@ -185,6 +214,10 @@ function handleFatalError(error: unknown): never {
 }
 
 async function main() {
+  // Recover from a possibly broken terminal left by a prior crashed instance
+  // (SIGKILL, OOM, etc) before pi-tui re-enables its extended modes. Safe to
+  // emit unconditionally — codes are no-ops on a clean terminal.
+  restoreTerminalKeyboardModes();
   if (hasHeadlessFlag(process.argv) || process.argv.includes('--help') || process.argv.includes('-h')) {
     return headlessMain();
   }

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -8,6 +8,7 @@ import type { Component } from '@mariozechner/pi-tui';
 import type { HarnessEvent, HarnessMessage } from '@mastra/core/harness';
 import type { Workspace } from '@mastra/core/workspace';
 import { getOAuthProviders } from '../auth/storage.js';
+import { MastraCodeSessionLeaseRecoveryError } from '../harness/index.js';
 import {
   OnboardingInlineComponent,
   getAvailableModePacks,
@@ -514,8 +515,21 @@ export class MastraTUI {
   private async init(): Promise<void> {
     if (this.state.isInitialized) return;
 
-    // Initialize harness (but don't select thread yet)
-    await this.state.harness.init();
+    const unsubscribeStartupInfo = this.state.harness.subscribe((event: HarnessEvent) => {
+      if (event.type === 'info') {
+        process.stderr.write(`${event.message}\n`);
+      }
+    });
+    try {
+      await this.state.harness.init();
+    } catch (err) {
+      if (err instanceof MastraCodeSessionLeaseRecoveryError) {
+        process.stderr.write(`${err.message}\n`);
+      }
+      throw err;
+    } finally {
+      unsubscribeStartupInfo();
+    }
 
     // Check for existing threads and prompt for resume
     await promptForThreadSelection(this.state);


### PR DESCRIPTION
A crashed or killed MastraCode used to block the next launch with an opaque error because the dead process left its v1 session lease in storage until TTL. The runtime now waits the lease out and adopts the previous session once it's free.

Before:

```
$ mastracode
HarnessSessionLockedError: Session "sess-..." is locked by owner "harness-..." until 2026-05-26T13:32:01.000Z
```

After:

```
$ mastracode
A previous MastraCode Harness session lease is still held by another process until 14:32:01; retrying in 5.0s. Set MASTRACODE_LEASE_RECOVERY=force-claim to take the lease immediately if the other process is known dead.
Recovered the previous MastraCode Harness session after its stale lease expired.
(TUI loads)
```

On a TTY, after 5 seconds of waiting, an interactive `(W)ait / (F)orce-claim / (N)ew thread / (Q)uit` prompt is shown with a 30s response budget so an unattended terminal still recovers automatically. For scripts and CI, `MASTRACODE_LEASE_RECOVERY=wait|force-claim|new-thread|quit` skips the prompt.

On exhaustion, `MastraCodeSessionLeaseRecoveryError` is thrown (exported from `mastracode`) carrying the underlying `HarnessSessionLockedError` as `cause` and the `sessionId/currentOwnerId/expiresAt` fields for downstream handlers.

Also bundles a small fix for the related terminal-state issue surfaced by the same crash scenario: pi-tui's extended keyboard modes used to stick around after a SIGKILL'd mastracode, leaving the parent shell stuck emitting raw CSI-u keypress sequences. `main.ts` now restores the terminal on every trappable exit signal and once at launch so the next mastracode invocation heals any prior breakage.

Stacked on #17042 because the v1 runtime only exists on that base. Rebase target after that lands will be `feat/mastracode-harness-v1-runtime`.

Closes MASTRA-4344.