### PR TITLE
fix(mastracode): decode kitty CSI-u keys for tool approval shortcuts

### DIFF
--- a/.changeset/five-regions-kick.md
+++ b/.changeset/five-regions-kick.md
@@ -1,0 +1,11 @@
+---
+'mastracode': patch
+---
+
+**Fixed tool approval and other in-app keyboard shortcuts in modern terminals.**
+
+In iTerm2, Ghostty, WezTerm, kitty and similar terminals, pressing `y` / `n` / `a` / `Y` on the tool approval dialog did nothing. The same was true for the `r` key on `/mcp` (reload servers), the `c` key on `/threads` (clone thread), and the space / enter shortcut on multi-step progress collapse.
+
+The root cause was the Kitty keyboard protocol that pi-tui enables on supported terminals: printable keys arrive as CSI-u escape sequences (`\x1b[121u` for `y`) instead of raw bytes, so direct character comparisons silently dropped every press. Apple Terminal.app wasn't affected because it doesn't advertise the protocol.
+
+All four surfaces now decode through pi-tui's `parseKey` so the same shortcut works regardless of which keyboard protocol the terminal negotiates. `Shift+y` correctly maps to the uppercase `Y` YOLO shortcut; `Ctrl+Y` and `Alt+Y` no longer alias `Y`.

--- a/.changeset/five-regions-kick.md
+++ b/.changeset/five-regions-kick.md
@@ -8,4 +8,4 @@ In iTerm2, Ghostty, WezTerm, kitty and similar terminals, pressing `y` / `n` / `
 
 The root cause was the Kitty keyboard protocol that pi-tui enables on supported terminals: printable keys arrive as CSI-u escape sequences (`\x1b[121u` for `y`) instead of raw bytes, so direct character comparisons silently dropped every press. Apple Terminal.app wasn't affected because it doesn't advertise the protocol.
 
-All four surfaces now decode through pi-tui's `parseKey` so the same shortcut works regardless of which keyboard protocol the terminal negotiates. `Shift+y` correctly maps to the uppercase `Y` YOLO shortcut; `Ctrl+Y` and `Alt+Y` no longer alias `Y`.
+All four surfaces now decode their shortcut keys through pi-tui's keyboard helpers so the same press works regardless of which keyboard protocol the terminal negotiates. `Shift+y` correctly maps to the uppercase `Y` YOLO shortcut; `Ctrl+Y` and `Alt+Y` no longer alias `Y`.

--- a/mastracode/src/tui/__tests__/key-input.test.ts
+++ b/mastracode/src/tui/__tests__/key-input.test.ts
@@ -4,12 +4,9 @@ import { decodePrintableShortcut } from '../key-input.js';
 
 describe('decodePrintableShortcut', () => {
   describe('literal single-character input', () => {
-    it.each([['y'], ['n'], ['a'], ['Y'], ['c'], ['r'], ['0'], ['?']])(
-      'returns the literal %j unchanged',
-      input => {
-        expect(decodePrintableShortcut(input)).toBe(input);
-      },
-    );
+    it.each([['y'], ['n'], ['a'], ['Y'], ['c'], ['r'], ['0'], ['?']])('returns the literal %j unchanged', input => {
+      expect(decodePrintableShortcut(input)).toBe(input);
+    });
 
     it('rejects control characters', () => {
       expect(decodePrintableShortcut('\x03')).toBeUndefined();
@@ -113,12 +110,9 @@ describe('decodePrintableShortcut', () => {
   });
 
   describe('non-printable and malformed input', () => {
-    it.each([['\x1b[A'], ['\x1b[B'], ['\r'], ['\t']])(
-      'returns undefined for navigation/whitespace key %j',
-      input => {
-        expect(decodePrintableShortcut(input)).toBeUndefined();
-      },
-    );
+    it.each([['\x1b[A'], ['\x1b[B'], ['\r'], ['\t']])('returns undefined for navigation/whitespace key %j', input => {
+      expect(decodePrintableShortcut(input)).toBeUndefined();
+    });
 
     it.each([['\x1b[u'], ['\x1b[abcu'], [''], ['yes']])(
       'returns undefined for malformed/multi-byte input %j',

--- a/mastracode/src/tui/__tests__/key-input.test.ts
+++ b/mastracode/src/tui/__tests__/key-input.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodePrintableShortcut } from '../key-input.js';
+
+describe('decodePrintableShortcut', () => {
+  describe('literal single-character input', () => {
+    it.each([['y'], ['n'], ['a'], ['Y'], ['c'], ['r'], ['0'], ['?']])(
+      'returns the literal %j unchanged',
+      input => {
+        expect(decodePrintableShortcut(input)).toBe(input);
+      },
+    );
+
+    it('rejects control characters', () => {
+      expect(decodePrintableShortcut('\x03')).toBeUndefined();
+      expect(decodePrintableShortcut('\x1b')).toBeUndefined();
+    });
+  });
+
+  describe('Kitty CSI-u printables', () => {
+    it.each([
+      ['\x1b[121u', 'y'],
+      ['\x1b[110u', 'n'],
+      ['\x1b[97u', 'a'],
+      ['\x1b[99u', 'c'],
+      ['\x1b[114u', 'r'],
+    ])('decodes %j as %j', (input, expected) => {
+      expect(decodePrintableShortcut(input)).toBe(expected);
+    });
+
+    it('returns undefined for non-letter keys parseKey resolves to a name (e.g. space)', () => {
+      // `parseKey(' ')` returns the semantic name `'space'`, not the byte;
+      // callers that care about space should use pi-tui's `matchesKey`
+      // primitive instead of this helper.
+      expect(decodePrintableShortcut(' ')).toBeUndefined();
+      expect(decodePrintableShortcut('\x1b[32u')).toBeUndefined();
+    });
+
+    it('decodes plain CSI-u with explicit no-modifier (mod=1)', () => {
+      expect(decodePrintableShortcut('\x1b[121;1u')).toBe('y');
+    });
+
+    it.each([
+      // Base codepoint + shift modifier — terminals without alternate-keys flag.
+      ['\x1b[121;2u', 'Y'],
+      // Shifted codepoint reported directly.
+      ['\x1b[89;2u', 'Y'],
+      // Alternate-keys form: codepoint:shifted:base ; modifier.
+      ['\x1b[121:89:121;2u', 'Y'],
+    ])('decodes Shift+y form %j as %j', (input, expected) => {
+      expect(decodePrintableShortcut(input)).toBe(expected);
+    });
+
+    it('rejects Ctrl-modified printables', () => {
+      expect(decodePrintableShortcut('\x1b[121;5u')).toBeUndefined();
+    });
+
+    it('rejects Alt-modified printables', () => {
+      expect(decodePrintableShortcut('\x1b[121;3u')).toBeUndefined();
+    });
+
+    it('rejects Ctrl+Shift-modified printables', () => {
+      expect(decodePrintableShortcut('\x1b[121;6u')).toBeUndefined();
+    });
+
+    it.each([
+      // Kitty event-type suffix: ":1" = press, ":2" = repeat, ":3" = release.
+      // The TUI filters releases above the component layer; press/repeat
+      // arrive here and must still decode.
+      ['\x1b[121;2:1u', 'Y', 'Shift+y press with explicit event type'],
+      ['\x1b[121;2:2u', 'Y', 'Shift+y repeat'],
+    ])('decodes Kitty event-suffix form %j as %j (%s)', (input, expected) => {
+      expect(decodePrintableShortcut(input)).toBe(expected);
+    });
+
+    it.each([
+      // pi-tui keeps shifted digits/symbols as their semantic key id, not as
+      // the resulting glyph. Callers that need them must use matchesKey.
+      ['\x1b[49;2u', 'Shift+1 base codepoint'],
+      ['\x1b[33;2u', 'Shift+1 shifted codepoint (!)'],
+    ])('returns undefined for shifted non-letter %j (%s)', input => {
+      expect(decodePrintableShortcut(input)).toBeUndefined();
+    });
+  });
+
+  describe('xterm modifyOtherKeys printables', () => {
+    it.each([
+      ['\x1b[27;1;121~', 'y'],
+      ['\x1b[27;1;110~', 'n'],
+      ['\x1b[27;1;97~', 'a'],
+      ['\x1b[27;1;99~', 'c'],
+      ['\x1b[27;1;114~', 'r'],
+    ])('decodes %j as %j (no modifier)', (input, expected) => {
+      expect(decodePrintableShortcut(input)).toBe(expected);
+    });
+
+    it.each([
+      // Shift+y with the base codepoint.
+      ['\x1b[27;2;121~', 'Y'],
+      // Shift+y with the shifted codepoint.
+      ['\x1b[27;2;89~', 'Y'],
+    ])('decodes Shift+y form %j as %j', (input, expected) => {
+      expect(decodePrintableShortcut(input)).toBe(expected);
+    });
+
+    it('rejects Ctrl-modified modifyOtherKeys printables', () => {
+      expect(decodePrintableShortcut('\x1b[27;5;121~')).toBeUndefined();
+    });
+
+    it('rejects Alt-modified modifyOtherKeys printables', () => {
+      expect(decodePrintableShortcut('\x1b[27;3;121~')).toBeUndefined();
+    });
+  });
+
+  describe('non-printable and malformed input', () => {
+    it.each([['\x1b[A'], ['\x1b[B'], ['\r'], ['\t']])(
+      'returns undefined for navigation/whitespace key %j',
+      input => {
+        expect(decodePrintableShortcut(input)).toBeUndefined();
+      },
+    );
+
+    it.each([['\x1b[u'], ['\x1b[abcu'], [''], ['yes']])(
+      'returns undefined for malformed/multi-byte input %j',
+      input => {
+        expect(decodePrintableShortcut(input)).toBeUndefined();
+      },
+    );
+  });
+});

--- a/mastracode/src/tui/components/__tests__/tool-approval-dialog.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-approval-dialog.test.ts
@@ -1,0 +1,185 @@
+import type * as PiTui from '@mariozechner/pi-tui';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@mariozechner/pi-tui', async () => {
+  const actual = await vi.importActual<typeof PiTui>('@mariozechner/pi-tui');
+
+  class MockNode {
+    children: any[] = [];
+    addChild(child: any) {
+      this.children.push(child);
+      return child;
+    }
+  }
+
+  class Box extends MockNode {
+    constructor(..._args: any[]) {
+      super();
+    }
+  }
+
+  class Text {
+    constructor(
+      public text: string,
+      public x = 0,
+      public y = 0,
+    ) {}
+    render() {
+      return [this.text];
+    }
+  }
+
+  class Spacer {
+    constructor(public size: number) {}
+  }
+
+  return {
+    ...actual,
+    Box,
+    Text,
+    Spacer,
+    getKeybindings: () => ({
+      matches: (data: string, action: string) => {
+        if (action === 'tui.select.cancel') return data === '\x1b' || data === 'ESC';
+        return false;
+      },
+    }),
+  };
+});
+
+vi.mock('../../theme.js', () => ({
+  theme: {
+    bg: (_token: string, text: string) => text,
+    fg: (_token: string, text: string) => text,
+    getTheme: () => ({ dim: '#888888', text: '#ffffff' }),
+  },
+}));
+
+import { ToolApprovalDialogComponent } from '../tool-approval-dialog.js';
+
+function makeDialog(onAction = vi.fn()) {
+  const dialog = new ToolApprovalDialogComponent({
+    toolCallId: 'call-1',
+    toolName: 'shell',
+    args: { command: 'ls' },
+    categoryLabel: 'Execute',
+    onAction,
+  });
+  return { dialog, onAction };
+}
+
+describe('ToolApprovalDialogComponent.handleInput', () => {
+  describe('literal byte input (Apple Terminal.app and friends)', () => {
+    it('approves on y', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('y');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'approve' });
+    });
+
+    it('declines on n', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('n');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'decline' });
+    });
+
+    it('always-allows-category on a', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('a');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'always_allow_category' });
+    });
+
+    it('switches to yolo on Y, not approve', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('Y');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'yolo' });
+    });
+
+    it('declines on Escape', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('\x1b');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'decline' });
+    });
+  });
+
+  describe('Kitty CSI-u input (iTerm2 / Ghostty / WezTerm / kitty)', () => {
+    it('approves on CSI-u y', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('\x1b[121u');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'approve' });
+    });
+
+    it('declines on CSI-u n', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('\x1b[110u');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'decline' });
+    });
+
+    it('always-allows-category on CSI-u a', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('\x1b[97u');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'always_allow_category' });
+    });
+
+    it.each([
+      ['\x1b[121;2u', 'Shift+y base codepoint'],
+      ['\x1b[89;2u', 'Shift+y shifted codepoint'],
+      ['\x1b[121:89:121;2u', 'Shift+y alternate-keys form'],
+    ])('switches to yolo on %j (%s)', input => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput(input);
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'yolo' });
+    });
+  });
+
+  describe('modifyOtherKeys input (xterm fallback)', () => {
+    it('approves on modifyOtherKeys y', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('\x1b[27;1;121~');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'approve' });
+    });
+
+    it('switches to yolo on modifyOtherKeys Shift+y', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('\x1b[27;2;121~');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'yolo' });
+    });
+  });
+
+  describe('modifier rejection', () => {
+    it.each([
+      ['\x1b[121;5u', 'Ctrl+y'],
+      ['\x1b[121;3u', 'Alt+y'],
+      ['\x1b[27;5;121~', 'modifyOtherKeys Ctrl+y'],
+      ['\x1b[27;3;121~', 'modifyOtherKeys Alt+y'],
+    ])('does not fire onAction for %s (%j)', input => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput(input);
+      expect(onAction).not.toHaveBeenCalled();
+    });
+
+    it('ignores raw Ctrl+C (no escape-equivalent mapping)', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('\x03');
+      expect(onAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('one-shot guard', () => {
+    it('fires onAction at most once across repeated presses', () => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput('y');
+      dialog.handleInput('y');
+      dialog.handleInput('Y');
+      dialog.handleInput('n');
+      expect(onAction).toHaveBeenCalledExactlyOnceWith({ type: 'approve' });
+    });
+  });
+
+  describe('unrelated input', () => {
+    it.each([['\t'], ['\x1b[A'], ['x'], ['1'], ['']])('ignores %j', input => {
+      const { dialog, onAction } = makeDialog();
+      dialog.handleInput(input);
+      expect(onAction).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/mastracode/src/tui/components/mcp-selector.ts
+++ b/mastracode/src/tui/components/mcp-selector.ts
@@ -7,6 +7,7 @@ import { Box, Container, getKeybindings, Spacer, Text } from '@mariozechner/pi-t
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import type { McpServerStatus, McpSkippedServer } from '../../mcp/types.js';
+import { decodePrintableShortcut } from '../key-input.js';
 import { theme } from '../theme.js';
 
 // =============================================================================
@@ -301,7 +302,7 @@ export class McpSelectorComponent extends Box implements Focusable {
       // Skipped servers have no sub-menu actions
     }
     // 'r' — reload all servers
-    else if (data === 'r') {
+    else if (decodePrintableShortcut(data) === 'r') {
       this.doReloadAll();
     }
     // Escape or Ctrl+C

--- a/mastracode/src/tui/components/multi-step-progress.ts
+++ b/mastracode/src/tui/components/multi-step-progress.ts
@@ -3,7 +3,7 @@
  * Shows detailed progress with steps, timing, and visual feedback.
  */
 
-import { Container, Text, Spacer } from '@mariozechner/pi-tui';
+import { Container, matchesKey, Text, Spacer } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import { theme, mastra } from '../theme.js';
 
@@ -257,7 +257,7 @@ export class MultiStepProgressComponent extends Container {
    * Handle keyboard input for expanding/collapsing.
    */
   handleInput(data: string): boolean {
-    if (data === ' ' || data === '\r') {
+    if (matchesKey(data, 'space') || matchesKey(data, 'enter')) {
       this.toggleCollapsed();
       return true;
     }

--- a/mastracode/src/tui/components/thread-selector.ts
+++ b/mastracode/src/tui/components/thread-selector.ts
@@ -6,6 +6,7 @@
 import { Box, Container, fuzzyFilter, getKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import type { HarnessThread } from '@mastra/core/harness';
+import { decodePrintableShortcut } from '../key-input.js';
 import { theme } from '../theme.js';
 
 // =============================================================================
@@ -350,7 +351,11 @@ export class ThreadSelectorComponent extends Box implements Focusable {
       }
     } else if (kb.matches(keyData, 'tui.select.cancel')) {
       this.onCancelCallback();
-    } else if (keyData === 'c' && this.onCloneCallback && !this.searchInput.getValue()) {
+    } else if (
+      decodePrintableShortcut(keyData) === 'c' &&
+      this.onCloneCallback &&
+      !this.searchInput.getValue()
+    ) {
       const selected = this.filteredThreads[this.selectedIndex];
       if (selected) {
         this.onCloneCallback(selected);

--- a/mastracode/src/tui/components/thread-selector.ts
+++ b/mastracode/src/tui/components/thread-selector.ts
@@ -351,11 +351,7 @@ export class ThreadSelectorComponent extends Box implements Focusable {
       }
     } else if (kb.matches(keyData, 'tui.select.cancel')) {
       this.onCancelCallback();
-    } else if (
-      decodePrintableShortcut(keyData) === 'c' &&
-      this.onCloneCallback &&
-      !this.searchInput.getValue()
-    ) {
+    } else if (decodePrintableShortcut(keyData) === 'c' && this.onCloneCallback && !this.searchInput.getValue()) {
       const selected = this.filteredThreads[this.selectedIndex];
       if (selected) {
         this.onCloneCallback(selected);

--- a/mastracode/src/tui/components/tool-approval-dialog.ts
+++ b/mastracode/src/tui/components/tool-approval-dialog.ts
@@ -12,6 +12,7 @@ import { Box, getKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable } from '@mariozechner/pi-tui';
 import { safeStringify } from '@mastra/core/utils';
 import chalk from 'chalk';
+import { decodePrintableShortcut } from '../key-input.js';
 import { theme } from '../theme.js';
 
 export type ApprovalAction =
@@ -34,6 +35,7 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
   private args: unknown;
   private categoryLabel: string | undefined;
   private onAction: (action: ApprovalAction) => void;
+  private resolved = false;
 
   // Focusable implementation
   private _focused = false;
@@ -131,24 +133,35 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
     return lines.join('\n');
   }
 
+  private emit(action: ApprovalAction): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.onAction(action);
+  }
+
   handleInput(data: string): void {
+    if (this.resolved) return;
     const kb = getKeybindings();
 
     // Escape to decline
     if (kb.matches(data, 'tui.select.cancel')) {
-      this.onAction({ type: 'decline' });
+      this.emit({ type: 'decline' });
       return;
     }
 
-    // Single keypress shortcuts
-    if (data === 'y') {
-      this.onAction({ type: 'approve' });
-    } else if (data === 'n') {
-      this.onAction({ type: 'decline' });
-    } else if (data === 'a') {
-      this.onAction({ type: 'always_allow_category' });
-    } else if (data === 'Y') {
-      this.onAction({ type: 'yolo' });
+    switch (decodePrintableShortcut(data)) {
+      case 'y':
+        this.emit({ type: 'approve' });
+        break;
+      case 'n':
+        this.emit({ type: 'decline' });
+        break;
+      case 'a':
+        this.emit({ type: 'always_allow_category' });
+        break;
+      case 'Y':
+        this.emit({ type: 'yolo' });
+        break;
     }
   }
 

--- a/mastracode/src/tui/key-input.ts
+++ b/mastracode/src/tui/key-input.ts
@@ -1,0 +1,31 @@
+/**
+ * Decode a terminal input sequence into a single-character shortcut.
+ *
+ * pi-tui pushes the Kitty keyboard protocol when supported, so printable keys
+ * arrive as CSI-u sequences (`\x1b[121u` for `y`) instead of raw bytes —
+ * leaving `data === 'y'` style comparisons silently dropping every press.
+ * Falls back to xterm modifyOtherKeys (`\x1b[27;<mod>;<cp>~`) for terminals
+ * without Kitty support.
+ *
+ * `Shift+<letter>` decodes to the uppercase letter so `Y`-vs-`y` shortcuts
+ * survive both encodings. Shifted digits and symbols (`shift+1`, `shift+!`,
+ * etc.) return `undefined` because pi-tui's `parseKey` does not collapse
+ * them to a single shifted character. Ctrl/Alt/Super and non-printable keys
+ * return `undefined` so modifier-bearing variants never alias a shortcut.
+ *
+ * Only letter shortcuts are part of this helper's supported contract.
+ * Callers that want to react to space, digits-with-shift, or function keys
+ * should use pi-tui's `matchesKey` directly.
+ */
+import { parseKey } from '@mariozechner/pi-tui';
+
+const SHIFT_LETTER_RE = /^shift\+([a-z])$/;
+
+export function decodePrintableShortcut(data: string): string | undefined {
+  const key = parseKey(data);
+  if (key === undefined) return undefined;
+  if (key.length === 1) return key;
+  const shifted = SHIFT_LETTER_RE.exec(key);
+  if (shifted) return shifted[1]!.toUpperCase();
+  return undefined;
+}

--- a/mastracode/src/tui/key-input.ts
+++ b/mastracode/src/tui/key-input.ts
@@ -7,15 +7,17 @@
  * Falls back to xterm modifyOtherKeys (`\x1b[27;<mod>;<cp>~`) for terminals
  * without Kitty support.
  *
- * `Shift+<letter>` decodes to the uppercase letter so `Y`-vs-`y` shortcuts
- * survive both encodings. Shifted digits and symbols (`shift+1`, `shift+!`,
- * etc.) return `undefined` because pi-tui's `parseKey` does not collapse
- * them to a single shifted character. Ctrl/Alt/Super and non-printable keys
- * return `undefined` so modifier-bearing variants never alias a shortcut.
+ * Single-character `parseKey` results pass through unchanged — letters,
+ * digits, and unmodified punctuation (`y`, `?`, `0`). `Shift+<letter>`
+ * decodes to the uppercase letter so `Y`-vs-`y` shortcuts survive both
+ * encodings. Shifted digits and symbols (`shift+1`, `shift+!`, etc.) return
+ * `undefined` because pi-tui's `parseKey` does not collapse them to a
+ * single shifted glyph. Ctrl/Alt/Super and non-printable keys return
+ * `undefined` so modifier-bearing variants never alias a shortcut.
  *
- * Only letter shortcuts are part of this helper's supported contract.
- * Callers that want to react to space, digits-with-shift, or function keys
- * should use pi-tui's `matchesKey` directly.
+ * Callers that want to react to space or other keys whose `parseKey` name
+ * is multi-character (`space`, `enter`, `tab`, function keys) should use
+ * pi-tui's `matchesKey` directly.
  */
 import { parseKey } from '@mariozechner/pi-tui';
 


### PR DESCRIPTION
On terminals that advertise the Kitty keyboard protocol — iTerm2, Ghostty, WezTerm, kitty, Alacritty — pi-tui pushes CSI-u flags, and printable keys then arrive as escape sequences instead of raw bytes. The tool approval modal was comparing those directly to `'y'` / `'n'` / `'a'` / `'Y'`, so the press did nothing. Same shape of bug on the `r` key in `/mcp`, the `c` key in `/threads`, and the space / enter toggle on multi-step progress. Apple Terminal.app wasn't affected because it doesn't advertise the protocol — that's why this slipped through.

```ts
// before
if (data === 'y') this.onAction({ type: 'approve' });
else if (data === 'Y') this.onAction({ type: 'yolo' });

// after — works whether `data` is 'y', '\x1b[121u', '\x1b[121;2u', or '\x1b[27;1;121~'
switch (decodePrintableShortcut(data)) {
  case 'y': this.emit({ type: 'approve' }); break;
  case 'Y': this.emit({ type: 'yolo' }); break;
  ...
}
```

The new helper at `mastracode/src/tui/key-input.ts` is a thin wrapper around pi-tui's `parseKey`. `Shift+y` decodes to uppercase `Y`, and `Ctrl+Y` / `Alt+Y` return `undefined` so modifier-bearing variants can't accidentally alias a shortcut. Helper has its own unit test sweep; the dialog has an integration test using the real `parseKey` through `vi.importActual`.

Closes MASTRA-4345.

## Test plan
- [ ] In iTerm2 / Ghostty / kitty: run `mastracode`, ask it to run any tool, press `y` / `n` / `a` / `Y` on the approval modal — each fires the expected action
- [ ] `/mcp` → press `r` reloads servers
- [ ] `/threads` → highlight a thread, press `c` clones it (with empty search box)
- [ ] In Apple Terminal.app: regression check that the same keys still work as raw bytes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Some terminals send letters as special codes instead of plain keys, so pressing "y" or "n" didn't register. This PR decodes those terminal codes back into single letters so shortcuts like approve/decline and others work the same everywhere.

## Changes

### New Helper
- Added decodePrintableShortcut(data: string): string | undefined in mastracode/src/tui/key-input.ts.
  - Uses pi-tui's parseKey to decode printable inputs (e.g., CSI-u like '\x1b[121u' → 'y').
  - Returns the single-character result for printable keys; collapses only shift+letter into uppercase (Shift+y → 'Y').
  - Returns undefined for non-printable keys, modifier-bearing variants (Ctrl/Alt), shifted digits/symbols, and other unsupported forms to avoid aliasing.

### Component Updates
- tool-approval-dialog.ts
  - Replaced raw byte comparisons with decodePrintableShortcut; handles 'y' (approve), 'n' (decline), 'a' (always allow), and 'Y' (YOLO).
  - Added an internal resolved flag and emit() method to prevent duplicate actions.
- mcp-selector.ts
  - Use decodePrintableShortcut(data) === 'r' for reload-all-servers shortcut.
- thread-selector.ts
  - Use decodePrintableShortcut(keyData) === 'c' for clone-thread shortcut.
- multi-step-progress.ts
  - Use matchesKey to handle space/enter for expand/collapse consistently.

### Tests
- mastracode/src/tui/__tests__/key-input.test.ts
  - Unit tests covering literal characters, CSI-u sequences, shift normalization, rejection of Ctrl/Alt-modified inputs, Kitty event suffixes, and modifyOtherKeys formats.
- mastracode/src/tui/components/__tests__/tool-approval-dialog.test.ts
  - Integration tests exercising ToolApprovalDialogComponent.handleInput across literal keys, Kitty CSI-u, modifyOtherKeys, ensuring one-shot guard and rejecting modifier variants.

### Docs / Changeset
- .changeset/five-regions-kick.md updated to document the fix and note that pi-tui's keyboard helpers are used to decode printable shortcuts.

## Closes
MASTRA-4345

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->