### PR TITLE
feat(mastracode): multi-select support for ask_user questions

### DIFF
--- a/.changeset/cute-mails-brush.md
+++ b/.changeset/cute-mails-brush.md
@@ -1,0 +1,24 @@
+---
+'mastracode': patch
+---
+
+**Recover from stale Harness v1 session leases on startup.**
+
+A crashed or killed MastraCode process used to block the next launch with an opaque `HarnessSessionLockedError`. The runtime now waits out the stale lease automatically (up to 60s on startup, 2s mid-session) and emits status messages while it retries.
+
+After 5s of waiting, when stdin is a TTY, an interactive prompt offers `(W)ait / (F)orce-claim / (N)ew thread / (Q)uit`. The choice can also be set via environment variable for scripts, headless mode, or CI:
+
+```bash
+# Force-claim the foreign lease immediately on the next startup
+MASTRACODE_LEASE_RECOVERY=force-claim mastracode
+
+# Abandon the locked thread and start a new one
+MASTRACODE_LEASE_RECOVERY=new-thread mastracode
+
+# Fail fast with a recovery error instead of waiting
+MASTRACODE_LEASE_RECOVERY=quit mastracode
+```
+
+When recovery times out or the user quits, the runtime throws a new `MastraCodeSessionLeaseRecoveryError` (exported from `mastracode`) carrying the underlying `HarnessSessionLockedError` as its `cause`, plus `sessionId`, `currentOwnerId`, and `expiresAt` fields for downstream handlers.
+
+Also fixes a long-standing terminal-state bug surfaced by this scenario: after a crashed or `SIGKILL`'d MastraCode, the parent shell would stay stuck emitting raw CSI-u keypress sequences until manually `reset`. The CLI now restores pi-tui's keyboard mode (kitty progressive enhancement, modifyOtherKeys, bracketed paste) on `SIGINT`/`SIGTERM`/`SIGHUP`/`exit`/`uncaughtException`/`unhandledRejection`, and also emits the restore sequence once at launch so the next mastracode invocation cleans up after a prior ungraceful exit it couldn't trap.

--- a/.changeset/fuzzy-tasks-allow.md
+++ b/.changeset/fuzzy-tasks-allow.md
@@ -1,6 +1,0 @@
----
-'@mastra/core': patch
-'mastracode': patch
----
-
-Fixed Harness v1 tool approval handling so yolo turns and MastraCode task tools bypass approval prompts correctly.

--- a/.changeset/fuzzy-tasks-allow.md
+++ b/.changeset/fuzzy-tasks-allow.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastracode': patch
+---
+
+Fixed Harness v1 tool approval handling so yolo turns and MastraCode task tools bypass approval prompts correctly.

--- a/.changeset/quiet-rivers-laugh.md
+++ b/.changeset/quiet-rivers-laugh.md
@@ -1,0 +1,14 @@
+---
+'mastracode': minor
+---
+
+**Added multi-select support to `ask_user` questions in the TUI.**
+
+When the agent calls `ask_user` with `selectionMode: 'multi_select'`, the dialog now renders a checkbox list:
+
+- `↑/↓` to move the cursor between options
+- `Space` to toggle the focused option
+- `Enter` submits the selected values as a `string[]`
+- `Esc` cancels (responds with `'(skipped)'`)
+
+Single-select prompts, free-text prompts, and the streaming activation path are unchanged. The new `MultiSelectList` primitive in `mastracode/src/tui/components/multi-select-list.ts` is reusable for future multi-toggle UIs.

--- a/.changeset/quiet-rivers-laugh.md
+++ b/.changeset/quiet-rivers-laugh.md
@@ -6,6 +6,19 @@
 
 When the agent calls `ask_user` with `selectionMode: 'multi_select'`, the dialog now renders a checkbox list:
 
+```ts
+await ask_user({
+  question: 'Which features do you want to enable?',
+  options: [
+    { label: 'Tracing' },
+    { label: 'Cost tracking' },
+    { label: 'Long-running judge' },
+  ],
+  selectionMode: 'multi_select',
+});
+// answer arrives as `string[]`, e.g. ['Tracing', 'Cost tracking']
+```
+
 - `↑/↓` to move the cursor between options
 - `Space` to toggle the focused option
 - `Enter` submits the selected values as a `string[]`

--- a/.changeset/vast-wings-love.md
+++ b/.changeset/vast-wings-love.md
@@ -1,5 +1,0 @@
----
-'mastracode': patch
----
-
-Fixed Harness v1 startup so MastraCode initializes shared workspaces with project state and keeps expected startup logs quiet.

--- a/.changeset/vast-wings-love.md
+++ b/.changeset/vast-wings-love.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed Harness v1 startup so MastraCode initializes shared workspaces with project state and keeps expected startup logs quiet.

--- a/.changeset/warm-sandboxes-resume.md
+++ b/.changeset/warm-sandboxes-resume.md
@@ -1,6 +1,0 @@
----
-'@mastra/core': patch
-'mastracode': patch
----
-
-Fixed Harness v1 sandbox access resumes so request_access uses native sandbox prompts, resumes with model context, and keeps workspace tools available on follow-up turns.

--- a/.changeset/warm-sandboxes-resume.md
+++ b/.changeset/warm-sandboxes-resume.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastracode': patch
+---
+
+Fixed Harness v1 sandbox access resumes so request_access uses native sandbox prompts, resumes with model context, and keeps workspace tools available on follow-up turns.

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -212,6 +212,25 @@ Once saved, provider models appear in existing selectors like `/models` and `/su
 
 Custom providers are stored in `settings.json` in the same app data directory. If you save an API key, it is stored locally in plaintext, so use a machine/user profile you trust.
 
+### Recovering from a stale session lease
+
+If MastraCode crashes or is killed without a clean shutdown, the next launch can refuse to reopen the project's thread because the Harness v1 session lease for that thread is still held by the previous owner. The TUI now waits out the stale lease automatically (up to 60s) and emits status messages while it retries.
+
+If you know the other process is dead and do not want to wait, set the recovery action via environment variable:
+
+```bash
+# Force-claim the foreign lease immediately on the next startup
+MASTRACODE_LEASE_RECOVERY=force-claim mastracode
+
+# Abandon the current thread and start a fresh one
+MASTRACODE_LEASE_RECOVERY=new-thread mastracode
+
+# Fail fast with a recovery error instead of waiting
+MASTRACODE_LEASE_RECOVERY=quit mastracode
+```
+
+When stdin is a TTY and no env override is set, MastraCode also shows an interactive `(W)ait / (F)orce-claim / (N)ew thread / (Q)uit` prompt after 5 seconds of waiting.
+
 ### macOS sleep prevention
 
 On macOS, Mastra Code starts the built-in `caffeinate` utility while the agent is actively running, then stops it as soon as the run completes, errors, aborts, or the TUI exits. Idle sessions do not keep your machine awake.

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -26,6 +26,9 @@ const agentConstructorMock = vi.fn();
 
 const harnessConstructorMock = vi.fn();
 const loadSettingsMock = vi.fn();
+const observabilityConstructorMock = vi.fn();
+const mastraStorageExporterConstructorMock = vi.fn();
+const mastraPlatformExporterConstructorMock = vi.fn();
 const harnessSubscribeMock = vi.fn();
 const harnessGetCurrentThreadIdMock = vi.fn();
 const harnessListThreadsMock = vi.fn();
@@ -86,6 +89,25 @@ function createMockSettings() {
 vi.mock('@mastra/core/harness', () => ({
   taskWriteTool: {},
   taskCheckTool: {},
+}));
+
+vi.mock('@mastra/observability', () => ({
+  Observability: class {
+    constructor(config: unknown) {
+      observabilityConstructorMock(config);
+    }
+  },
+  MastraStorageExporter: class {
+    constructor(config: unknown) {
+      mastraStorageExporterConstructorMock(config);
+    }
+  },
+  MastraPlatformExporter: class {
+    constructor(config: unknown) {
+      mastraPlatformExporterConstructorMock(config);
+    }
+  },
+  SensitiveDataFilter: class {},
 }));
 
 vi.mock('../harness/index.js', () => ({
@@ -271,6 +293,9 @@ describe('createMastraCode', () => {
     createVectorStoreMock.mockReset();
     createVectorStoreMock.mockReturnValue({});
     getDynamicMemoryMock.mockReset();
+    observabilityConstructorMock.mockReset();
+    mastraStorageExporterConstructorMock.mockReset();
+    mastraPlatformExporterConstructorMock.mockReset();
     harnessSubscribeMock.mockReset();
     harnessGetCurrentThreadIdMock.mockReset();
     harnessGetCurrentThreadIdMock.mockReturnValue(undefined);
@@ -320,6 +345,24 @@ describe('createMastraCode', () => {
     await createMastraCode();
 
     expect(getDynamicMemoryMock).toHaveBeenCalled();
+  });
+
+  it('does not attach the local storage observability exporter when local tracing is disabled', async () => {
+    const { createMastraCode } = await import('../index.js');
+
+    await createMastraCode();
+
+    expect(mastraStorageExporterConstructorMock).not.toHaveBeenCalled();
+    expect(mastraPlatformExporterConstructorMock).toHaveBeenCalledOnce();
+    expect(observabilityConstructorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configs: expect.objectContaining({
+          default: expect.objectContaining({
+            exporters: [expect.any(Object)],
+          }),
+        }),
+      }),
+    );
   });
 
   it('rejects cross-process PubSub mode without a PubSub instance', async () => {

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -112,6 +112,10 @@ vi.mock('@mastra/observability', () => ({
 
 vi.mock('../harness/index.js', () => ({
   createHarnessV1SubagentAgents: vi.fn(() => ({})),
+  defaultStdioLeaseRecoveryPrompt: vi.fn(() => undefined),
+  MastraCodeSessionLeaseRecoveryError: class extends Error {
+    readonly name = 'MastraCodeSessionLeaseRecoveryError';
+  },
   MastraCodeHarnessRuntime: class {
     constructor(config: unknown) {
       harnessConstructorMock(config);

--- a/mastracode/src/harness/config.ts
+++ b/mastracode/src/harness/config.ts
@@ -30,6 +30,23 @@ export interface MastraCodeModelInfo {
   metadata?: Readonly<Record<string, unknown>>;
 }
 
+export type LeaseRecoveryAction = 'wait' | 'force-claim' | 'new-thread' | 'quit';
+
+export interface LeaseRecoveryPromptInfo {
+  threadId: string;
+  sessionId: string;
+  currentOwnerId: string;
+  expiresAt: number;
+  secondsWaited: number;
+  /** When false, the `new-thread` action must not be offered. Set by callers
+   * that need to bind to a specific threadId (createThread, switchThread). */
+  allowNewThread: boolean;
+}
+
+export type LeaseRecoveryPromptHandler = (
+  info: LeaseRecoveryPromptInfo,
+) => LeaseRecoveryAction | Promise<LeaseRecoveryAction>;
+
 export interface MastraCodeRuntimeConfig<TState extends Record<string, unknown>> {
   resourceId: string;
   storage: MastraCompositeStore;
@@ -49,6 +66,7 @@ export interface MastraCodeRuntimeConfig<TState extends Record<string, unknown>>
   resolveModel?: (modelId: string) => unknown;
   disabledTools?: string[];
   browser?: DynamicArgument<MastraBrowser | undefined>;
+  leaseRecoveryPrompt?: LeaseRecoveryPromptHandler;
 }
 
 /**

--- a/mastracode/src/harness/events.test.ts
+++ b/mastracode/src/harness/events.test.ts
@@ -124,6 +124,63 @@ describe('MastraCodeHarnessEventProjector', () => {
     });
   });
 
+  it('forwards multi-select selectionMode through the generic ask_question projection', async () => {
+    const { events, projector } = createProjector({
+      pending: {
+        itemId: 'q-multi',
+        payload: {
+          question: 'Pick all that apply',
+          options: [{ label: 'Alpha' }, { label: 'Beta' }],
+          selectionMode: 'multi_select',
+        },
+      },
+    });
+
+    await projector.project({
+      type: 'suspension_required',
+      kind: 'question',
+      toolCallId: 'tool-multi',
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+
+    expect(events[0]).toMatchObject({
+      type: 'ask_question',
+      questionId: 'q-multi',
+      question: 'Pick all that apply',
+      selectionMode: 'multi_select',
+    });
+  });
+
+  it('drops unrecognized selectionMode values on the ask_question projection', async () => {
+    const { events, projector } = createProjector({
+      pending: {
+        itemId: 'q-bogus',
+        payload: {
+          question: 'Pick one',
+          options: [{ label: 'Alpha' }],
+          selectionMode: 'checkboxes',
+        },
+      },
+    });
+
+    await projector.project({
+      type: 'suspension_required',
+      kind: 'question',
+      toolCallId: 'tool-bogus',
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+
+    expect(events[0]).toMatchObject({
+      type: 'ask_question',
+      questionId: 'q-bogus',
+      question: 'Pick one',
+    });
+    expect(events[0]).not.toHaveProperty('selectionMode', 'checkboxes');
+    expect((events[0] as { selectionMode?: unknown }).selectionMode).toBeUndefined();
+  });
+
   it('keeps malformed sandbox-like questions on the generic ask_question path', async () => {
     const { events, projector } = createProjector({
       pending: {

--- a/mastracode/src/harness/events.ts
+++ b/mastracode/src/harness/events.ts
@@ -161,6 +161,13 @@ export class MastraCodeHarnessEventProjector {
             questionId: itemId,
             question: payload.question ?? 'The agent needs your input.',
             options: payload.options,
+            // selectionMode reaches the TUI only when projected through this
+            // path; drop anything we don't recognize so a malformed payload
+            // can't end up as a stringy "mode".
+            selectionMode:
+              payload.selectionMode === 'single_select' || payload.selectionMode === 'multi_select'
+                ? payload.selectionMode
+                : undefined,
           } as unknown as LegacyHarnessEvent,
         ];
       case 'plan-approval':

--- a/mastracode/src/harness/index.ts
+++ b/mastracode/src/harness/index.ts
@@ -3,5 +3,11 @@ export {
   MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
   type MastraCodeRuntimeConfig,
 } from './config.js';
-export { MastraCodeHarnessRuntime } from './runtime.js';
+export { MastraCodeHarnessRuntime, MastraCodeSessionLeaseRecoveryError } from './runtime.js';
+export { defaultStdioLeaseRecoveryPrompt } from './lease-recovery-prompt.js';
+export type {
+  LeaseRecoveryAction,
+  LeaseRecoveryPromptHandler,
+  LeaseRecoveryPromptInfo,
+} from './config.js';
 export { createHarnessV1SubagentAgents } from './subagents.js';

--- a/mastracode/src/harness/lease-recovery-prompt.ts
+++ b/mastracode/src/harness/lease-recovery-prompt.ts
@@ -1,0 +1,62 @@
+import { createInterface } from 'node:readline';
+
+import type { LeaseRecoveryAction, LeaseRecoveryPromptHandler, LeaseRecoveryPromptInfo } from './config.js';
+
+/**
+ * Stdio-driven prompt invoked during `MastraCodeHarnessRuntime.init()` when a
+ * stale Harness v1 session lease is held by another process. The handler
+ * resolves to `wait` immediately when stdin is not a TTY so headless callers
+ * stay non-interactive without an explicit `MASTRACODE_LEASE_RECOVERY` value.
+ */
+export function defaultStdioLeaseRecoveryPrompt(): LeaseRecoveryPromptHandler {
+  return async (info: LeaseRecoveryPromptInfo): Promise<LeaseRecoveryAction> => {
+    // Re-check TTY state at invocation time so tests / embedders that flip
+    // `process.stdin.isTTY` after construction get the right behavior.
+    if (!process.stdin.isTTY) return 'wait';
+    const expires =
+      Number.isFinite(info.expiresAt) && info.expiresAt > 0
+        ? new Date(info.expiresAt).toLocaleTimeString()
+        : 'an unknown time';
+    const newThreadLine = info.allowNewThread
+      ? `  (N)ew thread — abandon this thread and start a new one (loses continuity with thread history)\n`
+      : '';
+    const choiceHint = info.allowNewThread ? '[W/f/n/q]' : '[W/f/q]';
+    process.stderr.write(
+      `\nA previous MastraCode Harness session lease for thread "${info.threadId}" is still held by another process (owner "${info.currentOwnerId}", expires at ${expires}). Waited ${info.secondsWaited}s.\n` +
+        `  (W)ait for the lease to expire (up to 60s total) — safe default\n` +
+        `  (F)orce-claim the lease — only safe if the other process is known dead\n` +
+        newThreadLine +
+        `  (Q)uit\n` +
+        `Tip: set MASTRACODE_LEASE_RECOVERY=force-claim|wait|new-thread|quit to skip this prompt next time.\n` +
+        `Choice ${choiceHint}: `,
+    );
+    const rl = createInterface({ input: process.stdin, output: process.stderr, terminal: false });
+    let closed = false;
+    rl.once('close', () => {
+      closed = true;
+    });
+    try {
+      for (;;) {
+        if (closed) return 'wait';
+        // `rl.question` never resolves if stdin closes mid-prompt (Ctrl+D,
+        // piped input ends); the `close` listener short-circuits to 'wait'
+        // via the loop guard above.
+        const answer = await new Promise<string>(resolve => {
+          rl.question('', resolve);
+          rl.once('close', () => resolve(''));
+        });
+        if (closed) return 'wait';
+        const normalized = answer.trim().toLowerCase();
+        if (normalized === '' || normalized === 'w' || normalized === 'wait') return 'wait';
+        if (normalized === 'f' || normalized === 'force' || normalized === 'force-claim') return 'force-claim';
+        if (info.allowNewThread && (normalized === 'n' || normalized === 'new' || normalized === 'new-thread')) {
+          return 'new-thread';
+        }
+        if (normalized === 'q' || normalized === 'quit') return 'quit';
+        process.stderr.write(`Please choose ${choiceHint.replace(/[\[\]]/g, '').toUpperCase()}: `);
+      }
+    } finally {
+      rl.close();
+    }
+  };
+}

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -1,7 +1,12 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { Agent } from '@mastra/core/agent';
 import { InMemoryStore } from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
 
+import { getDynamicWorkspace } from '../agents/workspace.js';
 import { MASTRACODE_HARNESS_NAME } from './config.js';
 import { MastraCodeHarnessRuntime } from './runtime.js';
 
@@ -16,6 +21,7 @@ function createRuntime(
     resolveModel?: (modelId: string) => unknown;
     browser?: unknown;
     disabledTools?: string[];
+    workspace?: ConstructorParameters<typeof MastraCodeHarnessRuntime>[0]['workspace'];
   } = {},
 ) {
   const agent = new Agent({
@@ -56,6 +62,7 @@ function createRuntime(
     resolveModel: options.resolveModel,
     browser: options.browser as never,
     disabledTools: options.disabledTools,
+    workspace: options.workspace,
   });
 }
 
@@ -68,6 +75,30 @@ describe('MastraCodeHarnessRuntime', () => {
     const runtime = createRuntime();
 
     expect(runtime.getMastra().getHarness(MASTRACODE_HARNESS_NAME)).toBe(runtime.core);
+  });
+
+  it('provides initial runtime state when Harness v1 initializes the shared workspace', async () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'mastracode-workspace-context-'));
+    let observedProjectPath: string | undefined;
+    const runtime = createRuntime({
+      projectPath,
+      workspace: ({ requestContext, mastra }) => {
+        const harnessContext = requestContext.get('harness') as
+          | { getState?: () => { projectPath?: string } }
+          | undefined;
+        observedProjectPath = harnessContext?.getState?.().projectPath;
+        return getDynamicWorkspace({ requestContext, mastra });
+      },
+    });
+
+    try {
+      await runtime.init();
+      expect(observedProjectPath).toBe(projectPath);
+      expect(runtime.getWorkspace()).toBeTruthy();
+    } finally {
+      await runtime.destroy();
+      rmSync(projectPath, { recursive: true, force: true });
+    }
   });
 
   it('restores Harness v1 thread metadata into MastraCode runtime state', async () => {

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -1016,3 +1016,427 @@ describe('MastraCodeHarnessRuntime', () => {
     expect(runtime.getCurrentThreadId()).toBe(currentThreadId);
   });
 });
+
+// Structural type covering only the harness-storage methods the lease-recovery
+// tests exercise. Avoids `as any` while keeping the test self-contained.
+type TestHarnessStorage = {
+  loadSession: (opts: { harnessName: string; sessionId: string }) => Promise<{ ownerId?: string } | null>;
+  releaseSessionLease: (opts: { harnessName: string; sessionId: string; ownerId: string }) => Promise<void>;
+  acquireSessionLease: (opts: {
+    harnessName: string;
+    sessionId: string;
+    ownerId: string;
+    ttlMs: number;
+  }) => Promise<unknown>;
+};
+
+describe('MastraCodeHarnessRuntime — stale session lease recovery (MASTRA-4344)', () => {
+  it('waits out a stale foreign lease and adopts the previous session at startup', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const storage = new InMemoryStore({ id: 'mc-runtime-stale-lease-startup' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-stale-lease-startup' });
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-stale-lease-startup' });
+
+    try {
+      await firstRuntime.init();
+      const threadId = firstRuntime.getCurrentThreadId();
+      const sessionId = firstRuntime.getCurrentSessionId();
+      if (!threadId || !sessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: 'harness-foreign-owner',
+        ttlMs: 250,
+      });
+
+      const infoMessages: string[] = [];
+      secondRuntime.subscribe(event => {
+        if (event.type === 'info') infoMessages.push(event.message);
+      });
+
+      const initPromise = secondRuntime.init();
+      await vi.advanceTimersByTimeAsync(750);
+      await initPromise;
+
+      expect(secondRuntime.getCurrentThreadId()).toBe(threadId);
+      expect(secondRuntime.getCurrentSessionId()).toBe(sessionId);
+      expect(infoMessages.some(m => /lease|retrying/i.test(m))).toBe(true);
+      expect(infoMessages.some(m => /Recovered/i.test(m))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('throws MastraCodeSessionLeaseRecoveryError when the foreign lease outlasts the startup cap', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const storage = new InMemoryStore({ id: 'mc-runtime-stale-lease-timeout' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-live-lease' });
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-live-lease' });
+
+    try {
+      await firstRuntime.init();
+      const sessionId = firstRuntime.getCurrentSessionId();
+      if (!sessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: 'harness-still-running-owner',
+        ttlMs: 120_000,
+      });
+
+      const initPromise = secondRuntime.init().catch(err => err);
+      await vi.advanceTimersByTimeAsync(65_000);
+      const err = await initPromise;
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).name).toBe('MastraCodeSessionLeaseRecoveryError');
+      expect((err as { code: string }).code).toBe('mastracode.session_lease_recovery_failed');
+      expect((err as Error).message).toContain('Another MastraCode instance may still be running');
+      expect((err as { cause: { name?: string } }).cause?.name).toBe('HarnessSessionLockedError');
+      expect((err as { sessionId: string }).sessionId).toBe(sessionId);
+      expect((err as { currentOwnerId: string }).currentOwnerId).toBe('harness-still-running-owner');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('propagates non-locked errors from session() without retrying', async () => {
+    const runtime = createRuntime();
+    const sessionSpy = vi
+      .spyOn(runtime.core, 'session')
+      .mockRejectedValueOnce(new Error('storage offline'));
+
+    await expect(runtime.init()).rejects.toThrow('storage offline');
+    expect(sessionSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('adopts the existing session without waiting when the lease is reentrant for this process', async () => {
+    const storage = new InMemoryStore({ id: 'mc-runtime-reentrant-lease' });
+    const runtime = createRuntime({ storage, projectPath: '/tmp/mastracode-reentrant' });
+
+    const infoMessages: string[] = [];
+    runtime.subscribe(event => {
+      if (event.type === 'info') infoMessages.push(event.message);
+    });
+
+    await runtime.init();
+    const sessionId = runtime.getCurrentSessionId();
+
+    expect(sessionId).toBeDefined();
+    expect(infoMessages.some(m => /lease|retrying|Recovered/i.test(m))).toBe(false);
+  });
+
+  it('uses the short mid-session cap when re-binding a session lazily after the bound one is dropped', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const storage = new InMemoryStore({ id: 'mc-runtime-midsession-cap' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-midsession' });
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-midsession' });
+
+    try {
+      await firstRuntime.init();
+      const sessionId = firstRuntime.getCurrentSessionId();
+      if (!sessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: 'harness-still-running-owner',
+        ttlMs: 120_000,
+      });
+
+      const reboundPromise = secondRuntime
+        .selectOrCreateThread({ leaseRecoveryMode: 'midsession' })
+        .catch(err => err);
+      await vi.advanceTimersByTimeAsync(3_000);
+      const err = await reboundPromise;
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).name).toBe('MastraCodeSessionLeaseRecoveryError');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('honors MASTRACODE_LEASE_RECOVERY=force-claim across owner-change races', async () => {
+    const storage = new InMemoryStore({ id: 'mc-runtime-force-claim-race' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-force-claim' });
+
+    const restore = process.env.MASTRACODE_LEASE_RECOVERY;
+    process.env.MASTRACODE_LEASE_RECOVERY = 'force-claim';
+    try {
+      await firstRuntime.init();
+      const sessionId = firstRuntime.getCurrentSessionId();
+      if (!sessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: 'harness-still-running-owner',
+        ttlMs: 120_000,
+      });
+
+      const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-force-claim' });
+      const infoMessages: string[] = [];
+      secondRuntime.subscribe(event => {
+        if (event.type === 'info') infoMessages.push(event.message);
+      });
+      await secondRuntime.init();
+      expect(secondRuntime.getCurrentSessionId()).toBe(sessionId);
+      expect(infoMessages.some(m => /Released.*harness-still-running-owner/.test(m))).toBe(true);
+    } finally {
+      if (restore === undefined) {
+        delete process.env.MASTRACODE_LEASE_RECOVERY;
+      } else {
+        process.env.MASTRACODE_LEASE_RECOVERY = restore;
+      }
+    }
+  });
+
+  it('force-claims again across an owner-change race between release and retry', async () => {
+    const storage = new InMemoryStore({ id: 'mc-runtime-owner-change-race' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-owner-race' });
+
+    const restore = process.env.MASTRACODE_LEASE_RECOVERY;
+    process.env.MASTRACODE_LEASE_RECOVERY = 'force-claim';
+    try {
+      await firstRuntime.init();
+      const sessionId = firstRuntime.getCurrentSessionId();
+      if (!sessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId,
+        ownerId: 'harness-owner-a',
+        ttlMs: 120_000,
+      });
+
+      const originalRelease = harnessStorage.releaseSessionLease.bind(harnessStorage);
+      let releaseCount = 0;
+      vi.spyOn(harnessStorage, 'releaseSessionLease').mockImplementation(async opts => {
+        await originalRelease(opts);
+        releaseCount += 1;
+        if (releaseCount === 1) {
+          // Racer process re-acquires the lease in the gap between our
+          // release and the next core.session() retry.
+          await harnessStorage.acquireSessionLease({
+            harnessName: MASTRACODE_HARNESS_NAME,
+            sessionId,
+            ownerId: 'harness-owner-b',
+            ttlMs: 120_000,
+          });
+        }
+      });
+
+      const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-owner-race' });
+      const infoMessages: string[] = [];
+      secondRuntime.subscribe(event => {
+        if (event.type === 'info') infoMessages.push(event.message);
+      });
+      await secondRuntime.init();
+
+      expect(secondRuntime.getCurrentSessionId()).toBe(sessionId);
+      expect(releaseCount).toBeGreaterThanOrEqual(2);
+      expect(infoMessages.some(m => /Released.*harness-owner-a/.test(m))).toBe(true);
+      expect(infoMessages.some(m => /Released.*harness-owner-b/.test(m))).toBe(true);
+    } finally {
+      if (restore === undefined) {
+        delete process.env.MASTRACODE_LEASE_RECOVERY;
+      } else {
+        process.env.MASTRACODE_LEASE_RECOVERY = restore;
+      }
+    }
+  });
+
+  it('honors MASTRACODE_LEASE_RECOVERY=new-thread at startup by creating a fresh thread', async () => {
+    const storage = new InMemoryStore({ id: 'mc-runtime-new-thread-startup' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-new-thread' });
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-new-thread' });
+
+    const restore = process.env.MASTRACODE_LEASE_RECOVERY;
+    process.env.MASTRACODE_LEASE_RECOVERY = 'new-thread';
+    try {
+      await firstRuntime.init();
+      const lockedThreadId = firstRuntime.getCurrentThreadId();
+      const lockedSessionId = firstRuntime.getCurrentSessionId();
+      if (!lockedThreadId || !lockedSessionId) throw new Error('expected first runtime to bind a session');
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+        ownerId: 'harness-still-running-owner',
+        ttlMs: 120_000,
+      });
+
+      await secondRuntime.init();
+      expect(secondRuntime.getCurrentThreadId()).not.toBe(lockedThreadId);
+      expect(secondRuntime.getCurrentSessionId()).not.toBe(lockedSessionId);
+    } finally {
+      if (restore === undefined) {
+        delete process.env.MASTRACODE_LEASE_RECOVERY;
+      } else {
+        process.env.MASTRACODE_LEASE_RECOVERY = restore;
+      }
+    }
+  });
+
+  it('warns and ignores an unrecognized MASTRACODE_LEASE_RECOVERY value', async () => {
+    const storage = new InMemoryStore({ id: 'mc-runtime-invalid-env' });
+    const runtime = createRuntime({ storage, projectPath: '/tmp/mastracode-invalid-env' });
+
+    const restore = process.env.MASTRACODE_LEASE_RECOVERY;
+    process.env.MASTRACODE_LEASE_RECOVERY = 'force';
+    const infoMessages: string[] = [];
+    runtime.subscribe(event => {
+      if (event.type === 'info') infoMessages.push(event.message);
+    });
+    try {
+      await runtime.init();
+      expect(runtime.getCurrentSessionId()).toBeDefined();
+      expect(infoMessages.some(m => /invalid MASTRACODE_LEASE_RECOVERY/i.test(m))).toBe(true);
+    } finally {
+      if (restore === undefined) {
+        delete process.env.MASTRACODE_LEASE_RECOVERY;
+      } else {
+        process.env.MASTRACODE_LEASE_RECOVERY = restore;
+      }
+    }
+  });
+
+  it('does not leak the new-thread sentinel when switchThread hits a stale foreign lease', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const storage = new InMemoryStore({ id: 'mc-runtime-switchthread-sentinel' });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-switch-sentinel-a' });
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/mastracode-switch-sentinel-b' });
+
+    try {
+      await firstRuntime.init();
+      const lockedThreadId = firstRuntime.getCurrentThreadId();
+      const lockedSessionId = firstRuntime.getCurrentSessionId();
+      if (!lockedThreadId || !lockedSessionId) throw new Error('expected first runtime to bind a session');
+
+      await secondRuntime.init();
+
+      const harnessStorage = (await storage.getStore('harness')) as TestHarnessStorage;
+      const stored = await harnessStorage.loadSession({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+      });
+      if (!stored?.ownerId) throw new Error('expected a live session owner');
+
+      await harnessStorage.releaseSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+        ownerId: stored.ownerId,
+      });
+      await harnessStorage.acquireSessionLease({
+        harnessName: MASTRACODE_HARNESS_NAME,
+        sessionId: lockedSessionId,
+        ownerId: 'harness-still-running-owner',
+        ttlMs: 120_000,
+      });
+
+      const restore = process.env.MASTRACODE_LEASE_RECOVERY;
+      process.env.MASTRACODE_LEASE_RECOVERY = 'new-thread';
+      try {
+        const switchPromise = secondRuntime.switchThread({ threadId: lockedThreadId }).catch(err => err);
+        await vi.advanceTimersByTimeAsync(65_000);
+        const err = await switchPromise;
+        // new-thread is not honored from switchThread (caller wants a SPECIFIC
+        // threadId); the env override down-converts to a clean recovery error
+        // instead of leaking MastraCodeLeaseRecoveryNewThreadError.
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).name).toBe('MastraCodeSessionLeaseRecoveryError');
+      } finally {
+        if (restore === undefined) {
+          delete process.env.MASTRACODE_LEASE_RECOVERY;
+        } else {
+          process.env.MASTRACODE_LEASE_RECOVERY = restore;
+        }
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -379,7 +379,9 @@ describe('MastraCodeHarnessRuntime', () => {
       models: {
         current: () => 'anthropic/claude-haiku-4-5',
         switch: vi.fn(async () => undefined),
+        getSubagent: vi.fn(() => undefined),
       },
+      permissions: { setPolicy: vi.fn(async () => undefined) },
       setState: vi.fn(async () => undefined),
     };
 
@@ -415,7 +417,9 @@ describe('MastraCodeHarnessRuntime', () => {
       models: {
         current: () => 'anthropic/claude-haiku-4-5',
         switch: vi.fn(async () => undefined),
+        getSubagent: vi.fn(() => undefined),
       },
+      permissions: { setPolicy: vi.fn(async () => undefined) },
       setState: vi.fn(async () => undefined),
     };
 
@@ -437,7 +441,9 @@ describe('MastraCodeHarnessRuntime', () => {
       models: {
         current: () => 'anthropic/claude-haiku-4-5',
         switch: vi.fn(async () => undefined),
+        getSubagent: vi.fn(() => undefined),
       },
+      permissions: { setPolicy: vi.fn(async () => undefined) },
       setState: vi.fn(async () => undefined),
     };
 
@@ -453,6 +459,29 @@ describe('MastraCodeHarnessRuntime', () => {
     await runtime.destroy();
   });
 
+  it('keeps MastraCode always-allowed tools allowed in Harness v1 permission rules', async () => {
+    const runtime = createRuntime({
+      initialState: {
+        permissionRules: {
+          categories: { execute: 'ask' },
+          tools: { task_write: 'deny', execute_command: 'ask' },
+        },
+      },
+    });
+    const setPolicy = vi.fn(async () => undefined);
+
+    await (runtime as any).syncPermissionRules({ permissions: { setPolicy } });
+
+    expect(setPolicy).not.toHaveBeenCalledWith({ toolName: 'task_write', policy: 'deny' });
+    expect(setPolicy).toHaveBeenCalledWith({ toolName: 'task_write', policy: 'allow' });
+    expect(setPolicy).toHaveBeenCalledWith({ toolName: 'task_update', policy: 'allow' });
+    expect(setPolicy).toHaveBeenCalledWith({ toolName: 'task_complete', policy: 'allow' });
+    expect(setPolicy).toHaveBeenCalledWith({ toolName: 'task_check', policy: 'allow' });
+    expect(setPolicy).toHaveBeenCalledWith({ toolName: 'execute_command', policy: 'ask' });
+
+    await runtime.destroy();
+  });
+
   it('filters active tools through prepareStep for non-admission messages', async () => {
     const runtime = createRuntime({ disabledTools: ['blocked_tool'] });
     const message = vi.fn(async () => undefined);
@@ -461,7 +490,9 @@ describe('MastraCodeHarnessRuntime', () => {
       models: {
         current: () => 'anthropic/claude-haiku-4-5',
         switch: vi.fn(async () => undefined),
+        getSubagent: vi.fn(() => undefined),
       },
+      permissions: { setPolicy: vi.fn(async () => undefined) },
       setState: vi.fn(async () => undefined),
     };
 
@@ -660,9 +691,15 @@ describe('MastraCodeHarnessRuntime', () => {
     await runtime.init();
 
     expect((runtime as any).filterActiveTools(['read_file', 'shell'])).toEqual(['read_file']);
-    expect((runtime as any).session.permissions.getRules()).toEqual({
+    expect((runtime as any).session.permissions.getRules()).toMatchObject({
       categories: { execute: 'deny' },
-      tools: { read_file: 'allow' },
+      tools: {
+        read_file: 'allow',
+        task_write: 'allow',
+        task_update: 'allow',
+        task_complete: 'allow',
+        task_check: 'allow',
+      },
     });
 
     await runtime.destroy();
@@ -902,7 +939,9 @@ describe('MastraCodeHarnessRuntime', () => {
       models: {
         current: () => 'anthropic/claude-haiku-4-5',
         switch: vi.fn(async () => undefined),
+        getSubagent: vi.fn(() => undefined),
       },
+      permissions: { setPolicy: vi.fn(async () => undefined) },
       setState: vi.fn(async () => undefined),
     };
     const selectOrCreateThread = vi.spyOn(runtime, 'selectOrCreateThread').mockImplementation(async () => {

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { Agent } from '@mastra/core/agent';
+import { RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -95,6 +96,49 @@ describe('MastraCodeHarnessRuntime', () => {
       await runtime.init();
       expect(observedProjectPath).toBe(projectPath);
       expect(runtime.getWorkspace()).toBeTruthy();
+    } finally {
+      await runtime.destroy();
+      rmSync(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('propagates the runtime workspace factory to Harness v1 agents', async () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'mastracode-agent-workspace-'));
+    const agent = new Agent({
+      id: 'code-agent',
+      name: 'Code Agent',
+      instructions: 'test',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    let observedProjectPath: string | undefined;
+    const runtime = createRuntime({
+      projectPath,
+      agents: { 'code-agent': agent },
+      modes: [
+        {
+          id: 'build',
+          name: 'Build',
+          color: 'green',
+          default: true,
+          defaultModelId: 'anthropic/claude-haiku-4-5',
+          agent,
+        },
+      ] as any,
+      workspace: ({ requestContext, mastra }) => {
+        const harnessContext = requestContext.get('harness') as
+          | { getState?: () => { projectPath?: string } }
+          | undefined;
+        observedProjectPath = harnessContext?.getState?.().projectPath;
+        return getDynamicWorkspace({ requestContext, mastra });
+      },
+    });
+
+    try {
+      await runtime.init();
+      observedProjectPath = undefined;
+      const workspace = await agent.getWorkspace({ requestContext: new RequestContext() });
+      expect(workspace).toBeTruthy();
+      expect(observedProjectPath).toBe(projectPath);
     } finally {
       await runtime.destroy();
       rmSync(projectPath, { recursive: true, force: true });

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -19,6 +19,7 @@ import type {
 import { convertStoredMessageToHarnessMessage, defaultDisplayState } from '@mastra/core/harness';
 import {
   Harness as HarnessV1,
+  HarnessSessionLockedError,
   getHarnessWorkspaceActionPathInput,
   isHarnessWorkspaceFileMutationTool,
 } from '@mastra/core/harness/v1';
@@ -48,7 +49,11 @@ import {
   toHarnessV1Subagents,
   toModelInfo,
 } from './config.js';
-import type { MastraCodeModelInfo, MastraCodeRuntimeConfig } from './config.js';
+import type {
+  LeaseRecoveryAction,
+  MastraCodeModelInfo,
+  MastraCodeRuntimeConfig,
+} from './config.js';
 import { MastraCodeHarnessEventProjector } from './events.js';
 import { emptyOMProgress, getOMModelState } from './observational-memory.js';
 
@@ -59,6 +64,76 @@ const HARNESS_SESSION_LIFECYCLE_ERROR_NAMES = new Set([
   'HarnessSessionClosingError',
   'HarnessSessionDeletedError',
 ]);
+
+const SESSION_LEASE_RECOVERY_STARTUP_WAIT_MS = 60_000;
+const SESSION_LEASE_RECOVERY_MIDSESSION_WAIT_MS = 2_000;
+const SESSION_LEASE_RETRY_GRACE_MS = 25;
+const SESSION_LEASE_RETRY_MIN_MS = 25;
+const SESSION_LEASE_RETRY_MAX_MS = 5_000;
+const SESSION_LEASE_PROMPT_THRESHOLD_MS = 5_000;
+// Prevent the interactive prompt from suspending the retry loop indefinitely:
+// if no answer arrives within this window, treat it as 'wait' so the runtime
+// keeps polling and can still acquire the lease automatically once expired.
+const SESSION_LEASE_PROMPT_RESPONSE_BUDGET_MS = 30_000;
+
+type LeaseRecoveryMode = 'startup' | 'midsession';
+
+class MastraCodeLeaseRecoveryNewThreadError extends Error {
+  readonly name = 'MastraCodeLeaseRecoveryNewThreadError';
+}
+
+/**
+ * Resolve the lease-recovery action override from `MASTRACODE_LEASE_RECOVERY`.
+ * Returns `{ action }` on a recognized value, `{ invalid }` when the env var
+ * is set to something unrecognized (so the caller can warn), or `{}` when
+ * unset.
+ */
+function resolveLeaseRecoveryEnvOverride(): { action?: LeaseRecoveryAction; invalid?: string } {
+  const raw = process.env.MASTRACODE_LEASE_RECOVERY?.trim().toLowerCase();
+  if (!raw) return {};
+  if (raw === 'wait' || raw === 'force-claim' || raw === 'new-thread' || raw === 'quit') return { action: raw };
+  return { invalid: raw };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function formatRetryDelay(ms: number): string {
+  if (ms < 1_000) return `${ms}ms`;
+  const seconds = ms / 1_000;
+  return `${seconds.toFixed(seconds >= 10 ? 0 : 1)}s`;
+}
+
+function sessionLeaseRetryDelayMs(error: HarnessSessionLockedError): number {
+  const expiresInMs =
+    Number.isFinite(error.expiresAt) && error.expiresAt > 0
+      ? error.expiresAt - Date.now()
+      : SESSION_LEASE_RETRY_MAX_MS;
+  return Math.min(
+    SESSION_LEASE_RETRY_MAX_MS,
+    Math.max(SESSION_LEASE_RETRY_MIN_MS, Math.ceil(expiresInMs + SESSION_LEASE_RETRY_GRACE_MS)),
+  );
+}
+
+export class MastraCodeSessionLeaseRecoveryError extends Error {
+  readonly name = 'MastraCodeSessionLeaseRecoveryError';
+  readonly code = 'mastracode.session_lease_recovery_failed';
+  constructor(
+    public readonly threadId: string,
+    public readonly sessionId: string,
+    public readonly currentOwnerId: string,
+    public readonly expiresAt: number,
+    options?: { cause?: unknown },
+  ) {
+    const expiresIso =
+      Number.isFinite(expiresAt) && expiresAt > 0 ? new Date(expiresAt).toISOString() : 'unknown';
+    super(
+      `MastraCode could not reopen thread "${threadId}" because its Harness v1 session "${sessionId}" is still locked by another process (owner "${currentOwnerId}", lease expires at ${expiresIso}). Another MastraCode instance may still be running. Quit the other instance or retry after the lease expires.`,
+      options,
+    );
+  }
+}
 type MastraCodeOMEvent = Extract<
   HarnessEvent,
   {
@@ -381,6 +456,10 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     };
   }
 
+  getCurrentSessionId(): string | undefined {
+    return this.session?.id;
+  }
+
   private emit(event: HarnessEvent): void {
     for (const listener of this.listeners) {
       try {
@@ -620,7 +699,9 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     }
   }
 
-  async selectOrCreateThread(): Promise<HarnessThread> {
+  async selectOrCreateThread(
+    options: { leaseRecoveryMode?: LeaseRecoveryMode } = {},
+  ): Promise<HarnessThread> {
     const existing = await this.core.threads.list({
       resourceId: this.resourceId,
       perPage: false,
@@ -630,7 +711,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     const existingThread = projectPath
       ? existing.threads.find(thread => thread.metadata?.projectPath === projectPath)
       : existing.threads[0];
-    const thread =
+    let thread =
       existingThread ??
       (await this.core.threads.create({
         resourceId: this.resourceId,
@@ -638,14 +719,22 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
         metadata: this.buildThreadMetadata(),
       }));
     await this.applyThreadMetadata(thread.metadata, { persist: false });
-    this.bindActiveSession(
-      await this.core.session({
+    try {
+      await this.bindSessionForThread(thread.id, options.leaseRecoveryMode ?? 'startup', {
+        allowNewThread: true,
+      });
+    } catch (error) {
+      if (!(error instanceof MastraCodeLeaseRecoveryNewThreadError)) throw error;
+      thread = await this.core.threads.create({
         resourceId: this.resourceId,
-        threadId: thread.id,
-        modeId: this.currentModeId,
-        modelId: this.resolveModeModel(this.currentModeId),
-      }),
-    );
+        title: 'New thread',
+        metadata: this.buildThreadMetadata(),
+      });
+      await this.applyThreadMetadata(thread.metadata, { persist: false });
+      await this.bindSessionForThread(thread.id, options.leaseRecoveryMode ?? 'startup', {
+        allowNewThread: false,
+      });
+    }
     await this.ensureSessionState();
     await this.syncSessionControls();
     await this.resolveWorkspace().catch(() => undefined);
@@ -659,14 +748,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       metadata: this.buildThreadMetadata(),
     });
     await this.applyThreadMetadata(thread.metadata, { persist: false });
-    this.bindActiveSession(
-      await this.core.session({
-        resourceId: this.resourceId,
-        threadId: thread.id,
-        modeId: this.currentModeId,
-        modelId: this.resolveModeModel(this.currentModeId),
-      }),
-    );
+    await this.bindSessionForThread(thread.id, 'startup');
     await this.ensureSessionState();
     await this.syncSessionControls();
     await this.resolveWorkspace().catch(() => undefined);
@@ -680,15 +762,19 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     if (!thread) {
       throw new Error(`Thread not found: ${threadId}`);
     }
+    // Snapshot mode/state so a bind failure (e.g. lease recovery timeout) does
+    // not leave the runtime with the target thread's metadata but the previous
+    // session still bound.
+    const previousModeId = this.currentModeId;
+    const previousState = { ...this.state };
     await this.applyThreadMetadata(thread.metadata, { persist: false });
-    this.bindActiveSession(
-      await this.core.session({
-        resourceId: this.resourceId,
-        threadId,
-        modeId: this.currentModeId,
-        modelId: this.resolveModeModel(this.currentModeId),
-      }),
-    );
+    try {
+      await this.bindSessionForThread(threadId, 'startup');
+    } catch (error) {
+      this.currentModeId = previousModeId;
+      this.state = previousState;
+      throw error;
+    }
     await this.ensureSessionState();
     await this.syncSessionControls();
     await this.resolveWorkspace().catch(() => undefined);
@@ -1603,7 +1689,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
 
   private async ensureSession(): Promise<Session> {
     if (!this.session) {
-      await this.selectOrCreateThread();
+      await this.selectOrCreateThread({ leaseRecoveryMode: 'midsession' });
     }
     return this.requireSession();
   }
@@ -1720,6 +1806,219 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       void this.handleCoreEvent(event).catch(error => {
         this.emitNonLifecycleError(error);
       });
+    });
+  }
+
+  private async bindSessionForThread(
+    threadId: string,
+    mode: LeaseRecoveryMode,
+    options: { allowNewThread?: boolean } = {},
+  ): Promise<void> {
+    this.bindActiveSession(await this.resolveThreadSessionWithLeaseRecovery(threadId, mode, options));
+  }
+
+  private async resolveThreadSessionWithLeaseRecovery(
+    threadId: string,
+    mode: LeaseRecoveryMode,
+    options: { allowNewThread?: boolean } = {},
+  ): Promise<Session> {
+    const allowNewThread = options.allowNewThread ?? false;
+    const maxWaitMs =
+      mode === 'startup'
+        ? SESSION_LEASE_RECOVERY_STARTUP_WAIT_MS
+        : SESSION_LEASE_RECOVERY_MIDSESSION_WAIT_MS;
+    const startedAt = Date.now();
+    let attempt = 0;
+    const envOverride = resolveLeaseRecoveryEnvOverride();
+    if (envOverride.invalid) {
+      this.emit({
+        type: 'info',
+        message: `Ignoring invalid MASTRACODE_LEASE_RECOVERY="${envOverride.invalid}"; expected wait|force-claim|new-thread|quit.`,
+      });
+    }
+    const envAction = envOverride.action;
+    const envQuit = envAction === 'quit';
+    const envNewThread = envAction === 'new-thread';
+    // `chosenPolicy === 'force-claim'` persists across owner changes so a race
+    // where another process re-acquires the lease between releaseSessionLease
+    // and the next core.session() does NOT silently downgrade the user's
+    // explicit force-claim choice back to wait-and-fail.
+    let chosenPolicy: 'force-claim' | undefined = envAction === 'force-claim' ? 'force-claim' : undefined;
+    // `MASTRACODE_LEASE_RECOVERY=wait` is an explicit "always wait, never prompt"
+    // policy. The prompt threshold is suppressed so the loop simply retries
+    // until maxWaitMs or successful acquisition.
+    let promptInvoked = envAction === 'wait' || mode !== 'startup' || !this.config.leaseRecoveryPrompt;
+    const promptHandler = mode === 'startup' ? this.config.leaseRecoveryPrompt : undefined;
+    let infoHintEmitted = false;
+
+    for (;;) {
+      try {
+        const session = await this.core.session({
+          resourceId: this.resourceId,
+          threadId,
+          modeId: this.currentModeId,
+          modelId: this.resolveModeModel(this.currentModeId),
+        });
+        if (attempt > 0) {
+          this.emit({
+            type: 'info',
+            message: 'Recovered the previous MastraCode Harness session after its stale lease expired.',
+          });
+        }
+        return session;
+      } catch (error) {
+        if (!(error instanceof HarnessSessionLockedError)) throw error;
+        attempt += 1;
+        const elapsedMs = Date.now() - startedAt;
+
+        if (envQuit) {
+          throw new MastraCodeSessionLeaseRecoveryError(
+            threadId,
+            error.sessionId,
+            error.currentOwnerId,
+            error.expiresAt,
+            { cause: error },
+          );
+        }
+        if (envNewThread) {
+          if (allowNewThread) throw new MastraCodeLeaseRecoveryNewThreadError();
+          // Caller (createThread/switchThread) needs a specific threadId and
+          // cannot honor the new-thread request — fail fast with a clean
+          // recovery error rather than the internal sentinel.
+          throw new MastraCodeSessionLeaseRecoveryError(
+            threadId,
+            error.sessionId,
+            error.currentOwnerId,
+            error.expiresAt,
+            { cause: error },
+          );
+        }
+
+        if (chosenPolicy === 'force-claim') {
+          try {
+            await this.forceReleaseForeignLease(error.sessionId, error.currentOwnerId);
+          } catch (releaseErr) {
+            throw new MastraCodeSessionLeaseRecoveryError(
+              threadId,
+              error.sessionId,
+              error.currentOwnerId,
+              error.expiresAt,
+              { cause: releaseErr },
+            );
+          }
+          this.emit({
+            type: 'info',
+            message: `Released the MastraCode Harness session lease previously owned by "${error.currentOwnerId}"; retrying acquisition.`,
+          });
+          continue;
+        }
+
+        if (!promptInvoked && mode === 'startup' && elapsedMs >= SESSION_LEASE_PROMPT_THRESHOLD_MS) {
+          promptInvoked = true;
+          // Race the prompt against a bounded response budget so a user who
+          // walks away from the terminal does NOT defeat the documented
+          // 60s automatic-wait guarantee. When the budget wins the loop
+          // resumes retrying as if 'wait' was chosen.
+          const rawAction: LeaseRecoveryAction = promptHandler
+            ? await Promise.race([
+                Promise.resolve(
+                  promptHandler({
+                    threadId,
+                    sessionId: error.sessionId,
+                    currentOwnerId: error.currentOwnerId,
+                    expiresAt: error.expiresAt,
+                    secondsWaited: Math.round(elapsedMs / 1000),
+                    allowNewThread,
+                  }),
+                ),
+                sleep(SESSION_LEASE_PROMPT_RESPONSE_BUDGET_MS).then<LeaseRecoveryAction>(() => 'wait'),
+              ])
+            : 'wait';
+          // Direct thread API callers (createThread / switchThread) cannot
+          // honor a new-thread choice — they must bind a specific threadId.
+          // Down-convert to quit so the caller sees a clean recovery error
+          // instead of the internal sentinel leaking out.
+          const action: LeaseRecoveryAction =
+            rawAction === 'new-thread' && !allowNewThread ? 'quit' : rawAction;
+          if (action === 'force-claim') {
+            chosenPolicy = 'force-claim';
+            try {
+              await this.forceReleaseForeignLease(error.sessionId, error.currentOwnerId);
+            } catch (releaseErr) {
+              throw new MastraCodeSessionLeaseRecoveryError(
+                threadId,
+                error.sessionId,
+                error.currentOwnerId,
+                error.expiresAt,
+                { cause: releaseErr },
+              );
+            }
+            this.emit({
+              type: 'info',
+              message: `Released the MastraCode Harness session lease previously owned by "${error.currentOwnerId}"; retrying acquisition.`,
+            });
+            continue;
+          }
+          if (action === 'new-thread') {
+            throw new MastraCodeLeaseRecoveryNewThreadError();
+          }
+          if (action === 'quit') {
+            throw new MastraCodeSessionLeaseRecoveryError(
+              threadId,
+              error.sessionId,
+              error.currentOwnerId,
+              error.expiresAt,
+              { cause: error },
+            );
+          }
+        }
+
+        const rawRetryDelayMs = sessionLeaseRetryDelayMs(error);
+        const remainingMs = maxWaitMs - elapsedMs;
+        if (remainingMs <= 0) {
+          throw new MastraCodeSessionLeaseRecoveryError(
+            threadId,
+            error.sessionId,
+            error.currentOwnerId,
+            error.expiresAt,
+            { cause: error },
+          );
+        }
+        // Cap the next sleep at the remaining budget so total wait never
+        // exceeds maxWaitMs by more than ~one storage round-trip.
+        const retryDelayMs = Math.min(rawRetryDelayMs, remainingMs);
+        const expiresLabel =
+          Number.isFinite(error.expiresAt) && error.expiresAt > 0
+            ? new Date(error.expiresAt).toLocaleTimeString()
+            : 'an unknown time';
+        // Show the env-var hint on the first wait message only; subsequent
+        // retries just say "still waiting" to avoid log spam.
+        const hint = infoHintEmitted
+          ? ''
+          : ' Set MASTRACODE_LEASE_RECOVERY=force-claim to take the lease immediately if the other process is known dead.';
+        infoHintEmitted = true;
+        this.emit({
+          type: 'info',
+          message: `A previous MastraCode Harness session lease is still held by another process until ${expiresLabel}; retrying in ${formatRetryDelay(retryDelayMs)}.${hint}`,
+        });
+        await sleep(retryDelayMs);
+      }
+    }
+  }
+
+  private async forceReleaseForeignLease(sessionId: string, ownerId: string): Promise<void> {
+    const harnessStorage = (await this.config.storage.getStore('harness')) as
+      | {
+          releaseSessionLease?: (opts: { harnessName: string; sessionId: string; ownerId: string }) => Promise<void>;
+        }
+      | undefined;
+    if (!harnessStorage || typeof harnessStorage.releaseSessionLease !== 'function') {
+      throw new Error('MastraCode Harness storage does not expose releaseSessionLease; cannot force-claim session lease.');
+    }
+    await harnessStorage.releaseSessionLease({
+      harnessName: MASTRACODE_HARNESS_NAME,
+      sessionId,
+      ownerId,
     });
   }
 

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -81,6 +81,13 @@ type AgentWithBrowser = {
   hasOwnBrowser?: () => boolean;
 };
 
+type AgentWithWorkspace = {
+  __setWorkspace?: (workspace: NonNullable<MastraCodeRuntimeConfig<Record<string, unknown>>['workspace']>) => void;
+  hasOwnWorkspace?: () => boolean;
+};
+
+type RuntimeWorkspaceFactory = NonNullable<MastraCodeRuntimeConfig<Record<string, unknown>>['workspace']>;
+
 type SignalInput =
   | {
       content: string | HarnessMessageContentPart[];
@@ -290,6 +297,13 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     this.state = { ...config.initialState };
     this.currentDisplayTasks = cloneTasks(this.state.tasks);
     const harnessV1Agents = toHarnessV1Agents(config.agents, config.modes);
+    const workspaceFactory: RuntimeWorkspaceFactory | undefined = config.workspace
+      ? ({ requestContext, mastra }) =>
+          config.workspace!({
+            requestContext: this.withRuntimeHarnessContext(requestContext),
+            mastra: mastra ?? this.mastra,
+          })
+      : undefined;
     const exposedSubagents = this.shouldExposeSubagentTool() ? config.subagents : [];
     const harnessV1Subagents =
       exposedSubagents.length > 0 ? { types: toHarnessV1Subagents(exposedSubagents) } : undefined;
@@ -302,14 +316,10 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       toolCategoryResolver: config.toolCategoryResolver,
       models: [],
       modelAuthStatusResolver: modelId => this.resolveHarnessV1AuthStatus(modelId),
-      workspace: config.workspace
+      workspace: workspaceFactory
         ? {
             kind: 'shared' as const,
-            workspace: ({ requestContext }) =>
-              config.workspace!({
-                requestContext: this.withRuntimeHarnessContext(requestContext),
-                mastra: this.mastra,
-              }),
+            workspace: ({ requestContext }) => workspaceFactory({ requestContext, mastra: this.mastra }),
           }
         : undefined,
     });
@@ -322,6 +332,10 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       workers: false,
       harnesses: { [MASTRACODE_HARNESS_NAME]: this.core },
     });
+
+    if (workspaceFactory) {
+      this.setWorkspaceOnAgents(harnessV1Agents, workspaceFactory);
+    }
 
     if (config.browser && typeof config.browser !== 'function') {
       this.setBrowser(config.browser);
@@ -1484,6 +1498,17 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
   getResolvedReflectorModel(): unknown {
     const modelId = this.getReflectorModelId();
     return modelId && this.config.resolveModel ? this.config.resolveModel(modelId) : undefined;
+  }
+
+  private setWorkspaceOnAgents(agents: Record<string, unknown>, workspaceFactory: RuntimeWorkspaceFactory): void {
+    const seen = new Set<unknown>();
+    for (const agent of Object.values(agents)) {
+      if (seen.has(agent)) continue;
+      seen.add(agent);
+      const workspaceAgent = agent as AgentWithWorkspace;
+      if (workspaceAgent.hasOwnWorkspace?.()) continue;
+      workspaceAgent.__setWorkspace?.(workspaceFactory);
+    }
   }
 
   private withRuntimeHarnessContext(requestContext: RequestContext): RequestContext {

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -36,6 +36,7 @@ import { Mastra } from '@mastra/core/mastra';
 import { RequestContext } from '@mastra/core/request-context';
 import type { WorkspaceActionJournalEntry } from '@mastra/core/storage';
 
+import { ALWAYS_ALLOW_TOOL_NAMES } from '../permissions.js';
 import { isSubagentToolName } from '../tool-names.js';
 import {
   MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
@@ -1800,13 +1801,15 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       (this.state.permissionRules as
         | { categories?: Record<string, PermissionPolicy>; tools?: Record<string, PermissionPolicy> }
         | undefined) ?? {};
+    const alwaysAllowTools = new Set<string>(ALWAYS_ALLOW_TOOL_NAMES);
     await Promise.all([
       ...Object.entries(rules.categories ?? {})
         .filter(([category]) => TOOL_CATEGORIES.includes(category as ToolCategory))
         .map(([category, policy]) => session.permissions.setPolicy({ category: category as ToolCategory, policy })),
-      ...Object.entries(rules.tools ?? {}).map(([toolName, policy]) =>
-        session.permissions.setPolicy({ toolName, policy }),
-      ),
+      ...Object.entries(rules.tools ?? {})
+        .filter(([toolName]) => !alwaysAllowTools.has(toolName))
+        .map(([toolName, policy]) => session.permissions.setPolicy({ toolName, policy })),
+      ...ALWAYS_ALLOW_TOOL_NAMES.map(toolName => session.permissions.setPolicy({ toolName, policy: 'allow' })),
     ]);
   }
 

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -304,12 +304,17 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       workspace: config.workspace
         ? {
             kind: 'shared' as const,
-            workspace: ({ requestContext }) => config.workspace!({ requestContext, mastra: this.mastra }),
+            workspace: ({ requestContext }) =>
+              config.workspace!({
+                requestContext: this.withRuntimeHarnessContext(requestContext),
+                mastra: this.mastra,
+              }),
           }
         : undefined,
     });
 
     this.mastra = new Mastra({
+      logger: false,
       agents: harnessV1Agents,
       storage: config.storage,
       observability: config.observability,
@@ -1480,26 +1485,28 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     return modelId && this.config.resolveModel ? this.config.resolveModel(modelId) : undefined;
   }
 
+  private withRuntimeHarnessContext(requestContext: RequestContext): RequestContext {
+    if (requestContext.get('harness')) return requestContext;
+
+    requestContext.set('harness', {
+      harnessId: 'mastra-code',
+      sessionId: this.session?.id,
+      threadId: this.getCurrentThreadId(),
+      resourceId: this.resourceId,
+      modeId: this.currentModeId,
+      state: this.state,
+      getState: () => this.state,
+      setState: (updates: Partial<TState>) => this.setState(updates),
+      getSubagentModelId: (params?: { agentType?: string }) => this.getSubagentModelId(params),
+      workspace: this.currentWorkspace,
+    });
+    return requestContext;
+  }
+
   async getResolvedMemory() {
     if (!this.config.memory) return null;
     if (typeof this.config.memory !== 'function') return this.config.memory;
-    const requestContext = new RequestContext([
-      [
-        'harness',
-        {
-          harnessId: 'mastra-code',
-          sessionId: this.session?.id,
-          threadId: this.getCurrentThreadId(),
-          resourceId: this.resourceId,
-          modeId: this.currentModeId,
-          state: this.state,
-          getState: () => this.state,
-          setState: (updates: Partial<TState>) => this.setState(updates),
-          getSubagentModelId: (params?: { agentType?: string }) => this.getSubagentModelId(params),
-          workspace: this.currentWorkspace,
-        },
-      ],
-    ]) as RequestContext<unknown>;
+    const requestContext = this.withRuntimeHarnessContext(new RequestContext());
     return this.config.memory({ requestContext, mastra: this.mastra });
   }
 

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -291,6 +291,11 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     },
   });
 
+  const observabilityExporters = [
+    ...(observabilityDomain ? [new MastraStorageExporter({ strategy: 'event-sourced' as const })] : []),
+    new MastraPlatformExporter(resolveCloudObservabilityConfig(globalSettings, authStorage, project.resourceId)),
+  ];
+
   // Observability (tracing, scoring, feedback)
   const observability = new Observability({
     configs: {
@@ -334,10 +339,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
           'harness.state.observationThreshold',
           'harness.state.reflectionThreshold',
         ],
-        exporters: [
-          new MastraStorageExporter({ strategy: 'event-sourced' }),
-          new MastraPlatformExporter(resolveCloudObservabilityConfig(globalSettings, authStorage, project.resourceId)),
-        ],
+        exporters: observabilityExporters,
         spanOutputProcessors: [new SensitiveDataFilter()],
       },
     },

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -42,7 +42,8 @@ import { createDynamicTools } from './agents/tools.js';
 import { getDynamicWorkspace } from './agents/workspace.js';
 import { AuthStorage } from './auth/storage.js';
 import { createOutcomeScorer, createEfficiencyScorer } from './evals/scorers/index.js';
-import { createHarnessV1SubagentAgents, MastraCodeHarnessRuntime } from './harness/index.js';
+import { createHarnessV1SubagentAgents, defaultStdioLeaseRecoveryPrompt, MastraCodeHarnessRuntime } from './harness/index.js';
+import type { LeaseRecoveryPromptHandler } from './harness/index.js';
 import { HookManager } from './hooks/index.js';
 import { createMcpManager } from './mcp/index.js';
 import type { McpServerConfig } from './mcp/index.js';
@@ -138,7 +139,25 @@ export interface MastraCodeConfig {
   unixSocketPubSub?: boolean;
   /** Marks the configured PubSub as cross-process-safe, allowing Mastra Code to skip file thread locks. */
   crossProcessPubSub?: boolean;
+  /**
+   * Interactive prompt invoked during startup when a stale Harness v1 session
+   * lease is still held by another process. Defaults to a stdio readline
+   * prompt when stdin is a TTY (`(W)ait/(F)orce-claim/(N)ew thread/(Q)uit`).
+   * Set `MASTRACODE_LEASE_RECOVERY=wait|force-claim|new-thread|quit` to skip
+   * the prompt programmatically.
+   */
+  leaseRecoveryPrompt?: LeaseRecoveryPromptHandler;
 }
+
+export {
+  MastraCodeSessionLeaseRecoveryError,
+  defaultStdioLeaseRecoveryPrompt,
+} from './harness/index.js';
+export type {
+  LeaseRecoveryAction,
+  LeaseRecoveryPromptInfo,
+  LeaseRecoveryPromptHandler,
+} from './harness/index.js';
 
 export type MastraCodeHarnessPublic = Harness<Record<string, unknown>> & {
   actions: MastraCodeHarnessRuntime<Record<string, unknown>>['actions'];
@@ -670,6 +689,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     resolveModel,
     disabledTools: config?.disabledTools,
     browser: config?.browser,
+    leaseRecoveryPrompt: config?.leaseRecoveryPrompt ?? defaultStdioLeaseRecoveryPrompt(),
   });
 
   // Sync hookManager session ID on thread changes

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -23,16 +23,34 @@ let hookManager: Awaited<ReturnType<typeof createMastraCode>>['hookManager'];
 let authStorage: Awaited<ReturnType<typeof createMastraCode>>['authStorage'];
 let signalsPubSub: Awaited<ReturnType<typeof createMastraCode>>['signalsPubSub'];
 let analytics: ReturnType<typeof createMastraCodeAnalytics> | undefined;
+let activeTui: MastraTUI | undefined;
+
+// Reset extended terminal modes (bracketed paste, kitty progressive-enhancement
+// keyboard protocol, modifyOtherKeys) that pi-tui enables at startup. pi-tui
+// restores these via `TUI.stop()` on a clean exit, but a SIGKILL or unhandled
+// crash leaves the parent shell stuck — every subsequent keypress emits raw
+// CSI-u sequences. Calling this on every trappable exit path AND once at
+// launch time recovers cleanly from a previous ungraceful exit.
+function restoreTerminalKeyboardModes(): void {
+  if (!process.stdout.isTTY) return;
+  // \x1b[<u  — pop kitty kbd protocol layer
+  // \x1b[>4;0m — disable xterm modifyOtherKeys mode 2
+  // \x1b[?2004l — disable bracketed paste
+  // \x1b[?1l — leave cursor-key application mode
+  process.stdout.write('\x1b[<u\x1b[>4;0m\x1b[?2004l\x1b[?1l');
+}
 
 // Global safety nets — catch any uncaught errors from storage init, etc.
 process.on('uncaughtException', error => {
   // ERR_STREAM_DESTROYED is non-fatal — happens routinely when streams close
   // during shutdown, cancelled LLM requests, or LSP/subprocess exits (#13548, #13549)
   if (isStreamDestroyedError(error)) return;
+  restoreTerminalKeyboardModes();
   handleFatalError(error);
 });
 process.on('unhandledRejection', reason => {
   if (isStreamDestroyedError(reason)) return;
+  restoreTerminalKeyboardModes();
   handleFatalError(reason instanceof Error ? reason : new Error(String(reason)));
 });
 
@@ -104,6 +122,7 @@ async function tuiMain(pipedInput?: string | null) {
     inlineQuestions: true,
     ...(pipedInput ? { initialMessage: `The following was piped via stdin:\n\n${pipedInput}` } : {}),
   });
+  activeTui = tui;
   tui.run().catch(error => {
     handleFatalError(error);
   });
@@ -134,13 +153,23 @@ process.on('beforeExit', () => {
   void asyncCleanup();
 });
 process.on('exit', () => {
+  restoreTerminalKeyboardModes();
   restoreTerminalForeground();
   releaseAllThreadLocks();
 });
 process.on('SIGINT', () => {
+  activeTui?.stop();
+  restoreTerminalKeyboardModes();
   void asyncCleanup().finally(() => process.exit(0));
 });
 process.on('SIGTERM', () => {
+  activeTui?.stop();
+  restoreTerminalKeyboardModes();
+  void asyncCleanup().finally(() => process.exit(0));
+});
+process.on('SIGHUP', () => {
+  activeTui?.stop();
+  restoreTerminalKeyboardModes();
   void asyncCleanup().finally(() => process.exit(0));
 });
 
@@ -185,6 +214,10 @@ function handleFatalError(error: unknown): never {
 }
 
 async function main() {
+  // Recover from a possibly broken terminal left by a prior crashed instance
+  // (SIGKILL, OOM, etc) before pi-tui re-enables its extended modes. Safe to
+  // emit unconditionally — codes are no-ops on a clean terminal.
+  restoreTerminalKeyboardModes();
   if (hasHeadlessFlag(process.argv) || process.argv.includes('--help') || process.argv.includes('-h')) {
     return headlessMain();
   }

--- a/mastracode/src/permissions.ts
+++ b/mastracode/src/permissions.ts
@@ -62,7 +62,7 @@ const TOOL_CATEGORY_MAP: Record<string, ToolCategory> = {
 };
 
 // Tools that never need approval regardless of policy
-const ALWAYS_ALLOW_TOOLS = new Set([
+export const ALWAYS_ALLOW_TOOL_NAMES = [
   'ask_user',
   'task_write',
   'task_update',
@@ -70,7 +70,9 @@ const ALWAYS_ALLOW_TOOLS = new Set([
   'task_check',
   'submit_plan',
   'request_access',
-]);
+] as const;
+
+const ALWAYS_ALLOW_TOOLS = new Set<string>(ALWAYS_ALLOW_TOOL_NAMES);
 
 /**
  * Get the category for a tool, or null if the tool is always-allowed.

--- a/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
+++ b/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
@@ -178,9 +178,10 @@ describe('request_access', () => {
     expect(result.content).toContain('Access granted');
   });
 
-  it('registers a Harness v1 durable question when no legacy event emitter is present', async () => {
+  it('registers a Harness v1 native sandbox access request when no legacy event emitter is present', async () => {
     const registerQuestion = vi.fn(async () => undefined);
-    const suspend = vi.fn(async () => {
+    const registerSandboxAccess = vi.fn(async () => undefined);
+    const suspend = vi.fn(async (_payload?: unknown) => {
       throw new Error('suspended');
     });
 
@@ -195,6 +196,7 @@ describe('request_access', () => {
           key === 'harness'
             ? {
                 registerQuestion,
+                registerSandboxAccess,
                 getState: () => ({ sandboxAllowedPaths: [] }),
                 setState: vi.fn(),
               }
@@ -210,15 +212,17 @@ describe('request_access', () => {
       ),
     ).rejects.toThrow('suspended');
 
-    expect(registerQuestion).toHaveBeenCalledWith(
+    expect(registerSandboxAccess).toHaveBeenCalledWith(
       expect.objectContaining({
-        questionId: expect.stringMatching(/^sandbox_/),
-        question: expect.stringContaining('/outside/project/dir'),
+        requestId: expect.stringMatching(/^sandbox_/),
+        semanticType: 'file',
+        reason: 'need to read config',
+        payload: { path: '/outside/project/dir' },
         runId: 'run-1',
         toolCallId: 'tool-1',
-        selectionMode: 'single_select',
       }),
     );
+    expect(registerQuestion).not.toHaveBeenCalled();
     expect(suspend).toHaveBeenCalled();
     expect(suspend.mock.calls[0]?.[0]).toEqual({});
   });
@@ -229,7 +233,7 @@ describe('request_access', () => {
 
     const context = {
       agent: {
-        resumeData: { answer: 'yes' },
+        resumeData: { approved: true },
       },
       requestContext: {
         get: (key: string) =>

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -19,12 +19,20 @@ function expandTilde(p: string): string {
 }
 
 type MastraCodeState = z.infer<typeof stateSchema>;
-type HarnessV1QuestionContext = {
+type HarnessV1SuspensionContext = {
   registerQuestion: (params: {
     questionId: string;
     question: string;
     options?: Array<{ label: string; description?: string }>;
     selectionMode?: 'single_select' | 'multi_select';
+    runId?: string;
+    toolCallId?: string;
+  }) => Promise<void>;
+  registerSandboxAccess?: (params: {
+    requestId: string;
+    semanticType: 'file' | 'command' | 'network' | 'mcp' | 'custom';
+    reason?: string;
+    payload?: Record<string, unknown>;
     runId?: string;
     toolCallId?: string;
   }) => Promise<void>;
@@ -47,6 +55,9 @@ type ToolExecutionContext = {
 let requestCounter = 0;
 
 function answerApproved(answer: HarnessQuestionAnswer | unknown): boolean {
+  if (typeof answer === 'object' && answer !== null && 'approved' in answer) {
+    return (answer as { approved?: unknown }).approved === true;
+  }
   const value =
     typeof answer === 'object' && answer !== null && 'answer' in answer
       ? (answer as { answer: HarnessQuestionAnswer }).answer
@@ -94,19 +105,30 @@ export const requestSandboxAccessTool = createTool({
       let answer: HarnessQuestionAnswer | unknown = resumeData;
 
       if (answer === undefined && toolContext?.agent?.suspend) {
-        // Harness v1 path: park the tool through the durable question suspension surface.
-        const harnessV1Ctx = harnessCtx as unknown as HarnessV1QuestionContext;
-        await harnessV1Ctx.registerQuestion({
-          questionId,
-          question: `Allow Mastra Code to access ${absolutePath}?\n\n${reason}`,
-          options: [
-            { label: 'Yes', description: 'Grant access for this session.' },
-            { label: 'No', description: 'Deny this access request.' },
-          ],
-          selectionMode: 'single_select',
-          runId: toolContext.agent.runId,
-          toolCallId: toolContext.agent.toolCallId ?? questionId,
-        });
+        // Harness v1 path: park the tool through the native sandbox-access surface when available.
+        const harnessV1Ctx = harnessCtx as unknown as HarnessV1SuspensionContext;
+        if (harnessV1Ctx.registerSandboxAccess) {
+          await harnessV1Ctx.registerSandboxAccess({
+            requestId: questionId,
+            semanticType: 'file',
+            reason,
+            payload: { path: absolutePath },
+            runId: toolContext.agent.runId,
+            toolCallId: toolContext.agent.toolCallId ?? questionId,
+          });
+        } else {
+          await harnessV1Ctx.registerQuestion({
+            questionId,
+            question: `Allow Mastra Code to access ${absolutePath}?\n\n${reason}`,
+            options: [
+              { label: 'Yes', description: 'Grant access for this session.' },
+              { label: 'No', description: 'Deny this access request.' },
+            ],
+            selectionMode: 'single_select',
+            runId: toolContext.agent.runId,
+            toolCallId: toolContext.agent.toolCallId ?? questionId,
+          });
+        }
         propagatingHarnessV1Suspension = true;
         await toolContext.agent.suspend({});
         propagatingHarnessV1Suspension = false;

--- a/mastracode/src/tui/components/__tests__/ask-question-from-history.test.ts
+++ b/mastracode/src/tui/components/__tests__/ask-question-from-history.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub pi-tui so component construction doesn't touch a real terminal.
+vi.mock('@mariozechner/pi-tui', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  class StubBox {
+    children: unknown[] = [];
+    constructor(..._args: unknown[]) {}
+    addChild(c: unknown): void {
+      this.children.push(c);
+    }
+    removeChild(_c: unknown): void {}
+    invalidate(): void {}
+  }
+  class StubContainer extends StubBox {}
+  class StubText {
+    constructor(_text: string, _x: number, _y: number) {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  class StubSpacer {
+    constructor(_height: number) {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  class StubInput {
+    onSubmit?: (value: string) => void;
+    focused = false;
+    handleInput(_data: string): void {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  class StubSelectList {
+    onSelect?: (item: unknown) => void;
+    onCancel?: () => void;
+    constructor(
+      public items: unknown[],
+      _h: number,
+      _theme: unknown,
+    ) {}
+    handleInput(_data: string): void {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  return {
+    ...actual,
+    Box: StubBox,
+    Container: StubContainer,
+    Text: StubText,
+    Spacer: StubSpacer,
+    Input: StubInput,
+    SelectList: StubSelectList,
+    getKeybindings: () => ({ matches: () => false }),
+  };
+});
+
+vi.mock('../multiline-input.js', () => {
+  class StubMultilineInput {
+    onSubmit?: (value: string) => void;
+    onEscape?: () => void;
+    allowEmptySubmit = false;
+    focused = false;
+    constructor(_tui: unknown, _theme: unknown) {}
+    handleInput(_data: string): void {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  return { MultilineInput: StubMultilineInput };
+});
+
+import { AskQuestionInlineComponent } from '../ask-question-inline.js';
+
+function readBoxState(component: AskQuestionInlineComponent): {
+  selectedValue: string | undefined;
+  selectedValues: Set<string> | undefined;
+  cancelled: boolean;
+  answered: boolean;
+} {
+  const box = (component as unknown as { borderedBox: Record<string, unknown> }).borderedBox;
+  return {
+    selectedValue: box.selectedValue as string | undefined,
+    selectedValues: box.selectedValues as Set<string> | undefined,
+    cancelled: Boolean(box.cancelled),
+    answered: Boolean(box.answered),
+  };
+}
+
+describe('AskQuestionInlineComponent.fromHistory multi-select restoration', () => {
+  it('reconstructs multi-select state from a comma-joined answer', () => {
+    const component = AskQuestionInlineComponent.fromHistory(
+      'Pick all that apply',
+      [{ label: 'Alpha' }, { label: 'Beta' }, { label: 'Gamma' }],
+      'Alpha, Gamma',
+      false,
+      'multi_select',
+    );
+
+    const box = readBoxState(component);
+    expect(box.answered).toBe(true);
+    expect(box.cancelled).toBe(false);
+    expect(box.selectedValues).toEqual(new Set(['Alpha', 'Gamma']));
+    expect(box.selectedValue).toBeUndefined();
+  });
+
+  it('reconstructs a single-element multi-select answer', () => {
+    const component = AskQuestionInlineComponent.fromHistory(
+      'Pick all that apply',
+      [{ label: 'Alpha' }, { label: 'Beta' }],
+      'Alpha',
+      false,
+      'multi_select',
+    );
+
+    const box = readBoxState(component);
+    expect(box.selectedValues).toEqual(new Set(['Alpha']));
+  });
+
+  it('preserves item order in the reconstructed set independent of answer-string order', () => {
+    const component = AskQuestionInlineComponent.fromHistory(
+      'Pick all that apply',
+      [{ label: 'Alpha' }, { label: 'Beta' }, { label: 'Gamma' }],
+      'Gamma, Alpha',
+      false,
+      'multi_select',
+    );
+
+    const box = readBoxState(component);
+    expect(box.selectedValues).toEqual(new Set(['Alpha', 'Gamma']));
+  });
+
+  it('falls back to single-string render when comma-split matches no option', () => {
+    const component = AskQuestionInlineComponent.fromHistory(
+      'Pick all that apply',
+      [{ label: 'Alpha' }, { label: 'Beta' }],
+      'something unrelated',
+      false,
+      'multi_select',
+    );
+
+    const box = readBoxState(component);
+    expect(box.selectedValues).toBeUndefined();
+    expect(box.selectedValue).toBe('something unrelated');
+  });
+
+  it('renders single-select answers via setAnswered, not setAnsweredMulti', () => {
+    const component = AskQuestionInlineComponent.fromHistory(
+      'Pick one',
+      [{ label: 'Alpha' }, { label: 'Beta' }],
+      'Alpha',
+      false,
+      'single_select',
+    );
+
+    const box = readBoxState(component);
+    expect(box.selectedValues).toBeUndefined();
+    expect(box.selectedValue).toBe('Alpha');
+  });
+
+  it('ignores selectionMode when answer is cancelled', () => {
+    const component = AskQuestionInlineComponent.fromHistory(
+      'Pick all that apply',
+      [{ label: 'Alpha' }],
+      '(skipped)',
+      true,
+      'multi_select',
+    );
+
+    const box = readBoxState(component);
+    expect(box.cancelled).toBe(true);
+    expect(box.selectedValues).toBeUndefined();
+  });
+
+  it('keeps prior single-string behavior when selectionMode is not provided', () => {
+    const component = AskQuestionInlineComponent.fromHistory('Free text question', undefined, 'my answer', false);
+
+    const box = readBoxState(component);
+    expect(box.selectedValues).toBeUndefined();
+    expect(box.selectedValue).toBe('my answer');
+  });
+});

--- a/mastracode/src/tui/components/__tests__/ask-question-multi-select.test.ts
+++ b/mastracode/src/tui/components/__tests__/ask-question-multi-select.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub pi-tui so component construction doesn't touch a real terminal.
+vi.mock('@mariozechner/pi-tui', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  class StubBox {
+    children: unknown[] = [];
+    constructor(..._args: unknown[]) {}
+    addChild(c: unknown): void {
+      this.children.push(c);
+    }
+    removeChild(_c: unknown): void {}
+    invalidate(): void {}
+  }
+  class StubContainer extends StubBox {}
+  class StubText {
+    constructor(_text: string, _x: number, _y: number) {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  class StubSpacer {
+    constructor(_height: number) {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  class StubInput {
+    onSubmit?: (value: string) => void;
+    focused = false;
+    handleInput(_data: string): void {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  class StubSelectList {
+    onSelect?: (item: unknown) => void;
+    onCancel?: () => void;
+    constructor(
+      public items: unknown[],
+      _h: number,
+      _theme: unknown,
+    ) {}
+    handleInput(_data: string): void {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  return {
+    ...actual,
+    Box: StubBox,
+    Container: StubContainer,
+    Text: StubText,
+    Spacer: StubSpacer,
+    Input: StubInput,
+    SelectList: StubSelectList,
+    getKeybindings: () => ({ matches: () => false }),
+  };
+});
+
+vi.mock('../multiline-input.js', () => {
+  class StubMultilineInput {
+    onSubmit?: (value: string) => void;
+    onEscape?: () => void;
+    allowEmptySubmit = false;
+    focused = false;
+    constructor(_tui: unknown, _theme: unknown) {}
+    handleInput(_data: string): void {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  return { MultilineInput: StubMultilineInput };
+});
+
+import { AskQuestionDialogComponent } from '../ask-question-dialog.js';
+import { AskQuestionInlineComponent } from '../ask-question-inline.js';
+
+describe('multi-select onSubmit fallback when onSubmitMulti is omitted', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('inline: forwards joined values to onSubmit when onSubmitMulti is missing', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const component = new AskQuestionInlineComponent({
+      question: 'Pick',
+      options: [{ label: 'Alpha' }, { label: 'Beta' }],
+      selectionMode: 'multi_select',
+      onSubmit,
+      onCancel,
+    });
+
+    // Reach into the private multi-select primitive and submit two values.
+    const multi = (component as unknown as { multiSelectList: { onSubmit?: (v: string[]) => void } }).multiSelectList;
+    expect(multi).toBeDefined();
+    multi.onSubmit?.(['Alpha', 'Beta']);
+
+    expect(onSubmit).toHaveBeenCalledWith('Alpha, Beta');
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('inline: prefers onSubmitMulti when provided and never joins', () => {
+    const onSubmit = vi.fn();
+    const onSubmitMulti = vi.fn();
+    const onCancel = vi.fn();
+    const component = new AskQuestionInlineComponent({
+      question: 'Pick',
+      options: [{ label: 'Alpha' }, { label: 'Beta' }],
+      selectionMode: 'multi_select',
+      onSubmit,
+      onSubmitMulti,
+      onCancel,
+    });
+
+    const multi = (component as unknown as { multiSelectList: { onSubmit?: (v: string[]) => void } }).multiSelectList;
+    multi.onSubmit?.(['Alpha']);
+
+    expect(onSubmitMulti).toHaveBeenCalledWith(['Alpha']);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('dialog: forwards joined values to onSubmit when onSubmitMulti is missing', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    const component = new AskQuestionDialogComponent({
+      question: 'Pick',
+      options: [{ label: 'Alpha' }, { label: 'Gamma' }],
+      selectionMode: 'multi_select',
+      onSubmit,
+      onCancel,
+    });
+
+    const multi = (component as unknown as { multiSelectList: { onSubmit?: (v: string[]) => void } }).multiSelectList;
+    expect(multi).toBeDefined();
+    multi.onSubmit?.(['Alpha', 'Gamma']);
+
+    expect(onSubmit).toHaveBeenCalledWith('Alpha, Gamma');
+  });
+
+  it('dialog: prefers onSubmitMulti when provided', () => {
+    const onSubmit = vi.fn();
+    const onSubmitMulti = vi.fn();
+    const onCancel = vi.fn();
+    const component = new AskQuestionDialogComponent({
+      question: 'Pick',
+      options: [{ label: 'Alpha' }, { label: 'Gamma' }],
+      selectionMode: 'multi_select',
+      onSubmit,
+      onSubmitMulti,
+      onCancel,
+    });
+
+    const multi = (component as unknown as { multiSelectList: { onSubmit?: (v: string[]) => void } }).multiSelectList;
+    multi.onSubmit?.(['Gamma']);
+
+    expect(onSubmitMulti).toHaveBeenCalledWith(['Gamma']);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/src/tui/components/__tests__/multi-select-list.test.ts
+++ b/mastracode/src/tui/components/__tests__/multi-select-list.test.ts
@@ -1,0 +1,104 @@
+import type { SelectItem, SelectListTheme } from '@mariozechner/pi-tui';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MultiSelectList } from '../multi-select-list.js';
+
+function makeTheme(): SelectListTheme {
+  const identity = (s: string) => s;
+  return {
+    selectedPrefix: identity,
+    selectedText: identity,
+    description: identity,
+    scrollInfo: identity,
+    noMatch: identity,
+  };
+}
+
+function items(...values: string[]): SelectItem[] {
+  return values.map(v => ({ value: v, label: v }));
+}
+
+describe('MultiSelectList', () => {
+  it('starts with no values toggled', () => {
+    const list = new MultiSelectList(items('a', 'b', 'c'), 5, makeTheme());
+    expect(list.getToggled()).toEqual([]);
+  });
+
+  it('toggles the value under the cursor on Space', () => {
+    const list = new MultiSelectList(items('a', 'b', 'c'), 5, makeTheme());
+    list.handleInput(' ');
+    expect(list.getToggled()).toEqual(['a']);
+    list.handleInput(' ');
+    expect(list.getToggled()).toEqual([]);
+  });
+
+  it('navigates with arrow keys and toggles independently', () => {
+    const list = new MultiSelectList(items('a', 'b', 'c'), 5, makeTheme());
+    list.handleInput(' ');
+    list.handleInput('\x1b[B');
+    list.handleInput(' ');
+    list.handleInput('\x1b[B');
+    list.handleInput(' ');
+    expect(list.getToggled()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns values in items order regardless of selection order', () => {
+    const list = new MultiSelectList(items('a', 'b', 'c'), 5, makeTheme());
+    list.handleInput('\x1b[B');
+    list.handleInput('\x1b[B');
+    list.handleInput(' ');
+    list.handleInput('\x1b[A');
+    list.handleInput(' ');
+    list.handleInput('\x1b[A');
+    list.handleInput(' ');
+    expect(list.getToggled()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('submits the toggled values on Enter via onSubmit', () => {
+    const list = new MultiSelectList(items('a', 'b', 'c'), 5, makeTheme());
+    const onSubmit = vi.fn();
+    list.onSubmit = onSubmit;
+    list.handleInput(' ');
+    list.handleInput('\x1b[B');
+    list.handleInput('\x1b[B');
+    list.handleInput(' ');
+    list.handleInput('\r');
+    expect(onSubmit).toHaveBeenCalledWith(['a', 'c']);
+  });
+
+  it('submits an empty array when nothing is toggled', () => {
+    const list = new MultiSelectList(items('a', 'b', 'c'), 5, makeTheme());
+    const onSubmit = vi.fn();
+    list.onSubmit = onSubmit;
+    list.handleInput('\r');
+    expect(onSubmit).toHaveBeenCalledWith([]);
+  });
+
+  it('fires onCancel on Esc', () => {
+    const list = new MultiSelectList(items('a', 'b', 'c'), 5, makeTheme());
+    const onCancel = vi.fn();
+    list.onCancel = onCancel;
+    list.handleInput('\x1b');
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders empty items with the no-match theme', () => {
+    const list = new MultiSelectList([], 5, makeTheme());
+    expect(list.render(40)).toEqual(['  No options']);
+  });
+
+  it('renders cursor and checkbox markers', () => {
+    const list = new MultiSelectList(items('Alpha', 'Beta'), 5, makeTheme());
+    list.handleInput(' ');
+    const lines = list.render(40);
+    expect(lines[0]).toContain('[x] Alpha');
+    expect(lines[1]).toContain('[ ] Beta');
+    expect(lines[0]).toContain('→ ');
+  });
+
+  it('seeds initial toggled values via setToggled', () => {
+    const list = new MultiSelectList(items('a', 'b', 'c'), 5, makeTheme());
+    list.setToggled(['c']);
+    expect(list.getToggled()).toEqual(['c']);
+  });
+});

--- a/mastracode/src/tui/components/__tests__/multi-select-list.test.ts
+++ b/mastracode/src/tui/components/__tests__/multi-select-list.test.ts
@@ -101,4 +101,11 @@ describe('MultiSelectList', () => {
     list.setToggled(['c']);
     expect(list.getToggled()).toEqual(['c']);
   });
+
+  it('does not crash when items is empty', () => {
+    const list = new MultiSelectList([], 5, makeTheme());
+    expect(() => list.handleInput(' ')).not.toThrow();
+    expect(() => list.handleInput('\x1b[B')).not.toThrow();
+    expect(list.getToggled()).toEqual([]);
+  });
 });

--- a/mastracode/src/tui/components/ask-question-dialog.ts
+++ b/mastracode/src/tui/components/ask-question-dialog.ts
@@ -7,11 +7,19 @@
 import { Box, getKeybindings, Input, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, Component, TUI } from '@mariozechner/pi-tui';
 import { theme, getSelectListTheme, getEditorTheme } from '../theme.js';
+import { MultiSelectList } from './multi-select-list.js';
 import { MultilineInput } from './multiline-input.js';
+
+export type AskQuestionDialogSelectionMode = 'single_select' | 'multi_select';
 
 export interface AskQuestionDialogOptions {
   question: string;
   options?: Array<{ label: string; description?: string }>;
+  /**
+   * `multi_select` renders a checkbox list that submits `string[]`. Ignored
+   * when no `options` are provided.
+   */
+  selectionMode?: AskQuestionDialogSelectionMode;
   /**
    * Use a multiline editor for free-text input (Shift+Enter / \+Enter for new lines).
    * Defaults to false. Enable for prompts that legitimately want paragraph-length replies.
@@ -23,6 +31,11 @@ export interface AskQuestionDialogOptions {
   selectedOptionLabel?: string;
   tui?: TUI;
   onSubmit: (answer: string) => void;
+  /**
+   * Fires when a multi-select answer is submitted. When omitted, multi-select
+   * answers are joined with `, ` and forwarded to `onSubmit`.
+   */
+  onSubmitMulti?: (values: string[]) => void;
   onCancel: () => void;
 }
 
@@ -30,6 +43,7 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
   private static readonly CUSTOM_RESPONSE_VALUE = '__custom_response__';
 
   private selectList?: SelectList;
+  private multiSelectList?: MultiSelectList;
   private input?: Input | MultilineInput;
   private tui?: TUI;
   private multiline = false;
@@ -38,6 +52,7 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
   private allowCustomResponse = true;
   private selectedOptionLabel?: string;
   private onSubmit: (answer: string) => void;
+  private onSubmitMulti?: (values: string[]) => void;
   private onCancel: () => void;
 
   /** Children added by buildSelectMode/buildInputMode, tracked for removal on mode switch */
@@ -56,6 +71,7 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
     super(2, 1, text => theme.bg('overlayBg', text));
 
     this.onSubmit = options.onSubmit;
+    this.onSubmitMulti = options.onSubmitMulti;
     this.onCancel = options.onCancel;
     this.tui = options.tui;
     this.multiline = Boolean(options.multiline);
@@ -75,10 +91,44 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
     this.addChild(new Spacer(1));
 
     if (options.options && options.options.length > 0) {
-      this.buildSelectMode(options.options);
+      if (options.selectionMode === 'multi_select') {
+        this.buildMultiSelectMode(options.options);
+      } else {
+        this.buildSelectMode(options.options);
+      }
     } else {
       this.buildInputMode();
     }
+  }
+
+  private buildMultiSelectMode(opts: Array<{ label: string; description?: string }>): void {
+    const items: SelectItem[] = opts.map(opt => ({
+      value: opt.label,
+      label: opt.description ? `${opt.label}  ${theme.fg('dim', opt.description)}` : opt.label,
+    }));
+
+    this.multiSelectList = new MultiSelectList(items, Math.min(items.length, 8), getSelectListTheme());
+    this.multiSelectList.onSubmit = (values: string[]) => {
+      if (this.onSubmitMulti) {
+        this.onSubmitMulti(values);
+      } else {
+        this.onSubmit(values.join(', '));
+      }
+    };
+    this.multiSelectList.onCancel = () => {
+      this.onCancel();
+    };
+
+    this.modeChildren = [];
+    const selectChild = this.multiSelectList;
+    this.addChild(selectChild);
+    this.modeChildren.push(selectChild);
+    const spacer = new Spacer(1);
+    this.addChild(spacer);
+    this.modeChildren.push(spacer);
+    const hint = new Text(theme.fg('dim', '  ↑↓ to navigate · Space to toggle · Enter to submit · Esc to skip'), 0, 0);
+    this.addChild(hint);
+    this.modeChildren.push(hint);
   }
 
   private buildSelectMode(opts: Array<{ label: string; description?: string }>): void {
@@ -183,6 +233,8 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
   handleInput(data: string): void {
     if (this.selectList) {
       this.selectList.handleInput(data);
+    } else if (this.multiSelectList) {
+      this.multiSelectList.handleInput(data);
     } else if (this.input) {
       const kb = getKeybindings();
       if (kb.matches(data, 'tui.select.cancel')) {

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -23,11 +23,20 @@ import {
 } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, TUI } from '@mariozechner/pi-tui';
 import { BOX_INDENT_STR, theme, getSelectListTheme, getEditorTheme } from '../theme.js';
+import { MultiSelectList } from './multi-select-list.js';
 import { MultilineInput } from './multiline-input.js';
+
+export type AskQuestionSelectionMode = 'single_select' | 'multi_select';
 
 export interface AskQuestionInlineOptions {
   question: string;
   options?: Array<{ label: string; description?: string }>;
+  /**
+   * `single_select` shows a `SelectList`; `multi_select` shows a `MultiSelectList`
+   * where Space toggles per-option checkboxes and Enter submits a `string[]`.
+   * Ignored when no `options` are provided.
+   */
+  selectionMode?: AskQuestionSelectionMode;
   /** Format the text shown after an answer is selected. Defaults to `question → answer`. */
   formatResult?: (answer: string) => string;
   /** If provided, determines whether an answer should be shown with error styling (red ✗). */
@@ -43,6 +52,12 @@ export interface AskQuestionInlineOptions {
    */
   multiline?: boolean;
   onSubmit: (answer: string) => void;
+  /**
+   * Fires when a multi-select answer is submitted. When omitted, multi-select
+   * answers are joined with `, ` and forwarded to `onSubmit` so single-select
+   * consumers can opt out of the array shape entirely.
+   */
+  onSubmitMulti?: (values: string[]) => void;
   onCancel: () => void;
 }
 
@@ -53,12 +68,15 @@ export interface AskQuestionInlineOptions {
 class AskQuestionBorderedBox {
   questionLines: string[];
   private selectList?: SelectList;
+  private multiSelectList?: MultiSelectList;
   private input?: Input | MultilineInput;
   private hintText: string;
   items: Array<{ label: string; description?: string }>;
   private answered = false;
   private cancelled = false;
   private selectedValue?: string;
+  /** Set of selected labels in multi-select answered state. */
+  private selectedValues?: Set<string>;
   private answerIsNegative = false;
   /** True when created during streaming, before activate() is called */
   private streaming = false;
@@ -70,6 +88,7 @@ class AskQuestionBorderedBox {
     selectList?: SelectList,
     input?: Input | MultilineInput,
     streaming?: boolean,
+    multiSelectList?: MultiSelectList,
   ) {
     this.questionLines = questionLines;
     this.hintText = hintText;
@@ -77,16 +96,24 @@ class AskQuestionBorderedBox {
     this.selectList = selectList;
     this.input = input;
     this.streaming = streaming ?? false;
+    this.multiSelectList = multiSelectList;
   }
 
   invalidate() {
     this.selectList?.invalidate();
+    this.multiSelectList?.invalidate();
   }
 
-  setInteractive(selectList?: SelectList, input?: Input | MultilineInput, hintText?: string) {
+  setInteractive(
+    selectList: SelectList | undefined,
+    input: Input | MultilineInput | undefined,
+    hintText?: string,
+    multiSelectList?: MultiSelectList,
+  ) {
     this.streaming = false;
     this.selectList = selectList;
     this.input = input;
+    this.multiSelectList = multiSelectList;
     if (hintText) this.hintText = hintText;
   }
 
@@ -95,6 +122,13 @@ class AskQuestionBorderedBox {
     this.answered = true;
     this.selectedValue = selectedValue;
     this.answerIsNegative = isNegative;
+  }
+
+  setAnsweredMulti(selectedValues: string[]) {
+    this.streaming = false;
+    this.answered = true;
+    this.selectedValues = new Set(selectedValues);
+    this.answerIsNegative = false;
   }
 
   setCancelled() {
@@ -169,8 +203,21 @@ class AskQuestionBorderedBox {
         }
         const cancelLine = `${theme.fg('error', '✗')}  ${theme.fg('dim', '(cancelled)')}`;
         addLine(cancelLine, visibleWidth(cancelLine));
+      } else if (this.selectedValues) {
+        // Multi-select answered: ✓ on every selected item, dimmed unselected
+        for (const item of this.items) {
+          if (this.selectedValues.has(item.label)) {
+            const icon = theme.fg('success', '✓');
+            const label = theme.fg('text', item.label);
+            const line = `${icon}  ${label}`;
+            addLine(line, visibleWidth(line));
+          } else {
+            const line = theme.fg('dim', `   ${item.label}`);
+            addLine(line, visibleWidth(line));
+          }
+        }
       } else {
-        // ✓/✗ on selected, dimmed unselected
+        // Single-select answered: ✓/✗ on selected, dimmed unselected
         for (const item of this.items) {
           const isSelected = item.label === this.selectedValue;
           if (isSelected) {
@@ -202,10 +249,15 @@ class AskQuestionBorderedBox {
       const cancelLine = `${theme.fg('error', '✗')}  ${theme.fg('dim', '(cancelled)')}`;
       addLine(cancelLine, visibleWidth(cancelLine));
     } else {
-      // Interactive content (SelectList or Input)
+      // Interactive content (SelectList, MultiSelectList, or Input)
       if (this.selectList) {
         // SelectList renders its own lines — wrap each one with borders
         const selectLines = this.selectList.render(innerWidth);
+        for (const sLine of selectLines) {
+          addLine(sLine, visibleWidth(sLine));
+        }
+      } else if (this.multiSelectList) {
+        const selectLines = this.multiSelectList.render(innerWidth);
         for (const sLine of selectLines) {
           addLine(sLine, visibleWidth(sLine));
         }
@@ -231,9 +283,11 @@ class AskQuestionBorderedBox {
 export class AskQuestionInlineComponent extends Container implements Focusable {
   private borderedBox: AskQuestionBorderedBox;
   private selectList?: SelectList;
+  private multiSelectList?: MultiSelectList;
   private input?: Input | MultilineInput;
   private tui?: TUI;
   private onSubmit?: (answer: string) => void;
+  private onSubmitMulti?: (values: string[]) => void;
   private onCancel?: () => void;
   private isNegativeAnswer?: (answer: string) => boolean;
   private allowEmptyInput = false;
@@ -307,6 +361,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     if (options) {
       // Full construction with interactive elements
       this.onSubmit = options.onSubmit;
+      this.onSubmitMulti = options.onSubmitMulti;
       this.onCancel = options.onCancel;
       this.isNegativeAnswer = options.isNegativeAnswer;
       this.allowEmptyInput = Boolean(options.allowEmptyInput);
@@ -317,8 +372,13 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
 
       let hintText: string;
       if (options.options && options.options.length > 0) {
-        hintText = '↑↓ to navigate · Enter to select · Esc to skip';
-        this.buildSelectMode(options.options);
+        if (options.selectionMode === 'multi_select') {
+          hintText = '↑↓ to navigate · Space to toggle · Enter to submit · Esc to skip';
+          this.buildMultiSelectMode(options.options);
+        } else {
+          hintText = '↑↓ to navigate · Enter to select · Esc to skip';
+          this.buildSelectMode(options.options);
+        }
       } else {
         hintText = this.useMultiline()
           ? 'Enter to submit · Shift+Enter/\\+Enter for new line · Esc to skip'
@@ -332,6 +392,8 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
         options.options || [],
         this.selectList,
         this.input,
+        false,
+        this.multiSelectList,
       );
     } else {
       // Streaming mode — empty bordered box, will be populated by updateArgs()
@@ -368,17 +430,20 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
   activate(options: {
     question: string;
     options?: Array<{ label: string; description?: string }>;
+    selectionMode?: AskQuestionSelectionMode;
     isNegativeAnswer?: (answer: string) => boolean;
     allowEmptyInput?: boolean;
     allowCustomResponse?: boolean;
     multiline?: boolean;
     tui?: TUI;
     onSubmit: (answer: string) => void;
+    onSubmitMulti?: (values: string[]) => void;
     onCancel: () => void;
   }): void {
     if (this.answered) return;
     if (options.tui) this.tui = options.tui;
     this.onSubmit = options.onSubmit;
+    this.onSubmitMulti = options.onSubmitMulti;
     this.onCancel = options.onCancel;
     this.isNegativeAnswer = options.isNegativeAnswer;
     this.allowEmptyInput = Boolean(options.allowEmptyInput);
@@ -389,11 +454,21 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     this.borderedBox.questionLines = options.question.split('\n');
     this.borderedBox.items = options.options || [];
 
+    // Reset any leftover interactive state from a prior activation
+    this.selectList = undefined;
+    this.multiSelectList = undefined;
+    this.input = undefined;
+
     // Build interactive elements
     let hintText: string;
     if (options.options && options.options.length > 0) {
-      hintText = '↑↓ to navigate · Enter to select · Esc to skip';
-      this.buildSelectMode(options.options);
+      if (options.selectionMode === 'multi_select') {
+        hintText = '↑↓ to navigate · Space to toggle · Enter to submit · Esc to skip';
+        this.buildMultiSelectMode(options.options);
+      } else {
+        hintText = '↑↓ to navigate · Enter to select · Esc to skip';
+        this.buildSelectMode(options.options);
+      }
     } else {
       hintText = this.useMultiline()
         ? 'Enter to submit · Shift+Enter/\\+Enter for new line · Esc to skip'
@@ -402,10 +477,25 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     }
 
     // Switch bordered box out of streaming mode
-    this.borderedBox.setInteractive(this.selectList, this.input, hintText);
+    this.borderedBox.setInteractive(this.selectList, this.input, hintText, this.multiSelectList);
   }
 
   private static readonly CUSTOM_RESPONSE_VALUE = '__custom_response__';
+
+  private buildMultiSelectMode(opts: Array<{ label: string; description?: string }>): void {
+    const items: SelectItem[] = opts.map(opt => ({
+      value: opt.label,
+      label: opt.description ? `${opt.label}  ${theme.fg('dim', opt.description)}` : opt.label,
+    }));
+
+    this.multiSelectList = new MultiSelectList(items, Math.min(items.length, 8), getSelectListTheme());
+    this.multiSelectList.onSubmit = (values: string[]) => {
+      this.handleAnswer(values);
+    };
+    this.multiSelectList.onCancel = () => {
+      this.handleCancel();
+    };
+  }
 
   private buildSelectMode(opts: Array<{ label: string; description?: string }>): void {
     const items: SelectItem[] = opts.map(opt => ({
@@ -496,8 +586,23 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     this.borderedBox.setAnswered(answer, isNegative);
   }
 
-  private handleAnswer(answer: string): void {
+  private handleAnswer(answer: string | string[]): void {
     if (this.answered) return;
+
+    if (Array.isArray(answer)) {
+      this.answered = true;
+      this.borderedBox.setAnsweredMulti(answer);
+      if (this.onSubmitMulti) {
+        this.onSubmitMulti(answer);
+      } else {
+        // Fall back to the single-string callback so callers that wired only
+        // `onSubmit` still get a meaningful answer (mirrors how core's tool
+        // formatter joins multi-select values for storage).
+        this.onSubmit?.(answer.join(', '));
+      }
+      return;
+    }
+
     const isNegative = this.isNegativeAnswer?.(answer) ?? false;
     this.answer(answer, isNegative);
 
@@ -518,6 +623,8 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
 
     if (this.selectList) {
       this.selectList.handleInput(data);
+    } else if (this.multiSelectList) {
+      this.multiSelectList.handleInput(data);
     } else if (this.input) {
       const kb = getKeybindings();
       if (kb.matches(data, 'tui.select.cancel')) {

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -298,21 +298,39 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
   /**
    * Create a pre-answered instance for rendering from chat history.
    * No interactive elements — just shows the question and the answer in the bordered box.
+   *
+   * Multi-select answers arrive as a comma-joined string (`tools.ts` joins
+   * arrays with `, ` before storage). When `selectionMode === 'multi_select'`
+   * is supplied we reconstruct the original `string[]` by intersecting the
+   * comma-split parts with the known `options`, so the rendered history
+   * shows a ✓ next to every selected option instead of dimming all of them.
    */
   static fromHistory(
     question: string,
     options: Array<{ label: string; description?: string }> | undefined,
     answer: string,
     cancelled: boolean,
+    selectionMode?: AskQuestionSelectionMode,
   ): AskQuestionInlineComponent {
     const component = AskQuestionInlineComponent.createStreaming();
     component.updateArgs({ question, options });
     component.answered = true;
     if (cancelled) {
       component.borderedBox.setCancelled();
-    } else {
-      component.borderedBox.setAnswered(answer, false);
+      return component;
     }
+    if (selectionMode === 'multi_select' && options && options.length > 0) {
+      const parts = answer.split(/, ?/);
+      const selectedLabels = options.map(option => option.label).filter(label => parts.includes(label));
+      if (selectedLabels.length > 0) {
+        component.borderedBox.setAnsweredMulti(selectedLabels);
+        return component;
+      }
+      // Fall through: comma-split didn't match any option (labels with commas,
+      // mismatched options, etc.) — render as a single string answer so the
+      // user at least sees the raw value.
+    }
+    component.borderedBox.setAnswered(answer, false);
     return component;
   }
 

--- a/mastracode/src/tui/components/multi-select-list.ts
+++ b/mastracode/src/tui/components/multi-select-list.ts
@@ -1,4 +1,4 @@
-import { getKeybindings, visibleWidth } from '@mariozechner/pi-tui';
+import { getKeybindings, truncateToWidth } from '@mariozechner/pi-tui';
 import type { Component, SelectItem, SelectListTheme } from '@mariozechner/pi-tui';
 
 /**
@@ -44,6 +44,11 @@ export class MultiSelectList implements Component {
 
   handleInput(keyData: string): void {
     const kb = getKeybindings();
+    if (this.items.length === 0) {
+      if (kb.matches(keyData, 'tui.select.confirm')) this.onSubmit?.([]);
+      else if (kb.matches(keyData, 'tui.select.cancel')) this.onCancel?.();
+      return;
+    }
     if (kb.matches(keyData, 'tui.select.up')) {
       this.selectedIndex = this.selectedIndex === 0 ? this.items.length - 1 : this.selectedIndex - 1;
       return;
@@ -96,8 +101,9 @@ export class MultiSelectList implements Component {
       const styled = isCursor
         ? this.theme.selectedText(`${cursor}${checkbox}${label}`)
         : `${cursor}${checkbox}${label}`;
-      const truncated = visibleWidth(styled) > width ? styled.slice(0, Math.max(0, width)) : styled;
-      lines.push(truncated);
+      // ANSI-aware truncation: labels embed pre-styled descriptions, so a raw
+      // String.slice would cut mid-escape and corrupt the terminal output.
+      lines.push(truncateToWidth(styled, Math.max(0, width), ''));
     }
 
     if (startIndex > 0 || endIndex < this.items.length) {

--- a/mastracode/src/tui/components/multi-select-list.ts
+++ b/mastracode/src/tui/components/multi-select-list.ts
@@ -1,0 +1,110 @@
+import { getKeybindings, visibleWidth } from '@mariozechner/pi-tui';
+import type { Component, SelectItem, SelectListTheme } from '@mariozechner/pi-tui';
+
+/**
+ * Multi-select counterpart to pi-tui's `SelectList`. Cursor and rendering rules
+ * match `SelectList` so the two feel consistent; the difference is that Space
+ * toggles a checkbox per item and Enter submits the set of toggled values as
+ * `string[]` instead of selecting the cursor row.
+ *
+ * Used by `AskQuestionInlineComponent` and `AskQuestionDialogComponent` when
+ * the underlying ask_question event arrives with `selectionMode: 'multi_select'`.
+ */
+export class MultiSelectList implements Component {
+  private items: SelectItem[];
+  private selectedIndex = 0;
+  private maxVisible: number;
+  private theme: SelectListTheme;
+  private toggled = new Set<string>();
+
+  /** Fires when the user submits with Enter. Receives the values selected, in items order. */
+  onSubmit?: (values: string[]) => void;
+  /** Fires when the user cancels with Esc / Ctrl+C. */
+  onCancel?: () => void;
+
+  constructor(items: SelectItem[], maxVisible: number, theme: SelectListTheme) {
+    this.items = items;
+    this.maxVisible = maxVisible;
+    this.theme = theme;
+  }
+
+  invalidate(): void {
+    // No cached state to invalidate.
+  }
+
+  /** Pre-toggle a set of values (e.g. from streaming defaults). */
+  setToggled(values: Iterable<string>): void {
+    this.toggled = new Set(values);
+  }
+
+  /** Snapshot of currently-toggled values, ordered to match `items`. */
+  getToggled(): string[] {
+    return this.items.filter(item => this.toggled.has(item.value)).map(item => item.value);
+  }
+
+  handleInput(keyData: string): void {
+    const kb = getKeybindings();
+    if (kb.matches(keyData, 'tui.select.up')) {
+      this.selectedIndex = this.selectedIndex === 0 ? this.items.length - 1 : this.selectedIndex - 1;
+      return;
+    }
+    if (kb.matches(keyData, 'tui.select.down')) {
+      this.selectedIndex = this.selectedIndex === this.items.length - 1 ? 0 : this.selectedIndex + 1;
+      return;
+    }
+    if (keyData === ' ') {
+      const item = this.items[this.selectedIndex];
+      if (item) {
+        if (this.toggled.has(item.value)) {
+          this.toggled.delete(item.value);
+        } else {
+          this.toggled.add(item.value);
+        }
+      }
+      return;
+    }
+    if (kb.matches(keyData, 'tui.select.confirm')) {
+      this.onSubmit?.(this.getToggled());
+      return;
+    }
+    if (kb.matches(keyData, 'tui.select.cancel')) {
+      this.onCancel?.();
+    }
+  }
+
+  render(width: number): string[] {
+    const lines: string[] = [];
+    if (this.items.length === 0) {
+      lines.push(this.theme.noMatch('  No options'));
+      return lines;
+    }
+
+    const startIndex = Math.max(
+      0,
+      Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), this.items.length - this.maxVisible),
+    );
+    const endIndex = Math.min(startIndex + this.maxVisible, this.items.length);
+
+    for (let i = startIndex; i < endIndex; i++) {
+      const item = this.items[i];
+      if (!item) continue;
+      const isCursor = i === this.selectedIndex;
+      const isToggled = this.toggled.has(item.value);
+      const cursor = isCursor ? '→ ' : '  ';
+      const checkbox = isToggled ? '[x] ' : '[ ] ';
+      const label = item.label;
+      const styled = isCursor
+        ? this.theme.selectedText(`${cursor}${checkbox}${label}`)
+        : `${cursor}${checkbox}${label}`;
+      const truncated = visibleWidth(styled) > width ? styled.slice(0, Math.max(0, width)) : styled;
+      lines.push(truncated);
+    }
+
+    if (startIndex > 0 || endIndex < this.items.length) {
+      const scroll = `  (${this.selectedIndex + 1}/${this.items.length})`;
+      lines.push(this.theme.scrollInfo(scroll));
+    }
+
+    return lines;
+  }
+}

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -363,7 +363,7 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
     }
 
     case 'ask_question':
-      await handleAskQuestion(ectx, event.questionId, event.question, event.options);
+      await handleAskQuestion(ectx, event.questionId, event.question, event.options, event.selectionMode);
       break;
 
     case 'sandbox_access_request':

--- a/mastracode/src/tui/handlers/__tests__/prompts.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/prompts.test.ts
@@ -59,6 +59,73 @@ describe('handleAskQuestion goal mode', () => {
   });
 });
 
+describe('handleAskQuestion multi-select', () => {
+  it('responds with the selected values as a string[] when the user toggles and submits', async () => {
+    const { ctx, state } = createCtx();
+    const options = [
+      { label: 'Alpha', description: 'first' },
+      { label: 'Beta', description: 'second' },
+      { label: 'Gamma', description: 'third' },
+    ];
+
+    const promise = handleAskQuestion(ctx, 'q-multi', 'Pick all that apply', options, 'multi_select');
+
+    // Toggle Alpha, navigate to Gamma, toggle it, submit
+    state.activeInlineQuestion!.handleInput(' ');
+    state.activeInlineQuestion!.handleInput('\x1b[B');
+    state.activeInlineQuestion!.handleInput('\x1b[B');
+    state.activeInlineQuestion!.handleInput(' ');
+    state.activeInlineQuestion!.handleInput('\r');
+
+    await promise;
+
+    expect(state.harness.respondToQuestion).toHaveBeenCalledTimes(1);
+    expect(state.harness.respondToQuestion).toHaveBeenCalledWith({
+      questionId: 'q-multi',
+      answer: ['Alpha', 'Gamma'],
+    });
+  });
+
+  it('responds with an empty array when the user submits without toggling anything', async () => {
+    const { ctx, state } = createCtx();
+    const options = [{ label: 'Alpha' }, { label: 'Beta' }];
+
+    const promise = handleAskQuestion(ctx, 'q-empty', 'Pick all that apply', options, 'multi_select');
+
+    state.activeInlineQuestion!.handleInput('\r');
+    await promise;
+
+    expect(state.harness.respondToQuestion).toHaveBeenCalledWith({ questionId: 'q-empty', answer: [] });
+  });
+
+  it('still responds with "(skipped)" when the user cancels a multi-select prompt', async () => {
+    const { ctx, state } = createCtx();
+    const options = [{ label: 'Alpha' }, { label: 'Beta' }];
+
+    const promise = handleAskQuestion(ctx, 'q-cancel', 'Pick all that apply', options, 'multi_select');
+    state.activeInlineQuestion!.handleInput('\x1b');
+    await promise;
+
+    expect(state.harness.respondToQuestion).toHaveBeenCalledWith({ questionId: 'q-cancel', answer: '(skipped)' });
+  });
+
+  it('ignores selectionMode when no options are provided (falls back to free-text)', async () => {
+    const { ctx, state } = createCtx();
+
+    const promise = handleAskQuestion(ctx, 'q-text', 'What do you think?', undefined, 'multi_select');
+
+    // Free-text input — Enter submits empty string by default (allowEmptyInput is false).
+    // Use the underlying input directly to send a real answer.
+    (state.activeInlineQuestion as any).handleInput('h');
+    (state.activeInlineQuestion as any).handleInput('i');
+    (state.activeInlineQuestion as any).handleInput('\r');
+
+    await promise;
+
+    expect(state.harness.respondToQuestion).toHaveBeenCalledWith({ questionId: 'q-text', answer: 'hi' });
+  });
+});
+
 function createPlanApprovalCtx() {
   const sendSignal = vi.fn().mockReturnValue({
     id: 'sig-1',

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -17,6 +17,8 @@ type HarnessV1PromptResponseSurface = {
   respondToToolSuspension: (opts: { toolCallId?: string; resumeData: unknown }) => Promise<void>;
 };
 
+type SelectionMode = 'single_select' | 'multi_select';
+
 /**
  * Process the next pending inline question from the queue.
  * Called when the current active question is resolved (submitted or cancelled).
@@ -50,8 +52,12 @@ export async function handleAskQuestion(
   questionId: string,
   question: string,
   options?: Array<{ label: string; description?: string }>,
+  selectionMode?: SelectionMode,
 ): Promise<void> {
   const { state } = ctx;
+  // `selectionMode` is only meaningful when options are present. Strip it
+  // otherwise so a free-text fallback doesn't render a checkbox list.
+  const effectiveSelectionMode = options && options.length > 0 ? selectionMode : undefined;
 
   return new Promise(resolve => {
     if (state.options.inlineQuestions) {
@@ -70,11 +76,18 @@ export async function handleAskQuestion(
             askUserComponent.activate({
               question,
               options,
+              selectionMode: effectiveSelectionMode,
               multiline: true,
               tui: state.ui,
               onSubmit: answer => {
                 state.activeInlineQuestion = undefined;
                 state.harness.respondToQuestion({ questionId, answer });
+                resolve();
+                processNextInlineQuestion(state);
+              },
+              onSubmitMulti: values => {
+                state.activeInlineQuestion = undefined;
+                state.harness.respondToQuestion({ questionId, answer: values });
                 resolve();
                 processNextInlineQuestion(state);
               },
@@ -93,10 +106,17 @@ export async function handleAskQuestion(
               {
                 question,
                 options,
+                selectionMode: effectiveSelectionMode,
                 multiline: true,
                 onSubmit: answer => {
                   state.activeInlineQuestion = undefined;
                   state.harness.respondToQuestion({ questionId, answer });
+                  resolve();
+                  processNextInlineQuestion(state);
+                },
+                onSubmitMulti: values => {
+                  state.activeInlineQuestion = undefined;
+                  state.harness.respondToQuestion({ questionId, answer: values });
                   resolve();
                   processNextInlineQuestion(state);
                 },
@@ -142,11 +162,17 @@ export async function handleAskQuestion(
       const dialog = new AskQuestionDialogComponent({
         question,
         options,
+        selectionMode: effectiveSelectionMode,
         multiline: true,
         tui: state.ui,
         onSubmit: answer => {
           state.ui.hideOverlay();
           state.harness.respondToQuestion({ questionId, answer });
+          resolve();
+        },
+        onSubmitMulti: values => {
+          state.ui.hideOverlay();
+          state.harness.respondToQuestion({ questionId, answer: values });
           resolve();
         },
         onCancel: () => {

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -8,6 +8,7 @@ import type { Component } from '@mariozechner/pi-tui';
 import type { HarnessEvent, HarnessMessage } from '@mastra/core/harness';
 import type { Workspace } from '@mastra/core/workspace';
 import { getOAuthProviders } from '../auth/storage.js';
+import { MastraCodeSessionLeaseRecoveryError } from '../harness/index.js';
 import {
   OnboardingInlineComponent,
   getAvailableModePacks,
@@ -514,8 +515,21 @@ export class MastraTUI {
   private async init(): Promise<void> {
     if (this.state.isInitialized) return;
 
-    // Initialize harness (but don't select thread yet)
-    await this.state.harness.init();
+    const unsubscribeStartupInfo = this.state.harness.subscribe((event: HarnessEvent) => {
+      if (event.type === 'info') {
+        process.stderr.write(`${event.message}\n`);
+      }
+    });
+    try {
+      await this.state.harness.init();
+    } catch (err) {
+      if (err instanceof MastraCodeSessionLeaseRecoveryError) {
+        process.stderr.write(`${err.message}\n`);
+      }
+      throw err;
+    } finally {
+      unsubscribeStartupInfo();
+    }
 
     // Check for existing threads and prompt for resume
     await promptForThreadSelection(this.state);

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -660,7 +660,11 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
           // Render ask_user with the proper question component
           if (content.name === 'ask_user' && toolResult?.type === 'tool_result') {
             const askArgs = content.args as
-              | { question?: string; options?: Array<{ label: string; description?: string }> }
+              | {
+                  question?: string;
+                  options?: Array<{ label: string; description?: string }>;
+                  selectionMode?: 'single_select' | 'multi_select';
+                }
               | undefined;
             const answer =
               typeof toolResult.result === 'string' ? toolResult.result : formatToolResult(toolResult.result);
@@ -671,6 +675,7 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
                 askArgs.options,
                 answer,
                 cancelled,
+                askArgs.selectionMode,
               );
               state.chatContainer.addChild(askComponent);
               continue;

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -308,8 +308,12 @@ describe('Session.message() — default path', () => {
     await session.setState({ yolo: true });
     await session.message({ content: 'state yolo' });
 
+    const turnYoloHarnessSlot = agent.calls[0]!.options.requestContext.get('harness');
+    const stateYoloHarnessSlot = agent.calls[1]!.options.requestContext.get('harness');
     expect(agent.calls[0]!.options.requireToolApproval).toBeUndefined();
     expect(agent.calls[1]!.options.requireToolApproval).toBeUndefined();
+    expect(turnYoloHarnessSlot.resolveToolPermission({ toolName: 'run_command', args: {} })).toBe('allow');
+    expect(stateYoloHarnessSlot.resolveToolPermission({ toolName: 'run_command', args: {} })).toBe('allow');
   });
 
   it('forwards the caller-supplied abortSignal (chained into the per-turn signal)', async () => {

--- a/packages/core/src/harness/v1/session.suspend.test.ts
+++ b/packages/core/src/harness/v1/session.suspend.test.ts
@@ -44,7 +44,7 @@ interface RunSpec {
 
 interface ResumeCall {
   resumeData: unknown;
-  options: { runId?: string; toolCallId?: string; abortSignal?: AbortSignal };
+  options: any;
 }
 
 class FakeAgent extends Agent<any, any, any> {
@@ -373,6 +373,42 @@ describe('Session — suspend capture on message()', () => {
     expect(pending.payload).toEqual({ title: 'registered title', plan: 'registered plan' });
     expect(pending.transitionModeId).toBe('builder');
   });
+
+  it('keeps sandbox access registered by the tool before suspend capture', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await (session as any)._registerSandboxAccess({
+      requestId: 'sandbox-registered',
+      semanticType: 'file',
+      reason: 'needs repo access',
+      payload: { path: '/outside/project' },
+      runId: 'run-sandbox',
+      toolCallId: 'tc-sandbox',
+    });
+    await (session as any)._maybeCaptureSuspend({
+      runId: 'run-sandbox',
+      finishReason: 'suspended',
+      suspendPayload: {
+        toolCallId: 'tc-sandbox',
+        toolName: 'request_access',
+        args: { path: '/outside/project', reason: 'needs repo access' },
+        suspendPayload: {},
+      },
+    });
+
+    const pending = session.getRecord().pendingResume!;
+    expect(pending.kind).toBe('sandbox-access');
+    expect(pending.itemId).toBe('sandbox-registered');
+    expect(pending.toolCallId).toBe('tc-sandbox');
+    expect(pending.payload).toEqual({
+      sandboxAccess: {
+        semanticType: 'file',
+        reason: 'needs repo access',
+        payload: { path: '/outside/project' },
+      },
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -387,7 +423,12 @@ describe('Session — respondToToolApproval / Suspension / Question / PlanApprov
       runId: 'run-A',
       suspendPayload: { toolCallId: 'tc-1', toolName: 'shell', args: { cmd: 'ls' } },
     });
-    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const session = await harness.session({
+      resourceId: 'u',
+      threadId: { fresh: true },
+      modelId: 'anthropic/test-model',
+    });
+    await session.setState({ currentModelId: 'anthropic/test-model' });
     const first = await session.message({ content: 'go' });
 
     agent.enqueueRun({ finishReason: 'stop', runId: first.runId, text: 'done' });
@@ -400,6 +441,12 @@ describe('Session — respondToToolApproval / Suspension / Question / PlanApprov
     expect(agent.resumeCalls[0]!.resumeData).toEqual({ approved: true });
     expect(agent.resumeCalls[0]!.options).toMatchObject({ runId: first.runId, toolCallId: 'tc-1' });
     expect(agent.resumeCalls[0]!.options.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(agent.resumeCalls[0]!.options.memory).toEqual({ thread: session.threadId, resource: 'u' });
+    const requestContext = agent.resumeCalls[0]!.options.requestContext;
+    const harnessContext = requestContext.get('harness') as any;
+    expect(harnessContext.modelId).toBe('anthropic/test-model');
+    expect(harnessContext.state.currentModelId).toBe('anthropic/test-model');
+    expect(harnessContext.threadId).toBe(session.threadId);
     expect(session.getRecord().pendingResume).toBeUndefined();
     expect(session.getDisplayState().pending).toBeNull();
   });

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -3874,6 +3874,7 @@ export class Session {
           modeId: effectiveModeId,
           modelId: effectiveModelId,
           abortSignal: turnAbortSignal,
+          yolo: opts.yolo,
         }),
         activeTurnWaiter.promise,
       ]);
@@ -4811,6 +4812,8 @@ export class Session {
     toolName: string,
     opts?: { args?: Record<string, unknown>; actor?: HarnessActorIdentity },
   ): PermissionPolicy {
+    const state = this._record.state as { yolo?: unknown } | undefined;
+    if (state?.yolo === true) return 'allow';
     const category = this._harness.getToolCategory({ toolName });
     const toolRule = this._record.permissionRules.tools[toolName];
     const categoryRule = category ? this._record.permissionRules.categories[category] : undefined;
@@ -8669,6 +8672,7 @@ export class Session {
           modelId: this._modelIdForQueuedItem(item.id),
           abortSignal: turnAbortController.signal,
           persistedRequestContext: item.requestContext,
+          yolo: item.yolo,
         }),
         activeTurnWaiter.promise,
       ]);
@@ -9657,6 +9661,7 @@ export class Session {
     abortSignal: AbortSignal;
     persistedRequestContext?: PersistedRequestContextInput;
     resolveWorkspace?: boolean;
+    yolo?: boolean;
   }): Promise<RequestContext> {
     const session = this;
     const stateSnapshot = (this._record.state ?? {}) as unknown;
@@ -9744,24 +9749,26 @@ export class Session {
       registerSandboxAccess: params =>
         session._registerSandboxAccess({ ...params, modeId: turn.modeId, modelId: turn.modelId }),
       resolveToolPermission: params =>
-        session._resolveToolPermissionPolicy(params.toolName, {
-          // Prefer caller-supplied actor (an upstream resolver may have
-          // overridden) and fall back to the channel-derived actor on
-          // the slot so per-actor grants resolve for every channel-
-          // originated tool call without the dispatcher needing to
-          // forward identity explicitly.
-          ...((params.actor ?? derivedActor) !== undefined
-            ? { actor: (params.actor ?? derivedActor) as HarnessActorIdentity }
-            : {}),
-          // Forward per-call args. The session-level resolver does
-          // not introspect args itself yet — workspace-policy rules
-          // (file/command/network/mcp) produce the args-aware verdict
-          // recorded on the action journal post-execution today — but
-          // the signature is plumbed so a future profile-side resolver
-          // hook or operator override can read them without another
-          // wire-up commit.
-          ...(params.args ? { args: params.args } : {}),
-        }),
+        turn.yolo === true
+          ? 'allow'
+          : session._resolveToolPermissionPolicy(params.toolName, {
+              // Prefer caller-supplied actor (an upstream resolver may have
+              // overridden) and fall back to the channel-derived actor on
+              // the slot so per-actor grants resolve for every channel-
+              // originated tool call without the dispatcher needing to
+              // forward identity explicitly.
+              ...((params.actor ?? derivedActor) !== undefined
+                ? { actor: (params.actor ?? derivedActor) as HarnessActorIdentity }
+                : {}),
+              // Forward per-call args. The session-level resolver does
+              // not introspect args itself yet — workspace-policy rules
+              // (file/command/network/mcp) produce the args-aware verdict
+              // recorded on the action journal post-execution today — but
+              // the signature is plumbed so a future profile-side resolver
+              // hook or operator override can read them without another
+              // wire-up commit.
+              ...(params.args ? { args: params.args } : {}),
+            }),
       recordWorkspaceAction: params => session._recordWorkspaceAction(params),
       registerBackgroundProcess: handle => session._registerBackgroundProcess(handle),
       extendLease: extendOpts => session.extendLease(extendOpts),

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -5473,12 +5473,11 @@ export class Session {
 
     const kind = this._classifyResumeKind(payload);
     const existing = this._record.pendingResume;
-    if (
-      existing &&
-      existing.kind === kind &&
-      existing.runId === full.runId &&
-      existing.toolCallId === payload.toolCallId
-    ) {
+    if (existing && existing.runId === full.runId && existing.toolCallId === payload.toolCallId) {
+      // Tools can register richer pending resume records before calling
+      // suspend() (question, plan approval, sandbox access). The later
+      // generic suspended payload is only the transport signal; do not
+      // downgrade the explicit pending kind or emit a duplicate prompt.
       return;
     }
     const pending: PendingResume = {
@@ -7188,7 +7187,22 @@ export class Session {
     let full: FullOutput<unknown>;
     try {
       assertResumedTurnNotDeleted();
+      const mode = this._harness._getMode(resumeModeId);
+      const toolsets = this._buildToolsets(mode, undefined);
+      const requestContext = await Promise.race([
+        this._buildRequestContext({
+          modeId: resumeModeId,
+          modelId: resumeRuntimeDependencies.modelId ?? this._record.modelId,
+          abortSignal: turnAbortController.signal,
+          yolo: ((this._record.state ?? {}) as { yolo?: unknown }).yolo === true,
+        }),
+        activeTurnWaiter.promise,
+      ]);
       const resumeStream = agent.resumeStream(resumeData, {
+        memory: { thread: this.threadId, resource: this.resourceId },
+        requestContext,
+        ...(toolsets ? { toolsets } : {}),
+        ...(this._shouldRequireToolApproval() ? { requireToolApproval: true } : {}),
         runId: pending.runId,
         toolCallId: pending.toolCallId,
         abortSignal: turnAbortController.signal,

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -956,11 +956,11 @@ describe('createToolCallStep needsApprovalFn enriched context', () => {
     await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
   });
 
-  it('lets Harness allow policy bypass the global approval scheduling flag', async () => {
+  it('lets Harness allow policy bypass approval requirements', async () => {
     const tools = {
       'ctx-tool': {
         execute: vi.fn().mockResolvedValue({ ok: true }),
-        requireApproval: false,
+        requireApproval: true,
       },
     };
     const toolCallStep = createToolCallStep({

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -589,15 +589,18 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           };
         }
 
-        const toolRequiresApproval = await resolveToolRequiresApproval({
-          tool,
-          args,
-          requireToolApproval: harnessToolPermission ? harnessToolPermission === 'ask' : Boolean(requireToolApproval),
-          requestContext,
-          workspace: _internal?.stepWorkspace,
-          logger,
-          toolName: inputData.toolName,
-        });
+        const toolRequiresApproval =
+          harnessToolPermission === 'allow'
+            ? false
+            : await resolveToolRequiresApproval({
+                tool,
+                args,
+                requireToolApproval: harnessToolPermission ? harnessToolPermission === 'ask' : Boolean(requireToolApproval),
+                requestContext,
+                workspace: _internal?.stepWorkspace,
+                logger,
+                toolName: inputData.toolName,
+              });
 
         // Schema for tool call approval - used for both streaming and metadata
         const approvalSchema = toStandardSchema(


### PR DESCRIPTION
## Summary

Closes the selectionMode half of [MASTRA-4340](https://linear.app/mastra/issue/MASTRA-4340). Stacked on #17068.

`ask_user` already supported `selectionMode: 'multi_select'` end-to-end on the core side — events carried the field, `HarnessQuestionAnswer = string | string[]`, and the tool formatted array results — but mastracode's TUI dropped the field at two event boundaries and only knew how to collect a single string. Multi-select prompts silently fell back to single-select.

This PR closes both event drops and wires a real checkbox UI:

- `MultiSelectList` primitive (mastracode/src/tui/components/multi-select-list.ts): mirrors pi-tui's `SelectList` layout with Space-to-toggle / Enter-submits-`string[]` semantics. ANSI-aware truncation, empty-items guarded, cursor wraps at boundaries.
- Forwards `selectionMode` through `event-dispatch.ts:365` → `handleAskQuestion`. Also closes the second drop in the V1-to-legacy projector at `mastracode/src/harness/events.ts:projectSuspensionRequired` (covered by Codex review).
- `AskQuestionInlineComponent` and `AskQuestionDialogComponent` now switch to `MultiSelectList` when `selectionMode === 'multi_select'`. Both keep their existing `onSubmit: (answer: string)` signature and add an `onSubmitMulti?: (values: string[]) => void` callback so the dozen-plus single-select consumers (sandbox access, plan approval, tool suspension, ...) don't break. When `onSubmitMulti` is omitted the multi-select values join with `, ` and fall through to `onSubmit`.
- New answered-state rendering shows a ✓ next to every selected option instead of single-select's ✓/✗.

End-user outcome: when the agent emits a multi-select question, the TUI lets the user toggle multiple options with Space and submits them as a real array. Cancelling and free-text prompts behave exactly as before.

## Review history

Three rounds of `codex exec --sandbox read-only`, one independent Claude subagent review, and one `coderabbit review` pass. The reviewers found (and this PR addresses):

- Codex 1 caught that the V1-to-legacy projector at `mastracode/src/harness/events.ts:157-164` also dropped `selectionMode` — the actual path real `ask_user` suspensions take. Fixed with strict allow-listing of `'single_select' | 'multi_select'` and a regression test.
- Codex 3 / CodeRabbit caught an ANSI-unsafe truncation in `MultiSelectList.render` (raw `String.slice` against pre-styled labels could cut mid-escape on narrow terminals). Switched to pi-tui's `truncateToWidth`.
- CodeRabbit / Claude caught an unreachable-today but latent empty-items navigation bug in `MultiSelectList.handleInput`. Now early-returns when there are no items.
- Codex 2 asked for dialog-mode + onSubmitMulti-fallback coverage. New test file `ask-question-multi-select.test.ts` covers both for inline and dialog.
- CodeRabbit asked for a code example in the changeset. Added.

## Test plan

- [ ] CI green on `Lint`, `Build`, `UNIT Test Shards 1/3/4` (Shard 2 mcp test is a known pre-existing flake)
- [ ] Reviewer can verify locally:
  - `pnpm --filter mastracode exec vitest run` — 1087 pass (10 new multi-select primitive tests, 4 new dialog + inline fallback tests, 2 new events projector tests, 4 new handler tests, empty-items guard test)
  - `pnpm --filter mastracode check && pnpm --filter mastracode lint` — clean
- [ ] Manual TUI smoke: run mastracode in a kitty-protocol terminal, trigger an `ask_user` call with `selectionMode: 'multi_select'`, confirm Space toggles checkboxes and Enter submits the array

🤖 Generated with [Claude Code](https://claude.com/claude-code)