### PR TITLE
fix(ci): resolve GitHub Actions annotations

### DIFF
--- a/.github/actions/app-auth/action.yaml
+++ b/.github/actions/app-auth/action.yaml
@@ -1,8 +1,8 @@
 name: 'Dane App Auth'
 description: 'Create GitHub App installation token, expose outputs, set .netrc'
 inputs:
-  app-id:
-    description: 'GitHub App ID'
+  client-id:
+    description: 'GitHub App Client ID'
     required: true
   private-key:
     description: 'GitHub App private key'
@@ -35,7 +35,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.app-id }}
+        client-id: ${{ inputs.client-id }}
         private-key: ${{ inputs.private-key }}
         owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repositories }}

--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -18,6 +18,10 @@ inputs:
     description: 'Path to pnpm-lock.yaml for cache key (useful when checkout is not at workspace root)'
     required: false
     default: ''
+  version:
+    description: 'Explicit pnpm version (overrides packageManager detection)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -28,7 +32,10 @@ runs:
     # ~/setup-pnpm/node_modules/.bin/.
     - uses: pnpm/action-setup@v4
       name: Install pnpm
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       with:
+        version: ${{ inputs.version || '' }}
         run_install: false
         package_json_file: ${{ inputs.package-json-file || 'package.json' }}
         cache: ${{ inputs.package-manager-cache == 'true' }}

--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -30,10 +30,8 @@ runs:
     # setup-node's cache: 'pnpm' runs `pnpm store path --silent` which returns
     # a bogus path on self-hosted runners where pnpm is installed into
     # ~/setup-pnpm/node_modules/.bin/.
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
       name: Install pnpm
-      env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       with:
         version: ${{ inputs.version || '' }}
         run_install: false

--- a/.github/workflows/backport-auto.yml
+++ b/.github/workflows/backport-auto.yml
@@ -30,7 +30,7 @@ jobs:
         id: app-auth
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token

--- a/.github/workflows/changed-test-gate-labeler.yml
+++ b/.github/workflows/changed-test-gate-labeler.yml
@@ -31,7 +31,7 @@ jobs:
         id: app_token
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Setup pnpm and node
@@ -39,6 +39,7 @@ jobs:
         with:
           install-dependencies: false
           package-manager-cache: false
+          version: "10"
 
       - name: Install dependencies
         run: pnpm install --ignore-workspace --ignore-scripts

--- a/.github/workflows/changed-test-gate-labeler.yml
+++ b/.github/workflows/changed-test-gate-labeler.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           install-dependencies: false
           package-manager-cache: false
-          version: "10"
+          version: '10'
 
       - name: Install dependencies
         run: pnpm install --ignore-workspace --ignore-scripts

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -61,9 +61,7 @@ jobs:
 
       - name: Setup pnpm
         if: ${{ steps.changed_tests.outputs.has_tests == 'true' }}
-        uses: pnpm/action-setup@v4
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         with:
           run_install: false
           cache: true

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Setup pnpm
         if: ${{ steps.changed_tests.outputs.has_tests == 'true' }}
         uses: pnpm/action-setup@v4
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           run_install: false
           cache: true

--- a/.github/workflows/cron-alpha-publish.yml
+++ b/.github/workflows/cron-alpha-publish.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-auth
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Comment on PR if redirects are missing
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const logsUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
@@ -133,7 +133,7 @@ jobs:
 
       - name: Comment on PR if redirect issues found
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const logsUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -106,7 +106,7 @@ jobs:
         id: app_token
         uses: ./.github/actions/app-auth
         with:
-          client-id: ${{ secrets.DANE_CLIENT_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Check if major version bump is allowed

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Check for major changesets
         id: check_major
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload?.pull_request?.number || context.payload?.issue?.number;
@@ -112,7 +112,7 @@ jobs:
       - name: Check if major version bump is allowed
         if: steps.check_major.outputs.has_major_changeset == 'true'
         id: check_approval
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -106,7 +106,7 @@ jobs:
         id: app_token
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ secrets.DANE_APP_ID }}
+          client-id: ${{ secrets.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Check if major version bump is allowed

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -54,10 +54,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         name: Install pnpm
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           run_install: false
 
@@ -181,10 +179,8 @@ jobs:
             echo "files_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         name: Install pnpm
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           run_install: false
 
@@ -315,10 +311,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         name: Install pnpm
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           run_install: false
 
@@ -392,10 +386,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         name: Install pnpm
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           run_install: false
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,6 +56,8 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           run_install: false
 
@@ -159,7 +161,7 @@ jobs:
         id: app-auth
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token
@@ -181,6 +183,8 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           run_install: false
 
@@ -301,7 +305,7 @@ jobs:
         id: app-auth
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token
@@ -313,6 +317,8 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           run_install: false
 
@@ -376,7 +382,7 @@ jobs:
         id: app-auth
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token
@@ -388,6 +394,8 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           run_install: false
 

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -42,7 +42,7 @@ jobs:
         id: app_token
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Setup pnpm and node
@@ -50,6 +50,7 @@ jobs:
         with:
           install-dependencies: false
           package-manager-cache: false
+          version: "10"
 
       - name: Install dependencies
         run: pnpm install --ignore-workspace --ignore-scripts
@@ -88,7 +89,7 @@ jobs:
         id: app_token
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Setup pnpm and node
@@ -96,6 +97,7 @@ jobs:
         with:
           install-dependencies: false
           package-manager-cache: false
+          version: "10"
 
       - name: Install dependencies
         run: pnpm install --ignore-workspace --ignore-scripts
@@ -133,7 +135,7 @@ jobs:
         id: app_token
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Setup pnpm and node
@@ -141,6 +143,7 @@ jobs:
         with:
           install-dependencies: false
           package-manager-cache: false
+          version: "10"
 
       - name: Install dependencies
         run: pnpm install --ignore-workspace --ignore-scripts
@@ -175,7 +178,7 @@ jobs:
         id: app_token
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Setup pnpm and node
@@ -183,6 +186,7 @@ jobs:
         with:
           install-dependencies: false
           package-manager-cache: false
+          version: "10"
 
       - name: Install dependencies
         run: pnpm install --ignore-workspace --ignore-scripts

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           install-dependencies: false
           package-manager-cache: false
-          version: "10"
+          version: '10'
 
       - name: Install dependencies
         run: pnpm install --ignore-workspace --ignore-scripts
@@ -97,7 +97,7 @@ jobs:
         with:
           install-dependencies: false
           package-manager-cache: false
-          version: "10"
+          version: '10'
 
       - name: Install dependencies
         run: pnpm install --ignore-workspace --ignore-scripts
@@ -143,7 +143,7 @@ jobs:
         with:
           install-dependencies: false
           package-manager-cache: false
-          version: "10"
+          version: '10'
 
       - name: Install dependencies
         run: pnpm install --ignore-workspace --ignore-scripts
@@ -186,7 +186,7 @@ jobs:
         with:
           install-dependencies: false
           package-manager-cache: false
-          version: "10"
+          version: '10'
 
       - name: Install dependencies
         run: pnpm install --ignore-workspace --ignore-scripts

--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -37,7 +37,7 @@ jobs:
         id: app-auth
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-auth
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
           owner: mastra-ai
 

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-auth
         uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ vars.DANE_APP_ID }}
+          client-id: ${{ vars.DANE_CLIENT_ID }}
           private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Re-checkout with app token


### PR DESCRIPTION
Fixes the CI annotations by making sparse checkout workflows pass an explicit pnpm version, pinning pnpm/action-setup to 0e279bb959325dab635dd2c09392533439d90093, and migrating the Dane app auth wrapper from app-id to client-id.

The sparse checkout jobs now pass pnpm 10 explicitly so pnpm/action-setup does not need the root package.json. The app-auth callers now use DANE_CLIENT_ID instead of DANE_APP_ID, so that repo/org variable or secret needs to exist before these workflows run.

Verified locally by parsing the changed workflow/action YAML, running git diff --check, checking the sparse checkout pnpm version pins, confirming all pnpm/action-setup usages are pinned to the requested SHA, confirming FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 is removed, and confirming no app-id/DANE_APP_ID references remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the CI/CD workflows to fix build system issues by switching authentication methods (from app-id to client-id), pinning specific tool versions to prevent unexpected changes, and upgrading some GitHub Actions to newer versions that don't trigger deprecation warnings.

## Changes

### Authentication Migration
Updated all GitHub Actions workflows and the `app-auth` composite action to use `client-id` (from `DANE_CLIENT_ID`) instead of `app-id` (from `DANE_APP_ID`) for Dane app authentication. Affected files include:
- `.github/actions/app-auth/action.yaml` - changed action input from `app-id` to `client-id`
- `.github/workflows/backport-auto.yml`
- `.github/workflows/changed-test-gate-labeler.yml`
- `.github/workflows/cron-alpha-publish.yml`
- `.github/workflows/major-version-check.yml`
- `.github/workflows/npm-publish.yml`
- `.github/workflows/pr-triage.yml`
- `.github/workflows/regenerate-provider-registry.yml`
- `.github/workflows/sync-templates.yml`
- `.github/workflows/version-packages.yml`

### pnpm Version Pinning
- Updated `.github/actions/setup-pnpm-node/action.yaml` to add an explicit `version` input (defaults to empty string) for specifying pnpm versions
- Pinned `pnpm/action-setup` to commit SHA `0e279bb959325dab635dd2c09392533439d90093` across multiple workflows
- Added explicit pnpm version `'10'` in sparse-checkout workflows (`.github/workflows/changed-test-gate-labeler.yml` and `.github/workflows/pr-triage.yml`)

### GitHub Actions Upgrades
Upgraded `actions/github-script` from `v7` to `v8` in:
- `.github/workflows/lint-docs.yml` (2 step updates)
- `.github/workflows/major-version-check.yml` (2 step updates)

### Affected Workflows
- `.github/workflows/changed-test-gate.yml` - pinned pnpm/action-setup SHA
- `.github/workflows/npm-publish.yml` - pinned pnpm/action-setup SHA in 4 jobs and migrated to client-id in 3 jobs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->