### PR TITLE
test(core): fix tool-handling e2e for v1 subagent result shape

### DIFF
--- a/packages/core/src/agent/__tests__/tool-handling.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/tool-handling.e2e.test.ts
@@ -57,14 +57,10 @@ function toolhandlingE2ETests(version: 'v1' | 'v2' | 'v3') {
           ? toolCalls.find((tc: any) => tc.toolName === 'agent-researchAgent')
           : toolCalls.find((tc: any) => tc.payload?.toolName === 'agent-researchAgent');
 
-      expect(version === 'v1' ? toolCalls[0]?.result : toolCalls[0]?.payload?.result).toStrictEqual({
-        ...(version === 'v1'
-          ? {}
-          : {
-              subAgentResourceId: expect.any(String),
-              subAgentThreadId: expect.any(String),
-              subAgentToolResults: expect.any(Array),
-            }),
+      expect(version === 'v1' ? toolCalls[0]?.result : toolCalls[0]?.payload?.result).toMatchObject({
+        subAgentResourceId: expect.any(String),
+        subAgentThreadId: expect.any(String),
+        subAgentToolResults: expect.any(Array),
         text: 'Dummy response',
       });
 


### PR DESCRIPTION
## Summary

The `packages/core` `tool-handling.e2e.test.ts` started failing on `main` after #15825 ("Add usage to onDelegationComplete hook") landed. That PR unified the delegation result shape so v1 `generateLegacy` now returns the same `subAgentThreadId`, `subAgentResourceId`, `subAgentToolResults`, and `usage` fields as v2 `generate`. The test was still asserting `toStrictEqual({ text: 'Dummy response' })` for v1, so the extra fields produced a strict-equality failure.

This switches the assertion to `toMatchObject` and asserts the shared fields on both v1 and v2, matching the new unified shape. The `usage` field is left out of the matcher so the test tolerates code paths that don't populate it (e.g. `streamLegacy`).

Unblocks CI for the imminent release.

## Test Plan

- `pnpm exec vitest run src/agent/__tests__/tool-handling.e2e.test.ts` in `packages/core` → 3/3 passing locally
- `pnpm exec tsc --noEmit` clean
- prettier clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Two different versions of a function in this codebase were recently changed to return the same set of information. This test was checking that they returned different information, so it broke. This fix updates the test to accept the same format from both versions.

## Summary

This PR fixes the `tool-handling.e2e.test.ts` test in `packages/core` to account for a unified delegation result shape introduced by PR `#15825`.

### Changes

The test assertion for sub-agent tool results was updated from `toStrictEqual` (requiring exact field match) to `toMatchObject` (allowing extra fields). This reflects that both v1 `generateLegacy` and v2 `generate` now return the same fields: `subAgentResourceId`, `subAgentThreadId`, and `subAgentToolResults`.

The `usage` field is intentionally omitted from the matcher to allow for code paths that don't populate it (such as `streamLegacy`).

### Impact

- Unblocks CI for the impending release
- All tests (3/3) pass locally

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17087?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->