### PR TITLE
fix(mastracode): propagate runtime memory and pubsub to custom Harness v1 mode agents

### DIFF
--- a/.changeset/pretty-carrots-rest.md
+++ b/.changeset/pretty-carrots-rest.md
@@ -1,0 +1,31 @@
+---
+'mastracode': patch
+---
+
+**Fixed: custom Harness v1 mode agents now receive the configured Memory and signals PubSub.**
+
+When `createMastraCode` is called with a custom mode whose `agent` is a static `Agent` instance that does not own its own memory or PubSub, mastracode now wires the harness-level Memory and signals PubSub to that agent — matching legacy `Harness` behavior. Previously these services only reached the default `code-agent`, so observation persistence and signal routing were silently dropped for custom mode agents.
+
+Agents that own these services keep their own (the runtime guards on `hasOwnMemory()` / `hasOwnPubSub()`); the same agent reused across multiple modes is only updated once.
+
+```ts
+import { createMastraCode } from 'mastracode';
+import { Agent } from '@mastra/core/agent';
+
+const reviewAgent = new Agent({
+  id: 'review-agent',
+  name: 'Review',
+  instructions: 'review code',
+  model: '__GATEWAY_OPENAI_MODEL_MINI__',
+  // no own memory or pubsub — inherits both from the harness now
+});
+
+await createMastraCode({
+  modes: [
+    { id: 'review', name: 'Review', default: true, agent: reviewAgent },
+  ],
+});
+
+// before: reviewAgent.getMemory() === undefined, observations + signals dropped
+// after:  reviewAgent.getMemory() === harnessMemory, signals route via harness pubsub
+```

--- a/mastracode/src/harness/config.ts
+++ b/mastracode/src/harness/config.ts
@@ -1,5 +1,6 @@
 import type { Agent } from '@mastra/core/agent';
 import type { MastraBrowser } from '@mastra/core/browser';
+import type { PubSub } from '@mastra/core/events';
 import type {
   CustomModelCatalogProvider,
   HarnessMode as LegacyHarnessMode,
@@ -52,6 +53,7 @@ export interface MastraCodeRuntimeConfig<TState extends Record<string, unknown>>
   storage: MastraCompositeStore;
   observability?: Observability;
   memory?: DynamicArgument<MastraMemory>;
+  pubsub?: PubSub;
   agents: Record<string, Agent>;
   modes: LegacyHarnessMode<TState>[];
   subagents: LegacyHarnessSubagent[];

--- a/mastracode/src/harness/index.ts
+++ b/mastracode/src/harness/index.ts
@@ -5,9 +5,5 @@ export {
 } from './config.js';
 export { MastraCodeHarnessRuntime, MastraCodeSessionLeaseRecoveryError } from './runtime.js';
 export { defaultStdioLeaseRecoveryPrompt } from './lease-recovery-prompt.js';
-export type {
-  LeaseRecoveryAction,
-  LeaseRecoveryPromptHandler,
-  LeaseRecoveryPromptInfo,
-} from './config.js';
+export type { LeaseRecoveryAction, LeaseRecoveryPromptHandler, LeaseRecoveryPromptInfo } from './config.js';
 export { createHarnessV1SubagentAgents } from './subagents.js';

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -23,6 +23,8 @@ function createRuntime(
     browser?: unknown;
     disabledTools?: string[];
     workspace?: ConstructorParameters<typeof MastraCodeHarnessRuntime>[0]['workspace'];
+    memory?: ConstructorParameters<typeof MastraCodeHarnessRuntime>[0]['memory'];
+    pubsub?: ConstructorParameters<typeof MastraCodeHarnessRuntime>[0]['pubsub'];
   } = {},
 ) {
   const agent = new Agent({
@@ -64,6 +66,8 @@ function createRuntime(
     browser: options.browser as never,
     disabledTools: options.disabledTools,
     workspace: options.workspace,
+    memory: options.memory,
+    pubsub: options.pubsub,
   });
 }
 
@@ -1017,6 +1021,201 @@ describe('MastraCodeHarnessRuntime', () => {
   });
 });
 
+describe('MastraCodeHarnessRuntime — runtime service propagation to mode agents (MASTRA-4342)', () => {
+  type MastraMemoryStub = ConstructorParameters<typeof MastraCodeHarnessRuntime>[0]['memory'];
+  type PubSubStub = ConstructorParameters<typeof MastraCodeHarnessRuntime>[0]['pubsub'];
+
+  function memorySentinel(label: string): MastraMemoryStub {
+    return { __testMemory: label } as unknown as MastraMemoryStub;
+  }
+
+  function pubsubSentinel(label: string): PubSubStub {
+    return { __testPubSub: label } as unknown as PubSubStub;
+  }
+
+  function makeAgent(id: string, opts: { memory?: unknown; pubsub?: unknown } = {}) {
+    return new Agent({
+      id,
+      name: id,
+      instructions: 'test',
+      model: 'openai/gpt-4o-mini' as any,
+      ...(opts.memory ? { memory: opts.memory as any } : {}),
+      ...(opts.pubsub ? { pubsub: opts.pubsub as any } : {}),
+    });
+  }
+
+  it('propagates runtime memory and pubsub to a static custom mode agent that owns neither', () => {
+    const memory = memorySentinel('runtime-memory');
+    const pubsub = pubsubSentinel('runtime-pubsub');
+    const codeAgent = makeAgent('code-agent');
+    const reviewAgent = makeAgent('review-agent');
+    const setMemorySpy = vi.spyOn(reviewAgent, '__setMemory');
+    const setPubSubSpy = vi.spyOn(reviewAgent, '__setPubSub');
+
+    createRuntime({
+      agents: { 'code-agent': codeAgent },
+      modes: [
+        { id: 'build', name: 'Build', default: true, agent: codeAgent },
+        { id: 'review', name: 'Review', agent: reviewAgent },
+      ],
+      memory,
+      pubsub,
+    });
+
+    expect(setMemorySpy).toHaveBeenCalledTimes(1);
+    expect(setMemorySpy).toHaveBeenCalledWith(memory);
+    expect(setPubSubSpy).toHaveBeenCalledTimes(1);
+    expect(setPubSubSpy).toHaveBeenCalledWith(pubsub);
+    expect(reviewAgent.hasOwnMemory()).toBe(true);
+    expect(reviewAgent.getPubSub()).toBe(pubsub);
+  });
+
+  it("preserves a custom mode agent's own memory and skips propagation", () => {
+    const runtimeMemory = memorySentinel('runtime-memory');
+    const ownMemory = memorySentinel('own-memory');
+    const reviewAgent = makeAgent('review-agent', { memory: ownMemory });
+    const setMemorySpy = vi.spyOn(reviewAgent, '__setMemory');
+
+    createRuntime({
+      agents: { 'code-agent': makeAgent('code-agent') },
+      modes: [{ id: 'review', name: 'Review', default: true, agent: reviewAgent }],
+      memory: runtimeMemory,
+    });
+
+    expect(setMemorySpy).not.toHaveBeenCalled();
+    expect(reviewAgent.hasOwnMemory()).toBe(true);
+  });
+
+  it("preserves a custom mode agent's own pubsub and skips propagation", () => {
+    const runtimePubSub = pubsubSentinel('runtime-pubsub');
+    const ownPubSub = pubsubSentinel('own-pubsub');
+    const reviewAgent = makeAgent('review-agent', { pubsub: ownPubSub });
+    const setPubSubSpy = vi.spyOn(reviewAgent, '__setPubSub');
+
+    createRuntime({
+      agents: { 'code-agent': makeAgent('code-agent') },
+      modes: [{ id: 'review', name: 'Review', default: true, agent: reviewAgent }],
+      pubsub: runtimePubSub,
+    });
+
+    expect(setPubSubSpy).not.toHaveBeenCalled();
+    expect(reviewAgent.hasOwnPubSub()).toBe(true);
+    expect(reviewAgent.getPubSub()).toBe(ownPubSub);
+  });
+
+  it('propagates only pubsub when memory is not configured', () => {
+    const pubsub = pubsubSentinel('runtime-pubsub');
+    const reviewAgent = makeAgent('review-agent');
+    const setMemorySpy = vi.spyOn(reviewAgent, '__setMemory');
+    const setPubSubSpy = vi.spyOn(reviewAgent, '__setPubSub');
+
+    createRuntime({
+      agents: { 'code-agent': makeAgent('code-agent') },
+      modes: [{ id: 'review', name: 'Review', default: true, agent: reviewAgent }],
+      pubsub,
+    });
+
+    expect(setMemorySpy).not.toHaveBeenCalled();
+    expect(setPubSubSpy).toHaveBeenCalledTimes(1);
+    expect(setPubSubSpy).toHaveBeenCalledWith(pubsub);
+  });
+
+  it('propagates only memory when pubsub is not configured', () => {
+    const memory = memorySentinel('runtime-memory');
+    const reviewAgent = makeAgent('review-agent');
+    const setMemorySpy = vi.spyOn(reviewAgent, '__setMemory');
+    const setPubSubSpy = vi.spyOn(reviewAgent, '__setPubSub');
+
+    createRuntime({
+      agents: { 'code-agent': makeAgent('code-agent') },
+      modes: [{ id: 'review', name: 'Review', default: true, agent: reviewAgent }],
+      memory,
+    });
+
+    expect(setMemorySpy).toHaveBeenCalledTimes(1);
+    expect(setMemorySpy).toHaveBeenCalledWith(memory);
+    expect(setPubSubSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not double-propagate when the same agent is reused across multiple modes', () => {
+    const memory = memorySentinel('runtime-memory');
+    const pubsub = pubsubSentinel('runtime-pubsub');
+    const sharedAgent = makeAgent('shared-agent');
+    const setMemorySpy = vi.spyOn(sharedAgent, '__setMemory');
+    const setPubSubSpy = vi.spyOn(sharedAgent, '__setPubSub');
+
+    createRuntime({
+      agents: { 'code-agent': makeAgent('code-agent') },
+      modes: [
+        { id: 'build', name: 'Build', default: true, agent: sharedAgent },
+        { id: 'plan', name: 'Plan', agent: sharedAgent },
+        { id: 'fast', name: 'Fast', agent: sharedAgent },
+      ],
+      memory,
+      pubsub,
+    });
+
+    expect(setMemorySpy).toHaveBeenCalledTimes(1);
+    expect(setPubSubSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes when the same agent appears in both config.agents and config.modes', () => {
+    const memory = memorySentinel('runtime-memory');
+    const pubsub = pubsubSentinel('runtime-pubsub');
+    const sharedAgent = makeAgent('code-agent');
+    const setMemorySpy = vi.spyOn(sharedAgent, '__setMemory');
+    const setPubSubSpy = vi.spyOn(sharedAgent, '__setPubSub');
+
+    createRuntime({
+      agents: { 'code-agent': sharedAgent },
+      modes: [{ id: 'build', name: 'Build', default: true, agent: sharedAgent }],
+      memory,
+      pubsub,
+    });
+
+    expect(setMemorySpy).toHaveBeenCalledTimes(1);
+    expect(setPubSubSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips dynamic mode agents during constructor-time propagation', () => {
+    const memory = memorySentinel('runtime-memory');
+    const pubsub = pubsubSentinel('runtime-pubsub');
+    const codeAgent = makeAgent('code-agent');
+    const dynamicAgent = makeAgent('dynamic-agent');
+    const dynamicSetMemorySpy = vi.spyOn(dynamicAgent, '__setMemory');
+    const dynamicSetPubSubSpy = vi.spyOn(dynamicAgent, '__setPubSub');
+
+    expect(() =>
+      createRuntime({
+        agents: { 'code-agent': codeAgent },
+        modes: [
+          { id: 'build', name: 'Build', default: true, agent: codeAgent },
+          { id: 'dynamic', name: 'Dynamic', agent: () => dynamicAgent },
+        ],
+        memory,
+        pubsub,
+      }),
+    ).not.toThrow();
+
+    expect(dynamicSetMemorySpy).not.toHaveBeenCalled();
+    expect(dynamicSetPubSubSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when neither memory nor pubsub is configured', () => {
+    const reviewAgent = makeAgent('review-agent');
+    const setMemorySpy = vi.spyOn(reviewAgent, '__setMemory');
+    const setPubSubSpy = vi.spyOn(reviewAgent, '__setPubSub');
+
+    createRuntime({
+      agents: { 'code-agent': makeAgent('code-agent') },
+      modes: [{ id: 'review', name: 'Review', default: true, agent: reviewAgent }],
+    });
+
+    expect(setMemorySpy).not.toHaveBeenCalled();
+    expect(setPubSubSpy).not.toHaveBeenCalled();
+  });
+});
+
 // Structural type covering only the harness-storage methods the lease-recovery
 // tests exercise. Avoids `as any` while keeping the test self-contained.
 type TestHarnessStorage = {
@@ -1132,9 +1331,7 @@ describe('MastraCodeHarnessRuntime — stale session lease recovery (MASTRA-4344
 
   it('propagates non-locked errors from session() without retrying', async () => {
     const runtime = createRuntime();
-    const sessionSpy = vi
-      .spyOn(runtime.core, 'session')
-      .mockRejectedValueOnce(new Error('storage offline'));
+    const sessionSpy = vi.spyOn(runtime.core, 'session').mockRejectedValueOnce(new Error('storage offline'));
 
     await expect(runtime.init()).rejects.toThrow('storage offline');
     expect(sessionSpy).toHaveBeenCalledTimes(1);
@@ -1188,9 +1385,7 @@ describe('MastraCodeHarnessRuntime — stale session lease recovery (MASTRA-4344
         ttlMs: 120_000,
       });
 
-      const reboundPromise = secondRuntime
-        .selectOrCreateThread({ leaseRecoveryMode: 'midsession' })
-        .catch(err => err);
+      const reboundPromise = secondRuntime.selectOrCreateThread({ leaseRecoveryMode: 'midsession' }).catch(err => err);
       await vi.advanceTimersByTimeAsync(3_000);
       const err = await reboundPromise;
 

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
+import type { Agent } from '@mastra/core/agent';
 import type {
   AvailableModel,
   HarnessDisplayState,
@@ -49,11 +50,7 @@ import {
   toHarnessV1Subagents,
   toModelInfo,
 } from './config.js';
-import type {
-  LeaseRecoveryAction,
-  MastraCodeModelInfo,
-  MastraCodeRuntimeConfig,
-} from './config.js';
+import type { LeaseRecoveryAction, MastraCodeModelInfo, MastraCodeRuntimeConfig } from './config.js';
 import { MastraCodeHarnessEventProjector } from './events.js';
 import { emptyOMProgress, getOMModelState } from './observational-memory.js';
 
@@ -107,9 +104,7 @@ function formatRetryDelay(ms: number): string {
 
 function sessionLeaseRetryDelayMs(error: HarnessSessionLockedError): number {
   const expiresInMs =
-    Number.isFinite(error.expiresAt) && error.expiresAt > 0
-      ? error.expiresAt - Date.now()
-      : SESSION_LEASE_RETRY_MAX_MS;
+    Number.isFinite(error.expiresAt) && error.expiresAt > 0 ? error.expiresAt - Date.now() : SESSION_LEASE_RETRY_MAX_MS;
   return Math.min(
     SESSION_LEASE_RETRY_MAX_MS,
     Math.max(SESSION_LEASE_RETRY_MIN_MS, Math.ceil(expiresInMs + SESSION_LEASE_RETRY_GRACE_MS)),
@@ -126,8 +121,7 @@ export class MastraCodeSessionLeaseRecoveryError extends Error {
     public readonly expiresAt: number,
     options?: { cause?: unknown },
   ) {
-    const expiresIso =
-      Number.isFinite(expiresAt) && expiresAt > 0 ? new Date(expiresAt).toISOString() : 'unknown';
+    const expiresIso = Number.isFinite(expiresAt) && expiresAt > 0 ? new Date(expiresAt).toISOString() : 'unknown';
     super(
       `MastraCode could not reopen thread "${threadId}" because its Harness v1 session "${sessionId}" is still locked by another process (owner "${currentOwnerId}", lease expires at ${expiresIso}). Another MastraCode instance may still be running. Quit the other instance or retry after the lease expires.`,
       options,
@@ -416,6 +410,8 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       this.setBrowser(config.browser);
     }
 
+    this.propagateRuntimeServicesToAgents(harnessV1Agents);
+
     this.projector = new MastraCodeHarnessEventProjector(
       event => this.emit(event),
       () => this.getDisplayState(),
@@ -699,9 +695,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     }
   }
 
-  async selectOrCreateThread(
-    options: { leaseRecoveryMode?: LeaseRecoveryMode } = {},
-  ): Promise<HarnessThread> {
+  async selectOrCreateThread(options: { leaseRecoveryMode?: LeaseRecoveryMode } = {}): Promise<HarnessThread> {
     const existing = await this.core.threads.list({
       resourceId: this.resourceId,
       perPage: false,
@@ -1597,6 +1591,23 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     }
   }
 
+  private propagateRuntimeServicesToAgents(agents: Record<string, Agent>): void {
+    const memory = this.config.memory;
+    const pubsub = this.config.pubsub;
+    if (!memory && !pubsub) return;
+    const seen = new Set<Agent>();
+    for (const agent of Object.values(agents)) {
+      if (seen.has(agent)) continue;
+      seen.add(agent);
+      if (memory && !agent.hasOwnMemory()) {
+        agent.__setMemory(memory);
+      }
+      if (pubsub && !agent.hasOwnPubSub()) {
+        agent.__setPubSub(pubsub);
+      }
+    }
+  }
+
   private withRuntimeHarnessContext(requestContext: RequestContext): RequestContext {
     if (requestContext.get('harness')) return requestContext;
 
@@ -1824,9 +1835,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
   ): Promise<Session> {
     const allowNewThread = options.allowNewThread ?? false;
     const maxWaitMs =
-      mode === 'startup'
-        ? SESSION_LEASE_RECOVERY_STARTUP_WAIT_MS
-        : SESSION_LEASE_RECOVERY_MIDSESSION_WAIT_MS;
+      mode === 'startup' ? SESSION_LEASE_RECOVERY_STARTUP_WAIT_MS : SESSION_LEASE_RECOVERY_MIDSESSION_WAIT_MS;
     const startedAt = Date.now();
     let attempt = 0;
     const envOverride = resolveLeaseRecoveryEnvOverride();
@@ -1938,8 +1947,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
           // honor a new-thread choice — they must bind a specific threadId.
           // Down-convert to quit so the caller sees a clean recovery error
           // instead of the internal sentinel leaking out.
-          const action: LeaseRecoveryAction =
-            rawAction === 'new-thread' && !allowNewThread ? 'quit' : rawAction;
+          const action: LeaseRecoveryAction = rawAction === 'new-thread' && !allowNewThread ? 'quit' : rawAction;
           if (action === 'force-claim') {
             chosenPolicy = 'force-claim';
             try {
@@ -2013,7 +2021,9 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
         }
       | undefined;
     if (!harnessStorage || typeof harnessStorage.releaseSessionLease !== 'function') {
-      throw new Error('MastraCode Harness storage does not expose releaseSessionLease; cannot force-claim session lease.');
+      throw new Error(
+        'MastraCode Harness storage does not expose releaseSessionLease; cannot force-claim session lease.',
+      );
     }
     await harnessStorage.releaseSessionLease({
       harnessName: MASTRACODE_HARNESS_NAME,

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -42,7 +42,11 @@ import { createDynamicTools } from './agents/tools.js';
 import { getDynamicWorkspace } from './agents/workspace.js';
 import { AuthStorage } from './auth/storage.js';
 import { createOutcomeScorer, createEfficiencyScorer } from './evals/scorers/index.js';
-import { createHarnessV1SubagentAgents, defaultStdioLeaseRecoveryPrompt, MastraCodeHarnessRuntime } from './harness/index.js';
+import {
+  createHarnessV1SubagentAgents,
+  defaultStdioLeaseRecoveryPrompt,
+  MastraCodeHarnessRuntime,
+} from './harness/index.js';
 import type { LeaseRecoveryPromptHandler } from './harness/index.js';
 import { HookManager } from './hooks/index.js';
 import { createMcpManager } from './mcp/index.js';
@@ -149,15 +153,8 @@ export interface MastraCodeConfig {
   leaseRecoveryPrompt?: LeaseRecoveryPromptHandler;
 }
 
-export {
-  MastraCodeSessionLeaseRecoveryError,
-  defaultStdioLeaseRecoveryPrompt,
-} from './harness/index.js';
-export type {
-  LeaseRecoveryAction,
-  LeaseRecoveryPromptInfo,
-  LeaseRecoveryPromptHandler,
-} from './harness/index.js';
+export { MastraCodeSessionLeaseRecoveryError, defaultStdioLeaseRecoveryPrompt } from './harness/index.js';
+export type { LeaseRecoveryAction, LeaseRecoveryPromptInfo, LeaseRecoveryPromptHandler } from './harness/index.js';
 
 export type MastraCodeHarnessPublic = Harness<Record<string, unknown>> & {
   actions: MastraCodeHarnessRuntime<Record<string, unknown>>['actions'];
@@ -657,6 +654,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     storage,
     observability,
     memory,
+    pubsub: signalsPubSub,
     agents: {
       'code-agent': codeAgent,
       ...createHarnessV1SubagentAgents(subagents, getDynamicModel as never, { memory, pubsub: signalsPubSub }),


### PR DESCRIPTION
## Summary

Restores legacy `Harness` behavior on the v1 runtime: custom modes whose `agent` is a static `Agent` that does not own its own memory or PubSub now receive both from the harness, matching the contract `propagateRuntimeServicesToAgent` provides in `@mastra/core/harness`. Today only the default `code-agent` (and subagents) get these services, so custom mode agents silently lose observation persistence and signal routing.

- Adds `pubsub` to `MastraCodeRuntimeConfig`.
- `createMastraCode` passes `signalsPubSub` into the runtime config.
- `MastraCodeHarnessRuntime` gains `propagateRuntimeServicesToAgents`, called once in the constructor over the v1 agent map with `Set<Agent>` dedupe and `hasOwnMemory()` / `hasOwnPubSub()` guards. Mirrors the existing `setWorkspaceOnAgents` pattern.

Linear: MASTRA-4342. Stacked on #17083 (MASTRA-4340 multi-select questions).

## Out of scope

- **Browser propagation refactor** — addressed by the browser-ownership rework on `mohamed/mastra-4340-browser-ownership` (#17082).
- **Dynamic mode-agent re-resolution** — legacy `getCurrentAgent()` re-propagates per call; v1 has no equivalent. Separate v1 compatibility concern, not regressed by this PR.

## Tests

Nine new tests in `mastracode/src/harness/runtime.test.ts`:

1. Propagates runtime memory + pubsub to a static custom mode agent.
2. Preserves a custom mode agent's own memory.
3. Preserves a custom mode agent's own pubsub.
4. Propagates only pubsub when memory is not configured.
5. Propagates only memory when pubsub is not configured.
6. Does not double-propagate when the same agent is reused across multiple modes.
7. Dedupes when the same agent appears in both `config.agents` and `config.modes`.
8. Skips dynamic mode agents during constructor-time propagation.
9. No-op when neither memory nor pubsub is configured.

## Review

- Pre-implementation: 3 codex angles (parity, dedupe, dynamic+TDD) reached consensus on the minimal scope above.
- Post-implementation: codex round 2 on the diff = APPROVE, no blocking findings.
- CodeRabbit CLI on uncommitted diff = no findings.

## Test plan

- [x] \`pnpm --filter mastracode test\` → 99 files / 1103 tests pass
- [x] \`pnpm --filter mastracode check\` (tsc --noEmit) clean
- [x] \`pnpm --filter mastracode lint\` clean
- [x] \`pnpm --filter mastracode exec prettier --check 'src/**/*.ts'\` clean
- [ ] Manually verify a custom mode in a downstream app sees harness memory + signals pubsub.