### PR TITLE
fix(ci): include package manifest in PR triage checkout

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: |
+            package.json
             .github/actions
             scripts/pr-issue-link
           sparse-checkout-cone-mode: false
@@ -81,6 +82,7 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: |
+            package.json
             .github/actions
             scripts/pr-complexity
           sparse-checkout-cone-mode: false
@@ -127,6 +129,7 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: |
+            package.json
             .github/actions
             scripts/pr-automation-comment
           sparse-checkout-cone-mode: false
@@ -170,6 +173,7 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: |
+            package.json
             .github/actions
             scripts/pr-issue-link
           sparse-checkout-cone-mode: false

--- a/packages/core/src/agent/__tests__/tool-handling.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/tool-handling.e2e.test.ts
@@ -58,13 +58,9 @@ function toolhandlingE2ETests(version: 'v1' | 'v2' | 'v3') {
           : toolCalls.find((tc: any) => tc.payload?.toolName === 'agent-researchAgent');
 
       expect(version === 'v1' ? toolCalls[0]?.result : toolCalls[0]?.payload?.result).toStrictEqual({
-        ...(version === 'v1'
-          ? {}
-          : {
-              subAgentResourceId: expect.any(String),
-              subAgentThreadId: expect.any(String),
-              subAgentToolResults: expect.any(Array),
-            }),
+        subAgentResourceId: expect.any(String),
+        subAgentThreadId: expect.any(String),
+        subAgentToolResults: expect.any(Array),
         text: 'Dummy response',
       });
 

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -821,20 +821,26 @@ describe('mastraStorage bulk mutations', () => {
     ];
     const query = vi.fn((table: string) => ({
       withIndex: vi.fn((indexName: string, queryBuilder: (q: TestQueryBuilder) => TestQueryBuilder) => {
-        const eqValues: string[] = [];
+        const eqFilters: Array<{ field: string; value: string }> = [];
         const localBuilder: TestQueryBuilder = {
-          eq: vi.fn((_field: string, value: string) => {
-            eqValues.push(String(value));
+          eq: vi.fn((field: string, value: string) => {
+            eqFilters.push({ field, value: String(value) });
             return localBuilder;
           }),
         };
         queryBuilder(builder);
         queryBuilder(localBuilder);
         return {
-          take: vi.fn(async () => (table === 'mastra_documents' ? legacyDocs : typedDocs)),
+          take: vi.fn(async () =>
+            table === 'mastra_documents'
+              ? legacyDocs
+              : typedDocs.filter(doc =>
+                  eqFilters.every(({ field, value }) => doc[field as keyof typeof doc] === value),
+                ),
+          ),
           unique: vi.fn(async () =>
             table === 'mastra_background_tasks' && indexName === 'by_record_id'
-              ? (typedDocs.find(doc => doc.id === eqValues[0]) ?? null)
+              ? (typedDocs.find(doc => doc.id === eqFilters.find(filter => filter.field === 'id')?.value) ?? null)
               : null,
           ),
         };


### PR DESCRIPTION
## Summary
- Include the root package.json in PR Triage sparse checkouts so pnpm/action-setup can read the workspace packageManager value.
- Update the core agent E2E assertion for v1 sub-agent tools to expect the metadata now returned by the implementation.

## Verification
- git diff --check
- pnpm --filter ./packages/core test src/agent/__tests__/tool-handling.e2e.test.ts -- --bail 1 --reporter=dot
- coderabbit review --plain --base origin/main --dir .github/workflows
- coderabbit review --plain --base origin/main --dir packages/core/src/agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

CI jobs were only fetching a few files and missed the project's main instructions file (package.json), so the setup couldn't tell which package manager to use. This PR ensures the CI checks include package.json and fixes a test to match newly returned sub-agent metadata.

## Changes

- .github/workflows/pr-triage.yml
  - Add package.json to the actions/checkout sparse-checkout lists for jobs:
    - issue-link-nudge
    - complexity
    - summarize
    - close-stale-unlinked

- packages/core/src/agent/__tests__/tool-handling.e2e.test.ts
  - Update assertion to always expect sub-agent metadata fields (subAgentResourceId, subAgentThreadId, subAgentToolResults) in the tool result payload for the agent-researchAgent call (applies to v1 as well).

- stores/convex/src/server/storage.test.ts
  - Make the test stub for background task filtering explicit by building eqFilters from the query builder and selecting typed docs by their id filter; adjust unique stub to select by id derived from eqFilters.

## Why This Matters

Including the root package.json lets pnpm/action-setup read the workspace packageManager value so pnpm is configured correctly during sparse-checkout CI jobs. The test updates ensure assertions match the implementation's returned sub-agent metadata and make storage test filtering behavior explicit.

Lines changed: +18/-12  
Estimated code review effort: Low to Medium

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17092?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->