### PR TITLE
feat(playground): scaffold agent-builder sidebar pages (unrouted)

### DIFF
--- a/.changeset/agent-builder-sidebar-pages-scaffold.md
+++ b/.changeset/agent-builder-sidebar-pages-scaffold.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground': patch
+---
+
+Internal: scaffold the Agent Builder left-sidebar pages (My agents, Skills, Favorites, Library, Infrastructure) along with the root redirect, root layout, and their direct dependencies. The pages and supporting hooks/components are added to the codebase but are not yet wired into `App.tsx`, so they are unreachable at runtime in this change. Wiring and the create/edit/view flows ship in follow-up PRs.

--- a/.changeset/agent-builder-sidebar-pages-scaffold.md
+++ b/.changeset/agent-builder-sidebar-pages-scaffold.md
@@ -1,5 +1,0 @@
----
-'@mastra/playground': patch
----
-
-Internal: scaffold the Agent Builder left-sidebar pages (My agents, Skills, Favorites, Library, Infrastructure) along with the root redirect, root layout, and their direct dependencies. The pages and supporting hooks/components are added to the codebase but are not yet wired into `App.tsx`, so they are unreachable at runtime in this change. Wiring and the create/edit/view flows ship in follow-up PRs.

--- a/packages/playground/src/domains/agent-builder/components/agent-list/__tests__/agent-builder-list.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-list/__tests__/agent-builder-list.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import type { StoredAgentResponse } from '@mastra/client-js';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AgentBuilderList, AgentBuilderListSkeleton } from '../agent-builder-list';
+import type { AgentBuilderListProps } from '../agent-builder-list';
+import { LinkComponentProvider } from '@/lib/framework';
+
+vi.mock('@mastra/playground-ui', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+vi.mock('@/domains/agent-builder/components/agent-list/favorite-button', () => ({
+  FavoriteButton: () => <button type="button" aria-label="Star agent" />,
+}));
+
+const StubLink = ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a {...props}>{children}</a>
+);
+
+const noopPaths = {
+  agentLink: () => '',
+  agentMessageLink: () => '',
+  workflowLink: () => '',
+  toolLink: () => '',
+  scoreLink: () => '',
+  scorerLink: () => '',
+  toolByAgentLink: () => '',
+  toolByWorkflowLink: () => '',
+  promptLink: () => '',
+  legacyWorkflowLink: () => '',
+  policyLink: () => '',
+  vNextNetworkLink: () => '',
+  agentBuilderLink: () => '',
+  mcpServerLink: () => '',
+  mcpServerToolLink: () => '',
+  workflowRunLink: () => '',
+  datasetLink: () => '',
+  datasetItemLink: () => '',
+  datasetExperimentLink: () => '',
+  experimentLink: () => '',
+} as never;
+
+function renderList({ agents, search, ...props }: AgentBuilderListProps) {
+  return render(
+    <TooltipProvider>
+      <LinkComponentProvider Link={StubLink as never} navigate={() => {}} paths={noopPaths}>
+        <AgentBuilderList agents={agents} search={search} {...props} />
+      </LinkComponentProvider>
+    </TooltipProvider>,
+  );
+}
+
+const now = new Date().toISOString();
+
+const fixtureAgents: StoredAgentResponse[] = [
+  {
+    id: 'a1',
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+    name: 'Alpha Agent',
+    description: 'First agent description',
+    instructions: '',
+    model: { provider: 'openai', name: 'gpt-4' },
+    visibility: 'private',
+    authorId: 'user-1',
+  },
+  {
+    id: 'a2',
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+    name: 'Beta Agent',
+    description: 'Second agent description',
+    instructions: '',
+    model: { provider: 'anthropic', name: 'claude' },
+    visibility: 'public',
+    authorId: 'user-2',
+  },
+];
+
+describe('AgentBuilderList', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows a private lock icon with tooltip copy inline with private agent titles', () => {
+    renderList({ agents: fixtureAgents });
+
+    expect(screen.getAllByTestId('agent-builder-private-visibility-icon')).toHaveLength(1);
+    expect(screen.queryByText('Private')).toBeNull();
+    expect(screen.queryByText('Public')).toBeNull();
+    expect(screen.getByText('Only visible to you')).toBeTruthy();
+  });
+
+  it('renders agent name and description without technical metadata', () => {
+    renderList({ agents: fixtureAgents });
+
+    expect(screen.getByText('Alpha Agent')).toBeTruthy();
+    expect(screen.getByText('First agent description')).toBeTruthy();
+    expect(screen.getByText('Beta Agent')).toBeTruthy();
+    expect(screen.queryByText('openai/gpt-4')).toBeNull();
+    expect(screen.queryByText('anthropic/claude')).toBeNull();
+    expect(screen.queryByText(/Updated/)).toBeNull();
+  });
+
+  it('filters by search prop', () => {
+    renderList({ agents: fixtureAgents, search: 'alpha' });
+
+    expect(screen.getByText('Alpha Agent')).toBeTruthy();
+    expect(screen.queryByText('Beta Agent')).toBeNull();
+  });
+
+  it('links rows to the agent view page', () => {
+    renderList({ agents: fixtureAgents, rowTestId: 'agent-row' });
+
+    const rows = screen.getAllByTestId('agent-row');
+    expect(rows).toHaveLength(fixtureAgents.length);
+    for (const [i, row] of rows.entries()) {
+      expect(row.getAttribute('href')).toBe(`/agent-builder/agents/${fixtureAgents[i].id}/view`);
+    }
+  });
+
+  it('filters by description', () => {
+    renderList({ agents: fixtureAgents, search: 'second agent' });
+
+    expect(screen.getByText('Beta Agent')).toBeTruthy();
+    expect(screen.queryByText('Alpha Agent')).toBeNull();
+  });
+
+  it('shows empty state when no rows match', () => {
+    renderList({ agents: fixtureAgents, search: 'zzz', rowTestId: 'agent-row' });
+
+    expect(screen.getByText('No agents match your search')).toBeTruthy();
+    expect(screen.queryByTestId('agent-row')).toBeNull();
+  });
+
+  it('supports the library list presentation', () => {
+    renderList({
+      agents: fixtureAgents,
+      rowTestId: 'library-agent-row',
+    });
+
+    expect(screen.getAllByTestId('library-agent-row')).toHaveLength(fixtureAgents.length);
+    expect(screen.queryByText('Private')).toBeNull();
+  });
+});
+
+describe('AgentBuilderListSkeleton', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the requested number of rows for the library presentation', () => {
+    render(<AgentBuilderListSkeleton rows={6} rowTestId="library-skeleton-row" />);
+
+    expect(screen.getAllByTestId('library-skeleton-row')).toHaveLength(6);
+  });
+
+  it('defaults to 4 rows', () => {
+    render(<AgentBuilderListSkeleton rowTestId="library-skeleton-row" />);
+
+    expect(screen.getAllByTestId('library-skeleton-row')).toHaveLength(4);
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/agent-list/__tests__/agent-builder-list.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-list/__tests__/agent-builder-list.test.tsx
@@ -1,26 +1,43 @@
 // @vitest-environment jsdom
-import type { StoredAgentResponse } from '@mastra/client-js';
-import { TooltipProvider } from '@mastra/playground-ui';
+import type { BuilderSettingsResponse, StoredAgentResponse } from '@mastra/client-js';
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AgentBuilderList, AgentBuilderListSkeleton } from '../agent-builder-list';
 import type { AgentBuilderListProps } from '../agent-builder-list';
+import type { AuthCapabilities } from '@/domains/auth/types';
 import { LinkComponentProvider } from '@/lib/framework';
+import { server } from '@/test/msw-server';
 
-vi.mock('@mastra/playground-ui', async importOriginal => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
+// Tooltip primitives render their content lazily on hover; flatten them for
+// these structural tests so we can assert on the inline tooltip copy directly.
+// This is a UI-rendering seam only — it does NOT hide data/auth flow.
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
   return {
     ...actual,
-    TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   };
 });
 
-vi.mock('@/domains/agent-builder/components/agent-list/favorite-button', () => ({
-  FavoriteButton: () => <button type="button" aria-label="Star agent" />,
-}));
+const BASE_URL = 'http://localhost:4111';
+
+const unauthenticatedCapabilities = {
+  enabled: true,
+  login: { type: 'credentials' as const },
+} satisfies AuthCapabilities;
+
+const settingsFavoritesOn: BuilderSettingsResponse = {
+  enabled: true,
+  features: {
+    agent: { favorites: true },
+  },
+};
 
 const StubLink = ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
   <a {...props}>{children}</a>
@@ -50,12 +67,26 @@ const noopPaths = {
 } as never;
 
 function renderList({ agents, search, ...props }: AgentBuilderListProps) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  // Seed default handlers so the FavoriteButton instances rendered inside each
+  // row resolve their auth + builder-settings queries via MSW. Individual tests
+  // can still override these via server.use(...) before rendering.
+  server.use(
+    http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(unauthenticatedCapabilities)),
+    http.get(`${BASE_URL}/api/editor/builder/settings`, () => HttpResponse.json(settingsFavoritesOn)),
+  );
+
   return render(
-    <TooltipProvider>
-      <LinkComponentProvider Link={StubLink as never} navigate={() => {}} paths={noopPaths}>
-        <AgentBuilderList agents={agents} search={search} {...props} />
-      </LinkComponentProvider>
-    </TooltipProvider>,
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <LinkComponentProvider Link={StubLink as never} navigate={() => {}} paths={noopPaths}>
+          <AgentBuilderList agents={agents} search={search} {...props} />
+        </LinkComponentProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
   );
 }
 

--- a/packages/playground/src/domains/agent-builder/components/agent-list/__tests__/favorite-button.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-list/__tests__/favorite-button.test.tsx
@@ -1,58 +1,180 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BuilderSettingsResponse, FavoriteToggleResponse } from '@mastra/client-js';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
 import { FavoriteButton } from '../favorite-button';
+import type { AuthCapabilities } from '@/domains/auth/types';
+import { server } from '@/test/msw-server';
 
-vi.mock('@/domains/agent-builder', () => ({
-  useBuilderAgentFeatures: () => ({ favorites: true }),
-}));
+const BASE_URL = 'http://localhost:4111';
 
-vi.mock('@/domains/agent-builder/hooks/use-stored-agent-favorite', () => ({
-  useToggleStoredAgentFavorite: () => ({ isPending: false, mutate: vi.fn() }),
-}));
+const authenticatedCapabilities = {
+  enabled: true,
+  login: { type: 'credentials' as const },
+  user: { id: 'user-1', email: 'u@example.com' },
+  capabilities: { user: true, session: true, sso: false, rbac: false, acl: false },
+  access: null,
+} satisfies AuthCapabilities;
 
-const authCapabilitiesMock = vi.fn();
+const unauthenticatedCapabilities = {
+  enabled: true,
+  login: { type: 'credentials' as const },
+} satisfies AuthCapabilities;
 
-vi.mock('@/domains/auth/hooks/use-auth-capabilities', () => ({
-  useAuthCapabilities: () => authCapabilitiesMock(),
-}));
+const settingsFavoritesOn: BuilderSettingsResponse = {
+  enabled: true,
+  features: {
+    agent: { favorites: true },
+  },
+};
 
-describe('FavoriteButton', () => {
-  beforeEach(() => {
-    authCapabilitiesMock.mockReturnValue({
-      data: {
-        enabled: true,
-        login: { sso: false, credentials: false },
-        user: { id: 'u1' },
-        capabilities: {},
-        access: null,
-      },
-    });
+function useFavoritesHandlers(capabilities: AuthCapabilities) {
+  return [
+    http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(capabilities)),
+    http.get(`${BASE_URL}/api/editor/builder/settings`, () => HttpResponse.json(settingsFavoritesOn)),
+  ];
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
 
-  it('renders singular Star text with the count', () => {
-    render(<FavoriteButton agentId="agent-1" favoriteCount={1} />);
+  return (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>{children}</TooltipProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>
+  );
+}
 
+async function waitForFavoritesGate() {
+  // The features.favorites flag gates rendering; wait for it to resolve.
+  await waitFor(() => {
+    expect(screen.queryByRole('button')).not.toBeNull();
+  });
+}
+
+afterEach(() => cleanup());
+
+describe('FavoriteButton', () => {
+  it('renders singular Star text with the count when count is 1', async () => {
+    server.use(...useFavoritesHandlers(authenticatedCapabilities));
+
+    render(
+      <Wrapper>
+        <FavoriteButton agentId="agent-1" favoriteCount={1} />
+      </Wrapper>,
+    );
+
+    await waitForFavoritesGate();
     expect(screen.getByRole('button', { name: 'Star agent' })).toBeTruthy();
     expect(screen.getByText('Star')).toBeTruthy();
     expect(screen.getByText('1')).toBeTruthy();
   });
 
-  it('renders plural Stars text with the count', () => {
-    render(<FavoriteButton agentId="agent-1" favoriteCount={2} />);
+  it('renders plural Stars text with the count when count is not 1', async () => {
+    server.use(...useFavoritesHandlers(authenticatedCapabilities));
 
+    render(
+      <Wrapper>
+        <FavoriteButton agentId="agent-1" favoriteCount={2} />
+      </Wrapper>,
+    );
+
+    await waitForFavoritesGate();
     expect(screen.getByText('Stars')).toBeTruthy();
     expect(screen.getByText('2')).toBeTruthy();
   });
 
-  it('renders as disabled with a sign-in tooltip when the user is not authenticated', () => {
-    authCapabilitiesMock.mockReturnValue({
-      data: { enabled: true, login: { sso: false, credentials: false } },
-    });
-    render(<FavoriteButton agentId="agent-1" favoriteCount={1} />);
+  it('renders as disabled with a sign-in label when the user is not authenticated', async () => {
+    server.use(...useFavoritesHandlers(unauthenticatedCapabilities));
 
+    render(
+      <Wrapper>
+        <FavoriteButton agentId="agent-1" favoriteCount={1} />
+      </Wrapper>,
+    );
+
+    await waitForFavoritesGate();
     const button = screen.getByRole('button', { name: 'Sign in to star this agent' });
     expect(button).toBeTruthy();
     expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('does not issue a favorite request when an unauthenticated user clicks the button', async () => {
+    const favoriteCalls: string[] = [];
+    server.use(
+      ...useFavoritesHandlers(unauthenticatedCapabilities),
+      http.put(`${BASE_URL}/api/stored/agents/:id/favorite`, ({ request }) => {
+        favoriteCalls.push(request.url);
+        return HttpResponse.json({ favorited: true, favoriteCount: 2 } satisfies FavoriteToggleResponse);
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <FavoriteButton agentId="agent-1" favoriteCount={1} />
+      </Wrapper>,
+    );
+
+    await waitForFavoritesGate();
+    fireEvent.click(screen.getByRole('button'));
+
+    // Give any in-flight microtasks a tick to settle.
+    await act(() => new Promise(resolve => setTimeout(resolve, 0)));
+    expect(favoriteCalls).toHaveLength(0);
+  });
+
+  it('issues a PUT to the favorite endpoint when an authenticated user stars an agent', async () => {
+    const favoriteRequests: string[] = [];
+    server.use(
+      ...useFavoritesHandlers(authenticatedCapabilities),
+      http.put(`${BASE_URL}/api/stored/agents/:id/favorite`, ({ request, params }) => {
+        favoriteRequests.push(String(params.id));
+        return HttpResponse.json({ favorited: true, favoriteCount: 2 } satisfies FavoriteToggleResponse, {
+          headers: { 'x-method': request.method },
+        });
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <FavoriteButton agentId="agent-1" favoriteCount={1} />
+      </Wrapper>,
+    );
+
+    await waitForFavoritesGate();
+    fireEvent.click(screen.getByRole('button', { name: 'Star agent' }));
+
+    await waitFor(() => expect(favoriteRequests).toEqual(['agent-1']));
+  });
+
+  it('issues a DELETE to the favorite endpoint when an authenticated user unstars an agent', async () => {
+    const unfavoriteRequests: string[] = [];
+    server.use(
+      ...useFavoritesHandlers(authenticatedCapabilities),
+      http.delete(`${BASE_URL}/api/stored/agents/:id/favorite`, ({ params }) => {
+        unfavoriteRequests.push(String(params.id));
+        return HttpResponse.json({ favorited: false, favoriteCount: 0 } satisfies FavoriteToggleResponse);
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <FavoriteButton agentId="agent-1" isFavorited favoriteCount={1} />
+      </Wrapper>,
+    );
+
+    await waitForFavoritesGate();
+    fireEvent.click(screen.getByRole('button', { name: 'Unstar agent' }));
+
+    await waitFor(() => expect(unfavoriteRequests).toEqual(['agent-1']));
   });
 });

--- a/packages/playground/src/domains/agent-builder/components/agent-list/__tests__/favorite-button.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-list/__tests__/favorite-button.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FavoriteButton } from '../favorite-button';
+
+vi.mock('@/domains/agent-builder', () => ({
+  useBuilderAgentFeatures: () => ({ favorites: true }),
+}));
+
+vi.mock('@/domains/agent-builder/hooks/use-stored-agent-favorite', () => ({
+  useToggleStoredAgentFavorite: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+const authCapabilitiesMock = vi.fn();
+
+vi.mock('@/domains/auth/hooks/use-auth-capabilities', () => ({
+  useAuthCapabilities: () => authCapabilitiesMock(),
+}));
+
+describe('FavoriteButton', () => {
+  beforeEach(() => {
+    authCapabilitiesMock.mockReturnValue({
+      data: {
+        enabled: true,
+        login: { sso: false, credentials: false },
+        user: { id: 'u1' },
+        capabilities: {},
+        access: null,
+      },
+    });
+  });
+
+  it('renders singular Star text with the count', () => {
+    render(<FavoriteButton agentId="agent-1" favoriteCount={1} />);
+
+    expect(screen.getByRole('button', { name: 'Star agent' })).toBeTruthy();
+    expect(screen.getByText('Star')).toBeTruthy();
+    expect(screen.getByText('1')).toBeTruthy();
+  });
+
+  it('renders plural Stars text with the count', () => {
+    render(<FavoriteButton agentId="agent-1" favoriteCount={2} />);
+
+    expect(screen.getByText('Stars')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+  });
+
+  it('renders as disabled with a sign-in tooltip when the user is not authenticated', () => {
+    authCapabilitiesMock.mockReturnValue({
+      data: { enabled: true, login: { sso: false, credentials: false } },
+    });
+    render(<FavoriteButton agentId="agent-1" favoriteCount={1} />);
+
+    const button = screen.getByRole('button', { name: 'Sign in to star this agent' });
+    expect(button).toBeTruthy();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/agent-list/agent-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-list/agent-builder-list.tsx
@@ -22,6 +22,7 @@ function getAvatarUrl(agent: StoredAgentResponse): string | undefined {
   if (meta && typeof meta === 'object' && 'avatarUrl' in meta) {
     return meta.avatarUrl as string | undefined;
   }
+
   return undefined;
 }
 
@@ -50,6 +51,7 @@ export function AgentBuilderList({ agents, search, rowTestId, showFavorites = tr
   const filtered = useMemo(() => {
     const q = (search ?? '').trim().toLowerCase();
     if (!q) return agents;
+
     return agents.filter(a => {
       const name = a.name?.toLowerCase() ?? '';
       const description = a.description?.toLowerCase() ?? '';

--- a/packages/playground/src/domains/agent-builder/components/agent-list/agent-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-list/agent-builder-list.tsx
@@ -1,0 +1,134 @@
+import type { StoredAgentResponse } from '@mastra/client-js';
+import { Avatar, EmptyState, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
+import { LockIcon, SearchIcon } from 'lucide-react';
+import { useMemo } from 'react';
+import { FavoriteButton } from './favorite-button';
+import { useLinkComponent } from '@/lib/framework';
+
+export type AgentBuilderListProps = {
+  agents: StoredAgentResponse[];
+  search?: string;
+  rowTestId?: string;
+  showFavorites?: boolean;
+};
+
+export type AgentBuilderListSkeletonProps = {
+  rows?: number;
+  rowTestId?: string;
+};
+
+function getAvatarUrl(agent: StoredAgentResponse): string | undefined {
+  const meta = agent.metadata;
+  if (meta && typeof meta === 'object' && 'avatarUrl' in meta) {
+    return meta.avatarUrl as string | undefined;
+  }
+  return undefined;
+}
+
+function PrivateVisibilityIcon() {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="text-neutral3 shrink-0"
+          aria-label="Private agent"
+          data-testid="agent-builder-private-visibility-icon"
+        >
+          <Icon size="sm">
+            <LockIcon />
+          </Icon>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>Only visible to you</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function AgentBuilderList({ agents, search, rowTestId, showFavorites = true }: AgentBuilderListProps) {
+  const { Link } = useLinkComponent();
+
+  const filtered = useMemo(() => {
+    const q = (search ?? '').trim().toLowerCase();
+    if (!q) return agents;
+    return agents.filter(a => {
+      const name = a.name?.toLowerCase() ?? '';
+      const description = a.description?.toLowerCase() ?? '';
+      return name.includes(q) || description.includes(q);
+    });
+  }, [agents, search]);
+
+  if (filtered.length === 0) {
+    return (
+      <div className="flex items-center justify-center pt-10">
+        <EmptyState
+          iconSlot={<SearchIcon className="h-8 w-8 text-neutral3" />}
+          titleSlot="No agents match your search"
+          descriptionSlot="Try a different name or description."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface2 border h-full border-border1 rounded-xl divide-y divide-border1 overflow-y-auto content-start">
+      {filtered.map(agent => {
+        const avatar = getAvatarUrl(agent);
+
+        return (
+          <Link
+            key={agent.id}
+            href={`/agent-builder/agents/${agent.id}/view`}
+            className="px-6 py-5 flex items-start gap-4 hover:bg-surface3 transition-colors md:items-center"
+            data-testid={rowTestId}
+          >
+            <Avatar name={agent.name ?? ''} src={avatar} />
+
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 min-w-0">
+                <div className="text-ui-md text-neutral6 truncate">{agent.name}</div>
+                {agent.visibility === 'private' && <PrivateVisibilityIcon />}
+              </div>
+              <div className="flex items-center gap-2 mt-0.5">
+                <span className="text-ui-sm text-neutral3 line-clamp-1">{agent.description || 'No description'}</span>
+              </div>
+              {showFavorites && (
+                <div className="mt-2 md:hidden">
+                  <FavoriteButton
+                    agentId={agent.id}
+                    isFavorited={agent.isFavorited}
+                    favoriteCount={agent.favoriteCount}
+                    size="sm"
+                  />
+                </div>
+              )}
+            </div>
+            {showFavorites && (
+              <FavoriteButton
+                agentId={agent.id}
+                isFavorited={agent.isFavorited}
+                favoriteCount={agent.favoriteCount}
+                size="sm"
+                className="shrink-0 hidden md:inline-flex"
+              />
+            )}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+export function AgentBuilderListSkeleton({ rows = 4, rowTestId }: AgentBuilderListSkeletonProps) {
+  return (
+    <div className="bg-surface2 border border-border1 rounded-xl divide-y divide-border1 overflow-hidden">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="px-6 py-5 flex items-center gap-4" data-testid={rowTestId}>
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="h-3.5 w-48 bg-surface3 rounded animate-pulse" />
+            <div className="h-3 w-72 max-w-full bg-surface3 rounded animate-pulse" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/playground/src/domains/agent-builder/components/agent-list/favorite-button.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-list/favorite-button.tsx
@@ -36,8 +36,9 @@ export const FavoriteButton = ({
 }: FavoriteButtonProps) => {
   const features = useBuilderAgentFeatures();
   const toggle = useToggleStoredAgentFavorite(agentId);
-  const { data: capabilities } = useAuthCapabilities();
+  const { data: capabilities, isLoading } = useAuthCapabilities();
 
+  if (isLoading) return null;
   if (!features.favorites) return null;
 
   const signedIn = capabilities ? isAuthenticated(capabilities) : false;

--- a/packages/playground/src/domains/agent-builder/components/agent-list/favorite-button.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-list/favorite-button.tsx
@@ -1,0 +1,78 @@
+import { Button, cn } from '@mastra/playground-ui';
+import { Star } from 'lucide-react';
+import type { MouseEvent } from 'react';
+import { useBuilderAgentFeatures } from '@/domains/agent-builder';
+import { useToggleStoredAgentFavorite } from '@/domains/agent-builder/hooks/use-stored-agent-favorite';
+import { useAuthCapabilities } from '@/domains/auth/hooks/use-auth-capabilities';
+import { isAuthenticated } from '@/domains/auth/types';
+
+export interface FavoriteButtonProps {
+  agentId: string;
+  isFavorited?: boolean;
+  favoriteCount?: number;
+  size?: 'sm' | 'md';
+  className?: string;
+  /** Show the count badge next to the icon. Defaults to true. */
+  showCount?: boolean;
+}
+
+const iconSizes = {
+  sm: 14,
+  md: 16,
+} as const;
+
+/**
+ * Toggles the favorite state for a stored agent. Renders nothing if the EE
+ * `agent.favorites` flag is off. Stops click propagation so it can sit inside a
+ * row that is itself a link.
+ */
+export const FavoriteButton = ({
+  agentId,
+  isFavorited = false,
+  favoriteCount,
+  size = 'md',
+  className,
+  showCount = true,
+}: FavoriteButtonProps) => {
+  const features = useBuilderAgentFeatures();
+  const toggle = useToggleStoredAgentFavorite(agentId);
+  const { data: capabilities } = useAuthCapabilities();
+
+  if (!features.favorites) return null;
+
+  const signedIn = capabilities ? isAuthenticated(capabilities) : false;
+  const label = isFavorited ? 'Unstar agent' : 'Star agent';
+  const disabledLabel = 'Sign in to star this agent';
+  const countLabel = favoriteCount === 1 ? 'Star' : 'Stars';
+  const isDisabled = toggle.isPending || !signedIn;
+
+  return (
+    <Button
+      type="button"
+      variant="default"
+      size={size}
+      aria-pressed={isFavorited}
+      aria-label={signedIn ? label : disabledLabel}
+      title={signedIn ? label : disabledLabel}
+      disabled={isDisabled}
+      onClick={(event: MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!signedIn) return;
+        toggle.mutate({ favorited: !isFavorited });
+      }}
+      className={cn('shrink-0', signedIn ? 'cursor-pointer' : 'cursor-not-allowed', className)}
+    >
+      <Star
+        size={iconSizes[size]}
+        className={cn('shrink-0', isFavorited && 'fill-current text-yellow-300')}
+        aria-hidden
+      />
+      {showCount && typeof favoriteCount === 'number' && (
+        <span className="leading-none whitespace-nowrap">
+          <span className="tabular-nums">{favoriteCount}</span> {countLabel}
+        </span>
+      )}
+    </Button>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
@@ -1,0 +1,359 @@
+import type { BuilderRegistrySkillSummary } from '@mastra/client-js';
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  MarkdownRenderer,
+  ScrollArea,
+  SkillIcon,
+  cn,
+} from '@mastra/playground-ui';
+import { Check, Download, ExternalLink, Github, Loader2, Package, Search } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+
+import {
+  useBuilderRegistryPreview,
+  useInstallBuilderRegistrySkill,
+  usePopularBuilderRegistrySkills,
+  useSearchBuilderRegistry,
+} from '@/domains/agent-builder/hooks/use-builder-registries';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Parse a registry skill's `topSource` field to extract owner/repo. Mirrors
+ * the workspace-side helper but kept private to the Builder dialog so the two
+ * surfaces can evolve independently.
+ *
+ * Accepts:
+ *   - `owner/repo`
+ *   - `owner/repo/path/...`
+ *   - `github.com/owner/repo/...`
+ *   - `https://github.com/owner/repo/...`
+ */
+function parseSkillSource(topSource: string): { owner: string; repo: string } | null {
+  if (!topSource) return null;
+  let cleaned = topSource.replace(/^https?:\/\//, '').replace(/^github\.com\//, '');
+  const parts = cleaned.split('/').filter(Boolean);
+  if (parts.length < 2) return null;
+  return { owner: parts[0]!, repo: parts[1]! };
+}
+
+function getSkillUniqueId(skill: BuilderRegistrySkillSummary): string {
+  return `${skill.topSource}/${skill.name}`;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export interface BuilderAddSkillDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  registryId: string;
+  registryLabel: string;
+  /** Stored skill ids that already exist locally (collision check). */
+  installedSkillIds?: string[];
+  /** Called after a successful install with the new stored skill id. */
+  onInstalled?: (storedSkillId: string) => void;
+  /**
+   * Called when a 409 collision is detected. Receives the offending skill name
+   * so the parent can navigate to or focus the existing stored skill.
+   */
+  onCollision?: (skillName: string) => void;
+}
+
+export function BuilderAddSkillDialog({
+  open,
+  onOpenChange,
+  registryId,
+  registryLabel,
+  installedSkillIds = [],
+  onInstalled,
+  onCollision,
+}: BuilderAddSkillDialogProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedSkill, setSelectedSkill] = useState<BuilderRegistrySkillSummary | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
+
+  const { data: popularData, isLoading: isLoadingPopular } = usePopularBuilderRegistrySkills(
+    open ? registryId : undefined,
+  );
+  const searchMutation = useSearchBuilderRegistry(registryId);
+  const installMutation = useInstallBuilderRegistrySkill(registryId);
+
+  const parsedSource = useMemo(() => {
+    if (!selectedSkill?.topSource) return null;
+    return parseSkillSource(selectedSkill.topSource);
+  }, [selectedSkill]);
+
+  const { data: previewContent, isLoading: isLoadingPreview } = useBuilderRegistryPreview(
+    registryId,
+    parsedSource?.owner,
+    parsedSource?.repo,
+    selectedSkill?.name,
+    { enabled: !!parsedSource && !!selectedSkill && open },
+  );
+
+  const debouncedSearch = useDebouncedCallback((query: string) => {
+    if (query.trim().length >= 2) {
+      searchMutation.mutate(query);
+    }
+  }, 300);
+
+  const handleSearch = useCallback(
+    (query: string) => {
+      setSearchQuery(query);
+      debouncedSearch(query);
+    },
+    [debouncedSearch],
+  );
+
+  const displaySkills = useMemo(() => {
+    if (searchQuery.trim().length >= 2) {
+      return searchMutation.data?.skills ?? [];
+    }
+    return popularData?.skills ?? [];
+  }, [searchQuery, searchMutation.data, popularData]);
+
+  const isSearching = searchMutation.isPending;
+  const hasSearchResults = searchQuery.trim().length >= 2;
+
+  const isSelectedInstalled = useMemo(() => {
+    if (!selectedSkill) return false;
+    return installedSkillIds.includes(selectedSkill.name);
+  }, [selectedSkill, installedSkillIds]);
+
+  const githubUrl = useMemo(() => {
+    if (!parsedSource) return null;
+    return `https://github.com/${parsedSource.owner}/${parsedSource.repo}`;
+  }, [parsedSource]);
+
+  const handleInstall = useCallback(async () => {
+    if (!selectedSkill || !parsedSource) return;
+    setInstallError(null);
+    try {
+      const result = await installMutation.mutateAsync({
+        owner: parsedSource.owner,
+        repo: parsedSource.repo,
+        skillName: selectedSkill.name,
+      });
+      onInstalled?.(result.storedSkillId);
+      onOpenChange(false);
+    } catch (err: any) {
+      const message: string = err?.message ?? 'Install failed';
+      // Detect 409 from the stringified error body. The collision case is the
+      // only one we need to upgrade into a navigation hint.
+      if (/409/.test(message) || /already exists/i.test(message)) {
+        onCollision?.(selectedSkill.name);
+        setInstallError('A skill with this name already exists. Open the existing skill instead.');
+      } else {
+        setInstallError(message);
+      }
+    }
+  }, [selectedSkill, parsedSource, installMutation, onInstalled, onOpenChange, onCollision]);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) {
+        setSearchQuery('');
+        setSelectedSkill(null);
+        setInstallError(null);
+      }
+      onOpenChange(next);
+    },
+    [onOpenChange],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-4xl h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Browse {registryLabel}</DialogTitle>
+          <DialogDescription>
+            Find a public skill from {registryLabel} and import it into your Builder skill library.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogBody className="flex-1 flex flex-col gap-4 overflow-hidden max-h-none">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral3" />
+            <Input
+              placeholder={`Search ${registryLabel}...`}
+              value={searchQuery}
+              onChange={e => handleSearch(e.target.value)}
+              className="pl-9"
+              data-testid="builder-add-skill-search"
+            />
+          </div>
+
+          <div className="flex flex-1 gap-4 min-h-0">
+            {/* Skills list */}
+            <div className="w-1/2 flex flex-col min-h-0">
+              <div className="text-xs font-medium text-neutral4 uppercase tracking-wide mb-2">
+                {hasSearchResults ? 'Search results' : 'Popular skills'}
+              </div>
+              <ScrollArea className="flex-1 border border-border1 rounded-lg">
+                {isLoadingPopular || isSearching ? (
+                  <div className="flex items-center justify-center py-8">
+                    <Loader2 className="h-6 w-6 animate-spin text-neutral3" />
+                  </div>
+                ) : displaySkills.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-8 text-neutral4">
+                    <Package className="h-8 w-8 mb-2" />
+                    <p className="text-sm">{hasSearchResults ? 'No skills found' : 'No skills available'}</p>
+                  </div>
+                ) : (
+                  <div className="p-2 space-y-1">
+                    {displaySkills.map(skill => {
+                      const skillUniqueId = getSkillUniqueId(skill);
+                      const isInstalled = installedSkillIds.includes(skill.name);
+                      const selectedUniqueId = selectedSkill ? getSkillUniqueId(selectedSkill) : null;
+                      return (
+                        <button
+                          key={skillUniqueId}
+                          onClick={() => setSelectedSkill(skill)}
+                          className={cn(
+                            'w-full text-left px-3 py-2 rounded-md transition-colors',
+                            'hover:bg-surface4',
+                            selectedUniqueId === skillUniqueId && 'bg-surface5 border border-accent1',
+                          )}
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-2">
+                                <span className="font-medium text-sm text-neutral6 truncate">{skill.name}</span>
+                                {isInstalled && (
+                                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent1/20 text-accent1">
+                                    <Check className="h-2.5 w-2.5" />
+                                    Installed
+                                  </span>
+                                )}
+                              </div>
+                              <div className="text-xs text-neutral4 truncate">{skill.topSource}</div>
+                            </div>
+                            <div className="flex items-center gap-1 text-xs text-neutral3 shrink-0">
+                              <Download className="h-3 w-3" />
+                              <span>{skill.installs.toLocaleString()}</span>
+                            </div>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </ScrollArea>
+            </div>
+
+            {/* Preview pane */}
+            <div className="w-1/2 flex flex-col min-h-0 border border-border1 rounded-lg overflow-hidden">
+              {!selectedSkill ? (
+                <div className="flex-1 flex flex-col items-center justify-center text-neutral4">
+                  <Package className="h-8 w-8 mb-2" />
+                  <p className="text-sm">Select a skill to preview</p>
+                </div>
+              ) : (
+                <>
+                  <div className="p-4 border-b border-border1 bg-surface3">
+                    <div className="flex items-start gap-3">
+                      <div className="p-2 rounded-lg bg-surface5">
+                        <SkillIcon className="h-5 w-5 text-neutral4" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h3 className="font-semibold text-neutral6 truncate">{selectedSkill.name}</h3>
+                        <div className="flex items-center gap-3 mt-1 text-xs text-neutral4">
+                          <span className="flex items-center gap-1">
+                            <Github className="h-3 w-3" />
+                            {selectedSkill.topSource}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <Download className="h-3 w-3" />
+                            {selectedSkill.installs.toLocaleString()} installs
+                          </span>
+                        </div>
+                      </div>
+                      {githubUrl && (
+                        <a
+                          href={githubUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-neutral4 hover:text-neutral5 transition-colors"
+                          title="View on GitHub"
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </a>
+                      )}
+                    </div>
+                  </div>
+
+                  {isLoadingPreview ? (
+                    <div className="flex-1 flex items-center justify-center">
+                      <Loader2 className="h-6 w-6 animate-spin text-neutral3" />
+                    </div>
+                  ) : previewContent ? (
+                    <ScrollArea className="flex-1">
+                      <div className="p-4">
+                        <MarkdownRenderer>{previewContent}</MarkdownRenderer>
+                      </div>
+                    </ScrollArea>
+                  ) : (
+                    <div className="flex-1 flex flex-col items-center justify-center text-neutral4">
+                      <Package className="h-8 w-8 mb-2" />
+                      <p className="text-sm">Preview unavailable</p>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+
+          {selectedSkill && (
+            <div className="flex flex-col gap-3 pt-4 border-t border-border1">
+              {installError && (
+                <div className="text-sm text-red-400 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/20">
+                  {installError}
+                </div>
+              )}
+              <div className="flex items-center justify-end gap-2">
+                <Button variant="default" onClick={() => handleOpenChange(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  onClick={handleInstall}
+                  disabled={!parsedSource || installMutation.isPending || isSelectedInstalled}
+                  data-testid="builder-install-skill-button"
+                >
+                  {installMutation.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Installing...
+                    </>
+                  ) : isSelectedInstalled ? (
+                    <>
+                      <Check className="h-4 w-4 mr-2" />
+                      Already installed
+                    </>
+                  ) : (
+                    <>
+                      <Download className="h-4 w-4 mr-2" />
+                      Install
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/playground/src/domains/agent-builder/components/skill-list/copy-skill-dialog.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/copy-skill-dialog.tsx
@@ -1,0 +1,90 @@
+import { AlertDialog, Input } from '@mastra/playground-ui';
+import { useEffect, useState } from 'react';
+
+export interface CopySkillDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The original skill being copied. Used to suggest a default name. */
+  sourceName: string;
+  /** Names of the user's existing skills, to detect collisions before submit. */
+  existingNames: string[];
+  /** Whether a copy mutation is currently pending. */
+  isPending?: boolean;
+  /** Called with the chosen name when the user confirms. */
+  onConfirm: (name: string) => void;
+}
+
+function suggestCopyName(sourceName: string, existingNames: string[]): string {
+  const base = `${sourceName}-copy`;
+  if (!existingNames.includes(base)) return base;
+  for (let i = 2; i < 100; i++) {
+    const candidate = `${sourceName}-copy-${i}`;
+    if (!existingNames.includes(candidate)) return candidate;
+  }
+  return base;
+}
+
+export function CopySkillDialog({
+  open,
+  onOpenChange,
+  sourceName,
+  existingNames,
+  isPending,
+  onConfirm,
+}: CopySkillDialogProps) {
+  const [name, setName] = useState('');
+
+  // Re-seed the suggested name whenever the dialog opens for a different source.
+  useEffect(() => {
+    if (open) setName(suggestCopyName(sourceName, existingNames));
+  }, [open, sourceName, existingNames]);
+
+  const trimmed = name.trim();
+  const collides = existingNames.includes(trimmed);
+  const canSubmit = trimmed.length > 0 && !collides && !isPending;
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialog.Content>
+        <AlertDialog.Header>
+          <AlertDialog.Title>Copy "{sourceName}"</AlertDialog.Title>
+          <AlertDialog.Description>
+            Creates a private copy in your skills that you can edit. The original stays untouched.
+          </AlertDialog.Description>
+        </AlertDialog.Header>
+        <div className="px-6 py-2">
+          <label className="block text-ui-sm text-neutral4 mb-1.5" htmlFor="copy-skill-name">
+            New skill name
+          </label>
+          <Input
+            id="copy-skill-name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="my-skill-copy"
+            autoFocus
+            data-testid="copy-skill-name-input"
+          />
+          {collides && (
+            <div className="mt-1.5 text-ui-xs text-red-400">You already have a skill named "{trimmed}".</div>
+          )}
+        </div>
+        <AlertDialog.Footer>
+          <AlertDialog.Cancel disabled={isPending}>Cancel</AlertDialog.Cancel>
+          <AlertDialog.Action
+            disabled={!canSubmit}
+            onClick={e => {
+              if (!canSubmit) {
+                e.preventDefault();
+                return;
+              }
+              onConfirm(trimmed);
+            }}
+            data-testid="copy-skill-confirm"
+          >
+            {isPending ? 'Copying...' : 'Copy skill'}
+          </AlertDialog.Action>
+        </AlertDialog.Footer>
+      </AlertDialog.Content>
+    </AlertDialog>
+  );
+}

--- a/packages/playground/src/domains/agent-builder/components/skill-list/skill-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/skill-builder-list.tsx
@@ -1,0 +1,147 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import { EmptyState, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui';
+import { CopyIcon, DownloadIcon, LockIcon, SearchIcon } from 'lucide-react';
+import { useMemo } from 'react';
+import { SkillFavoriteButton } from './skill-favorite-button';
+import { getSkillOrigin } from '@/domains/agent-builder/utils/skill-origin';
+
+export type SkillBuilderListProps = {
+  skills: StoredSkillResponse[];
+  search?: string;
+  onSkillClick?: (skill: StoredSkillResponse) => void;
+  showFavorites?: boolean;
+};
+
+export function SkillBuilderList({ skills, search, onSkillClick, showFavorites = true }: SkillBuilderListProps) {
+  const filtered = useMemo(() => {
+    const q = (search ?? '').trim().toLowerCase();
+    if (!q) return skills;
+    return skills.filter(s => {
+      const name = s.name?.toLowerCase() ?? '';
+      const description = s.description?.toLowerCase() ?? '';
+      return name.includes(q) || description.includes(q);
+    });
+  }, [skills, search]);
+
+  if (filtered.length === 0) {
+    return (
+      <div className="flex items-center justify-center pt-10">
+        <EmptyState
+          iconSlot={<SearchIcon className="h-8 w-8 text-neutral3" />}
+          titleSlot="No skills match your search"
+          descriptionSlot="Try a different name or description."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface2 border border-border1 rounded-xl divide-y divide-border1 overflow-hidden">
+      {filtered.map(skill => {
+        const row = (
+          <>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 min-w-0">
+                <div className="text-ui-md text-neutral6 truncate">{skill.name}</div>
+                {skill.visibility === 'private' && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        className="text-neutral3 shrink-0"
+                        aria-label="Private skill"
+                        data-testid="skill-builder-private-visibility-icon"
+                      >
+                        <Icon size="sm">
+                          <LockIcon />
+                        </Icon>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>Only visible to you</TooltipContent>
+                  </Tooltip>
+                )}
+                {(() => {
+                  const origin = getSkillOrigin(skill.metadata);
+                  if (!origin) return null;
+                  const isCopy = origin.type === 'library-copy';
+                  return (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-surface5 text-neutral4 shrink-0"
+                          aria-label={isCopy ? 'Copied skill' : 'Imported skill'}
+                          data-testid="skill-builder-origin-badge"
+                        >
+                          {isCopy ? <CopyIcon className="h-2.5 w-2.5" /> : <DownloadIcon className="h-2.5 w-2.5" />}
+                          {origin.type === 'skills-sh' ? 'skills.sh' : isCopy ? 'copied' : 'imported'}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {origin.type === 'skills-sh'
+                          ? `Imported from ${origin.owner}/${origin.repo}`
+                          : isCopy
+                            ? `Copied from "${origin.sourceSkillName}"`
+                            : 'Imported from external registry'}
+                      </TooltipContent>
+                    </Tooltip>
+                  );
+                })()}
+              </div>
+              <div className="flex items-center gap-2 mt-0.5">
+                <span className="text-ui-sm text-neutral3 line-clamp-1">{skill.description || 'No description'}</span>
+              </div>
+              {showFavorites && (
+                <div className="mt-2 md:hidden">
+                  <SkillFavoriteButton
+                    skillId={skill.id}
+                    isFavorited={skill.isFavorited}
+                    favoriteCount={skill.favoriteCount}
+                    size="sm"
+                  />
+                </div>
+              )}
+            </div>
+            {showFavorites && (
+              <SkillFavoriteButton
+                skillId={skill.id}
+                isFavorited={skill.isFavorited}
+                favoriteCount={skill.favoriteCount}
+                size="sm"
+                className="shrink-0 hidden md:inline-flex"
+              />
+            )}
+          </>
+        );
+
+        return onSkillClick ? (
+          <button
+            key={skill.id}
+            className="px-6 py-5 flex items-start gap-4 w-full text-left hover:bg-surface3/50 transition-colors md:items-center"
+            onClick={() => onSkillClick(skill)}
+          >
+            {row}
+          </button>
+        ) : (
+          <div key={skill.id} className="px-6 py-5 flex items-start gap-4 md:items-center">
+            {row}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function SkillBuilderListSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div className="bg-surface2 border border-border1 rounded-xl divide-y divide-border1 overflow-hidden">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="px-6 py-5 flex items-center gap-4">
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="h-3.5 w-48 bg-surface3 rounded animate-pulse" />
+            <div className="h-3 w-72 max-w-full bg-surface3 rounded animate-pulse" />
+          </div>
+          <div className="h-3 w-16 bg-surface3 rounded animate-pulse" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/playground/src/domains/agent-builder/components/skill-list/skill-favorite-button.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/skill-favorite-button.tsx
@@ -1,0 +1,86 @@
+import { Button, cn } from '@mastra/playground-ui';
+import { Star } from 'lucide-react';
+import type { MouseEvent } from 'react';
+import { useBuilderAgentFeatures } from '@/domains/agent-builder';
+import { useToggleStoredSkillFavorite } from '@/domains/agent-builder/hooks/use-stored-skill-favorite';
+import { useAuthCapabilities } from '@/domains/auth/hooks/use-auth-capabilities';
+import { isAuthenticated } from '@/domains/auth/types';
+
+export interface SkillFavoriteButtonProps {
+  skillId: string;
+  isFavorited?: boolean;
+  favoriteCount?: number;
+  size?: 'sm' | 'md';
+  className?: string;
+  /** Show the count badge next to the icon. Defaults to true. */
+  showCount?: boolean;
+}
+
+const iconSizes = {
+  sm: 14,
+  md: 16,
+} as const;
+
+/**
+ * Toggles the favorite state for a stored skill. Mirrors the agent-list
+ * `FavoriteButton` shell so the skill list matches the agent list visually.
+ * Renders nothing if the EE `agent.favorites` flag is off. Stops click
+ * propagation so it can sit inside a row that is itself a link.
+ */
+export const SkillFavoriteButton = ({
+  skillId,
+  isFavorited = false,
+  favoriteCount,
+  size = 'md',
+  className,
+  showCount = true,
+}: SkillFavoriteButtonProps) => {
+  const features = useBuilderAgentFeatures();
+  const toggle = useToggleStoredSkillFavorite(skillId);
+  const { data: capabilities } = useAuthCapabilities();
+
+  if (!features.favorites) return null;
+
+  const signedIn = capabilities ? isAuthenticated(capabilities) : false;
+  const label = isFavorited ? 'Unstar skill' : 'Star skill';
+  const disabledLabel = 'Sign in to star this skill';
+  const hasCount = typeof favoriteCount === 'number' && favoriteCount > 0;
+  const countLabel = favoriteCount === 1 ? 'Star' : 'Stars';
+  const isDisabled = toggle.isPending || !signedIn;
+
+  return (
+    <Button
+      type="button"
+      variant="default"
+      size={size}
+      aria-pressed={isFavorited}
+      aria-label={signedIn ? label : disabledLabel}
+      title={signedIn ? label : disabledLabel}
+      disabled={isDisabled}
+      onClick={(event: MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!signedIn) return;
+        toggle.mutate({ favorited: !isFavorited });
+      }}
+      className={cn('shrink-0', signedIn ? 'cursor-pointer' : 'cursor-not-allowed', className)}
+    >
+      <Star
+        size={iconSizes[size]}
+        className={cn('shrink-0', isFavorited && 'fill-current text-yellow-300')}
+        aria-hidden
+      />
+      {showCount && (
+        <span className="leading-none whitespace-nowrap">
+          {hasCount ? (
+            <>
+              <span className="tabular-nums">{favoriteCount}</span> {countLabel}
+            </>
+          ) : (
+            'Star'
+          )}
+        </span>
+      )}
+    </Button>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/hooks/use-builder-agent-access.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-builder-agent-access.ts
@@ -1,5 +1,5 @@
-import { useBuilderSettings } from './use-builder-settings';
 import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+import { useBuilderSettings } from '@/domains/agent-builder/hooks/use-builder-settings';
 
 export type DenialReason = 'permission-denied' | 'not-configured' | 'error' | null;
 

--- a/packages/playground/src/domains/agent-builder/hooks/use-builder-agent-features.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-builder-agent-features.ts
@@ -1,4 +1,4 @@
-import { useBuilderSettings } from '../hooks/use-builder-settings';
+import { useBuilderSettings } from '@/domains/agent-builder/hooks/use-builder-settings';
 
 export const useBuilderAgentFeatures = () => {
   const { data } = useBuilderSettings();

--- a/packages/playground/src/domains/agent-builder/hooks/use-builder-filtered-models.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-builder-filtered-models.ts
@@ -1,0 +1,38 @@
+import type { BuilderModelPolicy, Provider } from '@mastra/client-js';
+import { isModelAllowed } from '@mastra/core/agent-builder/ee';
+import { useMemo } from 'react';
+import type { ModelInfo } from '../../llm/hooks/use-filtered-models';
+
+/**
+ * Returns the subset of providers that have at least one model allowed by the
+ * given policy. Pass-through when `policy.active === false` or `policy.allowed`
+ * is unset / empty (mirrors the server-side `isModelAllowed` contract).
+ */
+export const useBuilderFilteredProviders = (providers: Provider[], policy: BuilderModelPolicy): Provider[] => {
+  return useMemo(() => {
+    if (!policy.active || !policy.allowed || policy.allowed.length === 0) {
+      return providers;
+    }
+
+    return providers
+      .map(provider => ({
+        ...provider,
+        models: provider.models.filter(modelId => isModelAllowed(policy.allowed, { provider: provider.id, modelId })),
+      }))
+      .filter(provider => provider.models.length > 0);
+  }, [providers, policy]);
+};
+
+/**
+ * Returns the subset of flattened models allowed by the given policy.
+ * Pass-through when `policy.active === false` or `policy.allowed` is unset / empty.
+ */
+export const useBuilderFilteredModels = (models: ModelInfo[], policy: BuilderModelPolicy): ModelInfo[] => {
+  return useMemo(() => {
+    if (!policy.active || !policy.allowed || policy.allowed.length === 0) {
+      return models;
+    }
+
+    return models.filter(m => isModelAllowed(policy.allowed, { provider: m.provider, modelId: m.model }));
+  }, [models, policy]);
+};

--- a/packages/playground/src/domains/agent-builder/hooks/use-builder-registries.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-builder-registries.ts
@@ -1,0 +1,114 @@
+import type {
+  BuilderRegistryInstallBody,
+  BuilderRegistryInstallResponse,
+  BuilderRegistryPopularResponse,
+  BuilderRegistryPreviewResponse,
+  BuilderRegistrySearchResponse,
+  ListBuilderRegistriesResponse,
+} from '@mastra/client-js';
+import { useMastraClient } from '@mastra/react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+// =============================================================================
+// Builder skill registry hooks
+//
+// Wrap the `/editor/builder/registries/*` routes with React Query. The registry
+// surface is hard-gated server-side, so callers can rely on errors (404) rather
+// than guessing whether a registry is enabled.
+// =============================================================================
+
+const STALE_POPULAR_MS = 5 * 60 * 1000;
+
+/**
+ * List known builder skill registries with their enabled state.
+ */
+export function useBuilderRegistries(options?: { enabled?: boolean }) {
+  const client = useMastraClient();
+  return useQuery({
+    queryKey: ['builder-registries'],
+    queryFn: (): Promise<ListBuilderRegistriesResponse> => client.listBuilderRegistries(),
+    enabled: options?.enabled ?? true,
+    retry: false,
+  });
+}
+
+/**
+ * Run a free-text search against a builder skill registry. The mutation
+ * shape mirrors the existing skills.sh hook so the dialog can call it on
+ * submit.
+ */
+export function useSearchBuilderRegistry(registryId: string | undefined) {
+  const client = useMastraClient();
+  return useMutation({
+    mutationFn: async (query: string): Promise<BuilderRegistrySearchResponse> => {
+      if (!registryId) throw new Error('Registry ID is required');
+      return client.searchBuilderRegistry(registryId, { q: query, limit: 10 });
+    },
+  });
+}
+
+/**
+ * Fetch the popular skills feed for a registry. Cached for 5 minutes so
+ * navigating in and out of the dialog doesn't refetch.
+ */
+export function usePopularBuilderRegistrySkills(registryId: string | undefined) {
+  const client = useMastraClient();
+  return useQuery({
+    queryKey: ['builder-registry', registryId, 'popular'],
+    queryFn: (): Promise<BuilderRegistryPopularResponse> => {
+      if (!registryId) throw new Error('Registry ID is required');
+      return client.getBuilderRegistryPopular(registryId, { limit: 10, offset: 0 });
+    },
+    enabled: !!registryId,
+    staleTime: STALE_POPULAR_MS,
+    retry: false,
+  });
+}
+
+/**
+ * Fetch the rendered preview for a single registry skill.
+ */
+export function useBuilderRegistryPreview(
+  registryId: string | undefined,
+  owner: string | undefined,
+  repo: string | undefined,
+  skillPath: string | undefined,
+  options?: { enabled?: boolean },
+) {
+  const client = useMastraClient();
+  return useQuery({
+    queryKey: ['builder-registry', registryId, 'preview', owner, repo, skillPath],
+    queryFn: async (): Promise<string> => {
+      if (!registryId || !owner || !repo || !skillPath) {
+        throw new Error('registryId, owner, repo, and skillPath are required');
+      }
+      const data: BuilderRegistryPreviewResponse = await client.getBuilderRegistryPreview(registryId, {
+        owner,
+        repo,
+        path: skillPath,
+      });
+      return data.content;
+    },
+    enabled: options?.enabled !== false && !!registryId && !!owner && !!repo && !!skillPath,
+    retry: false,
+  });
+}
+
+/**
+ * Install a skill from a builder registry into the stored-skills DB.
+ * Returns 409 when a stored skill with the derived id already exists — the
+ * UI is responsible for surfacing the existing skill via "Open existing".
+ */
+export function useInstallBuilderRegistrySkill(registryId: string | undefined) {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: BuilderRegistryInstallBody): Promise<BuilderRegistryInstallResponse> => {
+      if (!registryId) throw new Error('Registry ID is required');
+      return client.installBuilderRegistrySkill(registryId, body);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['stored-skills'] });
+    },
+  });
+}

--- a/packages/playground/src/domains/agent-builder/hooks/use-infrastructure-status.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-infrastructure-status.ts
@@ -1,0 +1,21 @@
+import { useMastraClient } from '@mastra/react';
+import { useQuery } from '@tanstack/react-query';
+
+interface UseInfrastructureStatusOptions {
+  enabled?: boolean;
+}
+
+/**
+ * Fetches Agent Builder infrastructure configuration and resolution status from
+ * the server. Admin-only by default — the server requires `infrastructure:read`.
+ */
+export const useInfrastructureStatus = (options?: UseInfrastructureStatusOptions) => {
+  const client = useMastraClient();
+
+  return useQuery({
+    queryKey: ['infrastructure-status'],
+    queryFn: () => client.getInfrastructureStatus(),
+    enabled: options?.enabled ?? true,
+    retry: false,
+  });
+};

--- a/packages/playground/src/domains/agent-builder/hooks/use-stored-agent-favorite.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-stored-agent-favorite.ts
@@ -1,0 +1,83 @@
+import type { FavoriteToggleResponse, StoredAgentResponse, ListStoredAgentsResponse } from '@mastra/client-js';
+import { useMastraClient } from '@mastra/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { usePlaygroundStore } from '@/store/playground-store';
+
+type FavoriteContext = {
+  previousDetail?: StoredAgentResponse | null;
+  previousLists: Array<[unknown, ListStoredAgentsResponse | undefined]>;
+};
+
+const applyFavoriteToAgent = (agent: StoredAgentResponse, favorited: boolean): StoredAgentResponse => {
+  const currentCount = agent.favoriteCount ?? 0;
+  const nextCount = favorited
+    ? currentCount + (agent.isFavorited ? 0 : 1)
+    : Math.max(0, currentCount - (agent.isFavorited ? 1 : 0));
+  return { ...agent, isFavorited: favorited, favoriteCount: nextCount };
+};
+
+/**
+ * Toggle the favorite state for a stored agent. Optimistically updates both the
+ * detail cache (`['stored-agent', id, ...]`) and any list caches
+ * (`['stored-agents', ...]`) and rolls back on error.
+ */
+export const useToggleStoredAgentFavorite = (agentId?: string) => {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+  const { requestContext } = usePlaygroundStore();
+
+  return useMutation<FavoriteToggleResponse, Error, { favorited: boolean }, FavoriteContext>({
+    mutationFn: async ({ favorited }) => {
+      if (!agentId) throw new Error('agentId is required to toggle favorite');
+      const resource = client.getStoredAgent(agentId);
+      return favorited ? resource.favorite(requestContext) : resource.unfavorite(requestContext);
+    },
+    onMutate: async ({ favorited }) => {
+      if (!agentId) return { previousLists: [] };
+
+      // Cancel outgoing refetches so optimistic updates aren't overwritten
+      await queryClient.cancelQueries({ queryKey: ['stored-agents'] });
+      await queryClient.cancelQueries({ queryKey: ['stored-agent', agentId] });
+
+      // Snapshot detail
+      const previousDetail = queryClient.getQueryData<StoredAgentResponse | null>(['stored-agent', agentId]);
+
+      // Optimistically patch every matching list query
+      const listQueries = queryClient.getQueriesData<ListStoredAgentsResponse>({ queryKey: ['stored-agents'] });
+      const previousLists: FavoriteContext['previousLists'] = [];
+      for (const [key, value] of listQueries) {
+        previousLists.push([key, value]);
+        if (!value?.agents) continue;
+        queryClient.setQueryData<ListStoredAgentsResponse>(key as readonly unknown[], {
+          ...value,
+          agents: value.agents.map(a => (a.id === agentId ? applyFavoriteToAgent(a, favorited) : a)),
+        });
+      }
+
+      // Optimistically patch detail
+      if (previousDetail) {
+        queryClient.setQueryData<StoredAgentResponse>(
+          ['stored-agent', agentId],
+          applyFavoriteToAgent(previousDetail, favorited),
+        );
+      }
+
+      return { previousDetail, previousLists };
+    },
+    onError: (_error, _vars, context) => {
+      if (!context) return;
+      if (agentId && context.previousDetail !== undefined) {
+        queryClient.setQueryData(['stored-agent', agentId], context.previousDetail);
+      }
+      for (const [key, value] of context.previousLists) {
+        queryClient.setQueryData(key as readonly unknown[], value);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['stored-agents'] });
+      if (agentId) {
+        void queryClient.invalidateQueries({ queryKey: ['stored-agent', agentId] });
+      }
+    },
+  });
+};

--- a/packages/playground/src/domains/agent-builder/hooks/use-stored-skill-favorite.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-stored-skill-favorite.ts
@@ -1,0 +1,79 @@
+import type { FavoriteToggleResponse, StoredSkillResponse, ListStoredSkillsResponse } from '@mastra/client-js';
+import { useMastraClient } from '@mastra/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { usePlaygroundStore } from '@/store/playground-store';
+
+type FavoriteContext = {
+  previousDetail?: StoredSkillResponse | null;
+  previousLists: Array<[unknown, ListStoredSkillsResponse | undefined]>;
+};
+
+const applyFavoriteToSkill = (skill: StoredSkillResponse, favorited: boolean): StoredSkillResponse => {
+  const currentCount = skill.favoriteCount ?? 0;
+  const nextCount = favorited
+    ? currentCount + (skill.isFavorited ? 0 : 1)
+    : Math.max(0, currentCount - (skill.isFavorited ? 1 : 0));
+  return { ...skill, isFavorited: favorited, favoriteCount: nextCount };
+};
+
+/**
+ * Toggle the favorite state for a stored skill. Optimistically updates both the
+ * detail cache (`['stored-skill', id]`) and any list caches
+ * (`['stored-skills', ...]`) and rolls back on error.
+ */
+export const useToggleStoredSkillFavorite = (skillId?: string) => {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+  const { requestContext } = usePlaygroundStore();
+
+  return useMutation<FavoriteToggleResponse, Error, { favorited: boolean }, FavoriteContext>({
+    mutationFn: async ({ favorited }) => {
+      if (!skillId) throw new Error('skillId is required to toggle favorite');
+      const resource = client.getStoredSkill(skillId);
+      return favorited ? resource.favorite(requestContext) : resource.unfavorite(requestContext);
+    },
+    onMutate: async ({ favorited }) => {
+      if (!skillId) return { previousLists: [] };
+
+      await queryClient.cancelQueries({ queryKey: ['stored-skills'] });
+      await queryClient.cancelQueries({ queryKey: ['stored-skill', skillId] });
+
+      const previousDetail = queryClient.getQueryData<StoredSkillResponse | null>(['stored-skill', skillId]);
+
+      const listQueries = queryClient.getQueriesData<ListStoredSkillsResponse>({ queryKey: ['stored-skills'] });
+      const previousLists: FavoriteContext['previousLists'] = [];
+      for (const [key, value] of listQueries) {
+        previousLists.push([key, value]);
+        if (!value?.skills) continue;
+        queryClient.setQueryData<ListStoredSkillsResponse>(key as readonly unknown[], {
+          ...value,
+          skills: value.skills.map(s => (s.id === skillId ? applyFavoriteToSkill(s, favorited) : s)),
+        });
+      }
+
+      if (previousDetail) {
+        queryClient.setQueryData<StoredSkillResponse>(
+          ['stored-skill', skillId],
+          applyFavoriteToSkill(previousDetail, favorited),
+        );
+      }
+
+      return { previousDetail, previousLists };
+    },
+    onError: (_error, _vars, context) => {
+      if (!context) return;
+      if (skillId && context.previousDetail !== undefined) {
+        queryClient.setQueryData(['stored-skill', skillId], context.previousDetail);
+      }
+      for (const [key, value] of context.previousLists) {
+        queryClient.setQueryData(key as readonly unknown[], value);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['stored-skills'] });
+      if (skillId) {
+        void queryClient.invalidateQueries({ queryKey: ['stored-skill', skillId] });
+      }
+    },
+  });
+};

--- a/packages/playground/src/domains/agent-builder/layouts/__tests__/agent-builder-root-layout.test.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/__tests__/agent-builder-root-layout.test.tsx
@@ -1,29 +1,68 @@
 // @vitest-environment jsdom
+import type { BuilderSettingsResponse } from '@mastra/client-js';
+import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AgentBuilderRootLayout } from '../agent-builder-root-layout';
-
-const mockUseAuthCapabilities = vi.fn();
-const mockUseBuilderAgentAccess = vi.fn();
-
-vi.mock('@/domains/auth/hooks/use-auth-capabilities', () => ({
-  useAuthCapabilities: () => mockUseAuthCapabilities(),
-}));
-
-vi.mock('../../hooks/use-builder-agent-access', () => ({
-  useBuilderAgentAccess: () => mockUseBuilderAgentAccess(),
-}));
+import type { AuthCapabilities } from '@/domains/auth/types';
+import { server } from '@/test/msw-server';
 
 vi.mock('@/lib/link', () => ({
   Link: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props}>{children}</a>,
 }));
 
+const BASE_URL = 'http://localhost:4111';
+
+const unauthenticatedCapabilities = {
+  enabled: true,
+  login: { type: 'credentials' as const },
+} satisfies AuthCapabilities;
+
+const authenticatedCapabilities = {
+  enabled: true,
+  login: { type: 'credentials' as const },
+  user: { id: 'user-1', email: 'u@example.com' },
+  capabilities: { user: true, session: true, sso: false, rbac: false, acl: false },
+  access: null,
+} satisfies AuthCapabilities;
+
+const authDisabledCapabilities = {
+  enabled: false,
+  login: { type: 'credentials' as const },
+} satisfies AuthCapabilities;
+
+const builderFullySetUp: BuilderSettingsResponse = {
+  enabled: true,
+  features: {
+    agent: {},
+  },
+};
+
+const builderDisabled: BuilderSettingsResponse = {
+  enabled: false,
+};
+
+function authHandler(capabilities: AuthCapabilities) {
+  return http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(capabilities));
+}
+
+function builderHandler(settings: BuilderSettingsResponse | { error: true }) {
+  return http.get(`${BASE_URL}/api/editor/builder/settings`, () => {
+    if ('error' in settings && settings.error) {
+      return HttpResponse.json({ error: 'boom' }, { status: 500 });
+    }
+    return HttpResponse.json(settings);
+  });
+}
+
 function renderAgentBuilderRoute(initialEntry: string) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
+      mutations: { retry: false },
     },
   });
 
@@ -35,7 +74,7 @@ function renderAgentBuilderRoute(initialEntry: string) {
       },
       {
         path: '/agent-builder',
-        element: <AgentBuilderRootLayout paths={{ agentsLink: () => '/agents' }} />,
+        element: <AgentBuilderRootLayout paths={{ agentsLink: () => '/agents' } as never} />,
         children: [
           {
             path: 'agents',
@@ -54,31 +93,23 @@ function renderAgentBuilderRoute(initialEntry: string) {
   );
 
   render(
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>,
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </MastraReactProvider>,
   );
 
   return router;
 }
 
+afterEach(() => {
+  server.resetHandlers();
+});
+
 describe('AgentBuilderRootLayout', () => {
-  beforeEach(() => {
-    mockUseAuthCapabilities.mockReset();
-    mockUseBuilderAgentAccess.mockReset();
-
-    mockUseBuilderAgentAccess.mockReturnValue({
-      isLoading: false,
-      denialReason: null,
-      hasAgentFeature: true,
-    });
-  });
-
   it('redirects unauthenticated users to login with the requested agent-builder route', async () => {
-    mockUseAuthCapabilities.mockReturnValue({
-      data: { enabled: true, login: { enabled: true } },
-      isLoading: false,
-    });
+    server.use(authHandler(unauthenticatedCapabilities), builderHandler(builderFullySetUp));
 
     const router = renderAgentBuilderRoute('/agent-builder/agents/create?draft=1#details');
 
@@ -91,14 +122,7 @@ describe('AgentBuilderRootLayout', () => {
   });
 
   it('renders agent-builder children for authenticated users with access', async () => {
-    mockUseAuthCapabilities.mockReturnValue({
-      data: {
-        enabled: true,
-        login: { enabled: true },
-        user: { id: 'user-1' },
-      },
-      isLoading: false,
-    });
+    server.use(authHandler(authenticatedCapabilities), builderHandler(builderFullySetUp));
 
     renderAgentBuilderRoute('/agent-builder/agents/create');
 
@@ -106,13 +130,26 @@ describe('AgentBuilderRootLayout', () => {
   });
 
   it('does not redirect when auth is disabled', async () => {
-    mockUseAuthCapabilities.mockReturnValue({
-      data: { enabled: false, login: { enabled: true } },
-      isLoading: false,
-    });
+    server.use(authHandler(authDisabledCapabilities), builderHandler(builderFullySetUp));
 
     renderAgentBuilderRoute('/agent-builder/agents');
 
     expect(await screen.findByText('Agent builder home')).toBeTruthy();
+  });
+
+  it('shows the not-configured screen when the builder is disabled', async () => {
+    server.use(authHandler(authenticatedCapabilities), builderHandler(builderDisabled));
+
+    renderAgentBuilderRoute('/agent-builder/agents');
+
+    expect(await screen.findByText('Agent Builder Not Configured')).toBeTruthy();
+  });
+
+  it('shows the error screen when the builder settings fail to load', async () => {
+    server.use(authHandler(authenticatedCapabilities), builderHandler({ error: true }));
+
+    renderAgentBuilderRoute('/agent-builder/agents');
+
+    expect(await screen.findByText('Failed to load Agent Builder configuration.')).toBeTruthy();
   });
 });

--- a/packages/playground/src/domains/agent-builder/layouts/__tests__/agent-builder-root-layout.test.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/__tests__/agent-builder-root-layout.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { AgentBuilderRootLayout } from '../agent-builder-root-layout';
+
+const mockUseAuthCapabilities = vi.fn();
+const mockUseBuilderAgentAccess = vi.fn();
+
+vi.mock('@/domains/auth/hooks/use-auth-capabilities', () => ({
+  useAuthCapabilities: () => mockUseAuthCapabilities(),
+}));
+
+vi.mock('../../hooks/use-builder-agent-access', () => ({
+  useBuilderAgentAccess: () => mockUseBuilderAgentAccess(),
+}));
+
+vi.mock('@/lib/link', () => ({
+  Link: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props}>{children}</a>,
+}));
+
+function renderAgentBuilderRoute(initialEntry: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/login',
+        element: <div>Login page</div>,
+      },
+      {
+        path: '/agent-builder',
+        element: <AgentBuilderRootLayout paths={{ agentsLink: () => '/agents' }} />,
+        children: [
+          {
+            path: 'agents',
+            element: <div>Agent builder home</div>,
+          },
+          {
+            path: 'agents/create',
+            element: <div>Create agent</div>,
+          },
+        ],
+      },
+    ],
+    {
+      initialEntries: [initialEntry],
+    },
+  );
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+
+  return router;
+}
+
+describe('AgentBuilderRootLayout', () => {
+  beforeEach(() => {
+    mockUseAuthCapabilities.mockReset();
+    mockUseBuilderAgentAccess.mockReset();
+
+    mockUseBuilderAgentAccess.mockReturnValue({
+      isLoading: false,
+      denialReason: null,
+      hasAgentFeature: true,
+    });
+  });
+
+  it('redirects unauthenticated users to login with the requested agent-builder route', async () => {
+    mockUseAuthCapabilities.mockReturnValue({
+      data: { enabled: true, login: { enabled: true } },
+      isLoading: false,
+    });
+
+    const router = renderAgentBuilderRoute('/agent-builder/agents/create?draft=1#details');
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/login');
+    });
+
+    expect(router.state.location.search).toBe('?redirect=%2Fagent-builder%2Fagents%2Fcreate%3Fdraft%3D1%23details');
+    expect(screen.getByText('Login page')).toBeTruthy();
+  });
+
+  it('renders agent-builder children for authenticated users with access', async () => {
+    mockUseAuthCapabilities.mockReturnValue({
+      data: {
+        enabled: true,
+        login: { enabled: true },
+        user: { id: 'user-1' },
+      },
+      isLoading: false,
+    });
+
+    renderAgentBuilderRoute('/agent-builder/agents/create');
+
+    expect(await screen.findByText('Create agent')).toBeTruthy();
+  });
+
+  it('does not redirect when auth is disabled', async () => {
+    mockUseAuthCapabilities.mockReturnValue({
+      data: { enabled: false, login: { enabled: true } },
+      isLoading: false,
+    });
+
+    renderAgentBuilderRoute('/agent-builder/agents');
+
+    expect(await screen.findByText('Agent builder home')).toBeTruthy();
+  });
+});

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
@@ -1,0 +1,129 @@
+import { Button, EmptyState, Spinner, Toaster, TooltipProvider } from '@mastra/playground-ui';
+import { AlertTriangle, ArrowLeft, Eye, LockIcon, Settings } from 'lucide-react';
+import { Navigate, Outlet, useLocation, useNavigate } from 'react-router';
+import { useBuilderAgentAccess } from '../hooks/use-builder-agent-access';
+import { useAuthCapabilities } from '@/domains/auth/hooks/use-auth-capabilities';
+import { useRoleImpersonation } from '@/domains/auth/hooks/use-role-impersonation';
+import { isAuthenticated } from '@/domains/auth/types';
+import type { LinkComponentProviderProps } from '@/lib/framework';
+import { LinkComponentProvider } from '@/lib/framework';
+import { Link } from '@/lib/link';
+
+export interface AgentBuilderRootLayoutProps {
+  paths: LinkComponentProviderProps['paths'];
+}
+
+function buildAgentBuilderLoginRedirect(pathname: string, search = '', hash = '') {
+  const redirectPath = `${pathname}${search}${hash}`;
+  return `/login?redirect=${encodeURIComponent(redirectPath)}`;
+}
+
+export const AgentBuilderRootLayout = ({ paths }: AgentBuilderRootLayoutProps) => {
+  const location = useLocation();
+  const { data: authCapabilities, isLoading } = useAuthCapabilities();
+
+  if (isLoading) {
+    return (
+      <div className="h-screen w-full flex items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (authCapabilities?.enabled && !isAuthenticated(authCapabilities)) {
+    return <Navigate to={buildAgentBuilderLoginRedirect(location.pathname, location.search, location.hash)} replace />;
+  }
+
+  return <AgentBuilderPermissionsGuard paths={paths} />;
+};
+
+const AgentBuilderPermissionsGuard = ({ paths }: AgentBuilderRootLayoutProps) => {
+  const navigate = useNavigate();
+  const { isLoading, denialReason, hasAgentFeature } = useBuilderAgentAccess();
+
+  if (isLoading) {
+    return (
+      <div className="h-screen w-full flex items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (denialReason === 'permission-denied') {
+    return <AccessDeniedScreen />;
+  }
+
+  if (denialReason === 'error') {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <EmptyState
+          iconSlot={<AlertTriangle />}
+          titleSlot="Error"
+          descriptionSlot="Failed to load Agent Builder configuration."
+        />
+      </div>
+    );
+  }
+
+  if (denialReason === 'not-configured') {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <EmptyState
+          iconSlot={<Settings />}
+          titleSlot="Agent Builder Not Configured"
+          descriptionSlot="Agent Builder is not enabled. Contact your administrator to enable this feature."
+        />
+      </div>
+    );
+  }
+
+  // Redirect to first available feature
+  if (!hasAgentFeature) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <EmptyState
+          iconSlot={<Settings />}
+          titleSlot="No Features Enabled"
+          descriptionSlot="No Agent Builder features are configured."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <LinkComponentProvider Link={Link} navigate={navigate} paths={paths}>
+        <Outlet />
+        <Toaster position="bottom-right" />
+      </LinkComponentProvider>
+    </TooltipProvider>
+  );
+};
+
+function AccessDeniedScreen() {
+  const { isImpersonating, impersonatedRole, stopImpersonation } = useRoleImpersonation();
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="flex flex-col items-center gap-4">
+        <EmptyState
+          iconSlot={<LockIcon />}
+          titleSlot="Access Denied"
+          descriptionSlot="You don't have permission to access the Agent Builder."
+        />
+        <div className="flex items-center gap-2">
+          <Button as="a" href="/agents" variant="outline" size="sm">
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to Studio
+          </Button>
+          {isImpersonating && (
+            <Button variant="default" size="sm" onClick={stopImpersonation}>
+              <Eye className="h-3.5 w-3.5" />
+              Exit {impersonatedRole?.name} preview
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
@@ -13,11 +13,6 @@ export interface AgentBuilderRootLayoutProps {
   paths: LinkComponentProviderProps['paths'];
 }
 
-function buildAgentBuilderLoginRedirect(pathname: string, search = '', hash = '') {
-  const redirectPath = `${pathname}${search}${hash}`;
-  return `/login?redirect=${encodeURIComponent(redirectPath)}`;
-}
-
 export const AgentBuilderRootLayout = ({ paths }: AgentBuilderRootLayoutProps) => {
   const location = useLocation();
   const { data: authCapabilities, isLoading } = useAuthCapabilities();
@@ -31,7 +26,9 @@ export const AgentBuilderRootLayout = ({ paths }: AgentBuilderRootLayoutProps) =
   }
 
   if (authCapabilities?.enabled && !isAuthenticated(authCapabilities)) {
-    return <Navigate to={buildAgentBuilderLoginRedirect(location.pathname, location.search, location.hash)} replace />;
+    const redirectPath = `${location.pathname}${location.search}${location.hash}`;
+    const url = `/login?redirect=${encodeURIComponent(redirectPath)}`;
+    return <Navigate to={url} replace />;
   }
 
   return <AgentBuilderPermissionsGuard paths={paths} />;

--- a/packages/playground/src/domains/agent-builder/utils/is-model-not-allowed.ts
+++ b/packages/playground/src/domains/agent-builder/utils/is-model-not-allowed.ts
@@ -1,0 +1,14 @@
+/**
+ * Permissive UI-side detector for "model not allowed" errors surfaced by the
+ * agent-builder save/autosave flows. Matches any error object carrying
+ * `code: 'MODEL_NOT_ALLOWED'`, regardless of HTTP envelope. Use the stricter
+ * `domains/agent-builder/services/is-model-not-allowed` when you specifically need to
+ * recognize the server's HTTP 422 + body shape.
+ */
+export function isModelNotAllowedError(error: unknown) {
+  if (error && typeof error === 'object' && 'code' in error && error.code === 'MODEL_NOT_ALLOWED') {
+    return { message: error instanceof Error ? error.message : 'Model is not allowed' };
+  }
+
+  return null;
+}

--- a/packages/playground/src/domains/agent-builder/utils/skill-origin.ts
+++ b/packages/playground/src/domains/agent-builder/utils/skill-origin.ts
@@ -1,0 +1,87 @@
+/**
+ * Helpers for reading the `metadata.origin` field on stored skills. Skills
+ * that were imported from an external registry (skills.sh today, more later)
+ * carry their provenance here so the UI can show a badge and link back.
+ *
+ * The shape lines up with `skillOriginSchema` in
+ * `packages/server/src/server/schemas/stored-skills.ts`. We narrow at the
+ * boundary because `StoredSkillResponse.metadata` is loosely typed as
+ * `Record<string, unknown>` on the wire.
+ */
+
+export interface SkillsShOrigin {
+  type: 'skills-sh';
+  owner: string;
+  repo: string;
+  skillName: string;
+}
+
+export interface LibraryCopyOrigin {
+  type: 'library-copy';
+  sourceSkillId: string;
+  sourceSkillName: string;
+  sourceAuthorId?: string;
+}
+
+export type SkillOrigin = SkillsShOrigin | LibraryCopyOrigin;
+
+export function getSkillOrigin(metadata: Record<string, unknown> | undefined | null): SkillOrigin | null {
+  if (!metadata || typeof metadata !== 'object') return null;
+  const origin = (metadata as { origin?: unknown }).origin;
+  if (!origin || typeof origin !== 'object') return null;
+  const candidate = origin as Record<string, unknown>;
+  if (
+    candidate.type === 'skills-sh' &&
+    typeof candidate.owner === 'string' &&
+    typeof candidate.repo === 'string' &&
+    typeof candidate.skillName === 'string'
+  ) {
+    return {
+      type: 'skills-sh',
+      owner: candidate.owner,
+      repo: candidate.repo,
+      skillName: candidate.skillName,
+    };
+  }
+  if (
+    candidate.type === 'library-copy' &&
+    typeof candidate.sourceSkillId === 'string' &&
+    typeof candidate.sourceSkillName === 'string'
+  ) {
+    return {
+      type: 'library-copy',
+      sourceSkillId: candidate.sourceSkillId,
+      sourceSkillName: candidate.sourceSkillName,
+      sourceAuthorId: typeof candidate.sourceAuthorId === 'string' ? candidate.sourceAuthorId : undefined,
+    };
+  }
+  return null;
+}
+
+/**
+ * Build a human-readable label for an origin (e.g. `skills.sh · owner/repo`).
+ */
+export function formatSkillOriginLabel(origin: SkillOrigin): string {
+  switch (origin.type) {
+    case 'skills-sh':
+      return `skills.sh · ${origin.owner}/${origin.repo}`;
+    case 'library-copy':
+      return `Copied from "${origin.sourceSkillName}"`;
+    default:
+      return 'imported';
+  }
+}
+
+/**
+ * Build the upstream URL for an origin, when known.
+ */
+export function getSkillOriginUrl(origin: SkillOrigin): string | null {
+  switch (origin.type) {
+    case 'skills-sh':
+      return `https://skills.sh/${origin.owner}/${origin.repo}/${origin.skillName}`;
+    case 'library-copy':
+      return null;
+    default:
+      return null;
+  }
+}

--- a/packages/playground/src/domains/agents/hooks/use-stored-agents.ts
+++ b/packages/playground/src/domains/agents/hooks/use-stored-agents.ts
@@ -3,12 +3,13 @@ import { useMastraClient } from '@mastra/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePlaygroundStore } from '@/store/playground-store';
 
-export const useStoredAgents = (params?: ListStoredAgentsParams) => {
+export const useStoredAgents = (params?: ListStoredAgentsParams, options?: { enabled?: boolean }) => {
   const client = useMastraClient();
 
   return useQuery({
     queryKey: ['stored-agents', params],
     queryFn: () => client.listStoredAgents(params),
+    enabled: options?.enabled ?? true,
   });
 };
 

--- a/packages/playground/src/domains/auth/context/__tests__/fixtures/role-permissions.ts
+++ b/packages/playground/src/domains/auth/context/__tests__/fixtures/role-permissions.ts
@@ -1,0 +1,13 @@
+import type { RouteResponse } from '@mastra/client-js';
+
+type RolePermissionsResponse = RouteResponse<'GET /auth/roles/:roleId/permissions'>;
+
+export const adminPermissions: RolePermissionsResponse = {
+  roleId: 'admin',
+  permissions: ['*'],
+};
+
+export const viewerPermissions: RolePermissionsResponse = {
+  roleId: 'viewer',
+  permissions: ['stored-agents:read', 'stored-skills:read'],
+};

--- a/packages/playground/src/domains/auth/context/__tests__/role-impersonation-context.test.tsx
+++ b/packages/playground/src/domains/auth/context/__tests__/role-impersonation-context.test.tsx
@@ -1,0 +1,376 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { RoleImpersonationProvider, useRoleImpersonation } from '../role-impersonation-context';
+import { adminPermissions, viewerPermissions } from './fixtures/role-permissions';
+
+import { server } from '@/test/msw-server';
+
+
+
+const BASE_URL = 'http://localhost:4111';
+
+type ConsumerHandle = {
+  start: (role: { id: string; name: string }) => Promise<void>;
+  stop: () => void;
+};
+
+function TestConsumer({ onReady }: { onReady?: (handle: ConsumerHandle) => void }) {
+  const { isImpersonating, impersonatedRole, impersonatedPermissions, isSwitching, startImpersonation, stopImpersonation } =
+    useRoleImpersonation();
+
+  if (onReady) {
+    onReady({ start: startImpersonation, stop: stopImpersonation });
+  }
+
+  return (
+    <div>
+      <div data-testid="is-impersonating">{String(isImpersonating)}</div>
+      <div data-testid="is-switching">{String(isSwitching)}</div>
+      <div data-testid="impersonated-role-id">{impersonatedRole?.id ?? 'null'}</div>
+      <div data-testid="impersonated-role-name">{impersonatedRole?.name ?? 'null'}</div>
+      <div data-testid="impersonated-permissions">
+        {impersonatedPermissions === null ? 'null' : JSON.stringify(impersonatedPermissions)}
+      </div>
+    </div>
+  );
+}
+
+type RenderOptions = {
+  apiPrefix?: string;
+  headers?: Record<string, string>;
+  withProvider?: boolean;
+};
+
+function renderConsumer(options: RenderOptions = {}): {
+  handle: { current: ConsumerHandle | null };
+  unmount: () => void;
+} {
+  const { apiPrefix, headers, withProvider = true } = options;
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  const handleRef: { current: ConsumerHandle | null } = { current: null };
+  const consumer = <TestConsumer onReady={h => (handleRef.current = h)} />;
+
+  const wrapped: ReactNode = withProvider ? (
+    <RoleImpersonationProvider>{consumer}</RoleImpersonationProvider>
+  ) : (
+    consumer
+  );
+
+  const { unmount } = render(
+    <MastraReactProvider baseUrl={BASE_URL} apiPrefix={apiPrefix} headers={headers}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{wrapped}</MemoryRouter>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+
+  return { handle: handleRef, unmount };
+}
+
+afterEach(() => cleanup());
+
+describe('RoleImpersonationProvider', () => {
+  it('exposes a default non-impersonating state', () => {
+    renderConsumer();
+
+    expect(screen.getByTestId('is-impersonating').textContent).toBe('false');
+    expect(screen.getByTestId('is-switching').textContent).toBe('false');
+    expect(screen.getByTestId('impersonated-role-id').textContent).toBe('null');
+    expect(screen.getByTestId('impersonated-permissions').textContent).toBe('null');
+  });
+
+  it('starts impersonation on successful response', async () => {
+    const onRequest = vi.fn();
+    server.use(
+      http.get(`${BASE_URL}/api/auth/roles/admin/permissions`, ({ request }) => {
+        onRequest(request.url);
+        return HttpResponse.json(adminPermissions);
+      }),
+    );
+
+    const { handle } = renderConsumer();
+
+    await act(async () => {
+      await handle.current!.start({ id: 'admin', name: 'Admin' });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('is-impersonating').textContent).toBe('true'));
+    expect(screen.getByTestId('impersonated-role-id').textContent).toBe('admin');
+    expect(screen.getByTestId('impersonated-role-name').textContent).toBe('Admin');
+    expect(screen.getByTestId('impersonated-permissions').textContent).toBe(JSON.stringify(['*']));
+    expect(screen.getByTestId('is-switching').textContent).toBe('false');
+    expect(onRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects isSwitching=true while the mutation is pending and false after success', async () => {
+    let resolveGate: () => void = () => {};
+    const gate = new Promise<void>(resolve => {
+      resolveGate = resolve;
+    });
+
+    server.use(
+      http.get(`${BASE_URL}/api/auth/roles/viewer/permissions`, async () => {
+        await gate;
+        return HttpResponse.json(viewerPermissions);
+      }),
+    );
+
+    const { handle } = renderConsumer();
+
+    let startPromise!: Promise<void>;
+    act(() => {
+      startPromise = handle.current!.start({ id: 'viewer', name: 'Viewer' });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('is-switching').textContent).toBe('true'));
+    // State must not be committed before the response resolves
+    expect(screen.getByTestId('is-impersonating').textContent).toBe('false');
+    expect(screen.getByTestId('impersonated-permissions').textContent).toBe('null');
+
+    await act(async () => {
+      resolveGate();
+      await startPromise;
+    });
+
+    await waitFor(() => expect(screen.getByTestId('is-switching').textContent).toBe('false'));
+    expect(screen.getByTestId('is-impersonating').textContent).toBe('true');
+    expect(screen.getByTestId('impersonated-permissions').textContent).toBe(
+      JSON.stringify(viewerPermissions.permissions),
+    );
+  });
+
+  it('rejects and keeps state untouched on a 500 response', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/auth/roles/admin/permissions`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+      ),
+    );
+
+    const { handle } = renderConsumer();
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await handle.current!.start({ id: 'admin', name: 'Admin' });
+      } catch (error) {
+        caught = error;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/Failed to fetch role permissions: 500/);
+
+    await waitFor(() => expect(screen.getByTestId('is-switching').textContent).toBe('false'));
+    expect(screen.getByTestId('is-impersonating').textContent).toBe('false');
+    expect(screen.getByTestId('impersonated-role-id').textContent).toBe('null');
+    expect(screen.getByTestId('impersonated-permissions').textContent).toBe('null');
+  });
+
+  it('rejects and keeps state untouched on a 403 admin-required response', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/auth/roles/admin/permissions`, () =>
+        HttpResponse.json({ message: 'Admin access required' }, { status: 403 }),
+      ),
+    );
+
+    const { handle } = renderConsumer();
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await handle.current!.start({ id: 'admin', name: 'Admin' });
+      } catch (error) {
+        caught = error;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/Failed to fetch role permissions: 403/);
+    expect(screen.getByTestId('is-impersonating').textContent).toBe('false');
+    expect(screen.getByTestId('impersonated-permissions').textContent).toBe('null');
+    expect(screen.getByTestId('is-switching').textContent).toBe('false');
+  });
+
+  it('clears state when stopImpersonation is called after a successful start', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/auth/roles/admin/permissions`, () => HttpResponse.json(adminPermissions)),
+    );
+
+    const { handle } = renderConsumer();
+
+    await act(async () => {
+      await handle.current!.start({ id: 'admin', name: 'Admin' });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('is-impersonating').textContent).toBe('true'));
+
+    act(() => {
+      handle.current!.stop();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('is-impersonating').textContent).toBe('false'));
+    expect(screen.getByTestId('impersonated-role-id').textContent).toBe('null');
+    expect(screen.getByTestId('impersonated-permissions').textContent).toBe('null');
+  });
+
+  it('honors a custom apiPrefix', async () => {
+    const onRequest = vi.fn();
+    server.use(
+      http.get(`${BASE_URL}/mastra/auth/roles/admin/permissions`, ({ request }) => {
+        onRequest(request.url);
+        return HttpResponse.json(adminPermissions);
+      }),
+    );
+
+    const { handle } = renderConsumer({ apiPrefix: '/mastra' });
+
+    await act(async () => {
+      await handle.current!.start({ id: 'admin', name: 'Admin' });
+    });
+
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    expect(onRequest.mock.calls[0]![0]).toBe(`${BASE_URL}/mastra/auth/roles/admin/permissions`);
+  });
+
+  it('honors an explicitly empty apiPrefix', async () => {
+    const onRequest = vi.fn();
+    server.use(
+      http.get(`${BASE_URL}/auth/roles/admin/permissions`, ({ request }) => {
+        onRequest(request.url);
+        return HttpResponse.json(adminPermissions);
+      }),
+    );
+
+    const { handle } = renderConsumer({ apiPrefix: '' });
+
+    await act(async () => {
+      await handle.current!.start({ id: 'admin', name: 'Admin' });
+    });
+
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    expect(onRequest.mock.calls[0]![0]).toBe(`${BASE_URL}/auth/roles/admin/permissions`);
+  });
+
+  it('strips a trailing slash from apiPrefix', async () => {
+    const onRequest = vi.fn();
+    server.use(
+      http.get(`${BASE_URL}/mastra/auth/roles/admin/permissions`, ({ request }) => {
+        onRequest(request.url);
+        return HttpResponse.json(adminPermissions);
+      }),
+    );
+
+    const { handle } = renderConsumer({ apiPrefix: '/mastra/' });
+
+    await act(async () => {
+      await handle.current!.start({ id: 'admin', name: 'Admin' });
+    });
+
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    expect(onRequest.mock.calls[0]![0]).toBe(`${BASE_URL}/mastra/auth/roles/admin/permissions`);
+  });
+
+  it('adds a leading slash when apiPrefix has none', async () => {
+    const onRequest = vi.fn();
+    server.use(
+      http.get(`${BASE_URL}/mastra/auth/roles/admin/permissions`, ({ request }) => {
+        onRequest(request.url);
+        return HttpResponse.json(adminPermissions);
+      }),
+    );
+
+    const { handle } = renderConsumer({ apiPrefix: 'mastra' });
+
+    await act(async () => {
+      await handle.current!.start({ id: 'admin', name: 'Admin' });
+    });
+
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    expect(onRequest.mock.calls[0]![0]).toBe(`${BASE_URL}/mastra/auth/roles/admin/permissions`);
+  });
+
+  it('URL-encodes the roleId', async () => {
+    const onRequest = vi.fn();
+    server.use(
+      http.get(`${BASE_URL}/api/auth/roles/:roleId/permissions`, ({ request, params }) => {
+        onRequest(request.url, params.roleId);
+        return HttpResponse.json({ roleId: 'role with spaces', permissions: [] });
+      }),
+    );
+
+    const { handle } = renderConsumer();
+
+    await act(async () => {
+      await handle.current!.start({ id: 'role with spaces', name: 'Weird' });
+    });
+
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    expect(onRequest.mock.calls[0]![0]).toContain('role%20with%20spaces');
+  });
+
+  it('forwards client.options.headers on the request', async () => {
+    const onRequest = vi.fn();
+    server.use(
+      http.get(`${BASE_URL}/api/auth/roles/admin/permissions`, ({ request }) => {
+        onRequest(Object.fromEntries(request.headers));
+        return HttpResponse.json(adminPermissions);
+      }),
+    );
+
+    const { handle } = renderConsumer({ headers: { 'x-tenant-id': 'tenant-1' } });
+
+    await act(async () => {
+      await handle.current!.start({ id: 'admin', name: 'Admin' });
+    });
+
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    const headers = onRequest.mock.calls[0]![0] as Record<string, string>;
+    expect(headers['x-tenant-id']).toBe('tenant-1');
+  });
+
+  it('does not let client headers override Content-Type', async () => {
+    const onRequest = vi.fn();
+    server.use(
+      http.get(`${BASE_URL}/api/auth/roles/admin/permissions`, ({ request }) => {
+        onRequest(request.headers.get('content-type'));
+        return HttpResponse.json(adminPermissions);
+      }),
+    );
+
+    const { handle } = renderConsumer({ headers: { 'Content-Type': 'text/plain' } });
+
+    await act(async () => {
+      await handle.current!.start({ id: 'admin', name: 'Admin' });
+    });
+
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    expect(onRequest.mock.calls[0]![0]).toBe('application/json');
+  });
+
+  it('returns a no-op fallback when used outside the provider', async () => {
+    const { handle } = renderConsumer({ withProvider: false });
+
+    expect(screen.getByTestId('is-impersonating').textContent).toBe('false');
+    expect(screen.getByTestId('is-switching').textContent).toBe('false');
+    expect(screen.getByTestId('impersonated-role-id').textContent).toBe('null');
+    expect(screen.getByTestId('impersonated-permissions').textContent).toBe('null');
+
+    // Calling start outside the provider should resolve without ever
+    // hitting the network. No MSW handler is registered, so any call would
+    // explode under `onUnhandledRequest: 'error'`.
+    await expect(handle.current!.start({ id: 'admin', name: 'Admin' })).resolves.toBeUndefined();
+    handle.current!.stop();
+
+    expect(screen.getByTestId('is-impersonating').textContent).toBe('false');
+  });
+});

--- a/packages/playground/src/domains/auth/context/__tests__/role-impersonation-context.test.tsx
+++ b/packages/playground/src/domains/auth/context/__tests__/role-impersonation-context.test.tsx
@@ -12,8 +12,6 @@ import { adminPermissions, viewerPermissions } from './fixtures/role-permissions
 
 import { server } from '@/test/msw-server';
 
-
-
 const BASE_URL = 'http://localhost:4111';
 
 type ConsumerHandle = {
@@ -22,8 +20,14 @@ type ConsumerHandle = {
 };
 
 function TestConsumer({ onReady }: { onReady?: (handle: ConsumerHandle) => void }) {
-  const { isImpersonating, impersonatedRole, impersonatedPermissions, isSwitching, startImpersonation, stopImpersonation } =
-    useRoleImpersonation();
+  const {
+    isImpersonating,
+    impersonatedRole,
+    impersonatedPermissions,
+    isSwitching,
+    startImpersonation,
+    stopImpersonation,
+  } = useRoleImpersonation();
 
   if (onReady) {
     onReady({ start: startImpersonation, stop: stopImpersonation });
@@ -202,9 +206,7 @@ describe('RoleImpersonationProvider', () => {
   });
 
   it('clears state when stopImpersonation is called after a successful start', async () => {
-    server.use(
-      http.get(`${BASE_URL}/api/auth/roles/admin/permissions`, () => HttpResponse.json(adminPermissions)),
-    );
+    server.use(http.get(`${BASE_URL}/api/auth/roles/admin/permissions`, () => HttpResponse.json(adminPermissions)));
 
     const { handle } = renderConsumer();
 

--- a/packages/playground/src/domains/auth/context/role-impersonation-context.tsx
+++ b/packages/playground/src/domains/auth/context/role-impersonation-context.tsx
@@ -1,0 +1,129 @@
+/**
+ * Role impersonation context for "View as role" feature.
+ *
+ * Lets admin users preview the Studio UI as if they had a different role.
+ * This is a UI-only override — server calls still use real admin permissions.
+ */
+
+import type { MastraClient, RouteResponse } from '@mastra/client-js';
+import { useMastraClient } from '@mastra/react';
+import { useMutation } from '@tanstack/react-query';
+import { createContext, useCallback, useContext, useState  } from 'react';
+import type {ReactNode} from 'react';
+
+export type RoleImpersonationState = {
+  /** The role currently being impersonated, or null */
+  impersonatedRole: { id: string; name: string } | null;
+  /** Overridden permissions for the impersonated role */
+  impersonatedPermissions: string[] | null;
+  /** Whether impersonation is active */
+  isImpersonating: boolean;
+  /** Start impersonating a role */
+  startImpersonation: (role: { id: string; name: string }) => Promise<void>;
+  /** Stop impersonating */
+  stopImpersonation: () => void;
+  /** Whether a role switch is in progress */
+  isSwitching: boolean;
+};
+
+export const RoleImpersonationContext = createContext<RoleImpersonationState | null>(null);
+
+type RolePermissionsResponse = RouteResponse<'GET /auth/roles/:roleId/permissions'>;
+
+/**
+ * Makes a request to fetch the resolved permissions for a role.
+ * Exported for testing purposes.
+ *
+ * @internal
+ */
+export async function makeFetchRolePermissionsRequest(
+  client: MastraClient,
+  { roleId }: { roleId: string },
+): Promise<RolePermissionsResponse> {
+  const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options || {};
+  const raw = (apiPrefix ?? '/api').trim();
+  const normalized = raw === '' ? '' : raw.startsWith('/') ? raw : `/${raw}`;
+  const prefix = normalized.replace(/\/+$/, '');
+
+  const response = await fetch(`${baseUrl}${prefix}/auth/roles/${encodeURIComponent(roleId)}/permissions`, {
+    credentials: 'include',
+    headers: {
+      ...clientHeaders,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch role permissions: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+type ImpersonationMutationResult = {
+  role: { id: string; name: string };
+  permissions: string[];
+};
+
+export function RoleImpersonationProvider({ children }: { children: ReactNode }) {
+  const client = useMastraClient();
+  const [impersonatedRole, setImpersonatedRole] = useState<{ id: string; name: string } | null>(null);
+  const [impersonatedPermissions, setImpersonatedPermissions] = useState<string[] | null>(null);
+
+  const mutation = useMutation<ImpersonationMutationResult, Error, { role: { id: string; name: string } }>({
+    mutationFn: async ({ role }) => {
+      const data = await makeFetchRolePermissionsRequest(client, { roleId: role.id });
+      return { role, permissions: data.permissions };
+    },
+    onSuccess: ({ role, permissions }) => {
+      setImpersonatedRole(role);
+      setImpersonatedPermissions(permissions);
+    },
+  });
+
+  const { mutateAsync, reset, isPending } = mutation;
+
+  const startImpersonation = useCallback(
+    async (role: { id: string; name: string }) => {
+      await mutateAsync({ role });
+    },
+    [mutateAsync],
+  );
+
+  const stopImpersonation = useCallback(() => {
+    setImpersonatedRole(null);
+    setImpersonatedPermissions(null);
+    reset();
+  }, [reset]);
+
+  return (
+    <RoleImpersonationContext.Provider
+      value={{
+        impersonatedRole,
+        impersonatedPermissions,
+        isImpersonating: impersonatedRole !== null,
+        startImpersonation,
+        stopImpersonation,
+        isSwitching: isPending,
+      }}
+    >
+      {children}
+    </RoleImpersonationContext.Provider>
+  );
+}
+
+export function useRoleImpersonation(): RoleImpersonationState {
+  const ctx = useContext(RoleImpersonationContext);
+  if (!ctx) {
+    // Return a no-op implementation when outside the provider
+    return {
+      impersonatedRole: null,
+      impersonatedPermissions: null,
+      isImpersonating: false,
+      startImpersonation: async () => {},
+      stopImpersonation: () => {},
+      isSwitching: false,
+    };
+  }
+  return ctx;
+}

--- a/packages/playground/src/domains/auth/context/role-impersonation-context.tsx
+++ b/packages/playground/src/domains/auth/context/role-impersonation-context.tsx
@@ -5,11 +5,11 @@
  * This is a UI-only override — server calls still use real admin permissions.
  */
 
-import type { MastraClient, RouteResponse } from '@mastra/client-js';
 import { useMastraClient } from '@mastra/react';
 import { useMutation } from '@tanstack/react-query';
-import { createContext, useCallback, useContext, useState  } from 'react';
-import type {ReactNode} from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { fetchRolePermissionsRequest } from '../services/fetch-role-permissions';
 
 export type RoleImpersonationState = {
   /** The role currently being impersonated, or null */
@@ -26,39 +26,8 @@ export type RoleImpersonationState = {
   isSwitching: boolean;
 };
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const RoleImpersonationContext = createContext<RoleImpersonationState | null>(null);
-
-type RolePermissionsResponse = RouteResponse<'GET /auth/roles/:roleId/permissions'>;
-
-/**
- * Makes a request to fetch the resolved permissions for a role.
- * Exported for testing purposes.
- *
- * @internal
- */
-export async function makeFetchRolePermissionsRequest(
-  client: MastraClient,
-  { roleId }: { roleId: string },
-): Promise<RolePermissionsResponse> {
-  const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options || {};
-  const raw = (apiPrefix ?? '/api').trim();
-  const normalized = raw === '' ? '' : raw.startsWith('/') ? raw : `/${raw}`;
-  const prefix = normalized.replace(/\/+$/, '');
-
-  const response = await fetch(`${baseUrl}${prefix}/auth/roles/${encodeURIComponent(roleId)}/permissions`, {
-    credentials: 'include',
-    headers: {
-      ...clientHeaders,
-      'Content-Type': 'application/json',
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch role permissions: ${response.status}`);
-  }
-
-  return response.json();
-}
 
 type ImpersonationMutationResult = {
   role: { id: string; name: string };
@@ -72,7 +41,7 @@ export function RoleImpersonationProvider({ children }: { children: ReactNode })
 
   const mutation = useMutation<ImpersonationMutationResult, Error, { role: { id: string; name: string } }>({
     mutationFn: async ({ role }) => {
-      const data = await makeFetchRolePermissionsRequest(client, { roleId: role.id });
+      const data = await fetchRolePermissionsRequest(client, { roleId: role.id });
       return { role, permissions: data.permissions };
     },
     onSuccess: ({ role, permissions }) => {
@@ -83,35 +52,31 @@ export function RoleImpersonationProvider({ children }: { children: ReactNode })
 
   const { mutateAsync, reset, isPending } = mutation;
 
-  const startImpersonation = useCallback(
-    async (role: { id: string; name: string }) => {
+  const value = useMemo(() => {
+    const startImpersonation = async (role: { id: string; name: string }) => {
       await mutateAsync({ role });
-    },
-    [mutateAsync],
-  );
+    };
 
-  const stopImpersonation = useCallback(() => {
-    setImpersonatedRole(null);
-    setImpersonatedPermissions(null);
-    reset();
-  }, [reset]);
+    const stopImpersonation = () => {
+      setImpersonatedRole(null);
+      setImpersonatedPermissions(null);
+      reset();
+    };
 
-  return (
-    <RoleImpersonationContext.Provider
-      value={{
-        impersonatedRole,
-        impersonatedPermissions,
-        isImpersonating: impersonatedRole !== null,
-        startImpersonation,
-        stopImpersonation,
-        isSwitching: isPending,
-      }}
-    >
-      {children}
-    </RoleImpersonationContext.Provider>
-  );
+    return {
+      impersonatedRole,
+      impersonatedPermissions,
+      isImpersonating: impersonatedRole !== null,
+      startImpersonation,
+      stopImpersonation,
+      isSwitching: isPending,
+    };
+  }, [impersonatedRole, impersonatedPermissions, isPending, mutateAsync, reset]);
+
+  return <RoleImpersonationContext.Provider value={value}>{children}</RoleImpersonationContext.Provider>;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useRoleImpersonation(): RoleImpersonationState {
   const ctx = useContext(RoleImpersonationContext);
   if (!ctx) {
@@ -125,5 +90,6 @@ export function useRoleImpersonation(): RoleImpersonationState {
       isSwitching: false,
     };
   }
+
   return ctx;
 }

--- a/packages/playground/src/domains/auth/hooks/use-permissions.ts
+++ b/packages/playground/src/domains/auth/hooks/use-permissions.ts
@@ -24,6 +24,7 @@
 
 import { isAuthenticated } from '../types';
 import { useAuthCapabilities } from './use-auth-capabilities';
+import { useRoleImpersonation } from './use-role-impersonation';
 
 /**
  * Permission matching logic.
@@ -144,6 +145,7 @@ export type UsePermissionsResult = {
  */
 export function usePermissions(): UsePermissionsResult {
   const { data: capabilities, isLoading } = useAuthCapabilities();
+  const { isImpersonating, impersonatedPermissions, impersonatedRole } = useRoleImpersonation();
 
   // Extract roles and permissions from capabilities
   const authenticated = capabilities && isAuthenticated(capabilities);
@@ -153,13 +155,15 @@ export function usePermissions(): UsePermissionsResult {
   // If RBAC capability is false or not present, all permission checks should return true
   const rbacEnabled = authenticated ? capabilities.capabilities.rbac : false;
 
-  const roles = access?.roles ?? [];
-  const permissions = access?.permissions ?? [];
+  // When impersonating, use the overridden role and permissions
+  const roles = isImpersonating && impersonatedRole ? [impersonatedRole.id] : (access?.roles ?? []);
+  const permissions =
+    isImpersonating && impersonatedPermissions ? impersonatedPermissions : (access?.permissions ?? []);
 
   // Helper to check permission with RBAC bypass
   const checkPermission = (permission: string): boolean => {
-    // If RBAC is not enabled, allow everything
-    if (!rbacEnabled) return true;
+    // If RBAC is not enabled, allow everything (unless impersonating)
+    if (!rbacEnabled && !isImpersonating) return true;
     return checkHasPermission(permissions, permission);
   };
 
@@ -175,17 +179,17 @@ export function usePermissions(): UsePermissionsResult {
     },
 
     hasAllPermissions: (requiredPermissions: string[]) => {
-      if (!rbacEnabled) return true;
+      if (!rbacEnabled && !isImpersonating) return true;
       return requiredPermissions.every(p => checkHasPermission(permissions, p));
     },
 
     hasAnyPermission: (requiredPermissions: string[]) => {
-      if (!rbacEnabled) return true;
+      if (!rbacEnabled && !isImpersonating) return true;
       return requiredPermissions.some(p => checkHasPermission(permissions, p));
     },
 
     hasRole: (role: string) => {
-      if (!rbacEnabled) return true;
+      if (!rbacEnabled && !isImpersonating) return true;
       return roles.includes(role);
     },
 

--- a/packages/playground/src/domains/auth/hooks/use-role-impersonation.ts
+++ b/packages/playground/src/domains/auth/hooks/use-role-impersonation.ts
@@ -1,0 +1,2 @@
+export { useRoleImpersonation } from '../context/role-impersonation-context';
+export type { RoleImpersonationState } from '../context/role-impersonation-context';

--- a/packages/playground/src/domains/auth/services/fetch-role-permissions.ts
+++ b/packages/playground/src/domains/auth/services/fetch-role-permissions.ts
@@ -1,0 +1,33 @@
+import type { MastraClient, RouteResponse } from '@mastra/client-js';
+
+type RolePermissionsResponse = RouteResponse<'GET /auth/roles/:roleId/permissions'>;
+
+/**
+ * Makes a request to fetch the resolved permissions for a role.
+ * Exported for testing purposes.
+ *
+ * @internal
+ */
+export async function fetchRolePermissionsRequest(
+  client: MastraClient,
+  { roleId }: { roleId: string },
+): Promise<RolePermissionsResponse> {
+  const { baseUrl = '', apiPrefix, headers: clientHeaders = {} } = client.options || {};
+  const raw = (apiPrefix ?? '/api').trim();
+  const normalized = raw === '' ? '' : raw.startsWith('/') ? raw : `/${raw}`;
+  const prefix = normalized.replace(/\/+$/, '');
+
+  const response = await fetch(`${baseUrl}${prefix}/auth/roles/${encodeURIComponent(roleId)}/permissions`, {
+    credentials: 'include',
+    headers: {
+      ...clientHeaders,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch role permissions: ${response.status}`);
+  }
+
+  return response.json();
+}

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/index.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/index.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React, { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import AgentBuilderAgentsPage from '..';
+import { LinkComponentProvider } from '@/lib/framework';
+import { server } from '@/test/msw-server';
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+    usePlaygroundStore: () => ({ requestContext: undefined }),
+  };
+});
+
+let currentUser: { id: string } | undefined = { id: 'user-1' };
+let isCurrentUserLoading = false;
+
+vi.mock('@/domains/auth/hooks/use-current-user', () => ({
+  useCurrentUser: () => ({ data: currentUser, isLoading: isCurrentUserLoading }),
+}));
+
+const BASE_URL = 'http://localhost:4111';
+
+const StubLink = ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a {...props}>{children}</a>
+);
+
+const noopPaths = {
+  agentLink: () => '',
+  agentMessageLink: () => '',
+  workflowLink: () => '',
+  toolLink: () => '',
+  scoreLink: () => '',
+  scorerLink: () => '',
+  toolByAgentLink: () => '',
+  toolByWorkflowLink: () => '',
+  promptLink: () => '',
+  legacyWorkflowLink: () => '',
+  policyLink: () => '',
+  vNextNetworkLink: () => '',
+  agentBuilderLink: () => '',
+  mcpServerLink: () => '',
+  mcpServerToolLink: () => '',
+  workflowRunLink: () => '',
+  datasetLink: () => '',
+  datasetItemLink: () => '',
+  datasetExperimentLink: () => '',
+  experimentLink: () => '',
+} as never;
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <LinkComponentProvider Link={StubLink as never} navigate={() => {}} paths={noopPaths}>
+            <AgentBuilderAgentsPage />
+          </LinkComponentProvider>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+}
+
+const baseAgent = {
+  status: 'draft' as const,
+  visibility: 'private' as const,
+  instructions: '',
+  model: { provider: 'openai', name: 'gpt-4' },
+  authorId: 'user-1',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('AgentBuilderAgentsPage', () => {
+  afterEach(() => {
+    cleanup();
+    currentUser = { id: 'user-1' };
+    isCurrentUserLoading = false;
+  });
+
+  it('passes authorId to the API when the current user is available', async () => {
+    const capturedSearches: URLSearchParams[] = [];
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, ({ request }) => {
+        capturedSearches.push(new URL(request.url).searchParams);
+        return HttpResponse.json({
+          agents: [{ ...baseAgent, id: 'agent-1', name: 'My Agent', description: 'Personal draft' }],
+          total: 1,
+          page: 1,
+          perPage: 100,
+          hasMore: false,
+        });
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(capturedSearches).toHaveLength(1);
+    });
+    expect(capturedSearches[0].get('status')).toBeNull();
+    expect(capturedSearches[0].get('authorId')).toBe('user-1');
+    expect(capturedSearches[0].get('visibility')).toBeNull();
+    expect(screen.queryByText('All agents')).toBeNull();
+  });
+
+  it('waits for the current user query before fetching agents', async () => {
+    isCurrentUserLoading = true;
+    let requestCount = 0;
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, () => {
+        requestCount += 1;
+        return HttpResponse.json({ agents: [], total: 0, page: 1, perPage: 100, hasMore: false });
+      }),
+    );
+
+    renderPage();
+
+    await act(() => new Promise(resolve => setTimeout(resolve, 0)));
+    expect(requestCount).toBe(0);
+  });
+
+  it('renders the skeleton (not the empty state) while the current user is loading', async () => {
+    isCurrentUserLoading = true;
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, () => {
+        return HttpResponse.json({ agents: [], total: 0, page: 1, perPage: 100, hasMore: false });
+      }),
+    );
+
+    renderPage();
+
+    await act(() => new Promise(resolve => setTimeout(resolve, 0)));
+    expect(screen.queryByText('No agents yet')).toBeNull();
+    expect(screen.queryByText('Create an agent')).toBeNull();
+  });
+
+  it('omits authorId when no current user is available', async () => {
+    currentUser = undefined;
+    let capturedSearch: URLSearchParams | null = null;
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, ({ request }) => {
+        capturedSearch = new URL(request.url).searchParams;
+        return HttpResponse.json({ agents: [], total: 0, page: 1, perPage: 100, hasMore: false });
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(capturedSearch).not.toBeNull();
+    });
+    expect(capturedSearch!.get('status')).toBeNull();
+    expect(capturedSearch!.get('authorId')).toBeNull();
+    expect(capturedSearch!.get('visibility')).toBeNull();
+  });
+});

--- a/packages/playground/src/pages/agent-builder/agents/__tests__/index.test.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import type { BuilderSettingsResponse } from '@mastra/client-js';
 import type * as PlaygroundUi from '@mastra/playground-ui';
 import { TooltipProvider } from '@mastra/playground-ui';
 import { MastraReactProvider } from '@mastra/react';
@@ -8,8 +9,19 @@ import { http, HttpResponse } from 'msw';
 import React, { act } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import AgentBuilderAgentsPage from '..';
+import type { AuthCapabilities } from '@/domains/auth/types';
 import { LinkComponentProvider } from '@/lib/framework';
 import { server } from '@/test/msw-server';
+
+const builderEnabled: BuilderSettingsResponse = {
+  enabled: true,
+  features: { agent: {} },
+};
+
+const unauthenticatedCapabilities = {
+  enabled: true,
+  login: { type: 'credentials' as const },
+} satisfies AuthCapabilities;
 
 vi.mock('@mastra/playground-ui', async () => {
   const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
@@ -19,13 +31,6 @@ vi.mock('@mastra/playground-ui', async () => {
     usePlaygroundStore: () => ({ requestContext: undefined }),
   };
 });
-
-let currentUser: { id: string } | undefined = { id: 'user-1' };
-let isCurrentUserLoading = false;
-
-vi.mock('@/domains/auth/hooks/use-current-user', () => ({
-  useCurrentUser: () => ({ data: currentUser, isLoading: isCurrentUserLoading }),
-}));
 
 const BASE_URL = 'http://localhost:4111';
 
@@ -56,6 +61,25 @@ const noopPaths = {
   experimentLink: () => '',
 } as never;
 
+function userHandler(user: { id: string } | null) {
+  return [
+    http.get(`${BASE_URL}/api/auth/me`, () => {
+      if (user === null) {
+        return HttpResponse.json(null, { status: 401 });
+      }
+      return HttpResponse.json(user);
+    }),
+    http.post(`${BASE_URL}/api/auth/refresh`, () => HttpResponse.json(null, { status: 401 })),
+  ];
+}
+
+function pendingUserHandler() {
+  return http.get(`${BASE_URL}/api/auth/me`, () => {
+    // Never resolves; the query stays in the loading state.
+    return new Promise<Response>(() => {});
+  });
+}
+
 function renderPage() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -84,16 +108,23 @@ const baseAgent = {
   updatedAt: new Date().toISOString(),
 };
 
-describe('AgentBuilderAgentsPage', () => {
-  afterEach(() => {
-    cleanup();
-    currentUser = { id: 'user-1' };
-    isCurrentUserLoading = false;
-  });
+function defaultHandlers() {
+  return [
+    http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(unauthenticatedCapabilities)),
+    http.get(`${BASE_URL}/api/editor/builder/settings`, () => HttpResponse.json(builderEnabled)),
+  ];
+}
 
+afterEach(() => {
+  cleanup();
+});
+
+describe('AgentBuilderAgentsPage', () => {
   it('passes authorId to the API when the current user is available', async () => {
     const capturedSearches: URLSearchParams[] = [];
     server.use(
+      ...defaultHandlers(),
+      ...userHandler({ id: 'user-1' }),
       http.get(`${BASE_URL}/api/stored/agents`, ({ request }) => {
         capturedSearches.push(new URL(request.url).searchParams);
         return HttpResponse.json({
@@ -118,9 +149,10 @@ describe('AgentBuilderAgentsPage', () => {
   });
 
   it('waits for the current user query before fetching agents', async () => {
-    isCurrentUserLoading = true;
     let requestCount = 0;
     server.use(
+      ...defaultHandlers(),
+      pendingUserHandler(),
       http.get(`${BASE_URL}/api/stored/agents`, () => {
         requestCount += 1;
         return HttpResponse.json({ agents: [], total: 0, page: 1, perPage: 100, hasMore: false });
@@ -134,8 +166,9 @@ describe('AgentBuilderAgentsPage', () => {
   });
 
   it('renders the skeleton (not the empty state) while the current user is loading', async () => {
-    isCurrentUserLoading = true;
     server.use(
+      ...defaultHandlers(),
+      pendingUserHandler(),
       http.get(`${BASE_URL}/api/stored/agents`, () => {
         return HttpResponse.json({ agents: [], total: 0, page: 1, perPage: 100, hasMore: false });
       }),
@@ -149,9 +182,10 @@ describe('AgentBuilderAgentsPage', () => {
   });
 
   it('omits authorId when no current user is available', async () => {
-    currentUser = undefined;
     let capturedSearch: URLSearchParams | null = null;
     server.use(
+      ...defaultHandlers(),
+      ...userHandler(null),
       http.get(`${BASE_URL}/api/stored/agents`, ({ request }) => {
         capturedSearch = new URL(request.url).searchParams;
         return HttpResponse.json({ agents: [], total: 0, page: 1, perPage: 100, hasMore: false });

--- a/packages/playground/src/pages/agent-builder/agents/index.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/index.tsx
@@ -1,0 +1,124 @@
+import type { ListStoredAgentsParams } from '@mastra/client-js';
+import {
+  AgentIcon,
+  Button,
+  EmptyState,
+  ErrorState,
+  ListSearch,
+  PageHeader,
+  PageLayout,
+  PermissionDenied,
+  SessionExpired,
+  is401UnauthorizedError,
+  is403ForbiddenError,
+} from '@mastra/playground-ui';
+import { PlusIcon } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import {
+  AgentBuilderList,
+  AgentBuilderListSkeleton,
+} from '@/domains/agent-builder/components/agent-list/agent-builder-list';
+import { useBuilderAgentAccess } from '@/domains/agent-builder/hooks/use-builder-agent-access';
+import { useStoredAgents } from '@/domains/agents/hooks/use-stored-agents';
+import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
+import { useLinkComponent } from '@/lib/framework';
+
+export default function AgentBuilderAgentsPage() {
+  const { data: currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
+  const { canWrite, canUseFavorites } = useBuilderAgentAccess();
+  const [search, setSearch] = useState('');
+  const { Link: FrameworkLink } = useLinkComponent();
+
+  const listParams = useMemo<ListStoredAgentsParams>(() => {
+    const params: ListStoredAgentsParams = {};
+    if (currentUser?.id) {
+      params.authorId = currentUser.id;
+    }
+    return params;
+  }, [currentUser?.id]);
+
+  const { data, isLoading, error } = useStoredAgents(listParams, { enabled: !isCurrentUserLoading });
+  const agents = data?.agents ?? [];
+
+  const body = (() => {
+    if (isCurrentUserLoading || isLoading) {
+      return <AgentBuilderListSkeleton />;
+    }
+
+    if (error) {
+      if (is401UnauthorizedError(error)) {
+        return (
+          <div className="flex items-center justify-center pt-10">
+            <SessionExpired />
+          </div>
+        );
+      }
+      if (is403ForbiddenError(error)) {
+        return (
+          <div className="flex items-center justify-center pt-10">
+            <PermissionDenied resource="agents" />
+          </div>
+        );
+      }
+      return (
+        <div className="flex items-center justify-center pt-10">
+          <ErrorState title="Failed to load agents" message={error.message} />
+        </div>
+      );
+    }
+
+    if (agents.length === 0) {
+      return (
+        <div className="flex items-center justify-center pt-16">
+          <EmptyState
+            iconSlot={<AgentIcon className="h-8 w-8 text-neutral3" />}
+            titleSlot="No agents yet"
+            descriptionSlot="Start building your first agent with the Agent Builder."
+            actionSlot={
+              canWrite ? (
+                <Button as={FrameworkLink} to="/agent-builder/agents/create" variant="primary">
+                  <PlusIcon /> Create an agent
+                </Button>
+              ) : undefined
+            }
+          />
+        </div>
+      );
+    }
+
+    return <AgentBuilderList agents={agents} search={search} showFavorites={canUseFavorites} />;
+  })();
+
+  return (
+    <PageLayout className="px-4 md:px-10">
+      <PageLayout.TopArea>
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4">
+          <PageHeader>
+            <PageHeader.Title>
+              <AgentIcon /> My agents
+            </PageHeader.Title>
+            <PageHeader.Description>Agents you've created.</PageHeader.Description>
+          </PageHeader>
+          {agents.length > 0 && canWrite && (
+            <div className="w-full shrink-0 md:w-auto">
+              <Button
+                as={FrameworkLink}
+                to="/agent-builder/agents/create"
+                variant="primary"
+                className="w-full justify-center md:w-auto"
+              >
+                <PlusIcon /> New agent
+              </Button>
+            </div>
+          )}
+        </div>
+        <div className="max-w-120">
+          <ListSearch onSearch={setSearch} label="Filter agents" placeholder="Filter by name or description" />
+        </div>
+      </PageLayout.TopArea>
+
+      {body}
+    </PageLayout>
+  );
+}

--- a/packages/playground/src/pages/agent-builder/favorite/__tests__/favorite-page.test.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/__tests__/favorite-page.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import AgentBuilderFavoritePage from '..';
+import { LinkComponentProvider } from '@/lib/framework';
+import { server } from '@/test/msw-server';
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+    usePlaygroundStore: () => ({ requestContext: undefined }),
+  };
+});
+
+const BASE_URL = 'http://localhost:4111';
+
+const StubLink = ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a {...props}>{children}</a>
+);
+
+const noopPaths = {
+  agentLink: () => '',
+  agentMessageLink: () => '',
+  workflowLink: () => '',
+  toolLink: () => '',
+  scoreLink: () => '',
+  scorerLink: () => '',
+  toolByAgentLink: () => '',
+  toolByWorkflowLink: () => '',
+  promptLink: () => '',
+  legacyWorkflowLink: () => '',
+  policyLink: () => '',
+  vNextNetworkLink: () => '',
+  agentBuilderLink: () => '',
+  mcpServerLink: () => '',
+  mcpServerToolLink: () => '',
+  workflowRunLink: () => '',
+  datasetLink: () => '',
+  datasetItemLink: () => '',
+  datasetExperimentLink: () => '',
+  experimentLink: () => '',
+} as never;
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <LinkComponentProvider Link={StubLink as never} navigate={() => {}} paths={noopPaths}>
+          <MemoryRouter>
+            <TooltipProvider>
+              <AgentBuilderFavoritePage />
+            </TooltipProvider>
+          </MemoryRouter>
+        </LinkComponentProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+}
+
+const baseAgent = {
+  status: 'draft' as const,
+  visibility: 'private' as const,
+  instructions: '',
+  model: { provider: 'openai', name: 'gpt-4' },
+  authorId: 'user-1',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  isFavorited: true,
+  favoriteCount: 1,
+};
+
+describe('AgentBuilderFavoritePage', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('passes favoritedOnly=true and updatedAt descending order to the API without a status filter', async () => {
+    let capturedSearch: URLSearchParams | null = null;
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, ({ request }) => {
+        capturedSearch = new URL(request.url).searchParams;
+        return HttpResponse.json({
+          agents: [{ ...baseAgent, id: 'fav-1', name: 'Favorite Alpha', description: 'Alpha desc' }],
+          total: 1,
+          page: 1,
+          perPage: 100,
+          hasMore: false,
+        });
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(capturedSearch).not.toBeNull();
+    });
+    expect(capturedSearch!.get('favoritedOnly')).toBe('true');
+    expect(capturedSearch!.get('orderBy[field]')).toBe('updatedAt');
+    expect(capturedSearch!.get('orderBy[direction]')).toBe('DESC');
+    expect(capturedSearch!.get('status')).toBeNull();
+  });
+
+  it('renders rows from the response with view links', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, () =>
+        HttpResponse.json({
+          agents: [
+            { ...baseAgent, id: 'fav-1', name: 'Favorite Alpha', description: 'Alpha desc' },
+            { ...baseAgent, id: 'fav-2', name: 'Favorite Beta', description: 'Beta desc' },
+          ],
+          total: 2,
+          page: 1,
+          perPage: 100,
+          hasMore: false,
+        }),
+      ),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Favorite Alpha')).toBeTruthy();
+    });
+    expect(screen.getByText('Favorite Beta')).toBeTruthy();
+
+    const rows = screen.getAllByTestId('favorite-agent-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].getAttribute('href')).toBe('/agent-builder/agents/fav-1/view');
+    expect(rows[1].getAttribute('href')).toBe('/agent-builder/agents/fav-2/view');
+  });
+
+  it('shows the empty state when the API returns no agents', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, () =>
+        HttpResponse.json({ agents: [], total: 0, page: 1, perPage: 100, hasMore: false }),
+      ),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No favorite agents yet')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('favorite-agent-row')).toBeNull();
+  });
+
+  it('shows the error state when the API returns 500', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, () => HttpResponse.json({ message: 'boom' }, { status: 500 })),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load favorite agents')).toBeTruthy();
+    });
+  });
+});

--- a/packages/playground/src/pages/agent-builder/favorite/index.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/index.tsx
@@ -1,0 +1,166 @@
+import type { ListStoredAgentsParams, StoredSkillResponse } from '@mastra/client-js';
+import {
+  EmptyState,
+  ErrorState,
+  ListSearch,
+  PageHeader,
+  PageLayout,
+  PermissionDenied,
+  SessionExpired,
+  is401UnauthorizedError,
+  is403ForbiddenError,
+} from '@mastra/playground-ui';
+import { SparklesIcon, StarIcon } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import {
+  AgentBuilderList,
+  AgentBuilderListSkeleton,
+} from '@/domains/agent-builder/components/agent-list/agent-builder-list';
+import {
+  SkillBuilderList,
+  SkillBuilderListSkeleton,
+} from '@/domains/agent-builder/components/skill-list/skill-builder-list';
+import { useBuilderAgentFeatures } from '@/domains/agent-builder/hooks/use-builder-agent-features';
+import { useStoredAgents } from '@/domains/agents/hooks/use-stored-agents';
+import { useStoredSkills } from '@/domains/agents/hooks/use-stored-skills';
+import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
+
+type Tab = 'agents' | 'skills';
+
+export default function AgentBuilderFavoritePage() {
+  const navigate = useNavigate();
+  const [search, setSearch] = useState('');
+  const [tab, setTab] = useState<Tab>('agents');
+  const features = useBuilderAgentFeatures();
+  const { data: currentUser } = useCurrentUser();
+
+  const handleSkillClick = (skill: StoredSkillResponse) => {
+    const isOwner = !skill.authorId || currentUser?.id === skill.authorId;
+    const destination = isOwner ? 'edit' : 'view';
+    void navigate(`/agent-builder/skills/${skill.id}/${destination}`, { viewTransition: true });
+  };
+
+  const agentListParams = useMemo<ListStoredAgentsParams>(
+    () => ({
+      favoritedOnly: true,
+      orderBy: { field: 'updatedAt', direction: 'DESC' },
+    }),
+    [],
+  );
+
+  const { data: agentsData, isLoading: agentsLoading, error: agentsError } = useStoredAgents(agentListParams);
+  const {
+    data: skillsData,
+    isLoading: skillsLoading,
+    error: skillsError,
+  } = useStoredSkills({ enabled: tab === 'skills' && features.skills });
+
+  const agents = agentsData?.agents ?? [];
+  const skills = skillsData?.skills ?? [];
+
+  const renderError = (error: Error, resource: string) => {
+    if (is401UnauthorizedError(error)) {
+      return (
+        <div className="flex items-center justify-center pt-10">
+          <SessionExpired />
+        </div>
+      );
+    }
+    if (is403ForbiddenError(error)) {
+      return (
+        <div className="flex items-center justify-center pt-10">
+          <PermissionDenied resource={resource} />
+        </div>
+      );
+    }
+    return (
+      <div className="flex items-center justify-center pt-10">
+        <ErrorState title={`Failed to load favorite ${resource}`} message={error.message} />
+      </div>
+    );
+  };
+
+  const body = (() => {
+    if (tab === 'agents') {
+      if (agentsLoading) return <AgentBuilderListSkeleton rowTestId="favorite-skeleton-row" />;
+      if (agentsError) return renderError(agentsError, 'agents');
+      if (agents.length === 0) {
+        return (
+          <div className="flex items-center justify-center pt-16">
+            <EmptyState
+              iconSlot={<StarIcon className="h-8 w-8 text-neutral3" />}
+              titleSlot="No favorite agents yet"
+              descriptionSlot="Star agents to keep them here for quick access."
+            />
+          </div>
+        );
+      }
+      return <AgentBuilderList agents={agents} search={search} rowTestId="favorite-agent-row" />;
+    }
+
+    // Skills tab
+    if (skillsLoading) return <SkillBuilderListSkeleton />;
+    if (skillsError) return renderError(skillsError, 'skills');
+    if (skills.length === 0) {
+      return (
+        <div className="flex items-center justify-center pt-16">
+          <EmptyState
+            iconSlot={<SparklesIcon className="h-8 w-8 text-neutral3" />}
+            titleSlot="No favorite skills yet"
+            descriptionSlot="Star skills to keep them here for quick access."
+          />
+        </div>
+      );
+    }
+    return <SkillBuilderList skills={skills} search={search} onSkillClick={handleSkillClick} />;
+  })();
+
+  return (
+    <>
+      <PageLayout className="px-4 md:px-10">
+        <PageLayout.TopArea>
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4">
+            <PageHeader>
+              <PageHeader.Title>
+                <StarIcon /> Favorites
+              </PageHeader.Title>
+              <PageHeader.Description>
+                {tab === 'agents'
+                  ? "Agents you've starred in Agent Builder."
+                  : "Skills you've starred in Agent Builder."}
+              </PageHeader.Description>
+            </PageHeader>
+          </div>
+          <div className="flex items-center gap-4">
+            {features.skills && (
+              <div className="flex rounded-lg border border-border1 overflow-hidden">
+                <button
+                  onClick={() => setTab('agents')}
+                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                    tab === 'agents' ? 'bg-surface4 text-neutral6' : 'bg-surface2 text-neutral3 hover:text-neutral5'
+                  }`}
+                >
+                  Agents
+                </button>
+                <button
+                  onClick={() => setTab('skills')}
+                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                    tab === 'skills' ? 'bg-surface4 text-neutral6' : 'bg-surface2 text-neutral3 hover:text-neutral5'
+                  }`}
+                >
+                  Skills
+                </button>
+              </div>
+            )}
+            <div className="flex-1 max-w-120">
+              <ListSearch onSearch={setSearch} label="Filter favorites" placeholder="Filter by name or description" />
+            </div>
+          </div>
+        </PageLayout.TopArea>
+
+        {body}
+      </PageLayout>
+    </>
+  );
+}

--- a/packages/playground/src/pages/agent-builder/infrastructure/index.tsx
+++ b/packages/playground/src/pages/agent-builder/infrastructure/index.tsx
@@ -1,0 +1,239 @@
+import type { InfrastructureStatusResponse } from '@mastra/client-js';
+import { PageHeader, PageLayout, SectionCard, Txt } from '@mastra/playground-ui';
+
+import { useInfrastructureStatus } from '@/domains/agent-builder/hooks/use-infrastructure-status';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+
+const StatusBadge = ({ ok, label }: { ok: boolean; label: string }) => (
+  <span
+    className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs ${
+      ok ? 'bg-accent3/10 text-accent3' : 'bg-surface2 text-neutral3'
+    }`}
+    data-slot="infrastructure-status-badge"
+    data-ok={ok ? 'true' : 'false'}
+  >
+    <span className={`h-1.5 w-1.5 rounded-full ${ok ? 'bg-accent3' : 'bg-neutral3'}`} aria-hidden="true" />
+    {label}
+  </span>
+);
+
+const EmptyRow = ({ message }: { message: string }) => (
+  <Txt variant="ui-sm" className="text-neutral3">
+    {message}
+  </Txt>
+);
+
+const titleCase = (value: string | number | null | undefined) => {
+  if (value === null || value === undefined) return value;
+  return String(value)
+    .split(/([\s-]+)/)
+    .map(part => (/^[\s-]+$/.test(part) ? part : part.charAt(0).toUpperCase() + part.slice(1)))
+    .join('');
+};
+
+const Detail = ({ label, value }: { label: string; value: string | number | null | undefined }) => (
+  <div className="flex flex-col gap-0.5">
+    <Txt variant="ui-xs" className="text-neutral4">
+      {label}
+    </Txt>
+    <Txt variant="ui-sm" className="text-icon6">
+      {value ?? 'Not set'}
+    </Txt>
+  </div>
+);
+
+const ConfigDetails = ({ entries }: { entries: Array<{ key: string; value: string }> }) => {
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-1 gap-3 border-t border-border1 pt-3 sm:grid-cols-2">
+      {entries.map(entry => (
+        <Detail key={entry.key} label={`Config: ${entry.key}`} value={titleCase(entry.value)} />
+      ))}
+    </div>
+  );
+};
+
+export const AgentBuilderInfrastructure = () => {
+  const { hasPermission } = usePermissions();
+  const canViewInfrastructure = hasPermission('infrastructure:read');
+  const { data: infrastructureData, isLoading, error } = useInfrastructureStatus({ enabled: canViewInfrastructure });
+  const data = infrastructureData as InfrastructureStatusResponse | undefined;
+
+  return (
+    <PageLayout width="narrow">
+      <PageLayout.TopArea>
+        <PageHeader>
+          <PageHeader.Title>Infrastructure</PageHeader.Title>
+        </PageHeader>
+      </PageLayout.TopArea>
+
+      <PageLayout.MainArea className="flex flex-col gap-5 mt-6">
+        <SectionCard
+          title="Agent Builder Infrastructure"
+          description="Deployment-level defaults Agent Builder applies when users create or run builder agents."
+        >
+          {!canViewInfrastructure ? (
+            <Txt variant="ui-sm" className="text-neutral3">
+              You do not have permission to view Agent Builder infrastructure.
+            </Txt>
+          ) : isLoading ? (
+            <Txt variant="ui-sm" className="text-neutral3">
+              Loading infrastructure configuration…
+            </Txt>
+          ) : error || !data ? (
+            <Txt variant="ui-sm" className="text-neutral3">
+              Infrastructure configuration unavailable.
+            </Txt>
+          ) : (
+            <div className="flex flex-col gap-6">
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-1">
+                  <Txt variant="ui-md" className="font-medium">
+                    Channels
+                  </Txt>
+                  <Txt variant="ui-xs" className="text-neutral3">
+                    Configured channel providers available to Agent Builder publish/share flows. Unconfigured providers
+                    are omitted until their required environment/config is present.
+                  </Txt>
+                </div>
+                {data.channels.providers.length === 0 ? (
+                  <EmptyRow message="No configured channel providers for Agent Builder." />
+                ) : (
+                  <ul className="flex flex-col gap-2">
+                    {data.channels.providers.map(provider => (
+                      <li key={provider.id} className="rounded-md border border-border1 px-3 py-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex flex-col gap-1">
+                            <Txt variant="ui-sm" className="font-medium">
+                              {titleCase(provider.name)}
+                            </Txt>
+                            <Txt variant="ui-xs" className="text-neutral3">
+                              Provider ID: {provider.id}
+                            </Txt>
+                          </div>
+                          <StatusBadge
+                            ok={provider.isConfigured}
+                            label={provider.isConfigured ? 'Configured' : 'Not configured'}
+                          />
+                        </div>
+                        <div className="mt-3 grid grid-cols-1 gap-3 border-t border-border1 pt-3 sm:grid-cols-2">
+                          <Detail label="Registered by" value={`${titleCase(provider.name)} provider`} />
+                          <Detail label="Provider routes" value={provider.routeCount} />
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-1">
+                  <Txt variant="ui-md" className="font-medium">
+                    Browser
+                  </Txt>
+                  <Txt variant="ui-xs" className="text-neutral3">
+                    Browser automation provider configured for builder agents. The card shows the selected provider and
+                    only non-default options explicitly passed in configuration.
+                  </Txt>
+                </div>
+                {!data.browser.provider ? (
+                  <EmptyRow message="No browser configured." />
+                ) : (
+                  <div className="rounded-md border border-border1 px-3 py-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex flex-col gap-1">
+                        <Txt variant="ui-sm" className="font-medium">
+                          {titleCase(data.browser.provider)}
+                        </Txt>
+                      </div>
+                      <StatusBadge
+                        ok={data.browser.registered}
+                        label={data.browser.registered ? 'Provider available' : 'Provider missing'}
+                      />
+                    </div>
+                    {data.browser.env ? (
+                      <div className="mt-3 grid grid-cols-1 gap-3 border-t border-border1 pt-3 sm:grid-cols-2">
+                        <Detail label="Environment" value={titleCase(data.browser.env)} />
+                      </div>
+                    ) : null}
+                    <ConfigDetails entries={data.browser.config} />
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-1">
+                  <Txt variant="ui-md" className="font-medium">
+                    Registries
+                  </Txt>
+                  <Txt variant="ui-xs" className="text-neutral3">
+                    External skill registries available to import skills into the workspace.
+                  </Txt>
+                </div>
+                <div className="rounded-md border border-border1 px-3 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex flex-col gap-1">
+                      <Txt variant="ui-sm" className="font-medium">
+                        skills.sh
+                      </Txt>
+                      <Txt variant="ui-xs" className="text-neutral3">
+                        GitHub-backed public skills registry.
+                      </Txt>
+                    </div>
+                    <StatusBadge
+                      ok={data.registries?.skillsSh?.enabled ?? false}
+                      label={data.registries?.skillsSh?.enabled ? 'Enabled' : 'Disabled'}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-1">
+                  <Txt variant="ui-md" className="font-medium">
+                    Workspace
+                  </Txt>
+                  <Txt variant="ui-xs" className="text-neutral3">
+                    Workspace config used for generated files and sandbox execution. This reports the builder workspace
+                    only, not agent-specific runtime workspaces.
+                  </Txt>
+                </div>
+                {!data.workspace.type ? (
+                  <EmptyRow message="No workspace configured." />
+                ) : (
+                  <div className="rounded-md border border-border1 px-3 py-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <Txt variant="ui-sm" className="font-medium">
+                        {data.workspace.workspaceId ?? data.workspace.name ?? 'Inline workspace'}
+                      </Txt>
+                      <div className="flex gap-2">
+                        <StatusBadge ok={data.workspace.hasFilesystem} label="Filesystem" />
+                        <StatusBadge ok={data.workspace.hasSandbox} label="Sandbox" />
+                      </div>
+                    </div>
+                    <div className="mt-3 grid grid-cols-1 gap-3 border-t border-border1 pt-3 sm:grid-cols-2">
+                      <Detail
+                        label="Config type"
+                        value={data.workspace.type === 'id' ? 'Registered workspace' : 'Inline config'}
+                      />
+                      {data.workspace.workspaceId ? (
+                        <Detail label="Workspace ID" value={data.workspace.workspaceId} />
+                      ) : null}
+                      <Detail label="Name" value={data.workspace.name} />
+                      <Detail label="Filesystem provider" value={titleCase(data.workspace.filesystemProvider)} />
+                      <Detail label="Sandbox provider" value={titleCase(data.workspace.sandboxProvider)} />
+                    </div>
+                    <ConfigDetails entries={data.workspace.config} />
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </SectionCard>
+      </PageLayout.MainArea>
+    </PageLayout>
+  );
+};
+
+export default AgentBuilderInfrastructure;

--- a/packages/playground/src/pages/agent-builder/library/__tests__/library-page.test.tsx
+++ b/packages/playground/src/pages/agent-builder/library/__tests__/library-page.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import AgentBuilderLibraryPage from '..';
+import { LinkComponentProvider } from '@/lib/framework';
+import { server } from '@/test/msw-server';
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+    usePlaygroundStore: () => ({ requestContext: undefined }),
+  };
+});
+
+const BASE_URL = 'http://localhost:4111';
+
+const StubLink = ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a {...props}>{children}</a>
+);
+
+const noopPaths = {
+  agentLink: () => '',
+  agentMessageLink: () => '',
+  workflowLink: () => '',
+  toolLink: () => '',
+  scoreLink: () => '',
+  scorerLink: () => '',
+  toolByAgentLink: () => '',
+  toolByWorkflowLink: () => '',
+  promptLink: () => '',
+  legacyWorkflowLink: () => '',
+  policyLink: () => '',
+  vNextNetworkLink: () => '',
+  agentBuilderLink: () => '',
+  mcpServerLink: () => '',
+  mcpServerToolLink: () => '',
+  workflowRunLink: () => '',
+  datasetLink: () => '',
+  datasetItemLink: () => '',
+  datasetExperimentLink: () => '',
+  experimentLink: () => '',
+} as never;
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <LinkComponentProvider Link={StubLink as never} navigate={() => {}} paths={noopPaths}>
+          <MemoryRouter>
+            <AgentBuilderLibraryPage />
+          </MemoryRouter>
+        </LinkComponentProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+}
+
+const baseAgent = {
+  status: 'draft' as const,
+  visibility: 'public' as const,
+  instructions: '',
+  model: { provider: 'openai', name: 'gpt-4' },
+  authorId: 'user-1',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('AgentBuilderLibraryPage', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('passes visibility=public to the API without a status filter', async () => {
+    let capturedSearch: URLSearchParams | null = null;
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, ({ request }) => {
+        capturedSearch = new URL(request.url).searchParams;
+        return HttpResponse.json({
+          agents: [
+            { ...baseAgent, id: 'lib-1', name: 'Public Alpha', description: 'Alpha desc' },
+            { ...baseAgent, id: 'lib-2', name: 'Public Beta', description: 'Beta desc' },
+          ],
+          total: 2,
+          page: 1,
+          perPage: 100,
+          hasMore: false,
+        });
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(capturedSearch).not.toBeNull();
+    });
+    expect(capturedSearch!.get('visibility')).toBe('public');
+    expect(capturedSearch!.get('status')).toBeNull();
+  });
+
+  it('renders rows from the response with view links', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, () =>
+        HttpResponse.json({
+          agents: [
+            { ...baseAgent, id: 'lib-1', name: 'Public Alpha', description: 'Alpha desc' },
+            { ...baseAgent, id: 'lib-2', name: 'Public Beta', description: 'Beta desc' },
+          ],
+          total: 2,
+          page: 1,
+          perPage: 100,
+          hasMore: false,
+        }),
+      ),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Public Alpha')).toBeTruthy();
+    });
+    expect(screen.getByText('Public Beta')).toBeTruthy();
+
+    const rows = screen.getAllByTestId('library-agent-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].getAttribute('href')).toBe('/agent-builder/agents/lib-1/view');
+    expect(rows[1].getAttribute('href')).toBe('/agent-builder/agents/lib-2/view');
+  });
+
+  it('shows the empty state when the API returns no agents', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, () =>
+        HttpResponse.json({ agents: [], total: 0, page: 1, perPage: 100, hasMore: false }),
+      ),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No public agents yet')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('library-agent-row')).toBeNull();
+  });
+
+  it('shows the error state when the API returns 500', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, () => HttpResponse.json({ message: 'boom' }, { status: 500 })),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load the library')).toBeTruthy();
+    });
+  });
+
+  it('shows SessionExpired when the API returns 401', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/agents`, () => HttpResponse.json({ message: 'unauthorized' }, { status: 401 })),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByText('No public agents yet')).toBeNull();
+    });
+    // SessionExpired component renders "Session expired" copy by default
+    await waitFor(() => {
+      expect(screen.getByText(/session expired/i)).toBeTruthy();
+    });
+  });
+});

--- a/packages/playground/src/pages/agent-builder/library/index.tsx
+++ b/packages/playground/src/pages/agent-builder/library/index.tsx
@@ -1,0 +1,166 @@
+import type { ListStoredAgentsParams } from '@mastra/client-js';
+import {
+  EmptyState,
+  ErrorState,
+  ListSearch,
+  PageHeader,
+  PageLayout,
+  PermissionDenied,
+  SessionExpired,
+  is401UnauthorizedError,
+  is403ForbiddenError,
+} from '@mastra/playground-ui';
+import { LibraryIcon, SparklesIcon } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import {
+  AgentBuilderList,
+  AgentBuilderListSkeleton,
+} from '@/domains/agent-builder/components/agent-list/agent-builder-list';
+import {
+  SkillBuilderList,
+  SkillBuilderListSkeleton,
+} from '@/domains/agent-builder/components/skill-list/skill-builder-list';
+import { useBuilderAgentAccess } from '@/domains/agent-builder/hooks/use-builder-agent-access';
+import { useBuilderAgentFeatures } from '@/domains/agent-builder/hooks/use-builder-agent-features';
+import { useStoredAgents } from '@/domains/agents/hooks/use-stored-agents';
+import { useStoredSkills } from '@/domains/agents/hooks/use-stored-skills';
+
+type Tab = 'agents' | 'skills';
+
+export default function AgentBuilderLibraryPage() {
+  const navigate = useNavigate();
+  const [search, setSearch] = useState('');
+  const [tab, setTab] = useState<Tab>('agents');
+  const features = useBuilderAgentFeatures();
+  const { canUseFavorites } = useBuilderAgentAccess();
+
+  const agentListParams = useMemo<ListStoredAgentsParams>(() => ({ visibility: 'public' }), []);
+
+  const { data: agentsData, isLoading: agentsLoading, error: agentsError } = useStoredAgents(agentListParams);
+  const {
+    data: skillsData,
+    isLoading: skillsLoading,
+    error: skillsError,
+  } = useStoredSkills({ enabled: tab === 'skills' && features.skills });
+
+  const agents = agentsData?.agents ?? [];
+  const skills = skillsData?.skills ?? [];
+
+  const renderError = (error: Error) => {
+    if (is401UnauthorizedError(error)) {
+      return (
+        <div className="flex items-center justify-center pt-10">
+          <SessionExpired />
+        </div>
+      );
+    }
+    if (is403ForbiddenError(error)) {
+      return (
+        <div className="flex items-center justify-center pt-10">
+          <PermissionDenied resource={tab} />
+        </div>
+      );
+    }
+    return (
+      <div className="flex items-center justify-center pt-10">
+        <ErrorState title="Failed to load the library" message={error.message} />
+      </div>
+    );
+  };
+
+  const body = (() => {
+    if (tab === 'agents') {
+      if (agentsLoading) return <AgentBuilderListSkeleton rowTestId="library-skeleton-row" />;
+      if (agentsError) return renderError(agentsError);
+      if (agents.length === 0) {
+        return (
+          <div className="flex items-center justify-center pt-16">
+            <EmptyState
+              iconSlot={<LibraryIcon className="h-8 w-8 text-neutral3" />}
+              titleSlot="No public agents yet"
+              descriptionSlot="Mark an agent as Public to share it with the team library."
+            />
+          </div>
+        );
+      }
+      return (
+        <AgentBuilderList
+          agents={agents}
+          search={search}
+          rowTestId="library-agent-row"
+          showFavorites={canUseFavorites}
+        />
+      );
+    }
+
+    // Skills tab
+    if (skillsLoading) return <SkillBuilderListSkeleton />;
+    if (skillsError) return renderError(skillsError);
+    if (skills.length === 0) {
+      return (
+        <div className="flex items-center justify-center pt-16">
+          <EmptyState
+            iconSlot={<SparklesIcon className="h-8 w-8 text-neutral3" />}
+            titleSlot="No public skills yet"
+            descriptionSlot="Mark a skill as Public to share it with the team library."
+          />
+        </div>
+      );
+    }
+    return (
+      <SkillBuilderList
+        skills={skills}
+        search={search}
+        onSkillClick={skill => navigate(`/agent-builder/skills/${skill.id}/view`, { viewTransition: true })}
+        showFavorites={canUseFavorites}
+      />
+    );
+  })();
+
+  return (
+    <>
+      <PageLayout className="px-4 md:px-10">
+        <PageLayout.TopArea>
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4">
+            <PageHeader>
+              <PageHeader.Title>
+                <LibraryIcon /> Library
+              </PageHeader.Title>
+              <PageHeader.Description>
+                {tab === 'agents' ? 'Agents shared with the team library.' : 'Skills shared with the team library.'}
+              </PageHeader.Description>
+            </PageHeader>
+          </div>
+          <div className="flex items-center gap-4">
+            {features.skills && (
+              <div className="flex rounded-lg border border-border1 overflow-hidden">
+                <button
+                  onClick={() => setTab('agents')}
+                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                    tab === 'agents' ? 'bg-surface4 text-neutral6' : 'bg-surface2 text-neutral3 hover:text-neutral5'
+                  }`}
+                >
+                  Agents
+                </button>
+                <button
+                  onClick={() => setTab('skills')}
+                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                    tab === 'skills' ? 'bg-surface4 text-neutral6' : 'bg-surface2 text-neutral3 hover:text-neutral5'
+                  }`}
+                >
+                  Skills
+                </button>
+              </div>
+            )}
+            <div className="flex-1 max-w-120">
+              <ListSearch onSearch={setSearch} label="Filter library" placeholder="Filter by name or description" />
+            </div>
+          </div>
+        </PageLayout.TopArea>
+
+        {body}
+      </PageLayout>
+    </>
+  );
+}

--- a/packages/playground/src/pages/agent-builder/skills/index.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/index.tsx
@@ -1,0 +1,180 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import {
+  Button,
+  EmptyState,
+  ErrorState,
+  ListSearch,
+  PageHeader,
+  PageLayout,
+  PermissionDenied,
+  SessionExpired,
+  is401UnauthorizedError,
+  is403ForbiddenError,
+} from '@mastra/playground-ui';
+import { DownloadIcon, PlusIcon, SparklesIcon } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { toast } from 'sonner';
+import { BuilderAddSkillDialog } from '@/domains/agent-builder/components/skill-list/builder-add-skill-dialog';
+import {
+  SkillBuilderList,
+  SkillBuilderListSkeleton,
+} from '@/domains/agent-builder/components/skill-list/skill-builder-list';
+import { useBuilderRegistries } from '@/domains/agent-builder/hooks/use-builder-registries';
+import { useStoredSkills } from '@/domains/agents/hooks/use-stored-skills';
+import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+
+export default function AgentBuilderSkillsPage() {
+  const navigate = useNavigate();
+  const { isLoading: isCurrentUserLoading } = useCurrentUser();
+  const { hasPermission, rbacEnabled } = usePermissions();
+  const canWriteSkills = !rbacEnabled || hasPermission('stored-skills:write');
+  const canReadSkills = !rbacEnabled || hasPermission('stored-skills:read');
+  const [registryDialog, setRegistryDialog] = useState<{ id: string; label: string } | null>(null);
+
+  const goToCreate = () => navigate('/agent-builder/skills/create', { viewTransition: true });
+  const goToEdit = (skillId: string) => navigate(`/agent-builder/skills/${skillId}/edit`, { viewTransition: true });
+
+  const { data, isLoading, error } = useStoredSkills({ enabled: !isCurrentUserLoading });
+  const [search, setSearch] = useState('');
+
+  const skills = useMemo(() => data?.skills ?? [], [data?.skills]);
+  const installedSkillIds = useMemo(() => skills.map(s => s.id), [skills]);
+
+  // Surface registry browse only for users who can read AND write skills, and
+  // only when at least one registry is actually enabled. This is the gate
+  // requested in COR-832: invisible when there's nothing useful to do.
+  const { data: registriesData } = useBuilderRegistries({ enabled: canReadSkills && canWriteSkills });
+  const enabledRegistry = useMemo(() => registriesData?.registries.find(r => r.enabled) ?? null, [registriesData]);
+
+  const handleSkillClick = (skill: StoredSkillResponse) => {
+    void goToEdit(skill.id);
+  };
+
+  const body = (() => {
+    if (isCurrentUserLoading || isLoading) {
+      return <SkillBuilderListSkeleton />;
+    }
+
+    if (error) {
+      if (is401UnauthorizedError(error)) {
+        return (
+          <div className="flex items-center justify-center pt-10">
+            <SessionExpired />
+          </div>
+        );
+      }
+      if (is403ForbiddenError(error)) {
+        return (
+          <div className="flex items-center justify-center pt-10">
+            <PermissionDenied resource="skills" />
+          </div>
+        );
+      }
+      return (
+        <div className="flex items-center justify-center pt-10">
+          <ErrorState title="Failed to load skills" message={error.message} />
+        </div>
+      );
+    }
+
+    if (skills.length === 0) {
+      return (
+        <div className="flex items-center justify-center pt-16">
+          <EmptyState
+            iconSlot={<SparklesIcon className="h-8 w-8 text-neutral3" />}
+            titleSlot="No skills yet"
+            descriptionSlot="Create your first skill to give agents new capabilities."
+            actionSlot={
+              canWriteSkills ? (
+                <div className="flex items-center gap-2">
+                  <Button variant="primary" onClick={goToCreate}>
+                    <PlusIcon /> New skill
+                  </Button>
+                  {enabledRegistry && (
+                    <Button
+                      variant="default"
+                      onClick={() => setRegistryDialog({ id: enabledRegistry.id, label: enabledRegistry.label })}
+                    >
+                      <DownloadIcon /> Browse registry
+                    </Button>
+                  )}
+                </div>
+              ) : undefined
+            }
+          />
+        </div>
+      );
+    }
+
+    return <SkillBuilderList skills={skills} search={search} onSkillClick={handleSkillClick} />;
+  })();
+
+  return (
+    <>
+      <PageLayout className="px-4 md:px-10">
+        <PageLayout.TopArea>
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-4">
+            <PageHeader>
+              <PageHeader.Title>
+                <SparklesIcon /> My skills
+              </PageHeader.Title>
+              <PageHeader.Description>Skills you've created.</PageHeader.Description>
+            </PageHeader>
+            {skills.length > 0 && canWriteSkills && (
+              <div className="w-full shrink-0 flex flex-col items-stretch gap-2 md:w-auto md:flex-row md:items-center">
+                {enabledRegistry && (
+                  <Button
+                    variant="default"
+                    className="w-full justify-center md:w-auto"
+                    onClick={() => setRegistryDialog({ id: enabledRegistry.id, label: enabledRegistry.label })}
+                  >
+                    <DownloadIcon /> Browse registry
+                  </Button>
+                )}
+                <Button variant="primary" className="w-full justify-center md:w-auto" onClick={goToCreate}>
+                  <PlusIcon /> New skill
+                </Button>
+              </div>
+            )}
+          </div>
+          <div className="max-w-120">
+            <ListSearch onSearch={setSearch} label="Filter skills" placeholder="Filter by name or description" />
+          </div>
+        </PageLayout.TopArea>
+
+        {body}
+      </PageLayout>
+
+      {registryDialog && (
+        <BuilderAddSkillDialog
+          open={!!registryDialog}
+          onOpenChange={open => {
+            if (!open) setRegistryDialog(null);
+          }}
+          registryId={registryDialog.id}
+          registryLabel={registryDialog.label}
+          installedSkillIds={installedSkillIds}
+          onInstalled={storedSkillId => {
+            const installed = skills.find(s => s.id === storedSkillId);
+            toast.success(installed ? `Imported "${installed.name}"` : 'Skill imported');
+          }}
+          onCollision={skillName => {
+            const existing = skills.find(s => s.id === skillName || s.name === skillName);
+            if (existing) {
+              toast.error(`"${existing.name}" is already in your library`, {
+                action: {
+                  label: 'Open existing',
+                  onClick: () => goToEdit(existing.id),
+                },
+              });
+            } else {
+              toast.error(`A skill named "${skillName}" already exists.`);
+            }
+          }}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Incremental split from the large `yj/magnificent-marquess` branch (576 files). This PR introduces only the Agent Builder **left-sidebar pages** and their direct dependencies, so subsequent PRs can layer the create/edit/view flows on top with a manageable review surface.

What it adds:

- **Pages** (`packages/playground/src/pages/agent-builder/`):
  - Root index redirect
  - `agents/` — My agents listing
  - `skills/` — Skills listing
  - `favorite/` — Favorites split view (agents + skills)
  - `library/` — Public library split view (agents + skills)
  - `infrastructure/` — Channels / Browser / Registries status
- **Domain code** (`packages/playground/src/domains/agent-builder/`):
  - `layouts/agent-builder-root-layout.tsx` (+ tests)
  - `components/agent-list/*` and `components/skill-list/*` (+ tests)
  - Hooks: `use-builder-registries`, `use-stored-agent-favorite`, `use-stored-skill-favorite`, `use-infrastructure-status`, `use-builder-filtered-models`
  - Utils: `is-model-not-allowed`, `skill-origin`
- **Adjacent**:
  - `domains/auth/context/role-impersonation-context.tsx` + `hooks/use-role-impersonation.ts`
  - `domains/auth/hooks/use-permissions.ts` — extended to merge impersonated permissions
  - `domains/agents/hooks/use-stored-agents.ts` — adds `enabled` query option (needed by list pages that gate fetches behind tab/permission state)

## Important: nothing is wired into `App.tsx`

The pages compile, have passing tests, but are **unreachable at runtime** until a follow-up PR adds the routes. This is intentional — it keeps the diff small and additive while still giving reviewers concrete code to assess.

Confirmed: `grep -E "agent-builder" packages/playground/src/App.tsx` returns nothing.

## Deferred to follow-up PRs

- Wiring routes into `App.tsx`
- `nav-items.tsx` permission-field cleanup (coupled to `app-sidebar.tsx` + `route-permissions.ts` refactor — belongs with the routing PR to avoid silently disabling sidebar permission filtering)
- `agents/{create,edit,view}.tsx` and `skills/{create,edit,view}.tsx` page implementations
- `agent-starter`, `skill-starter`, `agent-view`, `agent-edit`, `skill-edit`, and chat-primitives
- Changes in `packages/agent-builder`, `packages/core`, `packages/editor`, `client-sdks/*`
- Docs under `docs/src/content/en/docs/agent-builder/*`

## Test plan

- [x] `pnpm --filter ./packages/playground typecheck` — clean
- [x] `pnpm --filter ./packages/playground exec vitest run pages/agent-builder domains/agent-builder/components/agent-list domains/agent-builder/layouts` — 36 tests / 8 files pass
- [x] `git diff --stat origin/main..HEAD` — 33 files / +3735 / −10, confined to expected paths
- [x] No `App.tsx` changes
- [x] Changeset added (`@mastra/playground` patch)

## Stats

| | |
|---|---|
| Original branch | `yj/magnificent-marquess` — 576 files, ~47k+/10k− |
| This PR | 33 files / +3735 / −10 |
| Reduction | ~94% file count |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds the UI pages, components, hooks, and utilities needed for an "Agent Builder" sidebar feature so users can browse and manage agents, skills, favorites, and infrastructure — everything is implemented and tested but not yet reachable because routes will be wired in a follow-up PR.

## Overview

Scaffolds Agent Builder sidebar pages and domain code for the playground package. The PR introduces ~33 files (+3735/−10) focused on pages, components, hooks, and utilities for managing agents, skills, and builder infrastructure. Changes are limited to packages/playground/src/ and do not modify App.tsx, ensuring new code compiles and is tested but remains unreachable at runtime until routes are wired in a follow-up.

## Pages Added

Six new Agent Builder pages under packages/playground/src/pages/agent-builder/:

- agents/index.tsx — My agents listing page with search, favorites visibility, and create/new buttons; filters by current user's authorId and shows empty/error states.
- skills/index.tsx — Skills listing page with registry browsing (permission-gated) and search; conditionally loads registries when feature is enabled and user has read/write access.
- favorite/index.tsx — Split-view favorites page with two tabs for favorited agents and favorited skills; tab visibility depends on feature flags.
- library/index.tsx — Public library split-view page displaying public agents and public skills; includes tab switching and feature-gated skills support.
- infrastructure/index.tsx — Infrastructure/configuration status page showing channels, browser, registries, and workspace details with status indicators; permission-gated via infrastructure:read.

All pages handle loading, error (401/403/5xx), and empty states; fetch/filter data via custom hooks; and support search filtering where applicable.

## Domain Components Added

Agent List (agent-builder/components/agent-list/)
- agent-builder-list.tsx — AgentBuilderList component rendering agent rows with avatar, name, description, private-visibility lock icon (tooltip), optional favorite controls; AgentBuilderListSkeleton for loading. Filters by case-insensitive search on name/description.
- favorite-button.tsx — FavoriteButton component for toggling agent favorites, showing star count badge, disabled for unauthenticated users or when feature is disabled, with sign-in prompts and proper aria labels.

Skill List (agent-builder/components/skill-list/)
- skill-builder-list.tsx — SkillBuilderList component displaying skill rows with name, private-visibility lock, origin badge (tooltips), optional favorite buttons; supports click handlers and includes SkillBuilderListSkeleton.
- skill-favorite-button.tsx — SkillFavoriteButton component for toggling skill favorites with sign-in state handling and optional count badge.
- builder-add-skill-dialog.tsx — Dialog for browsing registry skills, debounced search, markdown preview, and installing into the local library; handles 409 collisions and shows errors.
- copy-skill-dialog.tsx — Dialog for copying a skill with suggested name generation and collision validation.

Layouts (agent-builder/layouts/)
- agent-builder-root-layout.tsx — Root layout that gates access with auth capability checks, redirects to login when appropriate, shows permission/configuration guards and error/disabled states, and wraps Outlet with TooltipProvider/LinkComponentProvider; includes an AccessDeniedScreen with impersonation-exit support.

## Hooks Added

Agent/Skill Favorites
- use-stored-agent-favorite.ts — useToggleStoredAgentFavorite(agentId) mutation hook with optimistic updates, rollback, and list/detail cache patching/invalidation.
- use-stored-skill-favorite.ts — useToggleStoredSkillFavorite(skillId) with similar optimistic-update patterns for skills.

Builder Infrastructure & Registries
- use-builder-registries.ts — React Query hooks for /editor/builder/registries/*: list registries, search within registry, popular skills feed, registry skill preview, and install registry skill.
- use-infrastructure-status.ts — useInfrastructureStatus() querying infrastructure configuration/resolution status (retry disabled, optional enabled flag).

Model Filtering
- use-builder-filtered-models.ts — useBuilderFilteredProviders and useBuilderFilteredModels to memoize filtering providers/models by BuilderModelPolicy, returning allowed subsets.

Import Path Updates
- use-builder-agent-access.ts and use-builder-agent-features.ts — import path adjustments to `@/`... alias.

## Auth & Permissions

Role Impersonation Context (auth/context/role-impersonation-context.tsx)
- RoleImpersonationContext, RoleImpersonationProvider, and useRoleImpersonation to support "View as role" flows: startImpersonation triggers a permissions fetch and stores impersonated role + permissions; stopImpersonation clears it. The permissions fetch helper was moved to a dedicated service and provider value memoized (per commit notes).

Permissions Hook Updates (auth/hooks/use-permissions.ts)
- usePermissions now incorporates impersonation via useRoleImpersonation; RBAC bypass only applies when not impersonating. hasAllPermissions, hasAnyPermission, and hasRole updated accordingly.

Auth Barrel Export (auth/hooks/use-role-impersonation.ts)
- Re-exports useRoleImpersonation and RoleImpersonationState for convenience.

## Utilities Added

- is-model-not-allowed.ts — isModelNotAllowedError(error) detects model-not-allowed errors by code and returns a message or null.
- skill-origin.ts — getSkillOrigin(), formatSkillOriginLabel(), and getSkillOriginUrl() helpers to interpret stored-skill metadata origins (skills-sh, library-copy, etc.).

## Agent Hook Update

- use-stored-agents.ts — Added options?: { enabled?: boolean } parameter so callers can disable the query when desired.

## Tests Added

Comprehensive Vitest + React Testing Library + MSW coverage across pages/domains (36 tests across 8+ files):

- AgentBuilderList tests: icon/tooltip rendering, search filtering, row links, empty states, skeleton behavior.
- FavoriteButton tests: count/pluralization, authenticated/unauthenticated behavior, PUT/DELETE toggle requests, disabled sign-in state.
- AgentBuilderRootLayout tests: auth redirect with encoded path, permission guards, config error states, impersonation exit button.
- RoleImpersonationProvider tests: successful/failing impersonation flows, isSwitching transitions, URL/header handling, fallback no-op outside provider.
- AgentBuilderAgentsPage tests: authorId filtering based on current user, pending-state suppression of agent list requests, 401/403 handling.
- AgentBuilderFavoritePage tests: favoritedOnly=true query param, row hrefs/counts, empty/error states.
- AgentBuilderLibraryPage tests: visibility=public query param, row hrefs, empty/error/session-expired states.
- Role permissions fixtures: admin/viewer permission sets for tests.

All tests mock auth capabilities, builder settings, and API endpoints via MSW and verify query parameters, request behavior, and UI transitions.

## Verification

- Typecheck clean for packages/playground.
- 36 tests passing via Vitest across the new pages/domains code.
- Changeset added for `@mastra/playground`.
- Diff confirmed limited to expected playground paths; App.tsx not modified.

## Deferred to Follow-ups

- Wiring routes into App.tsx to make pages reachable.
- Sidebar permission-field cleanup tied to routing refactor.
- Implementations for agents/{create,edit,view}.tsx and skills/{create,edit,view}.tsx.
- Additional package and documentation changes as listed in the PR description.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->