### PR TITLE
feat(playground): add skill create/edit/view pages (no route wiring)

### DIFF
--- a/.changeset/skill-pages.md
+++ b/.changeset/skill-pages.md
@@ -1,0 +1,6 @@
+---
+'@mastra/client-js': patch
+'@internal/playground': patch
+---
+
+Add skill create, edit, and view pages to the Agent Builder playground, plus matching `StoredSkill.favorite()`/`unfavorite()` methods on `@mastra/client-js`. The pages and supporting components ship as importable modules; router wiring lands in a follow-up.

--- a/.changeset/skill-pages.md
+++ b/.changeset/skill-pages.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/client-js': patch
-'@internal/playground': patch
 ---
 
-Add skill create, edit, and view pages to the Agent Builder playground, plus matching `StoredSkill.favorite()`/`unfavorite()` methods on `@mastra/client-js`. The pages and supporting components ship as importable modules; router wiring lands in a follow-up.
+Add `StoredSkill.favorite()` and `StoredSkill.unfavorite()` methods, mirroring the existing `StoredAgent` favorite API. Both are idempotent and call `PUT`/`DELETE /api/stored/skills/:id/favorite`.

--- a/client-sdks/client-js/src/resources/stored-skill.test.ts
+++ b/client-sdks/client-js/src/resources/stored-skill.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, beforeEach, it, vi } from 'vitest';
+import { MastraClient } from '../client';
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+describe('StoredSkill Resource', () => {
+  let client: MastraClient;
+  const clientOptions = {
+    baseUrl: 'http://localhost:4111',
+    headers: {
+      Authorization: 'Bearer test-key',
+      'x-mastra-client-type': 'js',
+    },
+  };
+
+  // Helper to mock successful API responses
+  const mockFetchResponse = (data: any) => {
+    const response = new Response(undefined, {
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({
+        'Content-Type': 'application/json',
+      }),
+    });
+    response.json = () => Promise.resolve(data);
+    (global.fetch as any).mockResolvedValueOnce(response);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new MastraClient(clientOptions);
+  });
+
+  describe('Favorites', () => {
+    const storedSkillId = 'skill-1';
+
+    it('should favorite the skill via PUT /favorite', async () => {
+      const mockResponse = { favorited: true, favoriteCount: 3 };
+      mockFetchResponse(mockResponse);
+
+      const storedSkill = client.getStoredSkill(storedSkillId);
+      const result = await storedSkill.favorite();
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/skills/${storedSkillId}/favorite`,
+        expect.objectContaining({
+          method: 'PUT',
+        }),
+      );
+    });
+
+    it('should unfavorite the skill via DELETE /favorite', async () => {
+      const mockResponse = { favorited: false, favoriteCount: 2 };
+      mockFetchResponse(mockResponse);
+
+      const storedSkill = client.getStoredSkill(storedSkillId);
+      const result = await storedSkill.unfavorite();
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/skills/${storedSkillId}/favorite`,
+        expect.objectContaining({
+          method: 'DELETE',
+        }),
+      );
+    });
+
+    it('should encode special characters in skill id when favoriting', async () => {
+      const specialId = 'skill/with/slashes';
+      const encodedId = encodeURIComponent(specialId);
+      mockFetchResponse({ favorited: true, favoriteCount: 1 });
+
+      await client.getStoredSkill(specialId).favorite();
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${clientOptions.baseUrl}/api/stored/skills/${encodedId}/favorite`,
+        expect.objectContaining({ method: 'PUT' }),
+      );
+    });
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/autosave-indicator.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/autosave-indicator.tsx
@@ -1,0 +1,47 @@
+import { Spinner } from '@mastra/playground-ui';
+import { CheckIcon } from 'lucide-react';
+import type { AutosaveStatus } from '@/domains/agent-builder/hooks/use-autosave-agent';
+
+interface AutosaveIndicatorProps {
+  status: AutosaveStatus;
+  lastError: Error | null;
+  onRetry: () => void;
+}
+
+export const AutosaveIndicator = ({ status, lastError, onRetry }: AutosaveIndicatorProps) => {
+  if (status === 'saving') {
+    return (
+      <span className="flex items-center gap-1.5 text-ui-sm text-neutral3" data-testid="agent-builder-autosave-saving">
+        <Spinner size="sm" />
+        Saving…
+      </span>
+    );
+  }
+
+  if (status === 'saved') {
+    return (
+      <span className="flex items-center gap-1.5 text-ui-sm text-neutral3" data-testid="agent-builder-autosave-saved">
+        <CheckIcon className="h-3.5 w-3.5" />
+        Saved
+      </span>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <span className="flex items-center gap-1.5 text-ui-sm text-neutral3" data-testid="agent-builder-autosave-error">
+        <span title={lastError?.message}>Failed to save</span>
+        <button
+          type="button"
+          onClick={onRetry}
+          data-testid="agent-builder-autosave-retry"
+          className="underline underline-offset-2 hover:text-neutral4"
+        >
+          Retry
+        </button>
+      </span>
+    );
+  }
+
+  return null;
+};

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/chat-composer.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/chat-composer.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { TooltipProvider } from '@mastra/playground-ui';
+import { cleanup, render } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AgentColorProvider } from '../../../contexts/agent-color-context';
+import type { AgentBuilderEditFormValues } from '../../../schemas';
+
+import { ChatComposer } from '../chat-composer';
+
+const noop = () => {};
+
+interface RenderOptions {
+  agentId?: string;
+}
+
+const FormHarness = ({ agentId = 'agent_test', children }: { agentId?: string; children: React.ReactNode }) => {
+  const methods = useForm<AgentBuilderEditFormValues>({
+    defaultValues: {} as AgentBuilderEditFormValues,
+  });
+  return (
+    <FormProvider {...methods}>
+      <AgentColorProvider agentId={agentId}>{children}</AgentColorProvider>
+    </FormProvider>
+  );
+};
+
+const renderComposer = (
+  props: Partial<React.ComponentProps<typeof ChatComposer>> = {},
+  { agentId = 'agent_test' }: RenderOptions = {},
+) =>
+  render(
+    <TooltipProvider>
+      <FormHarness agentId={agentId}>
+        <ChatComposer
+          draft=""
+          onDraftChange={noop}
+          onSubmit={e => e.preventDefault()}
+          onKeyDown={noop}
+          disabled={false}
+          canSubmit={true}
+          inputTestId="composer-input"
+          submitTestId="composer-submit"
+          containerTestId="composer-container"
+          {...props}
+        />
+      </FormHarness>
+    </TooltipProvider>,
+  );
+
+describe('ChatComposer', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows Send tooltip and no spinner when not running', () => {
+    const { getByTestId } = renderComposer({ isRunning: false });
+    const submit = getByTestId('composer-submit');
+    expect(submit.getAttribute('aria-label')).toBe('Send');
+    expect(submit.querySelector('.animate-spin')).toBeNull();
+  });
+
+  it('shows spinner and Generating tooltip when running, with disabled textarea + submit', () => {
+    const { getByTestId } = renderComposer({
+      isRunning: true,
+      disabled: true,
+      canSubmit: false,
+    });
+    const submit = getByTestId('composer-submit');
+    const textarea = getByTestId('composer-input') as HTMLTextAreaElement;
+
+    expect(submit.getAttribute('aria-label')).toBe('Generating…');
+    expect(submit.querySelector('.animate-spin')).not.toBeNull();
+    expect(submit.hasAttribute('disabled')).toBe(true);
+    expect(textarea.disabled).toBe(true);
+  });
+
+  it('applies agent-color CSS variables to the composer container derived from the agentId', () => {
+    const { getByTestId } = renderComposer({}, { agentId: 'agent_support' });
+    const container = getByTestId('composer-container') as HTMLDivElement;
+    expect(container.style.getPropertyValue('--agent-color-fg')).toMatch(/^hsl\(/);
+    expect(container.style.getPropertyValue('--agent-color-bg')).toMatch(/^hsl\(/);
+    expect(container.className).toContain('border-border1');
+    expect(container.className).toContain('focus-within:border-[var(--agent-color-bg)]');
+    expect(container.className).not.toContain('focus-within:ring');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/message-list.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/message-list.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import type { MastraUIMessage } from '@mastra/react';
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MessageList } from '../message-list';
+
+const buildAssistantMessage = (parts: MastraUIMessage['parts']): MastraUIMessage => ({
+  id: 'msg-1',
+  role: 'assistant',
+  parts,
+});
+
+describe('MessageList pending indicator', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows the pending indicator while running with no messages', () => {
+    const { queryByTestId } = render(<MessageList messages={[]} isRunning={true} />);
+    expect(queryByTestId('agent-builder-chat-pending')).not.toBeNull();
+  });
+
+  it('does not show the pending indicator when not running', () => {
+    const { queryByTestId } = render(<MessageList messages={[]} isRunning={false} />);
+    expect(queryByTestId('agent-builder-chat-pending')).toBeNull();
+  });
+
+  it('hides the pending indicator when the last assistant message has a streaming reasoning part', () => {
+    const messages: MastraUIMessage[] = [
+      buildAssistantMessage([
+        {
+          type: 'reasoning',
+          state: 'streaming',
+          text: 'thinking',
+        } as MastraUIMessage['parts'][number],
+      ]),
+    ];
+    const { queryByTestId } = render(<MessageList messages={messages} isRunning={true} />);
+    expect(queryByTestId('agent-builder-chat-pending')).toBeNull();
+  });
+
+  it('shows the pending indicator after a user message while waiting for the assistant', () => {
+    const messages: MastraUIMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'hello', state: 'done' } as MastraUIMessage['parts'][number]],
+      },
+    ];
+    const { queryByTestId } = render(<MessageList messages={messages} isRunning={true} />);
+    expect(queryByTestId('agent-builder-chat-pending')).not.toBeNull();
+  });
+
+  it('does not show the pending indicator while the initial skeleton is rendered', () => {
+    const { queryByTestId } = render(<MessageList messages={[]} isRunning={true} isLoading={true} />);
+    expect(queryByTestId('agent-builder-chat-pending')).toBeNull();
+  });
+});
+
+describe('MessageList deferred skeleton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it('does not render the skeleton during the 300ms grace period', () => {
+    const { queryByTestId } = render(<MessageList messages={[]} isLoading={true} skeletonTestId="msg-skeleton" />);
+    expect(queryByTestId('msg-skeleton')).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(queryByTestId('msg-skeleton')).toBeNull();
+  });
+
+  it('renders the skeleton after the 300ms grace period elapses', () => {
+    const { queryByTestId } = render(<MessageList messages={[]} isLoading={true} skeletonTestId="msg-skeleton" />);
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(queryByTestId('msg-skeleton')).not.toBeNull();
+  });
+
+  it('never shows the skeleton if data resolves within the grace period', () => {
+    const { queryByTestId, rerender } = render(
+      <MessageList messages={[]} isLoading={true} skeletonTestId="msg-skeleton" />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    const messages: MastraUIMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'hi', state: 'done' } as MastraUIMessage['parts'][number]],
+      },
+    ];
+    rerender(<MessageList messages={messages} isLoading={false} skeletonTestId="msg-skeleton" />);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(queryByTestId('msg-skeleton')).toBeNull();
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/messages.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/__tests__/messages.test.tsx
@@ -1,0 +1,423 @@
+// @vitest-environment jsdom
+import type { MastraUIMessage } from '@mastra/react';
+import { cleanup, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MessageRow } from '../messages';
+import type { AgentBuilderEditFormValues } from '@/domains/agent-builder/schemas';
+import {
+  SET_AGENT_BROWSER_ENABLED_TOOL_NAME,
+  SET_AGENT_DESCRIPTION_TOOL_NAME,
+  SET_AGENT_INSTRUCTIONS_TOOL_NAME,
+  SET_AGENT_MODEL_TOOL_NAME,
+  SET_AGENT_NAME_TOOL_NAME,
+  SET_AGENT_SKILLS_TOOL_NAME,
+  SET_AGENT_TOOLS_TOOL_NAME,
+  SET_AGENT_WORKSPACE_ID_TOOL_NAME,
+} from '@/domains/agent-builder/services/tool-constants';
+
+type ToolPart = MastraUIMessage['parts'][number];
+
+interface PrimitivesMock {
+  agentId: string;
+  toolsData: Record<string, { description?: string }>;
+  agentsData: Record<string, { name?: string; description?: string }>;
+  workflowsData: Record<string, { name?: string; description?: string }>;
+  availableSkills: { id: string; name: string }[];
+}
+
+let primitivesMock: PrimitivesMock = {
+  agentId: 'agent-1',
+  toolsData: {},
+  agentsData: {},
+  workflowsData: {},
+  availableSkills: [],
+};
+
+vi.mock('../../../contexts/agent-primitives-context', () => ({
+  useAgentPrimitives: () => primitivesMock,
+}));
+
+vi.mock('../../../../agent-builder', () => ({
+  useBuilderPickerVisibility: () => ({
+    visibleTools: null,
+    visibleAgents: null,
+    visibleWorkflows: null,
+  }),
+}));
+
+const FormWrapper = ({
+  children,
+  defaultValues,
+}: {
+  children: ReactNode;
+  defaultValues?: Partial<AgentBuilderEditFormValues>;
+}) => {
+  const methods = useForm<AgentBuilderEditFormValues>({
+    defaultValues: { name: '', description: '', instructions: '', ...defaultValues },
+  });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+const renderRow = (parts: ToolPart[], defaultValues?: Partial<AgentBuilderEditFormValues>) =>
+  render(
+    <FormWrapper defaultValues={defaultValues}>
+      <MessageRow message={buildMessage(parts)} />
+    </FormWrapper>,
+  );
+
+const buildMessage = (parts: MastraUIMessage['parts']): MastraUIMessage => ({
+  id: 'msg-1',
+  role: 'assistant',
+  parts,
+});
+
+describe('MessageRow dynamic-tool rendering', () => {
+  beforeEach(() => {
+    primitivesMock = {
+      agentId: 'agent-1',
+      toolsData: {},
+      agentsData: {},
+      workflowsData: {},
+      availableSkills: [],
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the generic shimmer for non-builder dynamic tools', () => {
+    const { container } = renderRow([
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'call-5',
+        toolName: 'some-other-tool',
+        state: 'output-available',
+        input: { tools: [{ id: 'web-search', name: 'Web Search' }] },
+        output: { success: true },
+      } as ToolPart,
+    ]);
+
+    // Unknown dynamic tools render as a GenericTool ToolCard showing "Executing <toolName>".
+    expect(container.textContent).toContain('Executing');
+    expect(container.textContent).toContain('some-other-tool');
+    expect(container.textContent).not.toContain('Web Search');
+  });
+
+  it('renders MessageSetAgentName for streaming dynamic-tool', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-name',
+          toolName: SET_AGENT_NAME_TOOL_NAME,
+          state: 'output-available',
+          input: { name: 'Acme Bot' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { name: 'Acme Bot' },
+    );
+    expect(container.textContent).toContain('Setting the agent name:');
+    expect(container.textContent).toContain('Acme Bot');
+  });
+
+  it('renders MessageSetAgentName for persisted tool part', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: `tool-${SET_AGENT_NAME_TOOL_NAME}`,
+          toolCallId: 'call-name-r',
+          state: 'output-available',
+          input: { name: 'Acme Bot' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { name: 'Acme Bot' },
+    );
+    expect(container.textContent).toContain('Setting the agent name:');
+    expect(container.textContent).toContain('Acme Bot');
+  });
+
+  it('renders MessageSetAgentDescription for streaming dynamic-tool', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-desc',
+          toolName: SET_AGENT_DESCRIPTION_TOOL_NAME,
+          state: 'output-available',
+          input: { description: 'A helpful research assistant.' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { description: 'A helpful research assistant.' },
+    );
+    expect(container.textContent).toContain('Setting the agent description:');
+    expect(container.textContent).toContain('A helpful research assistant.');
+  });
+
+  it('renders MessageSetAgentDescription for persisted tool part', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: `tool-${SET_AGENT_DESCRIPTION_TOOL_NAME}`,
+          toolCallId: 'call-desc-r',
+          state: 'output-available',
+          input: { description: 'A helpful research assistant.' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { description: 'A helpful research assistant.' },
+    );
+    expect(container.textContent).toContain('Setting the agent description:');
+    expect(container.textContent).toContain('A helpful research assistant.');
+  });
+
+  it('renders MessageSetAgentInstructions for streaming dynamic-tool', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-instr',
+          toolName: SET_AGENT_INSTRUCTIONS_TOOL_NAME,
+          state: 'output-available',
+          input: { instructions: 'Always answer in French.' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { instructions: 'Always answer in French.' },
+    );
+    expect(container.textContent).toContain('Setting the agent instructions:');
+    expect(container.textContent).toContain('Always answer in French.');
+  });
+
+  it('renders MessageSetAgentInstructions for persisted tool part', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: `tool-${SET_AGENT_INSTRUCTIONS_TOOL_NAME}`,
+          toolCallId: 'call-instr-r',
+          state: 'output-available',
+          input: { instructions: 'Always answer in French.' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { instructions: 'Always answer in French.' },
+    );
+    expect(container.textContent).toContain('Setting the agent instructions:');
+    expect(container.textContent).toContain('Always answer in French.');
+  });
+
+  it('MessageSetAgentTools shows only the checked tools/agents/workflows from the form', () => {
+    primitivesMock = {
+      ...primitivesMock,
+      toolsData: { 'web-search': { description: 'Search' } },
+      agentsData: { 'my-agent': { name: 'My Agent' } },
+      workflowsData: { 'my-workflow': { name: 'My Workflow' } },
+    };
+
+    const { container } = renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-tools-mixed',
+          toolName: SET_AGENT_TOOLS_TOOL_NAME,
+          state: 'output-available',
+          input: { tools: [] },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      {
+        tools: {},
+        agents: { 'my-agent': true },
+        workflows: { 'my-workflow': true },
+      } as Partial<AgentBuilderEditFormValues>,
+    );
+
+    const text = container.textContent ?? '';
+    expect(text).toContain('Enabling tools:');
+    expect(text).toContain('My Agent');
+    expect(text).toContain('My Workflow');
+    expect(text).not.toContain('web-search');
+  });
+
+  it('MessageSetAgentTools renders "none" when nothing is selected', () => {
+    primitivesMock = {
+      ...primitivesMock,
+      toolsData: { 'web-search': { description: 'Search' } },
+    };
+
+    const { container } = renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-tools-none',
+          toolName: SET_AGENT_TOOLS_TOOL_NAME,
+          state: 'output-available',
+          input: { tools: [] },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { tools: {}, agents: {}, workflows: {} } as Partial<AgentBuilderEditFormValues>,
+    );
+
+    expect(container.textContent).toContain('Enabling tools: none');
+  });
+
+  it('MessageSetAgentSkills shows only the checked skills from the form', () => {
+    primitivesMock = {
+      ...primitivesMock,
+      availableSkills: [
+        { id: 'sk-1', name: 'Summarize' },
+        { id: 'sk-2', name: 'Translate' },
+      ],
+    };
+
+    const { container } = renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-skills',
+          toolName: SET_AGENT_SKILLS_TOOL_NAME,
+          state: 'output-available',
+          input: { skills: [] },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { skills: { 'sk-1': true, 'sk-2': true } } as Partial<AgentBuilderEditFormValues>,
+    );
+
+    expect(container.textContent).toContain('Enabling skills:');
+    expect(container.textContent).toContain('Summarize');
+    expect(container.textContent).toContain('Translate');
+  });
+
+  it('MessageSetAgentSkills renders "none" when no skill is checked', () => {
+    primitivesMock = {
+      ...primitivesMock,
+      availableSkills: [{ id: 'sk-1', name: 'Summarize' }],
+    };
+
+    const { container } = renderRow(
+      [
+        {
+          type: `tool-${SET_AGENT_SKILLS_TOOL_NAME}`,
+          toolCallId: 'call-skills-none',
+          state: 'output-available',
+          input: { skills: [] },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { skills: {} } as Partial<AgentBuilderEditFormValues>,
+    );
+
+    expect(container.textContent).toContain('Enabling skills: none');
+  });
+
+  it('renders MessageSetAgentModel for streaming dynamic-tool', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-model',
+          toolName: SET_AGENT_MODEL_TOOL_NAME,
+          state: 'output-available',
+          input: { model: { provider: 'openai', name: 'gpt-4o' } },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { model: { provider: 'openai', name: 'gpt-4o' } },
+    );
+    expect(container.textContent).toContain('Setting agent model to');
+    expect(container.textContent).toContain('openai/gpt-4o');
+  });
+
+  it('renders MessageSetAgentModel for persisted tool part', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: `tool-${SET_AGENT_MODEL_TOOL_NAME}`,
+          toolCallId: 'call-model-r',
+          state: 'output-available',
+          input: { model: { provider: 'openai', name: 'gpt-4o' } },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { model: { provider: 'openai', name: 'gpt-4o' } },
+    );
+    expect(container.textContent).toContain('Setting agent model to');
+    expect(container.textContent).toContain('openai/gpt-4o');
+  });
+
+  it('renders MessageSetAgentBrowserEnabled (enabled) for streaming dynamic-tool', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-browser',
+          toolName: SET_AGENT_BROWSER_ENABLED_TOOL_NAME,
+          state: 'output-available',
+          input: { browserEnabled: true },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { browserEnabled: true },
+    );
+    expect(container.textContent).toContain('Browser access');
+    expect(container.textContent).toContain('enabled');
+  });
+
+  it('renders MessageSetAgentBrowserEnabled (disabled) for persisted tool part', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: `tool-${SET_AGENT_BROWSER_ENABLED_TOOL_NAME}`,
+          toolCallId: 'call-browser-r',
+          state: 'output-available',
+          input: { browserEnabled: false },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { browserEnabled: false },
+    );
+    expect(container.textContent).toContain('Browser access');
+    expect(container.textContent).toContain('disabled');
+  });
+
+  it('renders MessageSetAgentWorkspaceId for streaming dynamic-tool', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-ws',
+          toolName: SET_AGENT_WORKSPACE_ID_TOOL_NAME,
+          state: 'output-available',
+          input: { workspaceId: 'ws-123' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { workspaceId: 'ws-123' },
+    );
+    expect(container.textContent).toContain('ws-123');
+  });
+
+  it('renders MessageSetAgentWorkspaceId for persisted tool part', () => {
+    const { container } = renderRow(
+      [
+        {
+          type: `tool-${SET_AGENT_WORKSPACE_ID_TOOL_NAME}`,
+          toolCallId: 'call-ws-r',
+          state: 'output-available',
+          input: { workspaceId: 'ws-123' },
+          output: { success: true },
+        } as ToolPart,
+      ],
+      { workspaceId: 'ws-123' },
+    );
+    expect(container.textContent).toContain('ws-123');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/chat-composer.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/chat-composer.tsx
@@ -1,0 +1,83 @@
+import { Button } from '@mastra/playground-ui';
+import { ArrowUpIcon, Loader2 } from 'lucide-react';
+import type { CSSProperties } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import { useAgentColor } from '../../contexts/agent-color-context';
+import { ChatTextarea } from './chat-textarea';
+
+interface ChatComposerProps {
+  draft: string;
+  onDraftChange: (value: string) => void;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  disabled: boolean;
+  canSubmit: boolean;
+  isRunning?: boolean;
+  placeholder?: string;
+  inputTestId?: string;
+  submitTestId?: string;
+  containerTestId?: string;
+}
+
+export const ChatComposer = ({
+  draft,
+  onDraftChange,
+  onSubmit,
+  onKeyDown,
+  disabled,
+  canSubmit,
+  isRunning = false,
+  placeholder = 'Ask a follow-up…',
+  inputTestId,
+  submitTestId,
+  containerTestId,
+}: ChatComposerProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const agentColor = useAgentColor();
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const containerStyle = useMemo<CSSProperties>(
+    () => ({
+      viewTransitionName: 'chat-composer',
+      ['--agent-color-fg' as string]: agentColor.foreground,
+      ['--agent-color-bg' as string]: agentColor.background,
+    }),
+    [agentColor],
+  );
+
+  return (
+    <form onSubmit={onSubmit} className="shrink-0">
+      <div
+        className="rounded-3xl border border-border1 bg-surface2 px-3 pt-2.5 transition-colors focus-within:border-[var(--agent-color-bg)]"
+        style={containerStyle}
+        data-testid={containerTestId}
+      >
+        <ChatTextarea
+          ref={textareaRef}
+          testId={inputTestId}
+          placeholder={placeholder}
+          value={draft}
+          onChange={e => onDraftChange(e.target.value)}
+          onKeyDown={onKeyDown}
+          disabled={disabled}
+        />
+        <div className="flex items-center justify-end pb-3">
+          <Button
+            type="submit"
+            variant="default"
+            size="icon-sm"
+            tooltip={isRunning ? 'Generating…' : 'Send'}
+            disabled={!canSubmit}
+            data-testid={submitTestId}
+            className="rounded-full"
+          >
+            {isRunning ? <Loader2 className="animate-spin" /> : <ArrowUpIcon />}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/chat-textarea.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/chat-textarea.tsx
@@ -1,0 +1,25 @@
+import { cn, Textarea } from '@mastra/playground-ui';
+import type { TextareaProps } from '@mastra/playground-ui';
+import { forwardRef } from 'react';
+
+export type ChatTextareaProps = Omit<TextareaProps, 'size' | 'variant' | 'rows'>;
+
+export const ChatTextarea = forwardRef<HTMLTextAreaElement, ChatTextareaProps>(({ className, ...props }, ref) => {
+  return (
+    <Textarea
+      ref={ref}
+      size="md"
+      variant="unstyled"
+      rows={1}
+      className={cn(
+        'min-h-[44px] resize-none text-ui-md bg-transparent text-neutral6 placeholder:text-neutral3',
+        'outline-none focus:outline-none focus-visible:outline-none',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+ChatTextarea.displayName = 'ChatTextarea';

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/message-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/message-list.tsx
@@ -1,0 +1,88 @@
+import type { MastraUIMessage } from '@mastra/react';
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { MessageRow, MessagesSkeleton, PendingIndicator } from './messages';
+import { useAutoScroll } from '@/domains/agent-builder/hooks/use-auto-scroll';
+
+/**
+ * Returns true only after `flag` has stayed true for `delayMs` continuously.
+ * If `flag` flips back to false before the delay elapses (e.g. data resolved
+ * locally), nothing is shown — preventing a brief skeleton flash.
+ */
+const useDelayedFlag = (flag: boolean, delayMs: number) => {
+  const [delayed, setDelayed] = useState(false);
+  useEffect(() => {
+    if (!flag) {
+      setDelayed(false);
+      return;
+    }
+    const id = setTimeout(() => setDelayed(true), delayMs);
+    return () => clearTimeout(id);
+  }, [flag, delayMs]);
+  return delayed;
+};
+
+const SKELETON_DELAY_MS = 300;
+
+interface MessageListProps {
+  messages: MastraUIMessage[];
+  isLoading?: boolean;
+  isRunning?: boolean;
+  emptyState?: ReactNode;
+  skeletonTestId?: string;
+}
+
+const hasStreamingPart = (message: MastraUIMessage | undefined) => {
+  if (!message) return false;
+  return message.parts.some(part => {
+    if (part.type === 'reasoning' || part.type === 'text') {
+      return (part as { state?: string }).state === 'streaming';
+    }
+    if (part.type === 'dynamic-tool') {
+      return true;
+    }
+    if (typeof part.type === 'string' && part.type.startsWith('tool-')) {
+      return true;
+    }
+    return false;
+  });
+};
+
+export const MessageList = ({
+  messages,
+  isLoading = false,
+  isRunning = false,
+  emptyState,
+  skeletonTestId,
+}: MessageListProps) => {
+  const scrollRef = useAutoScroll(messages);
+  const isLoadingEmpty = isLoading && messages.length === 0;
+  // Defer the skeleton by 300ms so it doesn't flash on fast (local) responses.
+  // If `isLoadingEmpty` flips false before the timer elapses, nothing renders.
+  const showSkeleton = useDelayedFlag(isLoadingEmpty, SKELETON_DELAY_MS);
+  const showEmpty = !isLoading && messages.length === 0 && emptyState !== undefined;
+  const lastMessage = messages[messages.length - 1];
+  const showPending =
+    isRunning && !isLoadingEmpty && (lastMessage?.role !== 'assistant' || !hasStreamingPart(lastMessage));
+
+  return (
+    <div
+      ref={scrollRef}
+      className="flex-1 min-h-0 overflow-y-auto py-6 px-6"
+      style={{ viewTransitionName: 'agent-builder-messages' }}
+    >
+      {showSkeleton ? (
+        <MessagesSkeleton testId={skeletonTestId} />
+      ) : showEmpty ? (
+        emptyState
+      ) : (
+        <div className="flex flex-col gap-6">
+          {messages.map(message => (
+            <MessageRow key={message.id} message={message} />
+          ))}
+          {showPending && <PendingIndicator />}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -1,0 +1,440 @@
+import {
+  Card,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Icon,
+  MarkdownRenderer,
+  Skeleton,
+  Txt,
+} from '@mastra/playground-ui';
+import type { MastraUIMessage } from '@mastra/react';
+import {
+  AlignLeft,
+  Check,
+  ChevronRight,
+  FileText,
+  Globe,
+  Loader2,
+  Wrench,
+  Zap,
+  GlobeLockIcon,
+  Building,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useAgentPrimitives } from '../../contexts/agent-primitives-context';
+import { useAvailableAgentTools } from '../../hooks/use-available-agent-tools';
+import { Shimmer } from './shimmer';
+import type { AgentBuilderEditFormValues } from '@/domains/agent-builder/schemas';
+import {
+  SET_AGENT_BROWSER_ENABLED_TOOL_NAME,
+  SET_AGENT_DESCRIPTION_TOOL_NAME,
+  SET_AGENT_INSTRUCTIONS_TOOL_NAME,
+  SET_AGENT_MODEL_TOOL_NAME,
+  SET_AGENT_NAME_TOOL_NAME,
+  SET_AGENT_SKILLS_TOOL_NAME,
+  SET_AGENT_TOOLS_TOOL_NAME,
+  SET_AGENT_WORKSPACE_ID_TOOL_NAME,
+} from '@/domains/agent-builder/services/tool-constants';
+import { ProviderLogo } from '@/domains/llm';
+
+interface MessageRowProps {
+  message: MastraUIMessage;
+}
+
+export const MessageRow = ({ message }: MessageRowProps) => {
+  return (
+    <>
+      {message.parts.map((part, index) => {
+        const key = `${message.id}-${index}`;
+        switch (part.type) {
+          case 'text':
+            return <Txtmessage key={key} txt={part.text} role={message.role} />;
+
+          case 'reasoning': {
+            if (part.state !== 'streaming') return null;
+
+            return <ReasoningMessage key={key} text="Reasoning..." streaming />;
+          }
+
+          case 'dynamic-tool': {
+            if (part?.state !== 'output-available') return null;
+            switch (part.toolName) {
+              case SET_AGENT_NAME_TOOL_NAME: {
+                return <MessageSetAgentName key={key} />;
+              }
+
+              case SET_AGENT_DESCRIPTION_TOOL_NAME: {
+                return <MessageSetAgentDescription key={key} />;
+              }
+
+              case SET_AGENT_INSTRUCTIONS_TOOL_NAME: {
+                return <MessageSetAgentInstructions key={key} />;
+              }
+
+              case SET_AGENT_TOOLS_TOOL_NAME: {
+                return <MessageSetAgentTools key={key} />;
+              }
+
+              case SET_AGENT_SKILLS_TOOL_NAME: {
+                return <MessageSetAgentSkills key={key} />;
+              }
+
+              case SET_AGENT_MODEL_TOOL_NAME: {
+                return <MessageSetAgentModel key={key} />;
+              }
+
+              case SET_AGENT_BROWSER_ENABLED_TOOL_NAME: {
+                return <MessageSetAgentBrowserEnabled key={key} />;
+              }
+
+              case SET_AGENT_WORKSPACE_ID_TOOL_NAME: {
+                return <MessageSetAgentWorkspaceId key={key} />;
+              }
+
+              default: {
+                if (part.toolName === 'skill') {
+                  return <SkillTool name={(part.input as { name?: string } | undefined)?.name ?? 'unknown'} />;
+                }
+
+                const extra = part as { input?: unknown; output?: unknown };
+                return <GenericTool key={key} toolName={part.toolName} input={extra.input} output={extra.output} />;
+              }
+            }
+          }
+
+          case `tool-${SET_AGENT_NAME_TOOL_NAME}`: {
+            if (part?.state !== 'output-available') return null;
+
+            return <MessageSetAgentName key={key} />;
+          }
+
+          case `tool-${SET_AGENT_DESCRIPTION_TOOL_NAME}`: {
+            if (part?.state !== 'output-available') return null;
+
+            return <MessageSetAgentDescription key={key} />;
+          }
+
+          case `tool-${SET_AGENT_INSTRUCTIONS_TOOL_NAME}`: {
+            if (part?.state !== 'output-available') return null;
+
+            return <MessageSetAgentInstructions key={key} />;
+          }
+          case `tool-${SET_AGENT_TOOLS_TOOL_NAME}`: {
+            if (part?.state !== 'output-available') return null;
+
+            return <MessageSetAgentTools key={key} />;
+          }
+          case `tool-${SET_AGENT_SKILLS_TOOL_NAME}`: {
+            if (part?.state !== 'output-available') return null;
+
+            return <MessageSetAgentSkills key={key} />;
+          }
+          case `tool-${SET_AGENT_MODEL_TOOL_NAME}`: {
+            if (part?.state !== 'output-available') return null;
+
+            return <MessageSetAgentModel key={key} />;
+          }
+          case `tool-${SET_AGENT_BROWSER_ENABLED_TOOL_NAME}`: {
+            if (part?.state !== 'output-available') return null;
+
+            return <MessageSetAgentBrowserEnabled key={key} />;
+          }
+          case `tool-${SET_AGENT_WORKSPACE_ID_TOOL_NAME}`: {
+            if (part?.state !== 'output-available') return null;
+
+            return <MessageSetAgentWorkspaceId key={key} />;
+          }
+
+          default: {
+            if (part.type === 'tool-skill' && part.state === 'output-available') {
+              const input = (part.input as { name?: string } | undefined) ?? {};
+              return <SkillTool name={input.name ?? 'unknown'} />;
+            }
+
+            if (typeof part.type === 'string' && part.type.startsWith('tool-')) {
+              const toolName = part.type.slice('tool-'.length);
+              const extra = part as { input?: unknown; output?: unknown };
+              return <GenericTool key={key} toolName={toolName} input={extra.input} output={extra.output} />;
+            }
+
+            return null;
+          }
+        }
+      })}
+    </>
+  );
+};
+
+export const Txtmessage = ({ txt, role }: { txt: string; role: MastraUIMessage['role'] }) => {
+  if (role === 'user') {
+    return (
+      <div className="flex justify-end">
+        <Txt
+          variant="ui-md"
+          className="bg-white text-black rounded-2xl px-4 py-2.5 max-w-[80%] [&_ul]:!space-y-1 [&_ol]:!space-y-1 [&_li]:!my-0 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_li]:!leading-normal"
+          as="div"
+        >
+          <MarkdownRenderer>{txt}</MarkdownRenderer>
+        </Txt>
+      </div>
+    );
+  }
+
+  if (role === 'assistant' || role === 'system') {
+    return (
+      <Txt
+        variant="ui-md"
+        className="text-neutral4 max-w-[80%] [&_ul]:!space-y-1 [&_ol]:!space-y-1 [&_li]:!my-0 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_li]:!leading-normal"
+        as="div"
+      >
+        <MarkdownRenderer>{txt}</MarkdownRenderer>
+      </Txt>
+    );
+  }
+
+  return null;
+};
+
+export const PendingIndicator = () => {
+  return (
+    <Txt
+      variant="ui-md"
+      className="whitespace-pre-wrap leading-relaxed text-neutral4 max-w-[80%] flex items-center gap-2"
+      as="div"
+      data-testid="agent-builder-chat-pending"
+    >
+      <Loader2 className="animate-spin size-4 text-neutral3" />
+      <Shimmer>Thinking…</Shimmer>
+    </Txt>
+  );
+};
+
+export const ReasoningMessage = ({ text, streaming = false }: { text: string; streaming?: boolean }) => {
+  return (
+    <Txt
+      variant="ui-md"
+      className="whitespace-pre-wrap leading-relaxed text-neutral4 max-w-[80%] flex items-center gap-2"
+      as="div"
+    >
+      {streaming ? (
+        <>
+          <Loader2 className="animate-spin size-4 text-neutral3" />
+
+          <Shimmer>{text}</Shimmer>
+        </>
+      ) : (
+        <>
+          <Check className="text-neutral3 size-4" />
+
+          {text}
+        </>
+      )}
+    </Txt>
+  );
+};
+
+export const MessagesSkeleton = ({ testId }: { testId?: string }) => {
+  return (
+    <div className="flex flex-col gap-6" data-testid={testId}>
+      <div className="flex justify-end">
+        <Skeleton className="h-10 w-56 rounded-2xl" />
+      </div>
+      <Skeleton className="h-6 w-[70%] rounded-full" />
+      <Skeleton className="h-6 w-[55%] rounded-full" />
+      <div className="flex justify-end">
+        <Skeleton className="h-10 w-40 rounded-2xl" />
+      </div>
+      <Skeleton className="h-6 w-[65%] rounded-full" />
+    </div>
+  );
+};
+
+const safeStringify = (value: unknown): string => {
+  if (value === undefined) return '';
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const GenericTool = ({ toolName, input, output }: { toolName: string; input?: unknown; output?: unknown }) => {
+  const inputJson = safeStringify(input);
+  const outputJson = safeStringify(output);
+  const hasOutput = outputJson.length > 0;
+
+  return (
+    <ToolCard testId="agent-builder-chat-generic-tool">
+      <Collapsible>
+        <CollapsibleTrigger
+          className="flex w-full items-center gap-2 text-left group"
+          data-testid="agent-builder-chat-generic-tool-trigger"
+        >
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-border1/60 bg-surface1 px-2 py-0.5">
+            <Wrench className="size-3.5 shrink-0 text-neutral4" aria-hidden />
+            <Txt variant="ui-sm" className="text-neutral5" as="span">
+              Executing <span className="font-mono text-neutral6">{toolName}</span>
+            </Txt>
+          </span>
+          <ChevronRight
+            className="size-4 shrink-0 text-neutral4 transition-transform group-data-[state=open]:rotate-90"
+            aria-hidden
+          />
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="mt-3 flex flex-col gap-2" data-testid="agent-builder-chat-generic-tool-content">
+            <div className="rounded-md border border-border1/60 bg-surface1 overflow-hidden">
+              <div className="px-2 py-1 border-b border-border1/60">
+                <Txt variant="ui-sm" className="text-neutral3" as="div">
+                  Input
+                </Txt>
+              </div>
+              <pre className="m-0 max-h-[320px] overflow-auto p-3 text-xs leading-relaxed text-neutral5 whitespace-pre-wrap break-words">
+                {inputJson || '{}'}
+              </pre>
+            </div>
+            {hasOutput ? (
+              <div className="rounded-md border border-border1/60 bg-surface1 overflow-hidden">
+                <div className="px-2 py-1 border-b border-border1/60">
+                  <Txt variant="ui-sm" className="text-neutral3" as="div">
+                    Output
+                  </Txt>
+                </div>
+                <pre className="m-0 max-h-[320px] overflow-auto p-3 text-xs leading-relaxed text-neutral5 whitespace-pre-wrap break-words">
+                  {outputJson}
+                </pre>
+              </div>
+            ) : null}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </ToolCard>
+  );
+};
+
+export const ToolCard = ({ children, testId }: { children: ReactNode; testId?: string }) => (
+  <Card
+    data-testid={testId}
+    className="max-w-[80%] p-3 bg-surface2/60 border-border1/60 animate-in fade-in slide-in-from-left-2 duration-300"
+  >
+    {children}
+  </Card>
+);
+
+const SkillToolLine = ({ icon, label, value }: { icon: ReactNode; label: string; value: ReactNode }) => (
+  <div className="flex items-start gap-2 min-w-0 max-w-full">
+    <div className="pt-0.5">
+      <Icon>{icon}</Icon>
+    </div>
+    <Txt variant="ui-md" className="text-neutral3 min-w-0 flex-1 truncate" as="div">
+      {label} <strong className="font-semibold text-neutral6">{value}</strong>
+    </Txt>
+  </div>
+);
+
+const MessageSetAgentName = () => {
+  const { watch } = useFormContext<AgentBuilderEditFormValues>();
+  const name = watch('name');
+
+  if (!name) return null;
+
+  return <SkillToolLine icon={<AlignLeft />} label="Setting the agent name:" value={name} />;
+};
+
+const MessageSetAgentDescription = () => {
+  const { watch } = useFormContext<AgentBuilderEditFormValues>();
+  const description = watch('description');
+
+  if (!description) return null;
+
+  return <SkillToolLine icon={<AlignLeft />} label="Setting the agent description:" value={description} />;
+};
+
+const MessageSetAgentInstructions = () => {
+  const { watch } = useFormContext<AgentBuilderEditFormValues>();
+  const instructions = watch('instructions');
+
+  if (!instructions) return null;
+
+  return <SkillToolLine icon={<FileText />} label="Setting the agent instructions:" value={instructions} />;
+};
+
+const MessageSetAgentTools = () => {
+  const { agentId, toolsData, agentsData, workflowsData } = useAgentPrimitives();
+  const { watch } = useFormContext<AgentBuilderEditFormValues>();
+  const selectedTools = watch('tools');
+  const selectedAgents = watch('agents');
+  const selectedWorkflows = watch('workflows');
+
+  const availableAgentTools = useAvailableAgentTools({
+    toolsData,
+    agentsData,
+    workflowsData,
+    selectedTools,
+    selectedAgents,
+    selectedWorkflows,
+    excludeAgentId: agentId,
+  });
+
+  const enabled = availableAgentTools.filter(t => t.isChecked);
+  const value = enabled.length === 0 ? 'none' : enabled.map(t => t.name).join(', ');
+
+  return <SkillToolLine icon={<Wrench />} label="Enabling tools:" value={value} />;
+};
+
+const MessageSetAgentSkills = () => {
+  const { availableSkills } = useAgentPrimitives();
+  const { watch } = useFormContext<AgentBuilderEditFormValues>();
+  const skillsField = watch('skills') as Record<string, boolean> | undefined;
+  const enabled = skillsField ? availableSkills.filter(s => skillsField[s.id] === true) : [];
+  const value = enabled.length === 0 ? 'none' : enabled.map(s => s.name).join(', ');
+
+  return <SkillToolLine icon={<Zap />} label="Enabling skills:" value={value} />;
+};
+
+const MessageSetAgentModel = () => {
+  const { watch } = useFormContext<AgentBuilderEditFormValues>();
+  const model = watch('model');
+
+  if (!model) return null;
+
+  return (
+    <SkillToolLine
+      icon={<ProviderLogo providerId={model.provider} size={16} />}
+      label="Setting agent model to"
+      value={`${model.provider}/${model.name}`}
+    />
+  );
+};
+
+const MessageSetAgentBrowserEnabled = () => {
+  const { watch } = useFormContext<AgentBuilderEditFormValues>();
+  const browserEnabled = watch('browserEnabled');
+
+  return (
+    <SkillToolLine
+      icon={browserEnabled ? <Globe /> : <GlobeLockIcon />}
+      label="Browser access"
+      value={browserEnabled ? 'enabled' : 'disabled'}
+    />
+  );
+};
+
+const MessageSetAgentWorkspaceId = () => {
+  const { watch } = useFormContext<AgentBuilderEditFormValues>();
+  const workspaceId = watch('workspaceId');
+
+  if (!workspaceId) return null;
+
+  return <SkillToolLine icon={<Building />} label="Setting workspace to" value={workspaceId} />;
+};
+
+interface SkillToolProps {
+  name: string;
+}
+
+const SkillTool = ({ name }: SkillToolProps) => (
+  <SkillToolLine icon={<Zap />} label="Using super-powers:" value={name} />
+);

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/shimmer.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/shimmer.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export const Shimmer = ({ children, className }: { children: ReactNode; className?: string }) => {
+  return (
+    <span
+      className={cn('inline-block text-transparent', className)}
+      style={{
+        backgroundImage: 'linear-gradient(to right, var(--neutral3), var(--neutral6), var(--neutral3))',
+        backgroundSize: '200% 100%',
+        backgroundClip: 'text',
+        WebkitBackgroundClip: 'text',
+        animation: 'shimmer-text 2s linear infinite',
+      }}
+    >
+      {children}
+    </span>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/__tests__/delete-skill-action.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/__tests__/delete-skill-action.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { DropdownMenu, TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import type * as ReactRouter from 'react-router';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeleteSkillMenuItem, DeleteSkillPanelButton } from '../delete-skill-action';
+import { server } from '@/test/msw-server';
+
+const navigate = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+    usePlaygroundStore: () => ({ requestContext: undefined }),
+  };
+});
+
+const { toast } = await import('@mastra/playground-ui');
+
+const BASE_URL = 'http://localhost:4111';
+
+const installRadixDomShims = () => {
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+  if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+  if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    class StubResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+  }
+};
+
+const Wrapper = ({ children }: { children: ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>{children}</TooltipProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+describe('DeleteSkillPanelButton', () => {
+  beforeAll(() => {
+    installRadixDomShims();
+  });
+
+  beforeEach(() => {
+    navigate.mockReset();
+    (toast.success as ReturnType<typeof vi.fn>).mockReset();
+    (toast.error as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens the confirmation dialog with the skill name when clicked', () => {
+    render(
+      <Wrapper>
+        <DeleteSkillPanelButton skillId="skill-123" skillName="My Skill" />
+      </Wrapper>,
+    );
+
+    const button = screen.getByTestId('skill-builder-delete-skill');
+    expect(button.textContent).toContain('Delete skill');
+
+    fireEvent.click(button);
+
+    const dialog = screen.getByTestId('skill-builder-delete-skill-dialog');
+    expect(dialog.textContent).toContain('My Skill');
+  });
+
+  it('does not fire a DELETE request when the user cancels', async () => {
+    let deleteCalled = false;
+    server.use(
+      http.delete(`${BASE_URL}/api/stored/skills/skill-123`, () => {
+        deleteCalled = true;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <DeleteSkillPanelButton skillId="skill-123" skillName="My Skill" />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('skill-builder-delete-skill'));
+    fireEvent.click(screen.getByTestId('skill-builder-delete-skill-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skill-builder-delete-skill-dialog')).toBeNull();
+    });
+    expect(deleteCalled).toBe(false);
+  });
+
+  it('calls DELETE, toasts success, and navigates after the request resolves', async () => {
+    let deleteCalled = false;
+    server.use(
+      http.delete(`${BASE_URL}/api/stored/skills/skill-123`, () => {
+        deleteCalled = true;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <DeleteSkillPanelButton skillId="skill-123" skillName="My Skill" />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('skill-builder-delete-skill'));
+    fireEvent.click(screen.getByTestId('skill-builder-delete-skill-confirm'));
+
+    await waitFor(() => {
+      expect(deleteCalled).toBe(true);
+    });
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Skill deleted');
+    });
+    expect(navigate).toHaveBeenCalledWith('/agent-builder/skills', { viewTransition: true });
+  });
+
+  it('toasts an error and keeps the dialog open when the DELETE fails', async () => {
+    server.use(
+      http.delete(`${BASE_URL}/api/stored/skills/skill-123`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+      ),
+    );
+
+    render(
+      <Wrapper>
+        <DeleteSkillPanelButton skillId="skill-123" skillName="My Skill" />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('skill-builder-delete-skill'));
+    fireEvent.click(screen.getByTestId('skill-builder-delete-skill-confirm'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.getByTestId('skill-builder-delete-skill-dialog')).toBeTruthy();
+  });
+});
+
+describe('DeleteSkillMenuItem', () => {
+  beforeAll(() => {
+    installRadixDomShims();
+  });
+
+  beforeEach(() => {
+    navigate.mockReset();
+    (toast.success as ReturnType<typeof vi.fn>).mockReset();
+    (toast.error as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens the confirmation dialog from inside a dropdown menu without auto-closing it', async () => {
+    render(
+      <Wrapper>
+        <DropdownMenu open>
+          <DropdownMenu.Trigger data-testid="dropdown-trigger">More</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DeleteSkillMenuItem skillId="skill-123" skillName="My Skill" />
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      </Wrapper>,
+    );
+
+    const item = await screen.findByTestId('skill-builder-mobile-menu-delete');
+    fireEvent.click(item);
+
+    const dialog = await screen.findByTestId('skill-builder-delete-skill-dialog');
+    expect(dialog.textContent).toContain('My Skill');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/__tests__/skill-builder-mobile-menu.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/__tests__/skill-builder-mobile-menu.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { SkillBuilderMobileMenu } from '../skill-builder-mobile-menu';
+import type { SkillEditFormValues } from '@/domains/agent-builder/hooks/use-autosave-skill';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+const SKILL_ID = 'skill-mobile';
+
+interface FormHarnessProps {
+  defaultVisibility?: SkillEditFormValues['visibility'];
+  children: ReactNode;
+}
+
+const FormHarness = ({ defaultVisibility = 'private', children }: FormHarnessProps) => {
+  const methods = useForm<SkillEditFormValues>({
+    defaultValues: {
+      name: '',
+      description: '',
+      instructions: '',
+      visibility: defaultVisibility,
+      workspaceId: undefined,
+    },
+  });
+  const value = methods.watch('visibility');
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <TooltipProvider>
+            <FormProvider {...methods}>
+              {children}
+              <span data-testid="form-visibility">{value}</span>
+            </FormProvider>
+          </TooltipProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+const installRadixDomShims = () => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    class StubResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+  }
+};
+
+const openDropdown = async () => {
+  const trigger = await screen.findByTestId('skill-builder-mobile-menu-trigger');
+  fireEvent.click(trigger);
+  await screen.findByRole('menu');
+};
+
+describe('SkillBuilderMobileMenu', () => {
+  beforeAll(() => {
+    installRadixDomShims();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders nothing when showSetVisibility is false', () => {
+    render(
+      <FormHarness>
+        <SkillBuilderMobileMenu skillId={SKILL_ID} showSetVisibility={false} />
+      </FormHarness>,
+    );
+
+    expect(screen.queryByTestId('skill-builder-mobile-menu')).toBeNull();
+    expect(screen.queryByTestId('skill-builder-mobile-menu-trigger')).toBeNull();
+  });
+
+  it('shows Add to library item when private and opens the confirm dialog on click', async () => {
+    render(
+      <FormHarness>
+        <SkillBuilderMobileMenu skillId={SKILL_ID} showSetVisibility />
+      </FormHarness>,
+    );
+
+    await openDropdown();
+
+    const item = await screen.findByTestId('skill-builder-mobile-menu-visibility-add');
+    expect(item.textContent).toContain('Add to library');
+
+    fireEvent.click(item);
+
+    const dialog = await screen.findByTestId('skill-builder-visibility-confirm-dialog');
+    expect(dialog.textContent).toContain('Add this skill to your library?');
+  });
+
+  it('shows Remove from library item when public', async () => {
+    render(
+      <FormHarness defaultVisibility="public">
+        <SkillBuilderMobileMenu skillId={SKILL_ID} showSetVisibility />
+      </FormHarness>,
+    );
+
+    await openDropdown();
+
+    const item = await screen.findByTestId('skill-builder-mobile-menu-visibility-remove');
+    expect(item.textContent).toContain('Remove from library');
+    expect(screen.queryByTestId('skill-builder-mobile-menu-visibility-add')).toBeNull();
+  });
+
+  it('confirming dispatches PATCH with the new visibility and updates the form value', async () => {
+    let capturedBody: any = null;
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ id: SKILL_ID, visibility: 'public' });
+      }),
+    );
+
+    render(
+      <FormHarness>
+        <SkillBuilderMobileMenu skillId={SKILL_ID} showSetVisibility />
+      </FormHarness>,
+    );
+
+    await openDropdown();
+    fireEvent.click(await screen.findByTestId('skill-builder-mobile-menu-visibility-add'));
+
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId('skill-builder-visibility-confirm-yes'));
+    });
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({ visibility: 'public' });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('form-visibility').textContent).toBe('public');
+    });
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/__tests__/visibility-select.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/__tests__/visibility-select.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { VisibilitySelect } from '../visibility-select';
+import type { SkillEditFormValues } from '@/domains/agent-builder/hooks/use-autosave-skill';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+const SKILL_ID = 'skill-1';
+
+interface FormHarnessProps {
+  defaultVisibility?: SkillEditFormValues['visibility'];
+  children: ReactNode;
+}
+
+const FormHarness = ({ defaultVisibility = 'private', children }: FormHarnessProps) => {
+  const methods = useForm<SkillEditFormValues>({
+    defaultValues: {
+      name: '',
+      description: '',
+      instructions: '',
+      visibility: defaultVisibility,
+      workspaceId: undefined,
+    },
+  });
+  const value = methods.watch('visibility');
+  const isDirty = methods.formState.isDirty;
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <TooltipProvider>
+            <FormProvider {...methods}>
+              {children}
+              <span data-testid="form-visibility">{value}</span>
+              <span data-testid="form-dirty">{isDirty ? 'true' : 'false'}</span>
+            </FormProvider>
+          </TooltipProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+describe('VisibilitySelect (skill)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the Add to library button when the saved value is private', () => {
+    render(
+      <FormHarness>
+        <VisibilitySelect skillId={SKILL_ID} />
+      </FormHarness>,
+    );
+
+    expect(screen.getByTestId('skill-builder-visibility-add')).toBeTruthy();
+    expect(screen.queryByTestId('skill-builder-visibility-remove')).toBeNull();
+  });
+
+  it('renders the Remove from library button when the saved value is public', () => {
+    render(
+      <FormHarness defaultVisibility="public">
+        <VisibilitySelect skillId={SKILL_ID} />
+      </FormHarness>,
+    );
+
+    expect(screen.getByTestId('skill-builder-visibility-remove')).toBeTruthy();
+    expect(screen.queryByTestId('skill-builder-visibility-add')).toBeNull();
+  });
+
+  it('opens the confirm dialog with add-to-library copy when Add is clicked, without issuing a request', async () => {
+    let patchCalled = false;
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, () => {
+        patchCalled = true;
+        return HttpResponse.json({ id: SKILL_ID, visibility: 'public' });
+      }),
+    );
+
+    render(
+      <FormHarness>
+        <VisibilitySelect skillId={SKILL_ID} />
+      </FormHarness>,
+    );
+
+    fireEvent.click(screen.getByTestId('skill-builder-visibility-add'));
+
+    const dialog = await screen.findByTestId('skill-builder-visibility-confirm-dialog');
+    expect(dialog.textContent).toContain('Add this skill to your library?');
+    expect(dialog.textContent).toContain('teammates will be able to discover');
+    expect(patchCalled).toBe(false);
+    expect(screen.getByTestId('form-visibility').textContent).toBe('private');
+  });
+
+  it('cancel leaves the saved value, leaves the form clean, and issues no request', async () => {
+    let patchCalled = false;
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, () => {
+        patchCalled = true;
+        return HttpResponse.json({ id: SKILL_ID, visibility: 'public' });
+      }),
+    );
+
+    render(
+      <FormHarness>
+        <VisibilitySelect skillId={SKILL_ID} />
+      </FormHarness>,
+    );
+
+    fireEvent.click(screen.getByTestId('skill-builder-visibility-add'));
+    fireEvent.click(await screen.findByTestId('skill-builder-visibility-confirm-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skill-builder-visibility-confirm-dialog')).toBeNull();
+    });
+
+    expect(patchCalled).toBe(false);
+    expect(screen.getByTestId('skill-builder-visibility-add')).toBeTruthy();
+    expect(screen.getByTestId('form-visibility').textContent).toBe('private');
+    expect(screen.getByTestId('form-dirty').textContent).toBe('false');
+  });
+
+  it('confirm issues PATCH with the new visibility, swaps the button to Remove, and keeps the form clean', async () => {
+    let capturedBody: any = null;
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ id: SKILL_ID, visibility: 'public' });
+      }),
+    );
+
+    render(
+      <FormHarness>
+        <VisibilitySelect skillId={SKILL_ID} />
+      </FormHarness>,
+    );
+
+    fireEvent.click(screen.getByTestId('skill-builder-visibility-add'));
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId('skill-builder-visibility-confirm-yes'));
+    });
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({ visibility: 'public' });
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('skill-builder-visibility-confirm-dialog')).toBeNull();
+    });
+    expect(screen.getByTestId('skill-builder-visibility-remove')).toBeTruthy();
+    expect(screen.getByTestId('form-visibility').textContent).toBe('public');
+    expect(screen.getByTestId('form-dirty').textContent).toBe('false');
+  });
+
+  it('shows the remove-from-library copy when starting from public and clicking Remove', async () => {
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, () =>
+        HttpResponse.json({ id: SKILL_ID, visibility: 'private' }),
+      ),
+    );
+
+    render(
+      <FormHarness defaultVisibility="public">
+        <VisibilitySelect skillId={SKILL_ID} />
+      </FormHarness>,
+    );
+
+    fireEvent.click(screen.getByTestId('skill-builder-visibility-remove'));
+
+    const dialog = await screen.findByTestId('skill-builder-visibility-confirm-dialog');
+    expect(dialog.textContent).toContain('Remove this skill from your library?');
+    expect(dialog.textContent).toContain('teammates will no longer be able to');
+    expect(dialog.textContent).toContain('only person with access');
+  });
+
+  it('reverts to the saved value when the PATCH fails', async () => {
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+      ),
+    );
+
+    render(
+      <FormHarness>
+        <VisibilitySelect skillId={SKILL_ID} />
+      </FormHarness>,
+    );
+
+    fireEvent.click(screen.getByTestId('skill-builder-visibility-add'));
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId('skill-builder-visibility-confirm-yes'));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skill-builder-visibility-confirm-dialog')).toBeNull();
+    });
+    expect(screen.getByTestId('skill-builder-visibility-add')).toBeTruthy();
+    expect(screen.getByTestId('form-visibility').textContent).toBe('private');
+    expect(screen.getByTestId('form-dirty').textContent).toBe('false');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/delete-skill-action.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/delete-skill-action.tsx
@@ -1,0 +1,132 @@
+import { AlertDialog, Button, DropdownMenu, toast } from '@mastra/playground-ui';
+import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import { useDeleteSkill } from '@/domains/agent-builder/hooks/use-delete-skill';
+
+interface UseDeleteSkillActionParams {
+  skillId: string;
+}
+
+const useDeleteSkillAction = ({ skillId }: UseDeleteSkillActionParams) => {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+  const deleteSkill = useDeleteSkill(skillId);
+
+  const confirm = async () => {
+    try {
+      await deleteSkill.mutateAsync();
+      toast.success('Skill deleted');
+      setOpen(false);
+      void navigate('/agent-builder/skills', { viewTransition: true });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete skill');
+    }
+  };
+
+  return {
+    open,
+    setOpen,
+    isPending: deleteSkill.isPending,
+    confirm,
+  };
+};
+
+interface DeleteSkillDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  skillName: string;
+  isPending: boolean;
+  onConfirm: () => void;
+}
+
+const DeleteSkillDialog = ({ open, onOpenChange, skillName, isPending, onConfirm }: DeleteSkillDialogProps) => (
+  <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialog.Content data-testid="skill-builder-delete-skill-dialog">
+      <AlertDialog.Header>
+        <AlertDialog.Title>Delete skill?</AlertDialog.Title>
+        <AlertDialog.Description>
+          This permanently deletes &quot;{skillName}&quot;. This cannot be undone.
+        </AlertDialog.Description>
+      </AlertDialog.Header>
+      <AlertDialog.Footer>
+        <AlertDialog.Cancel data-testid="skill-builder-delete-skill-cancel" disabled={isPending}>
+          Cancel
+        </AlertDialog.Cancel>
+        <Button
+          variant="primary"
+          data-testid="skill-builder-delete-skill-confirm"
+          disabled={isPending}
+          onClick={() => {
+            // Use a plain button (not AlertDialog.Close) so the dialog stays
+            // open while the request is in flight and on error.
+            onConfirm();
+          }}
+        >
+          {isPending ? 'Deleting…' : 'Delete skill'}
+        </Button>
+      </AlertDialog.Footer>
+    </AlertDialog.Content>
+  </AlertDialog>
+);
+
+interface DeleteSkillEntryProps {
+  skillId: string;
+  skillName: string;
+  disabled?: boolean;
+}
+
+export const DeleteSkillPanelButton = ({ skillId, skillName, disabled = false }: DeleteSkillEntryProps) => {
+  const { open, setOpen, isPending, confirm } = useDeleteSkillAction({ skillId });
+
+  return (
+    <>
+      <Button
+        size="lg"
+        variant="default"
+        onClick={() => setOpen(true)}
+        disabled={disabled || isPending}
+        className="w-full"
+        data-testid="skill-builder-delete-skill"
+      >
+        <Trash2 />
+        <span>Delete skill</span>
+      </Button>
+      <DeleteSkillDialog
+        open={open}
+        onOpenChange={setOpen}
+        skillName={skillName}
+        isPending={isPending}
+        onConfirm={confirm}
+      />
+    </>
+  );
+};
+
+export const DeleteSkillMenuItem = ({ skillId, skillName, disabled = false }: DeleteSkillEntryProps) => {
+  const { open, setOpen, isPending, confirm } = useDeleteSkillAction({ skillId });
+
+  return (
+    <>
+      <DropdownMenu.Item
+        data-testid="skill-builder-mobile-menu-delete"
+        disabled={disabled}
+        className="text-red-500 focus:text-red-400"
+        onSelect={event => {
+          event.preventDefault();
+          setOpen(true);
+        }}
+      >
+        <Trash2 />
+        <span>Delete skill</span>
+      </DropdownMenu.Item>
+      <DeleteSkillDialog
+        open={open}
+        onOpenChange={setOpen}
+        skillName={skillName}
+        isPending={isPending}
+        onConfirm={confirm}
+      />
+    </>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/skill-builder-mobile-menu.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/skill-builder-mobile-menu.tsx
@@ -1,0 +1,89 @@
+import { Button, DropdownMenu } from '@mastra/playground-ui';
+import { Globe, LockIcon, MoreVerticalIcon } from 'lucide-react';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import { useVisibilityChange } from '../../hooks/use-visibility-change-skill';
+import { DeleteSkillMenuItem } from './delete-skill-action';
+import type { Visibility } from './visibility-select';
+import type { SkillEditFormValues } from '@/domains/agent-builder/hooks/use-autosave-skill';
+
+export interface SkillBuilderMobileMenuProps {
+  skillId: string;
+  /** When true, includes the Add/Remove from library item. Owner-only. */
+  showSetVisibility?: boolean;
+  /** When true, includes the Delete skill item. Owner-only. */
+  showDelete?: boolean;
+  /** Current skill name, shown in the delete confirmation dialog. */
+  skillName?: string;
+  /** Disables all actions (e.g. during streaming). */
+  disabled?: boolean;
+}
+
+export function SkillBuilderMobileMenu({
+  skillId,
+  showSetVisibility = false,
+  showDelete = false,
+  skillName = '',
+  disabled = false,
+}: SkillBuilderMobileMenuProps) {
+  if (!showSetVisibility && !showDelete) return null;
+
+  return (
+    <div className="lg:hidden" data-testid="skill-builder-mobile-menu">
+      <DropdownMenu>
+        <DropdownMenu.Trigger asChild>
+          <Button size="icon-sm" variant="ghost" tooltip="More actions" data-testid="skill-builder-mobile-menu-trigger">
+            <MoreVerticalIcon />
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end">
+          {showSetVisibility && <VisibilityMenuItem skillId={skillId} disabled={disabled} />}
+          {showSetVisibility && showDelete && <DropdownMenu.Separator />}
+          {showDelete && <DeleteSkillMenuItem skillId={skillId} skillName={skillName} disabled={disabled} />}
+        </DropdownMenu.Content>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+interface VisibilityMenuItemProps {
+  skillId: string;
+  disabled: boolean;
+}
+
+function VisibilityMenuItem({ skillId, disabled }: VisibilityMenuItemProps) {
+  const formMethods = useFormContext<SkillEditFormValues>();
+  const value = (useWatch({ control: formMethods.control, name: 'visibility' }) ?? 'private') as Visibility;
+  const { requestChange, dialog } = useVisibilityChange(skillId);
+
+  return (
+    <>
+      {value === 'private' ? (
+        <DropdownMenu.Item
+          data-testid="skill-builder-mobile-menu-visibility-add"
+          disabled={disabled}
+          closeOnClick={false}
+          onSelect={() => {
+            requestChange('public');
+          }}
+        >
+          <Globe />
+          <span>Add to library</span>
+        </DropdownMenu.Item>
+      ) : (
+        <DropdownMenu.Item
+          data-testid="skill-builder-mobile-menu-visibility-remove"
+          disabled={disabled}
+          closeOnClick={false}
+          onSelect={() => {
+            requestChange('private');
+          }}
+        >
+          <LockIcon />
+          <span>Remove from library</span>
+        </DropdownMenu.Item>
+      )}
+      {dialog}
+    </>
+  );
+}

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/visibility-select.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/visibility-select.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@mastra/playground-ui';
+import { Globe, LockIcon } from 'lucide-react';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import { useVisibilityChange } from '../../hooks/use-visibility-change-skill';
+import type { SkillEditFormValues } from '@/domains/agent-builder/hooks/use-autosave-skill';
+
+export type Visibility = 'private' | 'public';
+
+export interface VisibilitySelectProps {
+  skillId: string;
+}
+
+export function VisibilitySelect({ skillId }: VisibilitySelectProps) {
+  const formMethods = useFormContext<SkillEditFormValues>();
+  const value = (useWatch({ control: formMethods.control, name: 'visibility' }) ?? 'private') as Visibility;
+  const { requestChange, dialog } = useVisibilityChange(skillId);
+
+  return (
+    <>
+      {value === 'private' ? (
+        <Button
+          size="sm"
+          variant="default"
+          onClick={() => requestChange('public')}
+          data-testid="skill-builder-visibility-add"
+        >
+          <Globe className="h-3.5 w-3.5" />
+          Add to library
+        </Button>
+      ) : (
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => requestChange('private')}
+          data-testid="skill-builder-visibility-remove"
+        >
+          <LockIcon className="h-3.5 w-3.5" />
+          Remove from library
+        </Button>
+      )}
+      {dialog}
+    </>
+  );
+}

--- a/packages/playground/src/domains/agent-builder/components/skill-starter/__tests__/skill-builder-starter.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-starter/__tests__/skill-builder-starter.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router';
+import type * as ReactRouter from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SkillBuilderStarter } from '../skill-builder-starter';
+import { server } from '@/test/msw-server';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+    usePlaygroundStore: () => ({ requestContext: undefined }),
+  };
+});
+
+vi.mock('@/domains/auth/hooks/use-default-visibility', () => ({
+  useDefaultVisibility: () => 'private',
+}));
+
+const BASE_URL = 'http://localhost:4111';
+
+const renderStarter = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <MemoryRouter>
+            <SkillBuilderStarter />
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+};
+
+describe('SkillBuilderStarter', () => {
+  beforeEach(() => {
+    // The starter pulls builder settings + stored workspaces so it can choose a
+    // default workspace. Stub both: builder enabled with no agent-workspace
+    // pin, and an empty workspace list so workspaceId stays undefined.
+    server.use(
+      http.get(`${BASE_URL}/api/editor/builder/settings`, () =>
+        HttpResponse.json({ enabled: true, modelPolicy: { active: false } }),
+      ),
+      http.get(`${BASE_URL}/api/stored/workspaces`, () => HttpResponse.json({ workspaces: [] })),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    navigateMock.mockReset();
+  });
+
+  it('renders a submit button that is disabled until the input has content', () => {
+    const { getByTestId } = renderStarter();
+    const submit = getByTestId('skill-builder-starter-submit') as HTMLButtonElement;
+    const input = getByTestId('skill-builder-starter-input') as HTMLTextAreaElement;
+
+    expect(submit.type).toBe('submit');
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: 'build something useful' } });
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('creates the skill with a client-side id and navigates to /agent-builder/skills/:id/edit with the prompt as userMessage', async () => {
+    let capturedBody: any = null;
+    server.use(
+      http.post(`${BASE_URL}/api/stored/skills`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ id: capturedBody.id });
+      }),
+    );
+
+    const { getByTestId } = renderStarter();
+    const input = getByTestId('skill-builder-starter-input') as HTMLTextAreaElement;
+    const submit = getByTestId('skill-builder-starter-submit');
+
+    fireEvent.change(input, { target: { value: 'code reviewer' } });
+
+    await act(async () => {
+      fireEvent.click(submit);
+    });
+
+    await waitFor(() => expect(capturedBody).toBeTruthy());
+    expect(typeof capturedBody.id).toBe('string');
+    expect(capturedBody.id.length).toBeGreaterThan(0);
+    expect(capturedBody.name).toBe('code reviewer');
+    expect(capturedBody.description).toBe('');
+    expect(capturedBody.instructions).toBe('');
+    expect(capturedBody.visibility).toBe('private');
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledTimes(1));
+    const [path, opts] = navigateMock.mock.calls[0];
+    expect(path).toBe(`/agent-builder/skills/${capturedBody.id}/edit`);
+    expect(opts).toMatchObject({
+      state: { userMessage: 'code reviewer' },
+      viewTransition: true,
+    });
+  });
+
+  it('truncates long prompts to 20 chars + ellipsis for the placeholder name', async () => {
+    let capturedBody: any = null;
+    server.use(
+      http.post(`${BASE_URL}/api/stored/skills`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ id: capturedBody.id });
+      }),
+    );
+
+    const longPrompt = 'build a skill that helps engineers review pull requests for typescript repos';
+    const { getByTestId } = renderStarter();
+    fireEvent.change(getByTestId('skill-builder-starter-input'), { target: { value: longPrompt } });
+
+    await act(async () => {
+      fireEvent.click(getByTestId('skill-builder-starter-submit'));
+    });
+
+    await waitFor(() => expect(capturedBody).toBeTruthy());
+    expect(capturedBody.name).toBe(longPrompt.slice(0, 20) + '…');
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled());
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/skill-starter/skill-builder-starter.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-starter/skill-builder-starter.tsx
@@ -1,0 +1,178 @@
+import { Button, Spinner, Textarea, toast } from '@mastra/playground-ui';
+import { ArrowUpIcon, BookOpen, FileText, GraduationCap, Wrench } from 'lucide-react';
+import { nanoid } from 'nanoid';
+import { useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { useBuilderSettings } from '@/domains/agent-builder/hooks/use-builder-settings';
+import { useCreateSkill } from '@/domains/agents/hooks/use-create-skill';
+import { useDefaultVisibility } from '@/domains/auth/hooks/use-default-visibility';
+import { useStoredWorkspaces } from '@/domains/workspace/hooks/use-stored-workspaces';
+
+const EXAMPLES = [
+  {
+    title: 'Code reviewer',
+    icon: Wrench,
+    prompt:
+      'Build a skill that reviews TypeScript code for type-safety issues, missing tests, and inconsistent patterns. Leave concrete suggestions with examples.',
+  },
+  {
+    title: 'Doc summarizer',
+    icon: FileText,
+    prompt:
+      'Build a skill that summarizes long technical documents into a one-page brief with the key points, action items, and open questions.',
+  },
+  {
+    title: 'Onboarding tutor',
+    icon: GraduationCap,
+    prompt:
+      'Build a skill that onboards new engineers to a codebase. Explain the architecture, point to the right docs, and answer questions in plain English with code examples.',
+  },
+  {
+    title: 'Research notes',
+    icon: BookOpen,
+    prompt:
+      'Build a skill that turns messy research notes into structured findings with sources, methodology, and a tl;dr at the top.',
+  },
+];
+
+const truncateName = (prompt: string): string => (prompt.length <= 20 ? prompt : prompt.slice(0, 20) + '…');
+
+export const SkillBuilderStarter = () => {
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const createSkill = useCreateSkill();
+  const defaultVisibility = useDefaultVisibility();
+  const { data: workspacesData } = useStoredWorkspaces();
+  const { data: builderSettings } = useBuilderSettings();
+
+  const workspaceOptions = useMemo(
+    () =>
+      (workspacesData?.workspaces ?? [])
+        .filter(ws => ws.status !== 'archived')
+        .sort((a, b) => (b.runtimeRegistered ? 1 : 0) - (a.runtimeRegistered ? 1 : 0))
+        .map(ws => ({ value: ws.id, label: ws.name })),
+    [workspacesData],
+  );
+
+  const builderDefaultWorkspaceId = useMemo(() => {
+    const ws = (builderSettings?.configuration?.agent as Record<string, unknown> | undefined)?.workspace as
+      | { type: string; workspaceId?: string }
+      | undefined;
+    return ws?.type === 'id' ? ws.workspaceId : undefined;
+  }, [builderSettings]);
+
+  const trimmed = message.trim();
+  const isCreating = createSkill.isPending;
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (trimmed.length === 0 || isCreating) return;
+    const id = nanoid();
+    const workspaceId =
+      builderDefaultWorkspaceId ?? (workspaceOptions.length === 1 ? workspaceOptions[0].value : undefined);
+    try {
+      await createSkill.mutateAsync({
+        id,
+        name: truncateName(trimmed),
+        description: '',
+        instructions: '',
+        visibility: defaultVisibility,
+        workspaceId,
+        files: [],
+      });
+    } catch {
+      toast.error('Failed to start a new skill');
+      return;
+    }
+    void navigate(`/agent-builder/skills/${id}/edit`, {
+      state: { userMessage: trimmed },
+      viewTransition: true,
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isCreating) return;
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      e.currentTarget.form?.requestSubmit();
+    }
+  };
+
+  const handleExampleClick = (prompt: string) => {
+    setMessage(prompt);
+    textareaRef.current?.focus();
+  };
+
+  return (
+    <div className="starter-aurora flex min-h-full flex-col items-center justify-center bg-surface1 px-6 py-24">
+      <div className="relative z-10 flex w-full max-w-3xl flex-col gap-12">
+        <h1
+          className="starter-heading text-center font-serif text-neutral6"
+          style={{ fontSize: 'clamp(1.875rem, 3.5vw, 2.5rem)', lineHeight: 1.1, letterSpacing: '-0.015em' }}
+        >
+          What skill do you want to build?
+        </h1>
+
+        <form onSubmit={handleSubmit}>
+          <div
+            className="starter-prompt rounded-2xl border border-border1 bg-surface2 transition-colors duration-normal ease-out-custom focus-within:border-neutral3"
+            style={{ viewTransitionName: 'skill-chat-composer' }}
+          >
+            <Textarea
+              ref={textareaRef}
+              testId="skill-builder-starter-input"
+              size="default"
+              variant="unstyled"
+              placeholder="Describe the skill you want to build…"
+              value={message}
+              onChange={e => setMessage(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={isCreating}
+              className="min-h-[112px] resize-none px-5 py-4 text-ui-md outline-none placeholder:text-neutral3 focus:outline-none focus-visible:outline-none"
+              rows={3}
+            />
+            <div className="flex items-center justify-end px-3 pb-2.5">
+              <Button
+                type="submit"
+                variant="default"
+                size="icon-md"
+                tooltip="Start building"
+                disabled={trimmed.length === 0 || isCreating}
+                data-testid="skill-builder-starter-submit"
+                className="rounded-full"
+              >
+                {isCreating ? (
+                  <span data-testid="skill-builder-starter-submit-spinner">
+                    <Spinner />
+                  </span>
+                ) : (
+                  <ArrowUpIcon />
+                )}
+              </Button>
+            </div>
+          </div>
+        </form>
+
+        <div className="flex flex-wrap justify-center gap-2">
+          {EXAMPLES.map((example, i) => {
+            const Icon = example.icon;
+            return (
+              <button
+                key={example.title}
+                type="button"
+                onClick={() => handleExampleClick(example.prompt)}
+                data-testid={`skill-builder-starter-example-${example.title.toLowerCase().replace(/\s+/g, '-')}`}
+                style={{ animationDelay: `${280 + i * 40}ms` }}
+                className="starter-chip group inline-flex items-center gap-2 rounded-full border border-border1 bg-transparent px-4 py-2 text-ui-sm text-neutral4 transition-colors duration-normal ease-out-custom hover:border-border2 hover:bg-surface2 hover:text-neutral6"
+              >
+                <Icon className="h-3.5 w-3.5 text-neutral3 transition-colors group-hover:text-neutral5" />
+                {example.title}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/playground/src/domains/agent-builder/contexts/__tests__/agent-color-context.test.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/__tests__/agent-color-context.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { stringToColor } from '@mastra/playground-ui';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AgentColors } from '../agent-color-context';
+import { AgentColorProvider, useAgentColor } from '../agent-color-context';
+
+const Consumer = ({ observed }: { observed: AgentColors[] }) => {
+  const color = useAgentColor();
+  observed.push(color);
+  return <div data-testid="consumer" data-bg={color.background} data-fg={color.foreground} data-tint={color.tint} />;
+};
+
+describe('AgentColorProvider', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('throws when mounted without an agentId', () => {
+    const observed: AgentColors[] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(
+        <AgentColorProvider agentId="">
+          <Consumer observed={observed} />
+        </AgentColorProvider>,
+      ),
+    ).toThrow(/AgentColorProvider requires a non-empty agentId/);
+    errorSpy.mockRestore();
+  });
+
+  it('derives background, foreground, and tint colors from the agentId', () => {
+    const observed: AgentColors[] = [];
+    const { getByTestId } = render(
+      <AgentColorProvider agentId="agent_123">
+        <Consumer observed={observed} />
+      </AgentColorProvider>,
+    );
+    const consumer = getByTestId('consumer');
+    expect(consumer.getAttribute('data-bg')).toBe(stringToColor('agent_123'));
+    expect(consumer.getAttribute('data-fg')).toBe(stringToColor('agent_123', 20));
+    expect(consumer.getAttribute('data-tint')).toBe(stringToColor('agent_123', 50));
+    // Background uses lightness 90%, foreground uses lightness 20%, tint uses lightness 50%.
+    expect(consumer.getAttribute('data-bg')).toMatch(/hsl\(-?\d+, 100%, 90%\)/);
+    expect(consumer.getAttribute('data-fg')).toMatch(/hsl\(-?\d+, 100%, 20%\)/);
+    expect(consumer.getAttribute('data-tint')).toMatch(/hsl\(-?\d+, 100%, 50%\)/);
+  });
+
+  it('keeps the color object referentially stable across re-renders with the same agentId', () => {
+    const observed: AgentColors[] = [];
+    const { rerender } = render(
+      <AgentColorProvider agentId="stable-id">
+        <Consumer observed={observed} />
+      </AgentColorProvider>,
+    );
+    const first = observed[observed.length - 1];
+
+    rerender(
+      <AgentColorProvider agentId="stable-id">
+        <Consumer observed={observed} />
+      </AgentColorProvider>,
+    );
+
+    const latest = observed[observed.length - 1];
+    expect(latest).toBe(first);
+  });
+
+  it('produces different colors for different agentIds', () => {
+    const observed: AgentColors[] = [];
+    const { getByTestId, rerender } = render(
+      <AgentColorProvider agentId="alpha">
+        <Consumer observed={observed} />
+      </AgentColorProvider>,
+    );
+    const consumer = getByTestId('consumer');
+    expect(consumer.getAttribute('data-bg')).toBe(stringToColor('alpha'));
+
+    rerender(
+      <AgentColorProvider agentId="omega">
+        <Consumer observed={observed} />
+      </AgentColorProvider>,
+    );
+
+    expect(consumer.getAttribute('data-bg')).toBe(stringToColor('omega'));
+  });
+});
+
+describe('useAgentColor', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('throws when used outside of an AgentColorProvider', () => {
+    const observed: AgentColors[] = [];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<Consumer observed={observed} />)).toThrow(
+      /useAgentColor must be used inside an AgentColorProvider/,
+    );
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/playground/src/domains/agent-builder/contexts/agent-color-context.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/agent-color-context.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable react-refresh/only-export-components */
+import { stringToColor } from '@mastra/playground-ui';
+import { createContext, useContext, useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+export type AgentColors = {
+  background: string;
+  foreground: string;
+  tint: string;
+};
+
+const AgentColorContext = createContext<AgentColors | null>(null);
+
+interface AgentColorProviderProps {
+  agentId: string;
+  children: ReactNode;
+}
+
+export const AgentColorProvider = ({ agentId, children }: AgentColorProviderProps) => {
+  const value = useMemo<AgentColors>(() => {
+    if (!agentId) {
+      throw new Error('AgentColorProvider requires a non-empty agentId');
+    }
+
+    return {
+      background: stringToColor(agentId),
+      foreground: stringToColor(agentId, 20),
+      tint: stringToColor(agentId, 50),
+    };
+  }, [agentId]);
+
+  return <AgentColorContext.Provider value={value}>{children}</AgentColorContext.Provider>;
+};
+
+export const useAgentColor = (): AgentColors => {
+  const value = useContext(AgentColorContext);
+  if (value === null) {
+    throw new Error('useAgentColor must be used inside an AgentColorProvider');
+  }
+  return value;
+};

--- a/packages/playground/src/domains/agent-builder/contexts/agent-primitives-context.tsx
+++ b/packages/playground/src/domains/agent-builder/contexts/agent-primitives-context.tsx
@@ -1,0 +1,128 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import { createContext, useContext, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import type { AvailableWorkspace } from '../hooks/use-agent-builder-tool';
+import { useBuilderAgentAccess } from '../hooks/use-builder-agent-access';
+import { useBuilderAgentFeatures } from '../hooks/use-builder-agent-features';
+import { useStarterUserMessage } from '../hooks/use-starter-user-message';
+import { useAgents } from '@/domains/agents/hooks/use-agents';
+import type { StoredAgent } from '@/domains/agents/hooks/use-stored-agents';
+import { useStoredAgent } from '@/domains/agents/hooks/use-stored-agents';
+import { useStoredSkills } from '@/domains/agents/hooks/use-stored-skills';
+import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
+import { useTools } from '@/domains/tools/hooks/use-all-tools';
+import { useWorkflows } from '@/domains/workflows/hooks/use-workflows';
+import { useStoredWorkspaces } from '@/domains/workspace/hooks/use-stored-workspaces';
+
+type ToolsData = NonNullable<ReturnType<typeof useTools>['data']>;
+type AgentsData = NonNullable<ReturnType<typeof useAgents>['data']>;
+type WorkflowsData = NonNullable<ReturnType<typeof useWorkflows>['data']>;
+
+export interface AgentPrimitivesValue {
+  agentId: string;
+  storedAgent?: StoredAgent;
+  toolsData: ToolsData;
+  agentsData: AgentsData;
+  workflowsData: WorkflowsData;
+  availableSkills: StoredSkillResponse[];
+  availableWorkspaces: AvailableWorkspace[];
+  initialUserMessage: string | undefined;
+  isOwner: boolean;
+  canWrite: boolean;
+  isReady: boolean;
+}
+
+const AgentPrimitivesContext = createContext<AgentPrimitivesValue | null>(null);
+
+interface AgentPrimitivesProviderProps {
+  agentId: string;
+  children: ReactNode;
+}
+
+/**
+ * Loads and shapes the data the edit/view surfaces share: stored agent,
+ * tools/agents/workflows pickers, skills, workspaces, current user, and the
+ * starter user message. Computes `isReady`, `isOwner`, and `canWrite` so
+ * downstream components don't have to repeat the same gating logic.
+ */
+export const AgentPrimitivesProvider = ({ agentId, children }: AgentPrimitivesProviderProps) => {
+  const features = useBuilderAgentFeatures();
+  const { canWrite } = useBuilderAgentAccess();
+  const initialUserMessage = useStarterUserMessage();
+
+  const { data: storedAgent, isLoading: isStoredAgentLoading } = useStoredAgent(agentId, { status: 'draft' });
+  const { data: toolsData, isPending: isToolsPending } = useTools({ enabled: features.tools });
+  const { data: agentsData, isPending: isAgentsPending } = useAgents({ enabled: features.agents });
+  const { data: workflowsData, isPending: isWorkflowsPending } = useWorkflows({ enabled: features.workflows });
+  const { data: storedSkillsResponse, isPending: isSkillsPending } = useStoredSkills({
+    enabled: features.skills,
+  });
+  const { data: workspacesData } = useStoredWorkspaces();
+  const { data: currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
+
+  const isOwner = !storedAgent?.authorId || currentUser?.id === storedAgent.authorId;
+  const isOwnershipLoading = Boolean(storedAgent?.authorId) && isCurrentUserLoading;
+
+  const isReady =
+    Boolean(agentId) &&
+    !isStoredAgentLoading &&
+    !isOwnershipLoading &&
+    (!features.tools || !isToolsPending) &&
+    (!features.skills || !isSkillsPending) &&
+    (!features.agents || !isAgentsPending) &&
+    (!features.workflows || !isWorkflowsPending);
+
+  const availableWorkspaces = useMemo<AvailableWorkspace[]>(
+    () =>
+      (workspacesData?.workspaces ?? [])
+        .filter(ws => ws.status !== 'archived')
+        .sort((a, b) => (b.runtimeRegistered ? 1 : 0) - (a.runtimeRegistered ? 1 : 0))
+        .map(ws => ({ id: ws.id, name: ws.name })),
+    [workspacesData],
+  );
+
+  const availableSkills = useMemo<StoredSkillResponse[]>(
+    () => storedSkillsResponse?.skills ?? [],
+    [storedSkillsResponse],
+  );
+
+  const value = useMemo<AgentPrimitivesValue>(
+    () => ({
+      agentId: agentId!,
+      storedAgent: storedAgent ?? undefined,
+      toolsData: toolsData ?? {},
+      agentsData: agentsData ?? {},
+      workflowsData: workflowsData ?? {},
+      availableSkills,
+      availableWorkspaces,
+      initialUserMessage,
+      isOwner,
+      canWrite,
+      isReady,
+    }),
+    [
+      agentId,
+      storedAgent,
+      toolsData,
+      agentsData,
+      workflowsData,
+      availableSkills,
+      availableWorkspaces,
+      initialUserMessage,
+      isOwner,
+      canWrite,
+      isReady,
+    ],
+  );
+
+  return <AgentPrimitivesContext.Provider value={value}>{children}</AgentPrimitivesContext.Provider>;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useAgentPrimitives = (): AgentPrimitivesValue => {
+  const ctx = useContext(AgentPrimitivesContext);
+  if (!ctx) {
+    throw new Error('useAgentPrimitives must be used inside <AgentPrimitivesProvider>');
+  }
+  return ctx;
+};

--- a/packages/playground/src/domains/agent-builder/hooks/__tests__/fixtures/stored-skills.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/__tests__/fixtures/stored-skills.ts
@@ -1,0 +1,30 @@
+import type { ListStoredSkillsResponse, StoredSkillResponse } from '@mastra/client-js';
+
+export const makeStoredSkill = (overrides: Partial<StoredSkillResponse> = {}): StoredSkillResponse => ({
+  id: overrides.id ?? 'skill-1',
+  status: overrides.status ?? 'active',
+  name: overrides.name ?? 'My Skill',
+  description: overrides.description ?? 'A useful skill',
+  instructions: overrides.instructions ?? 'Do useful things.',
+  visibility: overrides.visibility ?? 'private',
+  authorId: overrides.authorId ?? 'user-1',
+  createdAt: overrides.createdAt ?? '2026-01-01T00:00:00.000Z',
+  updatedAt: overrides.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+export const emptyStoredSkills: ListStoredSkillsResponse = {
+  skills: [],
+  total: 0,
+  page: 1,
+  perPage: 50,
+  hasMore: false,
+};
+
+export const oneStoredSkill: ListStoredSkillsResponse = {
+  skills: [makeStoredSkill()],
+  total: 1,
+  page: 1,
+  perPage: 50,
+  hasMore: false,
+};

--- a/packages/playground/src/domains/agent-builder/hooks/__tests__/use-available-agent-tools.test.tsx
+++ b/packages/playground/src/domains/agent-builder/hooks/__tests__/use-available-agent-tools.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BuilderPickerVisibility } from '../../../agent-builder';
+import { useAvailableAgentTools } from '../use-available-agent-tools';
+
+let pickerMock: BuilderPickerVisibility;
+
+vi.mock('../../../agent-builder', () => ({
+  useBuilderPickerVisibility: () => pickerMock,
+}));
+
+const UNRESTRICTED: BuilderPickerVisibility = {
+  visibleTools: null,
+  visibleAgents: null,
+  visibleWorkflows: null,
+};
+
+beforeEach(() => {
+  pickerMock = UNRESTRICTED;
+});
+
+describe('useAvailableAgentTools', () => {
+  it('builds AgentTool[] from tools and agents data', () => {
+    const { result } = renderHook(() =>
+      useAvailableAgentTools({
+        toolsData: { 'tool-a': { description: 'Tool A' } },
+        agentsData: { 'agent-x': { name: 'Agent X' } },
+        selectedTools: { 'tool-a': true },
+        selectedAgents: {},
+      }),
+    );
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current.find(t => t.id === 'tool-a')).toMatchObject({
+      type: 'tool',
+      isChecked: true,
+      description: 'Tool A',
+    });
+    expect(result.current.find(t => t.id === 'agent-x')).toMatchObject({
+      type: 'agent',
+      name: 'Agent X',
+      isChecked: false,
+    });
+  });
+
+  it('builds AgentTool[] including workflows with type "workflow"', () => {
+    const { result } = renderHook(() =>
+      useAvailableAgentTools({
+        toolsData: {},
+        agentsData: {},
+        workflowsData: { 'wf-1': { name: 'Workflow One', description: 'wf desc' } },
+        selectedTools: {},
+        selectedAgents: {},
+        selectedWorkflows: { 'wf-1': true },
+      }),
+    );
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({
+      id: 'wf-1',
+      name: 'Workflow One',
+      description: 'wf desc',
+      type: 'workflow',
+      isChecked: true,
+    });
+  });
+
+  it('excludes the agent matching excludeAgentId', () => {
+    const { result } = renderHook(() =>
+      useAvailableAgentTools({
+        toolsData: {},
+        agentsData: { 'agent-self': { name: 'Self' }, 'agent-other': { name: 'Other' } },
+        selectedTools: {},
+        selectedAgents: {},
+        excludeAgentId: 'agent-self',
+      }),
+    );
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].id).toBe('agent-other');
+  });
+
+  it('returns the same reference when inputs are referentially equal across renders', () => {
+    const toolsData = { 'tool-a': { description: 'Tool A' } };
+    const agentsData = { 'agent-x': { name: 'Agent X' } };
+    const selectedTools = { 'tool-a': true };
+    const selectedAgents = {};
+
+    const { result, rerender } = renderHook(
+      ({
+        tools,
+        agents,
+        selT,
+        selA,
+      }: {
+        tools: Record<string, unknown>;
+        agents: Record<string, unknown>;
+        selT: Record<string, boolean>;
+        selA: Record<string, boolean>;
+      }) =>
+        useAvailableAgentTools({
+          toolsData: tools,
+          agentsData: agents,
+          selectedTools: selT,
+          selectedAgents: selA,
+        }),
+      { initialProps: { tools: toolsData, agents: agentsData, selT: selectedTools, selA: selectedAgents } },
+    );
+
+    const first = result.current;
+    rerender({ tools: toolsData, agents: agentsData, selT: selectedTools, selA: selectedAgents });
+
+    expect(result.current).toBe(first);
+  });
+
+  it('filters tools when picker tools allowlist is restricted', () => {
+    pickerMock = {
+      ...UNRESTRICTED,
+      visibleTools: new Set(['tool-a']),
+    };
+    const { result } = renderHook(() =>
+      useAvailableAgentTools({
+        toolsData: { 'tool-a': { description: 'A' }, 'tool-b': { description: 'B' } },
+        agentsData: {},
+        selectedTools: {},
+        selectedAgents: {},
+      }),
+    );
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].id).toBe('tool-a');
+  });
+
+  it('filters agents and workflows independently from tools', () => {
+    pickerMock = {
+      visibleTools: null,
+      visibleAgents: new Set(['agent-x']),
+      visibleWorkflows: new Set(['wf-1']),
+    };
+    const { result } = renderHook(() =>
+      useAvailableAgentTools({
+        toolsData: { 'tool-a': {} },
+        agentsData: { 'agent-x': { name: 'X' }, 'agent-y': { name: 'Y' } },
+        workflowsData: { 'wf-1': { name: 'WF1' }, 'wf-2': { name: 'WF2' } },
+        selectedTools: {},
+        selectedAgents: {},
+        selectedWorkflows: {},
+      }),
+    );
+    const ids = result.current.map(t => t.id).sort();
+    expect(ids).toEqual(['agent-x', 'tool-a', 'wf-1']);
+  });
+
+  it('returns empty list when an allowlist is empty', () => {
+    pickerMock = {
+      ...UNRESTRICTED,
+      visibleTools: new Set(),
+    };
+    const { result } = renderHook(() =>
+      useAvailableAgentTools({
+        toolsData: { 'tool-a': {}, 'tool-b': {} },
+        agentsData: {},
+        selectedTools: {},
+        selectedAgents: {},
+      }),
+    );
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('matches allowlist against the response key (server normalizes IDs server-side)', () => {
+    // Server-side, picker IDs are normalized to the response keys of each
+    // GET /<kind> endpoint, so the client filter only needs to compare keys.
+    pickerMock = {
+      ...UNRESTRICTED,
+      visibleTools: new Set(['weatherKey', 'fallback-key']),
+    };
+    const { result } = renderHook(() =>
+      useAvailableAgentTools({
+        toolsData: {
+          weatherKey: { id: 'weather-id', description: 'W' },
+          'fallback-key': { description: 'F' },
+          otherKey: { id: 'other-id', description: 'O' },
+        },
+        agentsData: {},
+        selectedTools: {},
+        selectedAgents: {},
+      }),
+    );
+    const ids = result.current.map(t => t.id).sort();
+    expect(ids).toEqual(['fallback-key', 'weatherKey']);
+  });
+
+  it('ignores allowlist IDs not present in raw data', () => {
+    pickerMock = {
+      ...UNRESTRICTED,
+      visibleTools: new Set(['tool-a', 'ghost']),
+    };
+    const { result } = renderHook(() =>
+      useAvailableAgentTools({
+        toolsData: { 'tool-a': {} },
+        agentsData: {},
+        selectedTools: {},
+        selectedAgents: {},
+      }),
+    );
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].id).toBe('tool-a');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/hooks/__tests__/use-copy-skill.test.tsx
+++ b/packages/playground/src/domains/agent-builder/hooks/__tests__/use-copy-skill.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useCopySkill } from '../use-copy-skill';
+import { makeStoredSkill } from './fixtures/stored-skills';
+import { server } from '@/test/msw-server';
+
+vi.mock('@mastra/playground-ui', async importOriginal => {
+  const actual = await importOriginal<typeof PlaygroundUi>();
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
+const BASE_URL = 'http://localhost:4111';
+
+const makeHarness = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+  return { queryClient, Wrapper };
+};
+
+describe('useCopySkill', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a private copy with library-copy origin metadata', async () => {
+    const source = makeStoredSkill({
+      id: 'src-1',
+      name: 'Source Skill',
+      description: 'Original',
+      instructions: 'Do it',
+      authorId: 'author-1',
+      visibility: 'public',
+    });
+
+    let receivedBody: any = null;
+    server.use(
+      http.post(`${BASE_URL}/api/stored/skills`, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json(makeStoredSkill({ id: 'copy-1', name: 'My Copy' }));
+      }),
+    );
+
+    const { queryClient, Wrapper } = makeHarness();
+    queryClient.setQueryData(['stored-skills'], { skills: [], total: 0 });
+
+    const { result } = renderHook(() => useCopySkill(), { wrapper: Wrapper });
+
+    const created = await result.current.mutateAsync({ source, name: 'My Copy' });
+
+    expect(created.id).toBe('copy-1');
+    await waitFor(() => expect(receivedBody).not.toBeNull());
+
+    expect(receivedBody).toMatchObject({
+      name: 'My Copy',
+      description: 'Original',
+      visibility: 'private',
+      instructions: 'Do it',
+      metadata: {
+        origin: {
+          type: 'library-copy',
+          sourceSkillId: 'src-1',
+          sourceSkillName: 'Source Skill',
+          sourceAuthorId: 'author-1',
+        },
+      },
+    });
+    expect(receivedBody.metadata.origin.copiedAt).toEqual(expect.any(String));
+
+    expect(queryClient.getQueryState(['stored-skills'])?.isInvalidated).toBe(true);
+  });
+
+  it('omits null license and files from the create payload', async () => {
+    const source = makeStoredSkill({
+      id: 'src-2',
+      license: null as any,
+      files: null as any,
+    });
+
+    let receivedBody: any = null;
+    server.use(
+      http.post(`${BASE_URL}/api/stored/skills`, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json(makeStoredSkill({ id: 'copy-2' }));
+      }),
+    );
+
+    const { Wrapper } = makeHarness();
+    const { result } = renderHook(() => useCopySkill(), { wrapper: Wrapper });
+
+    await result.current.mutateAsync({ source, name: 'Copy' });
+
+    expect(receivedBody).not.toHaveProperty('license');
+    expect(receivedBody).not.toHaveProperty('files');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/hooks/__tests__/use-create-skill-tool.test.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/__tests__/use-create-skill-tool.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentBuilderEditFormValues } from '../../schemas';
+import { useCreateSkillTool } from '../use-create-skill-tool';
+import { extractSkillInstructions } from '@/domains/agents/components/agent-cms-pages/skill-file-tree';
+
+const mutateAsync = vi.fn();
+
+vi.mock('@/domains/agents/hooks/use-create-skill', () => ({
+  useCreateSkill: () => ({ mutateAsync }),
+}));
+
+vi.mock('@/domains/auth/hooks/use-default-visibility', () => ({
+  useDefaultVisibility: () => 'private',
+}));
+
+const renderCreateSkillTool = (options: { availableWorkspaces?: { id: string; name: string }[] } = {}) => {
+  const formRef: { current: ReturnType<typeof useForm<AgentBuilderEditFormValues>> | null } = {
+    current: null,
+  };
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => {
+    const methods = useForm<AgentBuilderEditFormValues>({
+      defaultValues: { name: '', description: '', instructions: '', tools: {}, agents: {}, skills: {} },
+    });
+    formRef.current = methods;
+    return React.createElement(FormProvider, methods, children);
+  };
+
+  const { result } = renderHook(() => useCreateSkillTool({ availableWorkspaces: options.availableWorkspaces }), {
+    wrapper: Wrapper,
+  });
+
+  return { tool: result.current, form: () => formRef.current! };
+};
+
+describe('useCreateSkillTool', () => {
+  beforeEach(() => {
+    mutateAsync.mockReset();
+  });
+
+  it('creates a skill, writes SKILL.md content, and attaches it to the form', async () => {
+    mutateAsync.mockResolvedValue({ id: 'skill-new' });
+    const { tool, form } = renderCreateSkillTool({
+      availableWorkspaces: [{ id: 'ws-1', name: 'Primary' }],
+    });
+
+    const result = await tool.execute!({
+      name: 'CSV Parser',
+      description: 'Parses CSV files',
+      instructions: '# How to parse CSV\nUse a streaming parser.',
+      workspaceId: 'ws-1',
+    } as any);
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    const payload = mutateAsync.mock.calls[0][0];
+    expect(payload.name).toBe('CSV Parser');
+    expect(payload.description).toBe('Parses CSV files');
+    expect(payload.workspaceId).toBe('ws-1');
+    expect(payload.visibility).toBe('private');
+    expect(extractSkillInstructions(payload.files)).toBe('# How to parse CSV\nUse a streaming parser.');
+
+    expect(result).toEqual({ success: true, skillId: 'skill-new' });
+    expect(form().getValues('skills')).toEqual({ 'skill-new': true });
+  });
+
+  it('preserves previously selected skills when attaching the new one', async () => {
+    mutateAsync.mockResolvedValue({ id: 'skill-new' });
+    const { tool, form } = renderCreateSkillTool({
+      availableWorkspaces: [{ id: 'ws-1', name: 'Primary' }],
+    });
+
+    form().setValue('skills', { 'skill-existing': true });
+
+    await tool.execute!({
+      name: 'CSV Parser',
+      description: 'Parses CSV files',
+      instructions: 'body',
+      workspaceId: 'ws-1',
+    } as any);
+
+    expect(form().getValues('skills')).toEqual({ 'skill-existing': true, 'skill-new': true });
+  });
+
+  it('falls back to the only available workspace when workspaceId is omitted', async () => {
+    mutateAsync.mockResolvedValue({ id: 'skill-new' });
+    const { tool } = renderCreateSkillTool({
+      availableWorkspaces: [{ id: 'ws-only', name: 'Only' }],
+    });
+
+    await tool.execute!({
+      name: 'Skill',
+      description: 'desc',
+      instructions: 'body',
+    } as any);
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mutateAsync.mock.calls[0][0].workspaceId).toBe('ws-only');
+  });
+
+  it('returns an error and does not call mutateAsync when no workspace is available', async () => {
+    const { tool, form } = renderCreateSkillTool({ availableWorkspaces: [] });
+
+    const result = await tool.execute!({
+      name: 'Skill',
+      description: 'desc',
+      instructions: 'body',
+    } as any);
+
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error: 'No workspace available for skill creation.',
+    });
+    expect(form().getValues('skills')).toEqual({});
+  });
+});

--- a/packages/playground/src/domains/agent-builder/hooks/__tests__/use-delete-skill.test.tsx
+++ b/packages/playground/src/domains/agent-builder/hooks/__tests__/use-delete-skill.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useDeleteSkill } from '../use-delete-skill';
+import { makeStoredSkill } from './fixtures/stored-skills';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+const makeHarness = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+  return { queryClient, Wrapper };
+};
+
+describe('useDeleteSkill', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('deletes the skill and invalidates the stored-skills list cache', async () => {
+    const seenDelete = vi.fn();
+    server.use(
+      http.delete(`${BASE_URL}/api/stored/skills/skill-1`, () => {
+        seenDelete();
+        return HttpResponse.json({ success: true, message: 'deleted' });
+      }),
+    );
+
+    const { queryClient, Wrapper } = makeHarness();
+    queryClient.setQueryData(['stored-skills'], { skills: [makeStoredSkill()], total: 1 });
+    queryClient.setQueryData(['stored-skill', 'skill-1'], makeStoredSkill());
+
+    const { result } = renderHook(() => useDeleteSkill('skill-1'), { wrapper: Wrapper });
+
+    await result.current.mutateAsync();
+
+    await waitFor(() => expect(seenDelete).toHaveBeenCalledTimes(1));
+    // List cache is invalidated (still present, but marked stale).
+    expect(queryClient.getQueryState(['stored-skills'])?.isInvalidated).toBe(true);
+    // The detail entry is removed entirely.
+    expect(queryClient.getQueryData(['stored-skill', 'skill-1'])).toBeUndefined();
+  });
+
+  it('throws when no skillId is provided', async () => {
+    const { Wrapper } = makeHarness();
+    const { result } = renderHook(() => useDeleteSkill(undefined), { wrapper: Wrapper });
+
+    await expect(result.current.mutateAsync()).rejects.toThrow(/skillId is required/);
+  });
+});

--- a/packages/playground/src/domains/agent-builder/hooks/__tests__/use-set-agent-skills-tool.test.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/__tests__/use-set-agent-skills-tool.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import type { StoredSkillResponse } from '@mastra/client-js';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { describe, expect, it } from 'vitest';
+
+import type { AgentBuilderEditFormValues } from '../../schemas';
+import { SET_AGENT_SKILLS_TOOL_NAME, useSetAgentSkillsTool } from '../use-set-agent-skills-tool';
+
+const availableSkills = [
+  { id: 'skill-1', name: 'Skill One', description: 'first' },
+  { id: 'skill-2', name: 'Skill Two', description: 'second' },
+] as unknown as StoredSkillResponse[];
+
+const renderTool = (skills: StoredSkillResponse[] = availableSkills) => {
+  const formRef: { current: ReturnType<typeof useForm<AgentBuilderEditFormValues>> | null } = { current: null };
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => {
+    const methods = useForm<AgentBuilderEditFormValues>({
+      defaultValues: { name: '', description: '', instructions: '', skills: {} },
+    });
+    formRef.current = methods;
+    return React.createElement(FormProvider, methods, children);
+  };
+
+  const { result } = renderHook(() => useSetAgentSkillsTool({ availableSkills: skills }), { wrapper: Wrapper });
+  return { tool: result.current, form: () => formRef.current! };
+};
+
+describe('useSetAgentSkillsTool', () => {
+  it('exposes the canonical tool id', () => {
+    const { tool } = renderTool();
+    expect(tool.id).toBe(SET_AGENT_SKILLS_TOOL_NAME);
+    expect(tool.id).toBe('set-agent-skills');
+  });
+
+  it('writes only skills present in availableSkills', async () => {
+    const { tool, form } = renderTool();
+    await tool.execute!({
+      skills: [
+        { id: 'skill-1', name: 'Skill One' },
+        { id: 'unknown', name: 'Unknown' },
+      ],
+    } as any);
+
+    expect(form().getValues('skills')).toEqual({ 'skill-1': true });
+  });
+
+  it('clears all skills when given an empty array', async () => {
+    const { tool, form } = renderTool();
+    form().setValue('skills', { 'skill-1': true, 'skill-2': true });
+    await tool.execute!({ skills: [] } as any);
+    expect(form().getValues('skills')).toEqual({});
+  });
+
+  it('does nothing when input is missing', async () => {
+    const { tool, form } = renderTool();
+    form().setValue('skills', { 'skill-1': true });
+    await tool.execute!({} as any);
+    expect(form().getValues('skills')).toEqual({ 'skill-1': true });
+  });
+});

--- a/packages/playground/src/domains/agent-builder/hooks/__tests__/use-stored-skill.test.tsx
+++ b/packages/playground/src/domains/agent-builder/hooks/__tests__/use-stored-skill.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useStoredSkill } from '../use-stored-skill';
+import { makeStoredSkill } from './fixtures/stored-skills';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MastraReactProvider baseUrl={BASE_URL}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </MastraReactProvider>
+    );
+  };
+};
+
+describe('useStoredSkill', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches stored skill details by id', async () => {
+    const skill = makeStoredSkill({ id: 'skill-7', name: 'Renamed' });
+    server.use(http.get(`${BASE_URL}/api/stored/skills/skill-7`, () => HttpResponse.json(skill)));
+
+    const { result } = renderHook(() => useStoredSkill('skill-7'), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toMatchObject({ id: 'skill-7', name: 'Renamed' });
+  });
+
+  it('does not fire the network request when skillId is undefined', async () => {
+    const onFetch = vi.fn();
+    server.use(
+      http.get(`${BASE_URL}/api/stored/skills/:id`, () => {
+        onFetch();
+        return HttpResponse.json(makeStoredSkill());
+      }),
+    );
+
+    const { result } = renderHook(() => useStoredSkill(undefined), { wrapper: makeWrapper() });
+
+    // Give react-query a tick to decide whether to fire.
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(onFetch).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/hooks/__tests__/use-visibility-change-skill.test.tsx
+++ b/packages/playground/src/domains/agent-builder/hooks/__tests__/use-visibility-change-skill.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useVisibilityChange } from '../use-visibility-change-skill';
+import type { SkillEditFormValues } from '@/domains/agent-builder/hooks/use-autosave-skill';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+const SKILL_ID = 'skill-vc';
+
+const makeWrapper = (defaultVisibility: SkillEditFormValues['visibility'] = 'private') => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const methods = useForm<SkillEditFormValues>({
+      defaultValues: {
+        name: '',
+        description: '',
+        instructions: '',
+        visibility: defaultVisibility,
+        workspaceId: undefined,
+      },
+    });
+    return (
+      <MastraReactProvider baseUrl={BASE_URL}>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <TooltipProvider>
+              <FormProvider {...methods}>
+                {children}
+                <span data-testid="form-visibility">{methods.watch('visibility')}</span>
+                <span data-testid="form-dirty">{methods.formState.isDirty ? 'true' : 'false'}</span>
+              </FormProvider>
+            </TooltipProvider>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </MastraReactProvider>
+    );
+  };
+};
+
+describe('useVisibilityChange (skill)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('cancel path: opens the dialog, closes on cancel, and never PATCHes', async () => {
+    let patchCalled = false;
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, () => {
+        patchCalled = true;
+        return HttpResponse.json({ id: SKILL_ID, visibility: 'public' });
+      }),
+    );
+
+    function Harness() {
+      const { requestChange, dialog } = useVisibilityChange(SKILL_ID);
+      return (
+        <>
+          <button data-testid="trigger-add" onClick={() => requestChange('public')}>
+            add
+          </button>
+          {dialog}
+        </>
+      );
+    }
+
+    const Wrapper = makeWrapper('private');
+    render(
+      <Wrapper>
+        <Harness />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('trigger-add'));
+    expect(await screen.findByTestId('skill-builder-visibility-confirm-dialog')).toBeTruthy();
+
+    fireEvent.click(await screen.findByTestId('skill-builder-visibility-confirm-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skill-builder-visibility-confirm-dialog')).toBeNull();
+    });
+    expect(patchCalled).toBe(false);
+  });
+
+  it('confirm path: issues exactly one PATCH and writes the form value without marking it dirty', async () => {
+    let callCount = 0;
+    let capturedBody: any = null;
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, async ({ request }) => {
+        callCount += 1;
+        capturedBody = await request.json();
+        return HttpResponse.json({ id: SKILL_ID, visibility: 'public' });
+      }),
+    );
+
+    const Wrapper = makeWrapper('private');
+
+    // Use a tiny in-render harness that hosts both the hook and an Add button,
+    // since renderHook does not let us click the dialog buttons inside the
+    // same React tree as the hook owner.
+    function Harness() {
+      const { requestChange, dialog } = useVisibilityChange(SKILL_ID);
+      return (
+        <>
+          <button data-testid="trigger-add" onClick={() => requestChange('public')}>
+            add
+          </button>
+          {dialog}
+        </>
+      );
+    }
+
+    render(
+      <Wrapper>
+        <Harness />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId('trigger-add'));
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId('skill-builder-visibility-confirm-yes'));
+    });
+
+    await waitFor(() => {
+      expect(callCount).toBe(1);
+    });
+    expect(capturedBody).toMatchObject({ visibility: 'public' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('form-visibility').textContent).toBe('public');
+    });
+    // The hook intentionally sets the form value with shouldDirty: false so
+    // autosave does not re-fire its own PATCH after a visibility change.
+    expect(screen.getByTestId('form-dirty').textContent).toBe('false');
+  });
+});

--- a/packages/playground/src/domains/agent-builder/hooks/use-available-agent-tools.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-available-agent-tools.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useBuilderPickerVisibility } from '../../builder';
+import { useBuilderPickerVisibility } from '../../agent-builder';
 import { buildAvailableToolRecords } from '../services/build-available-tool-records';
 import { buildAgentTools } from '../types/agent-tool';
 import type { AgentTool } from '../types/agent-tool';

--- a/packages/playground/src/domains/agent-builder/hooks/use-copy-skill.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-copy-skill.ts
@@ -1,0 +1,62 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import { toast } from '@mastra/playground-ui';
+import { useMastraClient } from '@mastra/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { LibraryCopyOrigin } from '@/domains/agent-builder/utils/skill-origin';
+
+export interface CopySkillParams {
+  /** The public Library skill being copied. */
+  source: StoredSkillResponse;
+  /** Name to give the new private copy. Should not collide with existing user skills. */
+  name: string;
+  /** Optional override of the description. Defaults to the source description. */
+  description?: string;
+}
+
+/**
+ * Copy a public Library skill into the caller's own catalog as a private skill.
+ *
+ * Users can take a public skill and customize it without affecting the
+ * canonical version. We call `createStoredSkill` with the source's content and
+ * an `origin: library-copy` tag so the UI can show provenance later.
+ */
+export function useCopySkill() {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: CopySkillParams): Promise<StoredSkillResponse> => {
+      const { source, name } = params;
+      const description = params.description ?? source.description ?? '';
+
+      const origin: LibraryCopyOrigin = {
+        type: 'library-copy',
+        sourceSkillId: source.id,
+        sourceSkillName: source.name,
+        ...(source.authorId ? { sourceAuthorId: source.authorId } : {}),
+      };
+
+      return client.createStoredSkill({
+        name,
+        description,
+        visibility: 'private',
+        instructions: source.instructions,
+        // Optional fields may come back as null from the source; the create
+        // schema only accepts an object/array or omitted, so drop nulls.
+        ...(source.license != null ? { license: source.license } : {}),
+        ...(source.files != null ? { files: source.files } : {}),
+        metadata: {
+          origin: { ...origin, copiedAt: new Date().toISOString() },
+        },
+      });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['stored-skills'] });
+      toast.success('Skill copied');
+    },
+    onError: error => {
+      toast.error(`Failed to copy skill: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    },
+  });
+}

--- a/packages/playground/src/domains/agent-builder/hooks/use-delete-skill.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-delete-skill.ts
@@ -1,0 +1,22 @@
+import { useMastraClient } from '@mastra/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useDeleteSkill(skillId?: string) {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => {
+      if (!skillId) throw new Error('skillId is required for delete');
+      return client.getStoredSkill(skillId).delete();
+    },
+    onSuccess: () => {
+      // Invalidate lists so the skills list page refetches without the deleted entry
+      void queryClient.invalidateQueries({ queryKey: ['stored-skills'] });
+      // Drop the deleted entity from cache so active observers don't refetch a 404
+      if (skillId) {
+        queryClient.removeQueries({ queryKey: ['stored-skill', skillId] });
+      }
+    },
+  });
+}

--- a/packages/playground/src/domains/agent-builder/hooks/use-set-agent-skills-tool.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-set-agent-skills-tool.ts
@@ -1,0 +1,67 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import { createTool } from '@mastra/client-js';
+import { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { z } from 'zod-v4';
+
+import type { AgentBuilderEditFormValues } from '@/domains/agent-builder/schemas';
+
+export const SET_AGENT_SKILLS_TOOL_NAME = 'set-agent-skills';
+
+interface UseSetAgentSkillsToolArgs {
+  availableSkills: StoredSkillResponse[];
+}
+
+export function useSetAgentSkillsTool({ availableSkills }: UseSetAgentSkillsToolArgs) {
+  const formMethods = useFormContext<AgentBuilderEditFormValues>();
+
+  return useMemo(() => {
+    const skillIds = availableSkills.map(s => s.id);
+    const skillIdSchema = skillIds.length > 0 ? z.enum(skillIds as [string, ...string[]]) : z.string();
+
+    const availableSkillsBlock =
+      availableSkills.length > 0
+        ? `\n\nAvailable skills (use these ids in the "skills" field):\n${availableSkills
+            .map(s => `- ${s.id}${s.description ? `: ${s.description}` : ''}`)
+            .join('\n')}`
+        : '';
+
+    return createTool({
+      id: SET_AGENT_SKILLS_TOOL_NAME,
+      description:
+        'Attach existing skills to the agent. Each entry MUST include both `id` (from the available skills list) and `name` (a concise Title Case display label). Use the separate `createSkillTool` tool to create NEW skills.' +
+        availableSkillsBlock,
+      inputSchema: z.object({
+        skills: z
+          .array(
+            z.object({
+              id: skillIdSchema.describe(
+                'The skill id. Only use ids from the available skills list in this tool description.',
+              ),
+              name: z
+                .string()
+                .min(1)
+                .describe('A short, human-readable Title Case display label for this skill (max ~3 words).'),
+            }),
+          )
+          .describe(
+            'Skills to enable on the agent. Each entry must include both the skill `id` and a concise human-readable `name`.',
+          ),
+      }),
+      outputSchema: z.object({ success: z.boolean() }),
+      execute: async (inputData: any) => {
+        if (Array.isArray(inputData?.skills)) {
+          const validSkillIds = new Set(availableSkills.map(s => s.id));
+          const skills: Record<string, true> = {};
+          for (const entry of inputData.skills) {
+            if (entry && typeof entry.id === 'string' && validSkillIds.has(entry.id)) {
+              skills[entry.id] = true;
+            }
+          }
+          formMethods.setValue('skills', skills, { shouldDirty: true });
+        }
+        return { success: true };
+      },
+    });
+  }, [formMethods, availableSkills]);
+}

--- a/packages/playground/src/domains/agent-builder/hooks/use-stored-skill.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-stored-skill.ts
@@ -1,0 +1,12 @@
+import { useMastraClient } from '@mastra/react';
+import { useQuery } from '@tanstack/react-query';
+
+export function useStoredSkill(skillId: string | undefined) {
+  const client = useMastraClient();
+
+  return useQuery({
+    queryKey: ['stored-skill', skillId],
+    queryFn: () => client.getStoredSkill(skillId!).details(),
+    enabled: !!skillId,
+  });
+}

--- a/packages/playground/src/domains/agent-builder/index.ts
+++ b/packages/playground/src/domains/agent-builder/index.ts
@@ -3,3 +3,6 @@ export type { AgentFeatureFlags, DenialReason, UseBuilderAgentAccessResult } fro
 export { useBuilderAgentFeatures } from './hooks/use-builder-agent-features';
 export { useCanCreateAgent } from './hooks/use-can-create-agent';
 export type { UseCanCreateAgentResult } from './hooks/use-can-create-agent';
+export { useBuilderFilteredModels, useBuilderFilteredProviders } from './hooks/use-builder-filtered-models';
+export { useBuilderModelPolicy, useBuilderPickerVisibility } from './hooks/use-builder-settings';
+export type { BuilderPickerVisibility } from './hooks/use-builder-settings';

--- a/packages/playground/src/domains/agent-builder/layouts/skill-workspace-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/skill-workspace-layout.tsx
@@ -1,0 +1,166 @@
+import { Button, cn } from '@mastra/playground-ui';
+import { ArrowLeftIcon } from 'lucide-react';
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+import { useNavigate } from 'react-router';
+
+type ActiveTab = 'chat' | 'configure';
+
+interface SkillWorkspaceLayoutProps {
+  /** Title shown in the header (skill name). */
+  title: ReactNode;
+  /** Slot rendered first in the right action cluster (e.g. autosave indicator). */
+  rightAside?: ReactNode;
+  /** Slot for visibility select / other top-right actions. Shown on desktop only. */
+  primaryAction?: ReactNode;
+  /** Slot for mobile-only header actions (e.g. kebab menu). Shown below the lg breakpoint. */
+  mobileExtra?: ReactNode;
+  /** When false, hide the right-side form column entirely (chat takes the full width). */
+  showForm?: boolean;
+  chat: ReactNode;
+  form: ReactNode;
+  /** Optional destructive action rendered at the bottom of the configure panel. */
+  deleteAction?: ReactNode;
+}
+
+export const SkillWorkspaceLayout = ({
+  title,
+  rightAside,
+  primaryAction,
+  mobileExtra,
+  showForm = true,
+  chat,
+  form,
+  deleteAction,
+}: SkillWorkspaceLayoutProps) => {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<ActiveTab>('chat');
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header */}
+      <div className="flex min-w-0 items-center gap-2 bg-surface1 px-3 py-2 md:px-6 md:py-3">
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={() => navigate('/agent-builder/skills', { viewTransition: true })}
+          className="rounded-full"
+          tooltip="Skills list"
+          data-testid="skill-edit-back-button"
+        >
+          <ArrowLeftIcon />
+        </Button>
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <div className="min-w-0 truncate text-ui-md text-neutral6">{title}</div>
+          {rightAside && <div className="shrink-0">{rightAside}</div>}
+        </div>
+        {primaryAction && <div className="shrink-0">{primaryAction}</div>}
+        {mobileExtra && <div className="shrink-0 lg:hidden">{mobileExtra}</div>}
+      </div>
+
+      {/* Mobile tabs — only when there's a configure side to switch to.
+       *  Mirrors the agent-builder pill-style segmented switch for visual parity. */}
+      {showForm && (
+        <div className="md:hidden px-4 pt-4 pb-2">
+          <div
+            role="tablist"
+            aria-label="Workspace view"
+            className="relative mx-auto flex h-9 w-full max-w-sm items-center rounded-full border border-border1 bg-surface3 p-0.5"
+          >
+            <span
+              aria-hidden="true"
+              className={cn(
+                'absolute inset-y-0.5 left-0.5 w-[calc(50%-2px)] rounded-full bg-surface4',
+                'transition-transform duration-200 ease-out',
+                activeTab === 'configure' && 'translate-x-full',
+              )}
+            />
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'chat'}
+              data-testid="skill-edit-tab-chat"
+              onClick={() => setActiveTab('chat')}
+              className={cn(
+                'relative z-10 flex-1 rounded-full text-ui-md font-medium outline-none',
+                'transition-colors duration-200',
+                activeTab === 'chat' ? 'text-neutral5' : 'text-neutral3 hover:text-neutral4',
+              )}
+            >
+              Chat
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'configure'}
+              data-testid="skill-edit-tab-configure"
+              onClick={() => setActiveTab('configure')}
+              className={cn(
+                'relative z-10 flex-1 rounded-full text-ui-md font-medium outline-none',
+                'transition-colors duration-200',
+                activeTab === 'configure' ? 'text-neutral5' : 'text-neutral3 hover:text-neutral4',
+              )}
+            >
+              Configuration
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Body */}
+      <div
+        className={cn(
+          'grid min-h-0 flex-1 grid-cols-1',
+          // On desktop, reserve space for the floating skill panel only when it
+          // is visible — this lets the chat smoothly expand back to full width
+          // if the panel were ever hidden again.
+          showForm && 'md:grid-cols-[1fr_minmax(360px,40%)]',
+        )}
+      >
+        <div
+          className={cn(
+            'min-w-0 min-h-0 overflow-hidden bg-surface1',
+            showForm && activeTab !== 'chat' ? 'hidden' : 'block',
+            'md:block',
+            'md:transition-[grid-column] md:duration-300 md:ease-out',
+          )}
+        >
+          <div className="flex h-full min-h-0 flex-col px-4 pt-4 pb-6 md:px-10">
+            <div className="flex min-h-0 flex-1 flex-col md:max-w-[80ch] md:mx-auto w-full">{chat}</div>
+          </div>
+        </div>
+        {showForm && (
+          <div
+            className={cn(
+              'min-w-0 min-h-0 overflow-hidden bg-surface1',
+              activeTab === 'configure' ? 'block' : 'hidden',
+              'md:block',
+              // Mobile uses the same page-layout padding as the rest of the
+              // page so the configure panel sits flush at full width.
+              // On desktop, render an elevated, rounded, bordered card that
+              // slides in from the right. The slide is driven by a CSS
+              // keyframe animation triggered the first time this element
+              // mounts (which matches the moment showForm flips to true).
+              'px-4 pb-6 md:p-4 md:bg-transparent',
+            )}
+            data-testid="skill-edit-configure-panel"
+          >
+            <div
+              className={cn(
+                'skill-panel-slide-in flex h-full min-h-0 flex-col overflow-hidden',
+                'md:rounded-3xl md:border md:border-border1 md:bg-surface2',
+              )}
+            >
+              <div className="min-h-0 flex-1 overflow-hidden">{form}</div>
+              {deleteAction && (
+                <div className="border-t border-border1 px-4 pb-4 pt-4 md:px-6" data-testid="skill-edit-delete-action">
+                  {deleteAction}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-chat-composer.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-chat-composer.tsx
@@ -1,0 +1,174 @@
+import { Txt } from '@mastra/playground-ui';
+import { useChat } from '@mastra/react';
+import { Sparkles } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  SKILL_BUILDER_INSTRUCTIONS,
+  SKILL_BUILDER_TOOL_NAME,
+  SKILL_READER_TOOL_NAME,
+  useSkillBuilderTools,
+} from '../../hooks/use-skill-builder-tool';
+import type { SkillBuilderCallbacks, SkillFormState } from '../../hooks/use-skill-builder-tool';
+import { ChatComposer } from '@/domains/agent-builder/components/chat-primitives/chat-composer';
+import { MessageList } from '@/domains/agent-builder/components/chat-primitives/message-list';
+
+const BUILDER_AGENT_ID = 'builder-agent';
+
+export interface SkillChatComposerProps extends SkillBuilderCallbacks {
+  /** Reset key — when this changes the chat resets (e.g. dialog open/close) */
+  sessionKey: string;
+  /** Whether the form fields have been populated at least once */
+  hasFields: boolean;
+  /** Callback when the agent populates fields for the first time */
+  onFieldsPopulated?: () => void;
+  /** Current form state — exposed to the agent via a read tool */
+  formState: SkillFormState;
+  /** Optional one-shot user message to send as soon as the chat mounts (starter prompt). */
+  initialUserMessage?: string;
+  /** Notifies parent whenever the agent's run state changes (streaming start/stop). */
+  onRunningChange?: (isRunning: boolean) => void;
+}
+
+export function SkillChatComposer({
+  sessionKey,
+  hasFields,
+  onFieldsPopulated,
+  formState,
+  initialUserMessage,
+  onRunningChange,
+  ...callbacks
+}: SkillChatComposerProps) {
+  const populatedRef = useRef(false);
+
+  // Keep form state in a ref so the reader tool always gets the latest values
+  const formStateRef = useRef(formState);
+  formStateRef.current = formState;
+
+  // Wrap callbacks to detect first population
+  const wrappedCallbacks = useMemo<SkillBuilderCallbacks>(
+    () => ({
+      onNameChange: (name: string) => {
+        callbacks.onNameChange(name);
+        if (!populatedRef.current) {
+          populatedRef.current = true;
+          onFieldsPopulated?.();
+        }
+      },
+      onDescriptionChange: callbacks.onDescriptionChange,
+      onInstructionsChange: callbacks.onInstructionsChange,
+    }),
+    [callbacks, onFieldsPopulated],
+  );
+
+  const { writerTool, readerTool } = useSkillBuilderTools(wrappedCallbacks, formStateRef);
+  const clientTools = useMemo(
+    () => ({
+      [SKILL_BUILDER_TOOL_NAME]: writerTool,
+      [SKILL_READER_TOOL_NAME]: readerTool,
+    }),
+    [writerTool, readerTool],
+  );
+  const threadId = useMemo(() => `skill-builder-${sessionKey}`, [sessionKey]);
+
+  const { messages, sendMessage, isRunning, setMessages } = useChat({ agentId: BUILDER_AGENT_ID });
+
+  // Bubble run state up so parents can gate UI (e.g. revealing the form only
+  // after the agent's first turn completes with a title set).
+  useEffect(() => {
+    onRunningChange?.(isRunning);
+  }, [isRunning, onRunningChange]);
+
+  // Reset messages when session changes (dialog open/close)
+  const prevSessionRef = useRef(sessionKey);
+  useEffect(() => {
+    if (prevSessionRef.current !== sessionKey) {
+      prevSessionRef.current = sessionKey;
+      populatedRef.current = false;
+      setMessages([]);
+    }
+  }, [sessionKey, setMessages]);
+
+  // Draft state for the input
+  const [draft, setDraft] = useState('');
+  const trimmed = draft.trim();
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!trimmed || isRunning) return;
+      void sendMessage({
+        message: trimmed,
+        threadId,
+        clientTools,
+        modelSettings: { instructions: SKILL_BUILDER_INSTRUCTIONS },
+      });
+      setDraft('');
+    },
+    [trimmed, isRunning, sendMessage, threadId, clientTools],
+  );
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      e.currentTarget.form?.requestSubmit();
+    }
+  }, []);
+
+  // Auto-send the starter prompt once on mount when provided.
+  const sentStarterRef = useRef(false);
+  useEffect(() => {
+    if (sentStarterRef.current) return;
+    const starter = initialUserMessage?.trim();
+    if (!starter) return;
+    sentStarterRef.current = true;
+    void sendMessage({
+      message: starter,
+      threadId,
+      clientTools,
+      modelSettings: { instructions: SKILL_BUILDER_INSTRUCTIONS },
+    });
+  }, [initialUserMessage, sendMessage, threadId, clientTools]);
+
+  const emptyState = (
+    <div className="flex h-full flex-col items-center justify-center gap-3 text-center px-6 py-8">
+      <div className="rounded-full bg-accent5/10 p-3">
+        <Sparkles className="h-6 w-6 text-accent5" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Txt variant="ui-md" className="text-neutral5 font-medium" as="p">
+          {hasFields ? 'Refine your skill' : 'Describe your skill'}
+        </Txt>
+        <Txt variant="ui-sm" className="text-neutral3" as="p">
+          {hasFields
+            ? 'Ask the agent to adjust the name, description, or instructions.'
+            : 'Tell the agent what this skill should do and it will fill in the details for you.'}
+        </Txt>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <MessageList
+        messages={messages}
+        isRunning={isRunning}
+        emptyState={emptyState}
+        skeletonTestId="skill-builder-conversation-messages-skeleton"
+      />
+      <ChatComposer
+        draft={draft}
+        onDraftChange={setDraft}
+        onSubmit={handleSubmit}
+        onKeyDown={handleKeyDown}
+        disabled={isRunning}
+        canSubmit={!!trimmed && !isRunning}
+        isRunning={isRunning}
+        placeholder={hasFields ? 'Ask the agent to refine…' : 'Describe your skill…'}
+        inputTestId="skill-builder-conversation-input"
+        submitTestId="skill-builder-conversation-submit"
+        containerTestId="skill-builder-conversation-composer"
+      />
+    </div>
+  );
+}

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-simple-form.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-simple-form.tsx
@@ -1,0 +1,75 @@
+import { CodeEditor, Input, MarkdownRenderer, Txt } from '@mastra/playground-ui';
+
+export interface SkillSimpleFormProps {
+  name: string;
+  onNameChange: (name: string) => void;
+  description: string;
+  onDescriptionChange: (description: string) => void;
+  instructions: string;
+  onInstructionsChange: (instructions: string) => void;
+  readOnly?: boolean;
+}
+
+export function SkillSimpleForm({
+  name,
+  onNameChange,
+  description,
+  onDescriptionChange,
+  instructions,
+  onInstructionsChange,
+  readOnly,
+}: SkillSimpleFormProps) {
+  return (
+    <div className="flex flex-col gap-4 h-full">
+      <div className="flex flex-col gap-1.5">
+        <Txt as="label" variant="ui-sm" className="text-neutral3">
+          Name
+        </Txt>
+        <Input value={name} onChange={e => onNameChange(e.target.value)} placeholder="Skill name" disabled={readOnly} />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Txt as="label" variant="ui-sm" className="text-neutral3">
+          Description
+        </Txt>
+        <Input
+          value={description}
+          onChange={e => onDescriptionChange(e.target.value)}
+          placeholder="Brief description of the skill"
+          disabled={readOnly}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5 flex-1 min-h-0">
+        <Txt as="label" variant="ui-sm" className="text-neutral3">
+          Instructions
+        </Txt>
+
+        {readOnly ? (
+          <div className="flex-1 min-h-0 overflow-y-auto rounded-lg border border-border1 bg-surface2 p-4">
+            {instructions ? (
+              <MarkdownRenderer>{instructions}</MarkdownRenderer>
+            ) : (
+              <Txt variant="ui-sm" className="text-neutral3 italic">
+                No instructions provided.
+              </Txt>
+            )}
+          </div>
+        ) : (
+          <div className="flex-1 min-h-0 flex flex-col">
+            <CodeEditor
+              data-testid="skill-instructions-input"
+              value={instructions}
+              onChange={onInstructionsChange}
+              language="markdown"
+              editable
+              placeholder="You are a helpful assistant that…"
+              showCopyButton={false}
+              className="h-full w-full"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/playground/src/domains/agents/hooks/__tests__/use-create-skill.test.tsx
+++ b/packages/playground/src/domains/agents/hooks/__tests__/use-create-skill.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useCreateSkill } from '../use-create-skill';
+import { server } from '@/test/msw-server';
+
+vi.mock('@mastra/playground-ui', async importOriginal => {
+  const actual = await importOriginal<typeof PlaygroundUi>();
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
+const writeFileMock = vi.fn();
+vi.mock('@/domains/workspace/hooks', () => ({
+  useWriteWorkspaceFile: () => ({ mutateAsync: writeFileMock }),
+}));
+
+const hasPermissionMock = vi.fn();
+vi.mock('@/domains/auth/hooks', () => ({
+  usePermissions: () => ({ hasPermission: hasPermissionMock }),
+}));
+
+const BASE_URL = 'http://localhost:4111';
+
+const wrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+const baseFiles = [
+  { id: 'f1', type: 'file' as const, name: 'SKILL.md', content: '# Title\nDo X' },
+  { id: 'f2', type: 'file' as const, name: 'LICENSE', content: 'MIT' },
+];
+
+beforeEach(() => {
+  writeFileMock.mockReset();
+  hasPermissionMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useCreateSkill', () => {
+  it('writes skill files to the workspace and creates the DB record', async () => {
+    hasPermissionMock.mockReturnValue(true);
+    writeFileMock.mockResolvedValue(undefined);
+
+    let receivedBody: any = null;
+    server.use(
+      http.post(`${BASE_URL}/api/stored/skills`, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json({
+          id: 'created',
+          name: receivedBody.name,
+          description: receivedBody.description,
+          instructions: receivedBody.instructions,
+          status: 'active',
+          createdAt: '',
+          updatedAt: '',
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useCreateSkill(), { wrapper: wrapper() });
+
+    const created = await result.current.mutateAsync({
+      name: 'My Skill',
+      description: 'desc',
+      visibility: 'private',
+      workspaceId: 'ws-1',
+      files: baseFiles,
+    });
+
+    expect(created.id).toBe('created');
+    expect(writeFileMock).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      path: 'skills/SKILL.md',
+      content: '# Title\nDo X',
+      recursive: true,
+    });
+    expect(writeFileMock).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      path: 'skills/LICENSE',
+      content: 'MIT',
+      recursive: true,
+    });
+    expect(receivedBody).toMatchObject({
+      name: 'My Skill',
+      description: 'desc',
+      visibility: 'private',
+      files: baseFiles,
+    });
+  });
+
+  it('skips workspace file writes when the caller lacks workspaces:write', async () => {
+    hasPermissionMock.mockReturnValue(false);
+
+    server.use(
+      http.post(`${BASE_URL}/api/stored/skills`, () =>
+        HttpResponse.json({ id: 's', name: 'n', description: 'd', status: 'active', createdAt: '', updatedAt: '' }),
+      ),
+    );
+
+    const { result } = renderHook(() => useCreateSkill(), { wrapper: wrapper() });
+
+    await result.current.mutateAsync({
+      name: 'n',
+      description: 'd',
+      workspaceId: 'ws-1',
+      files: baseFiles,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it('still creates the DB record when workspace file writes fail', async () => {
+    hasPermissionMock.mockReturnValue(true);
+    writeFileMock.mockRejectedValue(new Error('disk full'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    let createCalled = false;
+    server.use(
+      http.post(`${BASE_URL}/api/stored/skills`, () => {
+        createCalled = true;
+        return HttpResponse.json({
+          id: 's',
+          name: 'n',
+          description: 'd',
+          status: 'active',
+          createdAt: '',
+          updatedAt: '',
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useCreateSkill(), { wrapper: wrapper() });
+
+    await result.current.mutateAsync({
+      name: 'n',
+      description: 'd',
+      workspaceId: 'ws-1',
+      files: baseFiles,
+    });
+
+    expect(createCalled).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/playground/src/domains/agents/hooks/__tests__/use-update-skill.test.tsx
+++ b/packages/playground/src/domains/agents/hooks/__tests__/use-update-skill.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUpdateSkill } from '../use-update-skill';
+import { server } from '@/test/msw-server';
+
+const { toastSuccess, toastError } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('@mastra/playground-ui', async importOriginal => {
+  const actual = await importOriginal<typeof PlaygroundUi>();
+  return {
+    ...actual,
+    toast: { success: toastSuccess, error: toastError },
+  };
+});
+
+vi.mock('@/domains/workspace/hooks', () => ({
+  useWriteWorkspaceFile: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('@/domains/auth/hooks', () => ({
+  usePermissions: () => ({ hasPermission: () => false }),
+}));
+
+const BASE_URL = 'http://localhost:4111';
+
+const wrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+beforeEach(() => {
+  toastSuccess.mockReset();
+  toastError.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useUpdateSkill', () => {
+  it('sends only the fields the caller provided (sparse body)', async () => {
+    let body: any = null;
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/skill-1`, async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ id: 'skill-1', status: 'active', createdAt: '', updatedAt: '' });
+      }),
+    );
+
+    const { result } = renderHook(() => useUpdateSkill(), { wrapper: wrapper() });
+
+    await result.current.mutateAsync({ id: 'skill-1', name: 'Renamed' });
+
+    expect(body).toEqual({ name: 'Renamed' });
+    expect(body).not.toHaveProperty('description');
+    expect(body).not.toHaveProperty('visibility');
+    expect(body).not.toHaveProperty('files');
+  });
+
+  it('shows success toast by default and suppresses it in silent mode', async () => {
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/skill-1`, () =>
+        HttpResponse.json({ id: 'skill-1', status: 'active', createdAt: '', updatedAt: '' }),
+      ),
+    );
+
+    const { result: defaultResult } = renderHook(() => useUpdateSkill(), { wrapper: wrapper() });
+    await defaultResult.current.mutateAsync({ id: 'skill-1', name: 'A' });
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+
+    toastSuccess.mockReset();
+    const { result: silentResult } = renderHook(() => useUpdateSkill({ silent: true }), { wrapper: wrapper() });
+    await silentResult.current.mutateAsync({ id: 'skill-1', name: 'B' });
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it('suppresses error toast in silent mode', async () => {
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/skill-1`, () => HttpResponse.json({ error: 'boom' }, { status: 500 })),
+    );
+
+    const { result } = renderHook(() => useUpdateSkill({ silent: true }), { wrapper: wrapper() });
+    await expect(result.current.mutateAsync({ id: 'skill-1', name: 'X' })).rejects.toThrow();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/playground/src/domains/agents/hooks/use-create-skill.ts
+++ b/packages/playground/src/domains/agents/hooks/use-create-skill.ts
@@ -5,13 +5,17 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { extractSkillInstructions, extractSkillLicense } from '../components/agent-cms-pages/skill-file-tree';
 import type { InMemoryFileNode } from '../components/agent-edit-page/utils/form-validation';
+import { usePermissions } from '@/domains/auth/hooks';
 import { useWriteWorkspaceFile } from '@/domains/workspace/hooks';
 
 interface CreateSkillParams {
+  /** Optional client-generated id. When omitted, the server derives one from the name. */
+  id?: string;
   name: string;
   description: string;
+  instructions?: string;
   visibility?: 'private' | 'public';
-  workspaceId: string;
+  workspaceId?: string;
   files: InMemoryFileNode[];
 }
 
@@ -32,37 +36,48 @@ export function useCreateSkill() {
   const client = useMastraClient();
   const queryClient = useQueryClient();
   const writeFile = useWriteWorkspaceFile();
+  const { hasPermission } = usePermissions();
+  const canWriteWorkspace = hasPermission('workspaces:write');
 
   return useMutation({
     mutationFn: async (params: CreateSkillParams): Promise<StoredSkillResponse> => {
-      const { name, description, visibility, workspaceId, files } = params;
-      // Write all files to workspace filesystem
-      const filesToWrite = flattenFiles(files, '');
-      await Promise.all(
-        filesToWrite.map(file =>
-          writeFile.mutateAsync({
-            workspaceId,
-            path: `skills/${file.path}`,
-            content: file.content,
-            recursive: true,
-          }),
-        ),
-      );
+      const { id, name, description, instructions, workspaceId, files } = params;
 
-      // Create stored skill via API
+      // Write files to workspace filesystem (best-effort — DB is the source of truth)
+      if (workspaceId && canWriteWorkspace) {
+        const filesToWrite = flattenFiles(files, '');
+        try {
+          await Promise.all(
+            filesToWrite.map(file =>
+              writeFile.mutateAsync({
+                workspaceId,
+                path: `skills/${file.path}`,
+                content: file.content,
+                recursive: true,
+              }),
+            ),
+          );
+        } catch (err) {
+          console.warn('[skill] Workspace file write failed, saving to DB only:', err);
+        }
+      }
+
+      // Create stored skill via API (DB record always created)
       return client.createStoredSkill({
+        ...(id ? { id } : {}),
         name,
         description,
-        visibility,
-        instructions: extractSkillInstructions(files),
+        visibility: params.visibility,
+        instructions: instructions ?? extractSkillInstructions(files),
         license: extractSkillLicense(files),
         files,
       });
     },
     onSuccess: (_, variables) => {
       void queryClient.invalidateQueries({ queryKey: ['stored-skills'] });
-      void queryClient.invalidateQueries({ queryKey: ['workspace', 'skills', variables.workspaceId] });
-      toast.success('Skill created');
+      if (variables.workspaceId) {
+        void queryClient.invalidateQueries({ queryKey: ['workspace', 'skills', variables.workspaceId] });
+      }
     },
     onError: error => {
       toast.error(`Failed to create skill: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/packages/playground/src/domains/agents/hooks/use-skill-builder-tool.ts
+++ b/packages/playground/src/domains/agents/hooks/use-skill-builder-tool.ts
@@ -1,0 +1,144 @@
+import { createTool } from '@mastra/client-js';
+import { useMemo, useRef } from 'react';
+import { z } from 'zod-v4';
+
+export const SKILL_BUILDER_TOOL_NAME = 'skillBuilderTool';
+export const SKILL_READER_TOOL_NAME = 'readSkillForm';
+
+export const SKILL_BUILDER_INSTRUCTIONS = `# Role
+You help a user build a skill: a focused set of instructions that gives an agent expertise in a specific area.
+
+Use simple, kind words. Avoid jargon.
+
+# Goal
+Help the user create a skill that is clear, useful, and well-defined.
+
+A good skill has:
+- a short, descriptive name
+- a clear one-line description
+- detailed markdown instructions covering purpose, inputs, outputs, rules, and workflow
+
+# How you work
+A form on the screen describes the skill being built.
+You have two client tools:
+1. **readSkillForm** — read the current form values. Always call this before making changes so you know what's already there.
+2. **skillBuilderTool** — update one or more form fields.
+
+Do the work instead of explaining the work.
+
+Do not show:
+- code
+- raw configuration
+- tool inputs or outputs
+- hidden reasoning
+- long explanations
+
+# Important workflow
+When the user asks you to change, refine, or improve the skill:
+1. First call readSkillForm to see the current state.
+2. Then call skillBuilderTool with only the fields you want to change.
+
+When creating a brand new skill from scratch, you can skip the read and go straight to skillBuilderTool.
+
+# Skill design checklist
+When creating or improving a skill, define:
+
+1. Purpose — What expertise does this skill provide?
+2. Inputs — What information does the skill work with?
+3. Outputs — What should the agent produce when using this skill?
+4. Rules — What must the agent always or never do?
+5. Workflow — What steps should the agent follow?
+6. Tone — How should the agent communicate?
+
+# Instructions format
+Write the instructions field in markdown. Structure it with clear headings:
+- Purpose
+- Actions / Workflow
+- Inputs / Outputs
+- Rules / Boundaries
+- Tone / Style
+
+# How you speak
+Stay brief.
+Prefer doing over explaining.
+When speaking, say what the skill now does or what changed.
+
+Good examples:
+- Your skill is ready — it helps summarize long articles.
+- Updated the instructions to include source citation rules.
+- Added boundaries to prevent hallucinating facts.
+
+Ask only when you cannot safely continue.
+Ask one simple question at a time.`;
+
+export interface SkillBuilderCallbacks {
+  onNameChange: (name: string) => void;
+  onDescriptionChange: (description: string) => void;
+  onInstructionsChange: (instructions: string) => void;
+}
+
+export interface SkillFormState {
+  name: string;
+  description: string;
+  instructions: string;
+}
+
+export function useSkillBuilderTools(callbacks: SkillBuilderCallbacks, formStateRef: React.RefObject<SkillFormState>) {
+  const callbacksRef = useRef(callbacks);
+  callbacksRef.current = callbacks;
+
+  const writerTool = useMemo(
+    () =>
+      createTool({
+        id: SKILL_BUILDER_TOOL_NAME,
+        description:
+          'Update the skill form fields. Call this tool to set or change the name, description, or instructions of the skill being created or edited. ' +
+          'You can update any combination of fields in a single call — omit fields you do not want to change. ' +
+          'The "instructions" field should be detailed markdown content describing the skill\'s purpose, workflow, rules, and tone.',
+        inputSchema: z.object({
+          name: z.string().optional().describe('Short, descriptive skill name (e.g. "article-summarizer")'),
+          description: z.string().optional().describe('One-line description of what the skill does'),
+          instructions: z
+            .string()
+            .optional()
+            .describe('Detailed markdown instructions for the skill (purpose, workflow, rules, tone)'),
+        }),
+        outputSchema: z.object({ success: z.boolean() }),
+        execute: async (input: any) => {
+          const cb = callbacksRef.current;
+          if (typeof input?.name === 'string') cb.onNameChange(input.name);
+          if (typeof input?.description === 'string') cb.onDescriptionChange(input.description);
+          if (typeof input?.instructions === 'string') cb.onInstructionsChange(input.instructions);
+          return { success: true };
+        },
+      }),
+    [], // callbacks accessed via ref, stable tool identity
+  );
+
+  const readerTool = useMemo(
+    () =>
+      createTool({
+        id: SKILL_READER_TOOL_NAME,
+        description:
+          'Read the current skill form values. Call this before making changes so you know what the user has on screen. ' +
+          'Returns the current name, description, and instructions (markdown).',
+        inputSchema: z.object({}),
+        outputSchema: z.object({
+          name: z.string(),
+          description: z.string(),
+          instructions: z.string(),
+        }),
+        execute: async () => {
+          const state = formStateRef.current;
+          return {
+            name: state.name || '',
+            description: state.description || '',
+            instructions: state.instructions || '',
+          };
+        },
+      }),
+    [formStateRef],
+  );
+
+  return { writerTool, readerTool };
+}

--- a/packages/playground/src/domains/agents/hooks/use-update-skill.ts
+++ b/packages/playground/src/domains/agents/hooks/use-update-skill.ts
@@ -1,29 +1,100 @@
+import type { StoredSkillResponse } from '@mastra/client-js';
+import { toast } from '@mastra/playground-ui';
 import { useMastraClient } from '@mastra/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { extractSkillInstructions, extractSkillLicense } from '../components/agent-cms-pages/skill-file-tree';
+import type { InMemoryFileNode } from '../components/agent-edit-page/utils/form-validation';
+import { usePermissions } from '@/domains/auth/hooks';
+import { useWriteWorkspaceFile } from '@/domains/workspace/hooks';
 
 interface UpdateSkillParams {
   id: string;
   name?: string;
   description?: string;
-  instructions?: string;
   visibility?: 'private' | 'public';
-  files?: unknown[];
+  instructions?: string;
+  files?: InMemoryFileNode[];
   workspaceId?: string;
 }
 
+function flattenFiles(nodes: InMemoryFileNode[], basePath: string): { path: string; content: string }[] {
+  const results: { path: string; content: string }[] = [];
+  for (const node of nodes) {
+    const nodePath = basePath ? `${basePath}/${node.name}` : node.name;
+    if (node.type === 'file' && node.content !== undefined) {
+      results.push({ path: nodePath, content: node.content });
+    } else if (node.type === 'folder' && node.children) {
+      results.push(...flattenFiles(node.children, nodePath));
+    }
+  }
+  return results;
+}
+
 interface UseUpdateSkillOptions {
-  // No-op today; reserved for future toast/surface control.
+  /** When true, suppresses success and error toasts. Used by autosave flows. */
   silent?: boolean;
 }
 
-export function useUpdateSkill(_options: UseUpdateSkillOptions = {}) {
+export function useUpdateSkill(options: UseUpdateSkillOptions = {}) {
   const client = useMastraClient();
   const queryClient = useQueryClient();
+  const writeFile = useWriteWorkspaceFile();
+  const { hasPermission } = usePermissions();
+  const canWriteWorkspace = hasPermission('workspaces:write');
+  const { silent = false } = options;
 
   return useMutation({
-    mutationFn: (params: UpdateSkillParams) => (client as any).updateStoredSkill(params.id, params),
+    mutationFn: async (params: UpdateSkillParams): Promise<StoredSkillResponse> => {
+      const { id, name, description, visibility, instructions, files, workspaceId } = params;
+
+      // Write updated files to workspace filesystem (best-effort — DB is the source of truth)
+      if (files?.length && workspaceId && canWriteWorkspace) {
+        const filesToWrite = flattenFiles(files, '');
+        try {
+          await Promise.all(
+            filesToWrite.map(file =>
+              writeFile.mutateAsync({
+                workspaceId,
+                path: `skills/${file.path}`,
+                content: file.content,
+                recursive: true,
+              }),
+            ),
+          );
+        } catch (err) {
+          console.warn('[skill] Workspace file write failed, saving to DB only:', err);
+        }
+      }
+
+      // Build a sparse update body — the server handler currently forwards
+      // every key (including `undefined`) to the storage driver, which then
+      // rejects "undefined cannot be passed as argument to the database".
+      // Only include fields the caller actually wants to change.
+      const resolvedInstructions = instructions ?? (files ? extractSkillInstructions(files) : undefined);
+      const resolvedLicense = files ? extractSkillLicense(files) : undefined;
+      const updateBody: Record<string, unknown> = {};
+      if (name !== undefined) updateBody.name = name;
+      if (description !== undefined) updateBody.description = description;
+      if (visibility !== undefined) updateBody.visibility = visibility;
+      if (resolvedInstructions !== undefined) updateBody.instructions = resolvedInstructions;
+      if (resolvedLicense !== undefined) updateBody.license = resolvedLicense;
+      if (files !== undefined) updateBody.files = files;
+
+      // Update stored skill via API
+      return client.getStoredSkill(id).update(updateBody);
+    },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['stored-skills'] });
+      void queryClient.invalidateQueries({ queryKey: ['stored-skill'] });
+      if (!silent) {
+        toast.success('Skill updated');
+      }
+    },
+    onError: error => {
+      if (!silent) {
+        toast.error(`Failed to update skill: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
     },
   });
 }

--- a/packages/playground/src/domains/auth/hooks/__tests__/use-default-visibility.test.tsx
+++ b/packages/playground/src/domains/auth/hooks/__tests__/use-default-visibility.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDefaultVisibility } from '../use-default-visibility';
+
+const BASE_URL = 'http://localhost:4111';
+
+const createMockResponse = (data: unknown): Response =>
+  ({
+    ok: true,
+    json: () => Promise.resolve(data),
+  }) as unknown as Response;
+
+const wrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+describe('useDefaultVisibility', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockFetch = vi.fn();
+    globalThis.fetch = mockFetch as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns private when auth is enabled', async () => {
+    mockFetch.mockResolvedValue(createMockResponse({ enabled: true, capabilities: {} }));
+
+    const { result } = renderHook(() => useDefaultVisibility(), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current).toBe('private'));
+  });
+
+  it('returns public when auth is disabled', async () => {
+    mockFetch.mockResolvedValue(createMockResponse({ enabled: false, capabilities: {} }));
+
+    const { result } = renderHook(() => useDefaultVisibility(), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current).toBe('public'));
+  });
+
+  it('falls back to public while loading', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useDefaultVisibility(), { wrapper: wrapper() });
+
+    expect(result.current).toBe('public');
+  });
+});

--- a/packages/playground/src/domains/auth/hooks/use-default-visibility.ts
+++ b/packages/playground/src/domains/auth/hooks/use-default-visibility.ts
@@ -1,3 +1,11 @@
-export function useDefaultVisibility() {
-  return 'private' as const;
+import { useAuthCapabilities } from './use-auth-capabilities';
+
+/**
+ * Returns the default visibility for new entities based on auth state.
+ * When auth is enabled, new items default to 'private' (owned by the creator).
+ * When auth is disabled, everything is 'public' (no ownership concept).
+ */
+export function useDefaultVisibility(): 'private' | 'public' {
+  const { data } = useAuthCapabilities();
+  return data?.enabled ? 'private' : 'public';
 }

--- a/packages/playground/src/domains/workspace/hooks/__tests__/use-stored-workspaces.test.tsx
+++ b/packages/playground/src/domains/workspace/hooks/__tests__/use-stored-workspaces.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useStoredWorkspaces } from '../use-stored-workspaces';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+const wrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+describe('useStoredWorkspaces', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('lists stored workspaces and forwards pagination + authorId params', async () => {
+    let receivedUrl: URL | undefined;
+    server.use(
+      http.get(`${BASE_URL}/api/stored/workspaces`, ({ request }) => {
+        receivedUrl = new URL(request.url);
+        return HttpResponse.json({
+          workspaces: [{ id: 'ws-1', name: 'WS', status: 'active', createdAt: '', updatedAt: '' }],
+          total: 1,
+          page: 2,
+          perPage: 10,
+          hasMore: false,
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useStoredWorkspaces({ page: 2, perPage: 10, authorId: 'me' }), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.workspaces).toHaveLength(1);
+    expect(receivedUrl?.searchParams.get('page')).toBe('2');
+    expect(receivedUrl?.searchParams.get('perPage')).toBe('10');
+    expect(receivedUrl?.searchParams.get('authorId')).toBe('me');
+  });
+
+  it('does not run when enabled is false', async () => {
+    const onFetch = vi.fn();
+    server.use(
+      http.get(`${BASE_URL}/api/stored/workspaces`, () => {
+        onFetch();
+        return HttpResponse.json({ workspaces: [], total: 0, page: 1, perPage: 50, hasMore: false });
+      }),
+    );
+
+    const { result } = renderHook(() => useStoredWorkspaces(undefined, { enabled: false }), {
+      wrapper: wrapper(),
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(onFetch).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/packages/playground/src/domains/workspace/hooks/index.ts
+++ b/packages/playground/src/domains/workspace/hooks/index.ts
@@ -16,6 +16,9 @@ export {
   useIndexWorkspaceContent,
 } from './use-workspace';
 
+// Stored workspace hooks
+export { useStoredWorkspaces } from './use-stored-workspaces';
+
 // Skills hooks
 export {
   useWorkspaceSkills,

--- a/packages/playground/src/domains/workspace/hooks/use-stored-workspaces.ts
+++ b/packages/playground/src/domains/workspace/hooks/use-stored-workspaces.ts
@@ -1,0 +1,20 @@
+import type { ListStoredWorkspacesParams, ListStoredWorkspacesResponse } from '@mastra/client-js';
+import { useMastraClient } from '@mastra/react';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Hook to list stored workspaces from the database.
+ * These are workspaces that have been persisted via the stored workspaces API,
+ * as opposed to runtime-registered workspaces from code-defined agents.
+ */
+export const useStoredWorkspaces = (params?: ListStoredWorkspacesParams, options?: { enabled?: boolean }) => {
+  const client = useMastraClient();
+
+  return useQuery({
+    queryKey: ['stored-workspaces', params],
+    queryFn: async (): Promise<ListStoredWorkspacesResponse> => {
+      return client.listStoredWorkspaces(params);
+    },
+    enabled: options?.enabled !== false,
+  });
+};

--- a/packages/playground/src/pages/agent-builder/skills/__tests__/create.msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/__tests__/create.msw.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AgentBuilderSkillsCreate from '../create';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+    usePlaygroundStore: () => ({ requestContext: undefined }),
+  };
+});
+
+const { hasPermissionMock, rbacEnabledMock } = vi.hoisted(() => ({
+  hasPermissionMock: vi.fn(),
+  rbacEnabledMock: { value: false },
+}));
+
+vi.mock('@/domains/auth/hooks/use-permissions', () => ({
+  usePermissions: () => ({ hasPermission: hasPermissionMock, rbacEnabled: rbacEnabledMock.value }),
+}));
+
+vi.mock('@/domains/auth/hooks/use-current-user', () => ({
+  useCurrentUser: () => ({ data: { id: 'user-1' }, isLoading: false }),
+}));
+
+// The starter renders a chat-driven builder that boots an SSE stream. Stub it
+// out and just verify the create page mounts it once permissions allow.
+vi.mock('@/domains/agent-builder/components/skill-starter/skill-builder-starter', () => ({
+  SkillBuilderStarter: () => <div data-testid="skill-builder-starter-stub" />,
+}));
+
+const renderPage = (initialPath = '/agent-builder/skills/create') => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={[initialPath]}>
+            <Routes>
+              <Route path="/agent-builder/skills/create" element={<AgentBuilderSkillsCreate />} />
+              <Route path="/agent-builder/skills" element={<div data-testid="skills-list-page" />} />
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+};
+
+beforeEach(() => {
+  hasPermissionMock.mockReset();
+  rbacEnabledMock.value = false;
+  // The page warms several caches; provide neutral handlers so they don't 404.
+  server.use(
+    http.get(`${BASE_URL}/api/stored/skills`, () =>
+      HttpResponse.json({ skills: [], total: 0, page: 1, perPage: 50, hasMore: false }),
+    ),
+    http.get(`${BASE_URL}/api/stored/workspaces`, () =>
+      HttpResponse.json({ workspaces: [], total: 0, page: 1, perPage: 50, hasMore: false }),
+    ),
+    http.get(`${BASE_URL}/api/editor/builder/settings`, () => HttpResponse.json({})),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('AgentBuilderSkillsCreate', () => {
+  it('renders the starter when the user can create skills', async () => {
+    hasPermissionMock.mockReturnValue(true);
+    renderPage();
+
+    expect(await screen.findByTestId('skill-builder-starter-stub')).toBeTruthy();
+  });
+
+  it('redirects to the skills list when RBAC denies stored-skills:write', async () => {
+    rbacEnabledMock.value = true;
+    hasPermissionMock.mockImplementation((perm: string) => perm !== 'stored-skills:write');
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('skills-list-page')).toBeTruthy());
+    expect(screen.queryByTestId('skill-builder-starter-stub')).toBeNull();
+  });
+});

--- a/packages/playground/src/pages/agent-builder/skills/__tests__/edit-autosave.msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/__tests__/edit-autosave.msw.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AgentBuilderSkillsEdit from '../edit';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+const SKILL_ID = 'skill-test-123';
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+    usePlaygroundStore: () => ({ requestContext: undefined }),
+  };
+});
+
+vi.mock('@/domains/auth/hooks/use-permissions', () => ({
+  usePermissions: () => ({ hasPermission: () => true, rbacEnabled: false }),
+}));
+
+vi.mock('@/domains/auth/hooks/use-current-user', () => ({
+  useCurrentUser: () => ({ data: { id: 'user-1' }, isLoading: false }),
+}));
+
+// The chat composer mounts an SSE-driven builder agent which we don't want to
+// boot in the autosave test. Stub it with a minimal shell — the form is the
+// surface under test.
+vi.mock('@/domains/agents/components/agent-cms-pages/skill-chat-composer', () => ({
+  SkillChatComposer: () => <div data-testid="skill-chat-composer-stub" />,
+}));
+
+const renderEditPage = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={[`/agent-builder/skills/${SKILL_ID}/edit`]}>
+            <Routes>
+              <Route path="/agent-builder/skills/:id/edit" element={<AgentBuilderSkillsEdit />} />
+              <Route path="/agent-builder/skills" element={<div data-testid="skills-list-page" />} />
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+};
+
+describe('AgentBuilderSkillsEdit autosave', () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, () =>
+        HttpResponse.json({
+          id: SKILL_ID,
+          name: 'initial name',
+          description: 'initial description',
+          instructions: 'initial instructions',
+          visibility: 'private',
+          authorId: 'user-1',
+          files: [],
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('debounces edits and PATCHes /api/stored/skills/:id with the latest form values', async () => {
+    const patchCalls: any[] = [];
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, async ({ request }) => {
+        patchCalls.push(await request.json());
+        return HttpResponse.json({ id: SKILL_ID });
+      }),
+    );
+
+    const { findByDisplayValue, getByDisplayValue } = renderEditPage();
+
+    // Wait for the form to hydrate from the GET response.
+    const nameInput = (await findByDisplayValue('initial name')) as HTMLInputElement;
+    getByDisplayValue('initial description');
+
+    // Edit the name. Autosave should debounce ~600ms.
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: 'renamed skill' } });
+    });
+
+    await waitFor(() => expect(patchCalls.length).toBeGreaterThanOrEqual(1), { timeout: 3000 });
+
+    const last = patchCalls[patchCalls.length - 1];
+    expect(last.name).toBe('renamed skill');
+    expect(last.description).toBe('initial description');
+    expect(last.instructions).toBe('initial instructions');
+    expect(last.visibility).toBe('private');
+  });
+
+  it('coalesces rapid edits into a single save for the final value', async () => {
+    const patchCalls: any[] = [];
+    server.use(
+      http.patch(`${BASE_URL}/api/stored/skills/${SKILL_ID}`, async ({ request }) => {
+        patchCalls.push(await request.json());
+        return HttpResponse.json({ id: SKILL_ID });
+      }),
+    );
+
+    const { findByDisplayValue } = renderEditPage();
+    const nameInput = (await findByDisplayValue('initial name')) as HTMLInputElement;
+
+    // Three rapid edits within the debounce window.
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: 'step 1' } });
+      fireEvent.change(nameInput, { target: { value: 'step 2' } });
+      fireEvent.change(nameInput, { target: { value: 'final' } });
+    });
+
+    await waitFor(() => expect(patchCalls.length).toBeGreaterThanOrEqual(1), { timeout: 3000 });
+
+    // Give any stragglers time to arrive, then assert we only saw one save with
+    // the final value.
+    await new Promise(resolve => setTimeout(resolve, 200));
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0].name).toBe('final');
+  });
+});

--- a/packages/playground/src/pages/agent-builder/skills/__tests__/view.msw.test.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/__tests__/view.msw.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AgentBuilderSkillsView from '../view';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+    usePlaygroundStore: () => ({ requestContext: undefined }),
+  };
+});
+
+vi.mock('@/domains/auth/hooks/use-permissions', () => ({
+  usePermissions: () => ({ hasPermission: () => true, rbacEnabled: false }),
+}));
+
+const { currentUserMock } = vi.hoisted(() => ({
+  currentUserMock: { id: 'viewer-1' as string | undefined },
+}));
+
+vi.mock('@/domains/auth/hooks/use-current-user', () => ({
+  useCurrentUser: () => ({ data: { id: currentUserMock.id }, isLoading: false }),
+}));
+
+const renderPage = (skillId: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={[`/agent-builder/skills/${skillId}`]}>
+            <Routes>
+              <Route path="/agent-builder/skills/:id" element={<AgentBuilderSkillsView />} />
+              <Route path="/agent-builder/skills" element={<div data-testid="skills-list-page" />} />
+              <Route path="/agent-builder/skills/:id/edit" element={<div data-testid="skills-edit-page" />} />
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+};
+
+beforeEach(() => {
+  currentUserMock.id = 'viewer-1';
+  server.use(
+    http.get(`${BASE_URL}/api/stored/skills`, () =>
+      HttpResponse.json({ skills: [], total: 0, page: 1, perPage: 50, hasMore: false }),
+    ),
+    http.get(`${BASE_URL}/api/editor/builder/settings`, () => HttpResponse.json({})),
+    http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json({ enabled: false, capabilities: {} })),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('AgentBuilderSkillsView', () => {
+  it('renders the public skill view for a non-owner', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/skills/skill-pub`, () =>
+        HttpResponse.json({
+          id: 'skill-pub',
+          name: 'Public Skill',
+          description: 'A shared skill',
+          instructions: 'How to use it',
+          visibility: 'public',
+          authorId: 'someone-else',
+          status: 'active',
+          createdAt: '',
+          updatedAt: '',
+        }),
+      ),
+    );
+
+    renderPage('skill-pub');
+
+    expect(await screen.findByTestId('skill-view-page')).toBeTruthy();
+    expect(screen.getByTestId('skill-view-title').textContent).toBe('Public Skill');
+    expect(screen.getByTestId('skill-view-description').textContent).toContain('A shared skill');
+    // Non-owner can copy.
+    expect(screen.getByTestId('skill-view-copy-button')).toBeTruthy();
+  });
+
+  it('redirects the owner to the edit page', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/stored/skills/skill-own`, () =>
+        HttpResponse.json({
+          id: 'skill-own',
+          name: 'Mine',
+          description: 'Mine',
+          instructions: '',
+          visibility: 'private',
+          authorId: 'viewer-1',
+          status: 'active',
+          createdAt: '',
+          updatedAt: '',
+        }),
+      ),
+    );
+
+    renderPage('skill-own');
+
+    await waitFor(() => expect(screen.getByTestId('skills-edit-page')).toBeTruthy());
+    expect(screen.queryByTestId('skill-view-page')).toBeNull();
+  });
+
+  it('redirects to the skills list when the skill does not exist', async () => {
+    server.use(http.get(`${BASE_URL}/api/stored/skills/missing`, () => HttpResponse.json(null)));
+
+    renderPage('missing');
+
+    await waitFor(() => expect(screen.getByTestId('skills-list-page')).toBeTruthy());
+  });
+});

--- a/packages/playground/src/pages/agent-builder/skills/create.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/create.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@mastra/playground-ui';
+import { ArrowLeftIcon } from 'lucide-react';
+import { Navigate, useNavigate } from 'react-router';
+import { SkillBuilderStarter } from '@/domains/agent-builder/components/skill-starter/skill-builder-starter';
+import { useBuilderSettings } from '@/domains/agent-builder/hooks/use-builder-settings';
+import { useStoredSkills } from '@/domains/agents/hooks/use-stored-skills';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+import { useStoredWorkspaces } from '@/domains/workspace/hooks/use-stored-workspaces';
+
+export default function AgentBuilderSkillsCreate() {
+  const { hasPermission, rbacEnabled } = usePermissions();
+  const canWrite = !rbacEnabled || hasPermission('stored-skills:write');
+  // Warm caches the edit page needs on first paint.
+  useStoredSkills({ enabled: canWrite });
+  useStoredWorkspaces();
+  useBuilderSettings();
+  const navigate = useNavigate();
+
+  if (!canWrite) {
+    return <Navigate to="/agent-builder/skills" replace />;
+  }
+  return (
+    <>
+      <div className="absolute top-3 left-3 md:top-6 md:left-6 z-10">
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={() =>
+            navigate('/agent-builder/skills', {
+              viewTransition: true,
+            })
+          }
+          className="rounded-full"
+          tooltip="Skills list"
+        >
+          <ArrowLeftIcon />
+        </Button>
+      </div>
+      <SkillBuilderStarter />
+    </>
+  );
+}

--- a/packages/playground/src/pages/agent-builder/skills/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/edit.tsx
@@ -1,0 +1,182 @@
+import { Spinner } from '@mastra/playground-ui';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { FormProvider, useForm, useFormContext, useWatch } from 'react-hook-form';
+import { Navigate, useParams } from 'react-router';
+import { AutosaveIndicator } from '@/domains/agent-builder/components/agent-edit/autosave-indicator';
+import { DeleteSkillPanelButton } from '@/domains/agent-builder/components/skill-edit/delete-skill-action';
+import { SkillBuilderMobileMenu } from '@/domains/agent-builder/components/skill-edit/skill-builder-mobile-menu';
+import { VisibilitySelect } from '@/domains/agent-builder/components/skill-edit/visibility-select';
+import { AgentColorProvider } from '@/domains/agent-builder/contexts/agent-color-context';
+import { useAutosaveSkill } from '@/domains/agent-builder/hooks/use-autosave-skill';
+import type { SkillEditFormValues } from '@/domains/agent-builder/hooks/use-autosave-skill';
+import { useStarterUserMessage } from '@/domains/agent-builder/hooks/use-starter-user-message';
+import { useStoredSkill } from '@/domains/agent-builder/hooks/use-stored-skill';
+import { SkillWorkspaceLayout } from '@/domains/agent-builder/layouts/skill-workspace-layout';
+import { SkillChatComposer } from '@/domains/agents/components/agent-cms-pages/skill-chat-composer';
+import { SkillSimpleForm } from '@/domains/agents/components/agent-cms-pages/skill-simple-form';
+import { useAuthCapabilities } from '@/domains/auth/hooks/use-auth-capabilities';
+import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+
+export default function AgentBuilderSkillsEdit() {
+  const { id } = useParams<{ id: string }>();
+  const { hasPermission, rbacEnabled } = usePermissions();
+  const canWrite = !rbacEnabled || hasPermission('stored-skills:write');
+  const { data: storedSkill, isLoading: isStoredSkillLoading } = useStoredSkill(id);
+  const { data: currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
+  const initialUserMessage = useStarterUserMessage();
+
+  const isOwner = !storedSkill?.authorId || currentUser?.id === storedSkill.authorId;
+  const isOwnershipLoading = Boolean(storedSkill?.authorId) && isCurrentUserLoading;
+  const isReady = Boolean(id) && !isStoredSkillLoading && !isOwnershipLoading;
+
+  if (!isReady) {
+    return <AgentBuilderSkillEditSkeleton />;
+  }
+
+  if (!storedSkill) {
+    return <Navigate to="/agent-builder/skills" replace />;
+  }
+
+  if (!canWrite || !isOwner) {
+    return <Navigate to={`/agent-builder/skills/${id}/view`} replace />;
+  }
+
+  return <AgentBuilderSkillEditPage id={id!} storedSkill={storedSkill} initialUserMessage={initialUserMessage} />;
+}
+
+const AgentBuilderSkillEditSkeleton = () => (
+  <div className="h-screen w-screen flex items-center justify-center">
+    <Spinner />
+  </div>
+);
+
+interface PageProps {
+  id: string;
+  storedSkill: NonNullable<ReturnType<typeof useStoredSkill>['data']>;
+  initialUserMessage: string | undefined;
+}
+
+const AgentBuilderSkillEditPage = ({ id, storedSkill, initialUserMessage }: PageProps) => {
+  const formMethods = useForm<SkillEditFormValues>({
+    defaultValues: {
+      name: storedSkill.name ?? '',
+      description: storedSkill.description ?? '',
+      instructions: storedSkill.instructions ?? '',
+      visibility: storedSkill.visibility ?? 'private',
+      workspaceId: undefined,
+    },
+  });
+
+  return (
+    <FormProvider {...formMethods}>
+      <AgentColorProvider agentId={id}>
+        <AgentBuilderSkillEditReady id={id} initialUserMessage={initialUserMessage} />
+      </AgentColorProvider>
+    </FormProvider>
+  );
+};
+
+interface ReadyProps {
+  id: string;
+  initialUserMessage: string | undefined;
+}
+
+const AgentBuilderSkillEditReady = ({ id, initialUserMessage }: ReadyProps) => {
+  const formMethods = useFormContext<SkillEditFormValues>();
+  const autosave = useAutosaveSkill({ skillId: id });
+
+  const name = useWatch({ control: formMethods.control, name: 'name' }) ?? '';
+  const description = useWatch({ control: formMethods.control, name: 'description' }) ?? '';
+  const instructions = useWatch({ control: formMethods.control, name: 'instructions' }) ?? '';
+
+  const setName = useCallback(
+    (next: string) => formMethods.setValue('name', next, { shouldDirty: true }),
+    [formMethods],
+  );
+  const setDescription = useCallback(
+    (next: string) => formMethods.setValue('description', next, { shouldDirty: true }),
+    [formMethods],
+  );
+  const setInstructions = useCallback(
+    (next: string) => formMethods.setValue('instructions', next, { shouldDirty: true }),
+    [formMethods],
+  );
+
+  const formState = useMemo(() => ({ name, description, instructions }), [name, description, instructions]);
+
+  // The composer takes an initialUserMessage by sending it on mount. We use a
+  // simple key strategy: the skill id is stable per route so chat resets only on navigation.
+  const sessionKey = id;
+  const hasTitle = name.trim().length > 0;
+
+  // Track whether the builder agent has completed at least one turn. When the
+  // edit page is opened with a starter prompt, the agent will stream and patch
+  // the title mid-run; the right-side form must stay hidden until that run
+  // finishes (avoiding flicker of an empty/partial form). For routes opened
+  // without a starter prompt (e.g. revisiting an existing skill), we treat the
+  // first turn as already complete since no auto-run will happen.
+  const hadStarterPromptRef = useRef(initialUserMessage !== undefined);
+  const [hasCompletedFirstTurn, setHasCompletedFirstTurn] = useState(!hadStarterPromptRef.current);
+  const wasRunningRef = useRef(false);
+  const onComposerRunningChange = useCallback((isRunning: boolean) => {
+    if (isRunning) {
+      wasRunningRef.current = true;
+      return;
+    }
+    if (wasRunningRef.current) {
+      setHasCompletedFirstTurn(true);
+    }
+  }, []);
+
+  const showForm = hasTitle && hasCompletedFirstTurn;
+
+  return (
+    <SkillWorkspaceLayout
+      title={name || 'Untitled skill'}
+      rightAside={
+        <AutosaveIndicator status={autosave.status} lastError={autosave.lastError} onRetry={autosave.retry} />
+      }
+      primaryAction={
+        <div className="hidden lg:flex items-center gap-2">
+          <VisibilitySelectConnected skillId={id} />
+        </div>
+      }
+      mobileExtra={
+        <SkillBuilderMobileMenu skillId={id} skillName={name || 'Untitled skill'} showSetVisibility showDelete />
+      }
+      showForm={showForm}
+      deleteAction={<DeleteSkillPanelButton skillId={id} skillName={name || 'Untitled skill'} />}
+      chat={
+        <SkillChatComposer
+          sessionKey={sessionKey}
+          hasFields={!!(name.trim() || description.trim() || instructions.trim())}
+          formState={formState}
+          initialUserMessage={initialUserMessage}
+          onRunningChange={onComposerRunningChange}
+          onNameChange={setName}
+          onDescriptionChange={setDescription}
+          onInstructionsChange={setInstructions}
+        />
+      }
+      form={
+        <div className="h-full min-h-0 overflow-y-auto p-4 md:p-6">
+          <SkillSimpleForm
+            name={name}
+            onNameChange={setName}
+            description={description}
+            onDescriptionChange={setDescription}
+            instructions={instructions}
+            onInstructionsChange={setInstructions}
+          />
+        </div>
+      }
+    />
+  );
+};
+
+const VisibilitySelectConnected = ({ skillId }: { skillId: string }) => {
+  const { data: capabilities } = useAuthCapabilities();
+  if (!capabilities?.enabled) return null;
+  return <VisibilitySelect skillId={skillId} />;
+};

--- a/packages/playground/src/pages/agent-builder/skills/view.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/view.tsx
@@ -1,0 +1,136 @@
+import { Button, MarkdownRenderer, Spinner } from '@mastra/playground-ui';
+import { ArrowLeftIcon, PlusIcon } from 'lucide-react';
+import { useState } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router';
+import { CopySkillDialog } from '@/domains/agent-builder/components/skill-list/copy-skill-dialog';
+import { SkillFavoriteButton } from '@/domains/agent-builder/components/skill-list/skill-favorite-button';
+import { useCopySkill } from '@/domains/agent-builder/hooks/use-copy-skill';
+import { useStoredSkill } from '@/domains/agent-builder/hooks/use-stored-skill';
+import { useStoredSkills } from '@/domains/agents/hooks/use-stored-skills';
+import { useCurrentUser } from '@/domains/auth/hooks/use-current-user';
+import { usePermissions } from '@/domains/auth/hooks/use-permissions';
+
+export default function AgentBuilderSkillsView() {
+  const { id } = useParams<{ id: string }>();
+  const { data: storedSkill, isLoading: isStoredSkillLoading } = useStoredSkill(id);
+  const { data: currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
+
+  const isOwner = !storedSkill?.authorId || currentUser?.id === storedSkill.authorId;
+  const isOwnershipLoading = Boolean(storedSkill?.authorId) && isCurrentUserLoading;
+  const isReady = Boolean(id) && !isStoredSkillLoading && !isOwnershipLoading;
+
+  if (!isReady) {
+    return <AgentBuilderSkillViewSkeleton />;
+  }
+
+  if (!storedSkill) {
+    return <Navigate to="/agent-builder/skills" replace />;
+  }
+
+  if (isOwner) {
+    return <Navigate to={`/agent-builder/skills/${id}/edit`} replace />;
+  }
+
+  return <AgentBuilderSkillViewPage skill={storedSkill} />;
+}
+
+const AgentBuilderSkillViewSkeleton = () => (
+  <div className="h-screen w-screen flex items-center justify-center">
+    <Spinner />
+  </div>
+);
+
+interface PageProps {
+  skill: NonNullable<ReturnType<typeof useStoredSkill>['data']>;
+}
+
+const AgentBuilderSkillViewPage = ({ skill }: PageProps) => {
+  const navigate = useNavigate();
+  const { hasPermission, rbacEnabled } = usePermissions();
+  const canCopy = !rbacEnabled || hasPermission('stored-skills:write');
+  const [copyOpen, setCopyOpen] = useState(false);
+  const copySkill = useCopySkill();
+
+  // Suggest a non-colliding copy name based on the caller's own skills.
+  const { data: ownSkillsData } = useStoredSkills({ enabled: canCopy });
+  const ownSkillNames = (ownSkillsData?.skills ?? []).map(s => s.name);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="skill-view-page">
+      {/* Header */}
+      <div className="flex min-w-0 items-center gap-2 bg-surface1 px-3 py-2 md:px-6 md:py-3">
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={() => navigate('/agent-builder/skills', { viewTransition: true })}
+          className="rounded-full"
+          tooltip="Skills list"
+          data-testid="skill-view-back-button"
+        >
+          <ArrowLeftIcon />
+        </Button>
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <div className="min-w-0 truncate text-ui-md text-neutral6" data-testid="skill-view-title">
+            {skill.name}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <SkillFavoriteButton
+            skillId={skill.id}
+            isFavorited={skill.isFavorited}
+            favoriteCount={skill.favoriteCount}
+            className=""
+          />
+          {canCopy && (
+            <Button
+              type="button"
+              variant="default"
+              size="md"
+              onClick={() => setCopyOpen(true)}
+              data-testid="skill-view-copy-button"
+            >
+              <PlusIcon />
+              Copy to my skills
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 min-h-0 overflow-y-auto bg-surface1">
+        <div className="mx-auto w-full max-w-[80ch] px-4 pt-6 pb-10 md:px-10">
+          <h1 className="text-display-md text-neutral6">{skill.name}</h1>
+          {skill.description && (
+            <p className="mt-2 text-ui-md text-neutral4" data-testid="skill-view-description">
+              {skill.description}
+            </p>
+          )}
+          <div className="mt-6" data-testid="skill-view-instructions">
+            <MarkdownRenderer>{skill.instructions ?? ''}</MarkdownRenderer>
+          </div>
+        </div>
+      </div>
+
+      {copyOpen && (
+        <CopySkillDialog
+          open={copyOpen}
+          onOpenChange={open => {
+            if (!open && !copySkill.isPending) setCopyOpen(false);
+          }}
+          sourceName={skill.name}
+          existingNames={ownSkillNames}
+          isPending={copySkill.isPending}
+          onConfirm={async name => {
+            try {
+              const created = await copySkill.mutateAsync({ source: skill, name });
+              setCopyOpen(false);
+              void navigate(`/agent-builder/skills/${created.id}/edit`, { viewTransition: true });
+            } catch {
+              // Errors surfaced via the mutation's onError toast; keep dialog open.
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Adds the Agent Builder **skill create/edit/view pages** to the playground, plus the full transitive dependency closure they need to compile, render, and pass tests. The pages exist as importable modules — **router wiring is intentionally not included** and will land in a follow-up PR alongside the skills nav entry.

This is the second slice of the `yj/magnificent-marquess` split, stacked on top of #17096 (the unrouted scaffold).

## What is in this PR

### `@mastra/client-js`
- `StoredSkill.favorite()` / `unfavorite()` (PUT/DELETE `/api/stored/skills/:id/favorite`)
- New `stored-skill.test.ts` covering the favorite/unfavorite happy paths

### Playground — skill pages
- `pages/agent-builder/skills/{create,edit,view}.tsx`
- `pages/agent-builder/skills/__tests__/edit-autosave.msw.test.tsx` (debounced PATCH coalescing)

### Playground — supporting modules
- **Skill-only hooks**: `use-stored-skill`, `use-copy-skill`, `use-delete-skill`, `use-set-agent-skills-tool`, `use-starter-user-message`, plus dedicated tests for `use-create-skill-tool`, `use-set-agent-skills-tool`, `use-visibility-change-skill`
- **Agents/workspace/auth deltas**: `use-create-skill`, `use-update-skill`, `use-skill-builder-tool`, `use-stored-workspaces`, `use-default-visibility`
- **Shared contexts**: `agent-color-context`, `agent-primitives-context`
- **Shared chat-primitives**: `chat-composer`, `chat-textarea`, `message-list`, `messages`, `shimmer`, `use-available-agent-tools`
- **Shared agent-edit**: `autosave-indicator`
- **Skill UI**: `skill-edit/{delete-skill-action, skill-builder-mobile-menu, visibility-select}`, `skill-starter/skill-builder-starter`, `layouts/skill-workspace-layout`, `agent-cms-pages/{skill-chat-composer, skill-simple-form}`
- `agent-builder/index.ts` now re-exports `useBuilderPickerVisibility`, `useBuilderModelPolicy`, and filtered-model helpers

### Not in this PR
- `App.tsx` is untouched. Route wiring + skills nav entry are deferred to the next PR.
- All agent-edit-only modules (agent-profile, conversation-panel, publish-channel-dialogs, edit/view/stream/wizard contexts, agent-builder pages, agent autosave/save hooks). They will follow.

## Test plan

- `pnpm --filter ./packages/playground typecheck` ✅
- `pnpm --filter ./client-sdks/client-js exec vitest --run src/resources/stored-skill.test.ts` — 3/3 ✅
- `pnpm --filter ./packages/playground exec vitest --run` on the new + adjacent test files: 13 files, 73 tests ✅

🤖 Generated with [Mastra Code](https://mastra.ai)

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds pages and the underlying UI/hooks so people can create, edit, and view reusable AI "skills" inside the Agent Builder playground. The pages are fully implemented and tested but are not yet wired into the app navigation (that will come in a follow-up).

## Summary

This PR implements the Agent Builder skill management surface (create, edit, view) and includes the full transitive dependency set required to compile, render, and test those pages. Routing and App.tsx/nav integration are intentionally omitted and will be added in a follow-up. This change is stacked on top of PR `#17096`.

### Key Additions

- API & Client SDK
  - `@mastra/client-js`: StoredSkill.favorite() and StoredSkill.unfavorite() (PUT/DELETE /api/stored/skills/:id/favorite) with tests.

- Pages
  - pages/agent-builder/skills/create.tsx — skill creation starter UI with workspace selection.
  - pages/agent-builder/skills/edit.tsx — full editor: form, chat-driven builder, autosave with debounced PATCH coalescing.
  - pages/agent-builder/skills/view.tsx — read-only public view with favorite and copy-to-library flows.

- Core Components & Layouts
  - SkillWorkspaceLayout (responsive chat/config layout).
  - Chat primitives: ChatComposer, ChatTextarea, MessageList, messages/PendingIndicator/MessagesSkeleton, Shimmer.
  - Skill-specific UI: DeleteSkillAction, SkillBuilderMobileMenu, VisibilitySelect, AutosaveIndicator.
  - Form components: SkillSimpleForm, SkillChatComposer.
  - Starter: SkillBuilderStarter.

- Contexts & State
  - AgentColorProvider & useAgentColor for deterministic colors.
  - AgentPrimitivesProvider & useAgentPrimitives aggregating tools/agents/skills/workspaces/auth.
  - New/use-modified hooks: useStoredSkill, useCopySkill, useDeleteSkill, useVisibilityChange (skill), useCreateSkillTool, useSetAgentSkillsTool, useStarterUserMessage, useStoredWorkspaces, useAvailableAgentTools (import path tweak).

- Hook Behavior Changes
  - useCreateSkill: optional client-provided id, optional workspaceId, conditional workspace filesystem writes (best-effort).
  - useUpdateSkill: sparse update payloads, optional workspace writes, silent-option for toasts, improved file flattening helper.
  - useDefaultVisibility: now driven by auth capability (returns 'private' when auth enabled, 'public' when disabled).

- Module re-exports
  - agent-builder/index.ts now re-exports builder visibility/model-policy/filtered-model helpers and picker visibility types/hooks.

### Tests

- Extensive Vitest + RTL + MSW coverage added for hooks, components, layouts, and pages (including autosave coalescing).
- New client-js stored-skill tests validate favorite/unfavorite API behavior and URL encoding.
- Test results included by author: typecheck and targeted test runs passed (playground tests: 13 files, 73 tests; client stored-skill: 3/3).

### Known Limitations

- Pages are not yet wired into app routing or main navigation—those changes will be added in a follow-up PR.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->