### PR TITLE
Fix changed test gate base-branch logic

### DIFF
--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -83,7 +83,7 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8192
         run: pnpm turbo --filter "!./examples/**/*" --filter "!./docs/" --filter "!./explorations/**/*" build
 
-      - name: Run changed tests
+      - name: Run changed tests against base
         if: ${{ steps.changed_tests.outputs.has_tests == 'true' }}
         shell: bash
         env:
@@ -91,4 +91,15 @@ jobs:
         run: |
           set -euo pipefail
           mapfile -t test_files < /tmp/changed-test-files
+
+          set +e
           pnpm vitest run --passWithNoTests "${test_files[@]}"
+          test_status=$?
+          set -e
+
+          if [ "$test_status" -eq 0 ]; then
+            echo "::error::Changed tests passed against the base branch. They should fail before the PR code is applied."
+            exit 1
+          fi
+
+          echo "Changed tests failed against the base branch as expected."

--- a/scripts/pr-automation-comment/index.ts
+++ b/scripts/pr-automation-comment/index.ts
@@ -36,11 +36,11 @@ async function buildChangedTestSummary() {
   const labels = await listIssueLabels();
 
   if (labels.includes('tests: green ✅')) {
-    return '## Changed test gate\n\nChanged tests passed.\n\nLabel: `tests: green ✅`';
+    return '## Changed test gate\n\nChanged tests failed against the base branch as expected.\n\nLabel: `tests: green ✅`';
   }
 
   if (labels.includes('tests: failing ❌')) {
-    return '## Changed test gate\n\nChanged tests failed.\n\nLabel: `tests: failing ❌`';
+    return '## Changed test gate\n\nChanged tests passed against the base branch; they should fail before the PR code is applied.\n\nLabel: `tests: failing ❌`';
   }
 
   if (labels.includes('tests: no tests added')) {

--- a/scripts/pr-test-gate/index.ts
+++ b/scripts/pr-test-gate/index.ts
@@ -8,8 +8,8 @@ const PHASE = process.env.PHASE ?? 'label';
 const PR_NUMBER = Number(process.env.PR_NUMBER ?? '0');
 
 const TEST_LABELS = [
-  { name: 'tests: green ✅', color: '0e8a16', description: 'Changed tests passed' },
-  { name: 'tests: failing ❌', color: 'b60205', description: 'Changed tests failed' },
+  { name: 'tests: green ✅', color: '0e8a16', description: 'Changed tests failed against base as expected' },
+  { name: 'tests: failing ❌', color: 'b60205', description: 'Changed tests passed against base' },
   { name: 'tests: no tests added', color: 'cccccc', description: 'PR does not change test files' },
 ];
 
@@ -53,9 +53,9 @@ async function label() {
     return;
   }
 
-  const passed = result === 'success';
-  await replaceTestLabel(passed ? 'tests: green ✅' : 'tests: failing ❌');
-  setOutput('summary', buildCompletedTestsSummary(passed));
+  const failedAgainstBase = result === 'success';
+  await replaceTestLabel(failedAgainstBase ? 'tests: green ✅' : 'tests: failing ❌');
+  setOutput('summary', buildCompletedTestsSummary(failedAgainstBase));
 }
 
 async function listPullFiles(): Promise<PullFile[]> {
@@ -91,12 +91,12 @@ No changed test files were detected.
 Applied label: \`tests: no tests added\``;
 }
 
-function buildCompletedTestsSummary(passed: boolean) {
+function buildCompletedTestsSummary(failedAgainstBase: boolean) {
   return `## Changed test gate
 
-Changed test files ${passed ? 'passed' : 'failed'}.
+Changed test files ${failedAgainstBase ? 'failed against the base branch as expected' : 'passed against the base branch'}.
 
-Applied label: \`${passed ? 'tests: green ✅' : 'tests: failing ❌'}\``;
+Applied label: \`${failedAgainstBase ? 'tests: green ✅' : 'tests: failing ❌'}\``;
 }
 
 async function ensureTestLabels() {


### PR DESCRIPTION
## Summary
- Invert the changed test gate so PR-added tests are expected to fail against the base branch.
- Fail the check when changed tests already pass without the PR implementation.
- Update automation labels and PR comment text to explain the inverted gate result.

## Test plan
- Parsed `.github/workflows/changed-test-gate.yml` as YAML.
- Ran `pnpm exec tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 index.ts` in `scripts/pr-test-gate`.
- Ran `pnpm exec tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 index.ts` in `scripts/pr-automation-comment`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR inverts how the test validation system works. Instead of just checking if new tests pass with the PR's code, it now ensures that new tests were actually needed—by verifying they fail when run against the base code (before the PR). If new tests already pass without the PR's changes, something is wrong and the workflow will fail.

## Changes

### `.github/workflows/changed-test-gate.yml`
- Added new step "Run changed tests against base" that executes changed test files against the PR's base branch with explicit failure handling
- The step reads test file list from `/tmp/changed-test-files` and runs `pnpm vitest run` while capturing the exit code
- Added validation: if tests unexpectedly pass against the base branch, the workflow fails with an error message
- If tests fail as expected, the workflow logs this and continues
- Removed the previous single "Run changed tests" step

### `scripts/pr-test-gate/index.ts`
- Updated label logic to reflect base-branch-relative test outcomes
- Renamed internal boolean to `failedAgainstBase` to clarify semantics
- `tests: green ✅` label now indicates "changed tests failed against the base branch as expected"
- `tests: failing ❌` label now indicates "changed tests passed against the base branch and should fail once PR code is applied"
- Updated completion summary text to use base-branch-oriented language

### `scripts/pr-automation-comment/index.ts`
- Updated PR comment text for consistency with inverted gate logic
- `tests: green ✅` comment: changed to state tests failed against base as expected
- `tests: failing ❌` comment: changed to state tests passed against base and should fail with PR code

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->