### PR TITLE
Improve Renovate update grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
   "major": {
     "dependencyDashboardApproval": true
   },
-  "schedule": ["before 6am on monday"],
+  "schedule": ["before 6am every weekday"],
   "vulnerabilityAlerts": {
     "groupName": "security updates",
     "labels": ["automation", "security"],
@@ -40,6 +40,7 @@
     "templates/**",
     "**/examples/**",
     "**/_examples/**",
+    ".claude/skills/**/assets/**/package.json",
     "e2e-tests/**/template/package.json"
   ],
   "packageRules": [
@@ -64,6 +65,81 @@
       "matchPackageNames": ["@types/node"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "groupName": "GitHub Actions",
+      "commitMessageTopic": "GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major", "minor", "patch", "digest"],
+      "dependencyDashboardApproval": false,
+      "automerge": true
+    },
+    {
+      "groupName": "Docker images",
+      "commitMessageTopic": "Docker images",
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "dependencyDashboardApproval": false
+    },
+    {
+      "groupName": "AI provider SDKs",
+      "commitMessageTopic": "AI provider SDKs",
+      "matchFileNames": ["+(package.json)", "**/package.json", "!./examples/**", "!./docs/**"],
+      "matchPackageNames": [
+        "@arcadeai/arcadejs",
+        "@deepgram/sdk",
+        "@google/genai",
+        "@mendable/firecrawl-js",
+        "@openrouter/ai-sdk-provider",
+        "@openrouter/ai-sdk-provider-v5",
+        "@tavily/core",
+        "elevenlabs"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "dependencyDashboardApproval": false
+    },
+    {
+      "groupName": "Observability providers",
+      "commitMessageTopic": "Observability providers",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": [
+        "@arizeai/*",
+        "@langfuse/*",
+        "@sentry/node",
+        "braintrust",
+        "dd-trace",
+        "langsmith",
+        "posthog-node"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "dependencyDashboardApproval": false
+    },
+    {
+      "groupName": "Database clients",
+      "commitMessageTopic": "Database clients",
+      "matchFileNames": ["+(package.json)", "**/package.json"],
+      "matchPackageNames": [
+        "@clickhouse/client",
+        "@datastax/astra-db-ts",
+        "@duckdb/node-api",
+        "@elastic/elasticsearch",
+        "@libsql/client",
+        "@opensearch-project/opensearch",
+        "@pinecone-database/pinecone",
+        "@supabase/supabase-js",
+        "@turbopuffer/turbopuffer",
+        "couchbase",
+        "ioredis",
+        "mongodb",
+        "mssql",
+        "pg",
+        "redis"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "dependencyDashboardApproval": false
     },
     {
       "groupName": "Hono",


### PR DESCRIPTION
## Summary
- group common dependency updates for GitHub Actions, Docker images, AI provider SDKs, observability providers, and database clients
- allow Renovate's scheduled PR creation window every weekday instead of only Monday morning
- ignore package manifests embedded in local Claude skill assets

## Test plan
- `node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8')); console.log('valid JSON')"`
- `npx --yes --package renovate@latest renovate-config-validator renovate.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR organizes how Renovate automatically updates dependencies in the project. Think of it like organizing your groceries - instead of checking for new items every Monday morning, the bot now checks every weekday morning. Plus, the bot now groups similar types of updates together (like all AI tools, all database tools, etc.) so they can be reviewed and approved as a package rather than individually.

## Overview

This PR improves Renovate's dependency update workflow by making updates more frequent, better organized, and more intelligent about which updates need manual approval.

## Key Changes

**Schedule Enhancement**
- Changed the main update schedule from "before 6am on monday" to "before 6am every weekday", allowing Renovate to check for and create updates throughout the workweek instead of just weekly

**Ignore Patterns**
- Added `.claude/skills/**/assets/**/package.json` to `ignorePaths` to prevent Renovate from managing package manifests embedded in local Claude skill assets

**Dependency Grouping**
Added five new `packageRules` with smart grouping and auto-approval settings:
- **GitHub Actions**: Groups all GitHub Actions updates (major, minor, patch, digest) with auto-merge enabled
- **Docker images**: Groups Docker image updates (major, minor, patch) with dependency dashboard approval disabled
- **AI provider SDKs**: Groups 8 AI provider packages (Arcade, Deepgram, Google Genai, Firecrawl, OpenRouter, Tavily, Elevenlabs) - minor/patch updates only
- **Observability providers**: Groups 7 observability/monitoring packages (Arize, Langfuse, Sentry, Braintrust, Datadog, LangSmith, PostHog) - minor/patch updates only  
- **Database clients**: Groups 15 database client packages (ClickHouse, Astra DB, DuckDB, Elasticsearch, LibSQL, OpenSearch, Pinecone, Supabase, Turbopuffer, Couchbase, Redis, MongoDB, MSSQL, PostgreSQL) - minor/patch updates only

All new grouping rules skip `dependencyDashboardApproval`, streamlining the approval process for these common dependency types.

## Testing
The changes are validated per the test plan:
- `renovate.json` parses as valid JSON
- Renovate configuration validates successfully with the official config validator

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->