### PR TITLE
fix(core): stop agentic loop for client-only tool calls

### DIFF
--- a/.changeset/fix-client-tool-loop.md
+++ b/.changeset/fix-client-tool-loop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix infinite agentic loop with client tools (no `execute`). When the model finished with `tool-calls` and every called tool was a client tool — that is, a tool whose `execute` function was stripped by `listClientTools` because it runs on the caller's side — the outer dowhile loop treated the tool calls as "pending" and re-invoked the model without adding a tool result. The model then produced the same tool call again, repeating until `maxSteps` was reached. The loop now considers a tool call "pending" only if the server can actually execute it (the resolved tool has an `execute` function) or the model already resolved it (`providerExecuted`). Mixed turns with at least one server-executable tool still continue as before.

--- a/.changeset/fix-client-tool-loop.md
+++ b/.changeset/fix-client-tool-loop.md
@@ -2,4 +2,8 @@
 '@mastra/core': patch
 ---
 
-Fix infinite agentic loop with client tools (no `execute`). When the model finished with `tool-calls` and every called tool was a client tool — that is, a tool whose `execute` function was stripped by `listClientTools` because it runs on the caller's side — the outer dowhile loop treated the tool calls as "pending" and re-invoked the model without adding a tool result. The model then produced the same tool call again, repeating until `maxSteps` was reached. The loop now considers a tool call "pending" only if the server can actually execute it (the resolved tool has an `execute` function) or the model already resolved it (`providerExecuted`). Mixed turns with at least one server-executable tool still continue as before.
+Fixed an infinite agentic loop when a step ends with `finishReason: 'tool-calls'` and all called tools are client-only.
+
+Previously, Mastra could call the model again without any new tool result, which repeated the same tool calls until `maxSteps`.
+
+Now, Mastra only continues when at least one called tool can run on the server or when a provider-executed tool result requires another model turn.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -460,6 +460,150 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     });
   });
 
+  it('does not continue the agentic loop when finishReason is tool-calls but all called tools are client tools (no execute)', async () => {
+    // Repro for https://github.com/mastra-ai/mastra/issues/14093 — when a client tool (no
+    // `execute` function) is the only thing the model calls, the server has nothing to run.
+    // Continuing the loop would re-invoke the model without adding a tool result, producing
+    // duplicate identical tool calls until maxSteps. The step must report isContinued=false
+    // so the outer dowhile stops and the tool-calls are returned to the caller.
+    const tools = {
+      getWeather: {
+        id: 'getWeather',
+        description: 'Get weather',
+        inputSchema: z.object({ location: z.string() }),
+        // No `execute` — this is a client tool. `listClientTools` strips execute before
+        // tools reach this loop, so this shape matches what we receive at runtime.
+      },
+    };
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream: vi.fn(async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'getWeather',
+                  input: '{"location":"Paris"}',
+                  providerExecuted: false,
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: testUsage,
+                },
+              ]),
+              request: {},
+              response: { headers: undefined },
+              warnings: [],
+            })),
+          } as any,
+        },
+      ],
+      tools,
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: { generateId: () => 'generated-id' },
+      logger: { error: vi.fn(), warn: vi.fn(), debug: vi.fn() } as any,
+    } as unknown as OuterLLMRun<typeof tools>);
+
+    const result = await llmExecutionStep.execute(createExecuteParams(createIterationInput()));
+
+    expect(result.stepResult.reason).toBe('tool-calls');
+    expect(result.stepResult.isContinued).toBe(false);
+    expect(result.output.toolCalls).toEqual([
+      expect.objectContaining({ toolCallId: 'call-1', toolName: 'getWeather' }),
+    ]);
+  });
+
+  it('continues the agentic loop when at least one called tool has an execute function', async () => {
+    // Mirror of the client-tool case above: when the model calls a mix of (or only) tools
+    // that the server can actually execute, the loop must continue so tool results are
+    // appended and the model gets another turn.
+    const tools = {
+      getWeather: {
+        id: 'getWeather',
+        description: 'Get weather',
+        inputSchema: z.object({ location: z.string() }),
+        execute: vi.fn(async () => ({ temperature: 20 })),
+      },
+    };
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream: vi.fn(async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'getWeather',
+                  input: '{"location":"Paris"}',
+                  providerExecuted: false,
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: testUsage,
+                },
+              ]),
+              request: {},
+              response: { headers: undefined },
+              warnings: [],
+            })),
+          } as any,
+        },
+      ],
+      tools,
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: { generateId: () => 'generated-id' },
+      logger: { error: vi.fn(), warn: vi.fn(), debug: vi.fn() } as any,
+    } as unknown as OuterLLMRun<typeof tools>);
+
+    const result = await llmExecutionStep.execute(createExecuteParams(createIterationInput()));
+
+    expect(result.stepResult.reason).toBe('tool-calls');
+    expect(result.stepResult.isContinued).toBe(true);
+  });
+
   it('merges model config headers with explicit modelSettings headers and lets modelSettings override duplicates', async () => {
     const doStream = vi.fn(async () => ({
       stream: convertArrayToReadableStream([

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1926,10 +1926,11 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
 
       // isContinued should be true if:
       // - shouldRetry is true (processor requested retry)
-      // - OR there are non-provider-executed tool calls to process (some LLMs return finishReason 'stop' even with tool calls)
-      // - OR finishReason indicates more work (e.g., tool-use)
-      // Provider-executed tools (e.g. web_search) are handled server-side — the response already
-      // contains both the tool execution and the text output, so no additional loop iteration is needed.
+      // - OR there are server-executable tool calls to run next (some LLMs return finishReason
+      //   'stop' even with tool calls, which is why we don't gate this on finishReason alone)
+      // - OR finishReason='tool-calls' AND there are provider-executed tool calls — the results
+      //   were streamed inline and the model needs another turn to produce its final text
+      // - OR finishReason indicates more work in some unrecognized way (e.g., 'tool-use')
       //
       // NOTE: hasPendingToolCalls must NOT override finishReason='length'.
       // When the provider hits max_tokens mid-generation, it returns finishReason='length' and
@@ -1938,10 +1939,44 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       // excluded 'length' from shouldContinue; this guard prevents hasPendingToolCalls from
       // inadvertently re-enabling it.
       // See: https://github.com/mastra-ai/mastra/issues/15717
-      const hasPendingToolCalls = toolCalls && toolCalls.some(tc => !tc.providerExecuted) && finishReason !== 'length';
+      //
+      // Client tools (passed via `clientTools` / tools without an `execute` function) cannot be
+      // resolved server-side: `listClientTools` strips `execute` before the tool reaches this
+      // loop, so the server has nothing to run. When finishReason='tool-calls' and every called
+      // tool is a client tool (no execute, not provider-executed), continuing would re-invoke
+      // the model with no tool result added to the context, producing duplicate identical tool
+      // calls until maxSteps is reached. Treat a tool call as server-pending only if the server
+      // can actually execute it; treat 'tool-calls' as terminal unless something will produce a
+      // result the model needs to see (server-executable tools to run, or provider-executed
+      // tools whose results were just streamed).
+      // See: https://github.com/mastra-ai/mastra/issues/14093
+      const lookupToolByName = (name: string): unknown =>
+        stepTools?.[name] ||
+        findProviderToolByName(stepTools, name) ||
+        Object.values(stepTools ?? {}).find((t: any) => t && typeof t === 'object' && t.id === name) ||
+        tools?.[name] ||
+        findProviderToolByName(tools, name) ||
+        Object.values(tools ?? {}).find((t: any) => t && typeof t === 'object' && t.id === name);
+      const hasServerExecutableToolCalls =
+        toolCalls?.some(tc => {
+          if (tc.providerExecuted) return false;
+          const tool = lookupToolByName(tc.toolName);
+          return typeof (tool as { execute?: unknown } | undefined)?.execute === 'function';
+        }) ?? false;
+      const hasProviderExecutedToolCalls = toolCalls?.some(tc => tc.providerExecuted) ?? false;
+      // Non-empty resolved tool calls that contain no server-executable and no provider-executed
+      // entries are exclusively client tools — the server has nothing to run and continuing would
+      // duplicate the same calls until maxSteps. (An empty toolCalls list here means the model
+      // streamed tool-call chunks that have not been assembled into completed calls yet; the
+      // downstream pipeline handles that case, so we must not stop on its behalf.)
+      const allCalledToolsAreClientTools =
+        (toolCalls?.length ?? 0) > 0 && !hasServerExecutableToolCalls && !hasProviderExecutedToolCalls;
+      const hasPendingToolCalls = hasServerExecutableToolCalls && finishReason !== 'length';
+      const finishReasonWantsContinuation = allCalledToolsAreClientTools
+        ? false
+        : !['stop', 'error', 'length'].includes(finishReason);
       const shouldContinue =
-        shouldRetry ||
-        (!tripwireTriggered && (hasPendingToolCalls || !['stop', 'error', 'length'].includes(finishReason)));
+        shouldRetry || (!tripwireTriggered && (hasPendingToolCalls || finishReasonWantsContinuation));
 
       // Reset retry count after a successful non-retry step; only consecutive retries carry forward.
       const nextProcessorRetryCount = shouldRetry ? currentProcessorRetryCount + 1 : 0;


### PR DESCRIPTION
## Description

When the model finished with `finishReason='tool-calls'` and every called tool was a client tool (no `execute` function — `listClientTools` strips `execute` before tools reach the loop), the outer `do/while` treated the calls as pending and re-invoked the model without adding any tool result. The model produced the same tool call again, repeating until `maxSteps`.

Fix: treat a call as server-pending only if the resolved tool has an `execute` function. When the only resolved calls are client tools, gate `'tool-calls'` continuation on having something that will produce a result the model needs to see next turn (server-executable or `providerExecuted`). Empty `toolCalls` keep the existing fallback so streaming tool-call chunks not yet assembled still let the downstream pipeline continue.

## Related issue(s)

Fixes #14093

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

A robot kept asking for the same help over and over because it thought those tools ran on its side, but they only run on your computer. This change makes the robot stop asking again when the tools are client-only, and only keeps asking if the server actually has work to do.

## Summary

Fixes an infinite agentic loop where Mastra's outer do/while loop continued when a step finished with `finishReason='tool-calls'` even though every called tool was client-only (had no `execute`). Because `listClientTools` strips `execute` before tools reach the loop, the loop treated those calls as pending and re-invoked the model without any `tool_result`, causing repeated identical tool calls until `maxSteps`.

### Root cause

The loop couldn't distinguish server-executable tools (have `execute`) from client-only tools (execute stripped), so it always set continuation for `finishReason='tool-calls'` even when nothing server-side would produce a result.

### Changes made

- packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
  - Refined continuation logic: treat a tool call as pending only if the resolved tool has an `execute` function or was `providerExecuted`.
  - When `finishReason='tool-calls'`, do not continue the outer loop if all resolved tool calls are client-only. Preserve continuation when at least one tool is server-executable or when provider-executed results require another model turn.
  - Keep existing fallback behavior for empty `toolCalls` to support streaming tool-call chunks not yet assembled.

- packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
  - Added tests:
    1. Confirms `isContinued === false` when all tool calls are client-only.
    2. Confirms `isContinued === true` when at least one tool is server-executable.

- .changeset/fix-client-tool-loop.md
  - Patch release note for `@mastra/core` documenting the fix.

### Behavior impact

- Fixed: outer loop no longer re-invokes the model for steps that only requested client-only tools.
- Unchanged: turns with at least one server-executable tool still continue as before.
- Preserved: streaming/tool-call chunk behavior and terminal `finishReason='length'` handling.

Closes `#14093`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->