### PR TITLE
fix(core): bind RBAC method receiver in buildCapabilities

### DIFF
--- a/.changeset/fix-rbac-this-binding.md
+++ b/.changeset/fix-rbac-this-binding.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Preserve `this` when resolving permissions for the "View as role" picker in `buildCapabilities`. Class-based RBAC providers (e.g. `@mastra/auth-workos`) read state from `this` inside `getPermissionsForRole`, but the method was being detached to a bare variable before invocation. This caused a `TypeError: Cannot read properties of undefined (reading 'options')` to be logged on every authenticated request and silently emptied the available roles list. The error was swallowed by a surrounding try/catch so admins saw an empty picker instead of a crash.

--- a/packages/core/src/auth/ee/__tests__/capabilities-rbac-binding.test.ts
+++ b/packages/core/src/auth/ee/__tests__/capabilities-rbac-binding.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @license Mastra Enterprise License - see ee/LICENSE
+ *
+ * Regression test for the `this`-binding bug in buildCapabilities when
+ * resolving permissions for the "View as role" picker. Class-based RBAC
+ * providers (e.g. @mastra/auth-workos) read state from `this.options` inside
+ * `getPermissionsForRole`, so the method must be invoked with its original
+ * receiver instead of being detached to a bare variable.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { buildCapabilities } from '../capabilities';
+import type { IRBACProvider } from '../interfaces/rbac';
+import { clearLicenseCache } from '../license';
+
+function createMockAuth(user: { id: string; email: string; name: string } | null) {
+  return {
+    getCurrentUser: vi.fn().mockResolvedValue(user),
+  };
+}
+
+/**
+ * Class-based RBAC provider whose `getPermissionsForRole` depends on `this`.
+ * Mirrors the shape of providers like MastraAuthWorkOS where role permissions
+ * are resolved via `this.options.roleMapping`.
+ */
+class ClassBasedRBACProvider implements IRBACProvider {
+  private readonly options: { roleMapping: Record<string, string[]> };
+
+  constructor(options: { roleMapping: Record<string, string[]> }) {
+    this.options = options;
+  }
+
+  async getRoles() {
+    return ['admin'];
+  }
+  async hasRole() {
+    return true;
+  }
+  async getPermissions() {
+    // Admin bypass permission - triggers the availableRoles branch.
+    return ['*'];
+  }
+  async hasPermission() {
+    return true;
+  }
+  async hasAllPermissions() {
+    return true;
+  }
+  async hasAnyPermission() {
+    return true;
+  }
+  async getAvailableRoles() {
+    return Object.keys(this.options.roleMapping).map(id => ({ id, name: id }));
+  }
+  async getPermissionsForRole(roleId: string) {
+    // Reads from `this.options` - blows up with TypeError if `this` was lost.
+    return this.options.roleMapping[roleId] ?? [];
+  }
+}
+
+describe('buildCapabilities - RBAC method `this` binding', () => {
+  let originalNodeEnv: string | undefined;
+  let originalLicense: string | undefined;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env['NODE_ENV'];
+    originalLicense = process.env['MASTRA_EE_LICENSE'];
+    process.env['MASTRA_EE_LICENSE'] = 'a'.repeat(32);
+    clearLicenseCache();
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv !== undefined) process.env['NODE_ENV'] = originalNodeEnv;
+    else delete process.env['NODE_ENV'];
+    if (originalLicense !== undefined) process.env['MASTRA_EE_LICENSE'] = originalLicense;
+    else delete process.env['MASTRA_EE_LICENSE'];
+    clearLicenseCache();
+  });
+
+  it('preserves `this` when resolving permissions for available roles', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const auth = createMockAuth({ id: 'user-1', email: 'admin@test.com', name: 'Admin' });
+    const rbac = new ClassBasedRBACProvider({
+      roleMapping: {
+        Engineering: ['agents:*', 'workflows:*'],
+        Product: ['agents:read'],
+        Admin: ['*'],
+      },
+    });
+
+    const result = await buildCapabilities(auth as any, new Request('http://localhost'), {
+      rbac,
+    });
+
+    expect('availableRoles' in result).toBe(true);
+    // Admin role is filtered out (has admin-bypass), the other two remain.
+    expect((result as any).availableRoles).toEqual(
+      expect.arrayContaining([
+        { id: 'Engineering', name: 'Engineering' },
+        { id: 'Product', name: 'Product' },
+      ]),
+    );
+    expect((result as any).availableRoles).not.toContainEqual({ id: 'Admin', name: 'Admin' });
+
+    // Should not log the "failed to list permissions for role" warning that
+    // surfaces when `this` is lost and `this.options` throws.
+    const sawBindingWarning = warn.mock.calls.some(args =>
+      String(args[0] ?? '').includes('failed to list permissions for role'),
+    );
+    expect(sawBindingWarning).toBe(false);
+
+    warn.mockRestore();
+  });
+});

--- a/packages/core/src/auth/ee/capabilities.ts
+++ b/packages/core/src/auth/ee/capabilities.ts
@@ -373,7 +373,7 @@ export async function buildCapabilities(
     if (hasAdminBypassPermissions(access.permissions)) {
       try {
         const allRoles = await rbacProvider.getAvailableRoles();
-        const getPermissionsForRole = rbacProvider.getPermissionsForRole;
+        const getPermissionsForRole = rbacProvider.getPermissionsForRole?.bind(rbacProvider);
         if (getPermissionsForRole) {
           // Use allSettled so one failing role lookup doesn't drop the whole picker.
           const rolePermissions = await Promise.allSettled(


### PR DESCRIPTION
## Summary

Preserve `this` when resolving permissions for the "View as role" picker in `buildCapabilities`. Class-based RBAC providers (e.g. `@mastra/auth-workos`) read state from `this` inside `getPermissionsForRole`, but the method was being detached to a bare variable before invocation.

## Reproduction

Running `@mastra/core@1.37.0-alpha.8` (and alpha.9) with `@mastra/auth-workos@1.5.0-alpha.0` configured, every authenticated request logged:

```
[auth/ee] failed to list permissions for role: TypeError: Cannot read properties of undefined (reading 'options')
    at getPermissionsForRole (.../@mastra/auth-workos/dist/index.js:740:57)
    at Array.map (<anonymous>)
    at buildCapabilities (.../@mastra/core/dist/chunk-RRIPZR36.js:690:22)
```

Surrounding `try/catch` swallowed the throw, so the user-visible symptom was the "View as role" picker silently dropping every role for WorkOS deployments.

## Root cause

```ts
// packages/core/src/auth/ee/capabilities.ts:376
const getPermissionsForRole = rbacProvider.getPermissionsForRole;
//                            ^ method detached from rbacProvider — loses `this`
...
perms: await getPermissionsForRole(role.id), // called with `this = undefined`
```

WorkOS' implementation reads `this.options.roleMapping`, so the detached call throws.

Introduced in #16578; present in `1.37.0-alpha.8` and `1.37.0-alpha.9`. Not in stable `1.36.0`.

## Fix

One-line change: bind the method to its provider before storing the reference.

```ts
const getPermissionsForRole = rbacProvider.getPermissionsForRole?.bind(rbacProvider);
```

## Test

Added `capabilities-rbac-binding.test.ts` — a regression test using a class-based mock provider whose `getPermissionsForRole` reads from `this.options.roleMapping`. Confirmed:

- ✅ Passes with the bind fix (returns the expected non-admin roles)
- ❌ Fails without the bind fix (empty `availableRoles` because every role lookup throws)

## Verification

- `pnpm vitest run src/auth/ee` in `packages/core` → 90/90 passing
- Manually reproduced original error against the alpha packages in `agent-builder-demo` before applying the fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a class-based RBAC provider method was moved to a variable, it forgot who it belonged to (lost its `this` context), causing it to fail when trying to read properties from itself. We fixed it by explicitly binding the method to its provider, and added a test to make sure it doesn't break again.

---

## Problem

Class-based RBAC providers (such as `@mastra/auth-workos`) implement a `getPermissionsForRole` method that depends on `this` context to access configuration like `this.options.roleMapping`. When `buildCapabilities` detached this method to a bare variable reference, the method lost its `this` binding, causing:

- `TypeError: Cannot read properties of undefined (reading 'options')` on authenticated requests
- The "View as role" picker silently dropped all roles due to a swallowed error
- Repeated error logging on every authenticated request

## Solution

Modified `buildCapabilities` in `packages/core/src/auth/ee/capabilities.ts` to bind the `getPermissionsForRole` method to its provider instance before storing it:

```typescript
const getPermissionsForRole = rbacProvider.getPermissionsForRole?.bind(rbacProvider);
```

This ensures the method retains its `this` context when invoked.

## Testing

Added `packages/core/src/auth/ee/__tests__/capabilities-rbac-binding.test.ts`, a regression test that:
- Defines a class-based mock RBAC provider whose `getPermissionsForRole` reads from `this.options.roleMapping`
- Verifies that `buildCapabilities` correctly filters roles and returns them without errors
- Confirms no warning logs are emitted, proving the `this` binding was preserved
- Passes with the fix and fails without it

## Verification

- All 90 tests passing in `src/auth/ee`
- Manual reproduction confirmed the original error before the fix was applied

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->