### PR TITLE
fix(core): preserve `this` when calling rbacProvider.getPermissionsForRole

### DIFF
--- a/.changeset/solid-rocks-laugh.md
+++ b/.changeset/solid-rocks-laugh.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the "View as role" picker losing roles for class-based RBAC providers (e.g. `MastraRBACWorkos`). `buildCapabilities` now invokes `rbacProvider.getPermissionsForRole` on the instance so `this` is preserved, instead of destructuring the method and calling it standalone.

--- a/packages/core/src/auth/ee/__tests__/capabilities-rbac.test.ts
+++ b/packages/core/src/auth/ee/__tests__/capabilities-rbac.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license Mastra Enterprise License - see ee/LICENSE
+ *
+ * Regression tests for buildCapabilities + RBAC role-listing.
+ *
+ * Specifically guards against `this`-binding loss when invoking
+ * optional methods on an IRBACProvider instance (e.g. MastraRBACWorkos
+ * whose getPermissionsForRole reads `this.options.roleMapping`).
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { buildCapabilities } from '../capabilities';
+import { clearLicenseCache } from '../license';
+
+function createMockAuth(user: { id: string; email: string; name: string } | null) {
+  return {
+    getCurrentUser: vi.fn().mockResolvedValue(user),
+  };
+}
+
+// Class-based RBAC provider whose methods rely on `this`.
+// Mirrors the shape that broke with MastraRBACWorkos.
+class FakeRBACProvider {
+  options = {
+    roleMapping: {
+      admin: ['*'] as string[],
+      member: ['tools:read'] as string[],
+      viewer: [] as string[],
+    } as Record<string, string[]>,
+  };
+
+  async getRoles() {
+    return ['admin'];
+  }
+  async hasRole() {
+    return true;
+  }
+  async getPermissions() {
+    // Admin bypass — triggers the availableRoles branch in buildCapabilities.
+    return ['*'];
+  }
+  async hasPermission() {
+    return true;
+  }
+  async hasAllPermissions() {
+    return true;
+  }
+  async hasAnyPermission() {
+    return true;
+  }
+  async getAvailableRoles() {
+    return Object.keys(this.options.roleMapping).map(id => ({ id, name: id }));
+  }
+  async getPermissionsForRole(roleId: string) {
+    // Will throw "Cannot read properties of undefined (reading 'options')"
+    // if invoked without proper `this` binding.
+    return this.options.roleMapping[roleId] ?? [];
+  }
+}
+
+describe('buildCapabilities — RBAC role listing', () => {
+  let originalNodeEnv: string | undefined;
+  let originalLicense: string | undefined;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env['NODE_ENV'];
+    originalLicense = process.env['MASTRA_EE_LICENSE'];
+    process.env['MASTRA_EE_LICENSE'] = 'a'.repeat(32);
+    clearLicenseCache();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv !== undefined) process.env['NODE_ENV'] = originalNodeEnv;
+    else delete process.env['NODE_ENV'];
+    if (originalLicense !== undefined) process.env['MASTRA_EE_LICENSE'] = originalLicense;
+    else delete process.env['MASTRA_EE_LICENSE'];
+    clearLicenseCache();
+    warnSpy.mockRestore();
+  });
+
+  it('preserves `this` when invoking rbacProvider.getPermissionsForRole', async () => {
+    const auth = createMockAuth({ id: 'user-1', email: 'admin@test.com', name: 'Admin' });
+    const rbac = new FakeRBACProvider();
+
+    const result = await buildCapabilities(auth as any, new Request('http://localhost'), {
+      rbac: rbac as any,
+    });
+
+    // Must not have logged the "failed to list permissions for role" warning.
+    const failedRolePermLog = warnSpy.mock.calls.find(
+      (args: unknown[]) => typeof args[0] === 'string' && args[0].includes('failed to list permissions for role'),
+    );
+    expect(failedRolePermLog).toBeUndefined();
+
+    // availableRoles should be returned and filtered to exclude admin-bypass roles.
+    expect('availableRoles' in result).toBe(true);
+    const availableRoles = (result as { availableRoles?: { id: string; name: string }[] }).availableRoles;
+    expect(availableRoles).toBeDefined();
+    // `admin` has ['*'] — excluded. `member` and `viewer` should remain.
+    expect(availableRoles!.map(r => r.id).sort()).toEqual(['member', 'viewer']);
+  });
+});

--- a/packages/core/src/auth/ee/capabilities.ts
+++ b/packages/core/src/auth/ee/capabilities.ts
@@ -373,13 +373,14 @@ export async function buildCapabilities(
     if (hasAdminBypassPermissions(access.permissions)) {
       try {
         const allRoles = await rbacProvider.getAvailableRoles();
-        const getPermissionsForRole = rbacProvider.getPermissionsForRole;
-        if (getPermissionsForRole) {
+        if (rbacProvider.getPermissionsForRole) {
           // Use allSettled so one failing role lookup doesn't drop the whole picker.
+          // Call via the instance to preserve `this` binding for provider implementations
+          // that rely on instance state (e.g. MastraRBACWorkos reads `this.options.roleMapping`).
           const rolePermissions = await Promise.allSettled(
             allRoles.map(async role => ({
               role,
-              perms: await getPermissionsForRole(role.id),
+              perms: await rbacProvider.getPermissionsForRole!(role.id),
             })),
           );
           availableRoles = rolePermissions.flatMap(result => {


### PR DESCRIPTION
The "View as role" picker was breaking for class-based RBAC providers like `MastraRBACWorkos`. `buildCapabilities` destructured the method off the provider, which dropped the `this` binding, so the call threw `TypeError: Cannot read properties of undefined (reading 'options')` and the picker fell back to an unfiltered role list.

Before:
```ts
const getPermissionsForRole = rbacProvider.getPermissionsForRole;
if (getPermissionsForRole) {
  perms: await getPermissionsForRole(role.id), // `this` is undefined
}
```

After:
```ts
if (rbacProvider.getPermissionsForRole) {
  perms: await rbacProvider.getPermissionsForRole(role.id), // `this` preserved
}
```

Added a regression test in `capabilities-rbac.test.ts` using a class-based fake RBAC provider whose method reads `this.options`. Verified the test fails without the fix and passes with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the "View as role" picker tried to get permissions for different roles, it accidentally forgot to call the method "the right way," which confused certain permission systems and caused them to crash. This PR fixes it by calling the method properly so it remembers what it needs to do, and adds a test to make sure it keeps working.

## Overview

This pull request fixes a bug in the "View as role" picker where class-based RBAC providers (such as `MastraRBACWorkos`) were failing at runtime. The issue occurred because `buildCapabilities` was destructuring the `getPermissionsForRole` method from the RBAC provider and calling it as an unbound function, which caused the method to lose its `this` context and fail when trying to access instance properties.

## Changes

**Root cause fix:** Modified `buildCapabilities` in `packages/core/src/auth/ee/capabilities.ts` to call `rbacProvider.getPermissionsForRole(role.id)` directly on the provider instance instead of extracting and invoking the method separately. This preserves the `this` binding required by class-based provider implementations.

**Test coverage:** Added a regression test in `packages/core/src/auth/ee/__tests__/capabilities-rbac.test.ts` that uses a class-based `FakeRBACProvider` whose `getPermissionsForRole` method depends on `this.options`. The test verifies that `buildCapabilities` correctly preserves the `this` binding and successfully filters roles, excluding admin-bypass roles while keeping regular roles like `member` and `viewer`.

**Changelog entry:** Added a Changesets entry documenting the patch fix for the "View as role" picker behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->