### PR TITLE
docs(agent-builder): add Agent Builder concept and reference docs

### DIFF
--- a/docs/src/content/en/docs/agent-builder/access-control.mdx
+++ b/docs/src/content/en/docs/agent-builder/access-control.mdx
@@ -1,0 +1,108 @@
+---
+title: "Access control | Agent Builder"
+description: Gate the Agent Builder with two roles — admin and member — using Mastra RBAC.
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+  - "@mastra/auth-workos"
+---
+
+# Access control
+
+:::note
+The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
+:::
+
+The Agent Builder ships with two supported roles: `admin` and `member`. Wire them through `Mastra.server.rbac`. Without an RBAC provider, every authenticated user has full Builder access; without authentication, the Builder is open to anyone who can reach the server.
+
+## Roles
+
+| Role | Permissions | What they can do |
+| - | - | - |
+| `admin` | `*` | Full access. Create, edit, publish, and delete agents and skills. Manage every Builder surface. |
+| `member` | scoped list (below) | Open the Builder, browse agents and skills, populate pickers, and chat with the Builder agent. |
+
+## Minimum permissions
+
+The Builder UI calls several resources on load, so a usable `member` role needs explicit grants on each. The Builder action layer (`/agent-builder/*`) is one resource; the data it reads and writes lives under separate resources.
+
+| Permission | Used for |
+| - | - |
+| `agent-builder:*` | Load Builder actions, runs, and stream Builder workflows |
+| `agents:read`, `agents:execute` | List registered agents and chat with the Builder agent |
+| `stored-agents:*` | List, view, create, and edit agents |
+| `stored-skills:*` | List, view, create, and edit stored skills |
+| `stored-workspaces:*` | Pick a workspace when editing an agent |
+| `tools:read`, `tools:execute` | Populate the tool picker and run tools through agents |
+| `workflows:read`, `workflows:execute` | Populate the workflow picker and run workflows through agents |
+| `memory:read` | Preview memory configuration in the picker |
+| `channels:read` | Show Slack/channel chips on agent pages |
+| `infrastructure:read` | Builder diagnostics banner on the shell |
+
+Grant `:write`, `:delete`, and `:publish` on `stored-agents` and `stored-skills` for users who should create or modify agents. The `:*` wildcards in the table above cover those actions. `admin` covers everything through the `*` wildcard.
+
+## Quickstart with WorkOS
+
+`@mastra/auth-workos` provides `MastraAuthWorkos` for SSO and `MastraRBACWorkos` for role-based access. Map WorkOS organization roles to the Builder's `admin` and `member` roles via `roleMapping`:
+
+```typescript title="src/mastra/auth.ts"
+import { MastraAuthWorkos, MastraRBACWorkos } from '@mastra/auth-workos'
+
+export const mastraAuth = new MastraAuthWorkos({
+  redirectUri: process.env.WORKOS_REDIRECT_URI || 'http://localhost:4111/api/auth/callback',
+})
+
+export const rbacProvider = new MastraRBACWorkos({
+  roleMapping: {
+    admin: ['*'],
+    member: [
+      'agent-builder:*',
+      'agents:read',
+      'agents:execute',
+      'stored-agents:*',
+      'stored-skills:*',
+      'stored-workspaces:*',
+      'tools:read',
+      'tools:execute',
+      'workflows:read',
+      'workflows:execute',
+      'memory:read',
+      'channels:read',
+      'infrastructure:read',
+    ],
+    _default: [],
+  },
+})
+```
+
+Register both providers on the Mastra server:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+import { mastraAuth, rbacProvider } from './auth'
+
+export const mastra = new Mastra({
+  server: {
+    auth: mastraAuth,
+    rbac: rbacProvider,
+  },
+  // ...storage, agents, editor
+})
+```
+
+`_default` covers WorkOS roles not listed in the mapping. Omit it to deny unmapped users. Set `WORKOS_API_KEY` and `WORKOS_CLIENT_ID` in your environment.
+
+## Permission grammar
+
+Permission patterns follow `resource:action`. Wildcards are supported on either side:
+
+- `*` — full access (every resource, every action). Used by `admin`.
+- `agent-builder:*` — every action on the `agent-builder` resource.
+- `*:read` — `read` across every resource.
+
+Patterns resolve through `matchesPermission()`. The first matching role permission grants the action.
+
+## Related
+
+- [Configuration](/docs/agent-builder/configuration) — wire RBAC alongside the rest of the Builder config.
+- [Deploying](/docs/agent-builder/deploying) — auth, RBAC, and EE license setup for production.

--- a/docs/src/content/en/docs/agent-builder/browser.mdx
+++ b/docs/src/content/en/docs/agent-builder/browser.mdx
@@ -1,0 +1,71 @@
+---
+title: "Browser | Agent Builder"
+description: Register browser providers and pin a default browser configuration for Agent Builder agents.
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+---
+
+# Browser
+
+:::note
+The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
+:::
+
+The Agent Builder can give end-user agents a browser tool driven by a registered provider. Unlike filesystems and sandboxes, **there are no built-in browser providers** — you must register one through `MastraEditor.browsers`.
+
+## Quickstart
+
+Register a browser provider on `MastraEditor`, then pin it as the Builder default through `builder.configuration.agent.browser`:
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+import { StagehandBrowser } from '@mastra/stagehand'
+
+new MastraEditor({
+  browsers: {
+    stagehand: {
+      id: 'stagehand',
+      name: 'Stagehand Browser',
+      createBrowser: config =>
+        new StagehandBrowser({
+          ...config,
+          apiKey: process.env.BROWSERBASE_API_KEY ?? '',
+          env: 'BROWSERBASE',
+          projectId: process.env.BROWSERBASE_PROJECT_ID ?? '',
+        }),
+    },
+  },
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        browser: {
+          type: 'inline',
+          config: { provider: 'stagehand', headless: true },
+        },
+      },
+    },
+  },
+})
+```
+
+## Browser providers
+
+`MastraEditor.browsers` accepts a `Record<string, BrowserProvider>`. Each provider exposes:
+
+- `id` — provider identifier, matched against `StorageBrowserConfig.provider` (e.g., `'stagehand'`).
+- `name` — display name shown in the Builder UI.
+- `createBrowser(config)` — hydrates a stored browser config into a runtime `MastraBrowser`. This is where you inject runtime-only credentials (API keys, project IDs) that are not stored in the agent snapshot.
+
+Browser classes ship as separate packages (e.g., `@mastra/stagehand`, `@mastra/agent-browser`). The provider entry is a plain object wrapping the class — register one entry per browser you want the Builder to expose to end users. See the [StorageBrowserRef reference](/reference/editor/storage-browser-ref) for the full `browser` field schema, including all `StorageBrowserConfig` options.
+
+## Feature toggle
+
+The `features.agent.browser` toggle controls whether end users can enable browser access per agent in the Builder UI. It defaults to `true` only when a valid `configuration.agent.browser` (with a `config.provider`) is provided. Without a registered provider matching the pinned config, the toggle is forced off.
+
+## Related
+
+- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults) — the full `browser` field schema.
+- [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) — the full Builder config surface, including `features.agent.browser`.
+- [Configuration](/docs/agent-builder/configuration) — wire `browser` alongside the rest of the Builder config.

--- a/docs/src/content/en/docs/agent-builder/channels.mdx
+++ b/docs/src/content/en/docs/agent-builder/channels.mdx
@@ -1,0 +1,67 @@
+---
+title: "Channels | Agent Builder"
+description: Connect Builder-created agents to Slack and other channel providers without writing code.
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+  - "@mastra/slack"
+---
+
+# Channels
+
+:::note
+The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
+:::
+
+Channels let Builder-created agents reach users outside the Mastra server. Register a channel provider on `Mastra.channels` and the Builder exposes the channel as an integration option for every agent.
+
+Slack is currently the only supported channel.
+
+## Quickstart
+
+Install the Slack provider:
+
+```bash npm2yarn
+npm install @mastra/slack
+```
+
+Register `SlackProvider` on `Mastra.channels`:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+import { MastraEditor } from '@mastra/editor'
+import { createBuilderAgent } from '@mastra/editor/ee'
+import { SlackProvider } from '@mastra/slack'
+
+export const mastra = new Mastra({
+  storage,
+  channels: {
+    slack: new SlackProvider({
+      refreshToken: process.env.SLACK_APP_CONFIG_REFRESH_TOKEN,
+      baseUrl: process.env.SLACK_BASE_URL,
+    }),
+  },
+  agents: { builderAgent: createBuilderAgent() },
+  editor: new MastraEditor({
+    builder: { enabled: true },
+  }),
+})
+```
+
+The Slack provider handles app creation, OAuth, slash commands, and message routing for every Builder-created agent that opts in.
+
+## Configuration
+
+`SlackProvider` requires one environment variable and accepts one optional override:
+
+- `SLACK_APP_CONFIG_REFRESH_TOKEN` (required): the refresh token from your Slack app configuration tokens, available under **Your App Configuration Tokens** on [api.slack.com/apps](https://api.slack.com/apps). The refresh token does not expire, but the access tokens it issues rotate every 12 hours and are auto-persisted to `Mastra.storage`.
+- `baseUrl` (optional): the public URL Slack should send events and OAuth callbacks to. Defaults to the running Mastra server's host and port (for example, `http://localhost:4111` in local development). Pass `baseUrl` explicitly when the public URL differs from the server's resolved address — typically a tunnel for local development (`cloudflared tunnel --url http://localhost:4111`) or a deployed URL in production.
+
+## Storage requirement
+
+`SlackProvider` requires a persistent storage backend on the `Mastra` instance. Without storage, rotated tokens and app installations are lost on restart.
+
+## Related
+
+- [Deploying](/docs/agent-builder/deploying) — set a public `baseUrl` for production deployments.
+- [Configuration](/docs/agent-builder/configuration) — wire channel toggles into the Builder UI.

--- a/docs/src/content/en/docs/agent-builder/configuration.mdx
+++ b/docs/src/content/en/docs/agent-builder/configuration.mdx
@@ -1,0 +1,157 @@
+---
+title: "Configuration | Agent Builder"
+description: Configure the Agent Builder by toggling UI sections, pinning admin defaults, and constraining tool, agent, and workflow pickers.
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+---
+
+# Configuration
+
+:::note
+The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
+:::
+
+The Agent Builder is configured through `MastraEditor.builder`. Two top-level keys control its behavior: `features` toggles UI visibility and `configuration` pins admin-controlled defaults onto every new agent.
+
+## Quickstart
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+
+new MastraEditor({
+  builder: {
+    enabled: true,
+    features: {
+      agent: { browser: false },
+    },
+    configuration: {
+      agent: {
+        memory: { observationalMemory: true },
+      },
+    },
+  },
+})
+```
+
+This hides the browser tab in the Builder UI and pins observational memory as the default for every Builder-created agent.
+
+## Feature toggles
+
+`builder.features.agent` controls which sections appear in the Agent Builder UI. Set a key to `false` to hide the corresponding surface.
+
+```typescript title="src/mastra/index.ts"
+new MastraEditor({
+  builder: {
+    enabled: true,
+    features: {
+      agent: {
+        tools: true,
+        agents: true,
+        workflows: true,
+        skills: true,
+        memory: true,
+        model: true,
+        browser: true,
+        avatarUpload: true,
+        favorites: true,
+      },
+    },
+  },
+})
+```
+
+The shipping UI consumes these `AgentFeatures` keys: `tools`, `agents`, `workflows`, `skills`, `memory`, `model`, `browser`, `avatarUpload`, and `favorites`. See the [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) for the full schema.
+
+## Admin defaults
+
+`builder.configuration.agent` pins admin-controlled defaults onto every agent the Builder produces.
+
+```typescript title="src/mastra/index.ts"
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        models: {
+          allowed: [
+            { provider: 'openai', modelId: 'gpt-5.4-mini' },
+            { provider: 'openai', modelId: 'gpt-5.4' },
+            { provider: 'anthropic', modelId: 'claude-opus-4-7' },
+          ],
+        },
+      },
+    },
+  },
+})
+```
+
+`configuration.agent` accepts `models`, `memory`, `workspace`, `browser`, `tools`, `agents`, and `workflows`. See the [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults) for the full shape.
+
+## Making tools, agents, and workflows available
+
+The Builder picks from whatever you register on the `Mastra` instance. Tools registered through `Mastra({ tools })`, agents registered through `Mastra({ agents })`, and workflows registered through `Mastra({ workflows })` are all candidates for Builder-created agents.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+import { MastraEditor } from '@mastra/editor'
+import { createBuilderAgent } from '@mastra/editor/ee'
+import { weatherInfo } from './tools/weather-info'
+import { webSearch } from './tools/web-search'
+
+export const mastra = new Mastra({
+  tools: {
+    weatherInfo,
+    webSearch,
+    // add MCP tools or additional tools here
+  },
+  agents: {
+    builderAgent: createBuilderAgent(),
+    // add additional agents here
+  },
+  workflows: {
+    // add workflows here
+  },
+  editor: new MastraEditor({
+    builder: { enabled: true },
+  }),
+})
+```
+
+With no `configuration.agent.tools.allowed` set, both `weather-info` and `web-search` appear in the Builder's tool picker. End users can attach either tool to any agent they create.
+
+Entries match on `tool.id`, `Agent.id`, or `workflow.id` — the string the entity reports at runtime, not the export name.
+
+MCP tools work the same way: load them via `MCPClient.getTools()` and spread the result into the `tools` map.
+
+## Tool, agent, and workflow allowlists
+
+`configuration.agent.tools`, `configuration.agent.agents`, and `configuration.agent.workflows` constrain which registered entries appear in the Builder's pickers. Allowlist semantics are the same for all three:
+
+- **Omitted**: unrestricted. The picker shows every registered entry.
+- **`allowed: []`**: explicit lockdown. The picker is empty.
+- **`allowed: [...ids]`**: the picker shows only the listed IDs.
+
+Unknown IDs are dropped and surfaced as warnings through `getModelPolicyWarnings()` and the server logs.
+
+```typescript title="src/mastra/index.ts"
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        tools: { allowed: ['weather-info', 'web-search'] },
+        agents: { allowed: ['weather-agent'] },
+        workflows: { allowed: ['greet-workflow'] },
+      },
+    },
+  },
+})
+```
+
+## Related
+
+- [Model policy](/docs/agent-builder/model-policy) — pin the allowed models and default model.
+- [Memory](/docs/agent-builder/memory) — set the default memory shape for new agents.
+- [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) — full property list.
+- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults) — every field on `configuration.agent`.

--- a/docs/src/content/en/docs/agent-builder/deploying.mdx
+++ b/docs/src/content/en/docs/agent-builder/deploying.mdx
@@ -1,0 +1,118 @@
+---
+title: "Deploying | Agent Builder"
+description: Swap local Agent Builder primitives for cloud-backed storage, filesystems, sandboxes, an EE license, auth, and a public channel URL for production.
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+  - "@mastra/libsql"
+  - "@mastra/s3"
+  - "@mastra/e2b"
+---
+
+# Deploying
+
+:::note
+The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
+:::
+
+Production deployments swap the local primitives in the Quickstart for cloud-backed equivalents. The shape of the `Mastra` and `MastraEditor` config doesn't change — only the providers behind it.
+
+## What a production deployment needs
+
+1. **EE license** — a valid `MASTRA_EE_LICENSE` so the server will start with the Builder enabled.
+1. **Hosted storage** — a shared store for agents, skills, runs, and memory.
+1. **Shared workspace filesystem** — survives across instances; `local` is single-node only.
+1. **Cloud sandbox** — runs agent commands safely; `local` is unsafe in shared environments.
+1. **Auth and RBAC** — gates the Builder UI and `/agent-builder/*` routes.
+1. **Public base URL for channels** — Slack and other channel providers need a reachable URL.
+
+## EE license
+
+Set `MASTRA_EE_LICENSE` in the deployment environment. The server refuses to start when `builder.enabled` is truthy without a valid license. Treat the license key as a secret.
+
+## Storage
+
+Replace the file-backed LibSQL store with a hosted backend. LibSQL Cloud, PostgreSQL, and any other Mastra storage adapter all work.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+import { LibSQLStore } from '@mastra/libsql'
+
+new Mastra({
+  storage: new LibSQLStore({
+    url: process.env.DATABASE_URL!,
+    authToken: process.env.DATABASE_AUTH_TOKEN,
+  }),
+})
+```
+
+## Workspace filesystem and sandbox
+
+`local` filesystem works only on the node that owns the directory. For multi-instance deployments, register cloud filesystem and sandbox providers on `MastraEditor` and reference them by id in the inline workspace config.
+
+```bash npm2yarn
+npm install @mastra/s3 @mastra/e2b
+```
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+import { MastraEditor } from '@mastra/editor'
+import { s3FilesystemProvider } from '@mastra/s3'
+import { e2bSandboxProvider } from '@mastra/e2b'
+
+new Mastra({
+  editor: new MastraEditor({
+    filesystems: { [s3FilesystemProvider.id]: s3FilesystemProvider },
+    sandboxes: { [e2bSandboxProvider.id]: e2bSandboxProvider },
+    builder: {
+      enabled: true,
+      configuration: {
+        agent: {
+          workspace: {
+            type: 'inline',
+            config: {
+              name: 'builder-workspace',
+              filesystem: {
+                provider: s3FilesystemProvider.id,
+                config: {
+                  bucket: process.env.S3_BUCKET!,
+                  region: process.env.S3_REGION!,
+                },
+              },
+              sandbox: {
+                provider: e2bSandboxProvider.id,
+                config: { apiKey: process.env.E2B_API_KEY! },
+              },
+            },
+          },
+        },
+      },
+    },
+  }),
+})
+```
+
+`S3Filesystem` uses the default AWS credential chain (environment variables, `~/.aws` config, IAM roles, EC2 instance profile). For long-running deployments, use a credential provider function so credentials refresh automatically.
+
+`DockerSandbox` and `VercelSandbox` are alternative cloud sandbox providers — pick whichever matches your runtime.
+
+:::warning
+
+A local sandbox can't run commands safely in a shared environment. Always register a cloud sandbox provider and reference it in the workspace config before deploying.
+
+:::
+
+## Auth and RBAC
+
+A production deployment without authentication exposes the Builder to the public internet. Register a `Mastra.server.auth` provider (for example, WorkOS or your own provider) and a `Mastra.server.rbac` provider to gate access.
+
+See [Access control](/docs/agent-builder/access-control) for the required role permissions and a WorkOS quickstart.
+
+## Public URL for channels
+
+Slack needs to reach your server through a public URL. Pass `baseUrl` to `SlackProvider` with the deployed URL (no trailing slash). See [Channels](/docs/agent-builder/channels) for the full setup.
+
+## Related
+
+- [Access control](/docs/agent-builder/access-control) — auth and RBAC setup.
+- [Channels](/docs/agent-builder/channels) — Slack `baseUrl` and channel-specific setup.

--- a/docs/src/content/en/docs/agent-builder/memory.mdx
+++ b/docs/src/content/en/docs/agent-builder/memory.mdx
@@ -47,7 +47,7 @@ new MastraEditor({
       agent: {
         memory: {
           observationalMemory: {
-            model: 'openai/gpt-5.4',
+            model: '__GATEWAY_OPENAI_MODEL__',
           },
         },
       },

--- a/docs/src/content/en/docs/agent-builder/memory.mdx
+++ b/docs/src/content/en/docs/agent-builder/memory.mdx
@@ -1,0 +1,75 @@
+---
+title: "Memory | Agent Builder"
+description: Configure the default memory shape for Agent Builder agents, including observational memory, message history, and semantic recall.
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+---
+
+# Memory
+
+:::note
+The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
+:::
+
+The Agent Builder pins a default memory shape onto every new agent through `builder.configuration.agent.memory`. The default applies when an end user creates a new agent and doesn't override it.
+
+## Quickstart
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        memory: { observationalMemory: true },
+      },
+    },
+  },
+})
+```
+
+Observational memory lets the agent learn long-lived facts from past conversations. Storage on the `Mastra` instance is required — see the [Memory overview](/docs/memory/overview) for the prerequisites.
+
+## Observational memory model
+
+Observational memory runs an Observer and Reflector model on top of every conversation. The default model is `google/gemini-2.5-flash`, which requires a `GOOGLE_GENERATIVE_AI_API_KEY` environment variable in any environment where the Builder agent will run.
+
+To use a different model, set `observationalMemory.model` to any model ID supported by the Mastra model router (and provide the matching provider credentials):
+
+```typescript title="src/mastra/index.ts"
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        memory: {
+          observationalMemory: {
+            model: 'openai/gpt-5.4',
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+The `model` field applies to both the Observer and Reflector. You can also override each one independently via `observation.model` and `reflection.model`. See the [SerializedMemoryConfig reference](/reference/memory/serialized-memory-config) for the full shape.
+
+## Storage and vector requirements
+
+Memory features layer on top of `Mastra.storage`:
+
+- **Message history** (`options.lastMessages`) requires storage.
+- **Observational memory** (`observationalMemory: true`) requires storage.
+- **Semantic recall** (`options.semanticRecall`) requires storage plus a registered vector adapter (`vector`) and an embedder (`embedder`).
+
+If a required adapter is missing, Mastra throws a descriptive error at agent run time. See [Semantic recall](/docs/memory/semantic-recall) for the full list of supported vector stores and embedders.
+
+## Related
+
+- [Memory overview](/docs/memory/overview) — concepts and core configuration.
+- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults) — the full `memory` field schema.
+- [Configuration](/docs/agent-builder/configuration) — wire `memory` alongside the rest of the Builder config.

--- a/docs/src/content/en/docs/agent-builder/model-policy.mdx
+++ b/docs/src/content/en/docs/agent-builder/model-policy.mdx
@@ -1,0 +1,58 @@
+---
+title: "Model policy | Agent Builder"
+description: Restrict which providers and models the Agent Builder exposes, pin a default model, and lock the picker.
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+---
+
+# Model policy
+
+:::note
+The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
+:::
+
+The model policy controls which providers and models Builder-created agents can use, which model is selected by default, and whether end users can change it. The policy lives at `builder.configuration.agent.models`.
+
+## Quickstart
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        models: {
+          allowed: [
+            { provider: 'openai', modelId: 'gpt-5.4-mini' },
+            { provider: 'openai', modelId: 'gpt-5.4' },
+            { provider: 'anthropic', modelId: 'claude-opus-4-7' },
+          ],
+        },
+      },
+    },
+  },
+})
+```
+
+This restricts the Builder's model picker to two OpenAI models and one Anthropic model. End users choose one when creating an agent.
+
+## Validation rules
+
+Mastra validates the model policy at server boot. Violations are surfaced as warnings through `getModelPolicyWarnings()`.
+
+- When `allowed` is empty or omitted, every registered model is available.
+- When `allowed` is non-empty, `default` (if set) must satisfy the allowlist. A `default` that fails this check is dropped and surfaced as a warning.
+- To hide the end-user model picker, set `features.agent.model: false` in [AgentBuilderOptions](/reference/editor/agent-builder/agent-builder-options). When the picker is hidden, provide a `default` so new agents resolve a model.
+
+Registered providers (`provider: 'openai'`, `provider: 'anthropic'`, and so on) can omit `modelId` to allow every model from that provider.
+
+See the [`builder.configuration.agent.models`](/reference/editor/agent-builder/builder-models) reference for every admin-writable field and validation rules.
+
+## Related
+
+- [Configuration](/docs/agent-builder/configuration) — wire the model policy into the broader Builder config.
+- [`builder.configuration.agent.models`](/reference/editor/agent-builder/builder-models) — full property list.
+- [Provider registry](https://github.com/mastra-ai/mastra/blob/main/packages/core/src/llm/model/provider-registry.json) — every model ID Mastra recognizes out of the box.

--- a/docs/src/content/en/docs/agent-builder/overview.mdx
+++ b/docs/src/content/en/docs/agent-builder/overview.mdx
@@ -71,6 +71,7 @@ The Agent Builder requires:
 
 - **Storage**: An `@mastra/core` storage adapter on the `Mastra` instance. Agents, memory, and workspace state all persist through `Mastra.storage`.
 - **The Builder agent**: Register a Builder agent created with the `createBuilderAgent()` factory from `@mastra/editor/ee` on `Mastra.agents`. The chat-based editor invokes it through the same `Mastra.getAgent(id)` lookup as any other agent. Without this registration, the chat-based editor returns 404.
+- **`OPENAI_API_KEY`**: The Builder agent created by `createBuilderAgent()` runs on an OpenAI model, so an `OPENAI_API_KEY` environment variable is required.
 
 ## Disabling the Builder
 

--- a/docs/src/content/en/docs/agent-builder/overview.mdx
+++ b/docs/src/content/en/docs/agent-builder/overview.mdx
@@ -1,0 +1,87 @@
+---
+title: "Agent Builder overview"
+description: Let teammates create, configure, and operate Mastra agents from a browser, with admin-pinned defaults, RBAC, and channel integrations.
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+  - "@mastra/libsql"
+---
+
+# Agent Builder overview
+
+:::note
+The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
+:::
+
+The Agent Builder lets you build, configure, and operate Mastra agents all within the UI. It runs inside your Mastra server, persists everything to `Mastra.storage`, and supports multi-tenant agent workflows with RBAC and channel integrations.
+
+- [**Configuration**](/docs/agent-builder/configuration): Toggle UI sections and pin admin-controlled defaults for every new agent.
+- [**Model policy**](/docs/agent-builder/model-policy): Restrict which providers and models the Builder exposes, and pin a default.
+- [**Memory**](/docs/agent-builder/memory): Configure the default memory shape for every Builder-created agent.
+- [**Access control**](/docs/agent-builder/access-control): Gate the Builder behind Mastra RBAC roles and permissions.
+- [**Channels**](/docs/agent-builder/channels): Connect Builder-created agents to Slack and other channels.
+- [**Skill registries**](/docs/agent-builder/skill-registries): Browse and install community skills from opt-in registries.
+- [**Deploying**](/docs/agent-builder/deploying): Swap local primitives for cloud-backed storage, filesystems, and sandboxes.
+
+For building agents entirely in code, see the [Agents overview](/docs/agents/overview). For editing code-defined agents through Studio, see the [Editor overview](/docs/editor/overview).
+
+## Get started
+
+Install `@mastra/editor` alongside a storage adapter:
+
+```bash npm2yarn
+npm install @mastra/editor @mastra/libsql
+```
+
+Wire the Agent Builder onto a `Mastra` instance:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+import { MastraEditor } from '@mastra/editor'
+import { createBuilderAgent } from '@mastra/editor/ee'
+import { LibSQLStore } from '@mastra/libsql'
+
+export const mastra = new Mastra({
+  storage: new LibSQLStore({ url: 'file:./mastra.db' }),
+  agents: { builderAgent: createBuilderAgent() },
+  editor: new MastraEditor({
+    builder: {
+      enabled: true,
+      configuration: {
+        agent: {
+          memory: { observationalMemory: true },
+        },
+      },
+    },
+  }),
+})
+```
+
+Start the dev server:
+
+```bash
+npx mastra dev
+```
+
+The Agent Builder is mounted at `http://localhost:4111/agent-builder`.
+
+## Prerequisites
+
+The Agent Builder requires:
+
+- **Storage**: An `@mastra/core` storage adapter on the `Mastra` instance. Agents, memory, and workspace state all persist through `Mastra.storage`.
+- **The Builder agent**: Register a Builder agent created with the `createBuilderAgent()` factory from `@mastra/editor/ee` on `Mastra.agents`. The chat-based editor invokes it through the same `Mastra.getAgent(id)` lookup as any other agent. Without this registration, the chat-based editor returns 404.
+
+## Disabling the Builder
+
+Set `enabled: false` to keep the config in place but turn the surface off:
+
+```typescript title="src/mastra/index.ts"
+new MastraEditor({
+  builder: {
+    enabled: false,
+  },
+})
+```
+
+Omitting the `builder` field has the same effect.

--- a/docs/src/content/en/docs/agent-builder/skill-registries.mdx
+++ b/docs/src/content/en/docs/agent-builder/skill-registries.mdx
@@ -1,0 +1,45 @@
+---
+title: "Skill registries | Agent Builder"
+description: Let the Agent Builder browse and install community skills from opt-in skill registries.
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+---
+
+# Skill registries
+
+:::note
+The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
+:::
+
+Registries let the Agent Builder browse and install community skills directly from the UI. All registries are opt-in. When no registry is enabled, the Builder hides registry browse UI entirely.
+
+## Quickstart
+
+Enable the [skills.sh](https://skills.sh) registry:
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+
+new MastraEditor({
+  builder: {
+    enabled: true,
+    registries: {
+      skillsSh: { enabled: true },
+    },
+  },
+})
+```
+
+The Builder library tab now exposes a **Browse** view backed by skills.sh. End users can preview a skill, then install it into an agent.
+
+:::note
+
+See the [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) for the full `registries` schema.
+
+:::
+
+## Related
+
+- [Configuration](/docs/agent-builder/configuration) — wire registries alongside the rest of the Builder config.
+- [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) — every field on `builder`.

--- a/docs/src/content/en/docs/agent-builder/workspace.mdx
+++ b/docs/src/content/en/docs/agent-builder/workspace.mdx
@@ -1,0 +1,70 @@
+---
+title: "Workspace | Agent Builder"
+description: Configure the default workspace for Agent Builder agents — filesystem, sandbox, and skills.
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+---
+
+# Workspace
+
+:::note
+The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
+:::
+
+A [workspace](/docs/workspace/overview) gives agents filesystem access, command execution, and skill loading. The Agent Builder pins a default workspace onto every new agent through `builder.configuration.agent.workspace`. End users can still override the workspace per agent through the Builder UI.
+
+## Quickstart
+
+Pin an inline workspace snapshot as the Builder default:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraEditor } from '@mastra/editor'
+
+export const mastra = new Mastra({
+  editor: new MastraEditor({
+    builder: {
+      enabled: true,
+      configuration: {
+        agent: {
+          workspace: {
+            type: 'inline',
+            config: {
+              name: 'project-workspace',
+              filesystem: {
+                provider: 'local',
+                config: { basePath: './workspace' },
+              },
+            },
+          },
+        },
+      },
+    },
+  }),
+})
+```
+
+The Builder derives a deterministic id from the inline config and persists the snapshot, so identical inline configs are deduplicated across agents.
+
+## Workspace references
+
+`configuration.agent.workspace` accepts a `StorageWorkspaceRef`:
+
+- **`{ type: 'inline', config }`** — embeds a serialized workspace snapshot directly on the agent. Useful for per-agent, ad-hoc configurations.
+- **`{ type: 'id', workspaceId }`** — references a workspace already registered on the `Mastra` instance via `new Mastra({ workspace })` or `mastra.addWorkspace(...)`. Use this for shared, named workspaces.
+
+See the [StorageWorkspaceRef reference](/reference/editor/storage-workspace-ref) for both variants.
+
+## Filesystem and sandbox
+
+A workspace combines a `filesystem` (file tools) and an optional `sandbox` (command execution). For local development, point both at the same directory so files written through the filesystem are immediately visible to commands in the sandbox.
+
+For cloud deployments, swap `LocalFilesystem` / `LocalSandbox` for managed providers (e.g., S3, E2B). See [Deploying](/docs/agent-builder/deploying) for the cloud-swap pattern.
+
+## Related
+
+- [Workspace overview](/docs/workspace/overview) — the underlying workspace model.
+- [Filesystem](/docs/workspace/filesystem) and [Sandbox](/docs/workspace/sandbox) — the building blocks.
+- [BuilderAgentDefaults reference](/reference/editor/agent-builder/builder-agent-defaults) — the full `workspace` field schema.
+- [Configuration](/docs/agent-builder/configuration) — wire `workspace` alongside the rest of the Builder config.

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -296,6 +296,25 @@ const sidebars = {
           id: 'editor/prompts',
           label: 'Prompts',
         },
+        {
+          type: 'category',
+          label: 'Agent Builder',
+          customProps: {
+            tags: ['new'],
+          },
+          items: [
+            { type: 'doc', id: 'agent-builder/overview', label: 'Overview' },
+            { type: 'doc', id: 'agent-builder/configuration', label: 'Configuration' },
+            { type: 'doc', id: 'agent-builder/access-control', label: 'Access control' },
+            { type: 'doc', id: 'agent-builder/model-policy', label: 'Model policy' },
+            { type: 'doc', id: 'agent-builder/memory', label: 'Memory' },
+            { type: 'doc', id: 'agent-builder/workspace', label: 'Workspace' },
+            { type: 'doc', id: 'agent-builder/browser', label: 'Browser' },
+            { type: 'doc', id: 'agent-builder/channels', label: 'Channels' },
+            { type: 'doc', id: 'agent-builder/skill-registries', label: 'Skill registries' },
+            { type: 'doc', id: 'agent-builder/deploying', label: 'Deploying' },
+          ],
+        },
       ],
     },
     {

--- a/docs/src/content/en/reference/client-js/agent-builder.mdx
+++ b/docs/src/content/en/reference/client-js/agent-builder.mdx
@@ -1,0 +1,169 @@
+---
+title: "Reference: Agent Builder API | Client SDK"
+description: Learn how to interact with Agent Builder actions, including starting runs, streaming progress, resuming suspended steps, and observing runs using the client-js SDK.
+packages:
+  - "@mastra/client-js"
+  - "@mastra/editor"
+---
+
+# Agent Builder API
+
+The Agent Builder API provides methods to interact with [Agent Builder](/docs/agent-builder/overview) actions on the server. Each action is a workflow exposed under `/agent-builder/:actionId/*`. The Builder must be enabled on the server via `MastraEditor.builder.enabled`, with a valid `MASTRA_EE_LICENSE` in production.
+
+## Getting all actions
+
+Retrieve a record of available Agent Builder actions:
+
+```typescript
+const actions = await mastraClient.getAgentBuilderActions()
+```
+
+Returns a `Record<string, WorkflowInfo>` keyed by action ID.
+
+## Working with a specific action
+
+Get an instance of a specific action by its ID:
+
+```typescript
+const action = mastraClient.getAgentBuilderAction('create-agent')
+```
+
+## Action methods
+
+### `details()`
+
+Retrieve metadata about an Agent Builder action:
+
+```typescript
+const info = await action.details()
+```
+
+### `createRun()`
+
+Create a new run for this action and receive a `runId`. Use the returned id with `startActionRun()`, `stream()`, `resume()`, or `observeStream()`.
+
+```typescript
+const { runId } = await action.createRun()
+```
+
+You can also pass an explicit `runId`:
+
+```typescript
+const { runId } = await action.createRun({ runId: 'my-run-id' })
+```
+
+### `startAsync()`
+
+Start the action and wait for completion. Returns the final `AgentBuilderActionResult` with `success`, `applied`, `branchName`, `message`, `validationResults`, `error`, `errors`, and `stepResults`.
+
+```typescript
+const result = await action.startAsync({
+  inputData: { agentName: 'support-bot' },
+})
+```
+
+Pass an existing `runId` as the second argument to start a previously created run:
+
+```typescript
+const { runId } = await action.createRun()
+const result = await action.startAsync({ inputData }, runId)
+```
+
+### `startActionRun()`
+
+Start an existing run without waiting for completion. Returns `{ message }`.
+
+```typescript
+const { runId } = await action.createRun()
+await action.startActionRun({ inputData }, runId)
+```
+
+### `stream()`
+
+Start an existing run and stream progress events as a `ReadableStream<{ type, payload }>`.
+
+```typescript
+const { runId } = await action.createRun()
+const stream = await action.stream({ inputData }, runId)
+
+for await (const event of stream) {
+  console.log(event.type, event.payload)
+}
+```
+
+### `resume()`
+
+Resume a suspended step on a run. Returns `{ message }`.
+
+```typescript
+await action.resume({ step: 'review', resumeData: { approved: true } }, runId)
+```
+
+### `resumeAsync()`
+
+Resume a suspended step and wait for completion. Returns an `AgentBuilderActionResult`.
+
+```typescript
+const result = await action.resumeAsync({ step: 'review', resumeData: { approved: true } }, runId)
+```
+
+### `resumeStream()`
+
+Resume a suspended step and stream subsequent events.
+
+```typescript
+const stream = await action.resumeStream({
+  runId,
+  step: 'review',
+  resumeData: { approved: true },
+})
+```
+
+### `observeStream()`
+
+Attach to an existing run, replaying cached events from the beginning, then continuing with live events. Use this to recover after a page refresh or hot reload.
+
+```typescript
+const stream = await action.observeStream({ runId })
+```
+
+### `observeStreamLegacy()`
+
+Same as `observeStream()` but uses the legacy streaming endpoint. Prefer `observeStream()` for new code.
+
+```typescript
+const stream = await action.observeStreamLegacy({ runId })
+```
+
+### `runs()`
+
+List runs for this action with optional filters.
+
+```typescript
+const runs = await action.runs({ page: 0, perPage: 20 })
+```
+
+Accepts `fromDate`, `toDate`, `page`, `perPage`, `resourceId`, and legacy `limit`/`offset`.
+
+### `runById()`
+
+Fetch a specific run by ID. Use `fields` to limit the returned payload and `withNestedWorkflows` to skip nested workflow data.
+
+```typescript
+const run = await action.runById(runId, {
+  fields: ['result', 'steps'],
+  withNestedWorkflows: false,
+})
+```
+
+### `cancelRun()`
+
+Cancel an in-flight run.
+
+```typescript
+await action.cancelRun(runId)
+```
+
+## Access control
+
+The `/agent-builder/*` routes are gated by the `agent-builder` permission resource. Calling clients need at minimum `agent-builder:read` and `agent-builder:execute`, plus any picker resources the action touches (`stored-agents`, `stored-skills`, `tools`, `workflows`, `memory`). See [Access control](/docs/agent-builder/access-control) for the full grant list.

--- a/docs/src/content/en/reference/client-js/mastra-client.mdx
+++ b/docs/src/content/en/reference/client-js/mastra-client.mdx
@@ -151,6 +151,18 @@ You can also pass `requestContext` as a `Record<string, any>`.
     description: 'Retrieves a specific workflow instance by ID.',
   },
   {
+    name: 'getAgentBuilderActions()',
+    type: 'Promise<Record<string, WorkflowInfo>>',
+    description:
+      'Returns all available Agent Builder actions. See [Agent Builder API](/reference/client-js/agent-builder).',
+  },
+  {
+    name: 'getAgentBuilderAction(actionId)',
+    type: 'AgentBuilder',
+    description:
+      'Retrieves an Agent Builder action by ID. See [Agent Builder API](/reference/client-js/agent-builder).',
+  },
+  {
     name: 'responses',
     type: 'Responses',
     description:

--- a/docs/src/content/en/reference/editor/agent-builder/agent-builder-options.mdx
+++ b/docs/src/content/en/reference/editor/agent-builder/agent-builder-options.mdx
@@ -1,0 +1,183 @@
+---
+title: "Reference: AgentBuilderOptions | Editor"
+description: "Reference for AgentBuilderOptions, the configuration object passed to MastraEditor.builder."
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+---
+
+# AgentBuilderOptions
+
+`AgentBuilderOptions` configures the Agent Builder. Pass it as `MastraEditor.builder` to enable the Builder UI, toggle visible surfaces, pin admin defaults, and opt into skill registries.
+
+See the [Configuration](/docs/agent-builder/configuration) page for concepts and worked examples.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+
+new MastraEditor({
+  builder: {
+    enabled: true,
+    features: {
+      agent: { browser: false },
+    },
+    configuration: {
+      agent: {
+        memory: { observationalMemory: true },
+        models: {
+          allowed: [
+            { provider: 'openai', modelId: 'gpt-5.4-mini' },
+            { provider: 'openai', modelId: 'gpt-5.4' },
+            { provider: 'anthropic', modelId: 'claude-opus-4-7' },
+          ],
+        },
+      },
+    },
+    registries: {
+      skillsSh: { enabled: true },
+    },
+  },
+})
+```
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'enabled',
+    type: 'boolean',
+    description:
+      'Master switch. When false, the Builder UI is disabled and `MastraEditor.resolveBuilder()` returns undefined.',
+    isOptional: true,
+    defaultValue: 'true',
+  },
+  {
+    name: 'features',
+    type: '{ agent?: AgentFeatures }',
+    description: 'UI toggles. Each key on `features.agent` defaults to true when omitted.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'AgentFeatures',
+        parameters: [
+          {
+            name: 'agent.tools',
+            type: 'boolean',
+            description: 'Show the tools tab in the agent editor.',
+            isOptional: true,
+            defaultValue: 'true',
+          },
+          {
+            name: 'agent.agents',
+            type: 'boolean',
+            description: 'Show the sub-agents picker in the agent editor.',
+            isOptional: true,
+            defaultValue: 'true',
+          },
+          {
+            name: 'agent.workflows',
+            type: 'boolean',
+            description: 'Show the workflows picker in the agent editor.',
+            isOptional: true,
+            defaultValue: 'true',
+          },
+          {
+            name: 'agent.skills',
+            type: 'boolean',
+            description: 'Show the skills tab and library for the agent.',
+            isOptional: true,
+            defaultValue: 'true',
+          },
+          {
+            name: 'agent.memory',
+            type: 'boolean',
+            description: 'Show the memory configuration in the agent editor.',
+            isOptional: true,
+            defaultValue: 'true',
+          },
+          {
+            name: 'agent.model',
+            type: 'boolean',
+            description:
+              'Show the model picker in the agent editor. When false, the admin-pinned default model applies.',
+            isOptional: true,
+            defaultValue: 'true',
+          },
+          {
+            name: 'agent.browser',
+            type: 'boolean',
+            description:
+              'Show the browser tab. Resolves to true only when a valid browser provider is registered on `MastraEditor.browsers`; otherwise it is downgraded to false and a warning is logged.',
+            isOptional: true,
+            defaultValue: 'true (conditional)',
+          },
+          {
+            name: 'agent.avatarUpload',
+            type: 'boolean',
+            description: 'Allow end users to upload an avatar for stored agents.',
+            isOptional: true,
+            defaultValue: 'true',
+          },
+          {
+            name: 'agent.favorites',
+            type: 'boolean',
+            description: 'Show favorite agents and skills with per-user state and aggregate counts.',
+            isOptional: true,
+            defaultValue: 'true',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'configuration',
+    type: '{ agent?: BuilderAgentDefaults }',
+    description:
+      'Admin-pinned defaults applied to every Builder-created agent. End users cannot override these values. See the BuilderAgentDefaults reference for the full schema.',
+    isOptional: true,
+  },
+  {
+    name: 'registries',
+    type: '{ skillsSh?: { enabled: boolean } }',
+    description:
+      'Opt-in third-party skill registries. When no registry is enabled, the Builder hides registry browse UI.',
+    isOptional: true,
+    properties: [
+      {
+        type: '{ skillsSh?: { enabled: boolean } }',
+        parameters: [
+          {
+            name: 'skillsSh',
+            type: '{ enabled: boolean }',
+            description:
+              'Enable the skills.sh registry. When enabled, the Builder shows registry browse UI for skills.sh skills.',
+            isOptional: true,
+            properties: [
+              {
+                type: '{ enabled: boolean }',
+                parameters: [
+                  {
+                    name: 'enabled',
+                    type: 'boolean',
+                    description: 'Set to `true` to opt in. Defaults to `false`.',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+## Related
+
+- [Configuration](/docs/agent-builder/configuration) — concept and worked examples.
+- [BuilderAgentDefaults](/reference/editor/agent-builder/builder-agent-defaults) — full schema for `configuration.agent`.
+- [builder.configuration.agent.models](/reference/editor/agent-builder/builder-models) — model allowlist and default model.
+- [MastraEditor class](/reference/editor/mastra-editor) — the parent surface that hosts `builder`.

--- a/docs/src/content/en/reference/editor/agent-builder/builder-agent-defaults.mdx
+++ b/docs/src/content/en/reference/editor/agent-builder/builder-agent-defaults.mdx
@@ -1,0 +1,178 @@
+---
+title: "Reference: BuilderAgentDefaults | Editor"
+description: "Reference for BuilderAgentDefaults, the admin-pinned defaults applied to every Agent Builder agent."
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+---
+
+# BuilderAgentDefaults
+
+`BuilderAgentDefaults` describes the admin-pinned defaults applied to every agent the Agent Builder produces. Pass it as `builder.configuration.agent`. End users can't override these values from the Builder UI.
+
+See [Configuration](/docs/agent-builder/configuration) and [Memory](/docs/agent-builder/memory) for worked examples.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        memory: { observationalMemory: true },
+        workspace: {
+          type: 'inline',
+          config: {
+            name: 'builder-workspace',
+            filesystem: {
+              provider: 'local',
+              config: { basePath: './workspace' },
+            },
+          },
+        },
+        models: {
+          allowed: [
+            { provider: 'openai', modelId: 'gpt-5.4-mini' },
+            { provider: 'openai', modelId: 'gpt-5.4' },
+            { provider: 'anthropic', modelId: 'claude-opus-4-7' },
+          ],
+        },
+        tools: { allowed: ['weather-info'] },
+        agents: { allowed: ['weather-agent'] },
+        workflows: { allowed: ['greet-workflow'] },
+      },
+    },
+  },
+})
+```
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'memory',
+    type: 'SerializedMemoryConfig',
+    description:
+      'Default memory configuration for new agents. Pass `{ observationalMemory: true }` to enable long-lived fact extraction. Requires `Mastra.storage`. See the SerializedMemoryConfig reference for the full schema.',
+    isOptional: true,
+  },
+  {
+    name: 'workspace',
+    type: 'StorageWorkspaceRef',
+    description:
+      "Default workspace reference for new agents. Pass `{ type: 'inline', config }` to embed a snapshot, or `{ type: 'id', workspaceId }` to point at a workspace registered on `Mastra.workspace`. See the StorageWorkspaceRef reference for both variants.",
+    isOptional: true,
+  },
+  {
+    name: 'browser',
+    type: 'StorageBrowserRef',
+    description:
+      "Default browser configuration for new agents. Pass `{ type: 'inline', config: { provider } }` to attach a registered browser provider. See the StorageBrowserRef reference for the full schema.",
+    isOptional: true,
+  },
+  {
+    name: 'models',
+    type: '{ allowed?: ProviderModelEntry[]; default?: DefaultModelEntry }',
+    description:
+      'Model allowlist and default applied to every Builder-created agent. See the BuilderModels reference for the full schema and validation rules.',
+    isOptional: true,
+    properties: [
+      {
+        type: '{ allowed?: ProviderModelEntry[]; default?: DefaultModelEntry }',
+        parameters: [
+          {
+            name: 'allowed',
+            type: 'ProviderModelEntry[]',
+            description:
+              'Allowlist of providers and models. Omit to allow every registered model. ProviderModelEntry is a discriminated union (known providers vs. custom).',
+            isOptional: true,
+          },
+          {
+            name: 'default',
+            type: 'DefaultModelEntry',
+            description:
+              'Pre-selected model on new-agent create. Required when the model picker is hidden. DefaultModelEntry requires `provider` and `modelId`, with an optional `kind`.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'tools',
+    type: '{ allowed?: string[] }',
+    description:
+      'Allowlist of tool IDs visible in the Builder tools picker. Unknown IDs are dropped and surfaced as warnings.',
+    isOptional: true,
+    properties: [
+      {
+        type: '{ allowed?: string[] }',
+        parameters: [
+          {
+            name: 'allowed',
+            type: 'string[]',
+            description:
+              'Allowlist of `tool.id` values. Omit for unrestricted, pass `[]` to lock the picker down, pass `[...ids]` to restrict to the listed tools.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'agents',
+    type: '{ allowed?: string[] }',
+    description:
+      'Allowlist of agent IDs visible in the Builder sub-agents picker. Unknown IDs are dropped and surfaced as warnings.',
+    isOptional: true,
+    properties: [
+      {
+        type: '{ allowed?: string[] }',
+        parameters: [
+          {
+            name: 'allowed',
+            type: 'string[]',
+            description:
+              'Allowlist of `Agent.id` values. Omit for unrestricted, pass `[]` to lock the picker down, pass `[...ids]` to restrict to the listed agents.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'workflows',
+    type: '{ allowed?: string[] }',
+    description:
+      'Allowlist of workflow IDs visible in the Builder workflows picker. Unknown IDs are dropped and surfaced as warnings.',
+    isOptional: true,
+    properties: [
+      {
+        type: '{ allowed?: string[] }',
+        parameters: [
+          {
+            name: 'allowed',
+            type: 'string[]',
+            description:
+              'Allowlist of `workflow.id` values. Omit for unrestricted, pass `[]` to lock the picker down, pass `[...ids]` to restrict to the listed workflows.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+## Related
+
+- [AgentBuilderOptions](/reference/editor/agent-builder/agent-builder-options) — the parent options object.
+- [builder.configuration.agent.models](/reference/editor/agent-builder/builder-models) — admin-facing model allowlist and default.
+- [SerializedMemoryConfig](/reference/memory/serialized-memory-config) — memory shape for new agents.
+- [StorageWorkspaceRef](/reference/editor/storage-workspace-ref) — workspace reference shape.
+- [StorageBrowserRef](/reference/editor/storage-browser-ref) — browser reference shape.
+- [Configuration](/docs/agent-builder/configuration) — concept and worked examples.

--- a/docs/src/content/en/reference/editor/agent-builder/builder-models.mdx
+++ b/docs/src/content/en/reference/editor/agent-builder/builder-models.mdx
@@ -1,0 +1,134 @@
+---
+title: "Reference: builder.configuration.agent.models | Editor"
+description: "Reference for the Agent Builder model allowlist and default model admin input."
+packages:
+  - "@mastra/core"
+  - "@mastra/editor"
+---
+
+# builder.configuration.agent.models
+
+`builder.configuration.agent.models` is the admin-facing model policy input on `AgentBuilderOptions`. It controls which providers and models the Agent Builder exposes, and which model is pre-selected on new-agent create.
+
+See [Model policy](/docs/agent-builder/model-policy) for concepts and worked examples.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        models: {
+          allowed: [
+            { provider: 'openai', modelId: 'gpt-5.4-mini' },
+            { provider: 'openai', modelId: 'gpt-5.4' },
+            { provider: 'anthropic', modelId: 'claude-opus-4-7' },
+          ],
+        },
+      },
+    },
+  },
+})
+```
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'allowed',
+    type: 'ProviderModelEntry[]',
+    isOptional: true,
+    description:
+      'Allowlist of providers and models. Omit to allow every registered model. When non-empty, only the listed entries are selectable in the Builder.',
+    properties: [
+      {
+        type: 'KnownProviderEntry',
+        parameters: [
+          {
+            name: 'provider',
+            type: 'Provider',
+            description: 'Provider id from the generated provider registry (for example, `openai`, `anthropic`).',
+          },
+          {
+            name: 'modelId',
+            type: 'ModelForProvider<Provider>',
+            isOptional: true,
+            description: 'Specific model id for that provider. Omit to allow every model under the provider.',
+          },
+        ],
+      },
+      {
+        type: 'CustomProviderEntry',
+        parameters: [
+          {
+            name: 'kind',
+            type: "'custom'",
+            description: 'Discriminant marking this entry as a gateway or self-hosted provider not in the registry.',
+          },
+          {
+            name: 'provider',
+            type: 'string',
+            description: 'Provider id for the custom provider.',
+          },
+          {
+            name: 'modelId',
+            type: 'string',
+            isOptional: true,
+            description: 'Specific model id under the custom provider. Omit to allow every model under it.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'default',
+    type: 'DefaultModelEntry',
+    isOptional: true,
+    description:
+      'Pre-selected model on new-agent create. Same shape as `ProviderModelEntry`, but `modelId` is required. Must satisfy the `allowed` list when set.',
+    properties: [
+      {
+        type: 'DefaultModelEntry',
+        parameters: [
+          {
+            name: 'provider',
+            type: 'Provider | string',
+            description:
+              "Provider id. Use a `Provider` literal for known providers, or any `string` with `kind: 'custom'`.",
+          },
+          {
+            name: 'modelId',
+            type: 'string',
+            description: 'Required model id. Points at a specific model, not a whole provider.',
+          },
+          {
+            name: 'kind',
+            type: "'custom'",
+            isOptional: true,
+            description: "Set to `custom` when targeting a provider that isn't in the generated registry.",
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+## Validation rules
+
+Mastra validates the admin policy at server boot. Violations surface as warnings on `GET /editor/builder/settings.modelPolicyWarnings`.
+
+- `allowed` empty or omitted: no restriction. Every registered model is available.
+- When `allowed` is non-empty and a `default` is set: `default` must satisfy `isModelAllowed(allowed, default)`. A `default` that fails this check is dropped and surfaced as a warning.
+- To hide the end-user model picker, set `features.agent.model: false` in [AgentBuilderOptions](/reference/editor/agent-builder/agent-builder-options). When the picker is hidden, provide a `default` so new agents resolve a model.
+
+## Related
+
+- [BuilderAgentDefaults](/reference/editor/agent-builder/builder-agent-defaults) — parent object containing `models`.
+- [AgentBuilderOptions](/reference/editor/agent-builder/agent-builder-options) — the top-level Builder options.
+- [Model policy](/docs/agent-builder/model-policy) — concept and worked examples.

--- a/docs/src/content/en/reference/editor/blob-store-provider.mdx
+++ b/docs/src/content/en/reference/editor/blob-store-provider.mdx
@@ -1,0 +1,89 @@
+---
+title: "Reference: BlobStoreProvider | Editor"
+description: "Reference for BlobStoreProvider, the interface that registers a blob store implementation with MastraEditor."
+packages:
+  - "@mastra/core"
+---
+
+# BlobStoreProvider
+
+`BlobStoreProvider` is the interface a package implements to register a blob store with [`MastraEditor`](/reference/editor/mastra-editor). Blob stores hold content-addressable skill blobs and other large artifacts produced by the editor.
+
+The built-in `storage` provider uses the configured storage backend's `blobs` domain. External providers (for example, S3) are supplied via `MastraEditorConfig.blobStores`.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+import { s3BlobStoreProvider } from '@mastra/s3'
+
+new MastraEditor({
+  blobStores: {
+    [s3BlobStoreProvider.id]: s3BlobStoreProvider,
+  },
+})
+```
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Unique provider identifier (for example, `"storage"`, `"s3"`).',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: 'Human-readable name for UI display.',
+  },
+  {
+    name: 'description',
+    type: 'string',
+    description: 'Short description.',
+    isOptional: true,
+  },
+  {
+    name: 'configSchema',
+    type: 'Record<string, unknown>',
+    description: 'JSON Schema describing provider-specific configuration. Used by the UI to render config forms.',
+    isOptional: true,
+  },
+  {
+    name: 'createBlobStore',
+    type: '(config: TConfig) => BlobStore | Promise<BlobStore>',
+    description:
+      'Create a runtime `BlobStore` instance from the stored config. Called when the editor resolves a blob store via `MastraEditor.resolveBlobStore(providerId, config)`.',
+  },
+]}
+/>
+
+## Implementing a provider
+
+```typescript title="src/providers/my-blob-store.ts"
+import type { BlobStore, BlobStoreProvider } from '@mastra/core/editor'
+
+export const myBlobStoreProvider: BlobStoreProvider<{ bucket: string; region: string }> = {
+  id: 'my-blob-store',
+  name: 'My Blob Store',
+  description: 'Object-store-backed blob storage.',
+  configSchema: {
+    type: 'object',
+    required: ['bucket', 'region'],
+    properties: {
+      bucket: { type: 'string' },
+      region: { type: 'string' },
+    },
+  },
+  async createBlobStore(config): Promise<BlobStore> {
+    return createMyBlobStore({ bucket: config.bucket, region: config.region })
+  },
+}
+```
+
+When no `providerId` is passed to `MastraEditor.resolveBlobStore()`, the editor falls back to the storage backend's `blobs` domain.
+
+## Related
+
+- [MastraEditor class](/reference/editor/mastra-editor) — provider registry and `resolveBlobStore()` method.

--- a/docs/src/content/en/reference/editor/browser-provider.mdx
+++ b/docs/src/content/en/reference/editor/browser-provider.mdx
@@ -1,0 +1,106 @@
+---
+title: "Reference: BrowserProvider | Editor"
+description: "Reference for BrowserProvider, the interface that registers a browser implementation with MastraEditor."
+packages:
+  - "@mastra/core"
+---
+
+# BrowserProvider
+
+`BrowserProvider` is the interface a package implements to register a browser with [`MastraEditor`](/reference/editor/mastra-editor). The editor calls `createBrowser(config)` at agent hydration time, using the `provider` id from the stored [`StorageBrowserRef`](/reference/editor/storage-browser-ref) as the lookup key.
+
+There are no built-in browser providers. To use the `browser` feature in the Agent Builder, register a provider package (for example, `@mastra/stagehand`).
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+import { stagehandBrowserProvider } from '@mastra/stagehand'
+
+new MastraEditor({
+  browsers: {
+    [stagehandBrowserProvider.id]: stagehandBrowserProvider,
+  },
+})
+```
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description:
+      'Unique provider identifier (for example, `"stagehand"`). Must match `StorageBrowserConfig.provider` on every stored agent that uses this provider.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: 'Human-readable name for UI display.',
+  },
+  {
+    name: 'description',
+    type: 'string',
+    description: 'Short description shown in the Agent Builder browser picker.',
+    isOptional: true,
+  },
+  {
+    name: 'configSchema',
+    type: 'Record<string, unknown>',
+    description: 'JSON Schema describing provider-specific configuration. Used by the UI to render config forms.',
+    isOptional: true,
+  },
+  {
+    name: 'createBrowser',
+    type: '(config: TConfig) => MastraBrowser | Promise<MastraBrowser>',
+    description:
+      'Create a runtime `MastraBrowser` instance from the stored config. Called once per agent hydration; the resulting instance is cached alongside the agent.',
+  },
+]}
+/>
+
+## Implementing a provider
+
+```typescript title="src/providers/my-browser.ts"
+import type { BrowserProvider, MastraBrowser } from '@mastra/core/editor'
+
+export const myBrowserProvider: BrowserProvider<{ apiKey: string }> = {
+  id: 'my-browser',
+  name: 'My Browser',
+  description: 'Headless browser for agent use.',
+  configSchema: {
+    type: 'object',
+    properties: {
+      apiKey: { type: 'string' },
+    },
+    required: ['apiKey'],
+  },
+  async createBrowser(config): Promise<MastraBrowser> {
+    // construct and return a MastraBrowser instance
+    return createMastraBrowser({ apiKey: config.apiKey })
+  },
+}
+```
+
+Once registered, admins can pin the provider as a Builder default via [`BuilderAgentDefaults.browser`](/reference/editor/agent-builder/builder-agent-defaults):
+
+```typescript
+new MastraEditor({
+  browsers: { [myBrowserProvider.id]: myBrowserProvider },
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        browser: { type: 'inline', config: { provider: 'my-browser' } },
+      },
+    },
+  },
+})
+```
+
+## Related
+
+- [Browser](/docs/agent-builder/browser) — concept and worked examples.
+- [StorageBrowserRef](/reference/editor/storage-browser-ref) — stored configuration consumed by `createBrowser`.
+- [MastraEditor class](/reference/editor/mastra-editor) — provider registry.

--- a/docs/src/content/en/reference/editor/filesystem-provider.mdx
+++ b/docs/src/content/en/reference/editor/filesystem-provider.mdx
@@ -1,0 +1,93 @@
+---
+title: "Reference: FilesystemProvider | Editor"
+description: "Reference for FilesystemProvider, the interface that registers a filesystem implementation with MastraEditor."
+packages:
+  - "@mastra/core"
+---
+
+# FilesystemProvider
+
+`FilesystemProvider` is the interface a package implements to register a filesystem with [`MastraEditor`](/reference/editor/mastra-editor). The editor calls `createFilesystem(config)` at workspace hydration time, using the `provider` id from the stored [`StorageWorkspaceRef`](/reference/editor/storage-workspace-ref) filesystem config as the lookup key.
+
+The built-in `local` filesystem provider is auto-registered. External providers (for example, S3 or GCS) are supplied via `MastraEditorConfig.filesystems`.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+import { s3FilesystemProvider } from '@mastra/s3'
+
+new MastraEditor({
+  filesystems: {
+    [s3FilesystemProvider.id]: s3FilesystemProvider,
+  },
+})
+```
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description:
+      'Unique provider identifier (for example, `"local"`, `"s3"`). Must match `StorageFilesystemConfig.provider` on every stored workspace that uses this provider.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: 'Human-readable name for UI display.',
+  },
+  {
+    name: 'description',
+    type: 'string',
+    description: 'Short description shown in the workspace filesystem picker.',
+    isOptional: true,
+  },
+  {
+    name: 'configSchema',
+    type: 'Record<string, unknown>',
+    description: 'JSON Schema describing provider-specific configuration. Used by the UI to render config forms.',
+    isOptional: true,
+  },
+  {
+    name: 'createFilesystem',
+    type: '(config: TConfig) => WorkspaceFilesystem | Promise<WorkspaceFilesystem>',
+    description:
+      'Create a runtime `WorkspaceFilesystem` instance from the stored config. Called at workspace hydration time.',
+  },
+]}
+/>
+
+## Implementing a provider
+
+```typescript title="src/providers/my-filesystem.ts"
+import type { FilesystemProvider, WorkspaceFilesystem } from '@mastra/core/editor'
+
+export const myFilesystemProvider: FilesystemProvider<{ bucket: string; region: string }> = {
+  id: 'my-fs',
+  name: 'My Filesystem',
+  description: 'Object-store-backed filesystem.',
+  configSchema: {
+    type: 'object',
+    required: ['bucket', 'region'],
+    properties: {
+      bucket: { type: 'string' },
+      region: { type: 'string' },
+    },
+  },
+  async createFilesystem(config): Promise<WorkspaceFilesystem> {
+    return createMyFilesystem({ bucket: config.bucket, region: config.region })
+  },
+}
+```
+
+Once registered, admins can reference the provider from an inline workspace config or a stored [`StorageWorkspaceRef`](/reference/editor/storage-workspace-ref).
+
+## Related
+
+- [Workspace](/docs/agent-builder/workspace) — concept and worked examples.
+- [StorageWorkspaceRef](/reference/editor/storage-workspace-ref) — stored configuration consumed by `createFilesystem`.
+- [SandboxProvider](/reference/editor/sandbox-provider) — sibling provider for command execution.
+- [MastraEditor class](/reference/editor/mastra-editor) — provider registry.

--- a/docs/src/content/en/reference/editor/mastra-editor.mdx
+++ b/docs/src/content/en/reference/editor/mastra-editor.mdx
@@ -83,8 +83,63 @@ export const mastra = new Mastra({
     isOptional: true,
     defaultValue: '{}',
   },
+  {
+    name: 'browsers',
+    type: 'Record<string, BrowserProvider>',
+    description:
+      'Browser providers for agent browser access (for example, Stagehand). No built-ins — required when `builder.features.agent.browser` is enabled. See the BrowserProvider reference for the provider interface.',
+    isOptional: true,
+    defaultValue: '{}',
+  },
+  {
+    name: 'builder',
+    type: 'AgentBuilderOptions',
+    description:
+      'Agent Builder configuration. See the AgentBuilderOptions reference. Omit or set `enabled: false` to disable the Builder.',
+    isOptional: true,
+  },
 ]}
 />
+
+### Provider interfaces
+
+Each provider field above takes a record keyed by provider id. See the per-provider reference pages for the implementation shape:
+
+- [ProcessorProvider](/reference/editor/processor-provider)
+- [FilesystemProvider](/reference/editor/filesystem-provider)
+- [SandboxProvider](/reference/editor/sandbox-provider)
+- [BlobStoreProvider](/reference/editor/blob-store-provider)
+- [BrowserProvider](/reference/editor/browser-provider)
+
+## Agent Builder
+
+The `builder` field enables the [Agent Builder](/docs/agent-builder/overview), a browser-based UI for creating and editing stored agents. See:
+
+- [Agent Builder overview](/docs/agent-builder/overview) — concepts and getting started.
+- [AgentBuilderOptions](/reference/editor/agent-builder/agent-builder-options) — full options schema.
+- [BuilderAgentDefaults](/reference/editor/agent-builder/builder-agent-defaults) — admin-pinned defaults for new agents.
+- [builder.configuration.agent.models](/reference/editor/agent-builder/builder-models) — model allowlist and default model.
+
+### Registering the Builder agent
+
+The Builder UI runs against an agent created by the `createBuilderAgent()` factory from `@mastra/editor/ee`. Import the factory, invoke it, and register the returned agent under `agents` on your Mastra instance:
+
+```typescript filename="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraEditor } from '@mastra/editor'
+import { createBuilderAgent } from '@mastra/editor/ee'
+
+export const mastra = new Mastra({
+  agents: { builderAgent: createBuilderAgent() },
+  editor: new MastraEditor({
+    builder: { enabled: true },
+  }),
+})
+```
+
+The key name (`builderAgent`) is conventional — any key works. The `@mastra/editor/ee` subpath is gated by the Mastra Enterprise Edition license at runtime.
+
+See the [Agent Builder overview](/docs/agent-builder/overview#prerequisites) for the full setup checklist.
 
 ## Namespaces
 

--- a/docs/src/content/en/reference/editor/processor-provider.mdx
+++ b/docs/src/content/en/reference/editor/processor-provider.mdx
@@ -1,0 +1,107 @@
+---
+title: "Reference: ProcessorProvider | Editor"
+description: "Reference for ProcessorProvider, the interface that registers a configurable processor with MastraEditor."
+packages:
+  - "@mastra/core"
+---
+
+# ProcessorProvider
+
+`ProcessorProvider` is the interface a package implements to register a configurable processor with [`MastraEditor`](/reference/editor/mastra-editor). Processor providers serve two purposes:
+
+1. **Discovery** — the UI uses `info`, `configSchema`, and `availablePhases` to render configuration forms.
+1. **Runtime** — the editor calls `createProcessor(config)` during agent hydration to instantiate processors from stored configuration.
+
+Providers are supplied via `MastraEditorConfig.processorProviders`.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+import { moderationProcessorProvider } from '@mastra/processors/moderation'
+
+new MastraEditor({
+  processorProviders: {
+    moderation: moderationProcessorProvider,
+  },
+})
+```
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'info',
+    type: 'ProcessorProviderInfo',
+    description: 'Metadata about the provider.',
+    properties: [
+      {
+        parameters: [
+          {
+            name: 'id',
+            type: 'string',
+            description: 'Unique identifier (for example, `"moderation"`, `"token-limiter"`).',
+          },
+          {
+            name: 'name',
+            type: 'string',
+            description: 'Human-readable name.',
+          },
+          {
+            name: 'description',
+            type: 'string',
+            description: 'Short description of the provider.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'configSchema',
+    type: 'ZodSchema',
+    description:
+      'Zod schema describing the configuration this provider accepts. Used by the UI to render a form. The validated config object is passed to `createProcessor()`.',
+  },
+  {
+    name: 'availablePhases',
+    type: 'ProcessorPhase[]',
+    description:
+      "Phases this provider's processors support. One or more of `'processInput'`, `'processInputStep'`, `'processOutputStream'`, `'processOutputResult'`, `'processOutputStep'`.",
+  },
+  {
+    name: 'createProcessor',
+    type: '(config: Record<string, unknown>) => Processor',
+    description:
+      'Create a `Processor` instance from the validated configuration. Called during agent hydration to resolve stored processor configs into live instances.',
+  },
+]}
+/>
+
+## Implementing a provider
+
+```typescript title="src/providers/my-processor.ts"
+import type { ProcessorProvider } from '@mastra/core/processor-provider'
+import { z } from 'zod'
+import { MyProcessor } from './my-processor-impl'
+
+export const myProcessorProvider: ProcessorProvider = {
+  info: {
+    id: 'my-processor',
+    name: 'My Processor',
+    description: 'Filters output for sensitive content.',
+  },
+  configSchema: z.object({
+    threshold: z.number().min(0).max(1),
+  }),
+  availablePhases: ['processOutputStream', 'processOutputResult'],
+  createProcessor(config) {
+    return new MyProcessor(config as { threshold: number })
+  },
+}
+```
+
+## Related
+
+- [MastraEditor class](/reference/editor/mastra-editor) — provider registry.

--- a/docs/src/content/en/reference/editor/sandbox-provider.mdx
+++ b/docs/src/content/en/reference/editor/sandbox-provider.mdx
@@ -1,0 +1,92 @@
+---
+title: "Reference: SandboxProvider | Editor"
+description: "Reference for SandboxProvider, the interface that registers a sandbox implementation with MastraEditor."
+packages:
+  - "@mastra/core"
+---
+
+# SandboxProvider
+
+`SandboxProvider` is the interface a package implements to register a sandbox with [`MastraEditor`](/reference/editor/mastra-editor). The editor calls `createSandbox(config)` at workspace hydration time, using the `provider` id from the stored [`StorageWorkspaceRef`](/reference/editor/storage-workspace-ref) sandbox config as the lookup key.
+
+The built-in `local` sandbox provider is auto-registered. External providers (for example, E2B) are supplied via `MastraEditorConfig.sandboxes`.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+import { e2bSandboxProvider } from '@mastra/e2b'
+
+new MastraEditor({
+  sandboxes: {
+    [e2bSandboxProvider.id]: e2bSandboxProvider,
+  },
+})
+```
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description:
+      'Unique provider identifier (for example, `"local"`, `"e2b"`). Must match `StorageSandboxConfig.provider` on every stored workspace that uses this provider.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: 'Human-readable name for UI display.',
+  },
+  {
+    name: 'description',
+    type: 'string',
+    description: 'Short description shown in the workspace sandbox picker.',
+    isOptional: true,
+  },
+  {
+    name: 'configSchema',
+    type: 'Record<string, unknown>',
+    description: 'JSON Schema describing provider-specific configuration. Used by the UI to render config forms.',
+    isOptional: true,
+  },
+  {
+    name: 'createSandbox',
+    type: '(config: TConfig) => WorkspaceSandbox | Promise<WorkspaceSandbox>',
+    description:
+      'Create a runtime `WorkspaceSandbox` instance from the stored config. Called at workspace hydration time.',
+  },
+]}
+/>
+
+## Implementing a provider
+
+```typescript title="src/providers/my-sandbox.ts"
+import type { SandboxProvider, WorkspaceSandbox } from '@mastra/core/editor'
+
+export const mySandboxProvider: SandboxProvider<{ apiKey: string }> = {
+  id: 'my-sandbox',
+  name: 'My Sandbox',
+  description: 'Cloud sandbox for command execution.',
+  configSchema: {
+    type: 'object',
+    required: ['apiKey'],
+    properties: {
+      apiKey: { type: 'string' },
+    },
+  },
+  async createSandbox(config): Promise<WorkspaceSandbox> {
+    return createMySandbox({ apiKey: config.apiKey })
+  },
+}
+```
+
+Once registered, admins can reference the provider from an inline workspace config or a stored [`StorageWorkspaceRef`](/reference/editor/storage-workspace-ref).
+
+## Related
+
+- [Workspace](/docs/agent-builder/workspace) — concept and worked examples.
+- [StorageWorkspaceRef](/reference/editor/storage-workspace-ref) — stored configuration consumed by `createSandbox`.
+- [FilesystemProvider](/reference/editor/filesystem-provider) — sibling provider for file access.
+- [MastraEditor class](/reference/editor/mastra-editor) — provider registry.

--- a/docs/src/content/en/reference/editor/storage-browser-ref.mdx
+++ b/docs/src/content/en/reference/editor/storage-browser-ref.mdx
@@ -1,0 +1,157 @@
+---
+title: "Reference: StorageBrowserRef | Editor"
+description: "Reference for StorageBrowserRef and StorageBrowserConfig, the inline browser configuration attached to a stored agent."
+packages:
+  - "@mastra/core"
+---
+
+# StorageBrowserRef
+
+`StorageBrowserRef` is the inline browser configuration attached to a stored agent. The `provider` id is resolved at hydration time against the [`BrowserProvider`](/reference/editor/browser-provider) registered on [`MastraEditor.browsers`](/reference/editor/mastra-editor).
+
+It is the type used by [`BuilderAgentDefaults.browser`](/reference/editor/agent-builder/builder-agent-defaults) and by stored agent records.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+import { stagehandBrowserProvider } from '@mastra/stagehand'
+
+new MastraEditor({
+  browsers: { [stagehandBrowserProvider.id]: stagehandBrowserProvider },
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        browser: {
+          type: 'inline',
+          config: {
+            provider: 'stagehand',
+            headless: true,
+            viewport: { width: 1280, height: 720 },
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+## Type
+
+```typescript
+type StorageBrowserRef = { type: 'inline'; config: StorageBrowserConfig }
+```
+
+There is no `{ type: 'id' }` variant for browsers — they are always inlined.
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'type',
+    type: "'inline'",
+    description: 'Discriminant. Must be the literal `"inline"`.',
+  },
+  {
+    name: 'config',
+    type: 'StorageBrowserConfig',
+    description: 'Provider id and per-instance browser configuration. See the section below.',
+  },
+]}
+/>
+
+## `StorageBrowserConfig`
+
+The shape embedded under `config`. Defined in `@mastra/core/storage`.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'provider',
+    type: 'string',
+    description:
+      'Provider identifier (for example, `"stagehand"`). Must match a `BrowserProvider.id` registered on `MastraEditor.browsers`. There are no built-in providers.',
+  },
+  {
+    name: 'headless',
+    type: 'boolean',
+    description: 'Run the browser in headless mode (no visible UI).',
+    isOptional: true,
+    defaultValue: 'true',
+  },
+  {
+    name: 'viewport',
+    type: '{ width: number; height: number }',
+    description: 'Browser viewport dimensions. Controls window size and how pages render.',
+    isOptional: true,
+  },
+  {
+    name: 'timeout',
+    type: 'number',
+    description: 'Default timeout in milliseconds for browser operations.',
+    isOptional: true,
+    defaultValue: '10000',
+  },
+  {
+    name: 'screencast',
+    type: 'ScreencastOptions',
+    description: 'Screencast options for streaming browser frames to the UI.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'ScreencastOptions',
+        parameters: [
+          {
+            name: 'format',
+            type: "'jpeg' | 'png'",
+            description: 'Image format.',
+            isOptional: true,
+            defaultValue: "'jpeg'",
+          },
+          {
+            name: 'quality',
+            type: 'number',
+            description: 'JPEG quality 0–100.',
+            isOptional: true,
+            defaultValue: '80',
+          },
+          {
+            name: 'maxWidth',
+            type: 'number',
+            description: 'Max width in pixels.',
+            isOptional: true,
+            defaultValue: '1280',
+          },
+          {
+            name: 'maxHeight',
+            type: 'number',
+            description: 'Max height in pixels.',
+            isOptional: true,
+            defaultValue: '720',
+          },
+          {
+            name: 'everyNthFrame',
+            type: 'number',
+            description: 'Capture every Nth frame.',
+            isOptional: true,
+            defaultValue: '1',
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+## Hydration
+
+`StorageBrowserRef` is resolved lazily on `mastra.editor.agent.getById()`. The editor looks up `config.provider` on `MastraEditor.browsers` and calls `provider.createBrowser(config)`. If the provider is not registered, the editor logs a warning and returns `undefined` — the agent still loads, but without a browser.
+
+## Related
+
+- [Browser](/docs/agent-builder/browser) — concept and worked examples.
+- [BrowserProvider](/reference/editor/browser-provider) — implementer-facing provider interface.
+- [BuilderAgentDefaults](/reference/editor/agent-builder/builder-agent-defaults) — where this type is pinned as the Builder default.
+- [StorageWorkspaceRef](/reference/editor/storage-workspace-ref) — sibling reference type for workspace configuration.

--- a/docs/src/content/en/reference/editor/storage-workspace-ref.mdx
+++ b/docs/src/content/en/reference/editor/storage-workspace-ref.mdx
@@ -1,0 +1,188 @@
+---
+title: "Reference: StorageWorkspaceRef | Editor"
+description: "Reference for StorageWorkspaceRef, the discriminated union that points a stored agent at a workspace."
+packages:
+  - "@mastra/core"
+---
+
+# StorageWorkspaceRef
+
+`StorageWorkspaceRef` is the discriminated union used to attach a workspace to a stored agent. It either points at a workspace registered on the Mastra runtime by ID, or embeds a workspace snapshot inline.
+
+It is the type used by [`BuilderAgentDefaults.workspace`](/reference/editor/agent-builder/builder-agent-defaults) and by stored agent records.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+
+// Variant 1 — reference a runtime workspace by id
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        workspace: { type: 'id', workspaceId: 'builder-workspace' },
+      },
+    },
+  },
+})
+
+// Variant 2 — inline a workspace snapshot
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        workspace: {
+          type: 'inline',
+          config: {
+            name: 'inline-builder-workspace',
+            filesystem: {
+              provider: 'local',
+              config: { basePath: './agent-files' },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+## Variants
+
+<PropertiesTable
+  content={[
+  {
+    name: "{ type: 'id'; workspaceId: string }",
+    type: 'IdRef',
+    description:
+      'Reference a workspace registered on the Mastra runtime via `new Mastra({ workspace })` or `mastra.addWorkspace()`. The id is the join key between admin config, stored agent record, and hydration.',
+    properties: [
+      {
+        type: "{ type: 'id'; workspaceId: string }",
+        parameters: [
+          {
+            name: 'type',
+            type: "'id'",
+            description: 'Discriminant. Must be the literal `"id"`.',
+          },
+          {
+            name: 'workspaceId',
+            type: 'string',
+            description:
+              'Id of a workspace registered on the Mastra runtime. Used by the Builder to snapshot, persist, and later hydrate the workspace.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "{ type: 'inline'; config: StorageWorkspaceSnapshotType }",
+    type: 'InlineRef',
+    description:
+      'Embed a workspace snapshot directly. The Builder derives a deterministic id of the form `inline-<sha256(config)[:12]>` and persists the snapshot, so identical inline configs are deduplicated across agents.',
+    properties: [
+      {
+        type: "{ type: 'inline'; config: StorageWorkspaceSnapshotType }",
+        parameters: [
+          {
+            name: 'type',
+            type: "'inline'",
+            description: 'Discriminant. Must be the literal `"inline"`.',
+          },
+          {
+            name: 'config',
+            type: 'StorageWorkspaceSnapshotType',
+            description:
+              'Serialized workspace configuration (filesystem, sandbox, mounts, search, skills, tools). See the `StorageWorkspaceSnapshotType` section below for the field list.',
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+## `StorageWorkspaceSnapshotType`
+
+The shape embedded under `{ type: 'inline', config }`. Defined in `@mastra/core/storage`.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'name',
+    type: 'string',
+    description: 'Display name of the workspace.',
+  },
+  {
+    name: 'description',
+    type: 'string',
+    description: 'Purpose description shown in the workspace listing.',
+    isOptional: true,
+  },
+  {
+    name: 'filesystem',
+    type: 'StorageFilesystemConfig',
+    description:
+      'Primary filesystem configuration. `provider` must match an id registered on `MastraEditor.filesystems` (built-in: `local`).',
+    isOptional: true,
+  },
+  {
+    name: 'sandbox',
+    type: 'StorageSandboxConfig',
+    description:
+      'Sandbox configuration. `provider` must match an id registered on `MastraEditor.sandboxes` (built-in: `local`).',
+    isOptional: true,
+  },
+  {
+    name: 'mounts',
+    type: 'Record<string, StorageFilesystemConfig>',
+    description: 'Additional filesystems mounted on the workspace, keyed by mount path.',
+    isOptional: true,
+  },
+  {
+    name: 'search',
+    type: 'StorageSearchConfig',
+    description: 'Search configuration (vector provider, embedder, BM25 settings).',
+    isOptional: true,
+  },
+  {
+    name: 'skills',
+    type: 'string[]',
+    description: 'Skill entity IDs assigned to this workspace.',
+    isOptional: true,
+  },
+  {
+    name: 'tools',
+    type: 'StorageWorkspaceToolsConfig',
+    description: 'Workspace tool configuration (allowlists, defaults).',
+    isOptional: true,
+  },
+  {
+    name: 'autoSync',
+    type: 'boolean',
+    description: 'Auto-sync between filesystem and sandbox.',
+    isOptional: true,
+    defaultValue: 'false',
+  },
+  {
+    name: 'operationTimeout',
+    type: 'number',
+    description: 'Timeout for individual operations in milliseconds.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Hydration
+
+`StorageWorkspaceRef` is resolved lazily on `mastra.editor.agent.getById()`, not on `list()`. The editor looks up filesystem and sandbox providers on `MastraEditor.filesystems` / `MastraEditor.sandboxes` and materializes a runtime `Workspace`. Missing providers surface as a warning and the workspace is omitted.
+
+## Related
+
+- [Workspace](/docs/agent-builder/workspace) — concept and worked examples.
+- [BuilderAgentDefaults](/reference/editor/agent-builder/builder-agent-defaults) — where this type is pinned as the Builder default.
+- [MastraEditor class](/reference/editor/mastra-editor) — registers filesystem and sandbox providers.
+- [StorageBrowserRef](/reference/editor/storage-browser-ref) — sibling reference type for browser configuration.

--- a/docs/src/content/en/reference/memory/serialized-memory-config.mdx
+++ b/docs/src/content/en/reference/memory/serialized-memory-config.mdx
@@ -1,0 +1,172 @@
+---
+title: "Reference: SerializedMemoryConfig | Memory"
+description: "Reference for SerializedMemoryConfig, the JSON-serializable subset of Memory configuration stored on agent records."
+packages:
+  - "@mastra/core"
+---
+
+# SerializedMemoryConfig
+
+`SerializedMemoryConfig` is the JSON-serializable subset of [`Memory`](/reference/memory/memory-class) configuration that lives on a stored agent record. The runtime hydrates it back into a `Memory` instance by resolving the vector and embedder IDs against the configured `Mastra` instance.
+
+It is the type used by [`BuilderAgentDefaults.memory`](/reference/editor/agent-builder/builder-agent-defaults) and by `EditorAgentNamespace.create({ memory })`.
+
+## Usage example
+
+```typescript title="src/mastra/index.ts"
+import { MastraEditor } from '@mastra/editor'
+
+new MastraEditor({
+  builder: {
+    enabled: true,
+    configuration: {
+      agent: {
+        memory: {
+          observationalMemory: true,
+          options: { lastMessages: 50 },
+        },
+      },
+    },
+  },
+})
+```
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'vector',
+    type: 'string | false',
+    description:
+      'Vector store identifier. The vector instance must be registered with the Mastra instance to resolve from this ID. Set to `false` to disable vector search.',
+    isOptional: true,
+  },
+  {
+    name: 'embedder',
+    type: 'string',
+    description:
+      'Embedding model ID in the format `"provider/model"` (for example, `"openai/text-embedding-3-small"`).',
+    isOptional: true,
+  },
+  {
+    name: 'embedderOptions',
+    type: "Omit<MastraEmbeddingOptions, 'telemetry'>",
+    description: 'Options passed to the embedder. Telemetry options are stripped.',
+    isOptional: true,
+  },
+  {
+    name: 'options',
+    type: 'SerializedMemoryOptions',
+    description: 'Configuration for memory behaviors. Omits non-serializable fields like working memory and threads.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'SerializedMemoryOptions',
+        parameters: [
+          {
+            name: 'readOnly',
+            type: 'boolean',
+            description: 'Treat memory as read-only — no new messages are stored.',
+            isOptional: true,
+          },
+          {
+            name: 'lastMessages',
+            type: 'number | false',
+            description: 'Number of recent messages to include in context, or `false` to disable.',
+            isOptional: true,
+          },
+          {
+            name: 'semanticRecall',
+            type: 'boolean | SemanticRecall',
+            description: 'Semantic recall configuration. See the Memory class reference for the full shape.',
+            isOptional: true,
+          },
+          {
+            name: 'generateTitle',
+            type: 'boolean | { model: ModelRouterModelId; instructions?: string }',
+            description:
+              'Title generation configuration. Pass an object with `model` (in `"provider/model"` form) and optional `instructions`.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'observationalMemory',
+    type: 'boolean | SerializedObservationalMemoryConfig',
+    description:
+      'Long-lived fact extraction. Pass `true` to enable with defaults, or an object to override observer/reflector models, scope, and activation behavior.',
+    isOptional: true,
+  },
+]}
+/>
+
+## `SerializedObservationalMemoryConfig`
+
+<PropertiesTable
+  content={[
+  {
+    name: 'model',
+    type: 'string',
+    description: 'Model ID used by both the Observer and Reflector (for example, `"google/gemini-2.5-flash"`).',
+    isOptional: true,
+  },
+  {
+    name: 'scope',
+    type: "'resource' | 'thread'",
+    description: 'Whether observations are scoped to a resource or a single thread.',
+    isOptional: true,
+  },
+  {
+    name: 'activateAfterIdle',
+    type: 'ObservationalMemoryActivationTTL',
+    description: 'Inactivity TTL before forcing buffered observation activation.',
+    isOptional: true,
+  },
+  {
+    name: 'activateOnProviderChange',
+    type: 'boolean',
+    description: 'Force-activate buffered observations when the actor model changes.',
+    isOptional: true,
+  },
+  {
+    name: 'shareTokenBudget',
+    type: 'boolean',
+    description: 'Share the token budget between messages and observations.',
+    isOptional: true,
+  },
+  {
+    name: 'temporalMarkers',
+    type: 'boolean',
+    description: 'Persist inline temporal gap markers for long pauses between messages.',
+    isOptional: true,
+  },
+  {
+    name: 'retrieval',
+    type: "boolean | { vector?: boolean; scope?: 'thread' | 'resource' }",
+    description: 'Experimental. Enable retrieval-mode observation groups as durable pointers to raw message history.',
+    isOptional: true,
+  },
+  {
+    name: 'observation',
+    type: 'SerializedObservationalMemoryObservationConfig',
+    description: 'Observer-step configuration (model, token thresholds, buffering).',
+    isOptional: true,
+  },
+  {
+    name: 'reflection',
+    type: 'SerializedObservationalMemoryReflectionConfig',
+    description: 'Reflector-step configuration (model, observation token thresholds, buffering).',
+    isOptional: true,
+  },
+]}
+/>
+
+## Related
+
+- [Memory class](/reference/memory/memory-class) — the runtime type this config hydrates into.
+- [Observational memory](/reference/memory/observational-memory) — full observational memory reference.
+- [BuilderAgentDefaults](/reference/editor/agent-builder/builder-agent-defaults) — where this type is pinned as the Builder default.
+- [Agent Builder: Memory](/docs/agent-builder/memory) — concept and worked examples.

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -102,6 +102,7 @@ const sidebars = {
       label: 'Client SDK',
       collapsed: true,
       items: [
+        { type: 'doc', id: 'client-js/agent-builder', label: 'Agent Builder API' },
         { type: 'doc', id: 'client-js/agents', label: 'Agents API' },
         { type: 'doc', id: 'client-js/conversations', label: 'Conversations API' },
         { type: 'doc', id: 'client-js/error-handling', label: 'Error Handling' },
@@ -170,8 +171,48 @@ const sidebars = {
       label: 'Editor',
       collapsed: true,
       items: [
+        { type: 'doc', id: 'editor/blob-store-provider', label: 'BlobStoreProvider' },
         { type: 'doc', id: 'editor/mastra-editor', label: 'MastraEditor Class' },
+        { type: 'doc', id: 'editor/processor-provider', label: 'ProcessorProvider' },
         { type: 'doc', id: 'editor/tool-provider', label: 'ToolProvider' },
+        {
+          type: 'category',
+          label: 'Agent Builder',
+          collapsed: true,
+          customProps: { tags: ['new'] },
+          items: [
+            {
+              type: 'doc',
+              id: 'editor/agent-builder/agent-builder-options',
+              label: 'AgentBuilderOptions',
+            },
+            {
+              type: 'doc',
+              id: 'editor/agent-builder/builder-agent-defaults',
+              label: 'BuilderAgentDefaults',
+            },
+            { type: 'doc', id: 'editor/agent-builder/builder-models', label: 'Models default' },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Browser',
+          collapsed: true,
+          items: [
+            { type: 'doc', id: 'editor/browser-provider', label: 'BrowserProvider' },
+            { type: 'doc', id: 'editor/storage-browser-ref', label: 'StorageBrowserRef' },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Workspace',
+          collapsed: true,
+          items: [
+            { type: 'doc', id: 'editor/filesystem-provider', label: 'FilesystemProvider' },
+            { type: 'doc', id: 'editor/sandbox-provider', label: 'SandboxProvider' },
+            { type: 'doc', id: 'editor/storage-workspace-ref', label: 'StorageWorkspaceRef' },
+          ],
+        },
       ],
     },
     {
@@ -270,6 +311,7 @@ const sidebars = {
         { type: 'doc', id: 'memory/clone-utilities', label: 'Cloned Thread Utilities' },
         { type: 'doc', id: 'memory/memory-class', label: 'Memory Class' },
         { type: 'doc', id: 'memory/observational-memory', label: 'Observational Memory' },
+        { type: 'doc', id: 'memory/serialized-memory-config', label: 'SerializedMemoryConfig' },
         { type: 'doc', id: 'memory/cloneThread', label: '.cloneThread()' },
         { type: 'doc', id: 'memory/createThread', label: '.createThread()' },
         { type: 'doc', id: 'memory/deleteMessages', label: '.deleteMessages()' },
@@ -312,7 +354,11 @@ const sidebars = {
               type: 'category',
               label: 'Bridges',
               items: [
-                { type: 'doc', id: 'observability/tracing/bridges/datadog', label: 'DatadogBridge' },
+                {
+                  type: 'doc',
+                  id: 'observability/tracing/bridges/datadog',
+                  label: 'DatadogBridge',
+                },
                 { type: 'doc', id: 'observability/tracing/bridges/otel', label: 'OtelBridge' },
               ],
             },
@@ -331,7 +377,6 @@ const sidebars = {
                   type: 'doc',
                   id: 'observability/tracing/exporters/cloud-exporter',
                   label: 'CloudExporter (deprecated)',
-                  className: 'sidebar-item-deprecated',
                 },
                 {
                   type: 'doc',
@@ -343,7 +388,6 @@ const sidebars = {
                   type: 'doc',
                   id: 'observability/tracing/exporters/default-exporter',
                   label: 'DefaultExporter (deprecated)',
-                  className: 'sidebar-item-deprecated',
                 },
                 { type: 'doc', id: 'observability/tracing/exporters/laminar', label: 'Laminar' },
                 { type: 'doc', id: 'observability/tracing/exporters/langfuse', label: 'Langfuse' },
@@ -405,7 +449,11 @@ const sidebars = {
         { type: 'doc', id: 'processors/response-cache', label: 'ResponseCache' },
         { type: 'doc', id: 'processors/semantic-recall-processor', label: 'SemanticRecall' },
         { type: 'doc', id: 'processors/skill-search-processor', label: 'SkillSearchProcessor' },
-        { type: 'doc', id: 'processors/stream-error-retry-processor', label: 'StreamErrorRetryProcessor' },
+        {
+          type: 'doc',
+          id: 'processors/stream-error-retry-processor',
+          label: 'StreamErrorRetryProcessor',
+        },
         { type: 'doc', id: 'processors/system-prompt-scrubber', label: 'SystemPromptScrubber' },
         { type: 'doc', id: 'processors/token-limiter-processor', label: 'TokenLimiterProcessor' },
         { type: 'doc', id: 'processors/tool-call-filter', label: 'ToolCallFilter' },
@@ -440,11 +488,7 @@ const sidebars = {
         { type: 'doc', id: 'server/fastify-adapter', label: 'Fastify Adapter' },
         { type: 'doc', id: 'server/hono-adapter', label: 'Hono Adapter' },
         { type: 'doc', id: 'server/koa-adapter', label: 'Koa Adapter' },
-        {
-          type: 'doc',
-          id: 'server/mastra-server',
-          label: 'MastraServer',
-        },
+        { type: 'doc', id: 'server/mastra-server', label: 'MastraServer' },
         { type: 'doc', id: 'server/nestjs-adapter', label: 'NestJS Adapter' },
         { type: 'doc', id: 'server/register-api-route', label: 'registerApiRoute()' },
         { type: 'doc', id: 'server/routes', label: 'Server Routes' },


### PR DESCRIPTION
## Summary

Adds the Agent Builder documentation surface to `docs/` and `reference/`.

<img width="276" height="310" alt="image" src="https://github.com/user-attachments/assets/4bbfe291-dc1e-4623-961d-025813da3815" />

<img width="261" height="368" alt="image" src="https://github.com/user-attachments/assets/dc4a96c2-0784-49c0-9e48-56b79e5d079c" />


### Concept pages — `docs/src/content/en/docs/agent-builder/`

- `overview.mdx` — what it is, quickstart, prerequisites, disabling
- `configuration.mdx` — `MastraEditor.builder` feature toggles + admin defaults
- `model-policy.mdx` — allowed providers/models, validation rules
- `memory.mdx` — default memory shape, observational memory model
- `access-control.mdx` — `admin`/`member` roles, minimum permissions, WorkOS quickstart
- `channels.mdx` — Slack provider setup, `baseUrl`, storage requirement
- `skill-registries.mdx` — opt-in registries (skills.sh)
- `workspace.mdx` — inline + id workspace refs
- `browser.mdx` — browser provider registration, feature toggle
- `deploying.mdx` — EE license, hosted storage, cloud filesystem/sandbox, auth/RBAC, public channel URL

### Reference pages — `docs/src/content/en/reference/editor/`

- New: `BrowserProvider`, `BlobStoreProvider`, `FilesystemProvider`, `SandboxProvider`, `ProcessorProvider`, `StorageBrowserRef`, `StorageWorkspaceRef`
- New Agent Builder sub-category: `AgentBuilderOptions`, `BuilderAgentDefaults`, `Models default`
- Updated `MastraEditor` to cross-link new pages
- Removed unused `ToolProvider` reference page (will revisit in a later release)

### Client-js reference

- New `reference/client-js/agent-builder.mdx` documenting the `AgentBuilder` resource (12 methods)
- Updated `mastra-client.mdx` Methods table with `getAgentBuilderActions()` and `getAgentBuilderAction(actionId)`

### Sidebars

- Docs sidebar: nest Agent Builder category under Editor, tagged `new`
- Reference sidebar: group Editor entries into `Browser`, `Workspace`, and `Agent Builder` sub-categories with paired provider + stored shape types

## Test plan

- `pnpm --filter ./docs prettier --check` — clean
- `pnpm --filter ./docs validate` — 478 files pass, sidebar sorted, all docs linked
- `pnpm --filter ./docs lint:remark` — clean

## Notes

- Server routes that back this surface are already wired in `main` via PR #17085.
- Picks up the missing `FilesSDKFilesystem` sidebar entry that landed in main while this branch was being prepared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds full product and API documentation for a new visual tool called "Agent Builder" so teams can create, configure, secure, and deploy AI agents inside Mastra with step-by-step guides and API references.

## Overview

Introduces comprehensive concept and reference documentation, client SDK docs, and sidebar/nav changes to expose the Agent Builder feature across the docs site and `@mastra/client-js` reference. Docs are documentation-only; server routes for the feature already exist in main (PR `#17085`).

## Changes Summary

### Concept Documentation (docs/src/content/en/docs/agent-builder/)
Added 10 concept pages:
- overview.mdx — purpose, get-started, prerequisites, mounting/creating the Builder agent; notes OPENAI_API_KEY is required for createBuilderAgent() when using an OpenAI-backed model; shows how to disable the Builder.
- configuration.mdx — builder feature toggles, admin defaults, allowlist semantics, how pickers derive candidates, and validation/warnings.
- model-policy.mdx — model allowlist/default/picker-disable behavior and server-boot validation rules.
- memory.mdx — pinned default memory config, observational memory observer/reflector model details (placeholder for gateway model), storage/vector prerequisites, and runtime error behavior when adapters are missing.
- access-control.mdx — RBAC gating (admin/member), minimum permissions for member experience, resource:action grammar, and WorkOS quickstart for MastraAuthWorkos / MastraRBACWorkos with roleMapping.
- channels.mdx — channel integrations (Slack), SDK quickstart, EE notes, token/storage guidance, and deployment considerations.
- skill-registries.mdx — opt-in community skill registries (skills.sh) and UI visibility rules.
- workspace.mdx — pinned workspace defaults, StorageWorkspaceRef variants, filesystem/sandbox patterns, and EE notes.
- browser.mdx — browser providers must be registered via MastraEditor.browsers, provider contract, provider resolution behavior, and feature toggle semantics.
- deploying.mdx — Enterprise production requirements, provider swaps, shared storage/sandbox recommendations, auth/RBAC for /agent-builder/* routes, and Slack baseUrl guidance.

Also: replaced a concrete model ID with a gateway placeholder in a memory example to align with the model-token registry and added a commit noting OPENAI_API_KEY requirement.

### Reference Documentation (docs/src/content/en/reference/editor/)
New and updated editor reference pages:
- New provider/ref pages: browser-provider.mdx, blob-store-provider.mdx, sandbox-provider.mdx, processor-provider.mdx.
- Filesystem provider doc expanded (filesystem-provider.mdx) with usage, properties, and implementation example.
- Storage refs: storage-browser-ref.mdx and storage-workspace-ref.mdx (detailed variants and hydration behavior).
- Agent Builder sub-category: agent-builder-options.mdx, builder-agent-defaults.mdx, builder-models.mdx.
- MastraEditor reference (mastra-editor.mdx) updated to document new constructor options: browsers?: Record<string, BrowserProvider> and builder?: AgentBuilderOptions, plus provider interfaces and a createBuilderAgent() example.
- Removed unused ToolProvider reference page and added cross-links from MastraEditor to new pages.

### Client SDK Documentation
- Added client-js reference: reference/client-js/agent-builder.mdx — documents the AgentBuilder resource and action methods (list/get actions, details, createRun/startAsync/startActionRun/stream/resume/resumeAsync/resumeStream/observeStream/observeStreamLegacy/runs/runById/cancelRun) and required access control.
- Updated reference/client-js/mastra-client.mdx — adds MastraClient.getAgentBuilderActions() and MastraClient.getAgentBuilderAction(actionId).

### Memory Reference
- Added reference/memory/serialized-memory-config.mdx — SerializedMemoryConfig and SerializedObservationalMemoryConfig shapes and usage (used by builder defaults and editor namespace creation).

### Sidebars & Navigation
- docs sidebars: Added "Agent Builder" category under Editor (tagged "new") with the 10 concept docs.
- reference sidebars: Reorganized Editor into Browser, Workspace, and Agent Builder sub-categories; added Agent Builder API under Client SDK; added SerializedMemoryConfig under Memory; picked up FilesSDKFilesystem sidebar entry from main; removed deprecated styling from some exporters and reformatted several entries.

### Tests / Validation
- Prettier check clean.
- docs validate — 478 files pass, sidebar sorted, docs linked.
- remark lint clean.

## Size / Review Notes
- Documentation-only changes (no production code exports or runtime API signatures changed).
- Lines added across many new MDX files; per-file estimated review effort ranges Low→Medium depending on page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->