### PR TITLE
fix(deployer): preserve safe externals with custom bundler externals

### DIFF
--- a/.changeset/lucky-places-wonder.md
+++ b/.changeset/lucky-places-wonder.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed a deployer bundling regression where custom bundler externals could override safe Mastra runtime externals. This preserves internal runtime externalization and prevents ESM top-level await deadlocks from self-importing generated bundles, fixing the regression of #14860/#14863.

--- a/packages/deployer/src/build/analyze.test.ts
+++ b/packages/deployer/src/build/analyze.test.ts
@@ -1,14 +1,35 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { noopLogger } from '@mastra/core/logger';
+import virtual from '@rollup/plugin-virtual';
 import { afterEach, describe, expect, it } from 'vitest';
 import { analyzeBundle } from './analyze';
-import { slash } from './utils';
+import { getSafeBundlerExternals } from './analyze/constants';
+import { createBundler, getInputOptions } from './bundler';
+import { isDependencyPartOfPackage, slash } from './utils';
 
 const tempDirs: string[] = [];
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const tempRoot = join(packageRoot, '.tmp');
+
+async function readGeneratedModules(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const modules = await Promise.all(
+    entries.map(async entry => {
+      const entryPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return readGeneratedModules(entryPath);
+      }
+      if (!entry.name.endsWith('.mjs')) {
+        return [];
+      }
+      return [await readFile(entryPath, 'utf-8')];
+    }),
+  );
+
+  return modules.flat();
+}
 
 afterEach(async () => {
   await Promise.all(
@@ -67,5 +88,221 @@ describe('protocol imports', () => {
     );
 
     expect(result.externalDependencies.has('cloudflare:workers')).toBe(false);
+  }, 15000);
+});
+
+describe('safe runtime externals', () => {
+  it('preserves user externals while keeping Mastra runtime packages externalized', () => {
+    expect(getSafeBundlerExternals(['pg', '@mastra/core'])).toEqual(
+      expect.arrayContaining(['pg', '@mastra/core', '@mastra/memory']),
+    );
+
+    const merged = getSafeBundlerExternals(['pg', '@mastra/core']);
+    expect(merged.filter(external => external === 'pg')).toHaveLength(1);
+    expect(merged.filter(external => external === '@mastra/core')).toHaveLength(1);
+    expect(merged.some(external => isDependencyPartOfPackage('@mastra/core/storage', external))).toBe(true);
+  });
+
+  it('keeps @mastra/core external with custom externals and top-level dynamic imports', async () => {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'mastra-safe-externals-'));
+    tempDirs.push(tempDir);
+
+    const entryFile = join(tempDir, 'index.ts');
+    const outputDir = join(tempDir, '.mastra', '.build');
+    await mkdir(outputDir, { recursive: true });
+    await writeFile(
+      entryFile,
+      `
+        import { Mastra } from '@mastra/core/mastra';
+
+        export const storageModule = await import('@mastra/core/storage');
+        export const mastra = new Mastra({});
+      `,
+    );
+
+    const result = await analyzeBundle(
+      [entryFile],
+      entryFile,
+      {
+        outputDir,
+        projectRoot: tempDir,
+        platform: 'node',
+        bundlerOptions: {
+          externals: ['pg'],
+          enableSourcemap: false,
+        },
+      },
+      noopLogger,
+    );
+
+    expect(result.externalDependencies.has('@mastra/core')).toBe(true);
+    expect(result.externalDependencies.has('pg')).toBe(false);
+
+    const generatedModules = await readGeneratedModules(outputDir);
+    expect(generatedModules.join('\n')).not.toMatch(/import\(['"]\.\/(?:index|mastra)\.mjs['"]\)/);
+  }, 15000);
+
+  it('does not rewrite internal Mastra dynamic imports to self-imports in final output', async () => {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'mastra-no-self-imports-'));
+    tempDirs.push(tempDir);
+
+    const entryFile = join(tempDir, 'mastra.ts');
+    const outputDir = join(tempDir, '.mastra', '.build');
+    const bundleDir = join(tempDir, '.mastra', 'output');
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(bundleDir, { recursive: true });
+    await writeFile(
+      entryFile,
+      `
+        import { Mastra } from '@mastra/core/mastra';
+
+        export const mastra = new Mastra({});
+      `,
+    );
+
+    const analyzedBundleInfo = await analyzeBundle(
+      [
+        `
+          import { mastra } from '#mastra';
+
+          export { mastra };
+          export const storageModule = await import('@mastra/core/storage');
+        `,
+      ],
+      entryFile,
+      {
+        outputDir,
+        projectRoot: tempDir,
+        platform: 'node',
+        bundlerOptions: {
+          externals: ['pg'],
+          enableSourcemap: false,
+        },
+      },
+      noopLogger,
+    );
+
+    const inputOptions = await getInputOptions(
+      entryFile,
+      analyzedBundleInfo,
+      'node',
+      { 'process.env.NODE_ENV': JSON.stringify('production') },
+      {
+        projectRoot: tempDir,
+        enableEsmShim: true,
+        externalsPreset: false,
+      },
+    );
+
+    inputOptions.input = { index: '#entry' };
+    inputOptions.plugins = [
+      virtual({
+        '#entry': `
+          import { mastra } from '#mastra';
+
+          export { mastra };
+          export const storageModule = await import('@mastra/core/storage');
+        `,
+      }),
+      ...(Array.isArray(inputOptions.plugins) ? inputOptions.plugins : []),
+    ];
+
+    const bundler = await createBundler(inputOptions, {
+      dir: bundleDir,
+      manualChunks: {
+        mastra: ['#mastra'],
+      },
+    });
+
+    await bundler.write();
+    await bundler.close();
+
+    const generatedModules = await readGeneratedModules(bundleDir);
+    const generatedOutput = generatedModules.join('\n');
+    expect(generatedOutput).toContain("import('@mastra/core/storage')");
+    expect(generatedOutput).not.toMatch(/import\(['"]\.\/(?:index|mastra)\.mjs['"]\)/);
+  }, 15000);
+
+  it('preserves Mastra subpath dynamic imports inside the TLA mastra chunk', async () => {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'mastra-subpath-tla-'));
+    tempDirs.push(tempDir);
+
+    const entryFile = join(tempDir, 'mastra.ts');
+    const outputDir = join(tempDir, '.mastra', '.build');
+    const bundleDir = join(tempDir, '.mastra', 'output');
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(bundleDir, { recursive: true });
+    await writeFile(
+      entryFile,
+      `
+        import { Mastra } from '@mastra/core/mastra';
+
+        export const storageModule = await import('@mastra/core/storage');
+        export const mastra = new Mastra({});
+      `,
+    );
+
+    const serverEntry = `
+      import { mastra } from '#mastra';
+
+      export { mastra };
+    `;
+
+    const analyzedBundleInfo = await analyzeBundle(
+      [serverEntry],
+      entryFile,
+      {
+        outputDir,
+        projectRoot: tempDir,
+        platform: 'node',
+        bundlerOptions: {
+          externals: ['pg'],
+          enableSourcemap: false,
+        },
+      },
+      noopLogger,
+    );
+
+    const inputOptions = await getInputOptions(
+      entryFile,
+      analyzedBundleInfo,
+      'node',
+      { 'process.env.NODE_ENV': JSON.stringify('production') },
+      {
+        projectRoot: tempDir,
+        enableEsmShim: true,
+        externalsPreset: false,
+      },
+    );
+
+    inputOptions.input = { index: '#entry' };
+    inputOptions.plugins = [
+      virtual({
+        '#entry': serverEntry,
+      }),
+      ...(Array.isArray(inputOptions.plugins) ? inputOptions.plugins : []),
+    ];
+
+    const bundler = await createBundler(inputOptions, {
+      dir: bundleDir,
+      manualChunks: {
+        mastra: ['#mastra'],
+      },
+    });
+
+    const { output } = await bundler.write();
+    await bundler.close();
+
+    const generatedModules = await readGeneratedModules(bundleDir);
+    const generatedOutput = generatedModules.join('\n');
+    expect(generatedOutput).toContain("import('@mastra/core/storage')");
+    expect(generatedOutput).not.toMatch(/import\(['"]\.\/[^'"]+\.mjs['"]\)/);
+
+    const mastraChunk = output.find(chunk => chunk.type === 'chunk' && chunk.fileName === 'mastra.mjs');
+    expect(mastraChunk).toBeDefined();
+    expect(mastraChunk?.type === 'chunk' ? mastraChunk.imports : []).not.toContain('index.mjs');
   }, 15000);
 });

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -11,7 +11,7 @@ import type { WorkspacePackageInfo } from '../bundler/workspaceDependencies';
 import { validate, ValidationError } from '../validator/validate';
 import { analyzeEntry } from './analyze/analyzeEntry';
 import { bundleExternals } from './analyze/bundleExternals';
-import { DEPS_TO_IGNORE, GLOBAL_EXTERNALS } from './analyze/constants';
+import { DEPS_TO_IGNORE, GLOBAL_EXTERNALS, getSafeBundlerExternals } from './analyze/constants';
 import { checkConfigExport } from './babel/check-config-export';
 import { detectPinoTransports } from './babel/detect-pino-transports';
 import type { BundlerOptions, DependencyMetadata, ExternalDependencyInfo } from './types';
@@ -353,7 +353,7 @@ export async function analyzeBundle(
 
   let index = 0;
   const depsToOptimize = new Map<string, DependencyMetadata>();
-  const allExternals: string[] = [...GLOBAL_EXTERNALS, ...userExternals].filter(Boolean) as string[];
+  const allExternals = getSafeBundlerExternals(userExternals);
 
   // Collect pino transports detected across all entries
   const detectedPinoTransports = new Set<string>();
@@ -431,7 +431,7 @@ export async function analyzeBundle(
   const { output, fileNameToDependencyMap, usedExternals } = await bundleExternals(depsToOptimize, outputDir, {
     bundlerOptions: {
       ...bundlerOptions,
-      externals: bundlerOptions?.externals ?? allExternals,
+      externals: bundlerOptions?.externals === true ? true : allExternals,
       isDev,
     },
     projectRoot,

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -31,7 +31,7 @@ import {
   slash,
 } from '../utils';
 import type { BundlerPlatform } from '../utils';
-import { DEPS_TO_IGNORE, GLOBAL_EXTERNALS, DEPRECATED_EXTERNALS } from './constants';
+import { DEPS_TO_IGNORE, getSafeBundlerExternals } from './constants';
 
 type VirtualDependency = {
   name: string;
@@ -484,7 +484,7 @@ export async function bundleExternals(
 
   // If `externals` is an array (and not `true`), we proceed as normal
   const externalsList = Array.isArray(customExternals) ? customExternals : [];
-  const allExternals = [...GLOBAL_EXTERNALS, ...DEPRECATED_EXTERNALS, ...externalsList];
+  const allExternals = getSafeBundlerExternals(externalsList, { includeDeprecated: true });
 
   const workspacePackagesNames = Array.from(workspaceMap.keys());
   const packagesToTranspile = new Set([...transpilePackages, ...workspacePackagesNames]);

--- a/packages/deployer/src/build/analyze/constants.ts
+++ b/packages/deployer/src/build/analyze/constants.ts
@@ -1,5 +1,16 @@
 export const DEPS_TO_IGNORE = ['#tools', 'execa'];
 
+// Keep Mastra runtime packages external to avoid reintroducing the ESM TLA
+// circular chunk deadlocks fixed in #14860/#14863.
+export const MASTRA_RUNTIME_EXTERNALS = [
+  '@mastra/core',
+  '@mastra/dsql',
+  '@mastra/libsql',
+  '@mastra/memory',
+  '@mastra/mssql',
+  '@mastra/pg',
+];
+
 export const GLOBAL_EXTERNALS = [
   'pino',
   'pino-pretty',
@@ -15,3 +26,19 @@ export const GLOBAL_EXTERNALS = [
   'execa',
 ];
 export const DEPRECATED_EXTERNALS = ['fastembed', 'nodemailer', 'jsdom', 'sqlite3'];
+
+export function mergeBundlerExternals(...externalLists: (readonly string[] | undefined)[]) {
+  return Array.from(new Set(externalLists.flatMap(externals => externals ?? []).filter(Boolean)));
+}
+
+export function getSafeBundlerExternals(
+  userExternals: readonly string[] = [],
+  { includeDeprecated = false }: { includeDeprecated?: boolean } = {},
+) {
+  return mergeBundlerExternals(
+    GLOBAL_EXTERNALS,
+    includeDeprecated ? DEPRECATED_EXTERNALS : undefined,
+    MASTRA_RUNTIME_EXTERNALS,
+    userExternals,
+  );
+}


### PR DESCRIPTION
## Description

Fixes a regression where custom `bundler.externals` could override Mastra’s safe runtime externals and allow internal runtime packages to be bundled into generated chunks.

This could rewrite internal dynamic imports such as:

```ts
await import('@mastra/core/storage')
```

into generated self-imports like:

```js
await import('./index.mjs')
```

or:

```js
await import('./mastra.mjs')
```

reintroducing the ESM top-level-await deadlock fixed in #14860 / #14863.

This change centralizes safe runtime externals, preserves user-provided externals additively, and ensures protected Mastra runtime packages remain externalized even when custom `bundler.externals` are configured.

## Related issue(s)

Fixes #17115

Related:

* #14860
* #14863

## Type of change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement
* [x] Test update

## What changed

* added centralized `MASTRA_RUNTIME_EXTERNALS`
* added `mergeBundlerExternals()`
* added `getSafeBundlerExternals()`
* changed bundler external merging from replacement semantics to additive semantics
* preserved existing `externals: true` behavior
* protected Mastra runtime subpath imports such as `@mastra/core/storage`

## Regression coverage added

Added tests covering:

* preserving user externals while keeping safe runtime externals
* protecting `@mastra/core/storage` subpath imports
* custom externals + top-level dynamic imports
* generated bundle output inspection
* preventing generated self-imports (`./index.mjs`, `./mastra.mjs`)
* TLA `mastra.mjs` chunk safety

## Validation

Passed:

```bash
corepack pnpm --filter ./packages/deployer test src/build/analyze.test.ts
corepack pnpm --filter ./packages/deployer test src/build/analyze/bundleExternals.test.ts
corepack pnpm --filter ./packages/deployer lint
git diff --check
```

Generated bundle output was also inspected directly to verify:

* internal Mastra dynamic imports remain externalized
* no generated self-import rewrites occur
* no circular TLA chunk dependencies are introduced

## Checklist

* [x] I have linked the related issue(s) in the description above
* [ ] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a bug where custom external package configurations could accidentally bundle Mastra's internal packages into the output, breaking the application. The fix ensures Mastra's core internal packages always stay external (not bundled) while still allowing you to specify your own external packages.

## Overview

Fixes a regression in the deployer bundler where user-provided `bundler.externals` could override Mastra's safe runtime externals, causing internal runtime packages to be bundled into generated chunks. This could rewrite internal dynamic imports (e.g., `await import('`@mastra/core/storage`')`) into self-imports (e.g., `await import('./index.mjs')`), reintroducing an ESM top-level-await deadlock previously fixed in `#14860/`#14863.

## Changes

**New utilities in `packages/deployer/src/build/analyze/constants.ts`:**
- Added `MASTRA_RUNTIME_EXTERNALS` constant to centralize safe runtime externals for Mastra packages
- Added `mergeBundlerExternals()` function to deduplicate and flatten external package lists
- Added `getSafeBundlerExternals()` function to produce the final externals set by combining global externals, optional deprecated externals, Mastra runtime externals, and user-provided externals

**Updated integration points:**
- `bundleExternals.ts`: Now uses `getSafeBundlerExternals()` instead of manual concatenation of constants
- `analyze.ts`: Now uses `getSafeBundlerExternals()` to derive `allExternals` from user-provided externals, replacing prior manual concatenation and filtering logic

**Test coverage in `packages/deployer/src/build/analyze.test.ts`:**
- Added helper `readGeneratedModules` to load and concatenate generated `.mjs` module contents
- New `safe runtime externals` test suite validating:
  - `getSafeBundlerExternals` preserves user externals while ensuring Mastra runtime packages remain externalized and deduplicated
  - `analyzeBundle` marks `@mastra/core` as external even with custom externals, preventing rewritten internal dynamic imports
  - Final bundling output preserves dynamic imports to `@mastra/core/storage` without generating self-imports
  - Mastra subpath dynamic imports in TLA-driven chunks are not rewritten to relative imports

**Changeset:**
- Updated `.changeset/lucky-places-wonder.md` documenting the patch-level fix for the bundler regression

## Key Improvements

- Changed external merging from replacement semantics to additive semantics
- Preserved existing `externals: true` behavior
- Protected Mastra runtime subpath imports (e.g., `@mastra/core/storage`)
- Prevents generated self-imports and circular TLA chunk dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->