### PR TITLE
Fix memory integration Renovate lockfile updates

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -198,7 +198,7 @@ jobs:
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     outputs:
-      changed: ${{ steps.changes.outputs.changed == 'true' || steps.integration-test-manifest.outputs.changed == 'true' }}
+      changed: ${{ steps.changes.outputs.changed }}
     permissions:
       contents: read
     steps:
@@ -218,15 +218,6 @@ jobs:
           packages: '@mastra/memory'
           tasks: 'build,test'
           base-ref: 'origin/main'
-
-      - name: Check for memory integration test manifest changes
-        id: integration-test-manifest
-        run: |
-          if git diff --name-only origin/main...HEAD | grep -qx 'packages/memory/integration-tests/package.json'; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
 
   memory-test:
     name: Memory Tests

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -198,7 +198,7 @@ jobs:
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     outputs:
-      changed: ${{ steps.changes.outputs.changed }}
+      changed: ${{ steps.changes.outputs.changed == 'true' || steps.integration-test-manifest.outputs.changed == 'true' }}
     permissions:
       contents: read
     steps:
@@ -218,6 +218,15 @@ jobs:
           packages: '@mastra/memory'
           tasks: 'build,test'
           base-ref: 'origin/main'
+
+      - name: Check for memory integration test manifest changes
+        id: integration-test-manifest
+        run: |
+          if git diff --name-only origin/main...HEAD | grep -qx 'packages/memory/integration-tests/package.json'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
   memory-test:
     name: Memory Tests

--- a/.github/workflows/sync_renovate-changesets.yml
+++ b/.github/workflows/sync_renovate-changesets.yml
@@ -6,6 +6,7 @@ on:
       - '**/pnpm-lock.yaml'
       - 'examples/**/package.json'
       - 'e2e-tests/**/package.json'
+      - 'packages/**/integration-tests/package.json'
 
 jobs:
   changeset:
@@ -27,13 +28,13 @@ jobs:
           install-dependencies: 'false'
           package-manager-cache: 'false'
 
-      - name: Check for package.json changes in examples and e2e-tests
-        id: check-examples
+      - name: Check for standalone package.json changes
+        id: check-standalone-packages
         run: |
-          if git diff --name-only HEAD^ HEAD | grep -q -E "(examples|e2e-tests)/.*package.json"; then
-            echo "examples_changed=true" >> "$GITHUB_OUTPUT"
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep -q -E "(examples|e2e-tests|integration-tests)/.*package.json"; then
+            echo "standalone_changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "examples_changed=false" >> "$GITHUB_OUTPUT"
+            echo "standalone_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Configure git
@@ -50,7 +51,7 @@ jobs:
           INCLUDE_DEV_DEPS: '1'
 
       - name: Install dependencies
-        if: steps.check-examples.outputs.examples_changed == 'true'
+        if: steps.check-standalone-packages.outputs.standalone_changed == 'true'
         run: bash ./.github/scripts/install-deps.bash ${{ github.event.pull_request.base.sha }}
 
       - name: Approve PR


### PR DESCRIPTION
## Summary
- Run the Renovate sync dependency install step for standalone integration test package manifests.
- Refresh standalone lockfiles by comparing package manifest changes against the PR base SHA.
- Ensure memory integration tests run when their standalone package manifest changes.

## Test plan
- Parsed updated workflow YAML with Ruby YAML loader.
- Parsed renovate.json with Node JSON.parse.
- Verified the standalone package path regex matches packages/memory/integration-tests/package.json and ignores unrelated source files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes the build system so it properly notices when memory integration test files change and automatically updates their dependencies. Previously, the system wasn't checking these specific test files, so changes to them were being ignored.

## Overview

The PR updates two GitHub Actions workflows to ensure that memory integration test package manifest changes are detected and trigger appropriate dependency updates. This involves expanding the change detection logic in the build system to monitor `packages/memory/integration-tests/package.json` and include it in the Renovate dependency refresh pipeline.

## Changes

### `.github/workflows/prebuild.yml`

The "memory-check-changes" job now includes an additional change detection step for the memory integration test manifest file. The workflow:
- Adds a new step that detects changes to `packages/memory/integration-tests/package.json` by comparing the PR branch against `origin/main`
- Sets an `integration-test-manifest.changed` output based on whether this file was modified
- Updates the job's overall `changed` output to be true if either memory source code changes or the integration test manifest changes

### `.github/workflows/sync_renovate-changesets.yml`

The workflow's trigger path filter and change detection logic have been updated to include standalone integration test packages:
- Adds `packages/**/integration-tests/package.json` to the `pull_request.paths` trigger
- Replaces the previous examples/e2e-tests change detection step with a new `check-standalone-packages` step that detects changes to any `(examples|e2e-tests|integration-tests)/.*package.json` files
- Updates the dependency installation step to use the new `standalone_changed` output instead of the previous `examples_changed` output

## Impact

These changes ensure that when the memory integration test package manifest is updated (e.g., by Renovate), the build system properly recognizes these changes and runs the dependency synchronization step to refresh standalone lockfiles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->