### PR TITLE
fix(voice-google-gemini-live): replace hand-rolled Zod converter with zodToJsonSchema

### DIFF
--- a/.changeset/brown-poems-hammer.md
+++ b/.changeset/brown-poems-hammer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-google-gemini-live': patch
+---
+
+Fixed tool parameter schemas for all Zod types by replacing the hand-rolled converter with the canonical zodToJsonSchema from @mastra/schema-compat. Previously, types like z.union, z.discriminatedUnion, z.literal, z.nullable, z.record, z.tuple, and z.default all fell through to an empty object schema, so Gemini Live received no type information and returned empty tool arguments.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6807,6 +6807,9 @@ importers:
       '@google/genai':
         specifier: ^1.45.0
         version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(bufferutil@4.1.0)
+      '@mastra/schema-compat':
+        specifier: workspace:*
+        version: link:../../packages/schema-compat
       google-auth-library:
         specifier: ^10.6.1
         version: 10.6.2
@@ -6853,9 +6856,6 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
-      zod-to-json-schema:
-        specifier: ^3.25.1
-        version: 3.25.1(zod@4.4.3)
 
   voice/inworld:
     dependencies:
@@ -36232,7 +36232,7 @@ snapshots:
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0

--- a/voice/google-gemini-live-api/package.json
+++ b/voice/google-gemini-live-api/package.json
@@ -33,6 +33,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@google/genai": "^1.45.0",
+    "@mastra/schema-compat": "workspace:*",
     "google-auth-library": "^10.6.1",
     "ws": "^8.20.0"
   },
@@ -49,8 +50,7 @@
     "tsx": "^4.21.0",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "zod": "catalog:",
-    "zod-to-json-schema": "^3.25.1"
+    "zod": "catalog:"
   },
   "peerDependencies": {
     "@mastra/core": ">=1.0.0-0 <2.0.0-0"

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { ToolsInput } from '@mastra/core/agent';
 import { MastraVoice } from '@mastra/core/voice';
 import type { VoiceEventType, VoiceConfig } from '@mastra/core/voice';
+import { zodToJsonSchema } from '@mastra/schema-compat/zod-to-json';
 import type { WebSocket as WSType } from 'ws';
 import { WebSocket } from 'ws';
 import { AudioStreamManager, ConnectionManager, ContextManager, AuthManager, EventManager } from './managers';
@@ -2032,103 +2033,12 @@ export class GeminiLiveVoice extends MastraVoice<
     }
   }
 
-  /**
-   * Convert Zod schema to JSON Schema for tool parameters
-   * @private
-   */
   private convertZodSchemaToJsonSchema(schema: any): unknown {
     try {
-      // Try to use the schema's toJSON method if available
-      if (typeof schema.toJSON === 'function') {
-        return schema.toJSON();
-      }
-
-      // Try to use the schema's _def property if available (Zod internal)
-      if (schema._def) {
-        return this.convertZodDefToJsonSchema(schema._def);
-      }
-
-      // If it's already a plain object, return as is
-      if (typeof schema === 'object' && !schema.safeParse) {
-        return schema;
-      }
-
-      // Default fallback
-      return {
-        type: 'object',
-        properties: {},
-        description: schema.description || '',
-      };
+      return zodToJsonSchema(schema);
     } catch (error) {
       this.log('Failed to convert Zod schema to JSON schema', { error, schema });
-      return {
-        type: 'object',
-        properties: {},
-        description: 'Schema conversion failed',
-      };
-    }
-  }
-
-  /**
-   * Convert Zod definition to JSON Schema
-   * @private
-   */
-  private convertZodDefToJsonSchema(def: any): unknown {
-    switch (def.typeName) {
-      case 'ZodString':
-        return {
-          type: 'string',
-          description: def.description || '',
-        };
-      case 'ZodNumber':
-        return {
-          type: 'number',
-          description: def.description || '',
-        };
-      case 'ZodBoolean':
-        return {
-          type: 'boolean',
-          description: def.description || '',
-        };
-      case 'ZodArray':
-        return {
-          type: 'array',
-          items: this.convertZodDefToJsonSchema(def.type._def),
-          description: def.description || '',
-        };
-      case 'ZodObject':
-        const properties: Record<string, unknown> = {};
-        const required: string[] = [];
-
-        for (const [key, value] of Object.entries(def.shape())) {
-          properties[key] = this.convertZodDefToJsonSchema((value as any)._def);
-          if ((value as any)._def.typeName === 'ZodOptional') {
-            // Optional field, don't add to required
-          } else {
-            required.push(key);
-          }
-        }
-
-        return {
-          type: 'object',
-          properties,
-          required: required.length > 0 ? required : undefined,
-          description: def.description || '',
-        };
-      case 'ZodOptional':
-        return this.convertZodDefToJsonSchema(def.innerType._def);
-      case 'ZodEnum':
-        return {
-          type: 'string',
-          enum: def.values,
-          description: def.description || '',
-        };
-      default:
-        return {
-          type: 'object',
-          properties: {},
-          description: def.description || '',
-        };
+      return { type: 'object', properties: {} };
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #17020.

The package shipped a hand-rolled `convertZodSchemaToJsonSchema` / `convertZodDefToJsonSchema` that only handled 7 Zod types (`ZodString`, `ZodNumber`, `ZodBoolean`, `ZodArray`, `ZodObject`, `ZodOptional`, `ZodEnum`). Every other type fell through to `{ type: 'object', properties: {} }`, so tools with `z.union`, `z.discriminatedUnion`, `z.literal`, `z.nullable`, `z.record`, `z.tuple`, `z.date`, `z.default`, or `z.refine` schemas sent no parameter information to Gemini Live, causing the model to return empty tool arguments.

The converter also used the Zod v3-internal `def.typeName` API, which breaks on Zod v4.

## Changes

- Replace `convertZodSchemaToJsonSchema` + `convertZodDefToJsonSchema` (~95 lines) with a single call to `zodToJsonSchema` from `@mastra/schema-compat/zod-to-json` — the same canonical converter used by the rest of the monorepo
- Add `@mastra/schema-compat` as a direct dependency (following the pattern of `@mastra/voice-xai-realtime-api`)
- Remove the unused `zod-to-json-schema` devDependency

## Files Changed

| File | Change |
|------|--------|
| `voice/google-gemini-live-api/src/index.ts` | Deleted hand-rolled converter, added `zodToJsonSchema` import |
| `voice/google-gemini-live-api/package.json` | Added `@mastra/schema-compat` dep, removed dead `zod-to-json-schema` devDep |
| `pnpm-lock.yaml` | Updated lockfile |

## Testing

All 52 existing unit tests pass (`pnpm test` in `voice/google-gemini-live-api`). The hand-rolled converter had no dedicated unit tests; the existing tests exercise `addTools` and tool argument handling end-to-end.

## Related Issues

Closes #17020

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you have a translator that converts instruction manuals from one language to another, but it only knows how to translate a few words. When it encounters words it doesn't know, it just writes "something here" instead. This PR replaces that broken translator with a professional one that knows all the words and translates everything correctly.

## Summary

This PR fixes issue `#17020` by replacing a hand-rolled Zod-to-JSON-Schema converter with the canonical `zodToJsonSchema` from `@mastra/schema-compat`, the standard converter used across the monorepo.

### Problem

The package shipped a custom converter that only handled a small subset of Zod types (ZodString, ZodNumber, ZodBoolean, ZodArray, ZodObject, ZodOptional, ZodEnum). For all other types—including unions, discriminated unions, literals, nullable types, records, tuples, dates, defaults, and effects—it returned generic empty objects (`{ type: 'object', properties: {} }`). This meant Gemini Live received no parameter information at tool-registration time, causing tools to return empty arguments. Additionally, the converter relied on Zod v3 internal APIs that break on Zod v4, and the package declared `zod-to-json-schema` as a dependency but never used it.

### Solution

- Removed ~95 lines of `convertZodSchemaToJsonSchema` / `convertZodDefToJsonSchema` from `voice/google-gemini-live-api/src/index.ts`
- Added import of `zodToJsonSchema` from `@mastra/schema-compat/zod-to-json`
- Added `@mastra/schema-compat` as a direct dependency in `voice/google-gemini-live-api/package.json`
- Removed unused `zod-to-json-schema` devDependency
- Updated `pnpm-lock.yaml`

### Impact

The canonical converter provides full Zod surface coverage, including all complex constructs that previously produced empty schemas. This ensures Gemini Live receives proper type information and tools return meaningful arguments. The change also aligns the package with monorepo standards and eliminates the need for a dead dependency.

### Testing

All 52 existing unit tests in `voice/google-gemini-live-api` pass. Existing tests exercise `addTools` and tool argument handling end-to-end, validating the new converter's behavior through integration testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->