### PR TITLE
Exclude AI profiles from issue-link enforcement

### DIFF
--- a/scripts/pr-issue-link/index.ts
+++ b/scripts/pr-issue-link/index.ts
@@ -10,6 +10,7 @@ const STALE_DAYS = Number(process.env.STALE_DAYS ?? '14');
 
 const NEEDS_ISSUE_LABEL = 'needs-issue';
 const NEEDS_ISSUE_LABEL_COLOR = 'e4e669';
+const ISSUE_LINK_EXCLUDED_LOGINS = new Set(['dane-ai-mastra', 'devin-ai-integration']);
 
 const octokit = new Octokit({ auth: GITHUB_TOKEN });
 const coreContributorCache = new Map<string, Promise<boolean>>();
@@ -53,6 +54,14 @@ async function nudge(prNumber: number) {
   const { data: pr } = await octokit.rest.pulls.get({ owner: OWNER, repo: REPO, pull_number: prNumber });
   const author = pr.user?.login;
 
+  if (isIssueLinkExcluded(author)) {
+    console.log(`Skipping #${prNumber}: ${author} is excluded from linked issue enforcement`);
+    await removeLabelIfPresent(prNumber, NEEDS_ISSUE_LABEL);
+    setOutput('needs_issue', 'false');
+    setOutput('summary', buildIssueLinkExcludedSummary(author));
+    return;
+  }
+
   if (await isCoreContributor(author)) {
     console.log(`Skipping #${prNumber}: ${author} is a core contributor`);
     await removeLabelIfPresent(prNumber, NEEDS_ISSUE_LABEL);
@@ -89,6 +98,12 @@ async function closeStale() {
 
   for (const pr of prs) {
     const author = pr.user?.login;
+
+    if (isIssueLinkExcluded(author)) {
+      console.log(`Skipping #${pr.number}: ${author} is excluded from linked issue enforcement`);
+      await removeLabelIfPresent(pr.number, NEEDS_ISSUE_LABEL);
+      continue;
+    }
 
     if (await isCoreContributor(author)) {
       console.log(`Skipping #${pr.number}: ${author} is a core contributor`);
@@ -261,6 +276,12 @@ function buildCoreContributorSummary(author: string | undefined) {
 Linked issue check skipped${author ? ` for core contributor @${author}` : ''}.`;
 }
 
+function buildIssueLinkExcludedSummary(author: string | undefined) {
+  return `## PR triage
+
+Linked issue check skipped${author ? ` for excluded profile @${author}` : ''}.`;
+}
+
 function setOutput(name: string, value: string) {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (!outputPath) {
@@ -275,6 +296,10 @@ function setOutput(name: string, value: string) {
   }
 
   appendFileSync(outputPath, `${name}=${value}\n`);
+}
+
+function isIssueLinkExcluded(login: string | undefined) {
+  return login ? ISSUE_LINK_EXCLUDED_LOGINS.has(login.toLowerCase()) : false;
 }
 
 async function isCoreContributor(login: string | undefined) {


### PR DESCRIPTION
## Summary
- Skip linked issue enforcement for configured automation profiles.
- Remove the needs-issue label from excluded profiles in both nudge and stale-close modes.
- Return a skipped PR triage summary for excluded profiles instead of requesting an issue.

## Test plan
- Ran `pnpm --dir scripts/pr-issue-link exec tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --types node index.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR allows certain bot accounts (like CI/automation profiles) to skip the requirement of linking their pull requests to GitHub issues. Instead of asking these bots to add issue links, the system will just acknowledge that they're excluded and move on.

## Overview

Adds support for exempting specific GitHub logins from "linked issue" label enforcement in the PR triage automation script.

## Changes

- **Introduced configuration**: Added `ISSUE_LINK_EXCLUDED_LOGINS` set to define which GitHub profiles should bypass issue-link requirements
- **Helper functions**: 
  - `isIssueLinkExcluded()`: Checks if a given login is in the excluded list
  - `buildIssueLinkExcludedSummary()`: Generates an appropriate message when an excluded profile is detected
- **Nudge mode**: Now skips label enforcement for excluded profiles, sets `needs_issue` to `false`, and returns an exclusion-specific summary instead of requesting an issue
- **Stale-close mode**: Skips processing PRs from excluded authors to prevent stale-label closure

## Testing

Verified TypeScript compilation with `pnpm --dir scripts/pr-issue-link exec tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --types node index.ts`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->