### PR TITLE
fix(core): add updateThread as abstract method on MastraMemory base class

### DIFF
--- a/.changeset/memory-update-thread-api.md
+++ b/.changeset/memory-update-thread-api.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add `updateThread` as an abstract method on the `MastraMemory` base class and implement it in `MockMemory`. Previously the method existed only on the concrete `Memory` subclass, so calling `updateThread` on a variable typed as `MastraMemory` (or any other `MastraMemory` subclass) produced a TypeScript error. Callers can now rename or re-title threads through the base class API without casting.

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -525,6 +525,26 @@ https://mastra.ai/en/docs/memory/overview`,
   }
 
   /**
+   * Helper method to update an existing thread
+   * @param id - The thread ID to update
+   * @param title - The new title for the thread
+   * @param metadata - The new metadata for the thread
+   * @param memoryConfig - Optional memory config
+   * @returns Promise resolving to the updated thread
+   */
+  abstract updateThread({
+    id,
+    title,
+    metadata,
+    memoryConfig,
+  }: {
+    id: string;
+    title: string;
+    metadata: Record<string, unknown>;
+    memoryConfig?: MemoryConfigInternal;
+  }): Promise<StorageThreadType>;
+
+  /**
    * Helper method to delete a thread
    * @param threadId - the id of the thread to delete
    */

--- a/packages/core/src/memory/mock.ts
+++ b/packages/core/src/memory/mock.ts
@@ -180,6 +180,20 @@ export class MockMemory extends MastraMemory {
     };
   }
 
+  async updateThread({
+    id,
+    title,
+    metadata,
+  }: {
+    id: string;
+    title: string;
+    metadata: Record<string, unknown>;
+    memoryConfig?: MemoryConfigInternal;
+  }): Promise<StorageThreadType> {
+    const memoryStorage = await this.getMemoryStore();
+    return memoryStorage.updateThread({ id, title, metadata });
+  }
+
   async deleteThread(threadId: string) {
     const memoryStorage = await this.getMemoryStore();
     return memoryStorage.deleteThread({ threadId });


### PR DESCRIPTION
## Summary

Fixes #17076.

`MastraMemory` exposed `createThread`, `deleteThread`, and `listThreads` on its public API but omitted `updateThread`, forcing callers to reach through the internal storage adapter (`memory.storage.stores.memory.updateThread`) to rename or re-title a thread. This breaks encapsulation and is brittle against future storage routing changes.

## Changes

- Add `updateThread` as an `abstract` method on `MastraMemory` with the same signature already used by the concrete `Memory` subclass
- Implement `updateThread` on `MockMemory` by delegating to `getMemoryStore().updateThread`

## Files Changed

| File | Change |
|------|--------|
| `packages/core/src/memory/memory.ts` | Added `abstract updateThread(...)` declaration |
| `packages/core/src/memory/mock.ts` | Added `MockMemory.updateThread` implementation |

## Testing

All existing core unit tests pass (8571 passed, 110 skipped). No new tests added — the method delegates directly to the storage layer which is already covered.

## Related Issues

Closes #17076

🤖 Generated with [Claude Code](https://claude.com/claude-code)