### PR TITLE
fix(react): prevent first assistant message disappearing on new threads

### DIFF
--- a/.changeset/fix-new-thread-message-flicker.md
+++ b/.changeset/fix-new-thread-message-flicker.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Fix a race condition in the `useChat` hook where the first assistant message on a new thread would flash and then disappear. When a stream finishes, `refreshThreadList` triggers navigation to the persisted thread URL. The `useAgentMessages` query immediately fetches and can receive an empty result if the backend hasn't finished persisting messages yet. The resulting empty `initialMessages` prop caused `setMessages([])` to overwrite streamed messages that were still visible. The hook now skips the reset when `initialMessages` resolves to an empty list but there are already messages in local state — thread switches are unaffected because they remount the component via a `key` prop change.

--- a/.changeset/fix-new-thread-message-flicker.md
+++ b/.changeset/fix-new-thread-message-flicker.md
@@ -2,4 +2,4 @@
 '@mastra/react': patch
 ---
 
-Fix a race condition in the `useChat` hook where the first assistant message on a new thread would flash and then disappear. When a stream finishes, `refreshThreadList` triggers navigation to the persisted thread URL. The `useAgentMessages` query immediately fetches and can receive an empty result if the backend hasn't finished persisting messages yet. The resulting empty `initialMessages` prop caused `setMessages([])` to overwrite streamed messages that were still visible. The hook now skips the reset when `initialMessages` resolves to an empty list but there are already messages in local state — thread switches are unaffected because they remount the component via a `key` prop change.
+Fixes a bug where the assistant's first message could briefly flash and disappear when starting a new thread.

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -140,8 +140,16 @@ export const useChat = ({
 
   useEffect(() => {
     const formattedMessages = resolveInitialMessages(initialMessages || []);
-    setMessages(formattedMessages);
-    _currentRunId.current = extractRunIdFromMessages(formattedMessages);
+    // Guard against a race condition on new threads: the finish event can fire before
+    // the backend has persisted messages, so the first fetch may return an empty list.
+    // Thread switches are handled by key-based remounting which resets state to [],
+    // so prev.length > 0 here only means we have streamed messages worth keeping.
+    if (formattedMessages.length === 0) {
+      setMessages(prev => (prev.length > 0 ? prev : formattedMessages));
+    } else {
+      setMessages(formattedMessages);
+      _currentRunId.current = extractRunIdFromMessages(formattedMessages);
+    }
   }, [initialMessages]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #16650.

When a user sends the first message on a new thread, the assistant response would appear briefly then vanish. The root cause: on new threads the `finish` event fires before the backend has persisted the messages, so the first `initialMessages` fetch returns an empty array. The `useEffect` that syncs `initialMessages` was unconditionally calling `setMessages([])`, wiping out the streamed messages already in state.

## Root Cause

```ts
// Before — always overwrites, even with an empty fetch result
useEffect(() => {
  const formattedMessages = resolveInitialMessages(initialMessages || []);
  setMessages(formattedMessages);           // ← wipes streamed messages
  _currentRunId.current = extractRunIdFromMessages(formattedMessages);
}, [initialMessages]);
```

## Fix

Only overwrite state when the incoming list is non-empty. When it's empty, preserve any messages already in state (streamed messages from the current run). Thread switches are handled by key-based remounting which resets state to `[]` before this effect runs, so `prev.length > 0` only ever catches the race condition case.

```ts
// After
if (formattedMessages.length === 0) {
  setMessages(prev => (prev.length > 0 ? prev : formattedMessages));
} else {
  setMessages(formattedMessages);
  _currentRunId.current = extractRunIdFromMessages(formattedMessages);
}
```

## Files Changed

| File | Change |
|------|--------|
| `client-sdks/react/src/agent/hooks.ts` | Guard `setMessages` against empty fetch overwriting streamed messages |

## Testing

Manually reproducible by opening a new thread and sending a message that triggers tool use. The first assistant response now persists. All existing tests pass.

## Related Issues

Closes #16650

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation
When you start a new chat and the assistant replies, that first reply sometimes briefly appears and then disappears because the app was overwriting local messages with an empty server response; this PR stops the app from erasing already-shown messages when the server returns nothing yet.

## Problem
On new chat threads the first assistant response would flash and then vanish because:
- After a run completes the backend might not have persisted messages immediately.
- The `useChat` hook fetched `initialMessages`, which could be an empty array.
- An unconditional `setMessages([])` call erased streamed messages already in local state.
- This race only affected the initial assistant response on new threads.

## Solution
Change in client-sdks/react/src/agent/hooks.ts:
- Guard against overwriting local state when `resolveInitialMessages(initialMessages)` yields an empty list.
- If `formattedMessages.length === 0`, call `setMessages(prev => (prev.length > 0 ? prev : formattedMessages))` so existing streamed messages are preserved.
- If `formattedMessages` is non-empty, set messages to the fetched list and update the current run id as before.
- This prevents the empty initial fetch from wiping the UI’s streamed assistant message.

## Testing & Verification
- Manual reproduction (open new thread + trigger tool use) confirmed the first assistant response no longer disappears.
- All existing tests pass.
- Added a changeset entry for `@mastra/react` documenting the patch.

Closes `#16650`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->