### PR TITLE
fix(playground-ui): raise ContextMenu z-index above app chrome

### DIFF
--- a/.changeset/playground-ui-context-menu-z-index.md
+++ b/.changeset/playground-ui-context-menu-z-index.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+`ContextMenu` Positioner and popup raised from `z-50` to `z-1000` with `isolate`, so the menu sits above app chrome that uses higher stacking contexts (e.g. sticky headers with `z-500`). Previously the menu would render behind such elements when opened on triggers near them.

--- a/packages/playground-ui/src/ds/components/ContextMenu/context-menu.tsx
+++ b/packages/playground-ui/src/ds/components/ContextMenu/context-menu.tsx
@@ -15,7 +15,7 @@ const itemClass = cn(
 );
 
 const popupClass = cn(
-  'bg-surface3 text-neutral4 z-50 min-w-44 max-h-[min(20rem,var(--available-height))] overflow-x-hidden overflow-y-auto rounded-xl border border-border1 p-1 shadow-dialog origin-[var(--transform-origin)] outline-none',
+  'bg-surface3 text-neutral4 z-1000 min-w-44 max-h-[min(20rem,var(--available-height))] overflow-x-hidden overflow-y-auto rounded-xl border border-border1 p-1 shadow-dialog origin-[var(--transform-origin)] outline-none',
   'data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95',
   'data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1',
 );
@@ -35,7 +35,7 @@ const ContextMenuContent = React.forwardRef<HTMLDivElement, ContextMenuContentPr
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
-        className="z-50 outline-none"
+        className="isolate z-1000 outline-none"
       >
         <ContextMenuPrimitive.Popup
           ref={ref}
@@ -181,7 +181,7 @@ const ContextMenuSubContent = React.forwardRef<HTMLDivElement, ContextMenuSubCon
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
-        className="z-50 outline-none"
+        className="isolate z-1000 outline-none"
       >
         <ContextMenuPrimitive.Popup
           ref={ref}


### PR DESCRIPTION
## Summary

`ContextMenu` (Positioner Content + SubContent + popup class) was hardcoded at `z-50`, which is below the stacking contexts used by many app shells. Sticky headers commonly sit at `z-500`+ — when the menu trigger lived inside or near one, the popup rendered behind it.

Raises the three sites to `z-1000` and adds `isolate` on the Positioner so the portal anchors a fresh stacking context, matching the pattern `Tooltip` already uses (`isolate z-[100]`). One step higher than Tooltip because right-click menus should sit above tooltips when both are visible.

## Why this came up

Hit in `mastra-website` consuming `@mastra/playground-ui@30.0.0` — the site header is `z-500` (`src/app/_components/header.css`), so a logo-anchored ContextMenu rendered underneath it.

## Scope

Only `ContextMenu` is patched here. The other overlay primitives — `DropdownMenu`, `Popover`, `Dialog`, `Drawer` — are all still on `z-50` and likely have the same latent bug in any consumer with elevated chrome. Out of scope for this patch; happy to follow up with a sweep + a token (`--z-overlay`) if the maintainers want that direction.

## Test plan

- [ ] `pnpm --filter @mastra/playground-ui build` succeeds
- [ ] In a consumer app, place a `ContextMenu.Trigger` inside an element with a stacking context above 50; confirm the menu sits on top after the bump
- [ ] No visual regression in existing playground-ui consumers (Cloud Studio): ContextMenu still renders normally where it used to

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you have a menu that pops up when you right-click, but it was getting hidden behind other elements on the page (like sticky headers). This PR fixes that by making sure the menu always appears on top by giving it a higher "layer number" (z-index), similar to how tooltips already work.

## Changes

The PR addresses a z-index layering issue in the playground-ui ContextMenu component:

**Modified Files:**
- `.changeset/playground-ui-context-menu-z-index.md` - Changeset documentation for the fix
- `packages/playground-ui/src/ds/components/ContextMenu/context-menu.tsx` - Component implementation

**Technical Changes:**
- Raised the z-index for ContextMenu elements (Positioner, Content, SubContent, and popup class) from `z-50` to `z-1000`
- Added the `isolate` CSS class to the Positioner to establish a fresh stacking context
- Follows the existing Tooltip pattern which uses `isolate z-[100]` but at a higher z-index so context menus sit above tooltips

**Scope:**
The changes are limited to ContextMenu. Other overlay primitives (DropdownMenu, Popover, Dialog, Drawer) remain at `z-50` and are not modified.

**Rationale:**
The ContextMenu was rendering behind app chrome elements (such as sticky headers positioned at z-500+), making it unusable in certain scenarios. The higher z-index value ensures the context menu always appears above these high-stacking UI elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->