### PR TITLE
feat: add harness heartbeat handlers

### DIFF
--- a/.changeset/harness-v1-heartbeat-handlers.md
+++ b/.changeset/harness-v1-heartbeat-handlers.md
@@ -1,0 +1,26 @@
+---
+'@mastra/core': minor
+---
+
+Added heartbeat handler support to Harness v1, so background tasks can run on intervals and stop automatically with the harness lifecycle. Configured handlers start when `harness.init()` runs, duplicate configured ids are rejected, and registering a runtime handler with an existing `id` replaces the previous handler.
+
+**Example:**
+
+```typescript
+const harness = new Harness({
+  // ...existing Harness v1 config
+  heartbeatHandlers: [
+    {
+      id: 'sync-gateway',
+      intervalMs: 30_000,
+      handler: async () => {
+        await syncGatewayState();
+      },
+      immediate: true,
+      shutdown: async () => {
+        await closeGatewaySync();
+      },
+    },
+  ],
+});
+```

--- a/.changeset/mastracode-harness-heartbeats.md
+++ b/.changeset/mastracode-harness-heartbeats.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved heartbeat handler reliability in MastraCode. Handlers now start when the harness initializes and clean up on shutdown. Registering a heartbeat id that already exists now replaces the previous handler and runs its shutdown callback.

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -5,7 +5,9 @@ const gatewayRegistryGetProviders = vi.fn(() => ({}));
 const gatewayRegistryGetInstance = vi.fn(() => ({
   syncGateways: gatewayRegistrySyncGateways,
   getProviders: gatewayRegistryGetProviders,
+  getLastRefreshTime: vi.fn(() => undefined),
 }));
+const syncGatewaysMock = vi.fn();
 
 vi.mock('@mastra/core/llm', () => ({
   GatewayRegistry: {
@@ -256,8 +258,8 @@ vi.mock('./tui/theme.js', () => ({
   mastra: {},
 }));
 
-vi.mock('./utils/gateway-sync.js', () => ({
-  syncGateways: vi.fn(),
+vi.mock('../utils/gateway-sync.js', () => ({
+  syncGateways: syncGatewaysMock,
 }));
 
 vi.mock('./utils/project.js', () => ({
@@ -314,9 +316,11 @@ describe('createMastraCode', () => {
     loadSettingsMock.mockReturnValue(createMockSettings());
     agentConstructorMock.mockReset();
     harnessConstructorMock.mockReset();
+    syncGatewaysMock.mockReset();
     gatewayRegistryGetInstance.mockImplementation(() => ({
       syncGateways: gatewayRegistrySyncGateways,
       getProviders: gatewayRegistryGetProviders,
+      getLastRefreshTime: vi.fn(() => undefined),
     }));
   });
 
@@ -349,6 +353,47 @@ describe('createMastraCode', () => {
     await createMastraCode();
 
     expect(getDynamicMemoryMock).toHaveBeenCalled();
+  });
+
+  it('passes the default gateway sync heartbeat handler into the MastraCode runtime', async () => {
+    const { createMastraCode } = await import('../index.js');
+
+    await createMastraCode();
+
+    const harnessConfig = harnessConstructorMock.mock.calls[0]?.[0] as
+      | { heartbeatHandlers?: Array<{ id?: string; intervalMs?: number; handler?: unknown }> }
+      | undefined;
+    expect(harnessConfig?.heartbeatHandlers).toHaveLength(1);
+    expect(harnessConfig?.heartbeatHandlers?.[0]).toMatchObject({
+      id: 'gateway-sync',
+      intervalMs: 5 * 60 * 1000,
+    });
+    expect(typeof harnessConfig?.heartbeatHandlers?.[0]?.handler).toBe('function');
+  });
+
+  it('wires the default gateway sync heartbeat to syncGateways', async () => {
+    const { createMastraCode } = await import('../index.js');
+
+    await createMastraCode();
+
+    const harnessConfig = harnessConstructorMock.mock.calls[0]?.[0] as
+      | { heartbeatHandlers?: Array<{ handler?: () => unknown }> }
+      | undefined;
+    await harnessConfig?.heartbeatHandlers?.[0]?.handler?.();
+
+    expect(syncGatewaysMock).toHaveBeenCalledOnce();
+  });
+
+  it('passes configured heartbeat handlers into the MastraCode runtime', async () => {
+    const customHeartbeat = { id: 'custom-heartbeat', intervalMs: 1_000, handler: vi.fn() };
+    const { createMastraCode } = await import('../index.js');
+
+    await createMastraCode({ heartbeatHandlers: [customHeartbeat] });
+
+    const harnessConfig = harnessConstructorMock.mock.calls[0]?.[0] as
+      | { heartbeatHandlers?: Array<typeof customHeartbeat> }
+      | undefined;
+    expect(harnessConfig?.heartbeatHandlers).toEqual([customHeartbeat]);
   });
 
   it('does not attach the local storage observability exporter when local tracing is disabled', async () => {

--- a/mastracode/src/harness/config.ts
+++ b/mastracode/src/harness/config.ts
@@ -58,6 +58,7 @@ export interface MastraCodeRuntimeConfig<TState extends Record<string, unknown>>
   initialState: TState;
   workspace?: (ctx: { requestContext: RequestContext; mastra?: Mastra }) => Workspace | Promise<Workspace>;
   toolCategoryResolver?: (toolName: string) => any;
+  /** Configured handlers are started by Harness v1 during init, not runtime construction. */
   heartbeatHandlers?: HeartbeatHandler[];
   modelAuthChecker?: ModelAuthChecker;
   modelUseCountProvider?: ModelUseCountProvider;

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -215,7 +215,10 @@ describe('MastraCodeHarnessRuntime', () => {
       expect(session).toBeDefined();
       vi.spyOn(session!, '_internalAwaitFlushChain').mockRejectedValueOnce(failure);
 
-      await expect(runtime.destroy()).rejects.toBe(failure);
+      await expect(runtime.destroy()).rejects.toMatchObject({
+        name: 'HarnessStorageError',
+        cause: failure,
+      });
 
       expect(runtime.getWorkspace()).toBeUndefined();
       expect(listener).toHaveBeenCalledWith({ type: 'workspace_status_changed', status: 'destroying' });

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -24,6 +24,7 @@ function createRuntime(
     disabledTools?: string[];
     workspace?: ConstructorParameters<typeof MastraCodeHarnessRuntime>[0]['workspace'];
     memory?: any;
+    heartbeatHandlers?: ConstructorParameters<typeof MastraCodeHarnessRuntime>[0]['heartbeatHandlers'];
   } = {},
 ) {
   const agent = new Agent({
@@ -65,6 +66,7 @@ function createRuntime(
     memory: options.memory,
     browser: options.browser as never,
     disabledTools: options.disabledTools,
+    heartbeatHandlers: options.heartbeatHandlers,
     workspace: options.workspace,
   });
 }
@@ -80,6 +82,88 @@ describe('MastraCodeHarnessRuntime', () => {
     expect(runtime.getMastra().getHarness(MASTRACODE_HARNESS_NAME)).toBe(runtime.core);
   });
 
+  it('passes heartbeat handlers into Harness v1 instead of starting runtime-owned timers', async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn();
+    const shutdown = vi.fn();
+    const runtime = createRuntime({
+      heartbeatHandlers: [{ id: 'custom-sync', intervalMs: 1_000, handler, shutdown }],
+    });
+
+    try {
+      expect(handler).not.toHaveBeenCalled();
+
+      await runtime.initCore();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(handler).toHaveBeenCalledTimes(2);
+
+      await runtime.stopHeartbeats();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(shutdown).toHaveBeenCalledTimes(1);
+    } finally {
+      await runtime.destroy();
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops heartbeat handlers when destroyed without an explicit stopHeartbeats call', async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn();
+    const shutdown = vi.fn();
+    const runtime = createRuntime({
+      heartbeatHandlers: [{ id: 'custom-sync', intervalMs: 1_000, handler, shutdown }],
+    });
+
+    try {
+      await runtime.initCore();
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      await runtime.destroy();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(shutdown).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('delegates direct heartbeat registration and removal to Harness v1', async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn();
+    const shutdown = vi.fn();
+    const runtime = createRuntime();
+
+    try {
+      await runtime.initCore();
+      runtime.registerHeartbeat({ id: 'direct-sync', intervalMs: 1_000, handler, shutdown });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      await runtime.removeHeartbeat({ id: 'direct-sync' });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(shutdown).toHaveBeenCalledTimes(1);
+    } finally {
+      await runtime.destroy();
+      vi.useRealTimers();
+    }
+  });
+
+  it('lets Harness v1 own workspace teardown during destroy', async () => {
+    const runtime = createRuntime();
+    const destroyWorkspace = vi.spyOn(runtime, 'destroyWorkspace');
+
+    await runtime.destroy();
+
+    expect(destroyWorkspace).not.toHaveBeenCalled();
+  });
+
   it('provides initial runtime state when Harness v1 initializes the shared workspace', async () => {
     const projectPath = mkdtempSync(join(tmpdir(), 'mastracode-workspace-context-'));
     let observedProjectPath: string | undefined;
@@ -93,11 +177,49 @@ describe('MastraCodeHarnessRuntime', () => {
         return getDynamicWorkspace({ requestContext, mastra });
       },
     });
+    const listener = vi.fn();
+    runtime.subscribe(listener);
 
     try {
       await runtime.init();
       expect(observedProjectPath).toBe(projectPath);
       expect(runtime.getWorkspace()).toBeTruthy();
+      await runtime.destroy();
+
+      expect(runtime.getWorkspace()).toBeUndefined();
+      expect(listener).toHaveBeenCalledWith({ type: 'workspace_status_changed', status: 'destroying' });
+      expect(listener).toHaveBeenCalledWith({ type: 'workspace_status_changed', status: 'destroyed' });
+    } finally {
+      await runtime.destroy();
+      rmSync(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('emits workspace destroyed when destroy surfaces a shutdown error after teardown', async () => {
+    const projectPath = mkdtempSync(join(tmpdir(), 'mastracode-workspace-destroy-error-'));
+    const runtime = createRuntime({
+      projectPath,
+      workspace: ({ requestContext, mastra }) => getDynamicWorkspace({ requestContext, mastra }),
+    });
+    const listener = vi.fn();
+    runtime.subscribe(listener);
+
+    try {
+      await runtime.init();
+      expect(runtime.getWorkspace()).toBeTruthy();
+
+      const failure = new Error('flush failed');
+      const session = (runtime as any).session as
+        | { id: string; _internalAwaitFlushChain: () => Promise<void> }
+        | undefined;
+      expect(session).toBeDefined();
+      vi.spyOn(session!, '_internalAwaitFlushChain').mockRejectedValueOnce(failure);
+
+      await expect(runtime.destroy()).rejects.toBe(failure);
+
+      expect(runtime.getWorkspace()).toBeUndefined();
+      expect(listener).toHaveBeenCalledWith({ type: 'workspace_status_changed', status: 'destroying' });
+      expect(listener).toHaveBeenCalledWith({ type: 'workspace_status_changed', status: 'destroyed' });
     } finally {
       await runtime.destroy();
       rmSync(projectPath, { recursive: true, force: true });
@@ -282,10 +404,15 @@ describe('MastraCodeHarnessRuntime', () => {
     expect(signal).toHaveBeenCalledWith({
       content: 'hello',
       signalId: expect.stringMatching(/^signal-/),
+      prepareStep: expect.any(Function),
       ifActive: { attributes: { delivery: 'while-active' } },
       ifIdle: { attributes: { delivery: 'message' } },
     });
-    expect(signal).toHaveBeenCalledWith({ content: imageParts, signalId: expect.stringMatching(/^signal-/) });
+    expect(signal).toHaveBeenCalledWith({
+      content: imageParts,
+      signalId: expect.stringMatching(/^signal-/),
+      prepareStep: expect.any(Function),
+    });
     expect(injectSystemReminder).toHaveBeenCalledWith('continue', {
       attributes: { type: 'goal' },
       metadata: undefined,
@@ -575,7 +702,10 @@ describe('MastraCodeHarnessRuntime', () => {
     expect(setPolicy).toHaveBeenCalledWith({ toolName: 'task_complete', policy: 'allow' });
     expect(setPolicy).toHaveBeenCalledWith({ toolName: 'task_check', policy: 'allow' });
     expect(setPolicy).toHaveBeenCalledWith({ toolName: 'execute_command', policy: 'ask' });
-    expect((runtime as any).filterActiveTools(['task_write', 'execute_command'])).toEqual(['task_write', 'execute_command']);
+    expect((runtime as any).filterActiveTools(['task_write', 'execute_command'])).toEqual([
+      'task_write',
+      'execute_command',
+    ]);
 
     await runtime.destroy();
   });
@@ -1186,9 +1316,7 @@ describe('MastraCodeHarnessRuntime — stale session lease recovery (MASTRA-4344
 
   it('propagates non-locked errors from session() without retrying', async () => {
     const runtime = createRuntime();
-    const sessionSpy = vi
-      .spyOn(runtime.core, 'session')
-      .mockRejectedValueOnce(new Error('storage offline'));
+    const sessionSpy = vi.spyOn(runtime.core, 'session').mockRejectedValueOnce(new Error('storage offline'));
 
     await expect(runtime.init()).rejects.toThrow('storage offline');
     expect(sessionSpy).toHaveBeenCalledTimes(1);
@@ -1242,9 +1370,7 @@ describe('MastraCodeHarnessRuntime — stale session lease recovery (MASTRA-4344
         ttlMs: 120_000,
       });
 
-      const reboundPromise = secondRuntime
-        .selectOrCreateThread({ leaseRecoveryMode: 'midsession' })
-        .catch(err => err);
+      const reboundPromise = secondRuntime.selectOrCreateThread({ leaseRecoveryMode: 'midsession' }).catch(err => err);
       await vi.advanceTimersByTimeAsync(3_000);
       const err = await reboundPromise;
 

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -50,11 +50,7 @@ import {
   toHarnessV1Subagents,
   toModelInfo,
 } from './config.js';
-import type {
-  LeaseRecoveryAction,
-  MastraCodeModelInfo,
-  MastraCodeRuntimeConfig,
-} from './config.js';
+import type { LeaseRecoveryAction, MastraCodeModelInfo, MastraCodeRuntimeConfig } from './config.js';
 import { MastraCodeHarnessEventProjector } from './events.js';
 import { emptyOMProgress, getOMModelState } from './observational-memory.js';
 
@@ -108,9 +104,7 @@ function formatRetryDelay(ms: number): string {
 
 function sessionLeaseRetryDelayMs(error: HarnessSessionLockedError): number {
   const expiresInMs =
-    Number.isFinite(error.expiresAt) && error.expiresAt > 0
-      ? error.expiresAt - Date.now()
-      : SESSION_LEASE_RETRY_MAX_MS;
+    Number.isFinite(error.expiresAt) && error.expiresAt > 0 ? error.expiresAt - Date.now() : SESSION_LEASE_RETRY_MAX_MS;
   return Math.min(
     SESSION_LEASE_RETRY_MAX_MS,
     Math.max(SESSION_LEASE_RETRY_MIN_MS, Math.ceil(expiresInMs + SESSION_LEASE_RETRY_GRACE_MS)),
@@ -127,8 +121,7 @@ export class MastraCodeSessionLeaseRecoveryError extends Error {
     public readonly expiresAt: number,
     options?: { cause?: unknown },
   ) {
-    const expiresIso =
-      Number.isFinite(expiresAt) && expiresAt > 0 ? new Date(expiresAt).toISOString() : 'unknown';
+    const expiresIso = Number.isFinite(expiresAt) && expiresAt > 0 ? new Date(expiresAt).toISOString() : 'unknown';
     super(
       `MastraCode could not reopen thread "${threadId}" because its Harness v1 session "${sessionId}" is still locked by another process (owner "${currentOwnerId}", lease expires at ${expiresIso}). Another MastraCode instance may still be running. Quit the other instance or retry after the lease expires.`,
       options,
@@ -332,11 +325,6 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
   private readonly listeners = new Set<HarnessEventListener>();
   private readonly projector: MastraCodeHarnessEventProjector;
   private sessionEventUnsubscribe?: HarnessV1EventUnsubscribe;
-  private readonly heartbeatTimers = new Map<string, ReturnType<typeof setInterval>>();
-  private readonly heartbeatHandlers = new Map<
-    string,
-    NonNullable<MastraCodeRuntimeConfig<TState>['heartbeatHandlers']>[number]
-  >();
   private currentWorkspace: Awaited<ReturnType<Session['getWorkspace']>> | undefined;
   private followUpCount = 0;
   private currentRunId: string | null = null;
@@ -399,6 +387,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       toolCategoryResolver: config.toolCategoryResolver,
       models: [],
       modelAuthStatusResolver: modelId => this.resolveHarnessV1AuthStatus(modelId),
+      heartbeatHandlers: config.heartbeatHandlers,
       workspace: workspaceFactory
         ? {
             kind: 'shared' as const,
@@ -432,10 +421,6 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
         return thread ? toLegacyThread(thread) : undefined;
       },
     );
-
-    for (const handler of config.heartbeatHandlers ?? []) {
-      this.registerHeartbeat(handler);
-    }
   }
 
   getMastra(): Mastra {
@@ -707,9 +692,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     }
   }
 
-  async selectOrCreateThread(
-    options: { leaseRecoveryMode?: LeaseRecoveryMode } = {},
-  ): Promise<HarnessThread> {
+  async selectOrCreateThread(options: { leaseRecoveryMode?: LeaseRecoveryMode } = {}): Promise<HarnessThread> {
     const existing = await this.core.threads.list({
       resourceId: this.resourceId,
       perPage: false,
@@ -1151,6 +1134,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
         session.signal({
           content: signalContents(input) as never,
           signalId: handle.id,
+          prepareStep: this.prepareActiveToolsStep,
           ...('content' in input && input.ifActive ? { ifActive: input.ifActive } : {}),
           ...('content' in input && input.ifIdle ? { ifIdle: input.ifIdle } : {}),
         } as never),
@@ -1573,6 +1557,10 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     return this.currentWorkspace;
   }
 
+  /**
+   * Manually destroy the cached workspace without shutting down the Harness.
+   * `destroy()` lets Harness v1 own normal workspace teardown.
+   */
   async destroyWorkspace(): Promise<void> {
     const workspace = this.currentWorkspace as { destroy?: () => Promise<void> | void } | undefined;
     if (!workspace?.destroy) {
@@ -1660,35 +1648,33 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
   }
 
   registerHeartbeat(handler: NonNullable<MastraCodeRuntimeConfig<TState>['heartbeatHandlers']>[number]): void {
-    if (this.heartbeatTimers.has(handler.id)) return;
-    this.heartbeatHandlers.set(handler.id, handler);
-    const run = () => {
-      void Promise.resolve(handler.handler()).catch(error => console.error(`Heartbeat ${handler.id} failed`, error));
-    };
-    if (handler.immediate !== false) run();
-    this.heartbeatTimers.set(handler.id, setInterval(run, handler.intervalMs));
+    this.core.registerHeartbeat(handler);
   }
 
   async removeHeartbeat({ id }: { id: string }): Promise<void> {
-    const timer = this.heartbeatTimers.get(id);
-    if (timer) clearInterval(timer);
-    this.heartbeatTimers.delete(id);
-    const handler = this.heartbeatHandlers.get(id);
-    this.heartbeatHandlers.delete(id);
-    await Promise.resolve(handler?.shutdown?.());
+    await this.core.removeHeartbeat({ id });
   }
 
   async stopHeartbeats(): Promise<void> {
-    await Promise.all([...this.heartbeatHandlers.keys()].map(id => this.removeHeartbeat({ id })));
+    await this.core.stopHeartbeats();
   }
 
   async destroy(): Promise<void> {
-    this.harnessEventUnsubscribe?.();
-    this.harnessEventUnsubscribe = undefined;
     this.clearActiveSession();
-    await this.destroyWorkspace();
-    await this.stopHeartbeats();
-    await this.core.shutdown();
+    const hadWorkspace = this.currentWorkspace !== undefined;
+    if (hadWorkspace) {
+      this.emit({ type: 'workspace_status_changed', status: 'destroying' } as unknown as HarnessEvent);
+    }
+    try {
+      await this.core.shutdown();
+    } finally {
+      if (hadWorkspace) {
+        this.emit({ type: 'workspace_status_changed', status: 'destroyed' } as unknown as HarnessEvent);
+      }
+      this.currentWorkspace = undefined;
+      this.harnessEventUnsubscribe?.();
+      this.harnessEventUnsubscribe = undefined;
+    }
   }
 
   async getSession(): Promise<HarnessSession> {
@@ -1837,9 +1823,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
   ): Promise<Session> {
     const allowNewThread = options.allowNewThread ?? false;
     const maxWaitMs =
-      mode === 'startup'
-        ? SESSION_LEASE_RECOVERY_STARTUP_WAIT_MS
-        : SESSION_LEASE_RECOVERY_MIDSESSION_WAIT_MS;
+      mode === 'startup' ? SESSION_LEASE_RECOVERY_STARTUP_WAIT_MS : SESSION_LEASE_RECOVERY_MIDSESSION_WAIT_MS;
     const startedAt = Date.now();
     let attempt = 0;
     const envOverride = resolveLeaseRecoveryEnvOverride();
@@ -1951,8 +1935,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
           // honor a new-thread choice — they must bind a specific threadId.
           // Down-convert to quit so the caller sees a clean recovery error
           // instead of the internal sentinel leaking out.
-          const action: LeaseRecoveryAction =
-            rawAction === 'new-thread' && !allowNewThread ? 'quit' : rawAction;
+          const action: LeaseRecoveryAction = rawAction === 'new-thread' && !allowNewThread ? 'quit' : rawAction;
           if (action === 'force-claim') {
             chosenPolicy = 'force-claim';
             try {
@@ -2026,7 +2009,9 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
         }
       | undefined;
     if (!harnessStorage || typeof harnessStorage.releaseSessionLease !== 'function') {
-      throw new Error('MastraCode Harness storage does not expose releaseSessionLease; cannot force-claim session lease.');
+      throw new Error(
+        'MastraCode Harness storage does not expose releaseSessionLease; cannot force-claim session lease.',
+      );
     }
     await harnessStorage.releaseSessionLease({
       harnessName: MASTRACODE_HARNESS_NAME,

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -163,6 +163,8 @@ export type MastraCodeHarnessPublic = Harness<Record<string, unknown>> & {
   mcp: MastraCodeHarnessRuntime<Record<string, unknown>>['mcp'];
   getResolvedMemory: MastraCodeHarnessRuntime<Record<string, unknown>>['getResolvedMemory'];
   saveSystemReminderMessage: MastraCodeHarnessRuntime<Record<string, unknown>>['saveSystemReminderMessage'];
+  registerHeartbeat: MastraCodeHarnessRuntime<Record<string, unknown>>['registerHeartbeat'];
+  removeHeartbeat: MastraCodeHarnessRuntime<Record<string, unknown>>['removeHeartbeat'];
   stopHeartbeats: MastraCodeHarnessRuntime<Record<string, unknown>>['stopHeartbeats'];
   destroy: MastraCodeHarnessRuntime<Record<string, unknown>>['destroy'];
 };

--- a/packages/core/src/harness/v1/harness.config-keys.test.ts
+++ b/packages/core/src/harness/v1/harness.config-keys.test.ts
@@ -70,6 +70,7 @@ describe('Harness constructor — unknown HarnessConfig keys', () => {
       modes: [{ id: 'default', agentId: 'default' }],
       defaultModeId: 'default',
       defaultPermissionPolicy: 'ask',
+      heartbeatHandlers: undefined,
       sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
       files: undefined,
       subagents: undefined,

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -152,6 +152,7 @@ const DEFAULT_LEASE_TTL_MS = 30_000;
 const DEFAULT_MAX_QUEUE_DEPTH = 100;
 const DEFAULT_CLOSE_TIMEOUT_MS = 30_000;
 const MAX_CLOSE_TIMEOUT_MS = 2_147_483_647;
+const MAX_TIMER_INTERVAL_MS = 2_147_483_647;
 const DEFAULT_SUBAGENT_MAX_DEPTH = 1;
 const DEFAULT_GOAL_MAX_TURNS = 50;
 const DEFAULT_PERMISSION_POLICY: PermissionPolicy = 'ask';
@@ -1239,8 +1240,11 @@ export class Harness {
     if (typeof handler.id !== 'string' || handler.id.length === 0) {
       throw new HarnessConfigError(`${path}.id`, 'must be a non-empty string');
     }
-    if (!Number.isFinite(handler.intervalMs) || handler.intervalMs <= 0) {
-      throw new HarnessConfigError(`${path}["${handler.id}"].intervalMs`, 'must be a positive number');
+    if (!Number.isFinite(handler.intervalMs) || handler.intervalMs <= 0 || handler.intervalMs > MAX_TIMER_INTERVAL_MS) {
+      throw new HarnessConfigError(
+        `${path}["${handler.id}"].intervalMs`,
+        `must be a positive number no greater than ${MAX_TIMER_INTERVAL_MS}`,
+      );
     }
     if (typeof handler.handler !== 'function') {
       throw new HarnessConfigError(`${path}["${handler.id}"].handler`, 'must be a function');

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -18,6 +18,7 @@
  * acceptance evidence live in follow-up Harness v1 lanes.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash, randomUUID } from 'node:crypto';
 
 import type { Agent } from '../../agent';
@@ -114,6 +115,7 @@ import type {
   HarnessChannelConfig,
   HarnessConfig,
   HarnessFileConfig,
+  HeartbeatHandler,
   HarnessMode,
   HarnessQueueBackpressurePolicy,
   HarnessSkill,
@@ -176,6 +178,7 @@ const HARNESS_CONFIG_KNOWN_KEYS: ReadonlySet<string> = new Set([
   'defaultPermissionPolicy',
   'files',
   'goals',
+  'heartbeatHandlers',
   'modelAuthStatusResolver',
   'models',
   'modes',
@@ -198,6 +201,17 @@ type CloseTreeNode = {
   depth: number;
   live?: Session;
   leaseAcquired: boolean;
+};
+
+type HeartbeatEntry = {
+  timer: ReturnType<typeof setInterval>;
+  shutdown?: () => void | Promise<void>;
+};
+
+type TrackedHeartbeatWork = {
+  promise: Promise<void>;
+  enteredStop: Promise<void>;
+  markEnteredStop: () => void;
 };
 
 function cloneHarnessSkill(skill: HarnessSkill): HarnessSkill {
@@ -759,6 +773,12 @@ export class Harness {
   readonly _workspaceKind?: 'shared' | 'per-resource' | 'per-session';
   private readonly _workspaceEager: boolean;
   private readonly _workspacePolicy?: WorkspacePolicy;
+  private readonly _configuredHeartbeatHandlers: readonly HeartbeatHandler[];
+  private readonly _heartbeatEntries = new Map<string, HeartbeatEntry>();
+  private readonly _heartbeatRuns = new Map<symbol, TrackedHeartbeatWork>();
+  private readonly _heartbeatRunContext = new AsyncLocalStorage<symbol>();
+  private readonly _heartbeatShutdowns = new Map<symbol, TrackedHeartbeatWork>();
+  private readonly _heartbeatShutdownContext = new AsyncLocalStorage<symbol>();
 
   private _initialized = false;
   private _initPromise?: Promise<void>;
@@ -781,6 +801,16 @@ export class Harness {
       throw new HarnessConfigError('runtimeCompatibilityGeneration', 'must be a non-empty string when provided');
     }
     this._runtimeCompatibilityGeneration = runtimeCompatibilityGeneration?.trim();
+    const configuredHeartbeatHandlers = (config.heartbeatHandlers ?? []).map(handler => Object.freeze({ ...handler }));
+    const heartbeatHandlerIds = new Set<string>();
+    for (const handler of configuredHeartbeatHandlers) {
+      this.assertHeartbeatHandler(handler);
+      if (heartbeatHandlerIds.has(handler.id)) {
+        throw new HarnessConfigError(`heartbeatHandlers["${handler.id}"]`, 'duplicate heartbeat handler id');
+      }
+      heartbeatHandlerIds.add(handler.id);
+    }
+    this._configuredHeartbeatHandlers = Object.freeze(configuredHeartbeatHandlers);
     this._leaseTtlMs = DEFAULT_LEASE_TTL_MS;
     this._storageOverride = config.sessions?.storage;
     this._maxQueueDepth = config.sessions?.maxQueueDepth ?? DEFAULT_MAX_QUEUE_DEPTH;
@@ -1130,7 +1160,186 @@ export class Harness {
       throw new HarnessConfigError('shutdown', 'harness cannot be initialized after shutdown');
     }
 
+    this.startConfiguredHeartbeats();
     this._initialized = true;
+  }
+
+  private startConfiguredHeartbeats(): void {
+    const startedIds: string[] = [];
+    try {
+      for (const handler of this._configuredHeartbeatHandlers) {
+        this.registerHeartbeatEntry(handler, 'heartbeatHandlers');
+        startedIds.push(handler.id);
+      }
+    } catch (error) {
+      for (const id of startedIds) {
+        const entry = this.clearHeartbeatEntry(id);
+        if (entry) {
+          void this.startHeartbeatShutdown(id, entry);
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Register and start a heartbeat immediately. Re-registering the same id
+   * clears the old timer and starts the new one while the previous shutdown
+   * callback is queued in the background. Configured handlers that have not
+   * started yet are still controlled by `heartbeatHandlers` config. Replacement
+   * does not wait for the previous shutdown before starting the new timer, and
+   * ticks are not serialized; handlers should be safe to run concurrently if a
+   * previous tick is still pending. When `init()` starts configured handlers,
+   * configured ids take precedence over direct pre-init registrations.
+   */
+  registerHeartbeat(handler: HeartbeatHandler): void {
+    this.registerHeartbeatEntry(handler, 'registerHeartbeat');
+  }
+
+  private registerHeartbeatEntry(
+    handler: HeartbeatHandler,
+    validationPath: 'registerHeartbeat' | 'heartbeatHandlers',
+  ): void {
+    if (this._shutdown) {
+      throw new HarnessConfigError('shutdown', 'harness cannot register heartbeat handlers after shutdown');
+    }
+    this.assertHeartbeatHandler(handler, validationPath);
+
+    const previous = this.clearHeartbeatEntry(handler.id);
+    if (previous) {
+      void this.startHeartbeatShutdown(handler.id, previous);
+    }
+
+    const run = () => {
+      const runId = Symbol(`heartbeat:${handler.id}`);
+      const runPromise = this._heartbeatRunContext.run(runId, async () => {
+        try {
+          await handler.handler();
+        } catch (error) {
+          console.error(`[Heartbeat:${handler.id}] failed:`, error);
+        }
+      });
+      void this.trackHeartbeatRun(runId, runPromise);
+      return runPromise;
+    };
+
+    const timer = setInterval(run, handler.intervalMs);
+    timer.unref?.();
+    this._heartbeatEntries.set(handler.id, { timer, shutdown: handler.shutdown });
+
+    if (handler.immediate !== false) {
+      void run();
+    }
+  }
+
+  private assertHeartbeatHandler(handler: HeartbeatHandler, path = 'heartbeatHandlers'): void {
+    if (!handler || typeof handler !== 'object') {
+      throw new HarnessConfigError(path, 'every entry must be an object');
+    }
+    if (typeof handler.id !== 'string' || handler.id.length === 0) {
+      throw new HarnessConfigError(`${path}.id`, 'must be a non-empty string');
+    }
+    if (!Number.isFinite(handler.intervalMs) || handler.intervalMs <= 0) {
+      throw new HarnessConfigError(`${path}["${handler.id}"].intervalMs`, 'must be a positive number');
+    }
+    if (typeof handler.handler !== 'function') {
+      throw new HarnessConfigError(`${path}["${handler.id}"].handler`, 'must be a function');
+    }
+    if (handler.shutdown !== undefined && typeof handler.shutdown !== 'function') {
+      throw new HarnessConfigError(`${path}["${handler.id}"].shutdown`, 'must be a function when provided');
+    }
+  }
+
+  /**
+   * Remove a running heartbeat by id. This does not remove a configured
+   * handler that has not started yet during `init()`.
+   */
+  async removeHeartbeat({ id }: { id: string }): Promise<void> {
+    const entry = this.clearHeartbeatEntry(id);
+    if (!entry) return;
+    await this.startHeartbeatShutdown(id, entry);
+  }
+
+  /**
+   * Stop the currently running heartbeat snapshot. Later registrations can
+   * still start new heartbeats unless the harness is shutting down. Calling
+   * this before `init()` does not disable configured handlers; neither does
+   * calling it while `init()` is still pending and configured handlers have not
+   * started yet. After successful init has completed, this permanently stops
+   * configured handlers for this harness instance, and a later `init()` call
+   * does not restart them. This does not lock out concurrent direct
+   * `registerHeartbeat()` calls outside `shutdown()`.
+   */
+  async stopHeartbeats(): Promise<void> {
+    const entries = [...this._heartbeatEntries.entries()];
+    this._heartbeatEntries.clear();
+
+    const entryShutdowns = entries.map(([id, entry]) => {
+      clearInterval(entry.timer);
+      return this.startHeartbeatShutdown(id, entry);
+    });
+    const currentRunId = this._heartbeatRunContext.getStore();
+    const currentShutdownId = this._heartbeatShutdownContext.getStore();
+    const currentRun = currentRunId === undefined ? undefined : this._heartbeatRuns.get(currentRunId);
+    currentRun?.markEnteredStop();
+    const currentShutdown =
+      currentShutdownId === undefined ? undefined : this._heartbeatShutdowns.get(currentShutdownId);
+    currentShutdown?.markEnteredStop();
+    const inFlightRuns = this.snapshotHeartbeatWork(this._heartbeatRuns, currentRunId);
+    const pendingShutdowns = this.snapshotHeartbeatWork(this._heartbeatShutdowns, currentShutdownId);
+    await Promise.all([...entryShutdowns, ...pendingShutdowns, ...inFlightRuns]);
+  }
+
+  private snapshotHeartbeatWork(entries: Map<symbol, TrackedHeartbeatWork>, currentId?: symbol): Promise<void>[] {
+    return [...entries.entries()]
+      .filter(([id]) => id !== currentId)
+      .map(([, entry]) => (currentId === undefined ? entry.promise : Promise.race([entry.promise, entry.enteredStop])));
+  }
+
+  private clearHeartbeatEntry(id: string): HeartbeatEntry | undefined {
+    const entry = this._heartbeatEntries.get(id);
+    if (!entry) return undefined;
+    clearInterval(entry.timer);
+    this._heartbeatEntries.delete(id);
+    return entry;
+  }
+
+  private async runHeartbeatShutdown(id: string, entry: HeartbeatEntry): Promise<void> {
+    try {
+      await entry.shutdown?.();
+    } catch (error) {
+      console.error(`[Heartbeat:${id}] shutdown failed:`, error);
+    }
+  }
+
+  private startHeartbeatShutdown(id: string, entry: HeartbeatEntry): Promise<void> {
+    const shutdownId = Symbol(`heartbeat-shutdown:${id}`);
+    const shutdown = this._heartbeatShutdownContext.run(shutdownId, () => this.runHeartbeatShutdown(id, entry));
+    const tracked = this.trackHeartbeatWork(shutdown);
+    this._heartbeatShutdowns.set(shutdownId, tracked);
+    return shutdown.finally(() => {
+      if (this._heartbeatShutdowns.get(shutdownId) === tracked) {
+        this._heartbeatShutdowns.delete(shutdownId);
+      }
+    });
+  }
+
+  private trackHeartbeatRun(runId: symbol, run: Promise<void>): Promise<void> {
+    const tracked = this.trackHeartbeatWork(run);
+    this._heartbeatRuns.set(runId, tracked);
+    return run.finally(() => {
+      if (this._heartbeatRuns.get(runId) === tracked) {
+        this._heartbeatRuns.delete(runId);
+      }
+    });
+  }
+
+  private trackHeartbeatWork(promise: Promise<void>): TrackedHeartbeatWork {
+    let markEnteredStop!: () => void;
+    const enteredStop = new Promise<void>(resolve => {
+      markEnteredStop = resolve;
+    });
+    return { promise, enteredStop, markEnteredStop };
   }
 
   /**
@@ -3301,10 +3510,24 @@ export class Harness {
     if (this._shutdown) return;
     this._shutdown = true;
 
+    await this.stopHeartbeats();
+
     const pendingInit = this._initPromise;
     if (pendingInit) {
       await Promise.allSettled([pendingInit]);
     }
+
+    let workspacesShutdown = false;
+    const shutdownWorkspaces = async () => {
+      if (workspacesShutdown) return;
+      workspacesShutdown = true;
+      try {
+        await this._workspaceRegistry.shutdown();
+      } catch {
+        // Best-effort: errors surface through the workspace_error event.
+      }
+      this._untrackBoundStorage();
+    };
 
     let storage: HarnessStorage;
     try {
@@ -3312,72 +3535,67 @@ export class Harness {
     } catch {
       // No storage bound — nothing to release. Idempotent.
       this._liveSessions.clear();
-      try {
-        await this._workspaceRegistry.shutdown();
-      } catch {
-        // Best-effort: errors surface through the workspace_error event.
-      }
-      this._untrackBoundStorage();
+      await shutdownWorkspaces();
       return;
     }
 
-    const pendingCloses = new Set(this._closePromises.values());
-    if (pendingCloses.size > 0) {
-      await Promise.allSettled(pendingCloses);
-    }
-
-    this._stopLeaseRenewalLoop();
-
-    // Release every held lease. We keep the records active in storage —
-    // shutdown is not a close.
-    const sessions = Array.from(this._liveSessions.values());
-    let eventPersistenceError: { sessionId: string; error: unknown } | undefined;
-    for (const session of sessions) {
-      // Surface eviction to harness-level subscribers BEFORE we tear down
-      // the bridge so the event still propagates, and persist it before lease
-      // handoff so a fast new owner resumes from the correct event sequence.
-      session._emit({ type: 'session_evicted', reason: 'shutdown' });
-      try {
-        await session._flushEventPersistence();
-      } catch (err) {
-        eventPersistenceError ??= { sessionId: session.id, error: err };
-      }
-
-      // Drain any in-flight record writes (e.g. the trailing token-usage
-      // persist scheduled by `_recordTurnCompletion`) so a fresh harness
-      // resumes from the latest CAS-acknowledged state. Best-effort: lifecycle
-      // races are absorbed inside `_internalAwaitFlushChain`.
-      await session._internalAwaitFlushChain();
-
-      try {
-        await storage.releaseSessionLease({
-          harnessName: session.getRecord().harnessName,
-          sessionId: session.id,
-          ownerId: this.ownerId,
-        });
-      } catch {
-        // Best-effort: leases TTL out anyway.
-      }
-
-      session._markEvicted(session.getRecord() as SessionRecord);
-
-      const bridge = this._sessionEventBridges.get(session.id);
-      if (bridge) {
-        bridge();
-        this._sessionEventBridges.delete(session.id);
-      }
-    }
-    this._liveSessions.clear();
-
-    // Tear down every provisioned workspace (shared + per-resource + per-session).
     try {
-      await this._workspaceRegistry.shutdown();
-    } catch {
-      // Best-effort: errors surface through the workspace_error event.
-    }
-    this._untrackBoundStorage();
-    if (eventPersistenceError !== undefined) {
-      throw new HarnessStorageError(eventPersistenceError.sessionId, 'flush', eventPersistenceError.error);
+      const pendingCloses = new Set(this._closePromises.values());
+      if (pendingCloses.size > 0) {
+        await Promise.allSettled(pendingCloses);
+      }
+
+      this._stopLeaseRenewalLoop();
+
+      // Release every held lease. We keep the records active in storage —
+      // shutdown is not a close.
+      const sessions = Array.from(this._liveSessions.values());
+      let flushError: { sessionId: string; error: unknown } | undefined;
+      for (const session of sessions) {
+        // Surface eviction to harness-level subscribers BEFORE we tear down
+        // the bridge so the event still propagates, and persist it before lease
+        // handoff so a fast new owner resumes from the correct event sequence.
+        session._emit({ type: 'session_evicted', reason: 'shutdown' });
+        try {
+          await session._flushEventPersistence();
+        } catch (err) {
+          flushError ??= { sessionId: session.id, error: err };
+        }
+
+        // Drain any in-flight record writes (e.g. the trailing token-usage
+        // persist scheduled by `_recordTurnCompletion`) so a fresh harness
+        // resumes from the latest CAS-acknowledged state. Defer storage errors
+        // until after teardown so shutdown cannot leak workspaces or leases.
+        try {
+          await session._internalAwaitFlushChain();
+        } catch (err) {
+          flushError ??= { sessionId: session.id, error: err };
+        }
+
+        try {
+          await storage.releaseSessionLease({
+            harnessName: session.getRecord().harnessName,
+            sessionId: session.id,
+            ownerId: this.ownerId,
+          });
+        } catch {
+          // Best-effort: leases TTL out anyway.
+        }
+
+        session._markEvicted(session.getRecord() as SessionRecord);
+
+        const bridge = this._sessionEventBridges.get(session.id);
+        if (bridge) {
+          bridge();
+          this._sessionEventBridges.delete(session.id);
+        }
+      }
+      if (flushError !== undefined) {
+        throw new HarnessStorageError(flushError.sessionId, 'flush', flushError.error);
+      }
+    } finally {
+      this._liveSessions.clear();
+      await shutdownWorkspaces();
     }
   }
 

--- a/packages/core/src/harness/v1/heartbeat.test.ts
+++ b/packages/core/src/harness/v1/heartbeat.test.ts
@@ -1,0 +1,653 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Agent } from '../../agent';
+import { InMemoryStore } from '../../storage/mock';
+import type { Workspace } from '../../workspace';
+
+import { HarnessConfigError } from './errors';
+import { Harness } from './harness';
+import type { HeartbeatHandler } from './types';
+
+function makeAgent() {
+  return new Agent({
+    id: 'default',
+    name: 'Default',
+    instructions: 'test',
+    model: '__GATEWAY_OPENAI_MODEL_MINI__' as any,
+  });
+}
+
+function makeHarness(heartbeatHandlers?: HeartbeatHandler[]) {
+  return new Harness({
+    agents: { default: makeAgent() },
+    storage: new InMemoryStore(),
+    modes: [{ id: 'default', agentId: 'default' }],
+    defaultModeId: 'default',
+    heartbeatHandlers,
+  });
+}
+
+describe('Harness v1 — heartbeat handlers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('starts configured handlers on init and runs immediate handlers', async () => {
+    const handler = vi.fn();
+    const harness = makeHarness([{ id: 'sync', intervalMs: 1_000, handler }]);
+
+    await harness.init();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    await harness.shutdown();
+  });
+
+  it('does not start configured handlers before init', async () => {
+    const handler = vi.fn();
+    const harness = makeHarness([{ id: 'sync', intervalMs: 1_000, handler }]);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(handler).not.toHaveBeenCalled();
+
+    await harness.init();
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    await harness.shutdown();
+  });
+
+  it('does not start configured handlers when init fails before heartbeat startup', async () => {
+    const error = new Error('workspace init failed');
+    const handler = vi.fn();
+    const workspace = {
+      init: vi.fn(() => {
+        throw error;
+      }),
+      destroy: vi.fn(),
+    } as unknown as Workspace;
+    const harness = new Harness({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      workspace: { kind: 'shared', workspace, eager: true },
+      heartbeatHandlers: [{ id: 'sync', intervalMs: 1_000, handler }],
+    });
+
+    await expect(harness.init()).rejects.toThrow(error);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('starts directly registered handlers before init', async () => {
+    const handler = vi.fn();
+    const harness = makeHarness();
+
+    harness.registerHeartbeat({ id: 'direct', intervalMs: 1_000, handler });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    await harness.shutdown();
+  });
+
+  it('lets configured handlers replace direct pre-init registrations with the same id', async () => {
+    const direct = vi.fn();
+    const directShutdown = vi.fn();
+    const configured = vi.fn();
+    const harness = makeHarness([{ id: 'same-id', intervalMs: 1_000, handler: configured, immediate: false }]);
+
+    harness.registerHeartbeat({
+      id: 'same-id',
+      intervalMs: 1_000,
+      handler: direct,
+      immediate: false,
+      shutdown: directShutdown,
+    });
+    await harness.init();
+    await Promise.resolve();
+
+    expect(directShutdown).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(direct).not.toHaveBeenCalled();
+    expect(configured).toHaveBeenCalledTimes(1);
+
+    await harness.shutdown();
+  });
+
+  it('replaces duplicate handler ids when registering', async () => {
+    const first = vi.fn();
+    const firstShutdown = vi.fn();
+    const second = vi.fn();
+    const harness = makeHarness();
+
+    await harness.init();
+    harness.registerHeartbeat({ id: 'duplicate', intervalMs: 1_000, handler: first, shutdown: firstShutdown });
+    harness.registerHeartbeat({ id: 'duplicate', intervalMs: 1_000, handler: second, immediate: false });
+
+    await Promise.resolve();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(firstShutdown).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    await harness.shutdown();
+  });
+
+  it('removes handlers by clearing timers and running shutdown callbacks', async () => {
+    const handler = vi.fn();
+    const shutdown = vi.fn();
+    const harness = makeHarness();
+
+    await harness.init();
+    harness.registerHeartbeat({ id: 'remove-me', intervalMs: 1_000, handler, shutdown });
+
+    await harness.removeHeartbeat({ id: 'remove-me' });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await harness.removeHeartbeat({ id: 'remove-me' });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(shutdown).toHaveBeenCalledTimes(1);
+
+    await harness.shutdown();
+  });
+
+  it('lets immediate handlers remove themselves before their interval is installed', async () => {
+    let harness!: Harness;
+    const shutdown = vi.fn();
+    const handler = vi.fn(() => {
+      void harness.removeHeartbeat({ id: 'self-remove' });
+    });
+    harness = makeHarness([{ id: 'self-remove', intervalMs: 1_000, handler, shutdown }]);
+
+    await harness.init();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(shutdown).toHaveBeenCalledTimes(1);
+
+    await harness.shutdown();
+  });
+
+  it('ignores removal of unknown handler ids', async () => {
+    const harness = makeHarness();
+
+    await expect(harness.removeHeartbeat({ id: 'missing' })).resolves.toBeUndefined();
+
+    await harness.shutdown();
+  });
+
+  it('logs synchronous handler failures without failing init or timer ticks', async () => {
+    const error = new Error('handler failed');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const harness = makeHarness([
+      {
+        id: 'sync-failure',
+        intervalMs: 1_000,
+        handler: () => {
+          throw error;
+        },
+      },
+    ]);
+
+    await expect(harness.init()).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(errorSpy).toHaveBeenCalledWith('[Heartbeat:sync-failure] failed:', error);
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+
+    await harness.shutdown();
+  });
+
+  it('logs async configured handler failures without failing init or timer ticks', async () => {
+    const error = new Error('async handler failed');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const harness = makeHarness([
+      {
+        id: 'async-failure',
+        intervalMs: 1_000,
+        handler: vi.fn(() => Promise.reject(error)),
+      },
+    ]);
+
+    await expect(harness.init()).resolves.toBeUndefined();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(errorSpy).toHaveBeenCalledWith('[Heartbeat:async-failure] failed:', error);
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+
+    await harness.shutdown();
+  });
+
+  it('validates configured handlers before starting timers', async () => {
+    const handler = vi.fn();
+
+    expect(() =>
+      makeHarness([
+        { id: 'valid', intervalMs: 1_000, handler },
+        { id: 'invalid', intervalMs: 0, handler: vi.fn() },
+      ]),
+    ).toThrow(HarnessConfigError);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('uses the constructor-validated configured handler snapshot during init', async () => {
+    const handler = vi.fn();
+    const configured = { id: 'snapshot', intervalMs: 1_000, handler };
+    const harness = makeHarness([configured]);
+
+    configured.intervalMs = 0;
+
+    await harness.init();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    await harness.shutdown();
+  });
+
+  it('rejects duplicate configured handler ids', () => {
+    expect(() =>
+      makeHarness([
+        { id: 'duplicate', intervalMs: 1_000, handler: vi.fn() },
+        { id: 'duplicate', intervalMs: 2_000, handler: vi.fn() },
+      ]),
+    ).toThrow(HarnessConfigError);
+  });
+
+  it('uses direct registration paths in direct registration validation errors', () => {
+    const harness = makeHarness();
+
+    expect(() => harness.registerHeartbeat({ id: 'bad', intervalMs: 0, handler: vi.fn() })).toThrow(
+      /registerHeartbeat\["bad"\]\.intervalMs/,
+    );
+  });
+
+  it('rejects registration after shutdown', async () => {
+    const harness = makeHarness();
+
+    await harness.init();
+    await harness.shutdown();
+
+    expect(() => harness.registerHeartbeat({ id: 'late', intervalMs: 1_000, handler: vi.fn() })).toThrow(
+      HarnessConfigError,
+    );
+  });
+
+  it('logs shutdown callback failures without leaving stale state', async () => {
+    const error = new Error('shutdown failed');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const shutdown = vi.fn(() => {
+      throw error;
+    });
+    const harness = makeHarness();
+
+    await harness.init();
+    harness.registerHeartbeat({ id: 'failing-shutdown', intervalMs: 1_000, handler: vi.fn(), shutdown });
+
+    await expect(harness.removeHeartbeat({ id: 'failing-shutdown' })).resolves.toBeUndefined();
+    await expect(harness.removeHeartbeat({ id: 'failing-shutdown' })).resolves.toBeUndefined();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith('[Heartbeat:failing-shutdown] shutdown failed:', error);
+
+    await harness.shutdown();
+  });
+
+  it('logs async configured shutdown failures without leaving stale state', async () => {
+    const error = new Error('async shutdown failed');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const shutdown = vi.fn(() => Promise.reject(error));
+    const harness = makeHarness([{ id: 'configured-shutdown', intervalMs: 1_000, handler: vi.fn(), shutdown }]);
+
+    await harness.init();
+    await expect(harness.removeHeartbeat({ id: 'configured-shutdown' })).resolves.toBeUndefined();
+    await expect(harness.removeHeartbeat({ id: 'configured-shutdown' })).resolves.toBeUndefined();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith('[Heartbeat:configured-shutdown] shutdown failed:', error);
+
+    await harness.shutdown();
+  });
+
+  it('waits for replaced handler shutdowns during stopHeartbeats', async () => {
+    let resolveShutdown: (() => void) | undefined;
+    const shutdown = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveShutdown = resolve;
+        }),
+    );
+    const harness = makeHarness();
+
+    await harness.init();
+    harness.registerHeartbeat({ id: 'replace-me', intervalMs: 1_000, handler: vi.fn(), shutdown });
+    harness.registerHeartbeat({ id: 'replace-me', intervalMs: 1_000, handler: vi.fn(), immediate: false });
+
+    let stopped = false;
+    const stop = harness.stopHeartbeats().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(stopped).toBe(false);
+
+    resolveShutdown?.();
+    await stop;
+    expect(stopped).toBe(true);
+
+    await harness.shutdown();
+  });
+
+  it('waits for in-flight handler runs during stopHeartbeats', async () => {
+    let resolveRun: (() => void) | undefined;
+    const handler = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveRun = resolve;
+        }),
+    );
+    const harness = makeHarness([{ id: 'slow-run', intervalMs: 1_000, handler, immediate: false }]);
+
+    await harness.init();
+    vi.advanceTimersByTime(1_000);
+    await Promise.resolve();
+
+    let stopped = false;
+    const stop = harness.stopHeartbeats().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(stopped).toBe(false);
+
+    resolveRun?.();
+    await stop;
+    expect(stopped).toBe(true);
+
+    await harness.shutdown();
+  });
+
+  it('waits for other in-flight handler runs when a handler stops heartbeats', async () => {
+    let harness!: Harness;
+    let resolveSlowRun: (() => void) | undefined;
+    let stopped = false;
+    const slow = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveSlowRun = resolve;
+        }),
+    );
+    const stopper = vi.fn(async () => {
+      await Promise.resolve();
+      await harness.stopHeartbeats();
+      stopped = true;
+    });
+    harness = makeHarness([
+      { id: 'slow-run', intervalMs: 1_000, handler: slow },
+      { id: 'self-stop', intervalMs: 1_000, handler: stopper },
+    ]);
+
+    await harness.init();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(slow).toHaveBeenCalledTimes(1);
+    expect(stopper).toHaveBeenCalledTimes(1);
+    expect(stopped).toBe(false);
+
+    resolveSlowRun?.();
+    await vi.waitFor(() => {
+      expect(stopped).toBe(true);
+    });
+
+    await harness.shutdown();
+  });
+
+  it('does not wait on the current handler run when a handler stops heartbeats', async () => {
+    let harness!: Harness;
+    let stopped = false;
+    const handler = vi.fn(async () => {
+      await Promise.resolve();
+      await harness.stopHeartbeats();
+      stopped = true;
+    });
+    harness = makeHarness([{ id: 'self-stop', intervalMs: 1_000, handler }]);
+
+    await harness.init();
+
+    await vi.waitFor(() => {
+      expect(stopped).toBe(true);
+    });
+
+    await harness.shutdown();
+  });
+
+  it('does not wait on the current handler run when a handler shuts down the harness', async () => {
+    let harness!: Harness;
+    let shutDown = false;
+    const handler = vi.fn(async () => {
+      await Promise.resolve();
+      await harness.shutdown();
+      shutDown = true;
+    });
+    harness = makeHarness([{ id: 'self-shutdown', intervalMs: 1_000, handler }]);
+
+    await harness.init();
+
+    await vi.waitFor(() => {
+      expect(shutDown).toBe(true);
+    });
+    expect(() => harness.registerHeartbeat({ id: 'late', intervalMs: 1_000, handler: vi.fn() })).toThrow(
+      HarnessConfigError,
+    );
+  });
+
+  it('does not deadlock when multiple handler runs stop heartbeats concurrently', async () => {
+    let harness!: Harness;
+    let firstStopped = false;
+    let secondStopped = false;
+    const first = vi.fn(async () => {
+      await Promise.resolve();
+      await harness.stopHeartbeats();
+      firstStopped = true;
+    });
+    const second = vi.fn(async () => {
+      await Promise.resolve();
+      await harness.stopHeartbeats();
+      secondStopped = true;
+    });
+    harness = makeHarness([
+      { id: 'self-stop-a', intervalMs: 1_000, handler: first },
+      { id: 'self-stop-b', intervalMs: 1_000, handler: second },
+    ]);
+
+    await harness.init();
+
+    await vi.waitFor(() => {
+      expect(firstStopped).toBe(true);
+      expect(secondStopped).toBe(true);
+    });
+
+    await harness.shutdown();
+  });
+
+  it('does not deadlock when a shutdown callback stops heartbeats', async () => {
+    let harness!: Harness;
+    let shutdownStopped = false;
+    const shutdown = vi.fn(async () => {
+      await harness.stopHeartbeats();
+      shutdownStopped = true;
+    });
+    harness = makeHarness([{ id: 'shutdown-self-stop', intervalMs: 1_000, handler: vi.fn(), shutdown }]);
+
+    await harness.init();
+    await harness.stopHeartbeats();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(shutdownStopped).toBe(true);
+  });
+
+  it('stops all handlers from a deterministic snapshot', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const firstShutdown = vi.fn();
+    const secondShutdown = vi.fn();
+    const harness = makeHarness();
+
+    await harness.init();
+    harness.registerHeartbeat({ id: 'first', intervalMs: 1_000, handler: first, shutdown: firstShutdown });
+    harness.registerHeartbeat({ id: 'second', intervalMs: 1_000, handler: second, shutdown: secondShutdown });
+
+    await harness.stopHeartbeats();
+    await harness.stopHeartbeats();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(firstShutdown).toHaveBeenCalledTimes(1);
+    expect(secondShutdown).toHaveBeenCalledTimes(1);
+
+    await harness.shutdown();
+  });
+
+  it('allows direct registrations after stopHeartbeats when not shutting down', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const harness = makeHarness();
+
+    await harness.init();
+    harness.registerHeartbeat({ id: 'first', intervalMs: 1_000, handler: first });
+    await harness.stopHeartbeats();
+
+    harness.registerHeartbeat({ id: 'second', intervalMs: 1_000, handler: second });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(2);
+
+    await harness.shutdown();
+  });
+
+  it('stops heartbeat timers during shutdown', async () => {
+    const handler = vi.fn();
+    const shutdown = vi.fn();
+    const harness = makeHarness([{ id: 'shutdown-owned', intervalMs: 1_000, handler, shutdown }]);
+
+    await harness.init();
+    await harness.shutdown();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start configured handlers when shutdown interrupts init', async () => {
+    let resolveWorkspaceInit: (() => void) | undefined;
+    const handler = vi.fn();
+    const workspace = {
+      init: vi.fn(
+        () =>
+          new Promise<void>(resolve => {
+            resolveWorkspaceInit = resolve;
+          }),
+      ),
+      destroy: vi.fn(),
+    } as unknown as Workspace;
+    const harness = new Harness({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      workspace: { kind: 'shared', workspace, eager: true },
+      heartbeatHandlers: [{ id: 'sync', intervalMs: 1_000, handler }],
+    });
+
+    const init = harness.init().catch(error => error);
+    const shutdown = harness.shutdown();
+    resolveWorkspaceInit?.();
+
+    await expect(init).resolves.toBeInstanceOf(HarnessConfigError);
+    await shutdown;
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('stops direct pre-init handlers before waiting for interrupted init', async () => {
+    let resolveWorkspaceInit: (() => void) | undefined;
+    const handler = vi.fn();
+    const workspace = {
+      init: vi.fn(
+        () =>
+          new Promise<void>(resolve => {
+            resolveWorkspaceInit = resolve;
+          }),
+      ),
+      destroy: vi.fn(),
+    } as unknown as Workspace;
+    const harness = new Harness({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      workspace: { kind: 'shared', workspace, eager: true },
+    });
+
+    harness.registerHeartbeat({ id: 'direct', intervalMs: 1_000, handler });
+    const init = harness.init().catch(error => error);
+    const shutdown = harness.shutdown();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+    resolveWorkspaceInit?.();
+
+    await expect(init).resolves.toBeInstanceOf(HarnessConfigError);
+    await shutdown;
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts configured handlers when stopHeartbeats is called before init', async () => {
+    const handler = vi.fn();
+    const harness = makeHarness([{ id: 'configured', intervalMs: 1_000, handler }]);
+
+    await harness.stopHeartbeats();
+    await harness.init();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    await harness.shutdown();
+  });
+
+  it('does not restart configured handlers on repeated init after stopHeartbeats', async () => {
+    const handler = vi.fn();
+    const harness = makeHarness([{ id: 'configured', intervalMs: 1_000, handler }]);
+
+    await harness.init();
+    await harness.stopHeartbeats();
+    await harness.init();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    await harness.shutdown();
+  });
+});

--- a/packages/core/src/harness/v1/heartbeat.test.ts
+++ b/packages/core/src/harness/v1/heartbeat.test.ts
@@ -247,6 +247,12 @@ describe('Harness v1 — heartbeat handlers', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it('rejects heartbeat intervals above the Node timer limit', () => {
+    expect(() => makeHarness([{ id: 'too-large', intervalMs: 2_147_483_648, handler: vi.fn() }])).toThrow(
+      HarnessConfigError,
+    );
+  });
+
   it('uses the constructor-validated configured handler snapshot during init', async () => {
     const handler = vi.fn();
     const configured = { id: 'snapshot', intervalMs: 1_000, handler };

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -214,6 +214,7 @@ export type {
   HarnessSkillActionMetadata,
   HarnessSkillActionPermissionHints,
   HarnessSkillActionShortcut,
+  HeartbeatHandler,
   InboxResponseOptions,
   InboxResponseResult,
   PrimitiveAttachmentUploadOptions,

--- a/packages/core/src/harness/v1/session.signal.test.ts
+++ b/packages/core/src/harness/v1/session.signal.test.ts
@@ -77,6 +77,17 @@ describe('Session.signal()', () => {
     expect(messages.attributes).toEqual({ delivery: 'message' });
   });
 
+  it('forwards prepareStep when idle dispatch wakes a fresh run', async () => {
+    const { harness, agent } = setupHarness();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const prepareStep = () => ({ activeTools: [] });
+
+    const handle = await session.signal({ content: 'hi', prepareStep });
+    await handle.result;
+
+    expect(agent.streamCalls[0]!.options.prepareStep).toBe(prepareStep);
+  });
+
   it('active-delivery dispatch returns willInterleave: true and reuses the in-flight runId', async () => {
     const { harness, agent } = setupHarness();
     let releaseFirst!: () => void;
@@ -94,10 +105,13 @@ describe('Session.signal()', () => {
       content: 'second',
       ifActive: { attributes: { delivery: 'while-active' } },
       ifIdle: { attributes: { delivery: 'message' } },
+      prepareStep: () => ({ activeTools: [] }),
     });
 
     expect(second.willInterleave).toBe(true);
     expect(second.signal.attributes).toEqual({ delivery: 'while-active' });
+    expect(agent.streamCalls).toHaveLength(1);
+    expect(agent.streamCalls[0]!.options.prepareStep).toBeUndefined();
 
     releaseFirst();
     const firstResult = await firstPromise;

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -5213,6 +5213,7 @@ export class Session {
           abortSignal: turnAbortSignal,
           requestContext,
           ...(toolsets ? { toolsets } : {}),
+          ...(opts.prepareStep ? { prepareStep: opts.prepareStep } : {}),
           ...(mode.instructions ? { instructions: mode.instructions } : {}),
         };
         assertOwnedSignalTurnNotDeleted();

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -937,8 +937,8 @@ export interface HarnessConfigCommon {
 
   /**
    * Periodic background handlers owned by the Harness lifecycle. Configured
-   * handlers start during `init()`, must have unique ids, call `unref?.()`
-   * on their timers, and are stopped during `shutdown()`.
+   * handlers start during `init()`, must have unique ids, run on timers that
+   * the harness `unref`s internally, and are stopped during `shutdown()`.
    */
   heartbeatHandlers?: HeartbeatHandler[];
 

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -46,9 +46,12 @@ import type {
 import type { MastraModelOutput, FullOutput } from '../../stream/base/output';
 import type { Workspace } from '../../workspace';
 import type { ProcessHandle } from '../../workspace/sandbox/process-manager';
+import type { HeartbeatHandler } from '../types';
 import type { HarnessPermissionProfileName } from './permission-profiles';
 import type { WorkspacePolicy } from './workspace/policy';
 import type { WorkspaceProvider, WorkspaceProviderContext } from './workspace/provider';
+
+export type { HeartbeatHandler } from '../types';
 
 // ---------------------------------------------------------------------------
 // HarnessMode (§4.2).
@@ -931,6 +934,13 @@ export interface HarnessConfigCommon {
    * `modes` array can never silently change runtime behavior.
    */
   defaultModeId?: string;
+
+  /**
+   * Periodic background handlers owned by the Harness lifecycle. Configured
+   * handlers start during `init()`, must have unique ids, call `unref?.()`
+   * on their timers, and are stopped during `shutdown()`.
+   */
+  heartbeatHandlers?: HeartbeatHandler[];
 
   /**
    * Session-runtime config (§9 + §5). Currently only carries the storage
@@ -1847,6 +1857,12 @@ export interface SessionSignalOptions {
   ifIdle?: {
     attributes?: AgentSignalAttributes;
   };
+
+  /**
+   * Optional per-turn tool preparation hook forwarded to the backing agent
+   * when the signal wakes an idle run. Ignored on active delivery.
+   */
+  prepareStep?: AgentExecutionOptionsBase<unknown>['prepareStep'];
 
   /**
    * Forwarded to the underlying agent run when the signal wakes a fresh

--- a/packages/core/src/harness/v1/workspace-runtime.test.ts
+++ b/packages/core/src/harness/v1/workspace-runtime.test.ts
@@ -37,6 +37,7 @@ import type { Workspace } from '../../workspace';
 import { setupHarness } from './__test-utils__/setup';
 import { createSpawnSubagentTool } from './builtin-tools/spawn-subagent';
 import { HarnessConfigError, HarnessWorkspaceProvisioningError } from './errors';
+import type { HarnessStorageError } from './errors';
 import { Harness } from './harness';
 import type { HarnessRequestContext } from './types';
 import type { WorkspaceProvider, WorkspaceProviderContext } from './workspace/provider';
@@ -524,6 +525,26 @@ describe('Workspace lifecycle on harness.shutdown()', () => {
     await s.getWorkspace();
     await harness.shutdown();
     expect(created[0]!.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('shutdown() destroys workspaces before surfacing session flush failures', async () => {
+    const ws = makeWorkspace('shared') as unknown as StubWorkspace;
+    const { harness } = setupHarness({
+      workspace: { kind: 'shared', workspace: ws as unknown as Workspace },
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    await session.getWorkspace();
+
+    const failure = new Error('flush failed');
+    vi.spyOn(session, '_internalAwaitFlushChain').mockRejectedValueOnce(failure);
+
+    await expect(harness.shutdown()).rejects.toMatchObject({
+      name: 'HarnessStorageError',
+      sessionId: session.id,
+      operation: 'flush',
+      cause: failure,
+    } satisfies Partial<HarnessStorageError>);
+    expect(ws.destroy).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- add Harness v1-owned heartbeat handler registration, removal, shutdown, and config startup
- move MastraCode gateway sync heartbeat ownership into Harness v1
- forward prepareStep for idle Session.signal() wakeups so disabled-tool filtering applies there too
- harden Harness shutdown so workspace teardown still runs before surfacing session flush failures

## Related
- MASTRA-4346

## Testing
- pnpm --filter ./packages/core exec vitest run src/harness/v1/heartbeat.test.ts src/harness/v1/workspace-runtime.test.ts src/harness/v1/session.signal.test.ts src/harness/v1/harness.config-keys.test.ts
- pnpm --filter ./mastracode exec vitest run src/harness/runtime.test.ts src/__tests__/index.test.ts
- pnpm --filter ./packages/core exec eslint src/harness/v1/harness.ts src/harness/v1/types.ts src/harness/v1/session.ts src/harness/v1/heartbeat.test.ts src/harness/v1/session.signal.test.ts src/harness/v1/workspace-runtime.test.ts
- pnpm --filter ./packages/core check
- pnpm --filter ./mastracode check
- pnpm prettier --check packages/core/src/harness/v1/harness.ts packages/core/src/harness/v1/heartbeat.test.ts
- git diff --check