### PR TITLE
fix: allow Renovate lockfile trust policy exceptions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,5 +55,9 @@ trustPolicyExclude:
   # 3.47.4 is published with provenance attestation rather than trusted publisher,
   # but it is the official fix published on the @clerk/shared latest-v5 tag.
   - '@clerk/shared@3.47.4'
+  # Renovate cannot refresh lockfiles while pnpm rejects these official package
+  # versions as trust downgrades.
+  - 'effect@4.0.0-beta.59'
+  - 'tinyexec@1.2.2'
   # 0.7.4 is published with provenance attestation rather than trusted publisher.
   - 'prettier-plugin-tailwindcss@0.7.4'


### PR DESCRIPTION
Adds the exact pnpm trust-policy exclusions currently blocking Renovate from refreshing lockfile artifacts.

Renovate was updating branches, but pnpm rejected lockfile refreshes with ERR_PNPM_TRUST_DOWNGRADE for effect@4.0.0-beta.59 and tinyexec@1.2.2. This lets Renovate lockfile maintenance and dependency PRs generate pnpm-lock.yaml updates again while keeping the policy narrow.

Verified with:

```
pnpm install --lockfile-only --ignore-scripts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR tells the project's package manager (pnpm) to trust two specific package versions (`effect@4.0.0-beta.59` and `tinyexec@1.2.2`) that it was previously rejecting. pnpm was blocking automatic dependency updates from being created because it thought these versions were unsafe "downgrades," even though they're legitimate official releases. By adding them to the exception list, the automated update tool (Renovate) can now successfully refresh the project's lockfile.

## Changes

Updated `pnpm-workspace.yaml` to extend the `trustPolicyExclude` list with two additional package versions:
- `effect@4.0.0-beta.59`
- `tinyexec@1.2.2`

These packages were previously rejected by pnpm's trust-downgrade policy, which prevented Renovate from refreshing lockfile artifacts during branch updates and grouped dependency PRs. Adding them to the exclusion list allows these official package versions to be trusted and installed while maintaining the narrow security-focused policy for other dependencies.

The change was verified by running `pnpm install --lockfile-only --ignore-scripts`, confirming that lockfile maintenance can now proceed successfully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->