### PR TITLE
ci(changed-test-gate): surface workspace-config gaps instead of false-passing

### DIFF
--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -92,10 +92,26 @@ jobs:
           set -euo pipefail
           mapfile -t test_files < /tmp/changed-test-files
 
+          # `--passWithNoTests` makes vitest exit 0 when no project in the root
+          # workspace matches a given file. That's indistinguishable from
+          # "tests ran and passed" — so a PR adding tests in a package excluded
+          # from the workspace (e.g. `packages/playground-ui`) silently exits 0
+          # and the gate then mis-reports it as "tests passed against base".
+          # Capture stderr/stdout so we can detect that no-discovery case and
+          # surface it as a workspace-config error instead.
           set +e
-          pnpm vitest run --passWithNoTests "${test_files[@]}"
+          vitest_output=$(pnpm vitest run --passWithNoTests "${test_files[@]}" 2>&1)
           test_status=$?
           set -e
+
+          echo "$vitest_output"
+
+          if echo "$vitest_output" | grep -qE "No test files found"; then
+            echo "::error title=Workspace gap::Changed test files are not discoverable by the root vitest workspace. The gate cannot validate them."
+            echo "::error::Files affected: ${test_files[*]}"
+            echo "::error::Likely causes: the package is listed in EXCLUDED_DIRS of root vitest.config.ts, or it has no vitest.config.ts that matches the root PROJECT_GLOBS."
+            exit 1
+          fi
 
           if [ "$test_status" -eq 0 ]; then
             echo "::error::Changed tests passed against the base branch. They should fail before the PR code is applied."


### PR DESCRIPTION
## Summary

Tiny fix for a confusing edge case in the Changed Test Gate. **No behavioural change for the cases that already work** — only changes the outcome of the silent-skip case from "pass with the wrong reason" to "fail with the right reason".

## The bug

The gate runs:

```bash
pnpm vitest run --passWithNoTests "${test_files[@]}"
```

`--passWithNoTests` collapses two very different states into the same exit code 0:

1. **Tests ran and passed on base** — the legitimate "weak test" signal the gate is designed to catch.
2. **No vitest project in the root workspace matches the changed test files** — the tests never ran. The gate still sees exit 0 and reports them as "passed against base".

Case 2 hits **every PR** that touches tests in a package outside the root workspace:

- `packages/playground-ui` (UI library, 257 tests, listed in `EXCLUDED_DIRS`)
- `packages/playground` (the app)
- The various `_*` internal helpers

The gate then fails with `"Changed tests passed against the base branch. They should fail before the PR code is applied."` — which is the wrong diagnosis. The tests never ran.

This means the gate isn't just unhelpful for those packages: it actively misleads contributors into hunting for a problem in their test code that doesn't exist.

## The fix

Capture vitest's output, detect the `"No test files found"` line, and surface that as a workspace-config error with a clear pointer to the likely cause.

```bash
vitest_output=$(pnpm vitest run --passWithNoTests "${test_files[@]}" 2>&1)
test_status=$?

if echo "$vitest_output" | grep -qE "No test files found"; then
  echo "::error title=Workspace gap::Changed test files are not discoverable by the root vitest workspace..."
  exit 1
fi

# Existing pass/fail check is unchanged from here.
```

17 lines net added.

## Coverage / outcome table

| Scenario | Current behaviour | After this PR |
|----------|-------------------|---------------|
| Changed tests pass on base (weak/tautological) | Gate fails, message "tests passed" | **Unchanged** |
| Changed tests fail on base (legitimate new test) | Gate passes | **Unchanged** |
| No changed test files in PR | Gate skips entirely | **Unchanged** |
| Changed tests in excluded/no-config package | Gate fails, message "tests passed" (misleading) | Gate fails, message "workspace gap" (accurate) |
| `vitest` rewords the "No test files found" string in a future version | n/a | grep no longer matches → falls back to current behaviour. No regression. |

## What this PR does **not** address

The gate also misfires on **refactor PRs** that modify existing tests without adding new ones — modified tests still pass against base because the behaviour they exercise hasn't changed. Fixing that needs AST-level new-test detection (parse `it('...')` / `test('...')` names on both sides of the diff, only run the *added* names against base). That's a much larger change and worth its own discussion; this PR keeps strictly to the silent-skip fix.

## Verification

- Searched git history: the `--passWithNoTests` line dates to the original gate addition (#17041 by @greglobinski, then base-branch logic fix in #17103). No other workflow depends on this exit-code semantics.
- Manually reproduced the silent-skip on PR #16959 (playground-ui refactor): vitest emits exactly `"No test files found, exiting with code 0"` followed by the filter list. The grep matches.
- Branch protection: `changed-tests` is not in the required status checks on `main`, so this change is informational-only and safe to iterate.

## Discussion

Filed as draft for review and async feedback. Happy to fold in the AST-aware new-test detection as a follow-up if there's appetite.