### PR TITLE
fix(server-adapters): preserve zod validation error field paths under dual-zod consumers

### DIFF
--- a/.changeset/eight-insects-behave.md
+++ b/.changeset/eight-insects-behave.md
@@ -1,0 +1,21 @@
+---
+'@mastra/server': minor
+---
+
+Added `isZodError` helper and `ZodErrorLike` type, exported from `@mastra/server/server-adapter` (and `@mastra/server/handlers/error`). Use these instead of `instanceof ZodError` when handling validation errors in custom server adapters or middleware so the check survives consumers that pin a different `zod` package instance than the one bundled with `@mastra/server`.
+
+```ts
+import { isZodError } from '@mastra/server/server-adapter';
+
+try {
+  await schema.parseAsync(input);
+} catch (error) {
+  if (isZodError(error)) {
+    // structural check — works across zod v3/v4 realms
+    return formatValidationError(error);
+  }
+  throw error;
+}
+```
+
+Underpins the fix for [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/.changeset/express-zod-v3-validation.md
+++ b/.changeset/express-zod-v3-validation.md
@@ -1,0 +1,5 @@
+---
+'@mastra/express': patch
+---
+
+Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the zod issues blob stuffed into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/.changeset/express-zod-v3-validation.md
+++ b/.changeset/express-zod-v3-validation.md
@@ -2,4 +2,4 @@
 '@mastra/express': patch
 ---
 
-Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the zod issues blob stuffed into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).
+Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the raw Zod issues serialized into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/.changeset/fastify-zod-v3-validation.md
+++ b/.changeset/fastify-zod-v3-validation.md
@@ -2,4 +2,4 @@
 '@mastra/fastify': patch
 ---
 
-Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the zod issues blob stuffed into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).
+Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the raw Zod issues serialized into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/.changeset/fastify-zod-v3-validation.md
+++ b/.changeset/fastify-zod-v3-validation.md
@@ -1,0 +1,5 @@
+---
+'@mastra/fastify': patch
+---
+
+Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the zod issues blob stuffed into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/.changeset/hono-zod-v3-validation.md
+++ b/.changeset/hono-zod-v3-validation.md
@@ -2,4 +2,4 @@
 '@mastra/hono': patch
 ---
 
-Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the zod issues blob stuffed into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).
+Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the raw Zod issues serialized into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/.changeset/hono-zod-v3-validation.md
+++ b/.changeset/hono-zod-v3-validation.md
@@ -1,0 +1,5 @@
+---
+'@mastra/hono': patch
+---
+
+Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the zod issues blob stuffed into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/.changeset/koa-zod-v3-validation.md
+++ b/.changeset/koa-zod-v3-validation.md
@@ -2,4 +2,4 @@
 '@mastra/koa': patch
 ---
 
-Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the zod issues blob stuffed into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).
+Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the raw Zod issues serialized into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/.changeset/koa-zod-v3-validation.md
+++ b/.changeset/koa-zod-v3-validation.md
@@ -1,0 +1,5 @@
+---
+'@mastra/koa': patch
+---
+
+Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin `zod@^3`. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the zod issues blob stuffed into `issues[0].message`. Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/.changeset/nestjs-zod-v3-validation.md
+++ b/.changeset/nestjs-zod-v3-validation.md
@@ -2,8 +2,8 @@
 '@mastra/nestjs': patch
 ---
 
-Switched the internal Zod error check to use the shared `isZodError` helper from `@mastra/server`, removing a duplicated local implementation and keeping behavior consistent with the other server adapters under dual-`zod` consumer setups.
+Fixed validation error responses on routes with `bodySchema`, `queryParamSchema`, or `pathParamSchema` losing field path information when consumers pin a different `zod` major than the one bundled with this adapter. Responses now return the actual field name in `issues[].field` (e.g. `"agent_id"`) instead of `"unknown"` with the raw Zod issues serialized into `issues[0].message`.
 
-`ValidationError.zodError` is now typed as `ZodErrorLike` (a structural subset of `ZodError` exposing `issues[]`) so that consumers pinning a different `zod` major than the one bundled with this adapter still type-check. The runtime value is unchanged and still supports all `ZodError` methods — cast to your installed `ZodError` type if you need them.
+`ValidationError.zodError` is now typed as `ZodErrorLike` (a structural subset of `ZodError` exposing `issues[]`) so consumers pinning a different `zod` major still type-check. The runtime value is unchanged; cast to your installed `ZodError` type if you need its instance methods.
 
-Related to [#17167](https://github.com/mastra-ai/mastra/issues/17167).
+Fixes [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/.changeset/nestjs-zod-v3-validation.md
+++ b/.changeset/nestjs-zod-v3-validation.md
@@ -1,0 +1,9 @@
+---
+'@mastra/nestjs': patch
+---
+
+Switched the internal Zod error check to use the shared `isZodError` helper from `@mastra/server`, removing a duplicated local implementation and keeping behavior consistent with the other server adapters under dual-`zod` consumer setups.
+
+`ValidationError.zodError` is now typed as `ZodErrorLike` (a structural subset of `ZodError` exposing `issues[]`) so that consumers pinning a different `zod` major than the one bundled with this adapter still type-check. The runtime value is unchanged and still supports all `ZodError` methods — cast to your installed `ZodError` type if you need them.
+
+Related to [#17167](https://github.com/mastra-ai/mastra/issues/17167).

--- a/packages/server/src/server/handlers.ts
+++ b/packages/server/src/server/handlers.ts
@@ -1,5 +1,5 @@
 export * as agentBuilder from './handlers/agent-builder';
-export { formatZodError } from './handlers/error';
+export { formatZodError, isZodError, type ZodErrorLike } from './handlers/error';
 export * as agents from './handlers/agents';
 export * as a2a from './handlers/a2a';
 export * as conversations from './handlers/conversations';

--- a/packages/server/src/server/handlers/error.ts
+++ b/packages/server/src/server/handlers/error.ts
@@ -1,4 +1,5 @@
 import { isModelNotAllowedError } from '@mastra/core/agent-builder/ee';
+import type { ZodError } from 'zod';
 
 import { HTTPException } from '../http-exception';
 import type { StatusCode } from '../http-exception';
@@ -8,11 +9,30 @@ import type { ApiError } from '../types';
  * Duck-typed interface for ZodError-like objects.
  * Note: Zod v4 uses PropertyKey[] (string | number | symbol) for path.
  */
-interface ZodErrorLike {
+export interface ZodErrorLike {
   issues: Array<{
     path: PropertyKey[];
     message: string;
   }>;
+}
+
+/**
+ * Structural check for ZodError instances.
+ *
+ * Avoids `instanceof ZodError` because consumers can resolve `'zod'` to a
+ * different package instance (e.g. `zod@^3`) than the one a server adapter is
+ * bundled with (`zod@^4`). In that case `instanceof` is false and validation
+ * errors fall through to a generic response that drops field-path information.
+ *
+ * See https://github.com/mastra-ai/mastra/issues/17167.
+ */
+export function isZodError(error: unknown): error is ZodError<any> {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    (error as { name?: unknown }).name === 'ZodError' &&
+    Array.isArray((error as { issues?: unknown }).issues)
+  );
 }
 
 /**

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -19,6 +19,7 @@ import {
   isStudioClientTypeHeader,
 } from '../constants';
 import { formatZodError } from '../handlers/error';
+export { isZodError, type ZodErrorLike } from '../handlers/error';
 import { normalizeRoutePath } from '../utils';
 import { generateOpenAPIDocument, convertCustomRoutesToOpenAPIPaths } from './openapi-utils';
 import type { ServerRoute } from './routes';

--- a/server-adapters/express/src/__tests__/validation-error-zod-v3.test.ts
+++ b/server-adapters/express/src/__tests__/validation-error-zod-v3.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression coverage for https://github.com/mastra-ai/mastra/issues/17167
+ * applied to the Express adapter.
+ *
+ * When a consumer pins `zod@^3`, route schemas are constructed with v3 `z`
+ * and `parseAsync` throws a v3 `ZodError`. The Express adapter previously
+ * checked `error instanceof ZodError` against the v4 class bundled with this
+ * package, so the catch fell through to a generic response that dropped the
+ * field path. The fix uses a structural ZodError check; these tests prove it.
+ */
+import type { Server } from 'node:http';
+import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
+import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
+import express from 'express';
+import type { Application } from 'express';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z as zv3 } from 'zod/v3';
+import { MastraServer } from '../index';
+
+describe('Express adapter: zod v3 validation errors preserve field path (issue #17167)', () => {
+  let context: AdapterTestContext;
+  let app: Application;
+  let adapter: MastraServer;
+  let server: Server;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    context = await createDefaultTestContext();
+    app = express();
+    app.use(express.json());
+    adapter = new MastraServer({
+      app,
+      mastra: context.mastra,
+      taskStore: context.taskStore,
+    });
+    app.use(adapter.createContextMiddleware());
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
+  async function listen(): Promise<void> {
+    server = await new Promise<Server>(resolve => {
+      const s = app.listen(0, () => resolve(s));
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Failed to get server address');
+    }
+    baseUrl = `http://localhost:${address.port}`;
+  }
+
+  it('body schema built with zod v3 produces field-specific issues', async () => {
+    const bodySchema = zv3.object({ agent_id: zv3.string() });
+    await adapter.registerRoute(
+      app,
+      {
+        method: 'POST',
+        path: '/v1/conversations',
+        responseType: 'json',
+        bodySchema,
+        handler: async () => ({ ok: true }),
+      } as any,
+      { prefix: '' },
+    );
+
+    await listen();
+
+    const response = await fetch(`${baseUrl}/v1/conversations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { error: string; issues: Array<{ field: string; message: string }> };
+    expect(data.error).toBe('Invalid request body');
+    expect(data.issues[0]!.field).toBe('agent_id');
+    expect(data.issues[0]!.message).not.toMatch(/^\[\s*\{/);
+  });
+
+  it('query schema built with zod v3 produces field-specific issues', async () => {
+    const queryParamSchema = zv3.object({ page: zv3.coerce.number() });
+    await adapter.registerRoute(
+      app,
+      {
+        method: 'POST',
+        path: '/v1/q',
+        responseType: 'json',
+        queryParamSchema,
+        handler: async () => ({ ok: true }),
+      } as any,
+      { prefix: '' },
+    );
+
+    await listen();
+
+    const response = await fetch(`${baseUrl}/v1/q?page=not-a-number`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { error: string; issues: Array<{ field: string; message: string }> };
+    expect(data.error).toBe('Invalid query parameters');
+    expect(data.issues[0]!.field).toBe('page');
+  });
+
+  it('path schema built with zod v3 produces field-specific issues', async () => {
+    const pathParamSchema = zv3.object({ id: zv3.coerce.number() });
+    await adapter.registerRoute(
+      app,
+      {
+        method: 'POST',
+        path: '/v1/p/:id',
+        responseType: 'json',
+        pathParamSchema,
+        handler: async () => ({ ok: true }),
+      } as any,
+      { prefix: '' },
+    );
+
+    await listen();
+
+    const response = await fetch(`${baseUrl}/v1/p/not-a-number`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { error: string; issues: Array<{ field: string; message: string }> };
+    expect(data.error).toBe('Invalid path parameters');
+    expect(data.issues[0]!.field).toBe('id');
+  });
+});

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -9,11 +9,11 @@ import type { ParsedRequestParams, ServerRoute } from '@mastra/server/server-ada
 import {
   MastraServer as MastraServerBase,
   checkRouteFGA,
+  isZodError,
   normalizeQueryParams,
   redactStreamChunk,
 } from '@mastra/server/server-adapter';
 import type { Application, NextFunction, Request, Response } from 'express';
-import { ZodError } from 'zod';
 export { createAuthMiddleware } from './auth-middleware';
 export type { ExpressAuthMiddlewareOptions } from './auth-middleware';
 
@@ -480,7 +480,7 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
             this.mastra.getLogger()?.error('Error parsing query params', {
               error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
             });
-            if (error instanceof ZodError) {
+            if (isZodError(error)) {
               const { status, body } = this.resolveValidationError(route, error, 'query');
               return res.status(status).json(body);
             }
@@ -498,7 +498,7 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
             this.mastra.getLogger()?.error('Error parsing body', {
               error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
             });
-            if (error instanceof ZodError) {
+            if (isZodError(error)) {
               const { status, body } = this.resolveValidationError(route, error, 'body');
               return res.status(status).json(body);
             }
@@ -517,7 +517,7 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
             this.mastra.getLogger()?.error('Error parsing path params', {
               error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
             });
-            if (error instanceof ZodError) {
+            if (isZodError(error)) {
               const { status, body } = this.resolveValidationError(route, error, 'path');
               return res.status(status).json(body);
             }

--- a/server-adapters/fastify/src/__tests__/validation-error-zod-v3.test.ts
+++ b/server-adapters/fastify/src/__tests__/validation-error-zod-v3.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression coverage for https://github.com/mastra-ai/mastra/issues/17167
+ * applied to the Fastify adapter. Same diagnosis as Hono/Express/Koa: a
+ * consumer pinned to `zod@^3` builds schemas whose `ZodError` is not
+ * `instanceof` the v4 `ZodError` bundled with this adapter. The structural
+ * `isZodError` check restores the correct field-path response shape.
+ */
+import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
+import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z as zv3 } from 'zod/v3';
+import { MastraServer } from '../index';
+
+describe('Fastify adapter: zod v3 validation errors preserve field path (issue #17167)', () => {
+  let context: AdapterTestContext;
+  let app: FastifyInstance;
+  let adapter: MastraServer;
+
+  beforeEach(async () => {
+    context = await createDefaultTestContext();
+    app = Fastify();
+    adapter = new MastraServer({
+      app,
+      mastra: context.mastra,
+      taskStore: context.taskStore,
+    });
+    app.addHook('preHandler', adapter.createContextMiddleware());
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('body schema built with zod v3 produces field-specific issues', async () => {
+    const bodySchema = zv3.object({ agent_id: zv3.string() });
+    await adapter.registerRoute(
+      app,
+      {
+        method: 'POST',
+        path: '/v1/conversations',
+        responseType: 'json',
+        bodySchema,
+        handler: async () => ({ ok: true }),
+      } as any,
+      { prefix: '' },
+    );
+    await app.ready();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/conversations',
+      headers: { 'content-type': 'application/json' },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    const data = response.json() as { error: string; issues: Array<{ field: string; message: string }> };
+    expect(data.error).toBe('Invalid request body');
+    expect(data.issues[0]!.field).toBe('agent_id');
+    expect(data.issues[0]!.message).not.toMatch(/^\[\s*\{/);
+  });
+
+  it('query schema built with zod v3 produces field-specific issues', async () => {
+    const queryParamSchema = zv3.object({ page: zv3.coerce.number() });
+    await adapter.registerRoute(
+      app,
+      {
+        method: 'POST',
+        path: '/v1/q',
+        responseType: 'json',
+        queryParamSchema,
+        handler: async () => ({ ok: true }),
+      } as any,
+      { prefix: '' },
+    );
+    await app.ready();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/q?page=not-a-number',
+      headers: { 'content-type': 'application/json' },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    const data = response.json() as { error: string; issues: Array<{ field: string; message: string }> };
+    expect(data.error).toBe('Invalid query parameters');
+    expect(data.issues[0]!.field).toBe('page');
+  });
+
+  it('path schema built with zod v3 produces field-specific issues', async () => {
+    const pathParamSchema = zv3.object({ id: zv3.coerce.number() });
+    await adapter.registerRoute(
+      app,
+      {
+        method: 'POST',
+        path: '/v1/p/:id',
+        responseType: 'json',
+        pathParamSchema,
+        handler: async () => ({ ok: true }),
+      } as any,
+      { prefix: '' },
+    );
+    await app.ready();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/p/not-a-number',
+      headers: { 'content-type': 'application/json' },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    const data = response.json() as { error: string; issues: Array<{ field: string; message: string }> };
+    expect(data.error).toBe('Invalid path parameters');
+    expect(data.issues[0]!.field).toBe('id');
+  });
+});

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -8,11 +8,11 @@ import type { ParsedRequestParams, ServerRoute } from '@mastra/server/server-ada
 import {
   MastraServer as MastraServerBase,
   checkRouteFGA,
+  isZodError,
   normalizeQueryParams,
   redactStreamChunk,
 } from '@mastra/server/server-adapter';
 import type { FastifyInstance, FastifyReply, FastifyRequest, preHandlerHookHandler, RouteHandlerMethod } from 'fastify';
-import { ZodError } from 'zod';
 export { createAuthMiddleware } from './auth-middleware';
 export type { FastifyAuthMiddlewareOptions } from './auth-middleware';
 
@@ -570,7 +570,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
           this.mastra.getLogger()?.error('Error parsing query params', {
             error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
           });
-          if (error instanceof ZodError) {
+          if (isZodError(error)) {
             const { status, body } = this.resolveValidationError(route, error, 'query');
             return reply.status(status).send(body);
           }
@@ -588,7 +588,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
           this.mastra.getLogger()?.error('Error parsing body', {
             error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
           });
-          if (error instanceof ZodError) {
+          if (isZodError(error)) {
             const { status, body } = this.resolveValidationError(route, error, 'body');
             return reply.status(status).send(body);
           }
@@ -607,7 +607,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
           this.mastra.getLogger()?.error('Error parsing path params', {
             error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
           });
-          if (error instanceof ZodError) {
+          if (isZodError(error)) {
             const { status, body } = this.resolveValidationError(route, error, 'path');
             return reply.status(status).send(body);
           }

--- a/server-adapters/hono/src/__tests__/validation-error-hook.test.ts
+++ b/server-adapters/hono/src/__tests__/validation-error-hook.test.ts
@@ -3,6 +3,7 @@ import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
 import { Hono } from 'hono';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { z } from 'zod';
+import { z as zv3 } from 'zod/v3';
 import { MastraServer } from '../index';
 
 describe('Validation Error Hook', () => {
@@ -225,6 +226,118 @@ describe('Validation Error Hook', () => {
       expect(data.error).toBe('Invalid request body');
       expect(data.issues).toBeInstanceOf(Array);
       expect(data.issues.length).toBeGreaterThan(0);
+    });
+  });
+
+  /**
+   * Regression coverage for https://github.com/mastra-ai/mastra/issues/17167.
+   *
+   * When a consumer pins `zod@^3`, route schemas are constructed with v3 `z`
+   * and `parseAsync` throws a v3 `ZodError`. The Hono adapter imports `ZodError`
+   * from the top-level `zod` (v4 in this repo's graph), so an `instanceof`
+   * check across realms returns `false` and the response falls back to:
+   *
+   *   { error, issues: [{ field: "unknown", message: <stringified zod issues> }] }
+   *
+   * These tests construct schemas with `zod/v3` while the adapter uses the
+   * bundled top-level `zod`, reproducing the dual-instance hazard
+   * deterministically and proving the structural ZodError check is in effect.
+   */
+  describe('dual zod-instance (zod v3 consumer, issue #17167)', () => {
+    async function registerV3Route(app: Hono, route: any) {
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+        tools: context.tools,
+        taskStore: context.taskStore,
+      });
+      await adapter.registerRoute(app, route, { prefix: '' });
+      return adapter;
+    }
+
+    it('body schema built with zod v3 produces field-specific issues (not "unknown")', async () => {
+      // Mirrors packages/server/src/server/schemas/conversations.ts createConversationBodySchema.
+      const bodySchemaV3 = zv3.object({
+        agent_id: zv3.string(),
+        conversation_id: zv3.string().optional(),
+      });
+
+      const app = new Hono();
+      await registerV3Route(app, {
+        method: 'POST' as const,
+        path: '/v1/conversations',
+        responseType: 'json' as const,
+        bodySchema: bodySchemaV3,
+        handler: async () => ({ ok: true }),
+      });
+
+      const response = await app.request(
+        new Request('http://localhost/v1/conversations', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+
+      expect(data.error).toBe('Invalid request body');
+      expect(Array.isArray(data.issues)).toBe(true);
+      expect(data.issues.length).toBeGreaterThan(0);
+      expect(data.issues[0].field).toBe('agent_id');
+      // Must not be a JSON-stringified issues array.
+      expect(data.issues[0].message).not.toMatch(/^\[\s*\{/);
+    });
+
+    it('query schema built with zod v3 produces field-specific issues', async () => {
+      const queryParamSchemaV3 = zv3.object({ page: zv3.coerce.number() });
+
+      const app = new Hono();
+      await registerV3Route(app, {
+        method: 'POST' as const,
+        path: '/v1/query-test',
+        responseType: 'json' as const,
+        queryParamSchema: queryParamSchemaV3,
+        handler: async () => ({ ok: true }),
+      });
+
+      const response = await app.request(
+        new Request('http://localhost/v1/query-test?page=not-a-number', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toBe('Invalid query parameters');
+      expect(data.issues[0].field).toBe('page');
+    });
+
+    it('path schema built with zod v3 produces field-specific issues', async () => {
+      const pathParamSchemaV3 = zv3.object({ id: zv3.coerce.number() });
+
+      const app = new Hono();
+      await registerV3Route(app, {
+        method: 'POST' as const,
+        path: '/v1/path-test/:id',
+        responseType: 'json' as const,
+        pathParamSchema: pathParamSchemaV3,
+        handler: async () => ({ ok: true }),
+      });
+
+      const response = await app.request(
+        new Request('http://localhost/v1/path-test/not-a-number', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toBe('Invalid path parameters');
+      expect(data.issues[0].field).toBe('id');
     });
   });
 });

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -8,6 +8,7 @@ import type { ParsedRequestParams, ServerRoute } from '@mastra/server/server-ada
 import {
   MastraServer as MastraServerBase,
   checkRouteFGA,
+  isZodError,
   normalizeQueryParams,
   redactStreamChunk,
 } from '@mastra/server/server-adapter';
@@ -15,7 +16,6 @@ import { toReqRes, toFetchResponse } from 'fetch-to-node';
 import type { Context, HonoRequest, MiddlewareHandler } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { stream } from 'hono/streaming';
-import { ZodError } from 'zod';
 export { createAuthMiddleware } from './auth-middleware';
 export type { HonoAuthMiddlewareOptions } from './auth-middleware';
 // Browser stream setup (Hono-specific WebSocket implementation)
@@ -450,7 +450,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
             this.mastra.getLogger()?.error('Error parsing query params', {
               error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
             });
-            if (error instanceof ZodError) {
+            if (isZodError(error)) {
               const { status, body } = this.resolveValidationError(route, error, 'query');
               return c.json(body as any, status as any);
             }
@@ -471,7 +471,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
             this.mastra.getLogger()?.error('Error parsing body', {
               error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
             });
-            if (error instanceof ZodError) {
+            if (isZodError(error)) {
               const { status, body } = this.resolveValidationError(route, error, 'body');
               return c.json(body as any, status as any);
             }
@@ -493,7 +493,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
             this.mastra.getLogger()?.error('Error parsing path params', {
               error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
             });
-            if (error instanceof ZodError) {
+            if (isZodError(error)) {
               const { status, body } = this.resolveValidationError(route, error, 'path');
               return c.json(body as any, status as any);
             }

--- a/server-adapters/koa/src/__tests__/validation-error-zod-v3.test.ts
+++ b/server-adapters/koa/src/__tests__/validation-error-zod-v3.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression coverage for https://github.com/mastra-ai/mastra/issues/17167
+ * applied to the Koa adapter. Same diagnosis as Hono/Express/Fastify: a
+ * consumer pinned to `zod@^3` builds schemas whose `ZodError` is not
+ * `instanceof` the v4 `ZodError` bundled with this adapter. The structural
+ * `isZodError` check restores the correct field-path response shape.
+ */
+import type { Server } from 'node:http';
+import type { AdapterTestContext } from '@internal/server-adapter-test-utils';
+import { createDefaultTestContext } from '@internal/server-adapter-test-utils';
+import Koa from 'koa';
+import bodyParser from 'koa-bodyparser';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z as zv3 } from 'zod/v3';
+import { MastraServer } from '../index';
+
+describe('Koa adapter: zod v3 validation errors preserve field path (issue #17167)', () => {
+  let context: AdapterTestContext;
+  let app: Koa;
+  let adapter: MastraServer;
+  let server: Server;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    context = await createDefaultTestContext();
+    app = new Koa();
+    app.use(bodyParser());
+    adapter = new MastraServer({
+      app,
+      mastra: context.mastra,
+      taskStore: context.taskStore,
+    });
+    app.use(adapter.createContextMiddleware());
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
+  async function listen(): Promise<void> {
+    server = await new Promise<Server>(resolve => {
+      const s = app.listen(0, () => resolve(s));
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Failed to get server address');
+    }
+    baseUrl = `http://localhost:${address.port}`;
+  }
+
+  it('body schema built with zod v3 produces field-specific issues', async () => {
+    const bodySchema = zv3.object({ agent_id: zv3.string() });
+    await adapter.registerRoute(
+      app,
+      {
+        method: 'POST',
+        path: '/v1/conversations',
+        responseType: 'json',
+        bodySchema,
+        handler: async () => ({ ok: true }),
+      } as any,
+      { prefix: '' },
+    );
+    await listen();
+
+    const response = await fetch(`${baseUrl}/v1/conversations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { error: string; issues: Array<{ field: string; message: string }> };
+    expect(data.error).toBe('Invalid request body');
+    expect(data.issues[0]!.field).toBe('agent_id');
+    expect(data.issues[0]!.message).not.toMatch(/^\[\s*\{/);
+  });
+
+  it('query schema built with zod v3 produces field-specific issues', async () => {
+    const queryParamSchema = zv3.object({ page: zv3.coerce.number() });
+    await adapter.registerRoute(
+      app,
+      {
+        method: 'POST',
+        path: '/v1/q',
+        responseType: 'json',
+        queryParamSchema,
+        handler: async () => ({ ok: true }),
+      } as any,
+      { prefix: '' },
+    );
+    await listen();
+
+    const response = await fetch(`${baseUrl}/v1/q?page=not-a-number`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { error: string; issues: Array<{ field: string; message: string }> };
+    expect(data.error).toBe('Invalid query parameters');
+    expect(data.issues[0]!.field).toBe('page');
+  });
+
+  it('path schema built with zod v3 produces field-specific issues', async () => {
+    const pathParamSchema = zv3.object({ id: zv3.coerce.number() });
+    await adapter.registerRoute(
+      app,
+      {
+        method: 'POST',
+        path: '/v1/p/:id',
+        responseType: 'json',
+        pathParamSchema,
+        handler: async () => ({ ok: true }),
+      } as any,
+      { prefix: '' },
+    );
+    await listen();
+
+    const response = await fetch(`${baseUrl}/v1/p/not-a-number`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { error: string; issues: Array<{ field: string; message: string }> };
+    expect(data.error).toBe('Invalid path parameters');
+    expect(data.issues[0]!.field).toBe('id');
+  });
+});

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -9,12 +9,12 @@ import type { ParsedRequestParams, ServerRoute } from '@mastra/server/server-ada
 import {
   MastraServer as MastraServerBase,
   checkRouteFGA,
+  isZodError,
   normalizeQueryParams,
   redactStreamChunk,
 } from '@mastra/server/server-adapter';
 import type Koa from 'koa';
 import type { Context, Middleware, Next } from 'koa';
-import { ZodError } from 'zod';
 export { createAuthMiddleware } from './auth-middleware';
 export type { KoaAuthMiddlewareOptions } from './auth-middleware';
 
@@ -391,7 +391,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         this.mastra.getLogger()?.error('Error parsing query params', {
           error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
         });
-        if (error instanceof ZodError) {
+        if (isZodError(error)) {
           const resolved = this.resolveValidationError(route, error, 'query');
           ctx.status = resolved.status;
           ctx.body = resolved.body;
@@ -413,7 +413,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         this.mastra.getLogger()?.error('Error parsing body', {
           error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
         });
-        if (error instanceof ZodError) {
+        if (isZodError(error)) {
           const resolved = this.resolveValidationError(route, error, 'body');
           ctx.status = resolved.status;
           ctx.body = resolved.body;
@@ -436,7 +436,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         this.mastra.getLogger()?.error('Error parsing path params', {
           error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
         });
-        if (error instanceof ZodError) {
+        if (isZodError(error)) {
           const resolved = this.resolveValidationError(route, error, 'path');
           ctx.status = resolved.status;
           ctx.body = resolved.body;

--- a/server-adapters/nestjs/src/filters/mastra-exception.filter.ts
+++ b/server-adapters/nestjs/src/filters/mastra-exception.filter.ts
@@ -1,8 +1,7 @@
-import { formatZodError } from '@mastra/server/handlers/error';
+import { formatZodError, isZodError } from '@mastra/server/handlers/error';
 import { Catch, HttpException, HttpStatus, Logger } from '@nestjs/common';
 import type { ArgumentsHost, ExceptionFilter } from '@nestjs/common';
 import type { Request, Response } from 'express';
-import { ZodError } from 'zod';
 
 import { ValidationError } from '../services/route-handler.service';
 
@@ -11,18 +10,6 @@ interface NormalizedError {
   error: string;
   code?: string;
   issues?: Array<{ field?: string; path?: string[]; message: string }>;
-}
-
-function isZodErrorLike(exception: unknown): exception is ZodError {
-  return (
-    exception instanceof ZodError ||
-    (typeof exception === 'object' &&
-      exception !== null &&
-      'name' in exception &&
-      (exception as { name?: unknown }).name === 'ZodError' &&
-      'issues' in exception &&
-      Array.isArray((exception as { issues?: unknown }).issues))
-  );
 }
 
 /**
@@ -121,7 +108,7 @@ export class MastraExceptionFilter implements ExceptionFilter {
     }
 
     // Zod validation error
-    if (isZodErrorLike(exception)) {
+    if (isZodError(exception)) {
       const formatted = formatZodError(exception, 'request');
       return {
         status: HttpStatus.BAD_REQUEST,

--- a/server-adapters/nestjs/src/services/route-handler.service.ts
+++ b/server-adapters/nestjs/src/services/route-handler.service.ts
@@ -1,24 +1,11 @@
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
-import { SERVER_ROUTES } from '@mastra/server/server-adapter';
-import type { ServerRoute, ServerContext } from '@mastra/server/server-adapter';
+import { isZodError, SERVER_ROUTES } from '@mastra/server/server-adapter';
+import type { ServerRoute, ServerContext, ZodErrorLike } from '@mastra/server/server-adapter';
 import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
-import { ZodError } from 'zod';
 
 import { MASTRA, MASTRA_OPTIONS } from '../constants';
 import type { MastraModuleOptions } from '../mastra.module';
-
-function isZodErrorLike(error: unknown): error is ZodError {
-  return (
-    error instanceof ZodError ||
-    (typeof error === 'object' &&
-      error !== null &&
-      'name' in error &&
-      (error as { name?: unknown }).name === 'ZodError' &&
-      'issues' in error &&
-      Array.isArray((error as { issues?: unknown }).issues))
-  );
-}
 
 export interface RouteMatch {
   route: ServerRoute;
@@ -181,7 +168,7 @@ export class RouteHandlerService {
       try {
         validatedPathParams = (await route.pathParamSchema.parseAsync(params.pathParams)) as Record<string, string>;
       } catch (error) {
-        if (isZodErrorLike(error)) {
+        if (isZodError(error)) {
           throw new ValidationError('Invalid path parameters', error);
         }
         throw error;
@@ -193,7 +180,7 @@ export class RouteHandlerService {
       try {
         validatedQueryParams = (await route.queryParamSchema.parseAsync(params.queryParams)) as Record<string, unknown>;
       } catch (error) {
-        if (isZodErrorLike(error)) {
+        if (isZodError(error)) {
           throw new ValidationError('Invalid query parameters', error);
         }
         throw error;
@@ -205,7 +192,7 @@ export class RouteHandlerService {
       try {
         validatedBody = await route.bodySchema.parseAsync(params.body);
       } catch (error) {
-        if (isZodErrorLike(error)) {
+        if (isZodError(error)) {
           throw new ValidationError('Invalid request body', error);
         }
         throw error;
@@ -262,11 +249,17 @@ export class RouteHandlerService {
 
 /**
  * Error class for validation failures with Zod error details.
+ *
+ * `zodError` is typed as `ZodErrorLike` (a structural subset of `ZodError`
+ * exposing `issues[]`) so that consumers pinning a different `zod` major than
+ * the one bundled with this adapter still type-check. The runtime value is
+ * the actual `ZodError` thrown by the route schema and supports all of its
+ * methods at runtime — cast to your installed `ZodError` if you need them.
  */
 export class ValidationError extends Error {
   constructor(
     message: string,
-    public readonly zodError: ZodError,
+    public readonly zodError: ZodErrorLike,
   ) {
     super(message);
     this.name = 'ValidationError';


### PR DESCRIPTION
Fixes #17167

When a consumer pinned `zod@^3`, routes using `bodySchema`, `queryParamSchema`, or `pathParamSchema` returned 400 responses with `issues[].field === "unknown"` and the raw zod issues stringified into `issues[0].message`. Adapters checked `error instanceof ZodError` against their own bundled `zod` class, but the schema's error came from the consumer's `zod` instance, so the check was `false` and the catch fell through to a generic response that dropped the field path.

`@mastra/server` now exports a shared structural `isZodError` helper and `ZodErrorLike` type. All five adapters (Hono, Express, Fastify, Koa, NestJS) use it. `@mastra/nestjs` also drops its duplicated local copies.

Before:

```json
{
  "error": "Invalid request body",
  "issues": [{ "field": "unknown", "message": "[{\"code\":\"invalid_type\",\"path\":[\"agent_id\"],...}]" }]
}
```

After:

```json
{
  "error": "Invalid request body",
  "issues": [{ "field": "agent_id", "message": "Required" }]
}
```

Includes zod-v3 regression coverage for body/query/path on Hono, Express, Fastify, and Koa.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)
When the app and a user used different copies of the Zod validation library, the server couldn't tell a validation error was from Zod and erased which field was wrong. This PR makes error detection look at the shape of the error instead of relying on library identity, so the server preserves the correct field names in validation responses.

## Summary
Fixes a bug where routes using bodySchema, queryParamSchema, or pathParamSchema returned 400 responses with issues[].field === "unknown" when consumers pinned zod@^3. Root cause: adapters used instanceof ZodError against their bundled zod (v4), which failed for ZodError instances created by the consumer's zod (v3), producing a generic fallback that lost field paths.

## Solution
- Added a structural type guard and type to detect Zod-style errors across different zod package instances:
  - export function isZodError(error: unknown): error is ZodError<any>
  - export interface ZodErrorLike { issues: Array<{ path: PropertyKey[]; message: string }> }
- Exposed these from `@mastra/server` via server/handlers/error and server-adapter index so adapters can import them.
- Replaced adapter-specific instanceof checks with isZodError in all adapters (Hono, Express, Fastify, Koa, NestJS). NestJS also removed local duplicates and updated ValidationError.zodError typing to ZodErrorLike.
- formatZodError now maps issue.path -> field (dot-joined) so responses include the correct field names.

## Files changed (high level)
- packages/server/src/server/handlers/error.ts — added/exported isZodError and ZodErrorLike; formatZodError maps paths to fields.
- packages/server/src/server/handlers.ts — re-exports new utilities.
- packages/server/src/server/server-adapter/index.ts — re-exports isZodError and ZodErrorLike.
- server-adapters/{express,fastify,hono,koa}/src/index.ts — use isZodError instead of instanceof ZodError for body/query/path validation handling.
- server-adapters/nestjs/src/filters/mastra-exception.filter.ts — use shared isZodError.
- server-adapters/nestjs/src/services/route-handler.service.ts — use isZodError and ZodErrorLike; ValidationError.zodError typed as ZodErrorLike.
- Changeset files documenting the release notes for affected packages.
- Tests added: regression tests covering zod v3 body/query/path validation for Hono, Express, Fastify, and Koa.

## Test coverage
Added/regressed tests verify that when routes use zod@^3 schemas, validation failures return HTTP 400 with issues entries preserving real field paths (e.g., "agent_id", "page", "id") rather than "unknown".

## Behavior change (example)
Before:
{ "error": "Invalid request body", "issues":[{ "field":"unknown", "message":"[raw zod issues JSON]" }] }

After:
{ "error": "Invalid request body", "issues":[{ "field":"agent_id", "message":"Required" }] }

Fixes `#17167`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->