### PR TITLE
fix(core): respect default memory options in tool discovery

### DIFF
--- a/.changeset/dull-comics-tease.md
+++ b/.changeset/dull-comics-tease.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed supervisor sub-agent tool preparation so memory tools are available when agents derive their thread and resource from default options. This prevents misleading "Skipping memory tools (no thread or resource context)" debug logs for correctly configured sub-agents.

--- a/packages/core/src/agent/__tests__/working-memory-context.test.ts
+++ b/packages/core/src/agent/__tests__/working-memory-context.test.ts
@@ -2,6 +2,7 @@ import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { MockMemory } from '../../memory/mock';
+import { RequestContext } from '../../request-context';
 import type { ChunkType } from '../../stream/types';
 import { createTool, Tool } from '../../tools';
 import { createWorkflow, createStep } from '../../workflows';
@@ -325,6 +326,35 @@ describe('Working memory tool context propagation', () => {
     }
 
     expect(toolNames).not.toContain('updateWorkingMemory');
+  });
+
+  it('should use defaultOptions memory context when assembling tools for execution', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('testThreadId', 'default-thread');
+    requestContext.set('testResourceId', 'default-resource');
+
+    const mockMemory = new MockMemory({
+      enableWorkingMemory: true,
+      workingMemoryTemplate: `# Notes\n- **Key**:\n- **Value**:\n`,
+    });
+
+    const agent = new Agent({
+      id: 'default-tools-memory-test',
+      name: 'Default Tools Memory Test',
+      instructions: 'You are a helpful agent.',
+      model: createSimpleMockModel(),
+      memory: mockMemory,
+      defaultOptions: ({ requestContext }) => ({
+        memory: {
+          thread: requestContext.get('testThreadId') as string,
+          resource: requestContext.get('testResourceId') as string,
+        },
+      }),
+    });
+
+    const tools = await agent.getToolsForExecution({ requestContext });
+
+    expect(Object.keys(tools)).toContain('updateWorkingMemory');
   });
 
   it('should provide memory context when updateWorkingMemory is called inside a workflow step', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5006,9 +5006,34 @@ export class Agent<
     autoResumeSuspendedTools?: boolean;
   }): Promise<Record<string, CoreTool>> {
     const requestContext = options.requestContext ?? new RequestContext();
+    const defaultOptions = await this.getDefaultOptions({ requestContext });
+    const mergedOptions = deepMerge(
+      defaultOptions as Record<string, unknown>,
+      { ...options, requestContext } as Record<string, unknown>,
+    ) as AgentExecutionOptions & typeof options;
+    const optionMemory = (options as { memory?: AgentExecutionOptionsBase<any>['memory'] }).memory;
+    const mergedMemory = mergedOptions.memory;
+    const threadIdFromContext = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
+    const explicitThreadFromArgs = resolveThreadIdFromArgs({
+      memory: optionMemory,
+      threadId: options.threadId,
+      overrideId: threadIdFromContext,
+    });
+    const defaultThreadFromArgs = resolveThreadIdFromArgs({
+      memory: mergedMemory,
+      overrideId: threadIdFromContext,
+    });
+    const resourceIdFromContext = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+
     return this.convertTools({
-      ...options,
+      toolsets: mergedOptions.toolsets,
+      clientTools: mergedOptions.clientTools,
+      threadId: explicitThreadFromArgs?.id ?? defaultThreadFromArgs?.id,
+      resourceId: resourceIdFromContext || options.resourceId || optionMemory?.resource || mergedMemory?.resource,
+      runId: mergedOptions.runId,
       requestContext,
+      memoryConfig: options.memoryConfig ?? mergedMemory?.options,
+      autoResumeSuspendedTools: mergedOptions.autoResumeSuspendedTools,
       methodType: 'stream',
     });
   }


### PR DESCRIPTION
## Summary

This fixes a user-visible logging issue where supervisor runs could emit `Skipping memory tools (no thread or resource context)` while preparing sub-agent tools. The sub-agent could be correctly configured with memory through dynamic `defaultOptions`, but the supervisor background eligibility probe calls `Agent.getToolsForExecution()` directly, bypassing the normal `stream()` / `generate()` default option merge.

This PR updates `getToolsForExecution()` to resolve and merge the agent's `defaultOptions` before converting tools. That makes memory-backed tools discoverable when an agent derives its memory thread/resource from `requestContext`, matching the path used by normal agent execution.

## Alternative considered

Another option was to skip or suppress memory tool discovery specifically during the background eligibility probe. That would reduce the log noise, but it would also make the probe less representative of the sub-agent's actual tool surface. Merging the relevant defaults keeps tool discovery aligned with real execution behavior while preserving explicit per-call thread/resource overrides and reserved request-context keys.

## Validation

- `pnpm test packages/core/src/agent/__tests__/working-memory-context.test.ts`
- `pnpm --filter ./packages/core check`

CodeRabbit CLI is installed locally, but `coderabbit doctor` reports it is not signed in, so I could not run a local CodeRabbit review without an auth step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the supervisor peeked at what tools a sub-agent could use, it sometimes missed memory tools that should have been available. This change makes the probe use the same defaults-merging logic as normal runs, so it sees memory tools correctly.

## Summary

Fixes incorrect debug logs ("Skipping memory tools (no thread or resource context)") emitted during supervisor background eligibility probes by making tool discovery respect an agent's dynamic defaultOptions.

### Root Cause

The supervisor probe called Agent.getToolsForExecution() directly, bypassing the normal stream()/generate() merge of dynamic defaultOptions. Sub-agents can derive memory thread/resource from defaultOptions (e.g., via requestContext), so the probe could incorrectly consider memory tools unavailable.

### Solution

Agent.getToolsForExecution() now:
- Resolves the agent's dynamic defaultOptions for the provided requestContext.
- Deep-merges those defaults with call-site options.
- Resolves threadId and resourceId using merged defaults while preserving explicit per-call overrides and reserved request-context keys.
- Forwards merged runId, memoryConfig, and autoResumeSuspendedTools into convertTools() so memory-backed tools are discoverable during probe discovery.

### Changes

- .changeset/dull-comics-tease.md — bump/notes for `@mastra/core` patch release
- packages/core/src/agent/__tests__/working-memory-context.test.ts — adds test asserting defaultOptions can supply working-memory context when assembling tools
- packages/core/src/agent/agent.ts — update getToolsForExecution() to resolve & merge defaultOptions before converting tools

### Validation

- Ran tests: pnpm test packages/core/src/agent/__tests__/working-memory-context.test.ts
- Ran type/check: pnpm --filter ./packages/core check
- Note: CodeRabbit review not run locally due to auth state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->