### PR TITLE
fix: gate idle observational memory behind opt-in

### DIFF
--- a/.changeset/sour-parents-take.md
+++ b/.changeset/sour-parents-take.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Added `observation.bufferOnIdle` to opt idle turns into background observation buffering and carry the signal sender needed for background notifications.

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -133,6 +133,25 @@ const memory = new Memory({
 
 In this example, the top-level idle setting is disabled for observations, while reflections opt into idle and provider-change activation.
 
+### Buffer on idle
+
+Set `observation.bufferOnIdle` to `true` to run background observation buffering when an agent turn ends and the agent becomes idle. This is useful for apps that want short turns to be observed without waiting for the next turn or the `messageTokens` threshold.
+
+```typescript title="src/mastra/agents/agent.ts"
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      model: '__GATEWAY_OPENAI_MODEL_MINI__',
+      observation: {
+        bufferOnIdle: true,
+      },
+    },
+  },
+})
+```
+
+`bufferOnIdle` is off by default. It is separate from `bufferTokens`: `bufferTokens` controls step-time async buffering, while `bufferOnIdle` controls end-of-turn buffering for idle turns.
+
 See [the API reference](/reference/memory/observational-memory#configuration) for the full configuration shape.
 
 ## Benefits

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -195,6 +195,14 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
             defaultValue: '0.2',
           },
           {
+            name: 'bufferOnIdle',
+            type: 'boolean',
+            description:
+              'Run background observation buffering when an agent turn ends and the agent becomes idle. This is separate from `bufferTokens`, which controls step-time async buffering. Set this to `true` to buffer short idle turns without waiting for the next turn or the `messageTokens` threshold.',
+            isOptional: true,
+            defaultValue: 'false',
+          },
+          {
             name: 'bufferActivation',
             type: 'number',
             description:

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -2271,7 +2271,7 @@ describe('Memory', () => {
       await expect(memory.deleteMessages(['msg-789'])).resolves.not.toThrow();
     });
 
-    it('passes observeAttachments to the ObservationalMemory engine', async () => {
+    it('passes observation options to the ObservationalMemory engine', async () => {
       const storage = new InMemoryStore();
       const memory = new Memory({
         storage,
@@ -2279,6 +2279,7 @@ describe('Memory', () => {
           observationalMemory: {
             observation: {
               observeAttachments: 'auto',
+              bufferOnIdle: true,
             },
           },
         },
@@ -2287,6 +2288,7 @@ describe('Memory', () => {
       const engine = await (memory as any)._initOMEngine();
 
       expect(engine?.getObservationConfig().observeAttachments).toBe('auto');
+      expect(engine?.getObservationConfig().bufferOnIdle).toBe(true);
     });
 
     it('should clear thread-scoped observational memory when deleting a thread', async () => {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1616,6 +1616,7 @@ ${workingMemory}`;
             maxTokensPerBatch: omConfig.observation.maxTokensPerBatch,
             providerOptions: omConfig.observation.providerOptions,
             bufferTokens: omConfig.observation.bufferTokens,
+            bufferOnIdle: omConfig.observation.bufferOnIdle,
             bufferActivation: omConfig.observation.bufferActivation,
             blockAfter: omConfig.observation.blockAfter,
             previousObserverTokens: omConfig.observation.previousObserverTokens,

--- a/packages/memory/src/processors/observational-memory/__tests__/ai-sdk-usage.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/ai-sdk-usage.test.ts
@@ -626,6 +626,24 @@ describe('AI SDK: multi-turn buffer→activate lifecycle invariants', () => {
     expect(recordAfter!.lastObservedAt).toEqual(lastObservedBefore);
   });
 
+  it('can skip the minimum token gate for idle-triggered short turns', async () => {
+    const shortTurnOm = createOM(storage, { messageTokens: 2000, bufferTokens: 1000 });
+    const thresholdThreadId = `${threadId}-threshold-short`;
+    const idleThreadId = `${threadId}-idle-short`;
+
+    await storage.saveMessages({
+      messages: [{ ...createTestMessage('ok', 'user', `${thresholdThreadId}-msg`), threadId: thresholdThreadId }],
+    });
+    await storage.saveMessages({
+      messages: [{ ...createTestMessage('ok', 'user', `${idleThreadId}-msg`), threadId: idleThreadId }],
+    });
+
+    await expect(shortTurnOm.buffer({ threadId: thresholdThreadId })).resolves.toMatchObject({ buffered: false });
+    await expect(shortTurnOm.buffer({ threadId: idleThreadId, skipMinimumTokenCheck: true })).resolves.toMatchObject({
+      buffered: true,
+    });
+  });
+
   it('activate promotes buffered observations without LLM call', async () => {
     await storage.saveMessages({ messages: createMessagesExceedingThreshold(5, threadId) });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/idle-buffering.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/idle-buffering.test.ts
@@ -69,12 +69,13 @@ function createMessages(count: number): MastraDBMessage[] {
  * Create a minimal mock of ObservationalMemory with only the methods
  * that ObservationTurn.end() needs.
  */
-function createMockOM(opts: { asyncEnabled: boolean; unobservedMessages?: MastraDBMessage[] }) {
+function createMockOM(opts: { asyncEnabled: boolean; bufferOnIdle?: boolean; unobservedMessages?: MastraDBMessage[] }) {
   const record = createMockRecord();
   return {
     buffering: {
       isAsyncObservationEnabled: vi.fn(() => opts.asyncEnabled),
     },
+    getObservationConfig: vi.fn(() => ({ bufferOnIdle: opts.bufferOnIdle ?? true })),
     getOrCreateRecord: vi.fn(async () => record),
     getUnobservedMessages: vi.fn(() => opts.unobservedMessages ?? []),
     persistMessages: vi.fn(async () => {}),
@@ -116,6 +117,8 @@ describe('turn.end() idle buffering', () => {
       threadId,
       resourceId,
       messageList: mockMessageList as any,
+      sendSignal: vi.fn(),
+      requestContext: { get: vi.fn() } as any,
     });
 
     (turn as any)._started = true;
@@ -135,6 +138,28 @@ describe('turn.end() idle buffering', () => {
     );
   });
 
+  it('should NOT trigger buffer() when bufferOnIdle is disabled', async () => {
+    const messages = createMessages(5);
+    const mockOM = createMockOM({ asyncEnabled: true, bufferOnIdle: false, unobservedMessages: messages });
+    const mockMessageList = createMockMessageList(messages);
+
+    const turn = new ObservationTurn({
+      om: mockOM as any,
+      threadId,
+      resourceId,
+      messageList: mockMessageList as any,
+      sendSignal: vi.fn(),
+      requestContext: { get: vi.fn() } as any,
+    });
+
+    (turn as any)._started = true;
+    (turn as any)._record = mockOM._mockRecord;
+
+    await turn.end();
+
+    expect(mockOM.buffer).not.toHaveBeenCalled();
+  });
+
   it('should NOT trigger buffer() when buffering is disabled', async () => {
     const messages = createMessages(5);
     const mockOM = createMockOM({ asyncEnabled: false, unobservedMessages: messages });
@@ -145,6 +170,8 @@ describe('turn.end() idle buffering', () => {
       threadId,
       resourceId,
       messageList: mockMessageList as any,
+      sendSignal: vi.fn(),
+      requestContext: { get: vi.fn() } as any,
     });
 
     (turn as any)._started = true;
@@ -165,6 +192,8 @@ describe('turn.end() idle buffering', () => {
       threadId,
       resourceId,
       messageList: mockMessageList as any,
+      sendSignal: vi.fn(),
+      requestContext: { get: vi.fn() } as any,
     });
 
     (turn as any)._started = true;
@@ -186,6 +215,8 @@ describe('turn.end() idle buffering', () => {
       threadId,
       resourceId,
       messageList: mockMessageList as any,
+      sendSignal: vi.fn(),
+      requestContext: { get: vi.fn() } as any,
     });
 
     (turn as any)._started = true;
@@ -220,6 +251,8 @@ describe('turn.end() idle buffering', () => {
       threadId,
       resourceId,
       messageList: mockMessageList as any,
+      sendSignal: vi.fn(),
+      requestContext: { get: vi.fn() } as any,
     });
 
     (turn as any)._started = true;
@@ -237,18 +270,22 @@ describe('turn.end() idle buffering', () => {
     const mockOM = createMockOM({ asyncEnabled: true, unobservedMessages });
     const mockMessageList = createMockMessageList(unobservedMessages);
     const mockWriter = { custom: vi.fn() };
+    const mockSendSignal = vi.fn();
     const mockRequestContext = { get: vi.fn() };
     const mockObservabilityContext = { span: vi.fn() };
+    const mockActorModelContext = { provider: 'test-provider', modelId: 'test-model' };
 
     const turn = new ObservationTurn({
       om: mockOM as any,
       threadId,
       resourceId,
       messageList: mockMessageList as any,
+      sendSignal: mockSendSignal,
+      requestContext: mockRequestContext as any,
       observabilityContext: mockObservabilityContext as any,
     });
     turn.writer = mockWriter as any;
-    turn.requestContext = mockRequestContext as any;
+    turn.actorModelContext = mockActorModelContext;
 
     (turn as any)._started = true;
     (turn as any)._record = mockOM._mockRecord;
@@ -261,8 +298,11 @@ describe('turn.end() idle buffering', () => {
       messages: unobservedMessages,
       record: mockOM._mockRecord,
       writer: mockWriter,
+      sendSignal: mockSendSignal,
       requestContext: mockRequestContext,
+      currentModel: mockActorModelContext,
       observabilityContext: mockObservabilityContext,
+      skipMinimumTokenCheck: true,
     });
   });
 });

--- a/packages/memory/src/processors/observational-memory/observation-strategies/types.ts
+++ b/packages/memory/src/processors/observational-memory/observation-strategies/types.ts
@@ -1,10 +1,10 @@
 import type { MastraDBMessage } from '@mastra/core/agent';
 import type { ObservabilityContext } from '@mastra/core/observability';
-import type { ProcessorStreamWriter } from '@mastra/core/processors';
+import type { ProcessorContext, ProcessorStreamWriter } from '@mastra/core/processors';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { ObservationalMemoryRecord } from '@mastra/core/storage';
 
-import type { ObserveHooks } from '../types';
+import type { ObservationModelContext, ObserveHooks } from '../types';
 
 /** Parameters for running an observation via a strategy. */
 export interface ObservationRunOpts {
@@ -21,7 +21,9 @@ export interface ObservationRunOpts {
   writer?: ProcessorStreamWriter;
   abortSignal?: AbortSignal;
   reflectionHooks?: Pick<ObserveHooks, 'onReflectionStart' | 'onReflectionEnd'>;
+  sendSignal?: ProcessorContext['sendSignal'];
   requestContext?: RequestContext;
+  currentModel?: ObservationModelContext;
   observabilityContext?: ObservabilityContext;
 }
 

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -1,6 +1,6 @@
 import type { MessageList } from '@mastra/core/agent';
 import type { ObservabilityContext } from '@mastra/core/observability';
-import type { ProcessorStreamWriter } from '@mastra/core/processors';
+import type { ProcessorContext, ProcessorStreamWriter } from '@mastra/core/processors';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { ObservationalMemoryRecord } from '@mastra/core/storage';
 
@@ -58,6 +58,11 @@ export class ObservationTurn {
   /** Optional observability context for nested OM spans. */
   observabilityContext?: ObservabilityContext;
 
+  /** Optional signal sender for processor-originated notifications. */
+  sendSignal?: (
+    signal: Parameters<NonNullable<ProcessorContext['sendSignal']>>[0],
+  ) => ReturnType<NonNullable<ProcessorContext['sendSignal']>>;
+
   /** Current actor model for this step. Updated by the processor before prepare(). */
   actorModelContext?: ObservationModelContext;
 
@@ -69,6 +74,8 @@ export class ObservationTurn {
     threadId: string;
     resourceId?: string;
     messageList: MessageList;
+    sendSignal?: ProcessorContext['sendSignal'];
+    requestContext?: RequestContext;
     observabilityContext?: ObservabilityContext;
     hooks?: ObservationTurnHooks;
   }) {
@@ -76,6 +83,8 @@ export class ObservationTurn {
     this.threadId = opts.threadId;
     this.resourceId = opts.resourceId;
     this.messageList = opts.messageList;
+    this.sendSignal = opts.sendSignal;
+    this.requestContext = opts.requestContext;
     this.observabilityContext = opts.observabilityContext;
     this.hooks = opts.hooks ?? {};
   }
@@ -184,7 +193,9 @@ export class ObservationTurn {
     // When the agent goes idle, start buffering any unobserved messages in the background.
     // This ensures messages accumulated during the turn are observed proactively
     // rather than waiting for the next turn's step.prepare() to trigger buffering.
-    if (this.om.buffering.isAsyncObservationEnabled()) {
+    const asyncObservationEnabled = this.om.buffering.isAsyncObservationEnabled();
+    const bufferOnIdle = this.om.getObservationConfig().bufferOnIdle;
+    if (asyncObservationEnabled && bufferOnIdle) {
       const allMessages = this.messageList.get.all.db();
       const record = this._record!;
       const unobservedMessages = this.om.getUnobservedMessages(allMessages, record);
@@ -196,8 +207,11 @@ export class ObservationTurn {
             messages: unobservedMessages,
             record,
             writer: this.writer,
+            sendSignal: this.sendSignal,
             requestContext: this.requestContext,
+            currentModel: this.actorModelContext,
             observabilityContext: this.observabilityContext,
+            skipMinimumTokenCheck: true,
           })
           .catch((err: Error) => {
             omDebug(`[OM:turn.end] idle buffer failed: ${err?.message}`);

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -5,7 +5,7 @@ import { resolveModelConfig } from '@mastra/core/llm';
 import type { Mastra } from '@mastra/core/mastra';
 import { getThreadOMMetadata, setThreadOMMetadata } from '@mastra/core/memory';
 import type { ObservabilityContext } from '@mastra/core/observability';
-import type { ProcessorStreamWriter } from '@mastra/core/processors';
+import type { ProcessorContext, ProcessorStreamWriter } from '@mastra/core/processors';
 import { MessageHistory } from '@mastra/core/processors';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { MemoryStorage, ObservationalMemoryRecord, ObservationalMemoryHistoryOptions } from '@mastra/core/storage';
@@ -485,6 +485,7 @@ export class ObservationalMemory {
             config.observation?.bufferTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.bufferTokens,
             config.observation?.messageTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.messageTokens,
           ),
+      bufferOnIdle: config.observation?.bufferOnIdle ?? false,
       bufferActivation: asyncBufferingDisabled
         ? undefined
         : (config.observation?.bufferActivation ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.bufferActivation),
@@ -2889,8 +2890,12 @@ ${formattedMessages}
      *  before lastBufferedBoundary is set. */
     record?: ObservationalMemoryRecord;
     writer?: ProcessorStreamWriter;
+    sendSignal?: ProcessorContext['sendSignal'];
     requestContext?: RequestContext;
+    currentModel?: ObservationModelContext;
     observabilityContext?: ObservabilityContext;
+    /** Allow idle-triggered buffering to observe any non-empty candidate set. */
+    skipMinimumTokenCheck?: boolean;
     /** Called with the final candidate messages after cursor filtering, before the observer runs.
      *  Use this to seal messages in a live MessageList and persist them to storage. */
     beforeBuffer?: (candidates: MastraDBMessage[]) => Promise<void>;
@@ -2995,7 +3000,7 @@ ${formattedMessages}
       const minNewTokens = bufferTokens / 2;
       const newTokens = await this.tokenCounter.countMessagesAsync(candidateMessages);
 
-      if (newTokens < minNewTokens || candidateMessages.length === 0) {
+      if (candidateMessages.length === 0 || (!opts.skipMinimumTokenCheck && newTokens < minNewTokens)) {
         return { buffered: false, record };
       }
 
@@ -3039,7 +3044,9 @@ ${formattedMessages}
         cycleId,
         startedAt,
         writer,
+        sendSignal: opts.sendSignal,
         requestContext,
+        currentModel: opts.currentModel,
         observabilityContext,
       }).run();
 

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -241,6 +241,7 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
           },
         });
         this.turn.writer = writer;
+        this.turn.sendSignal = args.sendSignal;
         this.turn.requestContext = requestContext;
         await this.turn.start(this.memory);
         if (stepNumber === 0 && this.temporalMarkers) {

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -123,6 +123,16 @@ export interface ObservationConfig {
   bufferTokens?: number | false;
 
   /**
+   * Whether to run background observation buffering when a turn ends and the agent becomes idle.
+   *
+   * This is separate from `bufferTokens`: `bufferTokens` controls step-time async buffering,
+   * while `bufferOnIdle` controls end-of-turn buffering for short idle turns.
+   *
+   * @default false
+   */
+  bufferOnIdle?: boolean;
+
+  /**
    * Controls how many raw message tokens to retain after activation.
    *
    * - **Ratio (0 < value <= 1):** fraction of `messageTokens` to activate.
@@ -955,6 +965,8 @@ export interface ResolvedObservationConfig {
   maxTokensPerBatch: number;
   /** Token interval for async background observation buffering (resolved from config) */
   bufferTokens?: number;
+  /** Whether to buffer unobserved messages at the end of an idle turn */
+  bufferOnIdle: boolean;
   /** Ratio of buffered observations to activate (0-1 float) */
   bufferActivation?: number;
   /** Time in milliseconds, or auto provider-aware TTL, before buffered observations are force-activated based on the last assistant message part timestamp */


### PR DESCRIPTION
Idle observational memory used to run any time async buffering was enabled, which made the behavior effectively always-on. However the feature was broken (created by devin and not verified) so it was always effectively opted out for everyone already.

```ts
observationalMemory: {
  observation: {
    bufferTokens: 0.2,
    observeOnIdle: true,
  },
}
```

This keeps idle observation opt-in, preserves existing step-time buffering behavior, and threads `sendSignal` through the idle buffer path so background observers can notify correctly. Added docs, a patch changeset, and regression coverage for the idle path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Idle background observation used to run automatically whenever async buffering was on, which could surprise users and was effectively broken; this PR makes idle observation opt-in via a new bufferOnIdle flag so background observation only runs when you explicitly enable it.

## Overview

Gate end-of-turn (idle) observational memory buffering behind an explicit observationalMemory.observation.bufferOnIdle option and ensure processor context (notably sendSignal and model/actor context) is forwarded into the idle buffering path so background observers run correctly when enabled. Preserve existing step-time buffering behavior and add docs, a patch changeset, and regression tests for the idle observation path.

## Key Changes

- Configuration
  - Add bufferOnIdle?: boolean to ObservationConfig (defaults false) and bufferOnIdle: boolean to ResolvedObservationConfig.
  - ObservationalMemory initialization forwards omConfig.observation.bufferOnIdle into the engine.

- APIs & Types
  - ObservationRunOpts extended with sendSignal?: ProcessorContext['sendSignal'] and currentModel?: ObservationModelContext.
  - ObservationalMemory.buffer(...) signature extended to accept sendSignal, currentModel, and skipMinimumTokenCheck; skipMinimumTokenCheck bypasses the minimum-new-token gate for idle-triggered short turns while still preventing empty-candidate runs.

- Turn / Processor wiring
  - ObservationTurn now stores an optional sendSignal and request/observability contexts and forwards them when end() triggers idle buffering.
  - ObservationTurn constructor accepts sendSignal and preserves actor/model context for extraction hooks.
  - ObservationalMemoryProcessor assigns this.turn.sendSignal when creating turns so processor-originated signals are available to background buffering.

- Buffering behavior
  - Idle buffering only triggers when async buffering is enabled AND observation.bufferOnIdle (bufferOnIdle) is true.
  - sendSignal, requestContext, observabilityContext and currentModel are threaded into the async buffer path so background observers can notify and run with the correct agent/model context.
  - Added skipMinimumTokenCheck to allow buffering during short idle turns when appropriate.

## Tests

- Added and updated tests covering idle buffering and lifecycle invariants:
  - Verify buffer() can skip the minimum token gate for idle-triggered short turns.
  - Verify buffer() does not trigger when bufferOnIdle is false even if async buffering and unobserved messages exist.
  - Updated idle-buffering tests to assert buffer() receives sendSignal, requestContext, currentModel, observabilityContext and skipMinimumTokenCheck: true.
  - Preserved assertions: persisting unsaved messages before buffering, behavior when buffering disabled or no unobserved messages, and end() returning the record even if buffer() rejects.

## Documentation

- docs: Added "Buffer on idle" / observe-on-idle documentation describing observationalMemory.observation.bufferOnIdle, with examples and clarification that bufferOnIdle is off by default and distinct from step-time bufferTokens.
- Reference docs: Documented observation.bufferOnIdle boolean option and default false.

## Changeset

- Added a patch changeset for `@mastra/memory` describing the change: idle observational memory only runs when bufferOnIdle is enabled and the background buffer path carries the signal sender for notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->