### PR TITLE
fix(gateway): support custom gateways without apiKeyEnvVar

### DIFF
--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -722,7 +722,7 @@ export class Harness<TState = {}> {
       const providerConfig = registry[provider];
       const envVars = providerConfig?.apiKeyEnvVar;
       const apiKeyEnvVar = Array.isArray(envVars) ? envVars[0] : envVars;
-      if (apiKeyEnvVar && process.env[apiKeyEnvVar]) {
+      if (!apiKeyEnvVar || (apiKeyEnvVar && process.env[apiKeyEnvVar])) {
         return { hasAuth: true };
       }
       return { hasAuth: false, apiKeyEnvVar: apiKeyEnvVar || undefined };
@@ -767,7 +767,7 @@ export class Harness<TState = {}> {
         const providerConfig = registry[provider];
         const envVars = providerConfig?.apiKeyEnvVar;
         const apiKeyEnvVar = Array.isArray(envVars) ? envVars[0] : envVars;
-        const hasEnvKey = apiKeyEnvVar ? !!process.env[apiKeyEnvVar] : false;
+        const hasEnvKey = apiKeyEnvVar ? !!process.env[apiKeyEnvVar] : true;
 
         let hasApiKey = hasEnvKey;
         if (!hasApiKey && this.config.modelAuthChecker) {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -721,11 +721,14 @@ export class Harness<TState = {}> {
       const registry = PROVIDER_REGISTRY as Record<string, { apiKeyEnvVar?: string | string[] }>;
       const providerConfig = registry[provider];
       const envVars = providerConfig?.apiKeyEnvVar;
-      const apiKeyEnvVar = Array.isArray(envVars) ? envVars[0] : envVars;
-      if (!apiKeyEnvVar || (apiKeyEnvVar && process.env[apiKeyEnvVar])) {
-        return { hasAuth: true };
-      }
-      return { hasAuth: false, apiKeyEnvVar: apiKeyEnvVar || undefined };
+      const normalizedEnvVars = Array.isArray(envVars) ? envVars.filter(Boolean) : envVars ? [envVars] : [];
+
+      const hasAuth = normalizedEnvVars.length === 0 || normalizedEnvVars.some(envVar => !!process.env[envVar]);
+
+      return {
+        hasAuth,
+        apiKeyEnvVar: normalizedEnvVars[0] || undefined,
+      };
     } catch {
       return { hasAuth: true };
     }
@@ -766,10 +769,13 @@ export class Harness<TState = {}> {
       for (const provider of providers) {
         const providerConfig = registry[provider];
         const envVars = providerConfig?.apiKeyEnvVar;
-        const apiKeyEnvVar = Array.isArray(envVars) ? envVars[0] : envVars;
-        const hasEnvKey = apiKeyEnvVar ? !!process.env[apiKeyEnvVar] : true;
+
+        const normalizedEnvVars = Array.isArray(envVars) ? envVars.filter(Boolean) : envVars ? [envVars] : [];
+
+        const hasEnvKey = normalizedEnvVars.length === 0 || normalizedEnvVars.some(envVar => !!process.env[envVar]);
 
         let hasApiKey = hasEnvKey;
+
         if (!hasApiKey && this.config.modelAuthChecker) {
           const customAuth = this.config.modelAuthChecker(provider);
           if (customAuth === true) hasApiKey = true;
@@ -782,7 +788,7 @@ export class Harness<TState = {}> {
               provider,
               modelName,
               hasApiKey,
-              apiKeyEnvVar: apiKeyEnvVar || undefined,
+              apiKeyEnvVar: normalizedEnvVars[0] || undefined,
             });
           }
         }

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -164,7 +164,7 @@ export class ModelRouterEmbeddingModel<VALUE extends string = string> implements
 
       // Get API key from config or environment
       let apiKey = normalizedConfig.apiKey;
-      if (!apiKey) {
+      if (!apiKey && providerConfig.apiKeyEnvVar) {
         const apiKeyEnvVar = providerConfig.apiKeyEnvVar;
         if (Array.isArray(apiKeyEnvVar)) {
           // Try each possible environment variable
@@ -178,10 +178,14 @@ export class ModelRouterEmbeddingModel<VALUE extends string = string> implements
       }
 
       if (!apiKey) {
-        const envVarDisplay = Array.isArray(providerConfig.apiKeyEnvVar)
-          ? providerConfig.apiKeyEnvVar.join(' or ')
-          : providerConfig.apiKeyEnvVar;
-        throw new Error(`API key not found for provider ${normalizedConfig.providerId}. Set ${envVarDisplay}`);
+        if (providerConfig.apiKeyEnvVar) {
+          const envVarDisplay = Array.isArray(providerConfig.apiKeyEnvVar)
+            ? providerConfig.apiKeyEnvVar.join(' or ')
+            : providerConfig.apiKeyEnvVar;
+          throw new Error(`API key not found for provider ${normalizedConfig.providerId}. Set ${envVarDisplay}`);
+        } else {
+          apiKey = '';
+        }
       }
 
       // Initialize the provider model directly in constructor

--- a/packages/core/src/llm/model/gateways/base.ts
+++ b/packages/core/src/llm/model/gateways/base.ts
@@ -11,7 +11,7 @@ import type { OpenAITransport, ResponsesWebSocketOptions } from '../provider-opt
 export interface ProviderConfig {
   url?: string;
   apiKeyHeader?: string;
-  apiKeyEnvVar: string | string[];
+  apiKeyEnvVar?: string | string[];
   name: string;
   models: string[];
   docUrl?: string; // Optional documentation URL

--- a/packages/core/src/llm/model/gateways/custom-gateway.test.ts
+++ b/packages/core/src/llm/model/gateways/custom-gateway.test.ts
@@ -109,6 +109,52 @@ class AnotherCustomGateway extends MastraModelGateway {
   }
 }
 
+// Custom gateway without apiKeyEnvVar
+class NoEnvKeyCustomGateway extends MastraModelGateway {
+  readonly id = 'noenv';
+  readonly name = 'no-env-custom';
+
+  async fetchProviders(): Promise<Record<string, ProviderConfig>> {
+    return {
+      'noenv-provider': {
+        name: 'No Env Custom Provider',
+        models: ['model-x'],
+        gateway: 'noenv',
+        url: 'https://api.noenv-provider.com/v1',
+      },
+    };
+  }
+
+  buildUrl(_modelId: string): string {
+    return 'https://api.noenv-provider.com/v1';
+  }
+
+  async getApiKey(_modelId: string): Promise<string> {
+    return '';
+  }
+
+  async resolveLanguageModel({
+    modelId,
+    providerId,
+    apiKey,
+    headers,
+  }: {
+    modelId: string;
+    providerId: string;
+    apiKey: string;
+    headers?: Record<string, string>;
+  }): Promise<LanguageModelV2> {
+    const baseURL = this.buildUrl(`${providerId}/${modelId}`);
+    return createOpenAICompatible({
+      name: providerId,
+      apiKey,
+      baseURL,
+      headers,
+      supportsStructuredOutputs: true,
+    }).chatModel(modelId);
+  }
+}
+
 describe('Custom Gateway Integration', () => {
   beforeEach(() => {
     // Set up test environment variables
@@ -376,6 +422,26 @@ describe('Custom Gateway Integration', () => {
       expect(model).toBeDefined();
       expect(model.provider).toBe('my-provider');
       expect(model.modelId).toBe('model-1');
+    });
+  });
+
+  describe('Gateway without apiKeyEnvVar', () => {
+    it('should allow fetching providers without apiKeyEnvVar', async () => {
+      const customGateway = new NoEnvKeyCustomGateway();
+      const providers = await customGateway.fetchProviders();
+
+      expect(providers).toBeDefined();
+      expect(providers['noenv-provider']).toBeDefined();
+      expect(providers['noenv-provider'].apiKeyEnvVar).toBeUndefined();
+    });
+
+    it('should work with ModelRouterLanguageModel when apiKeyEnvVar is missing', () => {
+      const customGateway = new NoEnvKeyCustomGateway();
+      const model = new ModelRouterLanguageModel('noenv/noenv-provider/model-x', [customGateway]);
+
+      expect(model).toBeDefined();
+      expect(model.provider).toBe('noenv-provider');
+      expect(model.modelId).toBe('model-x');
     });
   });
 });

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -490,6 +490,58 @@ describe('isProviderConnected', () => {
       // Cleanup
       delete (global as any).__MOCK_PROVIDER_REGISTRY__;
     });
+
+    it('should return true when provider does not specify apiKeyEnvVar', () => {
+      (global as any).__MOCK_PROVIDER_REGISTRY__ = {
+        'acme/acme-openai': {
+          name: 'ACME OpenAI',
+          models: ['gpt-4.1'],
+          gateway: 'acme',
+        },
+      };
+
+      expect(isProviderConnected('acme/acme-openai')).toBe(true);
+      expect(isProviderConnected('acme-openai')).toBe(true);
+
+      // Cleanup
+      delete (global as any).__MOCK_PROVIDER_REGISTRY__;
+    });
+
+    it('should correctly output connected: true and undefined envVar in GET_PROVIDERS_ROUTE.handler when provider has no apiKeyEnvVar', async () => {
+      // Mock a custom gateway that returns a provider without apiKeyEnvVar
+      const mockGateway = {
+        id: 'test-gateway-no-key',
+        name: 'Test Gateway No Key',
+        getId: () => 'test-gateway-no-key',
+        fetchProviders: vi.fn().mockResolvedValue({
+          'custom-no-key': {
+            name: 'Custom No Key LLM',
+            models: ['custom-model-x'],
+            gateway: 'test-gateway-no-key',
+          },
+        }),
+        buildUrl: vi.fn(),
+        getApiKey: vi.fn(),
+        resolveLanguageModel: vi.fn(),
+      };
+
+      const mastra = new Mastra({
+        gateways: {
+          'test-gateway-no-key': mockGateway,
+        },
+      });
+
+      const requestContext = new RequestContext();
+      const abortSignal = new AbortController().signal;
+
+      const result = await GET_PROVIDERS_ROUTE.handler({ mastra, requestContext, abortSignal });
+
+      const customProvider = result.providers.find(p => p.id === 'test-gateway-no-key/custom-no-key');
+      expect(customProvider).toBeDefined();
+      expect(customProvider?.name).toBe('Custom No Key LLM');
+      expect(customProvider?.connected).toBe(true);
+      expect(customProvider?.envVar).toBeUndefined();
+    });
   });
 });
 

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -175,8 +175,16 @@ export function isProviderConnected(providerId: string, customProviders?: Record
 
   if (!provider) return false;
 
+  if (!provider.apiKeyEnvVar) {
+    return true;
+  }
+
   const envVars = Array.isArray(provider.apiKeyEnvVar) ? provider.apiKeyEnvVar : [provider.apiKeyEnvVar];
-  return envVars.every(envVar => !!process.env[envVar]);
+  const validEnvVars = envVars.filter(Boolean);
+  if (validEnvVars.length === 0) {
+    return true;
+  }
+  return validEnvVars.every(envVar => !!process.env[envVar]);
 }
 
 export interface SerializedProcessor {

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -184,7 +184,7 @@ export function isProviderConnected(providerId: string, customProviders?: Record
   if (validEnvVars.length === 0) {
     return true;
   }
-  return validEnvVars.every(envVar => !!process.env[envVar]);
+  return validEnvVars.some(envVar => !!process.env[envVar]);
 }
 
 export interface SerializedProcessor {

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -213,7 +213,7 @@ export const providerSchema = z.object({
   name: z.string(),
   label: z.string().optional(),
   description: z.string().optional(),
-  envVar: z.union([z.string(), z.array(z.string())]),
+  envVar: z.union([z.string(), z.array(z.string())]).optional(),
   connected: z.boolean(),
   docUrl: z.string().optional(),
   models: z.array(z.string()),


### PR DESCRIPTION
## Description

Supports custom gateways/providers that do not require an `apiKeyEnvVar`.

This updates provider auth handling to allow gateways that use alternative authentication flows (e.g. Azure default credentials, embedded config auth, custom runtime auth) without being incorrectly marked as disconnected.

Changes include:

* Making `apiKeyEnvVar` optional in `ProviderConfig`
* Treating providers without `apiKeyEnvVar` as connected by default
* Preventing embedding router failures when no env var is configured
* Updating provider connection logic in server handlers
* Updating provider schema typings
* Adding regression tests for gateways/providers without `apiKeyEnvVar`

This preserves backward compatibility for existing providers using env-based API keys.

## Related issue(s)

Fixes #17139

## Type of change

* [x] New feature (non-breaking change that adds functionality)
* [x] Test update

## Checklist

* [x] I have linked the related issue(s) in the description above
* [ ] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets gateway providers work without requiring a secret stored in an environment variable. If a provider doesn't declare an API-key env var, it's treated as connected and can handle auth itself.

## Overview

Make ProviderConfig.apiKeyEnvVar optional and update runtime, router, server handlers, schemas, and tests so providers that don't declare env-based API keys are considered connected by default. When env-var mappings are present, checks now treat the provider as connected if any configured env var is set. Embedding/router logic no longer forces env-var lookups when none are declared, and missing env-vars cause errors only when an env-var mapping was expected.

## Key Changes

- packages/core/src/llm/model/gateways/base.ts
  - ProviderConfig.apiKeyEnvVar changed from required (string | string[]) to optional (apiKeyEnvVar?: string | string[]).

- packages/core/src/harness/harness.ts
  - getCurrentModelAuthStatus() and listAvailableModels() now normalize apiKeyEnvVar (support string | string[]), treat providers with no declared env vars as having auth by default, and expose the first normalized env var (or undefined) per model.

- packages/core/src/llm/model/embedding-router.ts
  - Only attempts env var lookups when providerConfig.apiKeyEnvVar is defined. If no env-var mapping exists, the router will not throw an “API key not found” error and may fall back to an empty-string key or provider-supplied key.

- packages/server/src/server/handlers/agents.ts
  - isProviderConnected() now:
    - Returns true when provider.apiKeyEnvVar is missing/falsy or normalizes to no truthy entries (providers treated as connected by default).
    - When env-var names are declared, normalizes/filter them and returns true if any of the remaining env vars is set in process.env (previous behavior required all).
  - Server-side provider listing uses undefined for envVar when absent.

- packages/server/src/server/schemas/agents.ts
  - providersResponseSchema: envVar field changed from required to optional so provider responses may omit envVar.

- Tests
  - packages/core/src/llm/model/gateways/custom-gateway.test.ts: Added NoEnvKeyCustomGateway and tests ensuring fetchProviders() and ModelRouterLanguageModel work when apiKeyEnvVar is omitted.
  - packages/server/src/server/handlers/agents.test.ts: Added tests verifying isProviderConnected returns true for providers without apiKeyEnvVar and that GET_PROVIDERS_ROUTE.handler marks such providers connected while returning envVar as undefined.

## Compatibility & Behavior Notes

- Backward compatibility preserved for providers that still declare apiKeyEnvVar.
- Providers that omit apiKeyEnvVar must implement their own auth logic (e.g., getApiKey, resolveLanguageModel, embedded config, ADC, or runtime flows).
- Server-side connectivity checks now consider providers with any configured env var set as connected (logical OR), and consider providers without env-var mappings connected by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->