### PR TITLE
fix(core): register Mastra on execution workflow before createRun()

### DIFF
--- a/.changeset/eight-rules-pull.md
+++ b/.changeset/eight-rules-pull.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed internal execution workflow not using Mastra storage during agent generate and stream, which caused debug log noise when storage was configured.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5821,6 +5821,10 @@ export class Agent<
       drainPendingSignals: runId => agentThreadStreamRuntime.drainPendingSignals(runId, threadStreamPubSub),
     });
 
+    if (this.#mastra) {
+      executionWorkflow.__registerMastra(this.#mastra);
+    }
+
     const run = await executionWorkflow.createRun();
     const observabilityContext = createObservabilityContext({ currentSpan: agentSpan });
     const result = await run.start({ ...observabilityContext });


### PR DESCRIPTION
## Description

Wire the internal prepare-stream workflow to the agent's Mastra instance so agent generate/stream can use configured storage instead of falling back to in-memory state and emitting debug noise.

## Related issue(s)

Fixes #17137 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
The PR fixes annoying debug log messages that kept appearing when you asked an agent to generate responses. The agent was supposed to use a storage system you gave it, but the internal workflow it creates wasn't being told about that storage, so it complained about not having it (even though it was fine). This fix simply tells the internal workflow "hey, here's the storage" before it starts working, so it stops complaining.

## Changes

### Core Fix
- **packages/core/src/agent/agent.ts**: Modified `Agent.#execute` method to register the Mastra instance on the internal execution workflow via `executionWorkflow.__registerMastra(this.#mastra)` when Mastra is present, immediately before creating the workflow run via `createRun()`.

### Documentation
- **.changeset/eight-rules-pull.md**: Added changeset documenting a patch-level fix for `@mastra/core` that eliminates debug log noise from agent generate/stream operations by ensuring the internal execution workflow uses configured Mastra storage.

## Impact
- **Fixes**: Issue `#17137` — eliminates spurious "Cannot get workflow run. Mastra storage is not initialized" debug logs when calling `agent.generate()` or `agent.stream()` on agents registered to Mastra instances with configured storage
- **Behavior**: The internal agent execution workflow now properly receives the parent Mastra reference, allowing it to use configured storage instead of falling back to in-memory state while logging warnings
- **No breaking changes**: The fallback mechanism remains functional; this only prevents misleading debug noise

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->