### PR TITLE
03 feat(client): add message helper APIs

### DIFF
--- a/.changeset/client-js-message-helpers.md
+++ b/.changeset/client-js-message-helpers.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': minor
+---
+
+Add experimental `agent.sendMessage()` and `agent.queueMessage()` helpers for the new message-first server routes.

--- a/.changeset/react-message-helpers.md
+++ b/.changeset/react-message-helpers.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': minor
+---
+
+Use the message-first client helper for user-authored thread input while preserving fallback behavior for older servers that only support the legacy signal route.

--- a/client-sdks/client-js/src/resources/agent.test.ts
+++ b/client-sdks/client-js/src/resources/agent.test.ts
@@ -5,7 +5,13 @@ import { z } from 'zod/v3';
 
 import { MastraClient } from '../client';
 import type { Body } from '../route-types.generated';
-import type { ClientOptions, SendAgentSignalParams, SubscribeAgentThreadParams } from '../types';
+import type {
+  ClientOptions,
+  QueueAgentMessageParams,
+  SendAgentMessageParams,
+  SendAgentSignalParams,
+  SubscribeAgentThreadParams,
+} from '../types';
 import { processClientTools } from '../utils/process-client-tools';
 import { zodToJsonSchema } from '../utils/zod-to-json-schema';
 import { Agent } from './agent';
@@ -33,6 +39,75 @@ describe('Agent signal routes', () => {
       'x-mastra-client-type': 'js',
     },
   };
+
+  it('sends messages to the send-message route with string payloads unchanged', async () => {
+    const agent = new Agent(mockClientOptions, 'test-agent');
+    const mockRequest = vi.fn().mockResolvedValue({ accepted: true, runId: 'run-123' });
+    agent['request'] = mockRequest as (typeof agent)['request'];
+
+    const params = {
+      message: 'hello',
+      resourceId: 'resource-123',
+      threadId: 'thread-123',
+    } satisfies SendAgentMessageParams;
+    const routeBody: Body<'POST /agents/:agentId/send-message'> = params;
+
+    await agent.sendMessage(params);
+
+    expect(mockRequest).toHaveBeenCalledWith('/agents/test-agent/send-message', {
+      method: 'POST',
+      body: routeBody,
+    });
+  });
+
+  it('sends messages to the send-message route with object payloads unchanged', async () => {
+    const agent = new Agent(mockClientOptions, 'test-agent');
+    const mockRequest = vi.fn().mockResolvedValue({ accepted: true, runId: 'run-123' });
+    agent['request'] = mockRequest as (typeof agent)['request'];
+
+    const params = {
+      message: {
+        contents: 'hello',
+        attributes: { source: 'test' },
+        metadata: { client: 'sdk' },
+        providerOptions: { mastra: { channel: 'web' } },
+      },
+      resourceId: 'resource-123',
+      threadId: 'thread-123',
+    } satisfies SendAgentMessageParams;
+    const routeBody: Body<'POST /agents/:agentId/send-message'> = params;
+
+    await agent.sendMessage(params);
+
+    expect(mockRequest).toHaveBeenCalledWith('/agents/test-agent/send-message', {
+      method: 'POST',
+      body: routeBody,
+    });
+  });
+
+  it('queues messages to the queue-message route with parts payloads unchanged', async () => {
+    const agent = new Agent(mockClientOptions, 'test-agent');
+    const mockRequest = vi.fn().mockResolvedValue({ accepted: true, runId: 'queued-run-123' });
+    agent['request'] = mockRequest as (typeof agent)['request'];
+
+    const params = {
+      message: [
+        { type: 'text', text: 'describe this' },
+        { type: 'file', data: 'file-data', mediaType: 'text/plain' },
+      ],
+      resourceId: 'resource-123',
+      threadId: 'thread-123',
+      ifIdle: { streamOptions: { maxSteps: 3 } },
+    } satisfies QueueAgentMessageParams;
+    const routeBody: Body<'POST /agents/:agentId/queue-message'> = params;
+
+    await agent.queueMessage(params);
+
+    expect(mockRequest).toHaveBeenCalledWith('/agents/test-agent/queue-message', {
+      method: 'POST',
+      body: routeBody,
+    });
+  });
 
   it('sends run-targeted signals with active behavior unchanged', async () => {
     const agent = new Agent(mockClientOptions, 'test-agent');

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -40,7 +40,9 @@ import type {
   AgentVersionResponse,
   ListAgentVersionsParams,
   ListAgentVersionsResponse,
+  SendAgentMessageParams,
   SendAgentSignalParams,
+  QueueAgentMessageParams,
   SubscribeAgentThreadParams,
   ProcessAgentThreadStreamOptions,
   CreateCodeAgentVersionParams,
@@ -397,6 +399,26 @@ export class Agent extends BaseResource {
     return this.request(`/agents/${this.agentId}/instructions/enhance`, {
       method: 'POST',
       body: { instructions, comment },
+    });
+  }
+
+  /**
+   * @experimental Agent message APIs are experimental and may change in a future release.
+   */
+  sendMessage(params: SendAgentMessageParams): Promise<{ accepted: true; runId: string; signal?: unknown }> {
+    return this.request(`/agents/${this.agentId}/send-message`, {
+      method: 'POST',
+      body: params,
+    });
+  }
+
+  /**
+   * @experimental Agent message APIs are experimental and may change in a future release.
+   */
+  queueMessage(params: QueueAgentMessageParams): Promise<{ accepted: true; runId: string; signal?: unknown }> {
+    return this.request(`/agents/${this.agentId}/queue-message`, {
+      method: 'POST',
+      body: params,
     });
   }
 

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -5549,75 +5549,25 @@ export interface PostAgentsAgentIdObserve_RouteContract {
 }
 
 // ============================================================================
-// Route: POST /agents/:agentId/signals
+// Route: POST /agents/:agentId/send-message
 // ============================================================================
-export type PostAgentsAgentIdSignals_PathParams = {
+export type PostAgentsAgentIdSendMessage_PathParams = {
   /** Unique identifier for the agent */
   agentId: string;
 };
 
-type PostAgentsAgentIdSignals_Body_Auxiliary_2 =
+type PostAgentsAgentIdSendMessage_Body_Auxiliary_3 =
   | string
   | number
   | boolean
   | null
-  | PostAgentsAgentIdSignals_Body_Auxiliary_2[]
+  | PostAgentsAgentIdSendMessage_Body_Auxiliary_3[]
   | {
-      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
+      [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
     };
 
-export type PostAgentsAgentIdSignals_Body =
+export type PostAgentsAgentIdSendMessage_Body =
   | {
-      signal: {
-        id?: string | undefined;
-        createdAt?: (string | Date) | undefined;
-        metadata?:
-          | {
-              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-            }
-          | undefined;
-        attributes?:
-          | {
-              [key: string]: string | number | boolean | null | undefined;
-            }
-          | undefined;
-        type: string;
-        contents:
-          | string
-          | (
-              | {
-                  type: 'text';
-                  text: string;
-                  providerOptions?:
-                    | {
-                        [key: string]: {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        };
-                      }
-                    | undefined;
-                }
-              | {
-                  type: 'file';
-                  data: string;
-                  mediaType: string;
-                  filename?: string | undefined;
-                  providerOptions?:
-                    | {
-                        [key: string]: {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        };
-                      }
-                    | undefined;
-                }
-            )[];
-        providerOptions?:
-          | {
-              [key: string]: {
-                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-              };
-            }
-          | undefined;
-      };
       ifActive?:
         | {
             behavior?: ('deliver' | 'persist' | 'discard') | undefined;
@@ -5627,58 +5577,85 @@ export type PostAgentsAgentIdSignals_Body =
       resourceId?: string | undefined;
       threadId?: string | undefined;
       ifIdle?: undefined | undefined;
+      message:
+        | (
+            | string
+            | (
+                | {
+                    type: 'text';
+                    text: string;
+                    providerOptions?:
+                      | {
+                          [key: string]: {
+                            [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                          };
+                        }
+                      | undefined;
+                  }
+                | {
+                    type: 'file';
+                    data: string;
+                    mediaType: string;
+                    filename?: string | undefined;
+                    providerOptions?:
+                      | {
+                          [key: string]: {
+                            [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                          };
+                        }
+                      | undefined;
+                  }
+              )[]
+          )
+        | {
+            contents:
+              | string
+              | (
+                  | {
+                      type: 'text';
+                      text: string;
+                      providerOptions?:
+                        | {
+                            [key: string]: {
+                              [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                            };
+                          }
+                        | undefined;
+                    }
+                  | {
+                      type: 'file';
+                      data: string;
+                      mediaType: string;
+                      filename?: string | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: {
+                              [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                            };
+                          }
+                        | undefined;
+                    }
+                )[];
+            attributes?:
+              | {
+                  [key: string]: string | number | boolean | null | undefined;
+                }
+              | undefined;
+            metadata?:
+              | {
+                  [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                }
+              | undefined;
+            providerOptions?:
+              | {
+                  [key: string]: {
+                    [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                  };
+                }
+              | undefined;
+          };
     }
   | {
-      signal: {
-        id?: string | undefined;
-        createdAt?: (string | Date) | undefined;
-        metadata?:
-          | {
-              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-            }
-          | undefined;
-        attributes?:
-          | {
-              [key: string]: string | number | boolean | null | undefined;
-            }
-          | undefined;
-        type: string;
-        contents:
-          | string
-          | (
-              | {
-                  type: 'text';
-                  text: string;
-                  providerOptions?:
-                    | {
-                        [key: string]: {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        };
-                      }
-                    | undefined;
-                }
-              | {
-                  type: 'file';
-                  data: string;
-                  mediaType: string;
-                  filename?: string | undefined;
-                  providerOptions?:
-                    | {
-                        [key: string]: {
-                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-                        };
-                      }
-                    | undefined;
-                }
-            )[];
-        providerOptions?:
-          | {
-              [key: string]: {
-                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_2;
-              };
-            }
-          | undefined;
-      };
       ifActive?:
         | {
             behavior?: ('deliver' | 'persist' | 'discard') | undefined;
@@ -5829,11 +5806,761 @@ export type PostAgentsAgentIdSignals_Body =
               | undefined;
           }
         | undefined;
+      message:
+        | (
+            | string
+            | (
+                | {
+                    type: 'text';
+                    text: string;
+                    providerOptions?:
+                      | {
+                          [key: string]: {
+                            [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                          };
+                        }
+                      | undefined;
+                  }
+                | {
+                    type: 'file';
+                    data: string;
+                    mediaType: string;
+                    filename?: string | undefined;
+                    providerOptions?:
+                      | {
+                          [key: string]: {
+                            [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                          };
+                        }
+                      | undefined;
+                  }
+              )[]
+          )
+        | {
+            contents:
+              | string
+              | (
+                  | {
+                      type: 'text';
+                      text: string;
+                      providerOptions?:
+                        | {
+                            [key: string]: {
+                              [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                            };
+                          }
+                        | undefined;
+                    }
+                  | {
+                      type: 'file';
+                      data: string;
+                      mediaType: string;
+                      filename?: string | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: {
+                              [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                            };
+                          }
+                        | undefined;
+                    }
+                )[];
+            attributes?:
+              | {
+                  [key: string]: string | number | boolean | null | undefined;
+                }
+              | undefined;
+            metadata?:
+              | {
+                  [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                }
+              | undefined;
+            providerOptions?:
+              | {
+                  [key: string]: {
+                    [key: string]: PostAgentsAgentIdSendMessage_Body_Auxiliary_3;
+                  };
+                }
+              | undefined;
+          };
+    };
+
+export type PostAgentsAgentIdSendMessage_Response = {
+  accepted: true;
+  runId: string;
+  signal?: any | undefined;
+};
+
+export type PostAgentsAgentIdSendMessage_Request = Simplify<
+  (PostAgentsAgentIdSendMessage_PathParams extends never ? {} : { params: PostAgentsAgentIdSendMessage_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentsAgentIdSendMessage_Body extends never
+      ? {}
+      : {} extends PostAgentsAgentIdSendMessage_Body
+        ? { body?: PostAgentsAgentIdSendMessage_Body }
+        : { body: PostAgentsAgentIdSendMessage_Body })
+>;
+
+export interface PostAgentsAgentIdSendMessage_RouteContract {
+  pathParams: PostAgentsAgentIdSendMessage_PathParams;
+  queryParams: never;
+  body: PostAgentsAgentIdSendMessage_Body;
+  request: PostAgentsAgentIdSendMessage_Request;
+  response: PostAgentsAgentIdSendMessage_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: POST /agents/:agentId/queue-message
+// ============================================================================
+export type PostAgentsAgentIdQueueMessage_PathParams = {
+  /** Unique identifier for the agent */
+  agentId: string;
+};
+
+type PostAgentsAgentIdQueueMessage_Body_Auxiliary_3 =
+  | string
+  | number
+  | boolean
+  | null
+  | PostAgentsAgentIdQueueMessage_Body_Auxiliary_3[]
+  | {
+      [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+    };
+
+export type PostAgentsAgentIdQueueMessage_Body =
+  | {
+      ifActive?:
+        | {
+            behavior?: ('deliver' | 'persist' | 'discard') | undefined;
+          }
+        | undefined;
+      runId: string;
+      resourceId?: string | undefined;
+      threadId?: string | undefined;
+      ifIdle?: undefined | undefined;
+      message:
+        | (
+            | string
+            | (
+                | {
+                    type: 'text';
+                    text: string;
+                    providerOptions?:
+                      | {
+                          [key: string]: {
+                            [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                          };
+                        }
+                      | undefined;
+                  }
+                | {
+                    type: 'file';
+                    data: string;
+                    mediaType: string;
+                    filename?: string | undefined;
+                    providerOptions?:
+                      | {
+                          [key: string]: {
+                            [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                          };
+                        }
+                      | undefined;
+                  }
+              )[]
+          )
+        | {
+            contents:
+              | string
+              | (
+                  | {
+                      type: 'text';
+                      text: string;
+                      providerOptions?:
+                        | {
+                            [key: string]: {
+                              [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                            };
+                          }
+                        | undefined;
+                    }
+                  | {
+                      type: 'file';
+                      data: string;
+                      mediaType: string;
+                      filename?: string | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: {
+                              [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                            };
+                          }
+                        | undefined;
+                    }
+                )[];
+            attributes?:
+              | {
+                  [key: string]: string | number | boolean | null | undefined;
+                }
+              | undefined;
+            metadata?:
+              | {
+                  [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                }
+              | undefined;
+            providerOptions?:
+              | {
+                  [key: string]: {
+                    [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                  };
+                }
+              | undefined;
+          };
+    }
+  | {
+      ifActive?:
+        | {
+            behavior?: ('deliver' | 'persist' | 'discard') | undefined;
+          }
+        | undefined;
+      runId?: string | undefined;
+      resourceId: string;
+      threadId: string;
+      ifIdle?:
+        | {
+            behavior?: ('wake' | 'persist' | 'discard') | undefined;
+            streamOptions?:
+              | {
+                  instructions?: (string | string[] | any | any[]) | undefined;
+                  system?: (string | string[] | any | any[]) | undefined;
+                  context?: any[] | undefined;
+                  memory?:
+                    | {
+                        thread:
+                          | string
+                          | {
+                              id: string;
+                              [x: string]: unknown;
+                            };
+                        resource: string;
+                        options?:
+                          | {
+                              [key: string]: any;
+                            }
+                          | undefined;
+                        readOnly?: boolean | undefined;
+                      }
+                    | undefined;
+                  runId?: string | undefined;
+                  savePerStep?: boolean | undefined;
+                  requestContext?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                  versions?:
+                    | {
+                        agents?:
+                          | {
+                              [key: string]:
+                                | {
+                                    versionId: string;
+                                  }
+                                | {
+                                    status: 'draft' | 'published';
+                                  };
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                  maxSteps?: number | undefined;
+                  stopWhen?: any | undefined;
+                  providerOptions?:
+                    | {
+                        anthropic?:
+                          | {
+                              [key: string]: any;
+                            }
+                          | undefined;
+                        google?:
+                          | {
+                              [key: string]: any;
+                            }
+                          | undefined;
+                        openai?:
+                          | {
+                              [key: string]: any;
+                            }
+                          | undefined;
+                        xai?:
+                          | {
+                              [key: string]: any;
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                  modelSettings?: any | undefined;
+                  activeTools?: string[] | undefined;
+                  toolsets?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                  clientTools?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                  toolChoice?:
+                    | (
+                        | ('auto' | 'none' | 'required')
+                        | {
+                            type: 'tool';
+                            toolName: string;
+                          }
+                      )
+                    | undefined;
+                  requireToolApproval?: boolean | undefined;
+                  scorers?:
+                    | (
+                        | {
+                            [key: string]: any;
+                          }
+                        | {
+                            [key: string]: {
+                              scorer: string;
+                              sampling?: any | undefined;
+                            };
+                          }
+                      )
+                    | undefined;
+                  returnScorerData?: boolean | undefined;
+                  tracingOptions?:
+                    | {
+                        metadata?:
+                          | {
+                              [key: string]: unknown;
+                            }
+                          | undefined;
+                        requestContextKeys?: string[] | undefined;
+                        traceId?: string | undefined;
+                        parentSpanId?: string | undefined;
+                        tags?: string[] | undefined;
+                        hideInput?: boolean | undefined;
+                        hideOutput?: boolean | undefined;
+                      }
+                    | undefined;
+                  output?: any | undefined;
+                  structuredOutput?:
+                    | {
+                        schema: {
+                          [x: string]: unknown;
+                        };
+                        model?: (string | any) | undefined;
+                        instructions?: string | undefined;
+                        jsonPromptInjection?: boolean | undefined;
+                        errorStrategy?: ('strict' | 'warn' | 'fallback') | undefined;
+                        fallbackValue?: any | undefined;
+                      }
+                    | undefined;
+                  [x: string]: unknown;
+                }
+              | undefined;
+          }
+        | undefined;
+      message:
+        | (
+            | string
+            | (
+                | {
+                    type: 'text';
+                    text: string;
+                    providerOptions?:
+                      | {
+                          [key: string]: {
+                            [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                          };
+                        }
+                      | undefined;
+                  }
+                | {
+                    type: 'file';
+                    data: string;
+                    mediaType: string;
+                    filename?: string | undefined;
+                    providerOptions?:
+                      | {
+                          [key: string]: {
+                            [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                          };
+                        }
+                      | undefined;
+                  }
+              )[]
+          )
+        | {
+            contents:
+              | string
+              | (
+                  | {
+                      type: 'text';
+                      text: string;
+                      providerOptions?:
+                        | {
+                            [key: string]: {
+                              [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                            };
+                          }
+                        | undefined;
+                    }
+                  | {
+                      type: 'file';
+                      data: string;
+                      mediaType: string;
+                      filename?: string | undefined;
+                      providerOptions?:
+                        | {
+                            [key: string]: {
+                              [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                            };
+                          }
+                        | undefined;
+                    }
+                )[];
+            attributes?:
+              | {
+                  [key: string]: string | number | boolean | null | undefined;
+                }
+              | undefined;
+            metadata?:
+              | {
+                  [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                }
+              | undefined;
+            providerOptions?:
+              | {
+                  [key: string]: {
+                    [key: string]: PostAgentsAgentIdQueueMessage_Body_Auxiliary_3;
+                  };
+                }
+              | undefined;
+          };
+    };
+
+export type PostAgentsAgentIdQueueMessage_Response = {
+  accepted: true;
+  runId: string;
+  signal?: any | undefined;
+};
+
+export type PostAgentsAgentIdQueueMessage_Request = Simplify<
+  (PostAgentsAgentIdQueueMessage_PathParams extends never ? {} : { params: PostAgentsAgentIdQueueMessage_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentsAgentIdQueueMessage_Body extends never
+      ? {}
+      : {} extends PostAgentsAgentIdQueueMessage_Body
+        ? { body?: PostAgentsAgentIdQueueMessage_Body }
+        : { body: PostAgentsAgentIdQueueMessage_Body })
+>;
+
+export interface PostAgentsAgentIdQueueMessage_RouteContract {
+  pathParams: PostAgentsAgentIdQueueMessage_PathParams;
+  queryParams: never;
+  body: PostAgentsAgentIdQueueMessage_Body;
+  request: PostAgentsAgentIdQueueMessage_Request;
+  response: PostAgentsAgentIdQueueMessage_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: POST /agents/:agentId/signals
+// ============================================================================
+export type PostAgentsAgentIdSignals_PathParams = {
+  /** Unique identifier for the agent */
+  agentId: string;
+};
+
+type PostAgentsAgentIdSignals_Body_Auxiliary_3 =
+  | string
+  | number
+  | boolean
+  | null
+  | PostAgentsAgentIdSignals_Body_Auxiliary_3[]
+  | {
+      [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_3;
+    };
+
+export type PostAgentsAgentIdSignals_Body =
+  | {
+      ifActive?:
+        | {
+            behavior?: ('deliver' | 'persist' | 'discard') | undefined;
+          }
+        | undefined;
+      runId: string;
+      resourceId?: string | undefined;
+      threadId?: string | undefined;
+      ifIdle?: undefined | undefined;
+      signal: {
+        id?: string | undefined;
+        createdAt?: (string | Date) | undefined;
+        metadata?:
+          | {
+              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_3;
+            }
+          | undefined;
+        attributes?:
+          | {
+              [key: string]: string | number | boolean | null | undefined;
+            }
+          | undefined;
+        type: string;
+        tagName?: string | undefined;
+        contents:
+          | string
+          | (
+              | {
+                  type: 'text';
+                  text: string;
+                  providerOptions?:
+                    | {
+                        [key: string]: {
+                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_3;
+                        };
+                      }
+                    | undefined;
+                }
+              | {
+                  type: 'file';
+                  data: string;
+                  mediaType: string;
+                  filename?: string | undefined;
+                  providerOptions?:
+                    | {
+                        [key: string]: {
+                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_3;
+                        };
+                      }
+                    | undefined;
+                }
+            )[];
+        providerOptions?:
+          | {
+              [key: string]: {
+                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_3;
+              };
+            }
+          | undefined;
+      };
+    }
+  | {
+      ifActive?:
+        | {
+            behavior?: ('deliver' | 'persist' | 'discard') | undefined;
+          }
+        | undefined;
+      runId?: string | undefined;
+      resourceId: string;
+      threadId: string;
+      ifIdle?:
+        | {
+            behavior?: ('wake' | 'persist' | 'discard') | undefined;
+            streamOptions?:
+              | {
+                  instructions?: (string | string[] | any | any[]) | undefined;
+                  system?: (string | string[] | any | any[]) | undefined;
+                  context?: any[] | undefined;
+                  memory?:
+                    | {
+                        thread:
+                          | string
+                          | {
+                              id: string;
+                              [x: string]: unknown;
+                            };
+                        resource: string;
+                        options?:
+                          | {
+                              [key: string]: any;
+                            }
+                          | undefined;
+                        readOnly?: boolean | undefined;
+                      }
+                    | undefined;
+                  runId?: string | undefined;
+                  savePerStep?: boolean | undefined;
+                  requestContext?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                  versions?:
+                    | {
+                        agents?:
+                          | {
+                              [key: string]:
+                                | {
+                                    versionId: string;
+                                  }
+                                | {
+                                    status: 'draft' | 'published';
+                                  };
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                  maxSteps?: number | undefined;
+                  stopWhen?: any | undefined;
+                  providerOptions?:
+                    | {
+                        anthropic?:
+                          | {
+                              [key: string]: any;
+                            }
+                          | undefined;
+                        google?:
+                          | {
+                              [key: string]: any;
+                            }
+                          | undefined;
+                        openai?:
+                          | {
+                              [key: string]: any;
+                            }
+                          | undefined;
+                        xai?:
+                          | {
+                              [key: string]: any;
+                            }
+                          | undefined;
+                      }
+                    | undefined;
+                  modelSettings?: any | undefined;
+                  activeTools?: string[] | undefined;
+                  toolsets?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                  clientTools?:
+                    | {
+                        [key: string]: any;
+                      }
+                    | undefined;
+                  toolChoice?:
+                    | (
+                        | ('auto' | 'none' | 'required')
+                        | {
+                            type: 'tool';
+                            toolName: string;
+                          }
+                      )
+                    | undefined;
+                  requireToolApproval?: boolean | undefined;
+                  scorers?:
+                    | (
+                        | {
+                            [key: string]: any;
+                          }
+                        | {
+                            [key: string]: {
+                              scorer: string;
+                              sampling?: any | undefined;
+                            };
+                          }
+                      )
+                    | undefined;
+                  returnScorerData?: boolean | undefined;
+                  tracingOptions?:
+                    | {
+                        metadata?:
+                          | {
+                              [key: string]: unknown;
+                            }
+                          | undefined;
+                        requestContextKeys?: string[] | undefined;
+                        traceId?: string | undefined;
+                        parentSpanId?: string | undefined;
+                        tags?: string[] | undefined;
+                        hideInput?: boolean | undefined;
+                        hideOutput?: boolean | undefined;
+                      }
+                    | undefined;
+                  output?: any | undefined;
+                  structuredOutput?:
+                    | {
+                        schema: {
+                          [x: string]: unknown;
+                        };
+                        model?: (string | any) | undefined;
+                        instructions?: string | undefined;
+                        jsonPromptInjection?: boolean | undefined;
+                        errorStrategy?: ('strict' | 'warn' | 'fallback') | undefined;
+                        fallbackValue?: any | undefined;
+                      }
+                    | undefined;
+                  [x: string]: unknown;
+                }
+              | undefined;
+          }
+        | undefined;
+      signal: {
+        id?: string | undefined;
+        createdAt?: (string | Date) | undefined;
+        metadata?:
+          | {
+              [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_3;
+            }
+          | undefined;
+        attributes?:
+          | {
+              [key: string]: string | number | boolean | null | undefined;
+            }
+          | undefined;
+        type: string;
+        tagName?: string | undefined;
+        contents:
+          | string
+          | (
+              | {
+                  type: 'text';
+                  text: string;
+                  providerOptions?:
+                    | {
+                        [key: string]: {
+                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_3;
+                        };
+                      }
+                    | undefined;
+                }
+              | {
+                  type: 'file';
+                  data: string;
+                  mediaType: string;
+                  filename?: string | undefined;
+                  providerOptions?:
+                    | {
+                        [key: string]: {
+                          [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_3;
+                        };
+                      }
+                    | undefined;
+                }
+            )[];
+        providerOptions?:
+          | {
+              [key: string]: {
+                [key: string]: PostAgentsAgentIdSignals_Body_Auxiliary_3;
+              };
+            }
+          | undefined;
+      };
     };
 
 export type PostAgentsAgentIdSignals_Response = {
   accepted: true;
   runId: string;
+  signal?: any | undefined;
 };
 
 export type PostAgentsAgentIdSignals_Request = Simplify<
@@ -78128,6 +78855,8 @@ export interface RouteTypes {
   'POST /agents/:agentId/stream-until-idle': PostAgentsAgentIdStreamUntilIdle_RouteContract;
   'POST /agents/:agentId/stream/vnext': PostAgentsAgentIdStreamVnext_RouteContract;
   'POST /agents/:agentId/observe': PostAgentsAgentIdObserve_RouteContract;
+  'POST /agents/:agentId/send-message': PostAgentsAgentIdSendMessage_RouteContract;
+  'POST /agents/:agentId/queue-message': PostAgentsAgentIdQueueMessage_RouteContract;
   'POST /agents/:agentId/signals': PostAgentsAgentIdSignals_RouteContract;
   'POST /agents/:agentId/threads/subscribe': PostAgentsAgentIdThreadsSubscribe_RouteContract;
   'POST /agents/:agentId/tools/:toolId/execute': PostAgentsAgentIdToolsToolIdExecute_RouteContract;
@@ -78572,11 +79301,17 @@ export interface Client {
   '/agents/:agentId/observe': {
     POST: PostAgentsAgentIdObserve_RouteContract;
   };
+  '/agents/:agentId/queue-message': {
+    POST: PostAgentsAgentIdQueueMessage_RouteContract;
+  };
   '/agents/:agentId/resume-stream': {
     POST: PostAgentsAgentIdResumeStream_RouteContract;
   };
   '/agents/:agentId/resume-stream-until-idle': {
     POST: PostAgentsAgentIdResumeStreamUntilIdle_RouteContract;
+  };
+  '/agents/:agentId/send-message': {
+    POST: PostAgentsAgentIdSendMessage_RouteContract;
   };
   '/agents/:agentId/signals': {
     POST: PostAgentsAgentIdSignals_RouteContract;

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -126,6 +126,16 @@ export type AgentSignalIdleBehavior = 'wake' | 'persist' | 'discard';
 export type SendAgentSignalParams = GeneratedRequest<Body<'POST /agents/:agentId/signals'>>;
 
 /**
+ * @experimental Agent message APIs are experimental and may change in a future release.
+ */
+export type SendAgentMessageParams = GeneratedRequest<Body<'POST /agents/:agentId/send-message'>>;
+
+/**
+ * @experimental Agent message APIs are experimental and may change in a future release.
+ */
+export type QueueAgentMessageParams = GeneratedRequest<Body<'POST /agents/:agentId/queue-message'>>;
+
+/**
  * @experimental Agent signals are experimental and may change in a future release.
  */
 export interface SubscribeAgentThreadParams {

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -504,44 +504,62 @@ export const useChat = ({
     }
 
     const resolvedSignalId = signalId ?? uuid();
-    onSignalSent?.(resolvedSignalId, getSignalPreview(coreUserMessages));
+    const messageContents = getSignalContents(coreUserMessages);
+    const streamOptions = {
+      maxSteps,
+      modelSettings: {
+        frequencyPenalty,
+        presencePenalty,
+        maxRetries,
+        maxOutputTokens: maxTokens,
+        temperature,
+        topK,
+        topP,
+      },
+      instructions,
+      requestContext: resolvedRequestContext,
+      providerOptions: providerOptions as any,
+      requireToolApproval,
+      tracingOptions,
+    };
 
     try {
-      await agent.sendSignal({
-        signal: {
-          id: resolvedSignalId,
-          type: 'user-message',
-          contents: getSignalContents(coreUserMessages),
-        },
+      const result = await agent.sendMessage({
+        message: messageContents,
         resourceId: resourceId || agentId,
         threadId,
-        ifIdle: {
-          streamOptions: {
-            maxSteps,
-            modelSettings: {
-              frequencyPenalty,
-              presencePenalty,
-              maxRetries,
-              maxOutputTokens: maxTokens,
-              temperature,
-              topK,
-              topP,
-            },
-            instructions,
-            requestContext: resolvedRequestContext,
-            providerOptions: providerOptions as any,
-            requireToolApproval,
-            tracingOptions,
-          },
-        },
+        ifIdle: { streamOptions },
       });
+      const echoedSignalId =
+        result.signal && typeof result.signal === 'object' && 'id' in result.signal && typeof result.signal.id === 'string'
+          ? result.signal.id
+          : resolvedSignalId;
+      onSignalSent?.(echoedSignalId, getSignalPreview(coreUserMessages));
     } catch (error) {
-      onSignalEcho?.(resolvedSignalId);
       if (isThreadSignalUnsupportedError(error)) {
-        markThreadSignalsUnsupported();
-        setMessages(prev => [...prev, ...coreUserMessages.map(fromCoreUserMessageToUIMessage)] as MastraUIMessage[]);
-        await streamWithLegacyRoute();
-        return;
+        onSignalSent?.(resolvedSignalId, getSignalPreview(coreUserMessages));
+        try {
+          await agent.sendSignal({
+            signal: {
+              id: resolvedSignalId,
+              type: 'user-message',
+              contents: messageContents,
+            },
+            resourceId: resourceId || agentId,
+            threadId,
+            ifIdle: { streamOptions },
+          });
+          return;
+        } catch (signalError) {
+          onSignalEcho?.(resolvedSignalId);
+          if (isThreadSignalUnsupportedError(signalError)) {
+            markThreadSignalsUnsupported();
+            setMessages(prev => [...prev, ...coreUserMessages.map(fromCoreUserMessageToUIMessage)] as MastraUIMessage[]);
+            await streamWithLegacyRoute();
+            return;
+          }
+          throw signalError;
+        }
       }
       throw error;
     }

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
@@ -562,6 +562,30 @@ describe('toUIMessage', () => {
       ]);
     });
 
+    it('should append echoed canonical user signals as user messages', () => {
+      const chunk: ChunkType = {
+        type: 'data-user-message',
+        data: {
+          id: 'signal-1',
+          type: 'user',
+          contents: 'hello from signal',
+        },
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+      } as any;
+
+      const result = toUIMessage({ chunk, conversation: [], metadata: baseMetadata });
+
+      expect(result).toEqual([
+        {
+          id: 'signal-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'hello from signal' }],
+          metadata: baseMetadata,
+        },
+      ]);
+    });
+
     it('should dedupe echoed user-message signals by signal id', () => {
       const chunk: ChunkType = {
         type: 'data-user-message',

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts
@@ -270,7 +270,11 @@ export const toUIMessage = ({ chunk, conversation, metadata }: ToUIMessageArgs):
 
   // Handle data-* chunks (custom data chunks from writer.custom())
   if (chunk.type.startsWith('data-')) {
-    if (chunk.type === 'data-user-message' && 'data' in chunk && chunk.data?.type === 'user-message') {
+    if (
+      chunk.type === 'data-user-message' &&
+      'data' in chunk &&
+      (chunk.data?.type === 'user-message' || chunk.data?.type === 'user')
+    ) {
       const signalId = chunk.data.id;
       if (typeof signalId === 'string' && result.some(message => message.id === signalId)) {
         return result;

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -244,11 +244,8 @@ const subscription = await agent.subscribeToThread({
   threadId: 'thread_456',
 })
 
-await agent.sendSignal({
-  signal: {
-    type: 'user-message',
-    contents: 'Show the shorter version.',
-  },
+await agent.sendMessage({
+  message: 'Show the shorter version.',
   resourceId: 'user_123',
   threadId: 'thread_456',
 })
@@ -287,5 +284,7 @@ Use heartbeats together with client-side reconnect logic. Heartbeats reduce idle
 - [`Agent.queueMessage()`](/reference/agents/agent#queuemessagemessage-options)
 - [`Agent.sendSignal()`](/reference/agents/agent#sendsignalsignal-options)
 - [`Agent.subscribeToThread()`](/reference/agents/agent#subscribetothreadoptions)
+- [`client.getAgent().sendMessage()`](/reference/client-js/agents#sendmessage)
+- [`client.getAgent().queueMessage()`](/reference/client-js/agents#queuemessage)
 - [`client.getAgent().sendSignal()`](/reference/client-js/agents#sendsignal)
 - [`client.getAgent().subscribeToThread()`](/reference/client-js/agents#subscribetothread)

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -160,17 +160,51 @@ for await (const part of uiMessageStream) {
 }
 ```
 
+### `sendMessage()`
+
+Send user-authored input to an active agent run or idle memory thread. Use this with `subscribeToThread()` so the client can render the stream that wakes from, or receives, the message.
+
+```typescript
+const agent = mastraClient.getAgent('support-agent')
+
+const result = await agent.sendMessage({
+  message: {
+    contents: 'Also consider the customer note I just added.',
+    attributes: { sentFrom: 'web' },
+  },
+  resourceId: 'user-123',
+  threadId: 'thread-abc',
+})
+
+console.log(result.runId)
+```
+
+`message` accepts a string, an array of text/file parts, or an object with `contents`, `attributes`, `metadata`, and `providerOptions`.
+
+### `queueMessage()`
+
+Queue user-authored input for the next thread turn. If the thread is active, Mastra starts a new run after the current run completes. If the thread is idle, Mastra starts a run immediately.
+
+```typescript
+await agent.queueMessage({
+  message: 'Also check whether the tests need updates.',
+  resourceId: 'user-123',
+  threadId: 'thread-abc',
+})
+```
+
 ### `sendSignal()`
 
-Send a signal to an active agent run or memory thread. Use this with `subscribeToThread()` so the client can render the stream that wakes from, or receives, the signal.
+Send a lower-level signal to an active agent run or memory thread. Use this for system-generated context such as reactive reminders or notifications. For user-authored input, prefer `sendMessage()` or `queueMessage()`.
 
 ```typescript
 const agent = mastraClient.getAgent('support-agent')
 
 const result = await agent.sendSignal({
   signal: {
-    type: 'user-message',
-    contents: 'Also consider the customer note I just added.',
+    type: 'reactive',
+    tagName: 'system-reminder',
+    contents: 'Also consider the latest customer note.',
   },
   resourceId: 'user-123',
   threadId: 'thread-abc',
@@ -183,7 +217,7 @@ Use `ifActive.behavior` and `ifIdle.behavior` to control whether Mastra delivers
 
 ```typescript
 await agent.sendSignal({
-  signal: { type: 'user-message', contents: 'Store this for later.' },
+  signal: { type: 'reactive', tagName: 'system-reminder', contents: 'Store this for later.' },
   resourceId: 'user-123',
   threadId: 'thread-abc',
   ifIdle: {
@@ -196,7 +230,7 @@ Pass `ifIdle.streamOptions` when the idle wake-up stream needs options such as m
 
 ```typescript
 await agent.sendSignal({
-  signal: { type: 'user-message', contents: 'Start from this signal.' },
+  signal: { type: 'reactive', tagName: 'system-reminder', contents: 'Start from this signal.' },
   resourceId: 'user-123',
   threadId: 'thread-abc',
   ifIdle: {
@@ -214,9 +248,9 @@ Returns `{ accepted: true, runId: string }`.
   content={[
   {
     name: 'signal',
-    type: "{ type: 'user-message' | 'system-reminder' | string; contents: string | Array<TextPart | FilePart>; attributes?: Record<string, JSONValue>; metadata?: Record<string, unknown>; providerOptions?: ProviderMetadata }",
+    type: "{ type: 'user' | 'reactive' | 'state' | 'notification' | string; tagName?: string; contents: string | Array<TextPart | FilePart>; attributes?: Record<string, JSONValue>; metadata?: Record<string, unknown>; providerOptions?: ProviderMetadata }",
     description:
-      '`user-message` signals without attributes are treated as plain user input. All other signals \u2014 including `user-message` with `attributes`, `system-reminder`, and custom types \u2014 are wrapped in an XML element named after the signal type with `attributes` rendered as XML attributes (e.g. `<user name="Devin" from="slack">message</user>`). The model sees the XML; the UI sees the raw contents and can read `attributes` for custom rendering. `providerOptions` is attached to the resulting prompt turn and persisted on the stored signal message.',
+      'Lower-level signal payload. Use `type` for the semantic signal category and `tagName` for the XML tag shown to the model. `providerOptions` is attached to the resulting prompt turn and persisted on the stored signal message.',
   },
   {
     name: 'runId',


### PR DESCRIPTION
## Summary
- add client-js agent.sendMessage() and agent.queueMessage() helpers for the new server message routes
- migrate React thread user input to sendMessage() while preserving legacy sendSignal() fallback for older servers
- update client message docs and add package-scoped changesets

## Test plan
- pnpm --filter ./client-sdks/client-js test src/resources/agent.test.ts --bail 1 --reporter=dot
- pnpm --filter ./client-sdks/react test src/lib/ai-sdk/utils/toUIMessage.test.ts --bail 1 --reporter=dot
- pnpm --filter ./client-sdks/client-js exec tsc --noEmit --pretty false
- pnpm --filter ./client-sdks/client-js build:lib
- pnpm --filter ./client-sdks/react build:js

Stacked on #17193.