### PR TITLE
04 docs: audit message-first signal docs

### DIFF
--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -195,7 +195,7 @@ Mastra still accepts legacy signal payloads such as `type: 'user-message'` and `
 - `type: 'user-message'`: Normalizes to `type: 'user'` and `tagName: 'user'`
 - `type: 'system-reminder'`: Normalizes to `type: 'reactive'` and `tagName: 'system-reminder'`
 
-Existing stored signal rows and older clients continue to load through the compatibility layer.
+Existing stored signal rows and older clients continue to load through the compatibility layer. New clients call the message routes when the server supports them; React's thread signal path falls back to the legacy `/signals` route when it detects an older server.
 
 :::note
 Visit [Agent signals reference](/reference/agents/agent#thread-signals) for the full message, signal, and subscription types.
@@ -203,7 +203,7 @@ Visit [Agent signals reference](/reference/agents/agent#thread-signals) for the 
 
 ## Use the HTTP API
 
-Use the server message routes when you interact with Mastra over HTTP directly. They accept the same string, parts array, and object message shapes as `agent.sendMessage()` and `agent.queueMessage()`.
+Use the server message routes when you interact with Mastra over HTTP directly. They accept the same string, parts array, and object message shapes as `agent.sendMessage()` and `agent.queueMessage()`. Use `/agents/:agentId/signals` only for lower-level signals and legacy clients.
 
 ```bash
 curl -X POST http://localhost:4111/api/agents/supportAgent/send-message \

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -293,7 +293,7 @@ Returns `{ accepted: true, runId: string }`.
 
 ### `subscribeToThread()`
 
-Subscribe to raw stream chunks for a memory thread. Use this to render output from a thread that may be started or continued by `sendSignal()`.
+Subscribe to raw stream chunks for a memory thread. Use this to render output from a thread that may be started or continued by `sendMessage()`, `queueMessage()`, or `sendSignal()`.
 
 ```typescript
 const agent = mastraClient.getAgent('support-agent')


### PR DESCRIPTION
## Summary
- tighten message-first signal docs after core, server, and SDK helper stacks
- clarify that direct HTTP users should use message routes for user input and  for lower-level signals or legacy clients
- document React/client fallback behavior for older servers

## Test plan
- pnpm --dir docs exec remark --no-stdout --frail --quiet --ext mdx src/content/en/docs/agents/signals.mdx src/content/en/reference/agents/agent.mdx src/content/en/reference/client-js/agents.mdx
- pnpm --dir docs exec prettier --check src/content/en/docs/agents/signals.mdx src/content/en/reference/agents/agent.mdx src/content/en/reference/client-js/agents.mdx

Stacked on #17194.