### PR TITLE
05 feat(core): add processor state signals

### DIFF
--- a/.changeset/state-processor-browser-signals.md
+++ b/.changeset/state-processor-browser-signals.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": minor
+---
+
+Add experimental processor state signals with `computeStateSignal()` and browser state signal support backed by thread metadata.

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -188,6 +188,32 @@ When the agent is idle:
 
 Top-level `attributes` always apply. The selected branch's `attributes` are merged into them at delivery time. The `delivery` name shown above is not a special Mastra API field. It is a custom attribute name used for this example.
 
+## State signals
+
+Processors can expose thread-scoped state with `computeStateSignal()`. Mastra runs this hook once per model input step after normal per-step input processing and before the model request is finalized. State signal tracking requires memory because Mastra stores each processor's hash, version, last signal id, and active-copy bookkeeping on thread metadata.
+
+```typescript title="src/mastra/processors/browser-state.ts"
+const browserStateProcessor = {
+  id: 'browser-state',
+  computeStateSignal: ({ activeStateSignals }) => {
+    return {
+      tagName: 'state',
+      contents: activeStateSignals.length
+        ? 'changed: 11 open tabs'
+        : 'Browser is open. Active tab URL: https://example.com. 10 open tabs.',
+      attributes: { type: 'browser' },
+      metadata: {
+        state: { delta: activeStateSignals.length > 0 },
+        browser: { open: true, activeUrl: 'https://example.com', tabCount: 11 },
+        delta: { tabCount: 11 },
+      },
+    }
+  },
+}
+```
+
+The built-in browser context processor now emits an aggregate browser state signal with the active URL, open/closed status, tab count, and page metadata when those values are available. When a prior copy is still active, it emits a self-describing delta and keeps the delta marker in metadata instead of exposing it as an LLM-facing XML attribute.
+
 ## Compatibility
 
 Mastra still accepts legacy signal payloads such as `type: 'user-message'` and `type: 'system-reminder'`. It normalizes them internally to the new category and tag shape:

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3368,12 +3368,16 @@ export class Agent<
           llm instanceof MastraLLMVNext
             ? mergeProviderOptions(providerOptions, llm.getProviderOptions())
             : providerOptions;
+        const memory = await this.getMemory({ requestContext });
         const result = await runner.runProcessInputStep({
           messageList,
           stepNumber,
           steps: [],
           ...observabilityContext,
           requestContext,
+          memory,
+          resourceId,
+          threadId,
           // Cast needed: legacy v1 models return LanguageModelV1 which doesn't satisfy MastraLanguageModel.
           // OM's processInputStep doesn't use the model parameter, so this is safe.
           model: model as MastraLanguageModel,

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -258,6 +258,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 steps: (inputData as any).accumulatedSteps ?? [],
                 tracingContext: modelSpanTracker?.getTracingContext() ?? tracingContext,
                 requestContext,
+                memory: registryEntry.memory,
                 model: currentModel,
                 messageId: currentMessageId,
                 rotateResponseMessageId: () => {

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -448,4 +448,102 @@ describe('BrowserContextProcessor', () => {
       });
     });
   });
+
+  describe('computeStateSignal', () => {
+    const createStateArgs = (browserCtx?: BrowserContext, activeStateSignals: any[] = []) => {
+      const requestContext = new RequestContext();
+      if (browserCtx) requestContext.set('browser', browserCtx);
+      return {
+        messages: [],
+        messageList: createMockMessageList() as any,
+        requestContext,
+        state: {},
+        abort: vi.fn() as any,
+        retryCount: 0,
+        stepNumber: 0,
+        steps: [],
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        activeStateSignals,
+      };
+    };
+
+    it('returns an aggregate browser state snapshot', () => {
+      const result = processor.computeStateSignal(
+        createStateArgs({
+          provider: 'agent-browser',
+          currentUrl: 'https://example.com',
+          pageTitle: 'Example',
+          isOpen: true,
+          tabCount: 3,
+          pageMetadata: { ready: true },
+        }),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          tagName: 'state',
+          contents: expect.stringContaining('Active tab URL: https://example.com'),
+          attributes: expect.objectContaining({ type: 'browser' }),
+          metadata: expect.objectContaining({
+            state: expect.objectContaining({ delta: false }),
+            browser: expect.objectContaining({ open: true, activeUrl: 'https://example.com', tabCount: 3 }),
+          }),
+        }),
+      );
+    });
+
+    it('returns metadata-backed deltas when active state exists', () => {
+      const activeSignal = createSignal({
+        type: 'state',
+        contents: 'Browser is open. 2 open tabs.',
+        metadata: {
+          state: { processorId: processor.id, threadId: 'thread-1', hash: 'old', version: 1 },
+          browser: { open: true, activeUrl: 'https://example.com', pageTitle: 'Example', tabCount: 2 },
+        },
+      });
+
+      const result = processor.computeStateSignal(
+        createStateArgs(
+          {
+            provider: 'agent-browser',
+            currentUrl: 'https://example.com',
+            pageTitle: 'Example',
+            isOpen: true,
+            tabCount: 3,
+          },
+          [activeSignal as any],
+        ),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          contents: 'changed: 3 open tabs',
+          metadata: expect.objectContaining({
+            state: expect.objectContaining({ delta: true }),
+            delta: { tabCount: 3 },
+          }),
+        }),
+      );
+    });
+
+    it('does not emit when browser state has not changed', () => {
+      const activeSignal = createSignal({
+        type: 'state',
+        contents: 'Browser is open.',
+        metadata: {
+          state: { processorId: processor.id, threadId: 'thread-1', hash: 'old', version: 1 },
+          browser: { open: true, activeUrl: 'https://example.com' },
+        },
+      });
+
+      const result = processor.computeStateSignal(
+        createStateArgs({ provider: 'agent-browser', currentUrl: 'https://example.com', isOpen: true }, [
+          activeSignal as any,
+        ]),
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -20,7 +20,13 @@
  */
 
 import type { MastraDBMessage } from '../agent/message-list';
-import type { ProcessInputArgs, ProcessInputResult, ProcessInputStepArgs } from '../processors/index';
+import type {
+  ComputeStateSignalArgs,
+  ComputeStateSignalResult,
+  ProcessInputArgs,
+  ProcessInputResult,
+  ProcessInputStepArgs,
+} from '../processors/index';
 
 const REMINDER_TYPE = 'browser-context';
 
@@ -46,6 +52,15 @@ export interface BrowserContext {
 
   /** Current page title (updated per-request) */
   pageTitle?: string;
+
+  /** Whether the browser is currently open/connected. Defaults to true when browser context is present. */
+  isOpen?: boolean;
+
+  /** Number of currently open tabs, when available. */
+  tabCount?: number;
+
+  /** Additional active page metadata exposed by the browser provider. */
+  pageMetadata?: Record<string, string | number | boolean | null | undefined>;
 
   /**
    * CDP WebSocket URL for CLI providers.
@@ -127,6 +142,99 @@ export class BrowserContextProcessor {
 
     return args.messageList;
   }
+
+  computeStateSignal(args: ComputeStateSignalArgs): ComputeStateSignalResult {
+    const ctx = args.requestContext?.get('browser') as BrowserContext | undefined;
+    if (!ctx) return;
+
+    const browserState = getBrowserState(ctx);
+    const previousState = getMostRecentBrowserState(args.activeStateSignals);
+    const changed = getChangedBrowserState(previousState, browserState);
+    if (previousState && Object.keys(changed).length === 0) return;
+
+    const isDelta = Boolean(previousState);
+    return {
+      tagName: 'state',
+      contents: isDelta ? formatBrowserStateDelta(changed) : formatBrowserStateSnapshot(browserState),
+      attributes: {
+        type: 'browser',
+        updated: new Date().toISOString(),
+      },
+      metadata: {
+        state: {
+          delta: isDelta,
+        },
+        browser: browserState,
+        ...(isDelta ? { delta: changed } : {}),
+      },
+    };
+  }
+}
+
+type BrowserState = {
+  open: boolean;
+  activeUrl?: string;
+  pageTitle?: string;
+  tabCount?: number;
+  pageMetadata?: Record<string, string | number | boolean | null | undefined>;
+};
+
+function getBrowserState(ctx: BrowserContext): BrowserState {
+  return {
+    open: ctx.isOpen ?? true,
+    ...(ctx.currentUrl ? { activeUrl: ctx.currentUrl } : {}),
+    ...(ctx.pageTitle ? { pageTitle: ctx.pageTitle } : {}),
+    ...(typeof ctx.tabCount === 'number' ? { tabCount: ctx.tabCount } : {}),
+    ...(ctx.pageMetadata ? { pageMetadata: ctx.pageMetadata } : {}),
+  };
+}
+
+function getMostRecentBrowserState(
+  activeStateSignals: ComputeStateSignalArgs['activeStateSignals'],
+): BrowserState | undefined {
+  for (const signal of [...activeStateSignals].reverse()) {
+    const browser = signal.metadata?.browser;
+    if (browser && typeof browser === 'object' && !Array.isArray(browser)) {
+      return browser as BrowserState;
+    }
+  }
+  return undefined;
+}
+
+function getChangedBrowserState(previous: BrowserState | undefined, current: BrowserState): Partial<BrowserState> {
+  if (!previous) return current;
+
+  const changed: Partial<BrowserState> = {};
+  for (const key of Object.keys(current) as Array<keyof BrowserState>) {
+    if (JSON.stringify(previous[key]) !== JSON.stringify(current[key])) {
+      (changed as Record<string, unknown>)[key] = current[key];
+    }
+  }
+  return changed;
+}
+
+function formatBrowserStateSnapshot(state: BrowserState): string {
+  const parts = [`Browser is ${state.open ? 'open' : 'closed'}.`];
+  if (state.activeUrl) parts.push(`Active tab URL: ${state.activeUrl}.`);
+  if (state.pageTitle) parts.push(`Page title: ${state.pageTitle}.`);
+  if (typeof state.tabCount === 'number')
+    parts.push(`${state.tabCount} open ${state.tabCount === 1 ? 'tab' : 'tabs'}.`);
+  if (state.pageMetadata && Object.keys(state.pageMetadata).length > 0) {
+    parts.push(`Page metadata: ${JSON.stringify(state.pageMetadata)}.`);
+  }
+  return parts.join(' ');
+}
+
+function formatBrowserStateDelta(delta: Partial<BrowserState>): string {
+  const parts: string[] = [];
+  if (typeof delta.open === 'boolean') parts.push(`browser ${delta.open ? 'opened' : 'closed'}`);
+  if (delta.activeUrl) parts.push(`active tab URL changed to ${delta.activeUrl}`);
+  if (delta.pageTitle) parts.push(`page title changed to ${delta.pageTitle}`);
+  if (typeof delta.tabCount === 'number') parts.push(`${delta.tabCount} open ${delta.tabCount === 1 ? 'tab' : 'tabs'}`);
+  if (delta.pageMetadata && Object.keys(delta.pageMetadata).length > 0) {
+    parts.push(`page metadata changed to ${JSON.stringify(delta.pageMetadata)}`);
+  }
+  return `changed: ${parts.join('; ')}`;
 }
 
 interface BrowserReminderMetadata {

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -7,6 +7,7 @@ import type { TripWireOptions } from '../agent/trip-wire';
 import type { ModelRouterModelId } from '../llm/model';
 import type { MastraLanguageModel, OpenAICompatibleConfig, SharedProviderOptions } from '../llm/model/shared.types';
 import type { Mastra } from '../mastra';
+import type { MastraMemory } from '../memory/memory';
 import type { ObservabilityContext } from '../observability';
 import type { RequestContext } from '../request-context';
 import type { InferStandardSchemaOutput, StandardSchemaWithJSON } from '../schema';
@@ -201,6 +202,9 @@ export type RunProcessInputStepArgs = Omit<
   messageId?: string;
   rotateResponseMessageId?: () => string;
   retryCount?: number;
+  memory?: MastraMemory;
+  resourceId?: string;
+  threadId?: string;
 };
 
 /**
@@ -248,6 +252,61 @@ export type RunProcessInputStepResult = Omit<ProcessInputStepResult, 'model'> & 
  * tool-result formats, etc. can be rewritten transiently without losing data
  * in memory, UI, or future model swaps.
  */
+export type ProcessorStateSignal = Omit<AgentSignalInput, 'type'> & {
+  type?: 'state';
+};
+
+export type ProcessorActiveStateSignal = CreatedAgentSignal & {
+  type: 'state';
+  metadata?: Record<string, unknown> & {
+    state?: {
+      processorId?: string;
+      hash?: string;
+      version?: number;
+      delta?: boolean;
+    };
+  };
+};
+
+/**
+ * Arguments for computeStateSignal method.
+ *
+ * Called once per model input step after normal per-step input processing and
+ * before the LLM request is finalized. State signals require memory-backed
+ * threads so the runtime can track versions on thread metadata.
+ */
+export interface ComputeStateSignalArgs<
+  TTripwireMetadata = unknown,
+> extends ProcessorMessageContext<TTripwireMetadata> {
+  /** The current step number (0-indexed) */
+  stepNumber: number;
+  /** All completed steps so far. */
+  steps: Array<StepResult<any>>;
+  /** Per-processor state that persists across all method calls within this request */
+  state: Record<string, unknown>;
+  /** Memory resource id for the active thread. */
+  resourceId: string;
+  /** Memory thread id that scopes this processor's state signal identity. */
+  threadId: string;
+  /** Active state signal copies for this processor/thread currently known to the runtime. */
+  activeStateSignals: ProcessorActiveStateSignal[];
+  /** Last persisted tracking metadata for this processor/thread. */
+  tracking?: ProcessorStateSignalTracking;
+}
+
+/**
+ * Thread metadata stored under metadata.mastra.stateSignals[processorId].
+ */
+export type ProcessorStateSignalTracking = {
+  currentHash?: string;
+  version?: number;
+  lastSignalId?: string;
+  updatedAt?: string;
+  activeCopies?: Array<{ id: string; hash?: string; version?: number }>;
+};
+
+export type ComputeStateSignalResult = ProcessorStateSignal | CreatedAgentSignal | undefined | void;
+
 export interface ProcessLLMRequestArgs<TTripwireMetadata = unknown> extends ProcessorContext<TTripwireMetadata> {
   /** The LLM request prompt that will be sent to the provider on this call. Processors may return a modified copy. */
   prompt: LanguageModelV2Prompt;
@@ -531,6 +590,19 @@ export interface Processor<TId extends string = string, TTripwireMetadata = unkn
     | undefined;
 
   /**
+   * Compute this processor's thread-scoped state signal for the current model input step.
+   *
+   * Called after this processor's `processInputStep` hook and before the model request is finalized.
+   * The runtime persists version/hash tracking on memory thread metadata keyed by processor id.
+   * Returning `undefined` means the state has not changed for this step.
+   *
+   * @experimental Agent state signals are experimental and may change in a future release.
+   */
+  computeStateSignal?(
+    args: ComputeStateSignalArgs<TTripwireMetadata>,
+  ): Promise<ComputeStateSignalResult> | ComputeStateSignalResult;
+
+  /**
    * Process the LLM-shaped prompt after `MessageList` has been converted to
    * `LanguageModelV2Prompt` and immediately before it is forwarded to the
    * provider on this call.
@@ -656,10 +728,12 @@ export abstract class BaseProcessor<TId extends string = string, TTripwireMetada
 
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: NonNullable<T[P]> };
 
-// InputProcessor requires processInput, processInputStep, processLLMRequest, or processLLMResponse (or any combination)
+// InputProcessor requires processInput, processInputStep, computeStateSignal, processLLMRequest, or processLLMResponse (or any combination)
 export type InputProcessor<TTripwireMetadata = unknown> =
   | (WithRequired<Processor<string, TTripwireMetadata>, 'id' | 'processInput'> & Processor<string, TTripwireMetadata>)
   | (WithRequired<Processor<string, TTripwireMetadata>, 'id' | 'processInputStep'> &
+      Processor<string, TTripwireMetadata>)
+  | (WithRequired<Processor<string, TTripwireMetadata>, 'id' | 'computeStateSignal'> &
       Processor<string, TTripwireMetadata>)
   | (WithRequired<Processor<string, TTripwireMetadata>, 'id' | 'processLLMRequest'> &
       Processor<string, TTripwireMetadata>)

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MessageList } from '../agent/message-list';
 import { TripWire } from '../agent/trip-wire';
 import type { IMastraLogger } from '../logger';
+import { RequestContext } from '../request-context';
 import type { ChunkType } from '../stream';
 import { ChunkFrom } from '../stream/types';
 import { ProcessorRunner } from './runner';
@@ -2426,6 +2427,118 @@ describe('ProcessorRunner', () => {
     });
   });
 
+  describe('processor state signals', () => {
+    it('adds state signals and stores tracking on thread metadata', async () => {
+      const requestContext = new RequestContext();
+      requestContext.set('MastraMemory', {
+        thread: {
+          id: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          metadata: {},
+        },
+        resourceId: 'resource-1',
+      });
+      const savedThreads: unknown[] = [];
+      const memory = {
+        getThreadById: vi.fn(async () => ({
+          id: 'thread-1',
+          resourceId: 'resource-1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          metadata: {},
+        })),
+        saveThread: vi.fn(async ({ thread }) => {
+          savedThreads.push(thread);
+          return thread;
+        }),
+      };
+      const chunks: unknown[] = [];
+
+      runner = new ProcessorRunner({
+        inputProcessors: [
+          {
+            id: 'state-processor',
+            computeStateSignal: ({ threadId, resourceId, activeStateSignals, tracking }) => ({
+              contents: `state for ${resourceId}/${threadId} (${activeStateSignals.length})`,
+              metadata: { seenTracking: Boolean(tracking) },
+            }),
+          },
+        ],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await runner.runProcessInputStep({
+        messageList,
+        stepNumber: 0,
+        steps: [],
+        model: {} as any,
+        tools: {},
+        retryCount: 0,
+        requestContext,
+        memory: memory as any,
+        writer: {
+          custom: async chunk => {
+            chunks.push(chunk);
+          },
+        },
+      });
+
+      const signalMessage = messageList.get.all.db().at(-1);
+      expect(signalMessage?.role).toBe('signal');
+      expect(signalMessage?.content.metadata?.signal).toEqual(
+        expect.objectContaining({
+          type: 'state',
+          tagName: 'state',
+          metadata: expect.objectContaining({
+            state: expect.objectContaining({ processorId: 'state-processor', threadId: 'thread-1', version: 1 }),
+          }),
+        }),
+      );
+      expect(chunks).toEqual([
+        expect.objectContaining({
+          type: 'data-state',
+          data: expect.objectContaining({ type: 'state', contents: 'state for resource-1/thread-1 (0)' }),
+        }),
+      ]);
+      expect(memory.saveThread).toHaveBeenCalledTimes(1);
+      expect(savedThreads[0]).toEqual(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            mastra: expect.objectContaining({
+              stateSignals: expect.objectContaining({
+                'state-processor': expect.objectContaining({ version: 1, lastSignalId: expect.any(String) }),
+              }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('requires memory for computeStateSignal processors', async () => {
+      runner = new ProcessorRunner({
+        inputProcessors: [{ id: 'state-processor', computeStateSignal: () => ({ contents: 'state' }) }],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      await expect(
+        runner.runProcessInputStep({
+          messageList,
+          stepNumber: 0,
+          steps: [],
+          model: {} as any,
+          tools: {},
+          retryCount: 0,
+        }),
+      ).rejects.toThrow('computeStateSignal requires Mastra memory');
+    });
+  });
+
   describe('processor sendSignal', () => {
     it('adds a signal message, rotates the response id, and writes a data part', async () => {
       const rotateResponseMessageId = vi.fn(() => 'response-2');
@@ -2473,7 +2586,8 @@ describe('ProcessorRunner', () => {
         expect.objectContaining({
           type: 'data-system-reminder',
           data: expect.objectContaining({
-            type: 'system-reminder',
+            type: 'reactive',
+            tagName: 'system-reminder',
             contents: 'remember this',
             metadata: { type: 'test-reminder' },
           }),

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -2,7 +2,7 @@ import type { LanguageModelV2Prompt, LanguageModelV2CallWarning } from '@ai-sdk/
 import type { StepResult } from '@internal/ai-sdk-v5';
 import type { MastraDBMessage, MessageInput } from '../agent/message-list';
 import { MessageList, messagesAreEqual } from '../agent/message-list';
-import { createSignal } from '../agent/signals';
+import { createSignal, mastraDBMessageToSignal } from '../agent/signals';
 import type { AgentSignalInput, CreatedAgentSignal } from '../agent/signals';
 import { TripWire } from '../agent/trip-wire';
 import type { TripWireOptions } from '../agent/trip-wire';
@@ -10,6 +10,8 @@ import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '
 import { MastraError } from '../error';
 import { resolveModelConfig } from '../llm';
 import type { IMastraLogger } from '../logger';
+import type { MastraMemory } from '../memory/memory';
+import { parseMemoryRequestContext } from '../memory/types';
 import { EntityType, SpanType, createObservabilityContext, resolveObservabilityContext } from '../observability';
 import type { ObservabilityContext, Span } from '../observability';
 import type { TracingContext } from '../observability/types';
@@ -30,6 +32,7 @@ import { isProcessorWorkflow } from './index';
 import type {
   CachedLLMStepChunk,
   CachedLLMStepResponse,
+  ComputeStateSignalResult,
   ErrorProcessorOrWorkflow,
   OutputResult,
   ProcessInputStepResult,
@@ -59,6 +62,63 @@ async function invokeOnViolation(processor: Processor, error: TripWire): Promise
   } catch {
     // onViolation errors are silently caught
   }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(val as Record<string, unknown>).sort()) {
+        sorted[k] = (val as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return val;
+  });
+}
+
+function getStateSignalHash(
+  signal: Pick<AgentSignalInput, 'contents' | 'attributes' | 'metadata' | 'providerOptions'>,
+): string {
+  return stableStringify({
+    contents: signal.contents,
+    attributes: signal.attributes,
+    metadata: signal.metadata,
+    providerOptions: signal.providerOptions,
+  });
+}
+
+function getStateSignalsMetadata(threadMetadata?: Record<string, unknown>): Record<string, Record<string, unknown>> {
+  if (!threadMetadata) return {};
+  const mastra = threadMetadata.mastra;
+  if (!isPlainObject(mastra)) return {};
+  const stateSignals = mastra.stateSignals;
+  return isPlainObject(stateSignals) ? (stateSignals as Record<string, Record<string, unknown>>) : {};
+}
+
+function setStateSignalMetadata(
+  threadMetadata: Record<string, unknown> | undefined,
+  processorId: string,
+  tracking: Record<string, unknown>,
+): Record<string, unknown> {
+  const existing = threadMetadata ?? {};
+  const existingMastra = isPlainObject(existing.mastra) ? existing.mastra : {};
+  const existingStateSignals = isPlainObject(existingMastra.stateSignals) ? existingMastra.stateSignals : {};
+
+  return {
+    ...existing,
+    mastra: {
+      ...existingMastra,
+      stateSignals: {
+        ...existingStateSignals,
+        [processorId]: tracking,
+      },
+    },
+  };
 }
 
 /**
@@ -318,6 +378,147 @@ export class ProcessorRunner {
       this.processorStates.set(processorId, state);
     }
     return state;
+  }
+
+  private async runComputeStateSignal({
+    processor,
+    messageList,
+    stepNumber,
+    steps,
+    requestContext,
+    writer,
+    abort,
+    processorState,
+    memory,
+    resourceId,
+    threadId,
+    abortSignal,
+    retryCount,
+  }: {
+    processor: Processor;
+    messageList: MessageList;
+    stepNumber: number;
+    steps: Array<StepResult<any>>;
+    requestContext?: RequestContext;
+    writer?: ProcessorStreamWriter;
+    abort: (reason?: string, options?: TripWireOptions) => never;
+    processorState: ProcessorState;
+    memory?: MastraMemory;
+    resourceId?: string;
+    threadId?: string;
+    abortSignal?: AbortSignal;
+    retryCount: number;
+  }): Promise<void> {
+    const computeStateSignal = processor.computeStateSignal?.bind(processor);
+    if (!computeStateSignal) return;
+
+    const memoryContext = parseMemoryRequestContext(requestContext);
+    const resolvedMemory = memory;
+    const resolvedThreadId = threadId ?? memoryContext?.thread?.id;
+    const resolvedResourceId = resourceId ?? memoryContext?.resourceId;
+
+    if (!resolvedMemory || !resolvedThreadId || !resolvedResourceId) {
+      throw new Error(
+        `[Processor:${processor.id}] computeStateSignal requires Mastra memory with an active resourceId and threadId`,
+      );
+    }
+
+    const thread = (await resolvedMemory.getThreadById({ threadId: resolvedThreadId })) ?? memoryContext?.thread;
+    if (!thread) {
+      throw new Error(`[Processor:${processor.id}] computeStateSignal could not load thread ${resolvedThreadId}`);
+    }
+
+    const activeStateSignals = messageList.get.all
+      .db()
+      .filter(message => message.role === 'signal')
+      .map(message => {
+        try {
+          return mastraDBMessageToSignal(message);
+        } catch {
+          return undefined;
+        }
+      })
+      .filter(
+        (signal): signal is CreatedAgentSignal & { type: 'state' } =>
+          signal?.type === 'state' &&
+          isPlainObject(signal.metadata?.state) &&
+          signal.metadata.state.processorId === processor.id &&
+          signal.metadata.state.threadId === resolvedThreadId,
+      );
+
+    const tracking = getStateSignalsMetadata(thread.metadata)[processor.id];
+    const result = (await computeStateSignal({
+      messages: messageList.get.all.db(),
+      messageList,
+      stepNumber,
+      steps,
+      state: processorState.customState,
+      requestContext,
+      writer,
+      abortSignal,
+      abort,
+      retryCount,
+      resourceId: resolvedResourceId,
+      threadId: resolvedThreadId,
+      activeStateSignals,
+      tracking,
+    })) as ComputeStateSignalResult;
+
+    if (!result) return;
+
+    const signalInput: AgentSignalInput = {
+      ...result,
+      type: 'state',
+      tagName: result.tagName ?? 'state',
+      contents: result.contents,
+    };
+    const hash = getStateSignalHash(signalInput);
+    if (tracking?.currentHash === hash && activeStateSignals.length > 0) return;
+
+    const previousVersion = typeof tracking?.version === 'number' ? tracking.version : 0;
+    const version = tracking?.currentHash === hash ? previousVersion || 1 : previousVersion + 1;
+    const stateMetadata = isPlainObject(signalInput.metadata?.state) ? signalInput.metadata.state : {};
+    const signal = createSignal({
+      ...signalInput,
+      metadata: {
+        ...signalInput.metadata,
+        state: {
+          ...stateMetadata,
+          processorId: processor.id,
+          threadId: resolvedThreadId,
+          hash,
+          version,
+        },
+      },
+    });
+    const addedSignal = messageList.addSignal(signal);
+    await writer?.custom(addedSignal.toDataPart());
+
+    const updatedAt = new Date().toISOString();
+    await resolvedMemory.saveThread({
+      thread: {
+        ...thread,
+        id: resolvedThreadId,
+        resourceId: thread.resourceId ?? resolvedResourceId,
+        createdAt: thread.createdAt ?? new Date(),
+        updatedAt: new Date(updatedAt),
+        metadata: setStateSignalMetadata(thread.metadata, processor.id, {
+          currentHash: hash,
+          version,
+          lastSignalId: addedSignal.id,
+          updatedAt,
+          activeCopies: [...activeStateSignals, addedSignal].map(activeSignal => {
+            const activeStateMetadata = isPlainObject(activeSignal.metadata?.state) ? activeSignal.metadata.state : {};
+            return {
+              id: activeSignal.id,
+              ...(typeof activeStateMetadata.hash === 'string' ? { hash: activeStateMetadata.hash } : {}),
+              ...(typeof activeStateMetadata.version === 'number' ? { version: activeStateMetadata.version } : {}),
+            };
+          }),
+        }),
+      },
+      memoryConfig: memoryContext?.memoryConfig,
+    });
   }
 
   /**
@@ -1116,10 +1317,11 @@ export class ProcessorRunner {
       }
 
       // Handle regular processor
-      const processor = processorOrWorkflow;
+      const processor = processorOrWorkflow as Processor;
       const processMethod = processor.processInputStep?.bind(processor);
-      if (!processMethod) {
-        // Skip processors that don't implement processInputStep
+      const computeStateSignal = processor.computeStateSignal?.bind(processor);
+      if (!processMethod && !computeStateSignal) {
+        // Skip processors that don't implement per-step input hooks
         continue;
       }
 
@@ -1206,14 +1408,13 @@ export class ProcessorRunner {
           sendSignal: createProcessorSendSignal({ messageList, writer, rotateResponseMessageId }),
         };
 
-        const result = await ProcessorRunner.validateAndFormatProcessInputStepResult(
-          await processMethod(processMethodArgs),
-          {
-            messageList,
-            processor,
-            stepNumber,
-          },
-        );
+        const result = processMethod
+          ? await ProcessorRunner.validateAndFormatProcessInputStepResult(await processMethod(processMethodArgs), {
+              messageList,
+              processor,
+              stepNumber,
+            })
+          : {};
         const { messages, systemMessages, ...rest } = result;
         if (messages) {
           ProcessorRunner.applyMessagesToMessageList(messages, messageList, idsBeforeProcessing, check);
@@ -1222,6 +1423,22 @@ export class ProcessorRunner {
           messageList.replaceAllSystemMessages(systemMessages);
         }
         Object.assign(stepInput, rest);
+
+        await this.runComputeStateSignal({
+          processor,
+          messageList,
+          stepNumber,
+          steps,
+          requestContext,
+          writer,
+          abort,
+          processorState,
+          memory: args.memory,
+          resourceId: args.resourceId,
+          threadId: args.threadId,
+          abortSignal: args.abortSignal,
+          retryCount: args.retryCount ?? 0,
+        });
 
         // Stop recording and get mutations for this processor
         const mutations = messageList.stopRecording();


### PR DESCRIPTION
## Summary\n- add experimental computeStateSignal processor hook with memory-backed thread metadata tracking\n- emit aggregate browser state signals with active URL, open status, tab count, page metadata, and delta metadata when prior copies are active\n- document state signals and add an @mastra/core changeset\n\n## Test Plan\n- pnpm test:core -- src/browser/processor.test.ts src/processors/runner.test.ts src/processors/process-input-step.test.ts --bail 1 --reporter=dot\n- pnpm --filter ./packages/core check\n- pnpm build:core