### PR TITLE
06 feat(core): add notification inbox signals

### DIFF
--- a/.changeset/notification-inbox-signals.md
+++ b/.changeset/notification-inbox-signals.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": minor
+---
+
+Add experimental thread-scoped notification inbox storage, notification signal helpers, and a flexible notification inbox tool.

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -214,6 +214,22 @@ const browserStateProcessor = {
 
 The built-in browser context processor now emits an aggregate browser state signal with the active URL, open/closed status, tab count, and page metadata when those values are available. When a prior copy is still active, it emits a self-describing delta and keeps the delta marker in metadata instead of exposing it as an LLM-facing XML attribute.
 
+## Notification signals
+
+Notification signals represent external events such as GitHub activity, email, Slack mentions, CI status, incidents, recordings, or direct messages. Notifications are durable and thread-scoped: each inbox record belongs to the conversation thread where it can be delivered, summarized, re-surfaced, and managed.
+
+```xml
+<notification source="github" type="ci-status" priority="high">CI failed on main: 3 tests</notification>
+```
+
+Mastra also supports lossy summaries that point back to full inbox records:
+
+```xml
+<notification-summary pending="10">GitHub: 3, Email: 5, Slack: 2</notification-summary>
+```
+
+Use `createNotificationInboxTool()` to give agents one flexible tool for `list`, `read`, `markSeen`, `dismiss`, `archive`, and `search` actions instead of many small CRUD tools. Source, resource, and agent ids are filters or routing metadata; `threadId` remains the primary inbox scope.
+
 ## Compatibility
 
 Mastra still accepts legacy signal payloads such as `type: 'user-message'` and `type: 'system-reminder'`. It normalizes them internally to the new category and tag shape:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -451,6 +451,16 @@
         "default": "./dist/tools/index.cjs"
       }
     },
+    "./notifications": {
+      "import": {
+        "types": "./dist/notifications/index.d.ts",
+        "default": "./dist/notifications/index.js"
+      },
+      "require": {
+        "types": "./dist/notifications/index.d.ts",
+        "default": "./dist/notifications/index.cjs"
+      }
+    },
     "./tts": {
       "import": {
         "types": "./dist/tts/index.d.ts",

--- a/packages/core/src/notifications/index.ts
+++ b/packages/core/src/notifications/index.ts
@@ -1,0 +1,4 @@
+export * from './signals';
+export * from './storage';
+export * from './tool';
+export * from './types';

--- a/packages/core/src/notifications/notifications.test.ts
+++ b/packages/core/src/notifications/notifications.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryNotificationsStorage } from './storage';
+import {
+  createNotificationInboxTool,
+  createNotificationSignal,
+  createNotificationSummarySignal,
+  summarizeNotifications,
+} from '.';
+
+describe('notification inbox', () => {
+  it('stores thread-scoped notifications and filters inbox queries', async () => {
+    const storage = new InMemoryNotificationsStorage();
+    await storage.createNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      source: 'github',
+      kind: 'ci-status',
+      priority: 'high',
+      summary: 'CI failed on main',
+      resourceId: 'resource-1',
+      agentId: 'agent-1',
+    });
+    await storage.createNotification({
+      id: 'n2',
+      threadId: 'thread-2',
+      source: 'github',
+      kind: 'issue',
+      summary: 'Issue opened',
+    });
+
+    await expect(storage.listNotifications({ threadId: 'thread-1', status: 'pending' })).resolves.toMatchObject([
+      { id: 'n1', threadId: 'thread-1', source: 'github', priority: 'high', status: 'pending' },
+    ]);
+    await expect(storage.listNotifications({ threadId: 'thread-1', resourceId: 'missing' })).resolves.toEqual([]);
+  });
+
+  it('coalesces duplicate pending notifications by dedupe or coalesce key', async () => {
+    const storage = new InMemoryNotificationsStorage();
+    const first = await storage.createNotification({
+      threadId: 'thread-1',
+      source: 'github',
+      kind: 'ci-status',
+      summary: 'CI failed: 1 test',
+      dedupeKey: 'main-ci',
+    });
+    const second = await storage.createNotification({
+      threadId: 'thread-1',
+      source: 'github',
+      kind: 'ci-status',
+      summary: 'CI failed: 3 tests',
+      dedupeKey: 'main-ci',
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.summary).toBe('CI failed: 3 tests');
+    expect(second.coalescedCount).toBe(2);
+    await expect(storage.listNotifications({ threadId: 'thread-1' })).resolves.toHaveLength(1);
+  });
+
+  it('creates individual and summary notification signals', async () => {
+    const storage = new InMemoryNotificationsStorage();
+    const github = await storage.createNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      source: 'github',
+      kind: 'ci-status',
+      priority: 'high',
+      summary: 'CI failed on main: 3 tests',
+    });
+    const slack = await storage.createNotification({
+      id: 'n2',
+      threadId: 'thread-1',
+      source: 'slack',
+      kind: 'mention',
+      priority: 'medium',
+      summary: 'Jane mentioned you',
+    });
+
+    expect(createNotificationSignal(github)).toMatchObject({
+      type: 'notification',
+      tagName: 'notification',
+      contents: 'CI failed on main: 3 tests',
+      attributes: { source: 'github', type: 'ci-status', priority: 'high' },
+    });
+
+    const summarySignal = createNotificationSummarySignal(summarizeNotifications([github, slack]));
+    expect(summarySignal).toMatchObject({
+      type: 'notification',
+      tagName: 'notification-summary',
+      attributes: { pending: 2 },
+    });
+    expect(summarySignal.metadata?.notificationSummary).toMatchObject({
+      notificationIds: ['n1', 'n2'],
+      bySource: { github: 1, slack: 1 },
+    });
+  });
+
+  it('uses one inbox tool to list, read, search, and update notifications', async () => {
+    const storage = new InMemoryNotificationsStorage();
+    await storage.createNotification({
+      id: 'n1',
+      threadId: 'thread-1',
+      source: 'email',
+      kind: 'direct-message',
+      summary: 'Jane sent a launch update',
+      payload: { body: 'Launch moved to Friday' },
+    });
+    const tool = createNotificationInboxTool({ storage });
+
+    await expect(tool.execute?.({ action: 'list' }, { agent: { threadId: 'thread-1' } } as any)).resolves.toMatchObject(
+      {
+        notifications: [{ id: 'n1', status: 'pending' }],
+      },
+    );
+    await expect(
+      tool.execute?.({ action: 'search', query: 'launch' }, { agent: { threadId: 'thread-1' } } as any),
+    ).resolves.toMatchObject({ notifications: [{ id: 'n1' }] });
+    await expect(
+      tool.execute?.({ action: 'read', id: 'n1' }, { agent: { threadId: 'thread-1' } } as any),
+    ).resolves.toMatchObject({
+      notification: { id: 'n1', status: 'seen' },
+    });
+    await expect(
+      tool.execute?.({ action: 'archive', id: 'n1' }, { agent: { threadId: 'thread-1' } } as any),
+    ).resolves.toMatchObject({
+      notification: { id: 'n1', status: 'archived' },
+    });
+  });
+});

--- a/packages/core/src/notifications/signals.ts
+++ b/packages/core/src/notifications/signals.ts
@@ -1,0 +1,52 @@
+import { createSignal } from '../agent/signals';
+import type { CreatedAgentSignal } from '../agent/signals';
+import type { NotificationRecord, NotificationSummary } from './types';
+
+export function createNotificationSignal(notification: NotificationRecord): CreatedAgentSignal {
+  return createSignal({
+    type: 'notification',
+    tagName: 'notification',
+    contents: notification.summary,
+    attributes: {
+      id: notification.id,
+      source: notification.source,
+      type: notification.kind,
+      priority: notification.priority,
+      status: notification.status,
+    },
+    metadata: { notification },
+  });
+}
+
+export function createNotificationSummarySignal(summary: NotificationSummary): CreatedAgentSignal {
+  return createSignal({
+    type: 'notification',
+    tagName: 'notification-summary',
+    contents: Object.entries(summary.bySource)
+      .map(([source, count]) => `${source}: ${count}`)
+      .join(', '),
+    attributes: {
+      pending: summary.pending,
+    },
+    metadata: { notificationSummary: summary },
+  });
+}
+
+export function summarizeNotifications(notifications: NotificationRecord[]): NotificationSummary {
+  return notifications.reduce<NotificationSummary>(
+    (summary, notification) => {
+      summary.pending += notification.status === 'pending' ? 1 : 0;
+      summary.bySource[notification.source] = (summary.bySource[notification.source] ?? 0) + 1;
+      summary.byPriority[notification.priority] = (summary.byPriority[notification.priority] ?? 0) + 1;
+      summary.notificationIds.push(notification.id);
+      return summary;
+    },
+    {
+      threadId: notifications[0]?.threadId ?? '',
+      pending: 0,
+      bySource: {},
+      byPriority: {},
+      notificationIds: [],
+    },
+  );
+}

--- a/packages/core/src/notifications/storage.ts
+++ b/packages/core/src/notifications/storage.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from 'node:crypto';
+import { StorageDomain } from '../storage/domains/base';
+import type {
+  CreateNotificationInput,
+  ListNotificationsInput,
+  NotificationRecord,
+  NotificationStatus,
+  UpdateNotificationInput,
+} from './types';
+
+export abstract class NotificationsStorage extends StorageDomain {
+  constructor() {
+    super({ component: 'STORAGE', name: 'NOTIFICATIONS' });
+  }
+
+  abstract createNotification(input: CreateNotificationInput): Promise<NotificationRecord>;
+  abstract listNotifications(input: ListNotificationsInput): Promise<NotificationRecord[]>;
+  abstract getNotification(input: { threadId: string; id: string }): Promise<NotificationRecord | null>;
+  abstract updateNotification(input: UpdateNotificationInput): Promise<NotificationRecord>;
+}
+
+const cloneDate = (value?: Date) => (value ? new Date(value) : undefined);
+
+const cloneRecord = (record: NotificationRecord): NotificationRecord => ({
+  ...record,
+  createdAt: new Date(record.createdAt),
+  updatedAt: new Date(record.updatedAt),
+  deliveredAt: cloneDate(record.deliveredAt),
+  seenAt: cloneDate(record.seenAt),
+  dismissedAt: cloneDate(record.dismissedAt),
+  archivedAt: cloneDate(record.archivedAt),
+  metadata: record.metadata ? { ...record.metadata } : undefined,
+});
+
+const statusTimestamp = (status: NotificationStatus, now: Date) => {
+  if (status === 'delivered') return { deliveredAt: now };
+  if (status === 'seen') return { seenAt: now };
+  if (status === 'dismissed') return { dismissedAt: now };
+  if (status === 'archived') return { archivedAt: now };
+  return {};
+};
+
+const valueMatches = <T extends string>(value: T, filter?: T | T[]) => {
+  if (!filter) return true;
+  return Array.isArray(filter) ? filter.includes(value) : value === filter;
+};
+
+export class InMemoryNotificationsStorage extends NotificationsStorage {
+  #notifications = new Map<string, NotificationRecord>();
+
+  async createNotification(input: CreateNotificationInput): Promise<NotificationRecord> {
+    const existing = this.findCoalescable(input);
+    if (existing) {
+      const now = new Date();
+      const next: NotificationRecord = {
+        ...existing,
+        summary: input.summary,
+        payload: input.payload ?? existing.payload,
+        priority: input.priority ?? existing.priority,
+        updatedAt: now,
+        coalescedCount: (existing.coalescedCount ?? 1) + 1,
+        metadata: input.metadata ? { ...existing.metadata, ...input.metadata } : existing.metadata,
+      };
+      this.#notifications.set(existing.id, next);
+      return cloneRecord(next);
+    }
+
+    const now = input.createdAt ?? new Date();
+    const record: NotificationRecord = {
+      id: input.id ?? randomUUID(),
+      threadId: input.threadId,
+      source: input.source,
+      kind: input.kind,
+      priority: input.priority ?? 'medium',
+      status: 'pending',
+      summary: input.summary,
+      payload: input.payload,
+      resourceId: input.resourceId,
+      agentId: input.agentId,
+      sourceId: input.sourceId,
+      dedupeKey: input.dedupeKey,
+      coalesceKey: input.coalesceKey,
+      coalescedCount: 1,
+      createdAt: now,
+      updatedAt: now,
+      metadata: input.metadata ? { ...input.metadata } : undefined,
+    };
+    this.#notifications.set(record.id, record);
+    return cloneRecord(record);
+  }
+
+  async listNotifications(input: ListNotificationsInput): Promise<NotificationRecord[]> {
+    const search = input.search?.toLowerCase();
+    const results = [...this.#notifications.values()]
+      .filter(record => record.threadId === input.threadId)
+      .filter(record => valueMatches(record.status, input.status))
+      .filter(record => valueMatches(record.priority, input.priority))
+      .filter(record => !input.source || record.source === input.source)
+      .filter(record => !input.resourceId || record.resourceId === input.resourceId)
+      .filter(record => !input.agentId || record.agentId === input.agentId)
+      .filter(
+        record =>
+          !search || record.summary.toLowerCase().includes(search) || record.kind.toLowerCase().includes(search),
+      )
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+    return results.slice(0, input.limit ?? results.length).map(cloneRecord);
+  }
+
+  async getNotification(input: { threadId: string; id: string }): Promise<NotificationRecord | null> {
+    const record = this.#notifications.get(input.id);
+    if (!record || record.threadId !== input.threadId) return null;
+    return cloneRecord(record);
+  }
+
+  async updateNotification(input: UpdateNotificationInput): Promise<NotificationRecord> {
+    const existing = this.#notifications.get(input.id);
+    if (!existing || existing.threadId !== input.threadId) {
+      throw new Error(`Notification ${input.id} was not found for thread ${input.threadId}`);
+    }
+    const now = new Date();
+    const next: NotificationRecord = {
+      ...existing,
+      ...(input.status ? { status: input.status, ...statusTimestamp(input.status, now) } : {}),
+      ...(input.summary !== undefined ? { summary: input.summary } : {}),
+      ...(input.payload !== undefined ? { payload: input.payload } : {}),
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+      updatedAt: now,
+    };
+    this.#notifications.set(next.id, next);
+    return cloneRecord(next);
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    this.#notifications.clear();
+  }
+
+  private findCoalescable(input: CreateNotificationInput): NotificationRecord | undefined {
+    if (!input.dedupeKey && !input.coalesceKey) return undefined;
+    return [...this.#notifications.values()].find(record => {
+      if (record.threadId !== input.threadId || record.source !== input.source || record.status !== 'pending')
+        return false;
+      return Boolean(
+        (input.dedupeKey && record.dedupeKey === input.dedupeKey) ||
+        (input.coalesceKey && record.coalesceKey === input.coalesceKey),
+      );
+    });
+  }
+}

--- a/packages/core/src/notifications/tool.ts
+++ b/packages/core/src/notifications/tool.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+import { createTool } from '../tools';
+import type { NotificationsStorage } from './storage';
+import type { ListNotificationsInput, NotificationStatus } from './types';
+
+const notificationActionSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('list'),
+    threadId: z.string().optional(),
+    status: z.enum(['pending', 'delivered', 'seen', 'dismissed', 'archived']).optional(),
+    priority: z.enum(['low', 'medium', 'high', 'urgent']).optional(),
+    source: z.string().optional(),
+    limit: z.number().int().positive().optional(),
+  }),
+  z.object({ action: z.literal('read'), id: z.string(), threadId: z.string().optional() }),
+  z.object({ action: z.literal('markSeen'), id: z.string(), threadId: z.string().optional() }),
+  z.object({ action: z.literal('dismiss'), id: z.string(), threadId: z.string().optional() }),
+  z.object({ action: z.literal('archive'), id: z.string(), threadId: z.string().optional() }),
+  z.object({
+    action: z.literal('search'),
+    threadId: z.string().optional(),
+    query: z.string(),
+    limit: z.number().int().positive().optional(),
+  }),
+]);
+
+type NotificationInboxAction = z.infer<typeof notificationActionSchema>;
+
+export function createNotificationInboxTool({ storage }: { storage: NotificationsStorage }) {
+  return createTool({
+    id: 'notification-inbox',
+    description:
+      'Inspect and manage the current thread notification inbox. Use this to list pending notifications, read full details after a summary, mark notifications seen, dismiss, archive, or search old notifications.',
+    inputSchema: notificationActionSchema,
+    execute: async (input: NotificationInboxAction, context) => {
+      const threadId = input.threadId ?? context?.agent?.threadId;
+      if (!threadId) {
+        throw new Error('notification-inbox requires a threadId');
+      }
+
+      if (input.action === 'list') {
+        const listInput: ListNotificationsInput = {
+          threadId,
+          status: input.status,
+          priority: input.priority,
+          source: input.source,
+          limit: input.limit,
+        };
+        return { notifications: await storage.listNotifications(listInput) };
+      }
+
+      if (input.action === 'search') {
+        return {
+          notifications: await storage.listNotifications({ threadId, search: input.query, limit: input.limit }),
+        };
+      }
+
+      if (input.action === 'read') {
+        const notification = await storage.getNotification({ threadId, id: input.id });
+        if (!notification) throw new Error(`Notification ${input.id} was not found for thread ${threadId}`);
+        if (notification.status === 'pending' || notification.status === 'delivered') {
+          return { notification: await storage.updateNotification({ threadId, id: input.id, status: 'seen' }) };
+        }
+        return { notification };
+      }
+
+      const statusByAction = {
+        markSeen: 'seen',
+        dismiss: 'dismissed',
+        archive: 'archived',
+      } satisfies Record<'markSeen' | 'dismiss' | 'archive', NotificationStatus>;
+
+      return {
+        notification: await storage.updateNotification({
+          threadId,
+          id: input.id,
+          status: statusByAction[input.action],
+        }),
+      };
+    },
+  });
+}

--- a/packages/core/src/notifications/types.ts
+++ b/packages/core/src/notifications/types.ts
@@ -1,0 +1,72 @@
+export type NotificationPriority = 'low' | 'medium' | 'high' | 'urgent';
+
+export type NotificationStatus = 'pending' | 'delivered' | 'seen' | 'dismissed' | 'archived';
+
+export type NotificationRecord = {
+  id: string;
+  threadId: string;
+  source: string;
+  kind: string;
+  priority: NotificationPriority;
+  status: NotificationStatus;
+  summary: string;
+  payload?: unknown;
+  resourceId?: string;
+  agentId?: string;
+  sourceId?: string;
+  dedupeKey?: string;
+  coalesceKey?: string;
+  coalescedCount?: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deliveredAt?: Date;
+  seenAt?: Date;
+  dismissedAt?: Date;
+  archivedAt?: Date;
+  metadata?: Record<string, unknown>;
+};
+
+export type CreateNotificationInput = {
+  id?: string;
+  threadId: string;
+  source: string;
+  kind: string;
+  priority?: NotificationPriority;
+  summary: string;
+  payload?: unknown;
+  resourceId?: string;
+  agentId?: string;
+  sourceId?: string;
+  dedupeKey?: string;
+  coalesceKey?: string;
+  metadata?: Record<string, unknown>;
+  createdAt?: Date;
+};
+
+export type ListNotificationsInput = {
+  threadId: string;
+  status?: NotificationStatus | NotificationStatus[];
+  priority?: NotificationPriority | NotificationPriority[];
+  source?: string;
+  resourceId?: string;
+  agentId?: string;
+  search?: string;
+  limit?: number;
+};
+
+export type UpdateNotificationInput = {
+  id: string;
+  threadId: string;
+  status?: NotificationStatus;
+  summary?: string;
+  payload?: unknown;
+  metadata?: Record<string, unknown>;
+};
+
+export type NotificationSummary = {
+  threadId: string;
+  pending: number;
+  bySource: Record<string, number>;
+  byPriority: Partial<Record<NotificationPriority, number>>;
+  notificationIds: string[];
+};

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -19,6 +19,7 @@ import type {
   BackgroundTasksStorage,
   SchedulesStorage,
   ChannelsStorage,
+  NotificationsStorage,
 } from './domains';
 
 /** Map of all storage domain interfaces available in a composite store. */
@@ -27,6 +28,7 @@ export type StorageDomains = {
   scores?: ScoresStorage;
   memory?: MemoryStorage;
   channels?: ChannelsStorage;
+  notifications?: NotificationsStorage;
   observability?: ObservabilityStorage;
   agents?: AgentsStorage;
   datasets?: DatasetsStorage;
@@ -313,6 +315,7 @@ export class MastraCompositeStore extends MastraBase {
         backgroundTasks: resolve('backgroundTasks'),
         schedules: resolve('schedules'),
         channels: resolve('channels'),
+        notifications: resolve('notifications'),
       } as StorageDomains;
     }
     // Otherwise, subclasses set stores themselves
@@ -412,6 +415,7 @@ export class MastraCompositeStore extends MastraBase {
       maybeInit(this.stores.backgroundTasks);
       maybeInit(this.stores.schedules);
       maybeInit(this.stores.channels);
+      maybeInit(this.stores.notifications);
     }
 
     await Promise.all(initTasks);

--- a/packages/core/src/storage/domains/index.ts
+++ b/packages/core/src/storage/domains/index.ts
@@ -21,4 +21,4 @@ export * from './datasets';
 export * from './experiments';
 export * from './background-tasks';
 export * from './schedules';
-export * from './schedules';
+export * from './notifications';

--- a/packages/core/src/storage/domains/notifications/index.ts
+++ b/packages/core/src/storage/domains/notifications/index.ts
@@ -1,0 +1,10 @@
+export { NotificationsStorage, InMemoryNotificationsStorage } from '../../../notifications/storage';
+export type {
+  CreateNotificationInput,
+  ListNotificationsInput,
+  NotificationPriority,
+  NotificationRecord,
+  NotificationStatus,
+  NotificationSummary,
+  UpdateNotificationInput,
+} from '../../../notifications/types';

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -11,6 +11,7 @@ import { InMemoryDB } from './domains/inmemory-db';
 import { InMemoryMCPClientsStorage } from './domains/mcp-clients/inmemory';
 import { InMemoryMCPServersStorage } from './domains/mcp-servers/inmemory';
 import { InMemoryMemory } from './domains/memory/inmemory';
+import { InMemoryNotificationsStorage } from './domains/notifications';
 import { ObservabilityInMemory } from './domains/observability/inmemory';
 import { InMemoryPromptBlocksStorage } from './domains/prompt-blocks/inmemory';
 import { InMemorySchedulesStorage } from './domains/schedules/inmemory';
@@ -64,6 +65,7 @@ export class InMemoryStore extends MastraCompositeStore {
       observability: new ObservabilityInMemory({ db: this.#db }),
       agents: new InMemoryAgentsStorage({ db: this.#db }),
       channels: new InMemoryChannelsStorage(),
+      notifications: new InMemoryNotificationsStorage(),
       datasets: new DatasetsInMemory({ db: this.#db }),
       experiments: new ExperimentsInMemory({ db: this.#db }),
       promptBlocks: new InMemoryPromptBlocksStorage({ db: this.#db }),
@@ -86,8 +88,9 @@ export class InMemoryStore extends MastraCompositeStore {
    */
   clear(): void {
     this.#db.clear();
-    // InMemoryChannelsStorage doesn't share the InMemoryDB
+    // These domains don't share the InMemoryDB
     void this.stores.channels?.dangerouslyClearAll?.();
+    void this.stores.notifications?.dangerouslyClearAll?.();
   }
 }
 


### PR DESCRIPTION
## Summary\n- add experimental thread-scoped notification inbox storage and register it as an optional storage domain\n- add notification and notification-summary signal helpers with recoverable inbox metadata\n- add one flexible notification inbox tool for list/read/markSeen/dismiss/archive/search\n- document notification signals and add an @mastra/core changeset\n\n## Test Plan\n- pnpm test:core -- src/notifications/notifications.test.ts --bail 1 --reporter=dot\n- pnpm --filter ./packages/core check\n- pnpm run prettier:changed\n- pnpm build:core