### PR TITLE
07 feat(core): add signal delivery policies

### DIFF
--- a/.changeset/delivery-policy-signals.md
+++ b/.changeset/delivery-policy-signals.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Add experimental agent delivery policies for routing user, reactive, state, and notification signals by category and source.

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -531,7 +531,10 @@ export const useChat = ({
         ifIdle: { streamOptions },
       });
       const echoedSignalId =
-        result.signal && typeof result.signal === 'object' && 'id' in result.signal && typeof result.signal.id === 'string'
+        result.signal &&
+        typeof result.signal === 'object' &&
+        'id' in result.signal &&
+        typeof result.signal.id === 'string'
           ? result.signal.id
           : resolvedSignalId;
       onSignalSent?.(echoedSignalId, getSignalPreview(coreUserMessages));
@@ -554,7 +557,9 @@ export const useChat = ({
           onSignalEcho?.(resolvedSignalId);
           if (isThreadSignalUnsupportedError(signalError)) {
             markThreadSignalsUnsupported();
-            setMessages(prev => [...prev, ...coreUserMessages.map(fromCoreUserMessageToUIMessage)] as MastraUIMessage[]);
+            setMessages(
+              prev => [...prev, ...coreUserMessages.map(fromCoreUserMessageToUIMessage)] as MastraUIMessage[],
+            );
             await streamWithLegacyRoute();
             return;
           }

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -230,6 +230,33 @@ Mastra also supports lossy summaries that point back to full inbox records:
 
 Use `createNotificationInboxTool()` to give agents one flexible tool for `list`, `read`, `markSeen`, `dismiss`, `archive`, and `search` actions instead of many small CRUD tools. Source, resource, and agent ids are filters or routing metadata; `threadId` remains the primary inbox scope.
 
+## Delivery policy
+
+Agents can define an experimental `deliveryPolicy` when default routing is too noisy. The policy works by signal category (`user`, `reactive`, `state`, `notification`) instead of by XML tag name.
+
+```typescript title="src/mastra/agents/support-agent.ts"
+const agent = new Agent({
+  name: 'supportAgent',
+  instructions: 'Help users resolve support issues.',
+  model,
+  deliveryPolicy: {
+    categories: {
+      state: 'persist',
+      notification: 'summarize',
+    },
+    sources: {
+      pagerduty: {
+        notification: 'deliver',
+      },
+    },
+  },
+})
+```
+
+Policy outcomes are `deliver`, `queue`, `persist`, `wake`, `summarize`, `discard`, and `coalesce`. By default, user and reactive signals deliver to active runs and wake idle threads. State signals persist. Notifications summarize unless urgent; urgent notifications deliver immediately, and high-priority notifications can wake idle threads.
+
+Explicit message APIs stay predictable: `sendMessage()` still means immediate delivery by default, and `queueMessage()` still means next-turn queueing by default. Use `deliveryPolicy` only when you want to intentionally change those defaults for a category or source.
+
 ## Compatibility
 
 Mastra still accepts legacy signal payloads such as `type: 'user-message'` and `type: 'system-reminder'`. It normalizes them internally to the new category and tag shape:

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -1065,6 +1065,119 @@ describe('Agent signals', () => {
     subscription.unsubscribe();
   });
 
+  it('queues active messages when delivery policy returns queue', async () => {
+    let releaseFirst!: () => void;
+    const firstFinished = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    let streamCount = 0;
+    const prompts: any[][] = [];
+    const model = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        streamCount += 1;
+        prompts.push(prompt);
+        const responseText = streamCount === 1 ? 'first response' : 'policy queued response';
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: new ReadableStream({
+            async start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+              controller.enqueue({
+                type: 'response-metadata',
+                id: `policy-queue-${streamCount}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              });
+              controller.enqueue({ type: 'text-start', id: 'text-1' });
+              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: responseText });
+              controller.enqueue({ type: 'text-end', id: 'text-1' });
+              if (streamCount === 1) {
+                await firstFinished;
+              }
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+              controller.close();
+            },
+          }),
+        };
+      },
+    });
+    const agent = new Agent({
+      id: 'policy-queue-agent',
+      name: 'Policy Queue Agent',
+      instructions: 'Test',
+      model,
+      deliveryPolicy: { categories: { user: 'queue' } },
+    });
+    const subscription = await agent.subscribeToThread({
+      threadId: 'policy-queue-thread',
+      resourceId: 'policy-queue-user',
+    });
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+    const firstRun = readNextRunWithParts(iterator);
+
+    const stream = await agent.stream('Hello', {
+      memory: { thread: 'policy-queue-thread', resource: 'policy-queue-user' },
+    });
+    await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
+    const result = agent.sendMessage('Policy queued follow-up', {
+      resourceId: 'policy-queue-user',
+      threadId: 'policy-queue-thread',
+    });
+
+    expect(result.accepted).toBe(true);
+    expect(result.runId).not.toBe(stream.runId);
+    await nextTick();
+    expect(streamCount).toBe(1);
+
+    releaseFirst();
+    await expect(stream.text).resolves.toBe('first response');
+    await firstRun;
+    const secondRun = await readNextRunWithParts(iterator);
+    expect(secondRun.value.runId).toBe(result.runId);
+    expect(secondRun.value.text).toBe('policy queued response');
+    expect(JSON.stringify(prompts[1])).toContain('Policy queued follow-up');
+
+    subscription.unsubscribe();
+  });
+
+  it('persists low-priority notifications by default when delivery policy is enabled', async () => {
+    let streamCount = 0;
+    const agent = new Agent({
+      id: 'policy-notification-agent',
+      name: 'Policy Notification Agent',
+      instructions: 'Test',
+      model: new MockLanguageModelV2({
+        doStream: async () => {
+          streamCount += 1;
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+            ]),
+          };
+        },
+      }),
+      memory: new MockMemory(),
+      deliveryPolicy: {},
+    });
+
+    const result = agent.sendSignal(
+      { type: 'notification', contents: 'Background notification', attributes: { priority: 'low' } },
+      { resourceId: 'policy-notification-user', threadId: 'policy-notification-thread' },
+    );
+
+    expect(result.accepted).toBe(true);
+    await expect(result.persisted).resolves.toBeUndefined();
+    expect(streamCount).toBe(0);
+  });
+
   it('fans out sequential idle signal runs to many same-thread subscribers', async () => {
     const resourceId = 'share-resource';
     const threadId = 'share-thread';

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -116,6 +116,7 @@ import type {
   ToolsInput,
   AgentModelManagerConfig,
   AgentCreateOptions,
+  AgentDeliveryPolicyConfig,
   AgentExecuteOnFinishOptions,
   AgentInstructions,
   AgentMessageInput,
@@ -344,6 +345,7 @@ export class Agent<
   #requestContextSchema?: StandardSchemaWithJSON<TRequestContext>;
   #backgroundTasks?: AgentBackgroundConfig;
   #toolPayloadTransform?: ToolPayloadTransformPolicy;
+  #deliveryPolicy?: AgentDeliveryPolicyConfig;
   /**
    * Tracks the active `streamUntilIdle` wrapper per `(threadId|resourceId)`
    * scope on this Agent instance. A new call for the same scope aborts the
@@ -440,6 +442,7 @@ export class Agent<
     this.#defaultStreamOptionsLegacy = config.defaultStreamOptionsLegacy || {};
     this.#defaultOptions = config.defaultOptions || ({} as AgentExecutionOptions<TOutput>);
     this.#defaultNetworkOptions = config.defaultNetworkOptions || {};
+    this.#deliveryPolicy = config.deliveryPolicy;
     this.#toolPayloadTransform = normalizeToolPayloadTransformPolicy(
       config.transform ?? (config as any).toolPayloadProjection,
     );
@@ -6375,6 +6378,13 @@ export class Agent<
 
   abortRunStream(runId: string): boolean {
     return agentThreadStreamRuntime.abortRun(runId, this.getPubSub());
+  }
+
+  /**
+   * @experimental Agent signal delivery policy is experimental and may change in a future release.
+   */
+  getDeliveryPolicy(): AgentDeliveryPolicyConfig | undefined {
+    return this.#deliveryPolicy;
   }
 
   /**

--- a/packages/core/src/agent/delivery-policy.ts
+++ b/packages/core/src/agent/delivery-policy.ts
@@ -1,0 +1,73 @@
+import type { CreatedAgentSignal } from './signals';
+import type {
+  AgentDeliveryPolicyConfig,
+  AgentDeliveryPolicyInput,
+  AgentDeliveryPolicyOutcome,
+  AgentDeliveryPriority,
+  AgentDeliveryThreadState,
+} from './types';
+
+export function getSignalDeliveryPriority(signal: CreatedAgentSignal): AgentDeliveryPriority {
+  const priority =
+    signal.attributes?.priority ?? (signal.metadata?.notification as { priority?: unknown } | undefined)?.priority;
+  return priority === 'low' || priority === 'medium' || priority === 'high' || priority === 'urgent'
+    ? priority
+    : 'medium';
+}
+
+export function getSignalDeliverySource(signal: CreatedAgentSignal): string | undefined {
+  const notification = signal.metadata?.notification as { source?: unknown } | undefined;
+  return typeof signal.attributes?.source === 'string'
+    ? signal.attributes.source
+    : typeof notification?.source === 'string'
+      ? notification.source
+      : undefined;
+}
+
+export function defaultDeliveryPolicy(input: AgentDeliveryPolicyInput): AgentDeliveryPolicyOutcome {
+  if (input.explicitApi === 'queueMessage') return 'queue';
+  if (input.category === 'notification') {
+    if (input.priority === 'urgent') return 'deliver';
+    if (input.threadState === 'idle' && input.priority === 'high') return 'wake';
+    return 'summarize';
+  }
+  if (input.category === 'state') return 'persist';
+  if (input.threadState === 'idle') return 'wake';
+  return 'deliver';
+}
+
+export function resolveDeliveryPolicy(input: AgentDeliveryPolicyInput): AgentDeliveryPolicyOutcome {
+  const sourceOverride = input.source ? input.config?.sources?.[input.source] : undefined;
+  const configured = sourceOverride?.[input.category] ?? input.config?.categories?.[input.category];
+  if (configured) return configured;
+  return input.config?.decide?.(input) ?? defaultDeliveryPolicy(input);
+}
+
+export function shouldApplyDeliveryPolicy(
+  config: AgentDeliveryPolicyConfig | undefined,
+): config is AgentDeliveryPolicyConfig {
+  return Boolean(config);
+}
+
+export function createDeliveryPolicyInput({
+  signal,
+  threadState,
+  explicitApi,
+  config,
+}: {
+  signal: CreatedAgentSignal;
+  threadState: AgentDeliveryThreadState;
+  explicitApi: AgentDeliveryPolicyInput['explicitApi'];
+  config?: AgentDeliveryPolicyConfig;
+}): AgentDeliveryPolicyInput {
+  return {
+    signal,
+    category: signal.type,
+    tagName: signal.tagName,
+    priority: getSignalDeliveryPriority(signal),
+    source: getSignalDeliverySource(signal),
+    threadState,
+    explicitApi,
+    config,
+  };
+}

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -3,6 +3,7 @@ export { MessageList, convertMessages, aiV5ModelMessageToV2PromptMessage, TypeDe
 export type { OutputFormat } from './message-list';
 export * from './types';
 export * from './signals';
+export * from './delivery-policy';
 export * from './agent';
 export * from './utils';
 

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -8,6 +8,7 @@ import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context
 import type { MastraModelOutput } from '../stream/base/output';
 import type { Agent } from './agent';
 import type { AgentExecutionOptions } from './agent.types';
+import { createDeliveryPolicyInput, resolveDeliveryPolicy, shouldApplyDeliveryPolicy } from './delivery-policy';
 import { createMessageSignal, createSignal, resolveDeliveryAttributes } from './signals';
 import type { AgentMessageInput, CreatedAgentSignal } from './signals';
 import type {
@@ -33,6 +34,25 @@ function withThreadMemory(memory: unknown, resourceId: string, threadId: string)
     resource: (memory as { resource?: string } | undefined)?.resource ?? resourceId,
     thread: (memory as { thread?: string } | undefined)?.thread ?? threadId,
   };
+}
+
+function mapDeliveryOutcomeToBehaviors({
+  outcome,
+  activeBehavior,
+  idleBehavior,
+}: {
+  outcome: ReturnType<typeof resolveDeliveryPolicy>;
+  activeBehavior: 'deliver' | 'persist' | 'discard';
+  idleBehavior: 'wake' | 'persist' | 'discard';
+}): ResolvedSignalPolicy {
+  if (outcome === 'deliver') return { activeBehavior: 'deliver', idleBehavior: 'wake' };
+  if (outcome === 'wake') return { activeBehavior: 'deliver', idleBehavior: 'wake' };
+  if (outcome === 'queue') return { activeBehavior: 'queue', idleBehavior: 'wake' };
+  if (outcome === 'persist' || outcome === 'summarize' || outcome === 'coalesce') {
+    return { activeBehavior: 'persist', idleBehavior: 'persist' };
+  }
+  if (outcome === 'discard') return { activeBehavior: 'discard', idleBehavior: 'discard' };
+  return { activeBehavior, idleBehavior };
 }
 
 type AgentThreadRunRecord<OUTPUT = unknown> = {
@@ -71,6 +91,13 @@ type AgentThreadRuntimeState = {
 };
 
 type SerializableAgentSignal = AgentSignal & Pick<CreatedAgentSignal, 'id' | 'createdAt'>;
+
+type SignalExplicitApi = 'sendSignal' | 'sendMessage' | 'queueMessage';
+
+type ResolvedSignalPolicy = {
+  activeBehavior: 'deliver' | 'persist' | 'discard' | 'queue';
+  idleBehavior: 'wake' | 'persist' | 'discard';
+};
 
 type AgentThreadStreamRuntimeEvent =
   | { type: 'run-registered'; runId: string }
@@ -770,7 +797,13 @@ export class AgentThreadStreamRuntime {
     target: SendAgentMessageOptions<OUTPUT>,
     pubsub?: PubSub,
   ): SendAgentMessageResult {
-    return this.sendSignal(agent, createMessageSignal(message, { acceptedAt: new Date() }), target, pubsub);
+    return this.#sendSignal(
+      agent,
+      createMessageSignal(message, { acceptedAt: new Date() }),
+      target,
+      pubsub,
+      'sendMessage',
+    );
   }
 
   queueMessage<OUTPUT = unknown>(
@@ -848,12 +881,22 @@ export class AgentThreadStreamRuntime {
     target: SendAgentSignalOptions<OUTPUT>,
     pubsub?: PubSub,
   ): SendAgentSignalResult {
+    return this.#sendSignal(agent, signalInput, target, pubsub, 'sendSignal');
+  }
+
+  #sendSignal<OUTPUT = unknown>(
+    agent: Agent<any, any, any, any>,
+    signalInput: AgentSignal,
+    target: SendAgentSignalOptions<OUTPUT>,
+    pubsub: PubSub | undefined,
+    explicitApi: SignalExplicitApi,
+  ): SendAgentSignalResult {
     const state = this.#getState(pubsub);
     let signal = createSignal({ ...signalInput, acceptedAt: new Date() });
     let key: string | undefined;
     let runId = target.runId;
-    const activeBehavior = target.ifActive?.behavior ?? 'deliver';
-    const idleBehavior = target.ifIdle?.behavior ?? 'wake';
+    let activeBehavior: 'deliver' | 'persist' | 'discard' | 'queue' = target.ifActive?.behavior ?? 'deliver';
+    let idleBehavior: 'wake' | 'persist' | 'discard' = target.ifIdle?.behavior ?? 'wake';
 
     let activeRecord: AgentThreadRunRecord<any> | undefined;
     if (target.resourceId && target.threadId) {
@@ -881,12 +924,48 @@ export class AgentThreadStreamRuntime {
     );
     const resourceId = target.resourceId ?? activeRecord?.resourceId;
     const threadId = target.threadId ?? activeRecord?.threadId;
+    const deliveryPolicy = agent.getDeliveryPolicy?.();
+    if (shouldApplyDeliveryPolicy(deliveryPolicy)) {
+      const outcome = resolveDeliveryPolicy(
+        createDeliveryPolicyInput({
+          signal,
+          threadState: isActiveTarget ? 'active' : 'idle',
+          explicitApi,
+          config: deliveryPolicy,
+        }),
+      );
+      const behaviors = mapDeliveryOutcomeToBehaviors({ outcome, activeBehavior, idleBehavior });
+      activeBehavior = behaviors.activeBehavior;
+      idleBehavior = behaviors.idleBehavior;
+    }
 
     // Resolve conditional delivery attributes now that we know the delivery path.
     signal = resolveDeliveryAttributes(
       signal,
       isActiveTarget ? target.ifActive?.attributes : target.ifIdle?.attributes,
     );
+
+    if (isActiveTarget && activeBehavior === 'queue') {
+      if (!resourceId || !threadId) {
+        throw new Error('resourceId and threadId are required to queue an active signal');
+      }
+      key ??= this.#threadKey(resourceId, threadId);
+      const queuedRunId = randomUUID();
+      const idleQueue = state.pendingIdleSignalsByThread.get(key) ?? [];
+      idleQueue.push({
+        agent,
+        signal,
+        runId: queuedRunId,
+        resourceId,
+        threadId,
+        streamOptions: target.ifIdle?.streamOptions,
+      });
+      state.pendingIdleSignalsByThread.set(key, idleQueue);
+      if (activeRecord) {
+        this.#watchThreadRunCompletion(state, pubsub, key, activeRecord);
+      }
+      return { accepted: true, runId: queuedRunId, signal };
+    }
 
     if (isActiveTarget && activeBehavior !== 'deliver') {
       if (activeBehavior === 'persist') {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -101,6 +101,56 @@ export type AgentSignalActiveBehavior = 'deliver' | 'persist' | 'discard';
 export type AgentSignalIdleBehavior = 'wake' | 'persist' | 'discard';
 
 /**
+ * @experimental Agent signal delivery policy is experimental and may change in a future release.
+ */
+export type AgentDeliveryPriority = 'low' | 'medium' | 'high' | 'urgent';
+
+/**
+ * @experimental Agent signal delivery policy is experimental and may change in a future release.
+ */
+export type AgentDeliveryPolicyOutcome =
+  | 'deliver'
+  | 'queue'
+  | 'persist'
+  | 'wake'
+  | 'summarize'
+  | 'discard'
+  | 'coalesce';
+
+/**
+ * @experimental Agent signal delivery policy is experimental and may change in a future release.
+ */
+export type AgentDeliveryThreadState = 'active' | 'idle';
+
+/**
+ * @experimental Agent signal delivery policy is experimental and may change in a future release.
+ */
+export interface AgentDeliveryPolicyInput {
+  signal: CreatedAgentSignal;
+  category: CreatedAgentSignal['type'];
+  tagName?: string;
+  priority: AgentDeliveryPriority;
+  source?: string;
+  threadState: AgentDeliveryThreadState;
+  explicitApi: 'sendSignal' | 'sendMessage' | 'queueMessage';
+  config?: AgentDeliveryPolicyConfig;
+}
+
+/**
+ * @experimental Agent signal delivery policy is experimental and may change in a future release.
+ */
+export type AgentDeliveryPolicyDecider = (input: AgentDeliveryPolicyInput) => AgentDeliveryPolicyOutcome;
+
+/**
+ * @experimental Agent signal delivery policy is experimental and may change in a future release.
+ */
+export interface AgentDeliveryPolicyConfig {
+  categories?: Partial<Record<CreatedAgentSignal['type'], AgentDeliveryPolicyOutcome>>;
+  sources?: Record<string, Partial<Record<CreatedAgentSignal['type'], AgentDeliveryPolicyOutcome>>>;
+  decide?: AgentDeliveryPolicyDecider;
+}
+
+/**
  * @experimental Agent signals are experimental and may change in a future release.
  */
 export type SendAgentSignalOptions<OUTPUT = unknown> =
@@ -431,6 +481,11 @@ export interface AgentConfig<
    * When omitted, the agent uses its Mastra instance pubsub or the default in-memory pubsub.
    */
   pubsub?: PubSub;
+  /**
+   * Experimental delivery policy for non-explicit signal routing decisions.
+   * Explicit `sendMessage()` and `queueMessage()` calls keep their default semantics unless the policy returns an override.
+   */
+  deliveryPolicy?: AgentDeliveryPolicyConfig;
   /**
    * Sub-Agents that the agent can access. Can be provided statically or resolved dynamically.
    */


### PR DESCRIPTION
## Summary
- add experimental agent delivery policy types and config for category/source-based signal routing
- apply policy outcomes to thread signal routing, including queued active delivery and default notification/state behavior
- document delivery policies and add focused runtime coverage

## Test plan
- pnpm vitest run packages/core/src/agent/__tests__/agent-signals.test.ts packages/core/src/notifications/notifications.test.ts --bail 1 --reporter=dot
- pnpm --filter ./packages/core check
- pnpm build:core
- pnpm run prettier:changed