### PR TITLE
08 feat(playground): surface signal context panels

### DIFF
--- a/.changeset/ui-final-signal-panels.md
+++ b/.changeset/ui-final-signal-panels.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground': patch
+---
+
+Show state and notification signals as pinned thread context instead of normal chat messages.

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -214,6 +214,8 @@ const browserStateProcessor = {
 
 The built-in browser context processor now emits an aggregate browser state signal with the active URL, open/closed status, tab count, and page metadata when those values are available. When a prior copy is still active, it emits a self-describing delta and keeps the delta marker in metadata instead of exposing it as an LLM-facing XML attribute.
 
+Studio keeps state signals out of the normal transcript and shows them as pinned context above the thread instead. This keeps browser state and other processor state visible without turning every state refresh into chat noise.
+
 ## Notification signals
 
 Notification signals represent external events such as GitHub activity, email, Slack mentions, CI status, incidents, recordings, or direct messages. Notifications are durable and thread-scoped: each inbox record belongs to the conversation thread where it can be delivered, summarized, re-surfaced, and managed.
@@ -229,6 +231,8 @@ Mastra also supports lossy summaries that point back to full inbox records:
 ```
 
 Use `createNotificationInboxTool()` to give agents one flexible tool for `list`, `read`, `markSeen`, `dismiss`, `archive`, and `search` actions instead of many small CRUD tools. Source, resource, and agent ids are filters or routing metadata; `threadId` remains the primary inbox scope.
+
+Studio surfaces notification signals in a lightweight inbox panel above the thread. The panel groups the signal content with source, priority, and status metadata so notifications remain recoverable without being rendered as assistant chat bubbles.
 
 ## Delivery policy
 

--- a/packages/playground/src/lib/ai-ui/thread-runtime-state.ts
+++ b/packages/playground/src/lib/ai-ui/thread-runtime-state.ts
@@ -5,12 +5,33 @@ export type PendingSignalMessage = {
   preview: string;
 };
 
+export type ThreadStateSignal = {
+  id: string;
+  title: string;
+  preview: string;
+  source?: string;
+  updatedAt?: string;
+};
+
+export type ThreadNotificationSignal = {
+  id: string;
+  title: string;
+  preview: string;
+  source?: string;
+  priority?: string;
+  status?: string;
+  createdAt?: string;
+  count?: number;
+};
+
 export type ThreadRuntimeState = {
   isStreaming: boolean;
   canSendWhileStreaming: boolean;
   cancelStream: () => void | Promise<void>;
   pendingSignals: PendingSignalMessage[];
   hasPendingMessages: boolean;
+  stateSignals: ThreadStateSignal[];
+  notifications: ThreadNotificationSignal[];
 };
 
 const ThreadRuntimeStateContext = createContext<ThreadRuntimeState>({
@@ -19,6 +40,8 @@ const ThreadRuntimeStateContext = createContext<ThreadRuntimeState>({
   cancelStream: () => {},
   pendingSignals: [],
   hasPendingMessages: false,
+  stateSignals: [],
+  notifications: [],
 });
 
 export const ThreadRuntimeStateProvider = ThreadRuntimeStateContext.Provider;

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -1,7 +1,7 @@
 import type { MessagePrimitive } from '@assistant-ui/react';
 import { ComposerPrimitive, ThreadPrimitive, useComposer, useComposerRuntime } from '@assistant-ui/react';
 import { Avatar, Button, ButtonsGroup, cn, useAutoscroll } from '@mastra/playground-ui';
-import { ArrowUp, EyeIcon, Mic, PlusIcon } from 'lucide-react';
+import { ArrowUp, BellIcon, EyeIcon, Mic, PinIcon, PlusIcon } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { AttachFileDialog } from './attachments/attach-file-dialog';
 import { ComposerAttachments } from './attachments/attachment';
@@ -11,6 +11,7 @@ import { AssistantMessage } from './messages/assistant-message';
 import { SaveFullConversationAction } from './messages/dataset-save-action';
 import { UserMessage } from './messages/user-messages';
 import { useThreadRuntimeState } from './thread-runtime-state';
+import type { ThreadNotificationSignal, ThreadStateSignal } from './thread-runtime-state';
 import { BrowserThumbnail, useBrowserSession } from '@/domains/agents';
 import { ComposerModelSwitcher, ComposerModelWarning } from '@/domains/agents/components/composer-model-switcher';
 import { usePermissions } from '@/domains/auth/hooks/use-permissions';
@@ -33,6 +34,7 @@ export const Thread = ({ agentName, agentId, threadId, hasMemory, hasModelList, 
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   useAutoscroll(areaRef, { enabled: true });
   const { hasSession, viewMode, isInSidebar } = useBrowserSession();
+  const { stateSignals, notifications } = useThreadRuntimeState();
 
   // Show thumbnail in chat when:
   // 1. There's an active session
@@ -59,6 +61,7 @@ export const Thread = ({ agentName, agentId, threadId, hasMemory, hasModelList, 
           className="relative max-w-3xl w-full mx-auto px-4 pb-7 group-has-[[data-attachments-row]]/thread:pb-24"
         >
           <BracketOverlay containerRef={messagesContainerRef} />
+          <ThreadSignalContext stateSignals={stateSignals} notifications={notifications} />
           <ThreadPrimitive.Messages
             components={{
               UserMessage: UserMessage,
@@ -102,6 +105,69 @@ const ThreadWrapper = ({ children }: { children: React.ReactNode }) => {
     >
       {children}
     </ThreadPrimitive.Root>
+  );
+};
+
+const ThreadSignalContext = ({
+  stateSignals,
+  notifications,
+}: {
+  stateSignals: ThreadStateSignal[];
+  notifications: ThreadNotificationSignal[];
+}) => {
+  if (!stateSignals.length && !notifications.length) return null;
+
+  return (
+    <div className="mb-4 grid gap-2" data-testid="thread-signal-context">
+      {stateSignals.length ? (
+        <section className="rounded-lg border border-border2 bg-surface2 p-3" aria-label="Pinned state context">
+          <div className="mb-2 flex items-center gap-2 text-icon-sm font-medium text-icon6">
+            <PinIcon className="h-4 w-4" />
+            <span>Pinned state context</span>
+          </div>
+          <div className="grid gap-2">
+            {stateSignals.map(signal => (
+              <article
+                key={signal.id}
+                className="rounded-md bg-surface3 p-2 text-ui-sm"
+                data-testid="state-signal-card"
+              >
+                <div className="flex items-center justify-between gap-2 text-icon-xs text-icon3">
+                  <span>{signal.title}</span>
+                  {signal.updatedAt ? <time>{new Date(signal.updatedAt).toLocaleString()}</time> : null}
+                </div>
+                <p className="mt-1 text-icon5">{signal.preview}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {notifications.length ? (
+        <section className="rounded-lg border border-border2 bg-surface2 p-3" aria-label="Notification inbox">
+          <div className="mb-2 flex items-center gap-2 text-icon-sm font-medium text-icon6">
+            <BellIcon className="h-4 w-4" />
+            <span>Notification inbox</span>
+          </div>
+          <div className="grid gap-2">
+            {notifications.map(notification => (
+              <article
+                key={notification.id}
+                className="rounded-md bg-surface3 p-2 text-ui-sm"
+                data-testid="notification-signal-card"
+              >
+                <div className="flex items-center justify-between gap-2 text-icon-xs text-icon3">
+                  <span>{notification.source ?? notification.title}</span>
+                  {notification.priority ? <span>{notification.priority}</span> : null}
+                </div>
+                <p className="mt-1 text-icon5">{notification.preview}</p>
+                {notification.status ? <p className="mt-1 text-icon-xs text-icon3">{notification.status}</p> : null}
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </div>
   );
 };
 

--- a/packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx
+++ b/packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx
@@ -115,6 +115,84 @@ vi.mock('../tool-call-provider', () => ({
 }));
 
 import { MastraRuntimeProvider } from '../mastra-runtime-provider';
+import { extractThreadSignalPanels, removePinnedSignalParts } from '../signal-panels';
+
+describe('signal panel utilities', () => {
+  it('extracts state and notification signal panels from data parts', () => {
+    const messages = [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'data-state',
+            data: {
+              id: 'state-1',
+              type: 'state',
+              tagName: 'state',
+              contents: 'Browser is open. Active tab URL: https://example.com.',
+              createdAt: '2026-05-28T00:00:00.000Z',
+              attributes: { type: 'browser' },
+            },
+          },
+          {
+            type: 'data-notification',
+            data: {
+              id: 'notification-1',
+              type: 'notification',
+              tagName: 'notification',
+              contents: 'CI failed on main.',
+              createdAt: '2026-05-28T00:01:00.000Z',
+              attributes: { source: 'github', priority: 'high', status: 'pending' },
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(extractThreadSignalPanels(messages)).toEqual({
+      stateSignals: [
+        {
+          id: 'state-1',
+          title: 'browser state',
+          preview: 'Browser is open. Active tab URL: https://example.com.',
+          source: 'browser',
+          updatedAt: '2026-05-28T00:00:00.000Z',
+        },
+      ],
+      notifications: [
+        {
+          id: 'notification-1',
+          title: 'Notification',
+          preview: 'CI failed on main.',
+          source: 'github',
+          priority: 'high',
+          status: 'pending',
+          createdAt: '2026-05-28T00:01:00.000Z',
+          count: undefined,
+        },
+      ],
+    });
+  });
+
+  it('removes pinned state and notification parts from chat messages', () => {
+    const message = {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'Visible response' },
+        { type: 'data-state', data: { type: 'state', contents: 'Pinned context' } },
+        { type: 'data-notification', data: { type: 'notification', contents: 'Inbox event' } },
+      ],
+    };
+
+    expect(removePinnedSignalParts(message)).toEqual({
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Visible response' }],
+    });
+  });
+});
 
 describe('MastraRuntimeProvider', () => {
   beforeEach(() => {

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -10,6 +10,7 @@ import { toAssistantUIMessage, useMastraClient, useChat } from '@mastra/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
+import { extractThreadSignalPanels, removePinnedSignalParts } from './signal-panels';
 import {
   buildMaxStepsStreamErrorMessage,
   buildStreamErrorMessage,
@@ -1319,14 +1320,19 @@ export function MastraRuntimeProvider({
   // Build a global index of all OM cycle parts across all messages synchronously.
   // This gives each per-message converter the full picture of a cycle's state even when
   // parts are spread across messages (e.g., buffering-start on msg A, activation on msg B).
-  const globalOmParts = useMemo(() => buildGlobalOmPartsByCycleId(messages), [messages]);
+  const { stateSignals, notifications } = useMemo(() => extractThreadSignalPanels(messages), [messages]);
+  const chatMessages = useMemo(
+    () => messages.map(removePinnedSignalParts).filter((message): message is MastraUIMessage => Boolean(message)),
+    [messages],
+  );
+  const globalOmParts = useMemo(() => buildGlobalOmPartsByCycleId(chatMessages), [chatMessages]);
 
   // Convert data-om-* parts to dynamic-tool format BEFORE toAssistantUIMessage.
   // Strip transient error messages from `messages` because the same errors are
   // tracked in `streamErrors` (which survives the post-stream initialMessages
   // refresh). Without filtering here we would briefly render duplicate errors
   // during the streaming window.
-  const vnextmessages = [...messages.filter(msg => msg.metadata?.status !== 'error'), ...streamErrors].map(msg => {
+  const vnextmessages = [...chatMessages.filter(msg => msg.metadata?.status !== 'error'), ...streamErrors].map(msg => {
     const converted = convertOmPartsInMastraMessage(msg, globalOmParts);
     return toAssistantUIMessage(converted);
   });
@@ -1355,6 +1361,8 @@ export function MastraRuntimeProvider({
         cancelStream: onCancel,
         pendingSignals,
         hasPendingMessages: pendingSignals.length > 0,
+        stateSignals,
+        notifications,
       }}
     >
       <AssistantRuntimeProvider runtime={runtime}>

--- a/packages/playground/src/services/signal-panels.ts
+++ b/packages/playground/src/services/signal-panels.ts
@@ -1,0 +1,93 @@
+import type { ThreadNotificationSignal, ThreadStateSignal } from '@/lib/ai-ui/thread-runtime-state';
+
+type SignalDataPart = {
+  type?: string;
+  data?: {
+    id?: string;
+    type?: string;
+    tagName?: string;
+    contents?: unknown;
+    createdAt?: string;
+    attributes?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+  };
+};
+
+const signalContentsPreview = (contents: unknown): string => {
+  if (typeof contents === 'string') return contents;
+  if (Array.isArray(contents)) {
+    return contents
+      .map(part => (typeof part === 'object' && part !== null && 'text' in part ? String(part.text) : ''))
+      .filter(Boolean)
+      .join(' ');
+  }
+  return '';
+};
+
+const getSignalParts = (messages: Array<{ parts?: unknown[] }>): SignalDataPart[] => {
+  return messages.flatMap(message => {
+    const parts = message.parts ?? [];
+    return parts.filter(
+      (part): part is SignalDataPart =>
+        typeof part === 'object' && part !== null && typeof (part as SignalDataPart).type === 'string',
+    );
+  });
+};
+
+export const extractThreadSignalPanels = (messages: Array<{ parts?: unknown[] }>) => {
+  const stateSignals: ThreadStateSignal[] = [];
+  const notifications: ThreadNotificationSignal[] = [];
+
+  for (const part of getSignalParts(messages)) {
+    const category = part.data?.type;
+    if (category === 'state') {
+      const source =
+        typeof part.data?.attributes?.type === 'string'
+          ? part.data.attributes.type
+          : typeof part.data?.attributes?.source === 'string'
+            ? part.data.attributes.source
+            : undefined;
+      stateSignals.push({
+        id: part.data?.id ?? `state-${stateSignals.length}`,
+        title: source ? `${source} state` : 'State',
+        preview: signalContentsPreview(part.data?.contents),
+        source,
+        updatedAt: part.data?.createdAt,
+      });
+    } else if (category === 'notification') {
+      const attributes = part.data?.attributes ?? {};
+      const metadata = part.data?.metadata ?? {};
+      const notificationMetadata = metadata.notification as Record<string, unknown> | undefined;
+      notifications.push({
+        id: part.data?.id ?? `notification-${notifications.length}`,
+        title: part.data?.tagName === 'notification-summary' ? 'Notification summary' : 'Notification',
+        preview: signalContentsPreview(part.data?.contents),
+        source:
+          typeof attributes.source === 'string'
+            ? attributes.source
+            : typeof notificationMetadata?.source === 'string'
+              ? notificationMetadata.source
+              : undefined,
+        priority: typeof attributes.priority === 'string' ? attributes.priority : undefined,
+        status: typeof attributes.status === 'string' ? attributes.status : undefined,
+        createdAt: part.data?.createdAt,
+        count: typeof attributes.pending === 'number' ? attributes.pending : undefined,
+      });
+    }
+  }
+
+  return { stateSignals, notifications };
+};
+
+export const removePinnedSignalParts = <TMessage extends { role?: string; parts?: unknown[] }>(
+  message: TMessage,
+): TMessage | null => {
+  const parts = message.parts?.filter(part => {
+    const category = (part as SignalDataPart).data?.type;
+    return category !== 'state' && category !== 'notification';
+  });
+
+  if (!parts || parts.length === (message.parts?.length ?? 0)) return message;
+  if (parts.length === 0 && message.role === 'assistant') return null;
+  return { ...message, parts };
+};


### PR DESCRIPTION
## Summary
- surface state signal context and notification summaries in the Playground thread runtime instead of rendering them as normal assistant chat content
- add shared signal-panel extraction utilities and focused runtime-provider coverage
- update signal docs and add the Stack 8 changeset

## Test plan
- pnpm vitest run src/services/__tests__/mastra-runtime-provider.test.tsx --reporter=dot --bail 1 (from packages/playground)
- pnpm --filter ./packages/playground typecheck
- pnpm --filter ./packages/playground build