### PR TITLE
fix(core): end AGENT_RUN span when stream aborts mid-flight

### DIFF
--- a/.changeset/long-results-take.md
+++ b/.changeset/long-results-take.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed AGENT_RUN observability span not closing when an agent stream is aborted mid-flight (browser disconnect, consumer cancel, or AbortController.abort()). The span now ends with structured output `{ status: 'aborted', reason: 'abort' }` so traces reach Langfuse, Datadog, Braintrust, and other backends that export on SPAN_ENDED. Completes the work started in #17097 for issue #17074.
+Fixed AGENT_RUN spans not closing when an agent stream is aborted mid-flight (e.g. browser disconnect or `AbortController.abort()`). Aborted runs now end with `{ status: 'aborted', reason: 'abort' }` so traces are exported to observability backends.

--- a/.changeset/long-results-take.md
+++ b/.changeset/long-results-take.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed AGENT_RUN observability span not closing when an agent stream is aborted mid-flight (browser disconnect, consumer cancel, or AbortController.abort()). The span now ends with structured output `{ status: 'aborted', reason: 'abort' }` so traces reach Langfuse, Datadog, Braintrust, and other backends that export on SPAN_ENDED. Completes the work started in #17097 for issue #17074.

--- a/packages/core/src/agent/__tests__/save-and-errors.test.ts
+++ b/packages/core/src/agent/__tests__/save-and-errors.test.ts
@@ -2152,4 +2152,79 @@ describe('AGENT_RUN span must be ended on LLM errors', () => {
       spy.mockRestore();
     }
   });
+
+  it('should end the AGENT_RUN span when the stream is aborted mid-flight', async () => {
+    const { spy, getAgentRunSpan } = await mockGetOrCreateSpan();
+
+    try {
+      const abortController = new AbortController();
+      let pullCalls = 0;
+
+      const abortMidStreamModel = new MockLanguageModelV2({
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: new ReadableStream({
+            pull(controller) {
+              switch (pullCalls++) {
+                case 0:
+                  controller.enqueue({ type: 'stream-start', warnings: [] });
+                  break;
+                case 1:
+                  controller.enqueue({
+                    type: 'response-metadata',
+                    id: 'id-0',
+                    modelId: '__GATEWAY_OPENAI_MODEL__',
+                    timestamp: new Date(0),
+                  });
+                  break;
+                case 2:
+                  // Abort during streaming, before any finish chunk reaches output.ts.
+                  // This mirrors the browser-disconnect / AbortController.abort() path
+                  // that previously left the AGENT_RUN span orphaned.
+                  abortController.abort();
+                  controller.error(new DOMException('The user aborted a request.', 'AbortError'));
+                  break;
+              }
+            },
+          }),
+        }),
+      });
+
+      const agent = new Agent({
+        id: 'test-orphaned-span-abort',
+        name: 'Test Orphaned Span Abort',
+        model: abortMidStreamModel,
+        instructions: 'You are a helpful assistant.',
+      });
+
+      const output = await agent.stream('Hello', {
+        abortSignal: abortController.signal,
+        modelSettings: { maxRetries: 0 },
+      });
+
+      try {
+        for await (const _chunk of output.fullStream) {
+          // drain
+        }
+      } catch {
+        // expected: stream may error on abort
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      const agentRunSpan = getAgentRunSpan();
+      expect(agentRunSpan).toBeDefined();
+      expect(agentRunSpan.end).toHaveBeenCalled();
+      expect(agentRunSpan.error).not.toHaveBeenCalled();
+      expect(agentRunSpan.end.mock.calls[0][0]).toMatchObject({
+        output: {
+          status: 'aborted',
+          reason: 'abort',
+        },
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -296,6 +296,16 @@ export function createMapResultsStep<OUTPUT = undefined>({
             return;
           }
 
+          if (payload.finishReason === 'aborted') {
+            agentSpan?.end({
+              output: {
+                status: 'aborted',
+                reason: 'abort',
+              },
+            });
+            return;
+          }
+
           // Skip memory persistence when the abort signal has fired.
           // The LLM response may have continued after the caller disconnected,
           // and we should not persist a partial or full response for an aborted request.

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -535,6 +535,61 @@ describe('MastraModelOutput', () => {
       expect(finishPayload.content).toEqual([]);
     });
 
+    it('should call onFinish with the aborted payload shape when the stream is aborted', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      let finishPayload: any;
+
+      const stream = createChunkStream([
+        {
+          type: 'text-delta',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { text: 'partial answer' },
+        },
+        {
+          type: 'abort',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: {},
+        },
+      ] as ChunkType[]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: '__GATEWAY_OPENAI_MODEL__', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          onFinish: async payload => {
+            finishPayload = payload;
+          },
+        },
+      });
+
+      await output.consumeStream();
+
+      // Core field the AGENT_RUN span end reads.
+      expect(finishPayload).toMatchObject({
+        finishReason: 'aborted',
+      });
+      // Empty defaults keep the aborted callback payload contract-complete without
+      // reconstructing partial buffered state from a mid-flight canceled stream.
+      expect(finishPayload.text).toBe('');
+      expect(finishPayload.toolCalls).toEqual([]);
+      expect(finishPayload.toolResults).toEqual([]);
+      expect(finishPayload.steps).toEqual([]);
+      expect(finishPayload.usage).toEqual({ inputTokens: undefined, outputTokens: undefined, totalTokens: undefined });
+      expect(finishPayload.totalUsage).toEqual({
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      });
+      expect(finishPayload.response).toEqual({});
+      expect(finishPayload.content).toEqual([]);
+    });
+
     it('should keep the latest step raw usage across multiple steps', async () => {
       const runId = 'test-run';
       const firstRaw = {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -435,6 +435,14 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 await options?.onFinish?.(self.#createSuspendedOnFinishPayload(chunk));
               }
               break;
+            case 'abort':
+              self.#status = 'canceled';
+              if (!self.#finishCallbackSent) {
+                self.#finishCallbackSent = true;
+                await options?.onFinish?.(self.#createAbortedOnFinishPayload());
+              }
+              self.#closeTransportIfNeeded();
+              break;
             case 'raw':
               if (!self.#options.includeRawChunks) {
                 return;
@@ -1597,6 +1605,36 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
       cachedInputTokens: this.#usageCount.cachedInputTokens,
       cacheCreationInputTokens: this.#usageCount.cacheCreationInputTokens,
       ...(this.#usageCount.raw !== undefined && { raw: this.#usageCount.raw }),
+    };
+  }
+
+  #createAbortedOnFinishPayload(): MastraOnFinishCallbackArgs<OUTPUT> {
+    // Abort flow invokes options?.onFinish so map-results-step.ts can close the AGENT_RUN span.
+    // That span path only reads finishReason. The remaining LLMStepResult fields are empty
+    // defaults to satisfy the MastraOnFinishCallback shape without reconstructing partial
+    // buffered state from a stream that was canceled mid-flight.
+    return {
+      finishReason: 'aborted',
+      text: '',
+      reasoning: [],
+      reasoningText: undefined,
+      sources: [],
+      files: [],
+      toolCalls: [],
+      toolResults: [],
+      staticToolCalls: [],
+      staticToolResults: [],
+      dynamicToolCalls: [],
+      dynamicToolResults: [],
+      content: [],
+      usage: { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined },
+      warnings: [],
+      providerMetadata: undefined,
+      request: {},
+      response: {},
+      steps: [],
+      totalUsage: { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined },
+      object: undefined as OUTPUT,
     };
   }
 


### PR DESCRIPTION
## Description

When an agent stream terminated via abort (browser disconnect, consumer cancel, or `AbortController.abort()`), the `AGENT_RUN` observability span was never `.end()`-ed, so traces never reached Langfuse, Datadog, Braintrust, or any other backend that exports on `SPAN_ENDED`. This PR fires the existing `onFinish` callback from a new `abort` chunk arm in `MastraModelOutput` with `finishReason: 'aborted'`, mirroring the suspend pattern from #17097. Completes the remaining termination path from issue #17074.

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/63d95da0-251b-4800-b015-0af4ebba2d12" />

## Related Issue(s)

Fixes #17074

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an AI agent's response stream was stopped abruptly (like closing the browser), the system didn't tell its monitoring tools the job ended. This change makes the system send a clear "aborted" finish signal so traces and logs correctly show the run was cancelled.

---

## Problem

Agent streams terminated via abort (browser disconnect, consumer cancel, or AbortController.abort()) left the AGENT_RUN observability span un-ended, so tracing backends that export on SPAN_ENDED never received terminal information and traces remained incomplete.

## Solution

### Core Changes

1. packages/core/src/stream/base/output.ts (MastraModelOutput)
   - Added handling for an `abort` chunk: marks internal status as `canceled`, closes the transport, and invokes `options.onFinish` once with a complete aborted payload.
   - Added private helper `#createAbortedOnFinishPayload`() to produce a full MastraOnFinishCallbackArgs with finishReason: 'aborted' and safe defaults for text, toolCalls, toolResults, steps, usage, totalUsage, response, and content.

2. packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
   - In createMapResultsStep's onFinish handler, added an explicit branch for payload.finishReason === 'aborted' that ends the AGENT_RUN span with structured output { output: { status: 'aborted', reason: 'abort' } } and returns early (skipping memory persistence).

### Tests

- packages/core/src/stream/base/output.test.ts: New test asserting onFinish receives the aborted payload shape (finishReason: 'aborted' with empty defaults) when an abort chunk is emitted.
- packages/core/src/agent/__tests__/save-and-errors.test.ts: Regression test asserting agentRunSpan.end was called with { status: 'aborted', reason: 'abort' } (and agentSpan.error was not called) when AbortController.abort() aborts a stream mid-flight.

Both tests fail on main prior to this fix and pass with it.

## Type

Bug fix (low complexity) with unit and regression tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->