### PR TITLE
Remove legacy Playground chat runtime

### DIFF
--- a/packages/playground/src/domains/agents/components/agent-chat.tsx
+++ b/packages/playground/src/domains/agents/components/agent-chat.tsx
@@ -1,6 +1,6 @@
-import { toAISdkV4Messages, toAISdkV5Messages } from '@mastra/ai-sdk/ui';
+import { toAISdkV5Messages } from '@mastra/ai-sdk/ui';
 import type { MastraUIMessage } from '@mastra/react';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useAgentSettings } from '../context/agent-context';
 import { useMergedRequestContext } from '@/domains/request-context/context/schema-request-context';
 import { useAgentMessages } from '@/hooks/use-agent-messages';
@@ -21,7 +21,8 @@ export const AgentChat = ({
   messageId,
   isNewThread,
   hideModelSwitcher,
-}: Omit<ChatProps, 'initialMessages' | 'initialLegacyMessages'> & {
+}: Omit<ChatProps, 'initialMessages'> & {
+  memory?: boolean;
   messageId?: string;
   isNewThread?: boolean;
   hideModelSwitcher?: boolean;
@@ -55,11 +56,13 @@ export const AgentChat = ({
   // Stable empty array per thread: stays the same reference across re-renders
   // (preventing useChat from wiping streamed messages), but changes when threadId
   // changes (allowing useChat to reset when switching threads).
-  const emptyMessages = useMemo(() => [] as never[], [threadId]);
+  const emptyMessagesRef = useRef<{ threadId: string; messages: never[] }>({ threadId, messages: [] });
+  if (emptyMessagesRef.current.threadId !== threadId) {
+    emptyMessagesRef.current = { threadId, messages: [] };
+  }
 
-  const messages = data?.messages ?? emptyMessages;
+  const messages = data?.messages ?? emptyMessagesRef.current.messages;
   const v5Messages = useMemo(() => toAISdkV5Messages(messages) as MastraUIMessage[], [messages]);
-  const v4Messages = useMemo(() => toAISdkV4Messages(messages), [messages]);
 
   return (
     <MastraRuntimeProvider
@@ -69,8 +72,6 @@ export const AgentChat = ({
       agentVersionId={agentVersionId}
       threadId={threadId}
       initialMessages={v5Messages}
-      initialLegacyMessages={v4Messages}
-      memory={memory}
       refreshThreadList={refreshThreadList}
       settings={settings}
       requestContext={requestContext}

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -1,7 +1,5 @@
-import type { ThreadMessageLike, AppendMessage } from '@assistant-ui/react';
+import type { AppendMessage } from '@assistant-ui/react';
 import { useExternalStoreRuntime, AssistantRuntimeProvider } from '@assistant-ui/react';
-import type { UIMessageWithMetadata } from '@mastra/client-js';
-import { MastraClient } from '@mastra/client-js';
 import { RequestContext } from '@mastra/core/di';
 import type { CoreUserMessage } from '@mastra/core/llm';
 import { fileToBase64 } from '@mastra/playground-ui';
@@ -23,15 +21,6 @@ import { useTracingSettings } from '@/domains/observability/context/tracing-sett
 import { useAdapters } from '@/lib/ai-ui/hooks/use-adapters';
 import { ThreadRuntimeStateProvider } from '@/lib/ai-ui/thread-runtime-state';
 import type { ChatProps } from '@/types';
-
-const handleFinishReason = (finishReason: string) => {
-  switch (finishReason) {
-    case 'tool-calls':
-      throw new Error('Stream finished with reason tool-calls, try increasing maxSteps');
-    default:
-      break;
-  }
-};
 
 const getAppendMessageText = (message: AppendMessage) => {
   const text = (message.content[0] as { text?: unknown } | undefined)?.text;
@@ -296,103 +285,10 @@ const convertOmPartsInMastraMessage = (
   };
 };
 
-const initializeMessageState = (initialMessages: UIMessageWithMetadata[]) => {
-  // @ts-expect-error - TODO: fix the ThreadMessageLike type, it's missing some properties like "data" from the role.
-  const convertedMessages: ThreadMessageLike[] = initialMessages
-    ?.map((message: UIMessageWithMetadata) => {
-      const attachmentsAsContentParts = (message.experimental_attachments || []).map((image: any) => ({
-        type: image.contentType.startsWith(`image/`)
-          ? 'image'
-          : image.contentType.startsWith(`audio/`)
-            ? 'audio'
-            : 'file',
-        mimeType: image.contentType,
-        image: image.url,
-      }));
-
-      const formattedParts = (message.parts || [])
-        .map((part: any) => {
-          if (part.type === 'reasoning') {
-            return {
-              type: 'reasoning',
-              text:
-                part.reasoning ||
-                part?.details
-                  ?.filter((detail: any) => detail.type === 'text')
-                  ?.map((detail: any) => detail.text)
-                  .join(' '),
-            };
-          }
-          if (part.type === 'tool-invocation') {
-            if (part.toolInvocation.state === 'result') {
-              return {
-                type: 'tool-call',
-                toolCallId: part.toolInvocation.toolCallId,
-                toolName: part.toolInvocation.toolName,
-                args: part.toolInvocation.args,
-                result: part.toolInvocation.result,
-              };
-            } else if (part.toolInvocation.state === 'call') {
-              // Only return pending tool calls that are legitimately awaiting approval
-              const toolCallId = part.toolInvocation.toolCallId;
-              const toolName = part.toolInvocation.toolName;
-              const pendingToolApprovals = message.metadata?.pendingToolApprovals as Record<string, any> | undefined;
-              const suspensionData = pendingToolApprovals?.[toolCallId];
-              if (suspensionData) {
-                return {
-                  type: 'tool-call',
-                  toolCallId,
-                  toolName,
-                  args: part.toolInvocation.args,
-                  metadata: {
-                    mode: 'stream',
-                    requireApprovalMetadata: {
-                      [toolName]: suspensionData,
-                    },
-                  },
-                };
-              }
-            }
-          }
-
-          if (part.type === 'file') {
-            return {
-              type: 'file',
-              mimeType: part.mimeType,
-              data: part.data,
-            };
-          }
-
-          if (part.type === 'text') {
-            return {
-              type: 'text',
-              text: part.text,
-            };
-          }
-
-          // Keep data-om-* parts as-is - they'll be converted by convertOmPartsInMastraMessage later
-          if (part.type?.startsWith('data-om-')) {
-            return part;
-          }
-        })
-        .filter(Boolean);
-
-      return {
-        ...message,
-        content: [...formattedParts, ...attachmentsAsContentParts],
-      };
-    })
-    .filter(Boolean);
-
-  return convertedMessages;
-};
-
 export function MastraRuntimeProvider({
   children,
   agentId,
   initialMessages,
-  initialLegacyMessages,
-  memory,
   threadId,
   refreshThreadList,
   settings,
@@ -404,8 +300,7 @@ export function MastraRuntimeProvider({
 }> &
   ChatProps) {
   const { settings: tracingSettings } = useTracingSettings();
-  const [isLegacyRunning, setIsLegacyRunning] = useState(false);
-  const [legacyMessages, setLegacyMessages] = useState<ThreadMessageLike[]>([]);
+
   // Errors emitted as `error` chunks (or thrown by sendMessage) are not persisted to
   // server memory, so they get wiped from useChat's `messages` state when
   // `initialMessages` refreshes after a stream ends. Track them in a parallel
@@ -432,10 +327,6 @@ export function MastraRuntimeProvider({
     threadSignalsUnsupportedRef.current = false;
     setThreadSignalsUnsupported(false);
   }, [agentId, threadId]);
-
-  useEffect(() => {
-    setLegacyMessages(initializeMessageState(initialLegacyMessages || []));
-  }, [initialLegacyMessages]);
 
   const chatRequestContext = useMemo(() => {
     if (!agentVersionId && !requestContext) return undefined;
@@ -667,7 +558,6 @@ export function MastraRuntimeProvider({
 
     // Mark any in-progress observation markers as disconnected
     setMessages(prev => markOmMarkersAsDisconnected(prev));
-    setLegacyMessages(prev => markOmMarkersAsDisconnected(prev));
 
     // Refresh to get latest state from server
     void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
@@ -677,7 +567,7 @@ export function MastraRuntimeProvider({
   // On initial load, scan messages for activation markers and the last progress part.
   // This ensures buffering badges show as activated and token counts are accurate on reload.
   useEffect(() => {
-    const allMessages = [...(initialMessages || []), ...(initialLegacyMessages || [])];
+    const allMessages = [...(initialMessages || [])];
     let lastProgress: any = null;
     for (const msg of allMessages) {
       const parts = (msg as any).parts || (msg as any).content || [];
@@ -708,13 +598,11 @@ export function MastraRuntimeProvider({
     topK,
     topP,
     seed,
-    chatWithGenerateLegacy,
     chatWithGenerate,
     chatWithNetwork,
     providerOptions,
     requireToolApproval,
   } = settings?.modelSettings ?? {};
-  const toolCallIdToName = useRef<Record<string, string>>({});
 
   const modelSettingsArgs = {
     frequencyPenalty,
@@ -741,9 +629,6 @@ export function MastraRuntimeProvider({
     const attachments = await convertToAIAttachments(message.attachments);
 
     const input = getAppendMessageText(message);
-    if (!isSupportedModel) {
-      setLegacyMessages(s => [...s, { role: 'user', content: input, attachments: message.attachments }]);
-    }
 
     // Reset persisted errors at the start of a new turn so a fresh send doesn't
     // carry over errors from a previous failed run.
@@ -751,15 +636,6 @@ export function MastraRuntimeProvider({
 
     const controller = new AbortController();
     abortControllerRef.current = controller;
-
-    // Create a new client instance with the abort signal
-    // We can't use useMastraClient hook here, so we'll create the client directly
-    const clientWithAbort = new MastraClient({
-      ...baseClient.options,
-      abortSignal: controller.signal,
-    });
-
-    const agent = clientWithAbort.getAgent(agentId);
 
     const requestContextInstance = new RequestContext();
     Object.entries(requestContext ?? {}).forEach(([key, value]) => {
@@ -770,20 +646,100 @@ export function MastraRuntimeProvider({
     }
 
     try {
-      if (isSupportedModel) {
-        if (chatWithNetwork) {
+      if (chatWithNetwork) {
+        await sendMessage({
+          message: input,
+          mode: 'network',
+          coreUserMessages: attachments,
+          requestContext: requestContextInstance,
+          threadId,
+          modelSettings: modelSettingsArgs,
+          signal: controller.signal,
+          tracingOptions: tracingSettings?.tracingOptions,
+          onNetworkChunk: async chunk => {
+            if (
+              chunk.type === 'tool-execution-end' &&
+              chunk.payload?.toolName === 'updateWorkingMemory' &&
+              typeof chunk.payload.result === 'object' &&
+              'success' in chunk.payload.result! &&
+              chunk.payload.result?.success
+            ) {
+              void refreshWorkingMemory?.();
+            }
+
+            if (chunk.type === 'network-execution-event-step-finish') {
+              refreshThreadList?.();
+            }
+
+            if ((chunk as any).type === 'error') {
+              setStreamErrors(prev => [...prev, buildStreamErrorMessage(chunk as any)]);
+            }
+
+            // Signal observation/reflection started (for sidebar status)
+            if ((chunk as any).type === 'data-om-observation-start') {
+              handleObservationStart((chunk as any).data?.operationType);
+            }
+
+            // Update progress from streamed data-om-status parts
+            if ((chunk as any).type === 'data-om-status') {
+              handleProgressUpdate((chunk as any).data);
+            }
+
+            // Refresh OM sidebar when observation/reflection completes (if OM chunks are passed through network mode)
+            if (
+              (chunk as any).type === 'data-om-observation-end' ||
+              (chunk as any).type === 'data-om-observation-failed' ||
+              (chunk as any).type === 'data-om-activation'
+            ) {
+              refreshObservationalMemory((chunk as any).data?.operationType);
+            }
+
+            // Mark cycleIds as activated for UI update of buffering badges
+            if ((chunk as any).type === 'data-om-activation') {
+              handleActivation((chunk as any).data);
+            }
+          },
+        });
+      } else {
+        if (chatWithGenerate) {
           await sendMessage({
             message: input,
-            mode: 'network',
+            mode: 'generate',
             coreUserMessages: attachments,
             requestContext: requestContextInstance,
             threadId,
             modelSettings: modelSettingsArgs,
             signal: controller.signal,
             tracingOptions: tracingSettings?.tracingOptions,
-            onNetworkChunk: async chunk => {
+          });
+
+          await refreshThreadList?.();
+
+          return;
+        } else {
+          await sendMessage({
+            message: input,
+            mode: 'stream',
+            coreUserMessages: attachments,
+            requestContext: requestContextInstance,
+            threadId,
+            modelSettings: modelSettingsArgs,
+            tracingOptions: tracingSettings?.tracingOptions,
+            onChunk: async chunk => {
+              if (chunk.type === 'finish') {
+                if (isMaxStepsFinishChunk(chunk)) {
+                  setStreamErrors(prev => [...prev, buildMaxStepsStreamErrorMessage(chunk, maxSteps)]);
+                }
+
+                await refreshThreadList?.();
+              }
+
+              if (chunk.type === 'error') {
+                setStreamErrors(prev => [...prev, buildStreamErrorMessage(chunk)]);
+              }
+
               if (
-                chunk.type === 'tool-execution-end' &&
+                chunk.type === 'tool-result' &&
                 chunk.payload?.toolName === 'updateWorkingMemory' &&
                 typeof chunk.payload.result === 'object' &&
                 'success' in chunk.payload.result! &&
@@ -792,474 +748,47 @@ export function MastraRuntimeProvider({
                 void refreshWorkingMemory?.();
               }
 
-              if (chunk.type === 'network-execution-event-step-finish') {
-                refreshThreadList?.();
-              }
-
-              if ((chunk as any).type === 'error') {
-                setStreamErrors(prev => [...prev, buildStreamErrorMessage(chunk as any)]);
-              }
-
-              // Signal observation/reflection started (for sidebar status)
-              if ((chunk as any).type === 'data-om-observation-start') {
+              // Signal observation started (for sidebar status)
+              if (chunk.type === 'data-om-observation-start') {
                 handleObservationStart((chunk as any).data?.operationType);
               }
 
               // Update progress from streamed data-om-status parts
-              if ((chunk as any).type === 'data-om-status') {
+              if (chunk.type === 'data-om-status') {
                 handleProgressUpdate((chunk as any).data);
               }
 
-              // Refresh OM sidebar when observation/reflection completes (if OM chunks are passed through network mode)
+              // Refresh OM sidebar when observation completes or buffered observations are activated
               if (
-                (chunk as any).type === 'data-om-observation-end' ||
-                (chunk as any).type === 'data-om-observation-failed' ||
-                (chunk as any).type === 'data-om-activation'
+                chunk.type === 'data-om-observation-end' ||
+                chunk.type === 'data-om-observation-failed' ||
+                chunk.type === 'data-om-activation'
               ) {
                 refreshObservationalMemory((chunk as any).data?.operationType);
               }
 
               // Mark cycleIds as activated for UI update of buffering badges
-              if ((chunk as any).type === 'data-om-activation') {
+              if (chunk.type === 'data-om-activation') {
                 handleActivation((chunk as any).data);
               }
             },
+            signal: controller.signal,
           });
-        } else {
-          if (chatWithGenerate) {
-            await sendMessage({
-              message: input,
-              mode: 'generate',
-              coreUserMessages: attachments,
-              requestContext: requestContextInstance,
-              threadId,
-              modelSettings: modelSettingsArgs,
-              signal: controller.signal,
-              tracingOptions: tracingSettings?.tracingOptions,
-            });
 
-            await refreshThreadList?.();
-
-            return;
-          } else {
-            await sendMessage({
-              message: input,
-              mode: 'stream',
-              coreUserMessages: attachments,
-              requestContext: requestContextInstance,
-              threadId,
-              modelSettings: modelSettingsArgs,
-              tracingOptions: tracingSettings?.tracingOptions,
-              onChunk: async chunk => {
-                if (chunk.type === 'finish') {
-                  if (isMaxStepsFinishChunk(chunk)) {
-                    setStreamErrors(prev => [...prev, buildMaxStepsStreamErrorMessage(chunk, maxSteps)]);
-                  }
-
-                  await refreshThreadList?.();
-                }
-
-                if (chunk.type === 'error') {
-                  setStreamErrors(prev => [...prev, buildStreamErrorMessage(chunk)]);
-                }
-
-                if (
-                  chunk.type === 'tool-result' &&
-                  chunk.payload?.toolName === 'updateWorkingMemory' &&
-                  typeof chunk.payload.result === 'object' &&
-                  'success' in chunk.payload.result! &&
-                  chunk.payload.result?.success
-                ) {
-                  void refreshWorkingMemory?.();
-                }
-
-                // Signal observation started (for sidebar status)
-                if (chunk.type === 'data-om-observation-start') {
-                  handleObservationStart((chunk as any).data?.operationType);
-                }
-
-                // Update progress from streamed data-om-status parts
-                if (chunk.type === 'data-om-status') {
-                  handleProgressUpdate((chunk as any).data);
-                }
-
-                // Refresh OM sidebar when observation completes or buffered observations are activated
-                if (
-                  chunk.type === 'data-om-observation-end' ||
-                  chunk.type === 'data-om-observation-failed' ||
-                  chunk.type === 'data-om-activation'
-                ) {
-                  refreshObservationalMemory((chunk as any).data?.operationType);
-                }
-
-                // Mark cycleIds as activated for UI update of buffering badges
-                if (chunk.type === 'data-om-activation') {
-                  handleActivation((chunk as any).data);
-                }
-              },
-              signal: controller.signal,
-            });
-
-            // Fire-and-forget: await any in-flight buffering operations, then refresh sidebar
-            if (threadId && isOMEnabled) {
-              baseClient
-                .awaitBufferStatus({ agentId, resourceId: agentId, threadId })
-                .then(result => {
-                  setMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
-                  void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
-                  void queryClient.invalidateQueries({ queryKey: ['memory-status', agentId] });
-                })
-                .catch(() => {});
-            }
-
-            return;
+          // Fire-and-forget: await any in-flight buffering operations, then refresh sidebar
+          if (threadId && isOMEnabled) {
+            baseClient
+              .awaitBufferStatus({ agentId, resourceId: agentId, threadId })
+              .then(result => {
+                setMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
+                void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
+                void queryClient.invalidateQueries({ queryKey: ['memory-status', agentId] });
+              })
+              .catch(() => {});
           }
+
+          return;
         }
-      } else {
-        if (chatWithGenerateLegacy) {
-          setIsLegacyRunning(true);
-          const generateResponse = await agent.generateLegacy({
-            messages: [
-              {
-                role: 'user',
-                content: input,
-              },
-              ...attachments,
-            ],
-            frequencyPenalty,
-            presencePenalty,
-            maxRetries,
-            maxSteps,
-            maxTokens,
-            temperature,
-            topK,
-            topP,
-            seed,
-            requestContext: requestContextInstance,
-            ...(memory ? { threadId, resourceId: agentId } : {}),
-            providerOptions,
-          });
-          if (generateResponse.response && 'messages' in generateResponse.response) {
-            const latestMessage = generateResponse.response.messages.reduce(
-              (acc: ThreadMessageLike, message: any) => {
-                const _content = Array.isArray(acc.content) ? acc.content : [];
-                if (typeof message.content === 'string') {
-                  return {
-                    ...acc,
-                    content: [
-                      ..._content,
-                      ...(generateResponse.reasoning ? [{ type: 'reasoning', text: generateResponse.reasoning }] : []),
-                      {
-                        type: 'text',
-                        text: message.content,
-                      },
-                    ],
-                  };
-                }
-                if (message.role === 'assistant') {
-                  const toolCallContent = Array.isArray(message.content)
-                    ? message.content.find((content: any) => content.type === 'tool-call')
-                    : undefined;
-                  const reasoningContent = Array.isArray(message.content)
-                    ? message.content.find((content: any) => content.type === 'reasoning')
-                    : undefined;
-
-                  if (toolCallContent) {
-                    const newContent = _content.map(c => {
-                      if (c.type === 'tool-call' && c.toolCallId === toolCallContent?.toolCallId) {
-                        return { ...c, ...toolCallContent };
-                      }
-                      return c;
-                    });
-
-                    const containsToolCall = newContent.some(c => c.type === 'tool-call');
-                    return {
-                      ...acc,
-                      content: containsToolCall
-                        ? [...(reasoningContent ? [reasoningContent] : []), ...newContent]
-                        : [..._content, ...(reasoningContent ? [reasoningContent] : []), toolCallContent],
-                    };
-                  }
-
-                  const textContent = Array.isArray(message.content)
-                    ? message.content.find((content: any) => content.type === 'text' && content.text)
-                    : undefined;
-
-                  if (textContent) {
-                    return {
-                      ...acc,
-                      content: [..._content, ...(reasoningContent ? [reasoningContent] : []), textContent],
-                    };
-                  }
-                }
-
-                if (message.role === 'tool') {
-                  const toolResult = Array.isArray(message.content)
-                    ? message.content.find((content: any) => content.type === 'tool-result')
-                    : undefined;
-
-                  if (toolResult) {
-                    const newContent = _content.map(c => {
-                      if (c.type === 'tool-call' && c.toolCallId === toolResult?.toolCallId) {
-                        return { ...c, result: toolResult.result };
-                      }
-                      return c;
-                    });
-                    const containsToolCall = newContent.some(c => c.type === 'tool-call');
-
-                    return {
-                      ...acc,
-                      content: containsToolCall
-                        ? newContent
-                        : [
-                            ..._content,
-                            { type: 'tool-result', toolCallId: toolResult.toolCallId, result: toolResult.result },
-                          ],
-                    };
-                  }
-
-                  return {
-                    ...acc,
-                    content: [..._content, toolResult],
-                  };
-                }
-                return acc;
-              },
-              { role: 'assistant', content: [] },
-            );
-            setLegacyMessages(currentConversation => [...currentConversation, latestMessage as ThreadMessageLike]);
-            handleFinishReason(generateResponse.finishReason);
-          }
-
-          setIsLegacyRunning(false);
-        } else {
-          setIsLegacyRunning(true);
-          const response = await agent.streamLegacy({
-            messages: [
-              {
-                role: 'user',
-                content: input,
-              },
-              ...attachments,
-            ],
-            frequencyPenalty,
-            presencePenalty,
-            maxRetries,
-            maxSteps,
-            maxTokens,
-            temperature,
-            topK,
-            topP,
-            seed,
-            requestContext: requestContextInstance,
-            ...(memory ? { threadId, resourceId: agentId } : {}),
-            providerOptions,
-          });
-
-          if (!response.body) {
-            throw new Error('No response body');
-          }
-
-          let content = '';
-          let assistantMessageAdded = false;
-          let assistantToolCallAddedForUpdater = false;
-          let assistantToolCallAddedForContent = false;
-
-          function updater() {
-            setLegacyMessages(currentConversation => {
-              const message: ThreadMessageLike = {
-                role: 'assistant',
-                content: [{ type: 'text', text: content }],
-              };
-
-              if (!assistantMessageAdded) {
-                assistantMessageAdded = true;
-                if (assistantToolCallAddedForUpdater) {
-                  assistantToolCallAddedForUpdater = false;
-                }
-                return [...currentConversation, message];
-              }
-
-              if (assistantToolCallAddedForUpdater) {
-                // add as new message item in messages array if tool call was added
-                assistantToolCallAddedForUpdater = false;
-                return [...currentConversation, message];
-              }
-              return [...currentConversation.slice(0, -1), message];
-            });
-          }
-
-          await response.processDataStream({
-            onTextPart(value: any) {
-              if (assistantToolCallAddedForContent) {
-                // start new content value to add as next message item in messages array
-                assistantToolCallAddedForContent = false;
-                content = value;
-              } else {
-                content += value;
-              }
-              updater();
-            },
-            async onToolCallPart(value: any) {
-              // Update the messages state
-              setLegacyMessages(currentConversation => {
-                // Get the last message (should be the assistant's message)
-                const lastMessage = currentConversation[currentConversation.length - 1];
-
-                // Only process if the last message is from the assistant
-                if (lastMessage && lastMessage.role === 'assistant') {
-                  // Check if this tool call already exists in the content
-                  if (Array.isArray(lastMessage.content)) {
-                    const existingToolCall = lastMessage.content.find(
-                      (part: any) => part.type === 'tool-call' && part.toolCallId === value.toolCallId,
-                    );
-                    if (existingToolCall) {
-                      // Tool call already exists, skip adding duplicate
-                      return currentConversation;
-                    }
-                  }
-
-                  // Create a new message with the tool call part
-                  const updatedMessage: ThreadMessageLike = {
-                    ...lastMessage,
-                    content: Array.isArray(lastMessage.content)
-                      ? [
-                          ...lastMessage.content,
-                          {
-                            type: 'tool-call',
-                            toolCallId: value.toolCallId,
-                            toolName: value.toolName,
-                            args: value.args,
-                          },
-                        ]
-                      : [
-                          ...(typeof lastMessage.content === 'string'
-                            ? [{ type: 'text', text: lastMessage.content }]
-                            : []),
-                          {
-                            type: 'tool-call',
-                            toolCallId: value.toolCallId,
-                            toolName: value.toolName,
-                            args: value.args,
-                          },
-                        ],
-                  };
-
-                  assistantToolCallAddedForUpdater = true;
-                  assistantToolCallAddedForContent = true;
-
-                  // Replace the last message with the updated one
-                  return [...currentConversation.slice(0, -1), updatedMessage];
-                }
-
-                // If there's no assistant message yet, create one
-                const newMessage: ThreadMessageLike = {
-                  role: 'assistant',
-                  content: [
-                    { type: 'text', text: content },
-                    {
-                      type: 'tool-call',
-                      toolCallId: value.toolCallId,
-                      toolName: value.toolName,
-                      args: value.args,
-                    },
-                  ],
-                };
-                assistantToolCallAddedForUpdater = true;
-                assistantToolCallAddedForContent = true;
-                return [...currentConversation, newMessage];
-              });
-              toolCallIdToName.current[value.toolCallId] = value.toolName;
-            },
-            async onToolResultPart(value: any) {
-              // Update the messages state
-              setLegacyMessages(currentConversation => {
-                // Get the last message (should be the assistant's message)
-                const lastMessage = currentConversation[currentConversation.length - 1];
-
-                // Only process if the last message is from the assistant and has content array
-                if (lastMessage && lastMessage.role === 'assistant' && Array.isArray(lastMessage.content)) {
-                  // Find the tool call content part that this result belongs to
-                  const updatedContent = lastMessage.content.map(part => {
-                    if (typeof part === 'object' && part.type === 'tool-call' && part.toolCallId === value.toolCallId) {
-                      return {
-                        ...part,
-                        result: value.result,
-                      };
-                    }
-                    return part;
-                  });
-
-                  // Create a new message with the updated content
-                  const updatedMessage: ThreadMessageLike = {
-                    ...lastMessage,
-                    content: updatedContent,
-                  };
-                  // Replace the last message with the updated one
-                  return [...currentConversation.slice(0, -1), updatedMessage];
-                }
-                return currentConversation;
-              });
-              try {
-                const toolName = toolCallIdToName.current[value.toolCallId];
-                if (toolName === 'updateWorkingMemory' && value.result?.success) {
-                  await refreshWorkingMemory?.();
-                }
-              } finally {
-                // Clean up
-                delete toolCallIdToName.current[value.toolCallId];
-              }
-            },
-            onErrorPart(error: any) {
-              throw new Error(error);
-            },
-            onFinishMessagePart({ finishReason }: { finishReason: any }) {
-              handleFinishReason(finishReason);
-            },
-            onReasoningPart(value: any) {
-              setLegacyMessages(currentConversation => {
-                // Get the last message (should be the assistant's message)
-                const lastMessage = currentConversation[currentConversation.length - 1];
-
-                // Only process if the last message is from the assistant
-                if (lastMessage && lastMessage.role === 'assistant' && Array.isArray(lastMessage.content)) {
-                  // Find and update the reasoning content type
-                  const updatedContent = lastMessage.content.map(part => {
-                    if (typeof part === 'object' && part.type === 'reasoning') {
-                      return {
-                        ...part,
-                        text: part.text + value,
-                      };
-                    }
-                    return part;
-                  });
-                  // Create a new message with the updated reasoning content
-                  const updatedMessage: ThreadMessageLike = {
-                    ...lastMessage,
-                    content: updatedContent,
-                  };
-
-                  // Replace the last message with the updated one
-                  return [...currentConversation.slice(0, -1), updatedMessage];
-                }
-
-                // If there's no assistant message yet, create one
-                const newMessage: ThreadMessageLike = {
-                  role: 'assistant',
-                  content: [
-                    {
-                      type: 'reasoning',
-                      text: value,
-                    },
-                    { type: 'text', text: content },
-                  ],
-                };
-                return [...currentConversation, newMessage];
-              });
-            },
-          });
-        }
-        setIsLegacyRunning(false);
       }
 
       setTimeout(() => {
@@ -1272,7 +801,7 @@ export function MastraRuntimeProvider({
           .awaitBufferStatus({ agentId, resourceId: agentId, threadId })
           .then(result => {
             setMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
-            setLegacyMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
+
             void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
             void queryClient.invalidateQueries({ queryKey: ['memory-status', agentId] });
           })
@@ -1280,7 +809,6 @@ export function MastraRuntimeProvider({
       }
     } catch (error: any) {
       console.error('Error occurred in MastraRuntimeProvider', error);
-      setIsLegacyRunning(false);
 
       // Handle cancellation gracefully
       if (error.name === 'AbortError') {
@@ -1288,14 +816,7 @@ export function MastraRuntimeProvider({
         return;
       }
 
-      if (isSupportedModel) {
-        setStreamErrors(prev => [...prev, buildStreamErrorMessage({ runId: 'thrown', payload: { error } })]);
-      } else {
-        setLegacyMessages(currentConversation => [
-          ...currentConversation,
-          { role: 'assistant', content: [{ type: 'text', text: `${error}` }] },
-        ]);
-      }
+      setStreamErrors(prev => [...prev, buildStreamErrorMessage({ runId: 'thrown', payload: { error } })]);
       // Reset OM streaming state when an error occurs (stream was interrupted)
       resetObservationalMemoryStreamState();
     } finally {
@@ -1310,7 +831,6 @@ export function MastraRuntimeProvider({
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
     setPendingSignals([]);
-    setIsLegacyRunning(false);
     // Reset OM streaming state in case observation was in progress
     resetObservationalMemoryStreamState();
     cancelRun?.();
@@ -1321,7 +841,7 @@ export function MastraRuntimeProvider({
         .awaitBufferStatus({ agentId, resourceId: agentId, threadId })
         .then(result => {
           setMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
-          setLegacyMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
+
           void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
           void queryClient.invalidateQueries({ queryKey: ['memory-status', agentId] });
         })
@@ -1347,8 +867,8 @@ export function MastraRuntimeProvider({
   });
 
   const runtime = useExternalStoreRuntime({
-    isRunning: isLegacyRunning || isRunningStream,
-    messages: isSupportedModel ? vnextmessages : legacyMessages,
+    isRunning: isRunningStream,
+    messages: vnextmessages,
     convertMessage: x => x,
     onNew,
     onCancel,
@@ -1364,7 +884,7 @@ export function MastraRuntimeProvider({
   return (
     <ThreadRuntimeStateProvider
       value={{
-        isStreaming: isLegacyRunning || isRunningStream,
+        isStreaming: isRunningStream,
         canSendWhileStreaming:
           isSupportedModel && threadSignalsEnabled && Boolean(threadId) && !threadSignalsUnsupported,
         cancelStream: onCancel,

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -1,4 +1,4 @@
-import type { GetAgentResponse, UIMessageWithMetadata } from '@mastra/client-js';
+import type { GetAgentResponse } from '@mastra/client-js';
 import type { LLMStepResult } from '@mastra/core/agent';
 import type { AiMessageType } from '@mastra/core/memory';
 import type { MastraUIMessage } from '@mastra/react';
@@ -59,8 +59,6 @@ export interface ChatProps {
   agentVersionId?: string;
   threadId: string;
   initialMessages?: MastraUIMessage[];
-  initialLegacyMessages?: UIMessageWithMetadata[];
-  memory?: boolean;
   refreshThreadList?: () => void;
   settings?: AgentSettingsType;
   requestContext?: Record<string, any>;


### PR DESCRIPTION
## Summary
- route Playground agent chat through the current Mastra chat runtime
- remove legacy message state/props and stale ChatProps fields
- keep streamed network chunk handling for thread refreshes, errors, and observational memory updates

## Test plan
- pnpm --filter ./packages/playground typecheck
- pnpm --filter ./packages/playground lint (passes with existing warnings)
- pnpm --filter ./packages/playground build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes old, outdated chat code from the Playground (like the engine running it) and switches it to use the newer, current chat system that the rest of the app uses. This means simpler code, less duplication, and one main way to handle chat instead of two different ways.

## Changes

### Component Updates
- **AgentChat component**: Simplified to remove all legacy message handling paths. Now uses only the v5 message conversion. The `initialLegacyMessages` prop has been removed, and `memory` is now explicitly defined as an optional prop in the component's interface.

### Runtime Provider Refactoring  
- **MastraRuntimeProvider**: Significantly simplified by removing the legacy runtime and message flow entirely. The provider now:
  - Always uses the unified message path (removes dual-path logic)
  - Removes legacy props (`initialLegacyMessages`, `memory`) and legacy state variables (`isLegacyRunning`, `legacyMessages`)
  - Reorganizes message handling to consistently support observational-memory UI behavior with proper conversion of OM "cycle parts" into dynamic-tool badges
  - Improves error handling by always surfacing failures through `streamErrors` instead of conditional legacy message appending
  - Refactors the send flow so both network and non-network modes share the same observational memory, working memory, and progress signaling

### Type Definitions  
- **ChatProps interface**: Cleaned up by removing `initialLegacyMessages` and `memory` optional properties, keeping only `initialMessages` as the remaining initial message input.

## Testing
- `pnpm --filter ./packages/playground typecheck` — passes
- `pnpm --filter ./packages/playground lint` — passes
- `pnpm --filter ./packages/playground build` — passes

## Impact
Reduces codebase complexity by eliminating the legacy chat runtime while preserving all necessary streaming behavior for thread refreshes, error handling, and observational memory updates. The change aligns the Playground's agent chat with the current Mastra chat runtime architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->