### PR TITLE
[codex] Improve Studio startup error handling

### DIFF
--- a/.changeset/studio-startup-error-ui.md
+++ b/.changeset/studio-startup-error-ui.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Improved how the Studio surfaces startup failures before React mounts. Import errors and direct boot failures now render a clear fallback in the page instead of leaving a blank screen, while normal runtime errors stay with React, route error states, and Vite's dev overlay.

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -89,10 +89,6 @@
 
   <body class="overflow-hidden">
     <div id="root"></div>
-    <script type="module">
-      // Use relative import to work with any base path
-      // Vite transforms this during build to reference compiled output with correct paths
-      import('./src/main.tsx');
-    </script>
+    <script type="module" src="./src/bootstrap.ts"></script>
   </body>
 </html>

--- a/packages/playground/src/bootstrap.test.ts
+++ b/packages/playground/src/bootstrap.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock('./main');
+  vi.doUnmock('./startup-error');
+  vi.restoreAllMocks();
+});
+
+describe('bootstrap', () => {
+  it('preserves startup errors in the console before rendering the fallback', async () => {
+    const startupError = new Error('broken startup import');
+    const renderStartupError = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    vi.doMock('./main', () => ({
+      startStudio: () => {
+        throw startupError;
+      },
+    }));
+    vi.doMock('./startup-error', () => ({ renderStartupError }));
+
+    await import('./bootstrap');
+
+    expect(consoleError).toHaveBeenCalledWith('Mastra Studio failed to start', startupError);
+    expect(renderStartupError).toHaveBeenCalledWith(startupError);
+  });
+});

--- a/packages/playground/src/bootstrap.ts
+++ b/packages/playground/src/bootstrap.ts
@@ -1,0 +1,9 @@
+import { renderStartupError } from './startup-error';
+
+try {
+  const { startStudio } = await import('./main');
+  startStudio();
+} catch (error) {
+  console.error('Mastra Studio failed to start', error);
+  renderStartupError(error);
+}

--- a/packages/playground/src/main.tsx
+++ b/packages/playground/src/main.tsx
@@ -8,12 +8,14 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
-if (import.meta.env.DEV && import.meta.env.VITE_REACT_GRAB === 'true') {
-  void import('react-grab');
-}
+export function startStudio() {
+  if (import.meta.env.DEV && import.meta.env.VITE_REACT_GRAB === 'true') {
+    void import('react-grab');
+  }
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}

--- a/packages/playground/src/startup-error.test.ts
+++ b/packages/playground/src/startup-error.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderStartupError } from './startup-error';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('renderStartupError', () => {
+  it('renders detailed startup errors into an empty root', () => {
+    document.body.innerHTML = '<div id="root"></div>';
+
+    renderStartupError(new Error('broken import'), { showDetails: true });
+
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain('Mastra Studio failed to start');
+    expect(document.querySelector('pre')?.textContent).toContain('broken import');
+  });
+
+  it('hides raw details when diagnostics are disabled', () => {
+    document.body.innerHTML = '<div id="root"></div>';
+
+    renderStartupError(new Error('secret path'), { showDetails: false });
+
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+      'Run Studio in development mode to view detailed diagnostics',
+    );
+    expect(document.querySelector('[role="alert"]')?.textContent).not.toContain('secret path');
+    expect(document.querySelector('pre')).toBeNull();
+  });
+
+  it('does not replace an already rendered app', () => {
+    document.body.innerHTML = '<div id="root"><div>Studio loaded</div></div>';
+
+    renderStartupError(new Error('late error'), { showDetails: true });
+
+    expect(document.getElementById('root')?.textContent).toBe('Studio loaded');
+  });
+});

--- a/packages/playground/src/startup-error.ts
+++ b/packages/playground/src/startup-error.ts
@@ -1,0 +1,51 @@
+const STARTUP_ERROR_DETAILS_ENABLED =
+  import.meta.env.DEV || import.meta.env.VITE_MASTRA_STUDIO_SHOW_STARTUP_ERROR_DETAILS === 'true';
+
+type RenderStartupErrorOptions = {
+  showDetails?: boolean;
+};
+
+function getStartupErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack || error.message;
+  }
+
+  return String(error);
+}
+
+export function renderStartupError(
+  error: unknown,
+  { showDetails = STARTUP_ERROR_DETAILS_ENABLED }: RenderStartupErrorOptions = {},
+) {
+  const root = document.getElementById('root');
+  if (!root || root.childElementCount > 0) {
+    return;
+  }
+
+  const wrapper = document.createElement('main');
+  wrapper.setAttribute('role', 'alert');
+  wrapper.style.cssText =
+    'min-height:100vh;background:#0b0d10;color:#f4f4f5;font-family:Inter,ui-sans-serif,system-ui,sans-serif;padding:32px;box-sizing:border-box;';
+
+  const title = document.createElement('h1');
+  title.textContent = 'Mastra Studio failed to start';
+  title.style.cssText = 'font-size:20px;line-height:1.4;margin:0 0 8px;';
+
+  const detail = document.createElement('p');
+  detail.textContent = showDetails
+    ? 'The startup module failed before React could render. Check the Vite terminal and browser console for the original request details.'
+    : 'The startup module failed before React could render. Run Studio in development mode to view detailed diagnostics.';
+  detail.style.cssText = 'color:#a1a1aa;max-width:760px;margin:0 0 20px;line-height:1.6;';
+
+  wrapper.append(title, detail);
+
+  if (showDetails) {
+    const pre = document.createElement('pre');
+    pre.textContent = getStartupErrorMessage(error);
+    pre.style.cssText =
+      'white-space:pre-wrap;overflow:auto;background:#18181b;border:1px solid #3f3f46;border-radius:8px;padding:16px;max-width:100%;line-height:1.5;';
+    wrapper.append(pre);
+  }
+
+  root.replaceChildren(wrapper);
+}


### PR DESCRIPTION
## Summary
- move the pre-React Studio startup fallback out of `index.html` and into a small `bootstrap.ts` entrypoint
- catch only the app entry import/direct start failure path, so ordinary runtime errors still flow through React, route error handling, console reporting, and Vite's dev overlay
- preserve the original caught startup error with `console.error(...)` before rendering the fallback
- show raw startup error details in development, or in production-style builds only when `VITE_MASTRA_STUDIO_SHOW_STARTUP_ERROR_DETAILS=true` is explicitly set
- add focused jsdom coverage for console preservation, detailed output, hidden production-style details, and the guard that avoids replacing an already-rendered app

Before: (empty white screen)

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/5bc4b6eb-c240-4d74-823d-e7c8048d1bbd" />

After: with the error message

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/6c5c6a21-6993-4391-831e-09127cf282b9" />

## Security note
Raw startup errors can include implementation details such as stack frames, import URLs, local paths, or accidentally sensitive thrown values. This PR keeps those details dev-only by default while still avoiding a blank screen in production-style builds.

## Validation
- `pnpm --filter ./packages/playground exec vitest run src/bootstrap.test.ts src/startup-error.test.ts`
- `pnpm --filter ./packages/playground typecheck`
- `pnpm --filter ./packages/playground build`
- `pnpm --filter ./packages/playground lint` (passes with the existing 63 warnings)
- `pnpm dev:ui` from `examples/agent`, then local browser load of `http://localhost:5173/agents`: renders `Mastra Studio failed to start` with the original `@standard-schema/spec` startup import error instead of a blank screen
- CodeRabbit CLI doctor: installed and reachable, but not signed in, so no local review run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When Mastra Studio fails to start, this PR ensures users see a clear error screen instead of a blank page. It moves the startup fallback into small, tested files so the page stays minimal and error details are shown only in dev (or when explicitly enabled).

## Overview

This PR extracts the pre-React startup fallback out of index.html into a tiny bootstrap entrypoint (packages/playground/src/bootstrap.ts) and a DOM helper (packages/playground/src/startup-error.ts). The bootstrap only catches failures that occur while importing or calling the app's entry (startStudio); normal runtime errors continue to be handled by React, route boundaries, console reporting, and Vite's dev overlay.

## Key Changes

- index.html: load ./src/bootstrap.ts as the module entry instead of inlining startup logic.
- bootstrap.ts: new minimal entrypoint that dynamically imports ./main and calls startStudio(); on import/startup failure it logs the original error and calls renderStartupError(error).
- main.tsx: refactored to export startStudio(), moving prior top-level initialization into that function.
- startup-error.ts: new renderStartupError(error, { showDetails }) helper that:
  - computes a readable message from unknown errors,
  - renders a full-page alert into `#root` when startup fails before React mounts,
  - shows raw error details in dev (or when VITE_MASTRA_STUDIO_SHOW_STARTUP_ERROR_DETAILS=true),
  - avoids replacing content if `#root` is missing or already has children.
- Added changeset: .changeset/studio-startup-error-ui.md documenting the behavior change.

## Testing

- New Vitest/JSDOM tests:
  - bootstrap.test.ts: verifies console.error is preserved and renderStartupError is invoked on startup failure.
  - startup-error.test.ts: verifies detailed vs. hidden output, and that the renderer does not replace an already-rendered app.
- Validation performed: targeted vitest runs, typecheck/build/lint for playground package, manual dev run showing the fallback UI with original import error, and CodeRabbit CLI doctor noted.

## Security

Raw error details (stacks, import URLs, local paths, thrown values) are potentially sensitive. The PR keeps these details visible only in development by default; production-style builds hide details unless VITE_MASTRA_STUDIO_SHOW_STARTUP_ERROR_DETAILS=true is explicitly set.

## Notes

- Reviewer comment: add a changeset (a changeset was added in this PR).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->