### PR TITLE
[codex] Fix Studio browser startup imports

### DIFF
--- a/.changeset/short-lizards-bake.md
+++ b/.changeset/short-lizards-bake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added browser-safe Agent Builder model policy helpers.

--- a/.changeset/studio-browser-startup.md
+++ b/.changeset/studio-browser-startup.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed Studio startup in the browser when Vite dev optimization pulled server-only modules into the Playground bundle.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,6 +101,16 @@
         "default": "./dist/agent-builder/ee/index.cjs"
       }
     },
+    "./agent-builder/ee/model-policy": {
+      "import": {
+        "types": "./dist/agent-builder/ee/model-policy.d.ts",
+        "default": "./dist/agent-builder/ee/model-policy.js"
+      },
+      "require": {
+        "types": "./dist/agent-builder/ee/model-policy.d.ts",
+        "default": "./dist/agent-builder/ee/model-policy.cjs"
+      }
+    },
     "./background-tasks": {
       "import": {
         "types": "./dist/background-tasks/index.d.ts",

--- a/packages/core/src/agent-builder/ee/allowlist.ts
+++ b/packages/core/src/agent-builder/ee/allowlist.ts
@@ -1,32 +1,12 @@
 import { isProviderRegistered } from '../../llm/model/provider-registry.js';
 import { ModelNotAllowedError } from './errors.js';
+import { isModelAllowedByPolicy } from './model-policy.js';
+import type { ModelMatchCandidate } from './model-policy.js';
 import { toModelCandidates } from './normalize-candidate.js';
 import type { ModelCandidate, ModelCandidateInput } from './normalize-candidate.js';
 import type { ProviderModelEntry } from './types.js';
 
-/**
- * Candidate model to check against the allowlist.
- * Caller is responsible for normalizing the source shape via {@link toModelCandidates}
- * (in `./normalize-candidate.ts`) before reaching this matcher.
- */
-export interface ModelMatchCandidate {
-  provider: string;
-  modelId: string;
-}
-
-/**
- * Single-entry match: provider equality (case-sensitive). When the entry omits
- * `modelId` it matches every model under that provider (provider wildcard).
- *
- * Custom (`kind: 'custom'`) entries match by exact provider string. Known-provider
- * entries match by exact provider string too — the typed surface is purely a
- * compile-time guard.
- */
-export function matchesProvider(entry: ProviderModelEntry, candidate: ModelMatchCandidate): boolean {
-  if (entry.provider !== candidate.provider) return false;
-  if (!entry.modelId) return true; // wildcard
-  return entry.modelId === candidate.modelId;
-}
+export { matchesProvider, type ModelMatchCandidate } from './model-policy.js';
 
 /**
  * Returns `true` if the candidate is allowed under the given allowlist.
@@ -40,17 +20,7 @@ export function matchesProvider(entry: ProviderModelEntry, candidate: ModelMatch
  *   silently allows anything else; it is the documented "deny vs ignore" rule.
  */
 export function isModelAllowed(allowed: ProviderModelEntry[] | undefined, candidate: ModelMatchCandidate): boolean {
-  if (allowed === undefined) return true;
-  if (allowed.length === 0) return true;
-
-  const activeEntries = allowed.filter(entry => {
-    if ('kind' in entry && entry.kind === 'custom') return true;
-    return isProviderRegistered(entry.provider);
-  });
-
-  if (activeEntries.length === 0) return false;
-
-  return activeEntries.some(entry => matchesProvider(entry, candidate));
+  return isModelAllowedByPolicy(allowed, candidate, { isProviderRegistered });
 }
 
 /**

--- a/packages/core/src/agent-builder/ee/errors.ts
+++ b/packages/core/src/agent-builder/ee/errors.ts
@@ -1,7 +1,8 @@
+import { MODEL_NOT_ALLOWED_CODE } from './model-policy';
 import type { ModelCandidate } from './normalize-candidate';
 import type { ProviderModelEntry } from './types';
 
-export const MODEL_NOT_ALLOWED_CODE = 'MODEL_NOT_ALLOWED' as const;
+export { MODEL_NOT_ALLOWED_CODE };
 
 /**
  * Thrown by `enforceModelAllowlist` call sites when a write attempts to persist

--- a/packages/core/src/agent-builder/ee/index.ts
+++ b/packages/core/src/agent-builder/ee/index.ts
@@ -14,12 +14,18 @@ export type {
 export { BUILDER_FEATURE_DEFAULTS, resolveAgentFeatures } from './types';
 
 export {
+  isModelAllowedByPolicy,
+  MODEL_NOT_ALLOWED_CODE,
+  matchesProvider,
+  type IsModelAllowedByPolicyOptions,
+  type ModelMatchCandidate,
+} from './model-policy';
+
+export {
   assertModelAllowed,
   enforceModelAllowlist,
   isModelAllowed,
-  matchesProvider,
   type EnforceModelAllowlistResult,
-  type ModelMatchCandidate,
 } from './allowlist';
 
 export {
@@ -33,4 +39,4 @@ export { builderToModelPolicy, isBuilderModelPolicyActive, type BuilderModelPoli
 
 export { resolvePickerVisibility, type ResolvePickerVisibilityInputs, type ResolvedPickerVisibility } from './picker';
 
-export { ModelNotAllowedError, MODEL_NOT_ALLOWED_CODE, isModelNotAllowedError } from './errors';
+export { ModelNotAllowedError, isModelNotAllowedError } from './errors';

--- a/packages/core/src/agent-builder/ee/model-policy.test.ts
+++ b/packages/core/src/agent-builder/ee/model-policy.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { isModelAllowedByPolicy, matchesProvider } from './model-policy';
+import type { ProviderModelEntry } from './types';
+
+const MODEL_ID = '__AI_SDK_OPENAI_MODEL_REALTIME__';
+const OTHER_MODEL_ID = '__GATEWAY_OPENAI_MODEL_MINI__';
+
+describe('matchesProvider', () => {
+  it('matches every model for a provider wildcard', () => {
+    expect(matchesProvider({ provider: 'openai' }, { provider: 'openai', modelId: MODEL_ID })).toBe(true);
+  });
+
+  it('requires provider and modelId to match for explicit entries', () => {
+    expect(matchesProvider({ provider: 'openai', modelId: MODEL_ID }, { provider: 'openai', modelId: MODEL_ID })).toBe(
+      true,
+    );
+    expect(
+      matchesProvider({ provider: 'openai', modelId: MODEL_ID }, { provider: 'openai', modelId: OTHER_MODEL_ID }),
+    ).toBe(false);
+  });
+});
+
+describe('isModelAllowedByPolicy', () => {
+  it('treats undefined and empty allowlists as unrestricted', () => {
+    expect(isModelAllowedByPolicy(undefined, { provider: 'openai', modelId: MODEL_ID })).toBe(true);
+    expect(isModelAllowedByPolicy([], { provider: 'openai', modelId: MODEL_ID })).toBe(true);
+  });
+
+  it('applies provider wildcards and explicit model entries', () => {
+    const allowed: ProviderModelEntry[] = [{ provider: 'openai' }, { provider: 'anthropic', modelId: MODEL_ID }];
+
+    expect(isModelAllowedByPolicy(allowed, { provider: 'openai', modelId: OTHER_MODEL_ID })).toBe(true);
+    expect(isModelAllowedByPolicy(allowed, { provider: 'anthropic', modelId: MODEL_ID })).toBe(true);
+    expect(isModelAllowedByPolicy(allowed, { provider: 'anthropic', modelId: OTHER_MODEL_ID })).toBe(false);
+  });
+
+  it('ignores unknown non-custom providers when a provider registry predicate is supplied', () => {
+    const allowed: ProviderModelEntry[] = [{ provider: 'openaii' as unknown as 'openai' }, { provider: 'anthropic' }];
+    const registeredProviders = new Set(['anthropic']);
+
+    expect(
+      isModelAllowedByPolicy(
+        allowed,
+        { provider: 'anthropic', modelId: MODEL_ID },
+        {
+          isProviderRegistered: provider => registeredProviders.has(provider),
+        },
+      ),
+    ).toBe(true);
+    expect(
+      isModelAllowedByPolicy(
+        allowed,
+        { provider: 'openai', modelId: MODEL_ID },
+        {
+          isProviderRegistered: provider => registeredProviders.has(provider),
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('denies everything when all registry-aware entries are unknown non-custom providers', () => {
+    const allowed: ProviderModelEntry[] = [{ provider: 'openaii' as unknown as 'openai' }];
+
+    expect(
+      isModelAllowedByPolicy(allowed, { provider: 'openai', modelId: MODEL_ID }, { isProviderRegistered: () => false }),
+    ).toBe(false);
+  });
+
+  it('keeps custom entries active even when they are not in the provider registry', () => {
+    const allowed: ProviderModelEntry[] = [{ kind: 'custom', provider: 'acme/custom', modelId: MODEL_ID }];
+
+    expect(
+      isModelAllowedByPolicy(
+        allowed,
+        { provider: 'acme/custom', modelId: MODEL_ID },
+        {
+          isProviderRegistered: provider => provider === 'openai',
+        },
+      ),
+    ).toBe(true);
+    expect(
+      isModelAllowedByPolicy(
+        allowed,
+        { provider: 'openai', modelId: MODEL_ID },
+        {
+          isProviderRegistered: provider => provider === 'openai',
+        },
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/agent-builder/ee/model-policy.ts
+++ b/packages/core/src/agent-builder/ee/model-policy.ts
@@ -1,0 +1,50 @@
+import type { ProviderModelEntry } from './types';
+
+export const MODEL_NOT_ALLOWED_CODE = 'MODEL_NOT_ALLOWED' as const;
+
+/**
+ * Candidate model to check against the allowlist.
+ */
+export interface ModelMatchCandidate {
+  provider: string;
+  modelId: string;
+}
+
+export type IsModelAllowedByPolicyOptions = {
+  isProviderRegistered?: (providerId: string) => boolean;
+};
+
+/**
+ * Single-entry match: provider equality (case-sensitive). When the entry omits
+ * `modelId` it matches every model under that provider (provider wildcard).
+ */
+export function matchesProvider(entry: ProviderModelEntry, candidate: ModelMatchCandidate): boolean {
+  if (entry.provider !== candidate.provider) return false;
+  if (!entry.modelId) return true;
+  return entry.modelId === candidate.modelId;
+}
+
+function isCustomProviderEntry(entry: ProviderModelEntry): boolean {
+  return 'kind' in entry && entry.kind === 'custom';
+}
+
+/**
+ * Shared allowlist evaluation that stays browser-safe by accepting provider
+ * registration as an optional caller-supplied predicate.
+ */
+export function isModelAllowedByPolicy(
+  allowed: ProviderModelEntry[] | undefined,
+  candidate: ModelMatchCandidate,
+  { isProviderRegistered }: IsModelAllowedByPolicyOptions = {},
+): boolean {
+  if (allowed === undefined) return true;
+  if (allowed.length === 0) return true;
+
+  const activeEntries = isProviderRegistered
+    ? allowed.filter(entry => isCustomProviderEntry(entry) || isProviderRegistered(entry.provider))
+    : allowed;
+
+  if (activeEntries.length === 0) return false;
+
+  return activeEntries.some(entry => matchesProvider(entry, candidate));
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
     'src/agent/durable/index.ts',
     'src/auth/ee/index.ts',
     'src/agent-builder/ee/index.ts',
+    'src/agent-builder/ee/model-policy.ts',
     'src/storage/domains/agents/index.ts',
     'src/storage/domains/mcp-clients/index.ts',
     'src/storage/domains/mcp-servers/index.ts',

--- a/packages/playground/src/browser-runtime-imports.test.ts
+++ b/packages/playground/src/browser-runtime-imports.test.ts
@@ -1,0 +1,127 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const PLAYGROUND_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC_DIR = path.join(PLAYGROUND_ROOT, 'src');
+
+const SERVER_ONLY_CORE_MODULE_PREFIXES = [
+  '@mastra/core/agent-builder/ee',
+  '@mastra/core/auth/ee',
+  '@mastra/core/observability',
+] as const;
+
+const BROWSER_SAFE_CORE_MODULES = new Set(['@mastra/core/agent-builder/ee/model-policy']);
+
+function isServerOnlyRuntimeModule(moduleSpecifier: string): boolean {
+  if (BROWSER_SAFE_CORE_MODULES.has(moduleSpecifier)) return false;
+
+  return SERVER_ONLY_CORE_MODULE_PREFIXES.some(
+    prefix => moduleSpecifier === prefix || moduleSpecifier.startsWith(`${prefix}/`),
+  );
+}
+
+function getLiteralModuleSpecifier(node: ts.Node): string | undefined {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+}
+
+async function collectSourceFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async entry => {
+      const entryPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        return collectSourceFiles(entryPath);
+      }
+
+      if (!/\.[cm]?[jt]sx?$/.test(entry.name) || /\.test\.[cm]?[jt]sx?$/.test(entry.name)) {
+        return [];
+      }
+
+      return [entryPath];
+    }),
+  );
+
+  return files.flat();
+}
+
+function hasRuntimeImportClause(importClause: ts.ImportClause | undefined): boolean {
+  if (!importClause) return true;
+  if (importClause.isTypeOnly) return false;
+  if (importClause.name) return true;
+
+  const namedBindings = importClause.namedBindings;
+  if (namedBindings && ts.isNamedImports(namedBindings)) {
+    return namedBindings.elements.some(element => !element.isTypeOnly);
+  }
+
+  return Boolean(namedBindings);
+}
+
+function getServerOnlyRuntimeImports(filePath: string, sourceText: string): string[] {
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const imports: string[] = [];
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isImportDeclaration(node) &&
+      isServerOnlyRuntimeModule(getLiteralModuleSpecifier(node.moduleSpecifier) ?? '') &&
+      hasRuntimeImportClause(node.importClause)
+    ) {
+      imports.push(getLiteralModuleSpecifier(node.moduleSpecifier) ?? '');
+    }
+
+    if (
+      ts.isExportDeclaration(node) &&
+      !node.isTypeOnly &&
+      node.moduleSpecifier &&
+      isServerOnlyRuntimeModule(getLiteralModuleSpecifier(node.moduleSpecifier) ?? '')
+    ) {
+      imports.push(getLiteralModuleSpecifier(node.moduleSpecifier) ?? '');
+    }
+
+    if (ts.isImportEqualsDeclaration(node) && !node.isTypeOnly && ts.isExternalModuleReference(node.moduleReference)) {
+      const moduleSpecifier = getLiteralModuleSpecifier(node.moduleReference.expression);
+      if (moduleSpecifier && isServerOnlyRuntimeModule(moduleSpecifier)) {
+        imports.push(moduleSpecifier);
+      }
+    }
+
+    if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      const moduleSpecifier = node.arguments[0] ? getLiteralModuleSpecifier(node.arguments[0]) : undefined;
+      if (moduleSpecifier && isServerOnlyRuntimeModule(moduleSpecifier)) {
+        imports.push(moduleSpecifier);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return imports;
+}
+
+describe('browser runtime imports', () => {
+  it('does not value-import server-only core modules into Playground source', async () => {
+    const files = await collectSourceFiles(SRC_DIR);
+    const violations: string[] = [];
+
+    await Promise.all(
+      files.map(async filePath => {
+        const imports = getServerOnlyRuntimeImports(filePath, await fs.readFile(filePath, 'utf8'));
+
+        for (const importedModule of imports) {
+          violations.push(`${path.relative(PLAYGROUND_ROOT, filePath)} imports ${importedModule}`);
+        }
+      }),
+    );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/models.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/models.tsx
@@ -1,4 +1,4 @@
-import { isModelAllowed } from '@mastra/core/agent-builder/ee';
+import { isModelAllowedByPolicy } from '@mastra/core/agent-builder/ee/model-policy';
 import { Checkbox, Skeleton, Txt, cn } from '@mastra/playground-ui';
 import { LockIcon, TriangleAlertIcon } from 'lucide-react';
 import type { CSSProperties } from 'react';
@@ -131,7 +131,17 @@ const ModelPicker = ({ disabled = false }: ModelPickerProps) => {
   const modelId = model?.name ?? '';
 
   const isSet = Boolean(provider && modelId);
-  const isStale = isSet && policy.active && !isModelAllowed(policy.allowed, { provider, modelId });
+  const registeredProviderIds = new Set(allProviders.map(provider => provider.id));
+  const isStale =
+    isSet &&
+    policy.active &&
+    !isModelAllowedByPolicy(
+      policy.allowed,
+      { provider, modelId },
+      {
+        isProviderRegistered: registeredProviderIds.has.bind(registeredProviderIds),
+      },
+    );
 
   const groups = groupModelsByProvider(policyAllowedModels, selectedProviders, search, provider);
   const allProvidersUnchecked = selectedProviders !== null && selectedProviders.size === 0;

--- a/packages/playground/src/domains/agent-builder/hooks/use-builder-filtered-models.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-builder-filtered-models.ts
@@ -1,5 +1,5 @@
 import type { BuilderModelPolicy, Provider } from '@mastra/client-js';
-import { isModelAllowed } from '@mastra/core/agent-builder/ee';
+import { isModelAllowedByPolicy } from '@mastra/core/agent-builder/ee/model-policy';
 import { useMemo } from 'react';
 import type { ModelInfo } from '../../llm/hooks/use-filtered-models';
 
@@ -14,10 +14,20 @@ export const useBuilderFilteredProviders = (providers: Provider[], policy: Build
       return providers;
     }
 
+    const registeredProviderIds = new Set(providers.map(provider => provider.id));
+
     return providers
       .map(provider => ({
         ...provider,
-        models: provider.models.filter(modelId => isModelAllowed(policy.allowed, { provider: provider.id, modelId })),
+        models: provider.models.filter(modelId =>
+          isModelAllowedByPolicy(
+            policy.allowed,
+            { provider: provider.id, modelId },
+            {
+              isProviderRegistered: registeredProviderIds.has.bind(registeredProviderIds),
+            },
+          ),
+        ),
       }))
       .filter(provider => provider.models.length > 0);
   }, [providers, policy]);
@@ -33,6 +43,16 @@ export const useBuilderFilteredModels = (models: ModelInfo[], policy: BuilderMod
       return models;
     }
 
-    return models.filter(m => isModelAllowed(policy.allowed, { provider: m.provider, modelId: m.model }));
+    const registeredProviderIds = new Set(models.map(model => model.provider));
+
+    return models.filter(m =>
+      isModelAllowedByPolicy(
+        policy.allowed,
+        { provider: m.provider, modelId: m.model },
+        {
+          isProviderRegistered: registeredProviderIds.has.bind(registeredProviderIds),
+        },
+      ),
+    );
   }, [models, policy]);
 };

--- a/packages/playground/src/domains/agent-builder/services/__tests__/is-model-not-allowed.test.ts
+++ b/packages/playground/src/domains/agent-builder/services/__tests__/is-model-not-allowed.test.ts
@@ -1,4 +1,4 @@
-import { MODEL_NOT_ALLOWED_CODE } from '@mastra/core/agent-builder/ee';
+import { MODEL_NOT_ALLOWED_CODE } from '@mastra/core/agent-builder/ee/model-policy';
 import { describe, expect, it } from 'vitest';
 import { isModelNotAllowedError } from '../is-model-not-allowed';
 

--- a/packages/playground/src/domains/agent-builder/services/is-model-not-allowed.ts
+++ b/packages/playground/src/domains/agent-builder/services/is-model-not-allowed.ts
@@ -1,4 +1,4 @@
-import { MODEL_NOT_ALLOWED_CODE } from '@mastra/core/agent-builder/ee';
+import { MODEL_NOT_ALLOWED_CODE } from '@mastra/core/agent-builder/ee/model-policy';
 
 export interface ModelNotAllowedDetails {
   message: string;

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
@@ -1,5 +1,5 @@
 import type { UpdateModelParams } from '@mastra/client-js';
-import { isModelAllowed } from '@mastra/core/agent-builder/ee';
+import { isModelAllowedByPolicy } from '@mastra/core/agent-builder/ee/model-policy';
 import { Notice, Button, Spinner } from '@mastra/playground-ui';
 import { Lock, RotateCcw } from 'lucide-react';
 import { useState, useEffect, useMemo } from 'react';
@@ -163,6 +163,7 @@ export const AgentMetadataModelSwitcher = ({
   };
 
   const currentProvider = findProviderById(providers, currentModelProvider);
+  const registeredProviderIds = new Set(providers.map(provider => provider.id));
 
   // Admin locked the picker — surface a non-interactive chip instead.
   if (policy.active && policy.pickerVisible === false) {
@@ -188,7 +189,11 @@ export const AgentMetadataModelSwitcher = ({
     Boolean(currentModelProvider && selectedModel) &&
     policy.active &&
     policy.allowed !== undefined &&
-    !isModelAllowed(policy.allowed, { provider: currentModelProvider, modelId: selectedModel });
+    !isModelAllowedByPolicy(
+      policy.allowed,
+      { provider: fullProviderId, modelId: selectedModel },
+      { isProviderRegistered: registeredProviderIds.has.bind(registeredProviderIds) },
+    );
 
   return (
     <div className="@container">

--- a/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
@@ -1,5 +1,5 @@
 import type { UpdateModelParams } from '@mastra/client-js';
-import { isModelAllowed } from '@mastra/core/agent-builder/ee';
+import { isModelAllowedByPolicy } from '@mastra/core/agent-builder/ee/model-policy';
 import { cn } from '@mastra/playground-ui';
 import { Lock, TriangleAlert } from 'lucide-react';
 import { useState, useEffect } from 'react';
@@ -137,13 +137,19 @@ export const ComposerModelWarning = ({ agentId }: ComposerModelSwitcherProps) =>
   const providers = dataProviders?.providers || [];
   const currentModelProvider = cleanProviderId(agent.provider || '');
   const currentProvider = findProviderById(providers, currentModelProvider);
+  const fullProviderId = currentProvider?.id || currentModelProvider;
   const selectedModel = agent.modelId || '';
+  const registeredProviderIds = new Set(providers.map(provider => provider.id));
 
   const stale =
     Boolean(currentModelProvider && selectedModel) &&
     policy.active &&
     policy.allowed !== undefined &&
-    !isModelAllowed(policy.allowed, { provider: currentModelProvider, modelId: selectedModel });
+    !isModelAllowedByPolicy(
+      policy.allowed,
+      { provider: fullProviderId, modelId: selectedModel },
+      { isProviderRegistered: registeredProviderIds.has.bind(registeredProviderIds) },
+    );
 
   const showProviderWarning = currentProvider && !currentProvider.connected;
 

--- a/packages/playground/src/domains/auth/route-permissions.ts
+++ b/packages/playground/src/domains/auth/route-permissions.ts
@@ -6,7 +6,7 @@
  * - The order of routes for redirect priority (first accessible route wins)
  * - Sidebar link permission gating
  *
- * IMPORTANT: Permission strings are imported from `@mastra/core/auth/ee` (PERMISSION_PATTERNS).
+ * IMPORTANT: Permission strings are type-checked against `@mastra/core/auth/ee`.
  * This ensures type safety and prevents typos like 'scorers:read' vs 'scores:read'.
  *
  * @see COR-829 Studio View Permissions
@@ -14,15 +14,6 @@
  */
 
 import type { PermissionPattern } from '@mastra/core/auth/ee';
-import { PERMISSION_PATTERNS } from '@mastra/core/auth/ee';
-
-// Validated permission helper - ensures we're using valid patterns from the generated file
-const P = <T extends PermissionPattern>(pattern: T): T => {
-  if (!(pattern in PERMISSION_PATTERNS)) {
-    throw new Error(`Invalid permission pattern: ${pattern}`);
-  }
-  return pattern;
-};
 
 export type RoutePermission = {
   /** The route path (used for redirects) */
@@ -34,7 +25,7 @@ export type RoutePermission = {
    *
    * Use 'public' for routes that don't require authentication.
    */
-  permission: PermissionPattern | PermissionPattern[] | 'public';
+  permission: PermissionPattern | readonly PermissionPattern[] | 'public';
   /** Human-readable name for the route (for debugging/logging) */
   name: string;
 };
@@ -44,43 +35,43 @@ export type RoutePermission = {
  * Ordered by redirect priority - when determining where to send a user,
  * we'll redirect to the first route they have permission to access.
  *
- * Permission patterns are validated using P() to ensure they match PERMISSION_PATTERNS.
+ * Permission patterns are validated at compile time against PermissionPattern.
  * Common gotchas the types will catch:
  * - 'mcp' not 'mcps' (UI route is /mcps but resource is 'mcp')
  * - 'scores' not 'scorers' (UI route is /scorers but resource is 'scores')
  * - 'stored-prompt-blocks' for prompts (uses /stored/prompt-blocks routes)
  */
-export const ROUTE_PERMISSIONS: RoutePermission[] = [
+export const ROUTE_PERMISSIONS = [
   // Primary routes (highest priority for redirects)
-  { route: '/agents', permission: P('agents:read'), name: 'Agents' },
-  { route: '/workflows', permission: P('workflows:read'), name: 'Workflows' },
+  { route: '/agents', permission: 'agents:read', name: 'Agents' },
+  { route: '/workflows', permission: 'workflows:read', name: 'Workflows' },
 
   // Observability - uses 'observability' resource for traces/metrics, 'logs' for logs
-  { route: '/metrics', permission: P('observability:read'), name: 'Metrics' },
-  { route: '/observability', permission: P('observability:read'), name: 'Traces' },
-  { route: '/traces', permission: P('observability:read'), name: 'Traces' },
-  { route: '/logs', permission: P('logs:read'), name: 'Logs' },
+  { route: '/metrics', permission: 'observability:read', name: 'Metrics' },
+  { route: '/observability', permission: 'observability:read', name: 'Traces' },
+  { route: '/traces', permission: 'observability:read', name: 'Traces' },
+  { route: '/logs', permission: 'logs:read', name: 'Logs' },
 
   // Evaluation - uses 'scores' resource (not 'scorers')
-  { route: '/scorers', permission: P('scores:read'), name: 'Scorers' },
-  { route: '/datasets', permission: [P('datasets:read')], name: 'Datasets' },
-  { route: '/experiments', permission: [P('datasets:read')], name: 'Experiments' },
+  { route: '/scorers', permission: 'scores:read', name: 'Scorers' },
+  { route: '/datasets', permission: ['datasets:read'], name: 'Datasets' },
+  { route: '/experiments', permission: ['datasets:read'], name: 'Experiments' },
 
   // Primitives - note: 'mcp' not 'mcps', 'stored' for prompts (stored/prompt-blocks routes)
-  { route: '/tools', permission: P('tools:read'), name: 'Tools' },
-  { route: '/mcps', permission: P('mcp:read'), name: 'MCP Servers' },
-  { route: '/processors', permission: P('processors:read'), name: 'Processors' },
-  { route: '/prompts', permission: P('stored-prompt-blocks:read'), name: 'Prompts' },
-  { route: '/workspaces', permission: P('workspaces:read'), name: 'Workspaces' },
+  { route: '/tools', permission: 'tools:read', name: 'Tools' },
+  { route: '/mcps', permission: 'mcp:read', name: 'MCP Servers' },
+  { route: '/processors', permission: 'processors:read', name: 'Processors' },
+  { route: '/prompts', permission: 'stored-prompt-blocks:read', name: 'Prompts' },
+  { route: '/workspaces', permission: 'workspaces:read', name: 'Workspaces' },
 
   // Admin-only pages
-  { route: '/request-context', permission: P('*'), name: 'Request Context' },
+  { route: '/request-context', permission: '*', name: 'Request Context' },
 
   // UI-only pages (no corresponding API resource) - marked as public
   // These pages don't fetch protected data, so they're accessible to all authenticated users
   { route: '/settings', permission: 'public', name: 'Settings' },
   { route: '/resources', permission: 'public', name: 'Resources' },
-];
+] as const satisfies readonly RoutePermission[];
 
 /**
  * Get all unique permissions used for sidebar gating.
@@ -95,11 +86,15 @@ export const ALL_SIDEBAR_PERMISSIONS = [
   ),
 ];
 
+const isPermissionList = (permission: string | readonly string[] | undefined): permission is readonly string[] => {
+  return Array.isArray(permission);
+};
+
 /**
  * Find the permission(s) required for a given route.
  * Returns undefined if the route is not in the registry (public or unknown route).
  */
-export function getPermissionForRoute(route: string): string | string[] | undefined {
+export function getPermissionForRoute(route: string): string | readonly string[] | undefined {
   // Exact match first
   const exact = ROUTE_PERMISSIONS.find(r => r.route === route);
   if (exact) return exact.permission;
@@ -114,15 +109,15 @@ export function getPermissionForRoute(route: string): string | string[] | undefi
  * Handles both single permissions and "any of" permission arrays.
  */
 export function hasRoutePermission(
-  permission: string | string[] | undefined,
+  permission: string | readonly string[] | undefined,
   hasPermission: (p: string) => boolean,
   hasAnyPermission: (p: string[]) => boolean,
 ): boolean {
   // No permission required or explicitly public = accessible to all authenticated users
   if (!permission || permission === 'public') return true;
 
-  if (Array.isArray(permission)) {
-    return hasAnyPermission(permission);
+  if (isPermissionList(permission)) {
+    return hasAnyPermission([...permission]);
   }
 
   return hasPermission(permission);
@@ -145,7 +140,7 @@ export function getFirstAccessibleRoute(
     // Skip public routes - we want to redirect to a gated route if possible
     if (permission === 'public') continue;
 
-    const key = Array.isArray(permission) ? permission.sort().join(',') : permission;
+    const key = isPermissionList(permission) ? [...permission].sort().join(',') : permission;
     if (seen.has(key)) continue;
     seen.add(key);
 

--- a/packages/playground/src/domains/metrics/components/latency-card.tsx
+++ b/packages/playground/src/domains/metrics/components/latency-card.tsx
@@ -1,7 +1,7 @@
-import { EntityType } from '@mastra/core/observability';
 import { LatencyCardView, OpenInTracesButton, useDrilldown, useLatencyMetrics } from '@mastra/playground-ui';
 import type { LatencyTab } from '@mastra/playground-ui';
 import { useNavigate } from 'react-router';
+import { EntityType } from '@/domains/observability/entity-type';
 import { useLinkComponent } from '@/lib/framework';
 
 const TAB_TO_ROOT_ENTITY: Record<LatencyTab, EntityType> = {

--- a/packages/playground/src/domains/metrics/components/model-usage-cost-card.tsx
+++ b/packages/playground/src/domains/metrics/components/model-usage-cost-card.tsx
@@ -1,10 +1,10 @@
-import { EntityType } from '@mastra/core/observability';
 import {
   ModelUsageCostCardView,
   OpenInTracesButton,
   useDrilldown,
   useModelUsageCostMetrics,
 } from '@mastra/playground-ui';
+import { EntityType } from '@/domains/observability/entity-type';
 import { useLinkComponent } from '@/lib/framework';
 
 export function ModelUsageCostCard() {

--- a/packages/playground/src/domains/metrics/components/token-usage-by-agent-card.tsx
+++ b/packages/playground/src/domains/metrics/components/token-usage-by-agent-card.tsx
@@ -1,10 +1,10 @@
-import { EntityType } from '@mastra/core/observability';
 import {
   OpenInTracesButton,
   TokenUsageByAgentCardView,
   useDrilldown,
   useTokenUsageByAgentMetrics,
 } from '@mastra/playground-ui';
+import { EntityType } from '@/domains/observability/entity-type';
 import { useLinkComponent } from '@/lib/framework';
 
 export function TokenUsageByAgentCard() {

--- a/packages/playground/src/domains/metrics/components/traces-volume-card.tsx
+++ b/packages/playground/src/domains/metrics/components/traces-volume-card.tsx
@@ -1,4 +1,3 @@
-import { EntityType } from '@mastra/core/observability';
 import {
   OpenErrorsInLogsButton,
   OpenInTracesButton,
@@ -7,6 +6,7 @@ import {
   useTraceVolumeMetrics,
 } from '@mastra/playground-ui';
 import type { VolumeTab } from '@mastra/playground-ui';
+import { EntityType } from '@/domains/observability/entity-type';
 import { useLinkComponent } from '@/lib/framework';
 
 const TAB_TO_ROOT_ENTITY: Record<VolumeTab, EntityType> = {

--- a/packages/playground/src/domains/observability/entity-type.ts
+++ b/packages/playground/src/domains/observability/entity-type.ts
@@ -1,0 +1,9 @@
+import type { EntityType as CoreEntityType } from '@mastra/core/observability';
+
+export const EntityType = {
+  AGENT: 'agent' as CoreEntityType,
+  TOOL: 'tool' as CoreEntityType,
+  WORKFLOW_RUN: 'workflow_run' as CoreEntityType,
+} as const;
+
+export type EntityType = CoreEntityType;

--- a/packages/playground/src/pages/agents/agent-traces/index.tsx
+++ b/packages/playground/src/pages/agents/agent-traces/index.tsx
@@ -1,5 +1,5 @@
-import { EntityType } from '@mastra/core/observability';
 import { useParams } from 'react-router';
+import { EntityType } from '@/domains/observability/entity-type';
 import TracesPage from '@/pages/traces';
 
 function AgentTraces() {

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -1,4 +1,3 @@
-import { EntityType } from '@mastra/core/observability';
 import {
   Button,
   DateTimeRangePicker,
@@ -35,6 +34,7 @@ import { CircleSlash2, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { TraceAsItemDialog } from '@/domains/observability/components/trace-as-item-dialog';
+import { EntityType } from '@/domains/observability/entity-type';
 import { useScorers } from '@/domains/scores';
 import { useTraceSpanScores } from '@/domains/scores/hooks/use-trace-span-scores';
 import { ScoreDataPanel } from '@/domains/traces/components/score-data-panel';

--- a/packages/playground/src/pages/traces/trace/index.tsx
+++ b/packages/playground/src/pages/traces/trace/index.tsx
@@ -1,5 +1,4 @@
 import type { ScoreRowData } from '@mastra/core/evals';
-import { EntityType } from '@mastra/core/observability';
 import {
   Button,
   ButtonsGroup,
@@ -18,6 +17,7 @@ import { CircleGaugeIcon, SaveIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { TraceAsItemDialog } from '@/domains/observability/components/trace-as-item-dialog';
+import { EntityType } from '@/domains/observability/entity-type';
 import { useScorers } from '@/domains/scores';
 import { useTraceSpanScores } from '@/domains/scores/hooks/use-trace-span-scores';
 import { ScoreDataPanel } from '@/domains/traces/components/score-data-panel';

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -215,6 +215,11 @@ export default defineConfig(({ mode }) => {
   const commonConfig: UserConfig = {
     plugins: [stubNodeBuiltinsPlugin, tailwindcss(), react(), routesManifestPlugin()],
     base: './',
+    optimizeDeps: {
+      // This package is type-only at runtime. Vite's interop optimizer can rewrite
+      // namespace imports to a default import, which breaks because the module has no exports.
+      exclude: ['@standard-schema/spec'],
+    },
     resolve: {
       dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react-resizable-panels', '@tanstack/react-query'],
       alias: {


### PR DESCRIPTION
This fixes the blank Studio screen seen from `examples/agent` with `pnpm dev:ui` by keeping the Playground browser bundle away from server-heavy core EE and observability runtime modules.

The model policy logic now lives in a browser-safe core subpath, `@mastra/core/agent-builder/ee/model-policy`, and the server allowlist delegates to that same helper instead of duplicating behavior in Playground. Route permissions keep the existing `PermissionPattern` compile-time check through type-only imports, with no auth runtime helper in the browser bundle. Observability pages use local entity constants for the few values Studio needs. Vite excludes `@standard-schema/spec` from dev dependency optimization so the runtime-empty type package is not rewritten into a broken default import.

Added a Playground import-boundary test that parses source with TypeScript and fails on runtime imports, exports, or dynamic imports from server-only core modules while still allowing type-only imports and the new browser-safe model-policy subpath. I verified this test fails with a temporary bad `@mastra/core/agent-builder/ee` import, then removed the temporary file.

Validated with focused core and Playground Vitest coverage, core check, focused lint, React Doctor, the Playground build graph, and a fresh `examples/agent` smoke at `http://localhost:5173/agents`. The smoke rendered the Agents table and returned 200s for the core Studio API calls. Local backend setup needed linked package build artifacts plus `OPENAI_API_KEY=dummy`; without the key, the example backend fails before Studio APIs can start. CodeRabbit CLI is installed but not signed in, so local CodeRabbit review could not run.