### PR TITLE
fix(cli): select observability org during auth flow

### DIFF
--- a/.changeset/spotty-suits-sink.md
+++ b/.changeset/spotty-suits-sink.md
@@ -1,0 +1,6 @@
+---
+'mastra': patch
+'create-mastra': patch
+---
+
+Fixed observability setup so multi-organization users can choose the target organization without reopening an extra prompt during project provisioning.

--- a/packages/cli/src/commands/actions/init-project.ts
+++ b/packages/cli/src/commands/actions/init-project.ts
@@ -60,6 +60,8 @@ export const initProject = async (args: InitArgs) => {
           versionTag,
           observability: result?.observability,
           observabilityToken: result?.observabilityToken,
+          observabilityOrgId: result?.observabilityOrgId,
+          observabilityOrgName: result?.observabilityOrgName,
         });
         return;
       }

--- a/packages/cli/src/commands/auth/orgs.test.ts
+++ b/packages/cli/src/commands/auth/orgs.test.ts
@@ -29,6 +29,9 @@ describe('resolveCurrentOrg', () => {
     setCurrentOrgIdMock.mockReset();
     selectMock.mockReset();
     delete process.env.MASTRA_ORG_ID;
+    delete process.env.CI;
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
   });
 
   test('auto-selects when user belongs to a single org', async () => {
@@ -84,6 +87,26 @@ describe('resolveCurrentOrg', () => {
     await resolveCurrentOrg('tok', { forcePrompt: true });
 
     expect(setCurrentOrgIdMock).not.toHaveBeenCalled();
+  });
+
+  test('forcePrompt reuses the current org without prompting when non-interactive', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    fetchOrgsMock.mockResolvedValue([ORG_A, ORG_B]);
+    getCurrentOrgIdMock.mockResolvedValue('org_b');
+
+    const result = await resolveCurrentOrg('tok', { forcePrompt: true });
+
+    expect(result).toEqual({ orgId: 'org_b', orgName: 'Org B' });
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  test('forcePrompt throws a setup error instead of prompting when non-interactive and no current org exists', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    fetchOrgsMock.mockResolvedValue([ORG_A, ORG_B]);
+    getCurrentOrgIdMock.mockResolvedValue(null);
+
+    await expect(resolveCurrentOrg('tok', { forcePrompt: true })).rejects.toThrow(/set MASTRA_ORG_ID/i);
+    expect(selectMock).not.toHaveBeenCalled();
   });
 
   test('MASTRA_ORG_ID overrides forcePrompt and skips picker', async () => {

--- a/packages/cli/src/commands/auth/orgs.ts
+++ b/packages/cli/src/commands/auth/orgs.ts
@@ -14,11 +14,17 @@ export interface ResolveCurrentOrgOptions {
   forcePrompt?: boolean;
 }
 
+function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY) && !process.env.CI;
+}
+
 /**
  * Resolve the current org, auto-selecting if only one exists.
  * If multiple orgs exist and none is currently set, prompts the user.
  * Pass `{ forcePrompt: true }` to always prompt when there's more than one
- * org, even if a current org is persisted.
+ * org, even if a current org is persisted. In non-interactive environments,
+ * a persisted current org is reused and otherwise a clear setup error is
+ * thrown instead of starting a prompt that cannot be answered.
  */
 export async function resolveCurrentOrg(
   token: string,
@@ -43,9 +49,13 @@ export async function resolveCurrentOrg(
 
   const currentOrgId = await getCurrentOrgId();
 
-  if (!opts.forcePrompt && currentOrgId) {
+  if (currentOrgId && (!opts.forcePrompt || !isInteractive())) {
     const match = orgs.find(o => o.id === currentOrgId);
     if (match) return { orgId: match.id, orgName: match.name };
+  }
+
+  if (!isInteractive()) {
+    throw new Error('Multiple organizations found. Run `mastra auth orgs switch` interactively or set MASTRA_ORG_ID.');
   }
 
   const selected = await p.select({

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -97,6 +97,8 @@ export const create = async (args: {
       observabilityProject: args.observabilityProject,
       observabilityMode: 'create',
       observabilityToken: result?.observabilityToken,
+      observabilityOrgId: result?.observabilityOrgId,
+      observabilityOrgName: result?.observabilityOrgName,
     });
     postCreate({ projectName });
     return;

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -38,6 +38,8 @@ export const init = async ({
   observabilityProject,
   observabilityMode = 'pick',
   observabilityToken,
+  observabilityOrgId,
+  observabilityOrgName,
 }: {
   directory?: string;
   components: Component[];
@@ -51,10 +53,12 @@ export const init = async ({
   observability?: boolean;
   observabilityProject?: string;
   observabilityToken?: string;
+  observabilityOrgId?: string;
+  observabilityOrgName?: string;
   /**
-   * `'create'` skips the picker and always provisions a new platform project
-   * named after the local one (used by `create-mastra`). `'pick'` shows the
-   * existing-or-new picker (used by `mastra init`).
+   * `'create'` skips the project picker and always provisions a new platform
+   * project named after the local one (used by `create-mastra`). `'pick'`
+   * shows the existing-or-new project picker (used by `mastra init`).
    */
   observabilityMode?: 'create' | 'pick';
 }) => {
@@ -205,6 +209,10 @@ export const init = async ({
           observabilityProject,
           mode: observabilityMode,
           token: observabilityToken,
+          org:
+            observabilityOrgId && observabilityOrgName
+              ? { orgId: observabilityOrgId, orgName: observabilityOrgName }
+              : undefined,
         });
         await writeObservabilityEnv({
           token: result.token,

--- a/packages/cli/src/commands/init/observability-provision.test.ts
+++ b/packages/cli/src/commands/init/observability-provision.test.ts
@@ -72,6 +72,39 @@ describe('provisionObservabilityProject', () => {
     expect(resolveCurrentOrgMock).toHaveBeenCalledWith('prompt-token', { forcePrompt: true });
   });
 
+  test('uses a provided organization instead of prompting again', async () => {
+    platformFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          project: { id: 'p1', slug: 'my-app', name: 'my-app', organizationId: 'org_prompt' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ token: { id: 'k1', name: 'mastra observability – my-app' }, secret: 'sk_my_app' }),
+      );
+
+    const result = await provisionObservabilityProject({
+      defaultProjectName: 'my-app',
+      mode: 'create',
+      token: 'prompt-token',
+      org: { orgId: 'org_prompt', orgName: 'Prompt Org' },
+    });
+
+    expect(result.orgName).toBe('Prompt Org');
+    expect(result.projectId).toBe('p1');
+    expect(getTokenMock).not.toHaveBeenCalled();
+    expect(resolveCurrentOrgMock).not.toHaveBeenCalled();
+    expect(platformFetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://platform.test/v1/studio/projects',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-Mastra-Organization-Id': 'org_prompt' }),
+        body: JSON.stringify({ name: 'my-app', studioEnabled: false, serverEnabled: false }),
+      }),
+    );
+  });
+
   test('creates a new project when the org has none, defaulting to package name', async () => {
     platformFetchMock
       .mockResolvedValueOnce(jsonResponse({ projects: [] }))
@@ -328,7 +361,7 @@ describe('provisionObservabilityProject', () => {
     expect(result.projectId).toBe('p1');
     expect(result.projectName).toBe('my-app');
     expect(result.token).toBe('sk_my_app');
-    expect(resolveCurrentOrgMock).toHaveBeenCalledWith('test-token');
+    expect(resolveCurrentOrgMock).toHaveBeenCalledWith('test-token', { forcePrompt: true });
 
     // No picker, no name re-prompt, no list call.
     expect(selectMock).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/init/observability-provision.ts
+++ b/packages/cli/src/commands/init/observability-provision.ts
@@ -50,6 +50,7 @@ export async function provisionObservabilityProject({
   observabilityProject,
   mode = 'pick',
   token: providedToken,
+  org,
 }: {
   defaultProjectName?: string;
   /**
@@ -60,17 +61,18 @@ export async function provisionObservabilityProject({
   observabilityProject?: string;
   /**
    * `'create'` (used by `create-mastra`) always provisions a new platform
-   * project named after the local one — no picker, no extra name prompt.
+   * project named after the local one — no project picker, no extra name prompt.
    * `'pick'` (used by `mastra init` in an existing project) lets the user
    * attach to an existing project or create a new one.
    */
   mode?: 'create' | 'pick';
   /** Platform auth token already acquired during the observability opt-in prompt. */
   token?: string;
+  /** Organization already chosen during the observability auth prompt. */
+  org?: { orgId: string; orgName: string };
 } = {}): Promise<ObservabilityProvisionResult> {
   const token = providedToken ?? (await getToken());
-  const { orgId, orgName } =
-    mode === 'create' ? await resolveCurrentOrg(token) : await resolveCurrentOrg(token, { forcePrompt: true });
+  const { orgId, orgName } = org ?? (await resolveCurrentOrg(token, { forcePrompt: true }));
 
   let project: ObservabilityProject;
   if (observabilityProject) {

--- a/packages/cli/src/commands/init/utils.test.ts
+++ b/packages/cli/src/commands/init/utils.test.ts
@@ -24,22 +24,29 @@ vi.mock('../auth/credentials.js', () => ({
   loadCredentials: vi.fn(),
 }));
 
+vi.mock('../auth/orgs.js', () => ({
+  resolveCurrentOrg: vi.fn(),
+}));
+
 const { promptForObservability, writeObservabilityEnv } = await import('./utils');
 const prompts = await import('@clack/prompts');
 const { getToken, loadCredentials } = await import('../auth/credentials.js');
+const { resolveCurrentOrg } = await import('../auth/orgs.js');
 
 const selectMock = vi.mocked(prompts.select);
 const getTokenMock = vi.mocked(getToken);
 const loadCredentialsMock = vi.mocked(loadCredentials);
+const resolveCurrentOrgMock = vi.mocked(resolveCurrentOrg);
 
 describe('promptForObservability', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getTokenMock.mockResolvedValue('platform-token');
     loadCredentialsMock.mockResolvedValue(null);
+    resolveCurrentOrgMock.mockResolvedValue({ orgId: 'org_test', orgName: 'Test Org' });
   });
 
-  test('starts platform auth immediately when observability is enabled', async () => {
+  test('starts platform auth and prompts for an org immediately when observability is enabled', async () => {
     selectMock.mockResolvedValueOnce('yes' as never);
 
     await expect(
@@ -47,9 +54,12 @@ describe('promptForObservability', () => {
     ).resolves.toEqual({
       enabled: true,
       token: 'platform-token',
+      orgId: 'org_test',
+      orgName: 'Test Org',
     });
 
     expect(getTokenMock).toHaveBeenCalledTimes(1);
+    expect(resolveCurrentOrgMock).toHaveBeenCalledWith('platform-token', { forcePrompt: true });
     expect(trackEventMock).toHaveBeenCalledWith('cli_observability_selected', {
       command: undefined,
       enabled: true,
@@ -68,6 +78,7 @@ describe('promptForObservability', () => {
     });
 
     expect(getTokenMock).not.toHaveBeenCalled();
+    expect(resolveCurrentOrgMock).not.toHaveBeenCalled();
     expect(trackEventMock).toHaveBeenCalledWith('cli_observability_selected', {
       command: undefined,
       enabled: false,
@@ -137,7 +148,12 @@ describe('promptForObservability', () => {
     selectMock.mockResolvedValueOnce('yes' as never).mockResolvedValueOnce('yes' as never);
     getTokenMock.mockRejectedValueOnce(new Error('Login timed out (60s)')).mockResolvedValueOnce('retry-token');
 
-    await expect(promptForObservability()).resolves.toEqual({ enabled: true, token: 'retry-token' });
+    await expect(promptForObservability()).resolves.toEqual({
+      enabled: true,
+      token: 'retry-token',
+      orgId: 'org_test',
+      orgName: 'Test Org',
+    });
 
     expect(selectMock).toHaveBeenCalledTimes(2);
     expect(getTokenMock).toHaveBeenCalledTimes(2);

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -12,6 +12,7 @@ import yoctoSpinner from 'yocto-spinner';
 import { DepsService } from '../../services/service.deps';
 import { FileService } from '../../services/service.file';
 import { getToken, loadCredentials } from '../auth/credentials.js';
+import { resolveCurrentOrg } from '../auth/orgs.js';
 import {
   cursorGlobalMCPConfigPath,
   windsurfGlobalMCPConfigPath,
@@ -30,6 +31,8 @@ export type Component = (typeof COMPONENTS)[number];
 export interface ObservabilityPromptResult {
   enabled?: boolean;
   token?: string;
+  orgId?: string;
+  orgName?: string;
 }
 
 interface ObservabilitySelectionEvent {
@@ -81,7 +84,8 @@ export async function promptForObservability(
         const creds = await loadCredentials();
         if (creds) p.log.info(`Logged in as ${creds.user.email}`);
       }
-      return { enabled: true, token };
+      const org = await resolveCurrentOrg(token, { forcePrompt: true });
+      return { enabled: true, token, orgId: org.orgId, orgName: org.orgName };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       p.log.warn(`Could not sign in to Mastra: ${message}`);
@@ -1019,6 +1023,8 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
     ...rest,
     observability: observability?.enabled,
     observabilityToken: observability?.token,
+    observabilityOrgId: observability?.orgId,
+    observabilityOrgName: observability?.orgName,
     skills: configureMastraToolingForAgents?.skills as string[] | undefined,
     mcpServer: configureMastraToolingForAgents?.mcpServer as Editor | undefined,
   };


### PR DESCRIPTION
## Summary
- prompt for the target organization during the interactive observability auth/opt-in flow for multi-org users
- carry the selected org into observability project provisioning so the interactive create/init flow does not ask again later
- keep forced org resolution safe for non-interactive runs by reusing a saved org or requiring `MASTRA_ORG_ID`

## Context
PR #16644 fixed a late `create-mastra --observe` org prompt/hang by skipping `forcePrompt` in create mode, but that regressed multi-org users by silently using the saved org. PR #17098 restores the picker in provisioning, but can reintroduce the late prompt. This PR supersedes #17098 by moving org selection earlier into the interactive observability auth flow and passing that org through provisioning.

## Test plan
- `pnpm --filter ./packages/cli test src/commands/auth/orgs.test.ts src/commands/init/utils.test.ts src/commands/init/observability-provision.test.ts`
- `pnpm --filter ./packages/cli typecheck`
- `pnpm --filter ./packages/cli lint`
- local `create-mastra` interactive flow with observability enabled

CodeRabbit CLI was not installed locally, so I could not run a local CodeRabbit review.
