### PR TITLE
feat(core): per-entity filesystem storage and git history

### DIFF
--- a/.changeset/per-entity-filesystem-storage.md
+++ b/.changeset/per-entity-filesystem-storage.md
@@ -1,0 +1,32 @@
+---
+'@mastra/core': minor
+---
+
+Add per-entity file persistence and per-entity git history to `FilesystemVersionedHelpers`.
+
+`FilesystemVersionedHelpers` now accepts three optional hooks that let a storage
+domain split a published entity across many per-entity JSON files (e.g.
+`agents/<id>.json`) instead of one shared map file:
+
+- `perEntityFilesDir` — directory (under the FilesystemDB root) for per-entity files.
+- `shouldPersistToPerEntityFile(entity)` — decide per published entity whether
+  to write its snapshot to a per-entity file.
+- `perEntitySnapshotFilter(snapshot, entity)` — filter the snapshot before
+  writing it to the per-entity file (e.g. drop fields the user does not own).
+
+When configured, the helper:
+
+- Reads per-entity files on hydrate (alongside the shared map file).
+- Writes published snapshots to per-entity files with stable alphabetical key
+  ordering for friendly diffs.
+- Walks per-entity file git history and surfaces each commit as a read-only
+  version in `listVersions` (in addition to the existing shared-file git
+  history).
+- Skips writing an empty shared map file when every published entity is
+  persisted to per-entity files, so a code-only project does not end up with an
+  empty stub committed to git.
+
+Also adds `FilesystemDB.listDomainFiles`, `domainFileExists`, and
+`removeDomainFile` helpers, and broadens `GitHistory.getFileAtCommit` to be
+generic so callers can request a per-entity snapshot type rather than the
+shared-map shape.

--- a/.changeset/per-entity-filesystem-storage.md
+++ b/.changeset/per-entity-filesystem-storage.md
@@ -30,3 +30,35 @@ Also adds `FilesystemDB.listDomainFiles`, `domainFileExists`, and
 `removeDomainFile` helpers, and broadens `GitHistory.getFileAtCommit` to be
 generic so callers can request a per-entity snapshot type rather than the
 shared-map shape.
+
+Example — configure a domain to persist each entity to its own file:
+
+```typescript
+import { FilesystemDB, FilesystemVersionedHelpers } from '@mastra/core/storage';
+
+const db = new FilesystemDB('./mastra/editor');
+
+// Entities that should be persisted as their own files.
+const codeModeEntityIds = new Set(['support-bot']);
+
+const agents = new FilesystemVersionedHelpers({
+  db,
+  entitiesFile: 'agents.json',
+  parentIdField: 'agentId',
+  name: 'agents',
+  versionMetadataFields: ['id', 'agentId', 'versionNumber', 'createdAt'],
+  // New per-entity hooks:
+  perEntityFilesDir: 'agents',
+  // Decide per entity whether it gets its own file (vs. the shared agents.json).
+  shouldPersistToPerEntityFile: entity => codeModeEntityIds.has(entity.id),
+  // Drop fields that should not live in the per-entity file.
+  perEntitySnapshotFilter: snapshot => {
+    const { model, ...userOwned } = snapshot;
+    return userOwned;
+  },
+});
+
+// Published snapshots are now written to ./mastra/editor/agents/<id>.json,
+// and each git commit to those files shows up as a read-only version.
+const versions = await agents.listVersions({ agentId: 'support-bot' }, 'agentId');
+```

--- a/packages/core/src/storage/filesystem-db.ts
+++ b/packages/core/src/storage/filesystem-db.ts
@@ -107,6 +107,9 @@ export class FilesystemDB {
       throw new Error(`Path traversal detected: directory "${directory}" escapes storage directory`);
     }
     if (!existsSync(baseDir)) return [];
+    if (!statSync(baseDir).isDirectory()) {
+      throw new Error(`Configured domain path "${directory}" is a file, expected a directory`);
+    }
 
     return readdirSync(baseDir)
       .filter(file => extname(file) === extension && statSync(join(baseDir, file)).isFile())
@@ -117,7 +120,12 @@ export class FilesystemDB {
    * Check whether a domain file currently exists on disk.
    */
   domainFileExists(filename: string): boolean {
-    return existsSync(join(this.dir, filename));
+    const filePath = resolve(this.dir, filename);
+    const rootDir = resolve(this.dir);
+    if (!filePath.startsWith(rootDir + sep) && filePath !== rootDir) {
+      throw new Error(`Path traversal detected: file "${filename}" escapes storage directory`);
+    }
+    return existsSync(filePath);
   }
 
   removeDomainFile(filename: string): void {

--- a/packages/core/src/storage/filesystem-db.ts
+++ b/packages/core/src/storage/filesystem-db.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, readdirSync, statSync, rmSync } from 'node:fs';
-import { join, dirname, relative, resolve, sep } from 'node:path';
+import { join, dirname, relative, resolve, sep, extname } from 'node:path';
 
 /**
  * FilesystemDB is a thin I/O layer for filesystem-based storage.
@@ -98,6 +98,38 @@ export class FilesystemDB {
    */
   clearDomain(filename: string): void {
     this.writeDomain(filename, {});
+  }
+
+  listDomainFiles(directory: string, extension = '.json'): string[] {
+    const baseDir = resolve(this.dir, directory);
+    const rootDir = resolve(this.dir);
+    if (!baseDir.startsWith(rootDir + sep) && baseDir !== rootDir) {
+      throw new Error(`Path traversal detected: directory "${directory}" escapes storage directory`);
+    }
+    if (!existsSync(baseDir)) return [];
+
+    return readdirSync(baseDir)
+      .filter(file => extname(file) === extension && statSync(join(baseDir, file)).isFile())
+      .map(file => `${directory}/${file}`);
+  }
+
+  /**
+   * Check whether a domain file currently exists on disk.
+   */
+  domainFileExists(filename: string): boolean {
+    return existsSync(join(this.dir, filename));
+  }
+
+  removeDomainFile(filename: string): void {
+    this.cache.delete(filename);
+    const filePath = resolve(this.dir, filename);
+    const rootDir = resolve(this.dir);
+    if (!filePath.startsWith(rootDir + sep) && filePath !== rootDir) {
+      throw new Error(`Path traversal detected: file "${filename}" escapes storage directory`);
+    }
+    if (existsSync(filePath)) {
+      rmSync(filePath);
+    }
   }
 
   /**

--- a/packages/core/src/storage/filesystem-versioned.ts
+++ b/packages/core/src/storage/filesystem-versioned.ts
@@ -329,41 +329,8 @@ export class FilesystemVersionedHelpers<
       }
 
       for (const entityId of perEntityIds) {
-        const filename = this.perEntityFilename(entityId);
-        const perEntityCommits = await git.getFileHistory(dir, filename, this.gitHistoryLimit);
-        if (perEntityCommits.length === 0) continue;
-
-        const orderedPerEntity = [...perEntityCommits].reverse();
-        let previousSnapshotForEntity: string | undefined;
-        let count = entityVersionCount.get(entityId) ?? 0;
-
-        for (const commit of orderedPerEntity) {
-          const snapshotConfig = await git.getFileAtCommit<Record<string, unknown>>(dir, commit.hash, filename);
-          if (!snapshotConfig || typeof snapshotConfig !== 'object') continue;
-
-          // The per-entity file IS the snapshot, so flatten one level
-          // compared to the shared-file branch above.
-          const serialized = JSON.stringify(snapshotConfig);
-          if (previousSnapshotForEntity === serialized) continue;
-          previousSnapshotForEntity = serialized;
-
-          count += 1;
-          entityVersionCount.set(entityId, count);
-
-          const versionId = `${GIT_VERSION_PREFIX}${commit.hash}-${entityId}`;
-          if (this.versions.has(versionId)) continue;
-
-          const version = {
-            id: versionId,
-            [this.parentIdField]: entityId,
-            versionNumber: count,
-            changeMessage: commit.message,
-            ...snapshotConfig,
-            createdAt: commit.date,
-          } as TVersion;
-
-          this.versions.set(versionId, version);
-        }
+        const count = await this.loadPerEntityGitHistory(entityId, entityVersionCount.get(entityId) ?? 0);
+        entityVersionCount.set(entityId, count);
       }
     }
 
@@ -379,6 +346,54 @@ export class FilesystemVersionedHelpers<
         (version as Record<string, unknown>).versionNumber = gitCount + 1;
       }
     }
+  }
+
+  /**
+   * Load git-backed versions for a single per-entity file. Each commit that
+   * changes the file becomes one version. Returns the running version count
+   * for the entity (starting from `startCount`). Used both by the bulk
+   * git-history pass and by `listVersions` to lazily discover entities that
+   * were deleted on disk but still exist in git history.
+   */
+  private async loadPerEntityGitHistory(entityId: string, startCount: number): Promise<number> {
+    const git = FilesystemVersionedHelpers.gitHistory;
+    const dir = this.db.dir;
+    const filename = this.perEntityFilename(entityId);
+    const perEntityCommits = await git.getFileHistory(dir, filename, this.gitHistoryLimit);
+    if (perEntityCommits.length === 0) return startCount;
+
+    const orderedPerEntity = [...perEntityCommits].reverse();
+    let previousSnapshotForEntity: string | undefined;
+    let count = startCount;
+
+    for (const commit of orderedPerEntity) {
+      const snapshotConfig = await git.getFileAtCommit<Record<string, unknown>>(dir, commit.hash, filename);
+      if (!snapshotConfig || typeof snapshotConfig !== 'object') continue;
+
+      // The per-entity file IS the snapshot, so flatten one level
+      // compared to the shared-file branch.
+      const serialized = JSON.stringify(snapshotConfig);
+      if (previousSnapshotForEntity === serialized) continue;
+      previousSnapshotForEntity = serialized;
+
+      count += 1;
+
+      const versionId = `${GIT_VERSION_PREFIX}${commit.hash}-${entityId}`;
+      if (this.versions.has(versionId)) continue;
+
+      const version = {
+        id: versionId,
+        [this.parentIdField]: entityId,
+        versionNumber: count,
+        changeMessage: commit.message,
+        ...snapshotConfig,
+        createdAt: commit.date,
+      } as TVersion;
+
+      this.versions.set(versionId, version);
+    }
+
+    return count;
   }
 
   // ==========================================================================
@@ -637,6 +652,21 @@ export class FilesystemVersionedHelpers<
       v => (v as Record<string, unknown>)[this.parentIdField] === entityId,
     );
 
+    // Lazily discover per-entity files that were deleted on disk but still
+    // exist in git history. The bulk git-history pass only walks entities that
+    // are currently on disk or in memory, so a deleted-then-requested entity
+    // would otherwise surface no versions.
+    if (versions.length === 0 && this.perEntityFilesDir && entityId) {
+      const startCount = this.gitVersionCounts.get(entityId) ?? 0;
+      const newCount = await this.loadPerEntityGitHistory(entityId, startCount);
+      if (newCount > startCount) {
+        this.gitVersionCounts.set(entityId, newCount);
+        versions = Array.from(this.versions.values()).filter(
+          v => (v as Record<string, unknown>)[this.parentIdField] === entityId,
+        );
+      }
+    }
+
     // Sort
     const field = (orderBy?.field as string) ?? 'versionNumber';
     const direction = (orderBy?.direction as string) ?? 'DESC';
@@ -709,5 +739,13 @@ export class FilesystemVersionedHelpers<
     this.gitHistoryPromise = null;
     this.hydrated = false;
     this.db.clearDomain(this.entitiesFile);
+
+    // Per-entity files are real on-disk snapshots; clearing only the shared
+    // file leaves them behind and they get re-imported on the next hydrate.
+    if (this.perEntityFilesDir) {
+      for (const filename of this.db.listDomainFiles(this.perEntityFilesDir)) {
+        this.db.removeDomainFile(filename);
+      }
+    }
   }
 }

--- a/packages/core/src/storage/filesystem-versioned.ts
+++ b/packages/core/src/storage/filesystem-versioned.ts
@@ -368,7 +368,13 @@ export class FilesystemVersionedHelpers<
 
     for (const commit of orderedPerEntity) {
       const snapshotConfig = await git.getFileAtCommit<Record<string, unknown>>(dir, commit.hash, filename);
-      if (!snapshotConfig || typeof snapshotConfig !== 'object') continue;
+      if (!snapshotConfig || typeof snapshotConfig !== 'object') {
+        // The file did not exist at this commit (e.g. it was deleted). Reset the
+        // dedupe baseline so a later restore with identical content is still
+        // recorded as a distinct version rather than skipped.
+        previousSnapshotForEntity = undefined;
+        continue;
+      }
 
       // The per-entity file IS the snapshot, so flatten one level
       // compared to the shared-file branch.
@@ -422,7 +428,10 @@ export class FilesystemVersionedHelpers<
           : snapshotConfig;
         perEntityData.set(entityId, stableSortKeys(filtered) as Record<string, unknown>);
       } else {
-        diskData[entityId] = snapshotConfig;
+        // Sort keys here too so shared-file domains get deterministic ordering.
+        // The shared git-history path dedupes with JSON.stringify, so without
+        // stable ordering a reorder-only write could surface as a fake version.
+        diskData[entityId] = stableSortKeys(snapshotConfig) as Record<string, unknown>;
       }
     }
 
@@ -648,24 +657,15 @@ export class FilesystemVersionedHelpers<
     const perPage = normalizePerPage(perPageInput, 20);
     if (page < 0) throw new Error('page must be >= 0');
 
-    let versions = Array.from(this.versions.values()).filter(
-      v => (v as Record<string, unknown>)[this.parentIdField] === entityId,
-    );
-
     // Lazily discover per-entity files that were deleted on disk but still
     // exist in git history. The bulk git-history pass only walks entities that
     // are currently on disk or in memory, so a deleted-then-requested entity
     // would otherwise surface no versions.
-    if (versions.length === 0 && this.perEntityFilesDir && entityId) {
-      const startCount = this.gitVersionCounts.get(entityId) ?? 0;
-      const newCount = await this.loadPerEntityGitHistory(entityId, startCount);
-      if (newCount > startCount) {
-        this.gitVersionCounts.set(entityId, newCount);
-        versions = Array.from(this.versions.values()).filter(
-          v => (v as Record<string, unknown>)[this.parentIdField] === entityId,
-        );
-      }
-    }
+    await this.ensurePerEntityGitHistory(entityId);
+
+    const versions = Array.from(this.versions.values()).filter(
+      v => (v as Record<string, unknown>)[this.parentIdField] === entityId,
+    );
 
     // Sort
     const field = (orderBy?.field as string) ?? 'versionNumber';
@@ -716,8 +716,30 @@ export class FilesystemVersionedHelpers<
     return count;
   }
 
+  /**
+   * Lazily discover per-entity git history for an entity that was deleted on
+   * disk but still exists in git commits. The bulk git-history pass only walks
+   * entities currently on disk or in memory, so without this an entity that has
+   * no in-memory versions would surface no git versions (and `gitVersionCounts`
+   * would stay 0, letting a recreated entity collide with git version numbers).
+   */
+  private async ensurePerEntityGitHistory(entityId: string): Promise<void> {
+    if (!this.perEntityFilesDir || !entityId) return;
+    const hasVersions = Array.from(this.versions.values()).some(
+      v => (v as Record<string, unknown>)[this.parentIdField] === entityId,
+    );
+    if (hasVersions) return;
+
+    const startCount = this.gitVersionCounts.get(entityId) ?? 0;
+    const newCount = await this.loadPerEntityGitHistory(entityId, startCount);
+    if (newCount > startCount) {
+      this.gitVersionCounts.set(entityId, newCount);
+    }
+  }
+
   async getNextVersionNumber(entityId: string): Promise<number> {
     await this.ensureGitHistory();
+    await this.ensurePerEntityGitHistory(entityId);
     return this._getNextVersionNumber(entityId);
   }
 

--- a/packages/core/src/storage/filesystem-versioned.ts
+++ b/packages/core/src/storage/filesystem-versioned.ts
@@ -17,6 +17,26 @@ import type { StorageOrderBy } from './types';
 const GIT_VERSION_PREFIX = 'git-';
 
 /**
+ * Recursively sort object keys alphabetically so the on-disk JSON is stable
+ * across saves. Arrays preserve order; object entries are emitted in a
+ * deterministic order so git diffs only reflect real content changes.
+ */
+function stableSortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableSortKeys);
+  }
+  if (value && typeof value === 'object' && !(value instanceof Date)) {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, stableSortKeys(entry)]),
+    );
+  }
+  return value;
+}
+
+/**
  * Configuration for a filesystem-backed versioned storage domain.
  */
 export interface FilesystemVersionedConfig {
@@ -36,6 +56,17 @@ export interface FilesystemVersionedConfig {
   versionMetadataFields: string[];
   /** Maximum number of git commits to load per file (default: 50) */
   gitHistoryLimit?: number;
+  /** Directory for published entities that should be persisted as one JSON file per entity. */
+  perEntityFilesDir?: string;
+  /** Return true when an entity should persist as one JSON file instead of inside entitiesFile. */
+  shouldPersistToPerEntityFile?: (entity: VersionedEntityBase) => boolean;
+  /**
+   * Optional snapshot filter applied to per-entity files only.
+   * Lets per-entity files (e.g. code-mode JSON) exclude fields that are not
+   * user-editable from Studio (such as `model`) while keeping the shared
+   * `entitiesFile` snapshot unchanged.
+   */
+  perEntitySnapshotFilter?: (snapshot: Record<string, unknown>, entity: VersionedEntityBase) => Record<string, unknown>;
 }
 
 /**
@@ -72,6 +103,12 @@ export class FilesystemVersionedHelpers<
   readonly name: string;
   readonly versionMetadataFields: string[];
   private readonly gitHistoryLimit: number;
+  private readonly perEntityFilesDir?: string;
+  private readonly shouldPersistToPerEntityFile?: (entity: VersionedEntityBase) => boolean;
+  private readonly perEntitySnapshotFilter?: (
+    snapshot: Record<string, unknown>,
+    entity: VersionedEntityBase,
+  ) => Record<string, unknown>;
 
   /**
    * In-memory entity records (thin metadata), keyed by entity ID.
@@ -114,6 +151,21 @@ export class FilesystemVersionedHelpers<
     this.name = config.name;
     this.versionMetadataFields = config.versionMetadataFields;
     this.gitHistoryLimit = config.gitHistoryLimit ?? 50;
+    this.perEntityFilesDir = config.perEntityFilesDir;
+    this.shouldPersistToPerEntityFile = config.shouldPersistToPerEntityFile;
+    this.perEntitySnapshotFilter = config.perEntitySnapshotFilter;
+  }
+
+  private perEntityFilename(entityId: string): string {
+    if (!this.perEntityFilesDir) {
+      throw new Error(`${this.name}: per-entity files directory is not configured`);
+    }
+    return `${this.perEntityFilesDir}/${encodeURIComponent(entityId)}.json`;
+  }
+
+  private entityIdFromPerEntityFilename(filename: string): string {
+    const basename = filename.split('/').pop() ?? filename;
+    return decodeURIComponent(basename.replace(/\.json$/, ''));
   }
 
   /**
@@ -136,11 +188,7 @@ export class FilesystemVersionedHelpers<
     if (this.hydrated) return;
     this.hydrated = true;
 
-    const diskData = this.db.readDomain<Record<string, unknown>>(this.entitiesFile);
-
-    for (const [entityId, snapshotConfig] of Object.entries(diskData)) {
-      if (!snapshotConfig || typeof snapshotConfig !== 'object') continue;
-
+    const hydrateSnapshot = (entityId: string, snapshotConfig: Record<string, unknown>) => {
       const versionId = `hydrated-${entityId}-v1`;
       const now = new Date();
 
@@ -151,7 +199,7 @@ export class FilesystemVersionedHelpers<
         activeVersionId: versionId,
         createdAt: now,
         updatedAt: now,
-      } as TEntity;
+      } as unknown as TEntity;
 
       this.entities.set(entityId, entity);
 
@@ -166,6 +214,22 @@ export class FilesystemVersionedHelpers<
       } as TVersion;
 
       this.versions.set(versionId, version);
+    };
+
+    const diskData = this.db.readDomain<Record<string, unknown>>(this.entitiesFile);
+
+    for (const [entityId, snapshotConfig] of Object.entries(diskData)) {
+      if (!snapshotConfig || typeof snapshotConfig !== 'object') continue;
+      hydrateSnapshot(entityId, snapshotConfig);
+    }
+
+    if (this.perEntityFilesDir) {
+      for (const filename of this.db.listDomainFiles(this.perEntityFilesDir)) {
+        const entityId = this.entityIdFromPerEntityFilename(filename);
+        const snapshotConfig = this.db.readDomain(filename);
+        if (!snapshotConfig || typeof snapshotConfig !== 'object') continue;
+        hydrateSnapshot(entityId, snapshotConfig);
+      }
     }
 
     // Kick off async git history loading (fire and forget)
@@ -199,7 +263,6 @@ export class FilesystemVersionedHelpers<
 
     // Get commit history for this domain's file
     const commits = await git.getFileHistory(dir, this.entitiesFile, this.gitHistoryLimit);
-    if (commits.length === 0) return;
 
     // Process commits from oldest to newest so version numbers are sequential
     const orderedCommits = [...commits].reverse();
@@ -250,6 +313,60 @@ export class FilesystemVersionedHelpers<
       }
     }
 
+    // Walk git history for per-entity files (code mode). Each per-entity file
+    // is a standalone snapshot, not an entityId → snapshot map, so each commit
+    // touching the file becomes one version for that entity.
+    if (this.perEntityFilesDir) {
+      const perEntityIds = new Set<string>();
+      // Known entities currently on disk
+      for (const filename of this.db.listDomainFiles(this.perEntityFilesDir)) {
+        perEntityIds.add(this.entityIdFromPerEntityFilename(filename));
+      }
+      // Entities only present in git history (deleted on disk but still in commits)
+      // are discovered lazily by scanning entities map, which is already hydrated.
+      for (const entityId of this.entities.keys()) {
+        perEntityIds.add(entityId);
+      }
+
+      for (const entityId of perEntityIds) {
+        const filename = this.perEntityFilename(entityId);
+        const perEntityCommits = await git.getFileHistory(dir, filename, this.gitHistoryLimit);
+        if (perEntityCommits.length === 0) continue;
+
+        const orderedPerEntity = [...perEntityCommits].reverse();
+        let previousSnapshotForEntity: string | undefined;
+        let count = entityVersionCount.get(entityId) ?? 0;
+
+        for (const commit of orderedPerEntity) {
+          const snapshotConfig = await git.getFileAtCommit<Record<string, unknown>>(dir, commit.hash, filename);
+          if (!snapshotConfig || typeof snapshotConfig !== 'object') continue;
+
+          // The per-entity file IS the snapshot, so flatten one level
+          // compared to the shared-file branch above.
+          const serialized = JSON.stringify(snapshotConfig);
+          if (previousSnapshotForEntity === serialized) continue;
+          previousSnapshotForEntity = serialized;
+
+          count += 1;
+          entityVersionCount.set(entityId, count);
+
+          const versionId = `${GIT_VERSION_PREFIX}${commit.hash}-${entityId}`;
+          if (this.versions.has(versionId)) continue;
+
+          const version = {
+            id: versionId,
+            [this.parentIdField]: entityId,
+            versionNumber: count,
+            changeMessage: commit.message,
+            ...snapshotConfig,
+            createdAt: commit.date,
+          } as TVersion;
+
+          this.versions.set(versionId, version);
+        }
+      }
+    }
+
     // Save the max git version count per entity
     this.gitVersionCounts = entityVersionCount;
 
@@ -275,6 +392,7 @@ export class FilesystemVersionedHelpers<
    */
   private persistToDisk(): void {
     const diskData: Record<string, Record<string, unknown>> = {};
+    const perEntityData = new Map<string, Record<string, unknown>>();
 
     for (const [entityId, entity] of this.entities) {
       if (entity.status !== 'published' || !entity.activeVersionId) continue;
@@ -283,10 +401,39 @@ export class FilesystemVersionedHelpers<
       if (!version) continue;
 
       const snapshotConfig = this.extractSnapshotConfig(version);
-      diskData[entityId] = snapshotConfig;
+      if (this.perEntityFilesDir && this.shouldPersistToPerEntityFile?.(entity)) {
+        const filtered = this.perEntitySnapshotFilter
+          ? this.perEntitySnapshotFilter(snapshotConfig, entity)
+          : snapshotConfig;
+        perEntityData.set(entityId, stableSortKeys(filtered) as Record<string, unknown>);
+      } else {
+        diskData[entityId] = snapshotConfig;
+      }
     }
 
-    this.db.writeDomain(this.entitiesFile, diskData);
+    // When every published entity is persisted to per-entity files (code mode)
+    // and the shared file would otherwise be an empty `{}` stub, skip writing
+    // it so projects that only use code mode don't end up tracking an empty
+    // `agents.json` in git. Existing shared files keep being updated so
+    // db-mode and mixed setups behave the same as before.
+    const hasSharedEntries = Object.keys(diskData).length > 0;
+    const sharedFileExists = this.db.domainFileExists(this.entitiesFile);
+    if (hasSharedEntries || !this.perEntityFilesDir || sharedFileExists) {
+      this.db.writeDomain(this.entitiesFile, diskData);
+    }
+
+    if (this.perEntityFilesDir) {
+      for (const filename of this.db.listDomainFiles(this.perEntityFilesDir)) {
+        const entityId = this.entityIdFromPerEntityFilename(filename);
+        if (!perEntityData.has(entityId)) {
+          this.db.removeDomainFile(filename);
+        }
+      }
+
+      for (const [entityId, snapshotConfig] of perEntityData) {
+        this.db.writeDomain(this.perEntityFilename(entityId), snapshotConfig);
+      }
+    }
   }
 
   /**

--- a/packages/core/src/storage/git-history.test.ts
+++ b/packages/core/src/storage/git-history.test.ts
@@ -365,4 +365,54 @@ describe('FilesystemVersionedHelpers - Git integration', () => {
     expect(FilesystemVersionedHelpers.isGitVersion('hydrated-agent-1-v1')).toBe(false);
     expect(FilesystemVersionedHelpers.isGitVersion('some-random-uuid')).toBe(false);
   });
+
+  it('loads git commits for per-entity files (code mode)', async () => {
+    // Code mode persists each agent as its own JSON file under agents/<id>.json
+    mkdirSync(join(storageDir, 'agents'), { recursive: true });
+
+    writeAndCommit(
+      storageDir,
+      'agents/agent-1.json',
+      { name: 'Agent v1', instructions: 'Be helpful' },
+      'Initial code-mode commit',
+    );
+    writeAndCommit(
+      storageDir,
+      'agents/agent-1.json',
+      { name: 'Agent v2', instructions: 'Be very helpful' },
+      'Tighten instructions',
+    );
+
+    const db = new FilesystemDB(storageDir);
+    const helpers = new FilesystemVersionedHelpers<StorageAgentType, AgentVersion>({
+      db,
+      entitiesFile: 'agents.json',
+      parentIdField: 'agentId',
+      name: 'TestAgents',
+      versionMetadataFields: ['id', 'agentId', 'versionNumber', 'changedFields', 'changeMessage', 'createdAt'],
+      perEntityFilesDir: 'agents',
+      shouldPersistToPerEntityFile: () => true,
+    });
+
+    const result = await helpers.listVersions(versionInput('agent-1'), 'agentId');
+
+    // 2 git commits + 1 hydrated (current disk) = 3
+    expect(result.total).toBe(3);
+    const versions = result.versions;
+    expect(versions[0]!.versionNumber).toBe(3); // hydrated
+    expect(versions[1]!.versionNumber).toBe(2);
+    expect(versions[2]!.versionNumber).toBe(1);
+
+    expect(versions[2]!.changeMessage).toBe('Initial code-mode commit');
+    expect(versions[1]!.changeMessage).toBe('Tighten instructions');
+
+    // Git versions are properly tagged
+    expect(versions[1]!.id.startsWith('git-')).toBe(true);
+    expect(versions[2]!.id.startsWith('git-')).toBe(true);
+
+    // Snapshot content is the per-entity file content (flattened, no entityId key)
+    const v1 = versions[2] as unknown as Record<string, unknown>;
+    expect(v1.name).toBe('Agent v1');
+    expect(v1.instructions).toBe('Be helpful');
+  });
 });

--- a/packages/core/src/storage/git-history.test.ts
+++ b/packages/core/src/storage/git-history.test.ts
@@ -463,6 +463,42 @@ describe('FilesystemVersionedHelpers - Git integration', () => {
     expect(versions[1]!.id.startsWith('git-')).toBe(true);
   });
 
+  it('getNextVersionNumber accounts for git-only versions of a deleted-on-disk entity', async () => {
+    // A recreated entity must not be assigned a version number that collides
+    // with the git history that getNextVersionNumber would otherwise miss.
+    mkdirSync(join(storageDir, 'agents'), { recursive: true });
+    writeAndCommit(storageDir, 'agents.json', {}, 'Seed shared file');
+    writeAndCommit(
+      storageDir,
+      'agents/ghost-agent.json',
+      { name: 'Ghost v1', instructions: 'Be spooky' },
+      'Add ghost-agent',
+    );
+    writeAndCommit(
+      storageDir,
+      'agents/ghost-agent.json',
+      { name: 'Ghost v2', instructions: 'Be very spooky' },
+      'Update ghost-agent',
+    );
+    git(repoDir, ['rm', join('.mastra-storage', 'agents', 'ghost-agent.json')]);
+    git(repoDir, ['commit', '-m', 'Delete ghost-agent']);
+
+    const db = new FilesystemDB(storageDir);
+    const helpers = new FilesystemVersionedHelpers<StorageAgentType, AgentVersion>({
+      db,
+      entitiesFile: 'agents.json',
+      parentIdField: 'agentId',
+      name: 'TestAgents',
+      versionMetadataFields: ['id', 'agentId', 'versionNumber', 'changedFields', 'changeMessage', 'createdAt'],
+      perEntityFilesDir: 'agents',
+      shouldPersistToPerEntityFile: () => true,
+    });
+
+    // 2 git versions exist for the deleted entity, so the next number is 3 —
+    // not 1, which would collide with the lazily discovered git versions.
+    expect(await helpers.getNextVersionNumber('ghost-agent')).toBe(3);
+  });
+
   it('dangerouslyClearAll removes per-entity files', async () => {
     mkdirSync(join(storageDir, 'agents'), { recursive: true });
     writeFileSync(join(storageDir, 'agents', 'agent-1.json'), JSON.stringify({ name: 'Agent 1' }, null, 2));

--- a/packages/core/src/storage/git-history.test.ts
+++ b/packages/core/src/storage/git-history.test.ts
@@ -415,4 +415,74 @@ describe('FilesystemVersionedHelpers - Git integration', () => {
     expect(v1.name).toBe('Agent v1');
     expect(v1.instructions).toBe('Be helpful');
   });
+
+  it('lazily surfaces git history for a per-entity file deleted on disk', async () => {
+    // Commit a per-entity file, then delete it from disk in a later commit.
+    // It is no longer on disk and not in the entities map, so the bulk
+    // git-history pass would miss it; listVersions must discover it lazily.
+    mkdirSync(join(storageDir, 'agents'), { recursive: true });
+
+    // Keep another tracked file in the storage dir so it survives on disk after
+    // the per-entity file is removed (git does not track empty directories).
+    writeAndCommit(storageDir, 'agents.json', {}, 'Seed shared file');
+
+    writeAndCommit(
+      storageDir,
+      'agents/ghost-agent.json',
+      { name: 'Ghost v1', instructions: 'Be spooky' },
+      'Add ghost-agent',
+    );
+    writeAndCommit(
+      storageDir,
+      'agents/ghost-agent.json',
+      { name: 'Ghost v2', instructions: 'Be very spooky' },
+      'Update ghost-agent',
+    );
+    git(repoDir, ['rm', join('.mastra-storage', 'agents', 'ghost-agent.json')]);
+    git(repoDir, ['commit', '-m', 'Delete ghost-agent']);
+
+    const db = new FilesystemDB(storageDir);
+    const helpers = new FilesystemVersionedHelpers<StorageAgentType, AgentVersion>({
+      db,
+      entitiesFile: 'agents.json',
+      parentIdField: 'agentId',
+      name: 'TestAgents',
+      versionMetadataFields: ['id', 'agentId', 'versionNumber', 'changedFields', 'changeMessage', 'createdAt'],
+      perEntityFilesDir: 'agents',
+      shouldPersistToPerEntityFile: () => true,
+    });
+
+    const result = await helpers.listVersions(versionInput('ghost-agent'), 'agentId');
+
+    // 2 git commits, no hydrated version (deleted on disk)
+    expect(result.total).toBe(2);
+    const versions = result.versions;
+    expect(versions[0]!.changeMessage).toBe('Update ghost-agent');
+    expect(versions[1]!.changeMessage).toBe('Add ghost-agent');
+    expect(versions[0]!.id.startsWith('git-')).toBe(true);
+    expect(versions[1]!.id.startsWith('git-')).toBe(true);
+  });
+
+  it('dangerouslyClearAll removes per-entity files', async () => {
+    mkdirSync(join(storageDir, 'agents'), { recursive: true });
+    writeFileSync(join(storageDir, 'agents', 'agent-1.json'), JSON.stringify({ name: 'Agent 1' }, null, 2));
+    writeFileSync(join(storageDir, 'agents', 'agent-2.json'), JSON.stringify({ name: 'Agent 2' }, null, 2));
+
+    const db = new FilesystemDB(storageDir);
+    const helpers = new FilesystemVersionedHelpers<StorageAgentType, AgentVersion>({
+      db,
+      entitiesFile: 'agents.json',
+      parentIdField: 'agentId',
+      name: 'TestAgents',
+      versionMetadataFields: ['id', 'agentId', 'versionNumber', 'changedFields', 'changeMessage', 'createdAt'],
+      perEntityFilesDir: 'agents',
+      shouldPersistToPerEntityFile: () => true,
+    });
+
+    expect(db.listDomainFiles('agents')).toHaveLength(2);
+
+    await helpers.dangerouslyClearAll();
+
+    expect(db.listDomainFiles('agents')).toHaveLength(0);
+  });
 });

--- a/packages/core/src/storage/git-history.ts
+++ b/packages/core/src/storage/git-history.ts
@@ -33,8 +33,10 @@ export class GitHistory {
   /** Cache: `dir:filename:limit` → ordered commits (newest first). */
   private commitCache = new Map<string, GitCommit[]>();
 
-  /** Cache: `dir:commitHash:filename` → parsed JSON. */
-  private snapshotCache = new Map<string, Record<string, Record<string, unknown>>>();
+  /** Cache: `dir:commitHash:filename` → parsed JSON. Stored as unknown because
+   * shared files are `{ [entityId]: snapshot }` while per-entity files are the
+   * snapshot itself. */
+  private snapshotCache = new Map<string, unknown>();
 
   // ===========================================================================
   // Public API
@@ -140,7 +142,7 @@ export class GitHistory {
     try {
       const relPath = this.relativeToRepo(dir, filename);
       const raw = await this.exec(dir, ['show', `${commitHash}:${relPath}`]);
-      const parsed = JSON.parse(raw) as Record<string, Record<string, unknown>>;
+      const parsed = JSON.parse(raw);
       this.snapshotCache.set(cacheKey, parsed);
       return parsed as T;
     } catch {


### PR DESCRIPTION
## Summary

First in a stack of 5 PRs that introduce code-mode agent overrides.

Adds storage primitives to `FilesystemVersionedHelpers` that let a versioned storage domain persist each entity to its own JSON file under a subdirectory, and walk git history for those per-entity files as version records.

### Why
Today filesystem storage writes one shared `<domain>.json` file containing all entities. For code-mode agents we want per-agent JSON files that live in source control, so each agent has its own diff-friendly file and git commits on that file are surfaced as a version history.

### What's in this PR
- `FilesystemDB`: `listDomainFiles()`, `domainFileExists()`, `removeDomainFile()`.
- `FilesystemVersionedHelpers`: `perEntityFilesDir`, `shouldPersistToPerEntityFile`, `perEntitySnapshotFilter` options.
- Hydration reads per-entity JSON files when configured.
- `loadGitHistory` walks per-entity files individually so commits on per-agent JSONs surface as version records (`versionId = git-<sha>-<entityId>`).
- `stableSortKeys` for deterministic on-disk JSON.
- `snapshotCache` in `GitHistory` loosened to `Map<string, unknown>` so callers can cache per-entity snapshots (object instead of entityId map).

### Stack
1. **This PR** — storage primitive
2. refactor(core): storage __registerMastra back-pointer
3. feat(core/editor): MastraEditor mode + Agent editor ownership
4. feat(server): code-mode override export + ownership enforcement
5. feat(playground): code-mode Editor UI + db-mode chat fix

### Test plan
- `pnpm test:core -- src/storage/filesystem.test.ts` → 35 pass
- `pnpm test:core -- src/storage/git-history.test.ts` → 21 pass (incl. new per-entity git history case)
- `pnpm build:core` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Instead of storing every entity inside one big file, this change can save each entity to its own JSON file and treat commits to those per-entity files as independent version records — so you get per-item history you can list, restore, and reason about.

## Changes

- FilesystemDB
  - Added listDomainFiles(directory, extension = '.json') — lists files under a domain subdirectory (validates root-boundary, returns [] if missing).
  - Added domainFileExists(filename) — safe existence check with traversal protection.
  - Added removeDomainFile(filename) — invalidates in-memory cache and deletes the file from disk with root-boundary validation.

- FilesystemVersionedConfig / FilesystemVersionedHelpers
  - New optional hooks:
    - perEntityFilesDir?: string — directory under storage root for per-entity JSON files.
    - shouldPersistToPerEntityFile?(entity) — decide per-entity persistence target.
    - perEntitySnapshotFilter?(snapshot, entity) — transform/filter snapshot before writing per-entity file.
  - Deterministic on-disk JSON via stableSortKeys() (recursively alphabetizes object keys; preserves arrays & Date instances; filters undefined).
  - Hydration now reads both the shared entitiesFile and per-entity JSON files when configured; avoids creating an empty shared map when all entities are per-entity.
  - persistToDisk() rewritten to:
    - split writes between shared map and per-entity files based on shouldPersistToPerEntityFile,
    - apply perEntitySnapshotFilter,
    - write per-entity JSON with stableSortKeys,
    - remove stale per-entity files for entities no longer persisted per-entity,
    - apply stableSortKeys to shared-file writes to avoid reorder-only fake versions.
  - Added loadPerEntityGitHistory() to surface commits on per-entity files as read-only version records; assigns sequential versionNumber per entity and deduplicates unchanged snapshots (with a dedupe baseline reset when a per-entity file is absent at a commit so restores count as new versions).
  - listVersions() lazily discovers per-entity git history when in-memory versions are empty but per-entity history exists on disk/git.
  - getNextVersionNumber lazily loads per-entity git history to avoid version-number collisions for recreated entities.
  - dangerouslyClearAll() deletes on-disk per-entity JSON files when perEntityFilesDir is configured.

- Git history / GitHistory
  - snapshotCache loosened from a nested typed record to Map<string, unknown> to accommodate caching either shared maps or individual per-entity snapshots.
  - getFileAtCommit generalized to return generic parsed snapshot shapes (no longer assumes shared-map structure).
  - Per-entity git-backed version IDs use format git-<sha>-<entityId>.
  - getNextVersionNumber behavior improved with lazy per-entity history loading to prevent collisions.

- Tests & Build
  - Core filesystem tests updated/added (35 passing).
  - Git-history tests updated/added (21 passing), including per-entity git history, lazy discovery when per-entity files are deleted in later commits, getNextVersionNumber correctness for recreated entities, and dangerouslyClearAll cleanup.
  - pnpm build:core clean.

- Docs / API
  - Changeset docs updated with example configuration and behavior notes.
  - FilesystemVersionedConfig type extended with perEntityFilesDir, shouldPersistToPerEntityFile, perEntitySnapshotFilter.
  - FilesystemDB exposes the three new helpers.

## Notable fixes (from follow-up commits)
- Reset dedupe baseline when a per-entity file is absent at a commit so later restores with identical content are recorded as distinct versions.
- Apply stableSortKeys on shared-file writes to prevent reorder-only changes from producing fake new versions under JSON.stringify deduplication.
- Lazily load per-entity git history in getNextVersionNumber to avoid version-number collisions for recreated entities.

## Review / Comments
- Author addressed five review comments (commit b2ddd9b719) and later additional fixes (commit 99d174abf9). Automated reviewer bot acknowledged and resolved threads; no unresolved reviewer threads remain in the provided excerpt.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->