### PR TITLE
refactor(core): wire storage __registerMastra back-pointer

### DIFF
--- a/.changeset/storage-mastra-ref.md
+++ b/.changeset/storage-mastra-ref.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': minor
+---
+
+Storage adapters can now receive a narrow back-pointer to the Mastra instance
+via `MastraCompositeStore.__registerMastra`. This mirrors the existing
+registration pattern on agents, workflows, memory, scorers and processors,
+and lets a storage domain look up agents and editor config without pulling
+the full Mastra type into the storage layer (which would create a circular
+import).
+
+The reference is cascaded automatically to any parent composites and owned
+domain stores, and is wired both during Mastra construction and via
+`setStorage`. The editor is registered after storage so editor-driven
+storage overlays observe the assigned storage.
+
+A new `StorageMastraRef` interface exposes only the methods storage needs
+today (`getAgentById`, `getEditor`).

--- a/.changeset/storage-mastra-ref.md
+++ b/.changeset/storage-mastra-ref.md
@@ -16,3 +16,16 @@ storage overlays observe the assigned storage.
 
 A new `StorageMastraRef` interface exposes only the methods storage needs
 today (`getAgentById`, `getEditor`).
+
+```ts
+// Inside a domain store, read the registered reference after Mastra wires it up:
+class MyAgentsStore extends AgentsStorage {
+  protected getEditorConfig(agentId: string) {
+    // `this.mastra` is populated by MastraCompositeStore.__registerMastra,
+    // which runs during Mastra construction and on setStorage().
+    const agent = this.mastra?.getAgentById?.(agentId);
+    if (agent?.source !== 'code') return undefined;
+    return agent.__getEditorConfig?.();
+  }
+}
+```

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -908,11 +908,7 @@ export class Mastra<
     // Server cache for temporary persistence and durable agent resumable streams
     this.#serverCache = config?.cache ?? new InMemoryServerCache();
 
-    // Set the editor if provided and register this Mastra instance with it
     this.#editor = config?.editor;
-    if (this.#editor && typeof this.#editor.registerWithMastra === 'function') {
-      this.#editor.registerWithMastra(this);
-    }
 
     // Store global version overrides
     this.#versions = config?.versions;
@@ -1045,6 +1041,17 @@ export class Mastra<
     this.#logger = dualLogger as unknown as TLogger;
 
     this.#storage = storage;
+
+    // Give storage adapters a back-pointer to this Mastra instance so they
+    // can look up code-defined agents, editor config, etc. when needed
+    // (e.g. filesystem code-mode snapshot filtering).
+    storage?.__registerMastra?.(this as unknown as Parameters<NonNullable<typeof storage.__registerMastra>>[0]);
+
+    // Register the editor after storage is assigned so code mode can overlay
+    // filesystem-backed editor storage while preserving app storage domains.
+    if (this.#editor && typeof this.#editor.registerWithMastra === 'function') {
+      this.#editor.registerWithMastra(this);
+    }
 
     this.#backgroundTaskConfig = config?.backgroundTasks;
     // Auto-create the background-task manager only when this Mastra is
@@ -3306,6 +3313,7 @@ export class Mastra<
    */
   public setStorage(storage: MastraCompositeStore) {
     this.#storage = augmentWithInit(storage);
+    this.#storage?.__registerMastra?.(this as unknown as Parameters<NonNullable<typeof storage.__registerMastra>>[0]);
     this.#ensureBackgroundTaskManager();
     // If storage was attached after construction, the SchedulerWorker
     // will pick it up when startWorkers() is called.

--- a/packages/core/src/storage/base.test.ts
+++ b/packages/core/src/storage/base.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { MastraCompositeStore } from './base';
+import type { StorageMastraRef } from './base';
 import { InMemoryStore } from './mock';
 
 /**
@@ -102,5 +103,44 @@ describe('MastraCompositeStore — default delegation (issue #16782)', () => {
     });
 
     await expect(composite.init()).rejects.toThrow('inner init failed');
+  });
+});
+
+describe('MastraCompositeStore.__registerMastra', () => {
+  const mastra: StorageMastraRef = { getAgentById: () => undefined };
+
+  const getMastra = (store: MastraCompositeStore) => (store as unknown as { mastra?: StorageMastraRef }).mastra;
+  const setParent = (store: MastraCompositeStore, parent: MastraCompositeStore) =>
+    ((store as unknown as { parentDefault?: MastraCompositeStore }).parentDefault = parent);
+
+  it('cascades the reference to a parent composite', () => {
+    const parent = new MastraCompositeStore({ id: 'parent', default: new InMemoryStore({ id: 'parent-inner' }) });
+    const child = new MastraCompositeStore({ id: 'child', default: new InMemoryStore({ id: 'child-inner' }) });
+    setParent(child, parent);
+
+    child.__registerMastra(mastra);
+
+    expect(getMastra(child)).toBe(mastra);
+    expect(getMastra(parent)).toBe(mastra);
+  });
+
+  it('terminates on a parent cycle (A -> B -> A) without stack overflow', () => {
+    const a = new MastraCompositeStore({ id: 'a', default: new InMemoryStore({ id: 'a-inner' }) });
+    const b = new MastraCompositeStore({ id: 'b', default: new InMemoryStore({ id: 'b-inner' }) });
+    setParent(a, b);
+    setParent(b, a);
+
+    // Would recurse forever if `seen` were not shared across the cascade.
+    expect(() => a.__registerMastra(mastra)).not.toThrow();
+    expect(getMastra(a)).toBe(mastra);
+    expect(getMastra(b)).toBe(mastra);
+  });
+
+  it('terminates on a self-cycle', () => {
+    const a = new MastraCompositeStore({ id: 'a', default: new InMemoryStore({ id: 'a-inner' }) });
+    setParent(a, a);
+
+    expect(() => a.__registerMastra(mastra)).not.toThrow();
+    expect(getMastra(a)).toBe(mastra);
   });
 });

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -336,15 +336,17 @@ export class MastraCompositeStore extends MastraBase {
    * `this.mastra` after this is called.
    * @internal
    */
-  __registerMastra(mastra: StorageMastraRef): void {
+  __registerMastra(mastra: StorageMastraRef, seen: Set<unknown> = new Set<unknown>()): void {
+    if (seen.has(this)) return;
+    seen.add(this);
     this.mastra = mastra;
-    const seen = new Set<unknown>();
     const cascade = (target: unknown) => {
       if (!target || typeof target !== 'object' || seen.has(target)) return;
-      seen.add(target);
-      const fn = (target as { __registerMastra?: (m: StorageMastraRef) => void }).__registerMastra;
-      if (typeof fn === 'function' && target !== this) {
-        fn.call(target, mastra);
+      const fn = (target as { __registerMastra?: (m: StorageMastraRef, s?: Set<unknown>) => void }).__registerMastra;
+      if (typeof fn === 'function') {
+        fn.call(target, mastra, seen);
+      } else {
+        seen.add(target);
       }
     };
     if (this.parentDefault) cascade(this.parentDefault);

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -225,12 +225,23 @@ export interface MastraCompositeStoreConfig {
  * await memory?.saveThread({ thread });
  * ```
  */
+/**
+ * Minimal interface a storage adapter sees from the Mastra instance.
+ * Kept narrow on purpose to avoid pulling the full Mastra type into the
+ * storage layer (which would create a circular import).
+ */
+export interface StorageMastraRef {
+  getAgentById?: (id: string) => { source?: string; __getEditorConfig?: () => unknown } | undefined;
+  getEditor?: () => { getMode?: () => 'code' | 'db' | undefined } | undefined;
+}
+
 export class MastraCompositeStore extends MastraBase {
   protected hasInitialized: null | Promise<boolean> = null;
   protected shouldCacheInit = true;
 
   id: string;
   stores?: StorageDomains;
+  protected mastra?: StorageMastraRef;
 
   /**
    * When true, automatic initialization (table creation/migrations) is disabled.
@@ -316,6 +327,31 @@ export class MastraCompositeStore extends MastraBase {
       } as StorageDomains;
     }
     // Otherwise, subclasses set stores themselves
+  }
+
+  /**
+   * Register the Mastra instance with this storage adapter and cascade the
+   * reference to all owned domain stores and parent composites. Storage
+   * adapters that need to look up agents, editor config, etc. can read
+   * `this.mastra` after this is called.
+   * @internal
+   */
+  __registerMastra(mastra: StorageMastraRef): void {
+    this.mastra = mastra;
+    const seen = new Set<unknown>();
+    const cascade = (target: unknown) => {
+      if (!target || typeof target !== 'object' || seen.has(target)) return;
+      seen.add(target);
+      const fn = (target as { __registerMastra?: (m: StorageMastraRef) => void }).__registerMastra;
+      if (typeof fn === 'function' && target !== this) {
+        fn.call(target, mastra);
+      }
+    };
+    if (this.parentDefault) cascade(this.parentDefault);
+    if (this.parentEditor) cascade(this.parentEditor);
+    if (this.stores) {
+      for (const domain of Object.values(this.stores)) cascade(domain);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Second in the code-mode override stack. Adds a `__registerMastra` back-pointer on storage so storage domains can read live Mastra state (e.g. a code-defined agent's editor ownership config) without stamping that info into per-entity metadata.

### Why
Code-mode storage needs to know which fields each agent owns when writing per-entity JSON. Previously this was passed via per-entity metadata (`editorMode: 'code'`, `editorConfig: ...`), which leaked editor concerns into the storage layer and required casting through `unknown`. With a `mastra` back-pointer the agent's editor config can be read directly from the Agent instance.

### What's in this PR
- New `StorageMastraRef` interface in `storage/base.ts` exposing the minimum surface storage needs (`getAgentById`). Avoids a circular import on the full `Mastra` class.
- `MastraCompositeStore.__registerMastra(mastra)` cascades the ref to `parentDefault`, `parentEditor`, and each domain store.
- Mastra constructor and `setStorage()` call `storage.__registerMastra(this)`; editor `registerWithMastra` reordered to run after storage assignment.

### Stack
1. feat(core): per-entity filesystem storage + git history (#PR-A)
2. **This PR** — storage `__registerMastra` back-pointer
3. feat(core/editor): MastraEditor mode + Agent editor ownership
4. feat(server): code-mode override export + ownership enforcement
5. feat(playground): code-mode Editor UI + db-mode chat fix

### Test plan
- `pnpm test:core` → 817 tests pass
- `pnpm build:core` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets storage talk back to the main Mastra app so storage can read live agent/editor config instead of copying it into stored metadata, avoiding duplication and import cycles. It wires a small, safe Mastra reference into composite stores and their domains, with guards to prevent infinite recursion.

## Overview

Adds a narrow StorageMastraRef back-pointer and a registration cascade so storage domains can look up Mastra state (e.g., agent/editor config) without importing the full Mastra class. Ensures the back-pointer is set both at Mastra construction and when storage is replaced, and reorders editor registration so editor-driven overlays see the assigned storage.

## Changes

- New minimal interface:
  - exports StorageMastraRef in packages/core/src/storage/base.ts exposing getAgentById and getEditor (both optional).
- MastraCompositeStore:
  - adds protected mastra?: StorageMastraRef.
  - adds __registerMastra(mastra, seen?) which stores the reference and cascades it to parentDefault, parentEditor, and all domain stores.
  - cascade uses a shared seen Set and typeof fn === 'function' guard to prevent cycles and re-entry.
- Mastra integration:
  - Mastra constructor and setStorage now call storage?.__registerMastra?.(this) (storage registration occurs after storage assignment).
  - Editor registration is deferred until after storage registration so editor overlays observe assigned storage.
- Tests and docs:
  - Adds tests for __registerMastra cascade behavior and cycle prevention (A→B→A and self-cycle) in packages/core/src/storage/base.test.ts.
  - Adds a changeset documenting the new storage back-pointer and usage example; bumps `@mastra/core` minor.

## Tests / Build

- pnpm test:core → 817 tests pass
- pnpm build:core clean

## Notes

- No public API signatures were expanded beyond the new StorageMastraRef and the internal __registerMastra method; change is low complexity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->