### PR TITLE
feat(core/editor): MastraEditor mode + Agent editor ownership

### DIFF
--- a/.changeset/editor-code-mode-api.md
+++ b/.changeset/editor-code-mode-api.md
@@ -1,0 +1,30 @@
+---
+'@mastra/core': minor
+'@mastra/editor': minor
+---
+
+Added agent override support to the agent and editor APIs.
+
+Code-defined agents can now declare which fields Studio may edit with the `editor` option:
+
+```ts
+new Agent({
+  name: 'Weather Agent',
+  model,
+  editor: {
+    instructions: true,
+    tools: { description: true },
+  },
+});
+```
+
+The editor applies stored overrides only for fields the `editor` config owns, so locked fields keep their code-defined values. Per-agent `editor: false` locks an agent entirely.
+
+`MastraEditor` accepts a `source` setting that picks the editing experience:
+
+```ts
+new MastraEditor({ source: 'code' });
+```
+
+- `source: 'code'` — the editor auto-wires a `FilesystemStore` (defaulting to `./mastra/editor/`, overridable with `codePath`) when no editor storage is supplied, and persists overrides as deterministic per-agent JSON files.
+- `source: 'db'` (default) — keeps the existing storage-backed flow against whatever storage the project has configured.

--- a/packages/core/src/agent/agent-types.test-d.ts
+++ b/packages/core/src/agent/agent-types.test-d.ts
@@ -3,6 +3,7 @@ import { assertType, describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod/v4';
 import type { RequestContext } from '../request-context';
 import type { PublicSchema } from '../schema';
+import { Agent } from './agent';
 import type { AgentExecutionOptions, PublicAgentExecutionOptions } from './agent.types';
 import type { AgentConfig } from './types';
 
@@ -179,6 +180,76 @@ describe('Agent Type Tests', () => {
       // NonNullable<string | undefined> is `string`, which is not an object type,
       // so structuredOutput stays optional for the nullable-union case.
       assertType<AgentExecutionOptions<string | undefined>>({ maxSteps: 50 });
+    });
+  });
+
+  // Editor ownership is enforced via the `TEditor` generic inferred at
+  // `new Agent({...})` from the literal `editor` property. Annotating a value
+  // as the bare `AgentConfig` (default `TEditor`) intentionally does NOT narrow
+  // ownership, so these tests construct agents to exercise inference.
+  describe('editor config ownership', () => {
+    it('requires instructions when editor is absent', () => {
+      // @ts-expect-error - instructions is required when not owned by the editor
+      new Agent({ id: 'a', name: 'A', model: {} as any });
+    });
+
+    it('requires instructions when editor is false (nothing owned)', () => {
+      new Agent({ id: 'a', name: 'A', model: {} as any, editor: false, instructions: 'hi', tools: {} });
+
+      // @ts-expect-error - instructions still required when editor is false
+      new Agent({ id: 'a', name: 'A', model: {} as any, editor: false });
+    });
+
+    it('forbids instructions in code when editor owns instructions', () => {
+      new Agent({ id: 'a', name: 'A', model: {} as any, editor: { instructions: true }, tools: {} });
+
+      new Agent({
+        id: 'a',
+        name: 'A',
+        model: {} as any,
+        editor: { instructions: true },
+        // @ts-expect-error - instructions are owned by the editor, code must not set them
+        instructions: 'hi',
+      });
+    });
+
+    it('forbids tools in code when editor owns tool membership', () => {
+      new Agent({ id: 'a', name: 'A', model: {} as any, editor: { tools: true }, instructions: 'hi' });
+
+      new Agent({
+        id: 'a',
+        name: 'A',
+        model: {} as any,
+        editor: { tools: true },
+        instructions: 'hi',
+        // @ts-expect-error - tool membership is owned by the editor, code must not set tools
+        tools: {},
+      });
+    });
+
+    it('keeps tools code-owned in descriptions-only mode', () => {
+      // description-only editing leaves tool membership in code, so tools stay allowed
+      new Agent({
+        id: 'a',
+        name: 'A',
+        model: {} as any,
+        editor: { tools: { description: true } },
+        instructions: 'hi',
+        tools: {},
+      });
+    });
+
+    it('forbids both fields when editor owns instructions and tools', () => {
+      new Agent({ id: 'a', name: 'A', model: {} as any, editor: { instructions: true, tools: true } });
+
+      new Agent({
+        id: 'a',
+        name: 'A',
+        model: {} as any,
+        editor: { instructions: true, tools: true },
+        // @ts-expect-error - both fields owned by the editor
+        instructions: 'hi',
+      });
     });
   });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -308,6 +308,7 @@ export class Agent<
   TTools extends ToolsInput = ToolsInput,
   TOutput = undefined,
   TRequestContext extends Record<string, any> | unknown = unknown,
+  TEditor extends AgentEditorConfig | undefined = AgentEditorConfig | undefined,
 >
   extends MastraBase
   implements SubAgent<TAgentId, TRequestContext>
@@ -360,7 +361,7 @@ export class Agent<
   #activeStreamUntilIdle = new Map<string, () => void>();
   readonly #options?: AgentCreateOptions;
   #legacyHandler?: AgentLegacyHandler;
-  #config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext>;
+  #config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext, TEditor>;
 
   // This flag is for agent network messages. We should change the agent network formatting and remove this flag after.
   private _agentNetworkAppend = false;
@@ -384,7 +385,7 @@ export class Agent<
    * });
    * ```
    */
-  constructor(config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext>) {
+  constructor(config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext, TEditor>) {
     super({ component: RegisteredLogger.AGENT, rawConfig: config.rawConfig });
 
     this.#config = config;
@@ -2606,7 +2607,7 @@ export class Agent<
     const fork = new Agent<TAgentId, TTools, TOutput, TRequestContext>({
       ...this.#config,
       rawConfig: this.toRawConfig(),
-    });
+    } as AgentConfig<TAgentId, TTools, TOutput, TRequestContext>);
 
     // Preserve runtime state that may have been set after construction
     // (e.g. when Mastra registers agents via __registerMastra / __registerPrimitives).

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -118,6 +118,7 @@ import type {
   AgentModelManagerConfig,
   AgentCreateOptions,
   AgentExecuteOnFinishOptions,
+  AgentEditorConfig,
   AgentInstructions,
   AgentMessageInput,
   AgentMethodType,
@@ -345,6 +346,7 @@ export class Agent<
   #requestContextSchema?: StandardSchemaWithJSON<TRequestContext>;
   #backgroundTasks?: AgentBackgroundConfig;
   #toolPayloadTransform?: ToolPayloadTransformPolicy;
+  #editorConfig?: AgentEditorConfig;
   /**
    * Tracks the active `streamUntilIdle` wrapper per `(threadId|resourceId)`
    * scope on this Agent instance. A new call for the same scope aborts the
@@ -391,7 +393,8 @@ export class Agent<
     this.id = config.id ?? config.name;
     this.source = 'code';
 
-    this.#instructions = config.instructions;
+    this.#editorConfig = config.editor;
+    this.#instructions = config.instructions ?? '';
     this.#description = config.description;
     this.#metadata = config.metadata;
     this.#options = config.options;
@@ -2422,6 +2425,14 @@ export class Agent<
    */
   __resetToOriginalModel() {
     this.model = Array.isArray(this.#originalModel) ? [...this.#originalModel] : this.#originalModel;
+  }
+
+  /**
+   * Returns the editor ownership config for this agent.
+   * @internal
+   */
+  __getEditorConfig() {
+    return this.#editorConfig;
   }
 
   /**

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -261,7 +261,14 @@ export type ModelWithRetries = {
   headers?: DynamicArgument<Record<string, string>>;
 };
 
-export interface AgentConfig<
+export type AgentEditorConfig =
+  | false
+  | {
+      instructions?: boolean;
+      tools?: boolean | { description?: boolean };
+    };
+
+interface AgentConfigBase<
   TAgentId extends string = string,
   TTools extends ToolsInput = ToolsInput,
   TOutput = undefined,
@@ -547,6 +554,56 @@ export interface AgentConfig<
    */
   transform?: ToolPayloadTransformPolicy;
 }
+
+type AgentEditableFieldConfig<TTools extends ToolsInput, TRequestContext extends Record<string, any> | unknown> =
+  | {
+      editor?: undefined;
+      instructions: DynamicArgument<AgentInstructions, TRequestContext>;
+      tools?: DynamicArgument<TTools, TRequestContext>;
+    }
+  | {
+      editor: false;
+      instructions: DynamicArgument<AgentInstructions, TRequestContext>;
+      tools?: DynamicArgument<TTools, TRequestContext>;
+    }
+  | {
+      editor: { instructions?: false; tools?: false | { description?: false } };
+      instructions: DynamicArgument<AgentInstructions, TRequestContext>;
+      tools?: DynamicArgument<TTools, TRequestContext>;
+    }
+  | {
+      editor: { instructions: true; tools?: false | { description?: false } };
+      instructions?: never;
+      tools?: DynamicArgument<TTools, TRequestContext>;
+    }
+  | {
+      editor: { instructions?: false; tools: true };
+      instructions: DynamicArgument<AgentInstructions, TRequestContext>;
+      tools?: never;
+    }
+  | {
+      editor: { instructions: true; tools: true };
+      instructions?: never;
+      tools?: never;
+    }
+  | {
+      editor: { instructions?: false; tools: { description: true } };
+      instructions: DynamicArgument<AgentInstructions, TRequestContext>;
+      tools?: DynamicArgument<TTools, TRequestContext>;
+    }
+  | {
+      editor: { instructions: true; tools: { description: true } };
+      instructions?: never;
+      tools?: DynamicArgument<TTools, TRequestContext>;
+    };
+
+export type AgentConfig<
+  TAgentId extends string = string,
+  TTools extends ToolsInput = ToolsInput,
+  TOutput = undefined,
+  TRequestContext extends Record<string, any> | unknown = unknown,
+> = Omit<AgentConfigBase<TAgentId, TTools, TOutput, TRequestContext>, 'instructions' | 'tools'> &
+  AgentEditableFieldConfig<TTools, TRequestContext>;
 
 export type AgentMemoryOption = {
   thread: string | (Partial<StorageThreadType> & { id: string });

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -555,55 +555,46 @@ interface AgentConfigBase<
   transform?: ToolPayloadTransformPolicy;
 }
 
-type AgentEditableFieldConfig<TTools extends ToolsInput, TRequestContext extends Record<string, any> | unknown> =
-  | {
-      editor?: undefined;
-      instructions: DynamicArgument<AgentInstructions, TRequestContext>;
-      tools?: DynamicArgument<TTools, TRequestContext>;
-    }
-  | {
-      editor: false;
-      instructions: DynamicArgument<AgentInstructions, TRequestContext>;
-      tools?: DynamicArgument<TTools, TRequestContext>;
-    }
-  | {
-      editor: { instructions?: false; tools?: false | { description?: false } };
-      instructions: DynamicArgument<AgentInstructions, TRequestContext>;
-      tools?: DynamicArgument<TTools, TRequestContext>;
-    }
-  | {
-      editor: { instructions: true; tools?: false | { description?: false } };
-      instructions?: never;
-      tools?: DynamicArgument<TTools, TRequestContext>;
-    }
-  | {
-      editor: { instructions?: false; tools: true };
-      instructions: DynamicArgument<AgentInstructions, TRequestContext>;
-      tools?: never;
-    }
-  | {
-      editor: { instructions: true; tools: true };
-      instructions?: never;
-      tools?: never;
-    }
-  | {
-      editor: { instructions?: false; tools: { description: true } };
-      instructions: DynamicArgument<AgentInstructions, TRequestContext>;
-      tools?: DynamicArgument<TTools, TRequestContext>;
-    }
-  | {
-      editor: { instructions: true; tools: { description: true } };
-      instructions?: never;
-      tools?: DynamicArgument<TTools, TRequestContext>;
-    };
+/**
+ * Whether a given `editor` config hands a field to Studio (`true`) so that
+ * field becomes owned by Studio and must NOT be provided in code.
+ *
+ * To add a new editable field, add an `Owns*` helper here and a corresponding
+ * clause to {@link AgentEditableFieldConfig} — no combinatorial union needed.
+ */
+type EditorOwnsInstructions<TEditor> = TEditor extends { instructions: true } ? true : false;
+type EditorOwnsToolMembership<TEditor> = TEditor extends { tools: true } ? true : false;
+
+/**
+ * Resolves the `instructions`/`tools` portion of an agent config from the
+ * `editor` config inferred at `new Agent({...})`.
+ *
+ * `instructions` and `tools` are owned by *either* code or Studio, never both.
+ * When `editor` hands a field to Studio (`instructions: true` / `tools: true`),
+ * that field is forbidden in code (`?: never`); otherwise it keeps its normal
+ * code-owned shape. Tool *descriptions* (`tools: { description: true }`) keep
+ * tool membership in code, so they fall under the code-owned case.
+ */
+type AgentEditableFieldConfig<
+  TTools extends ToolsInput,
+  TRequestContext extends Record<string, any> | unknown,
+  TEditor extends AgentEditorConfig | undefined,
+> = (EditorOwnsInstructions<TEditor> extends true
+  ? { instructions?: never }
+  : { instructions: DynamicArgument<AgentInstructions, TRequestContext> }) &
+  (EditorOwnsToolMembership<TEditor> extends true
+    ? { tools?: never }
+    : { tools?: DynamicArgument<TTools, TRequestContext> });
 
 export type AgentConfig<
   TAgentId extends string = string,
   TTools extends ToolsInput = ToolsInput,
   TOutput = undefined,
   TRequestContext extends Record<string, any> | unknown = unknown,
-> = Omit<AgentConfigBase<TAgentId, TTools, TOutput, TRequestContext>, 'instructions' | 'tools'> &
-  AgentEditableFieldConfig<TTools, TRequestContext>;
+  TEditor extends AgentEditorConfig | undefined = AgentEditorConfig | undefined,
+> = Omit<AgentConfigBase<TAgentId, TTools, TOutput, TRequestContext>, 'instructions' | 'tools' | 'editor'> & {
+  editor?: TEditor;
+} & AgentEditableFieldConfig<TTools, TRequestContext, TEditor>;
 
 export type AgentMemoryOption = {
   thread: string | (Partial<StorageThreadType> & { id: string });

--- a/packages/core/src/editor/types.ts
+++ b/packages/core/src/editor/types.ts
@@ -178,6 +178,22 @@ export interface MastraEditorConfig {
    * When present and enabled, the editor provides agent building capabilities.
    */
   builder?: AgentBuilderOptions;
+  /**
+   * Editor mode controlling how agent overrides are persisted and surfaced in Studio.
+   *
+   * - `'code'` — overrides live as deterministic per-agent JSON files on disk
+   *   (default `./mastra/editor/`). Studio replaces Save/Publish with
+   *   filesystem/PR actions and routes editor storage domains through a local
+   *   `FilesystemStore` at `codePath`.
+   * - `'db'` — overrides live in the configured storage backend. Studio shows
+   *   the standard Save/Publish flow.
+   */
+  mode?: 'code' | 'db';
+  /**
+   * Filesystem path used by code mode for per-agent JSON files.
+   * Defaults to `./mastra/editor/`. Ignored when `mode` is not `'code'`.
+   */
+  codePath?: string;
 }
 
 export interface GetByIdOptions {
@@ -438,4 +454,11 @@ export interface IMastraEditor {
    * Optional for backwards compatibility.
    */
   resolveBuilder?(): Promise<IAgentBuilder | undefined>;
+
+  /**
+   * Returns the editor's configured mode (`'code'` | `'db'`), or `undefined`
+   * if the editor was constructed without an explicit mode. Optional for
+   * backwards compatibility.
+   */
+  getMode?(): 'code' | 'db' | undefined;
 }

--- a/packages/core/src/editor/types.ts
+++ b/packages/core/src/editor/types.ts
@@ -179,7 +179,8 @@ export interface MastraEditorConfig {
    */
   builder?: AgentBuilderOptions;
   /**
-   * Editor mode controlling how agent overrides are persisted and surfaced in Studio.
+   * Source of truth for agent overrides — controls how they are persisted and
+   * surfaced in Studio.
    *
    * - `'code'` — overrides live as deterministic per-agent JSON files on disk
    *   (default `./mastra/editor/`). Studio replaces Save/Publish with
@@ -188,10 +189,10 @@ export interface MastraEditorConfig {
    * - `'db'` — overrides live in the configured storage backend. Studio shows
    *   the standard Save/Publish flow.
    */
-  mode?: 'code' | 'db';
+  source?: 'code' | 'db';
   /**
-   * Filesystem path used by code mode for per-agent JSON files.
-   * Defaults to `./mastra/editor/`. Ignored when `mode` is not `'code'`.
+   * Filesystem path used by the `'code'` source for per-agent JSON files.
+   * Defaults to `./mastra/editor/`. Ignored when `source` is not `'code'`.
    */
   codePath?: string;
 }
@@ -456,9 +457,9 @@ export interface IMastraEditor {
   resolveBuilder?(): Promise<IAgentBuilder | undefined>;
 
   /**
-   * Returns the editor's configured mode (`'code'` | `'db'`), or `undefined`
-   * if the editor was constructed without an explicit mode. Optional for
+   * Returns the editor's configured source (`'code'` | `'db'`), or `undefined`
+   * if the editor was constructed without an explicit source. Optional for
    * backwards compatibility.
    */
-  getMode?(): 'code' | 'db' | undefined;
+  getSource?(): 'code' | 'db' | undefined;
 }

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -237,7 +237,7 @@ export interface MastraCompositeStoreConfig {
  */
 export interface StorageMastraRef {
   getAgentById?: (id: string) => { source?: string; __getEditorConfig?: () => unknown } | undefined;
-  getEditor?: () => { getMode?: () => 'code' | 'db' | undefined } | undefined;
+  getEditor?: () => { getSource?: () => 'code' | 'db' | undefined } | undefined;
 }
 
 export class MastraCompositeStore extends MastraBase {

--- a/packages/core/src/storage/domains/agents/filesystem.ts
+++ b/packages/core/src/storage/domains/agents/filesystem.ts
@@ -1,3 +1,4 @@
+import type { StorageMastraRef } from '../../base';
 import type { FilesystemDB } from '../../filesystem-db';
 import { FilesystemVersionedHelpers } from '../../filesystem-versioned';
 import type {
@@ -26,6 +27,49 @@ const PERSISTED_SNAPSHOT_FIELDS = new Set([
   'requestContextSchema',
 ]);
 
+/**
+ * Fields always excluded from per-entity (code-mode) JSON files regardless
+ * of editor config. `model`/`name` are not editable from Studio for
+ * code-defined agents, so they should not appear in the committed override
+ * JSON — they would otherwise look like settable fields in code review and
+ * could drift from the source-of-truth declaration in code.
+ */
+const CODE_MODE_EXCLUDED_FIELDS = new Set(['model', 'name']);
+
+/**
+ * Fields that depend on per-agent editor ownership.
+ * When the agent's editor config does not own a given field (e.g.
+ * descriptions-only mode does not own raw instructions), it should be
+ * omitted from the on-disk per-entity JSON entirely.
+ */
+const OWNED_FIELDS_BY_GROUP = {
+  instructions: ['instructions'],
+  tools: ['tools', 'integrationTools', 'mcpClients'],
+} as const;
+
+function ownershipFromEditorConfig(editorConfig: unknown): {
+  ownsInstructions: boolean;
+  ownsTools: boolean;
+} {
+  if (editorConfig === false) {
+    return { ownsInstructions: false, ownsTools: false };
+  }
+  if (editorConfig === undefined || editorConfig === null) {
+    // Code agents without explicit editor config behave as fully editable.
+    return { ownsInstructions: true, ownsTools: true };
+  }
+  if (typeof editorConfig !== 'object') {
+    return { ownsInstructions: false, ownsTools: false };
+  }
+  const cfg = editorConfig as { instructions?: unknown; tools?: unknown };
+  const ownsInstructions = cfg.instructions === true;
+  const toolsCfg = cfg.tools;
+  const ownsTools =
+    toolsCfg === true ||
+    (typeof toolsCfg === 'object' && toolsCfg !== null && (toolsCfg as { description?: unknown }).description === true);
+  return { ownsInstructions, ownsTools };
+}
+
 function stripUnusedFields<T extends Record<string, unknown>>(obj: T): T {
   const result = {} as Record<string, unknown>;
   for (const [key, value] of Object.entries(obj)) {
@@ -38,16 +82,51 @@ function stripUnusedFields<T extends Record<string, unknown>>(obj: T): T {
 
 export class FilesystemAgentsStorage extends AgentsStorage {
   private helpers: FilesystemVersionedHelpers<StorageAgentType, AgentVersion>;
+  private storageMastra?: StorageMastraRef;
 
   constructor({ db }: { db: FilesystemDB }) {
     super();
+    const isCodeAgent = (entityId: string): boolean => {
+      const agent = this.storageMastra?.getAgentById?.(entityId);
+      return agent?.source === 'code';
+    };
+    const editorConfigFor = (entityId: string): unknown => {
+      const agent = this.storageMastra?.getAgentById?.(entityId);
+      return agent?.__getEditorConfig?.();
+    };
     this.helpers = new FilesystemVersionedHelpers({
       db,
       entitiesFile: 'agents.json',
       parentIdField: 'agentId',
       name: 'FilesystemAgentsStorage',
       versionMetadataFields: ['id', 'agentId', 'versionNumber', 'changedFields', 'changeMessage', 'createdAt'],
+      perEntityFilesDir: 'agents',
+      // Per-entity layout is used only for code-mode agents — i.e. agents
+      // that are declared in code (`source === 'code'`). For db-mode and
+      // user-created stored agents we keep the shared `agents.json` layout.
+      shouldPersistToPerEntityFile: entity => isCodeAgent(entity.id),
+      perEntitySnapshotFilter: (snapshot, entity) => {
+        const { ownsInstructions, ownsTools } = ownershipFromEditorConfig(editorConfigFor(entity.id));
+        const excludedByOwnership = new Set<string>();
+        if (!ownsInstructions) {
+          for (const field of OWNED_FIELDS_BY_GROUP.instructions) excludedByOwnership.add(field);
+        }
+        if (!ownsTools) {
+          for (const field of OWNED_FIELDS_BY_GROUP.tools) excludedByOwnership.add(field);
+        }
+        const result: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(snapshot)) {
+          if (CODE_MODE_EXCLUDED_FIELDS.has(key)) continue;
+          if (excludedByOwnership.has(key)) continue;
+          result[key] = value;
+        }
+        return result;
+      },
     });
+  }
+
+  __registerMastra(mastra: StorageMastraRef): void {
+    this.storageMastra = mastra;
   }
 
   override async init(): Promise<void> {

--- a/packages/core/src/storage/filesystem.test.ts
+++ b/packages/core/src/storage/filesystem.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -500,6 +500,144 @@ describe('FilesystemStore', () => {
 
       raw = JSON.parse(readFileSync(join(dir, 'agents.json'), 'utf-8'));
       expect(raw['a1']).toBeUndefined();
+    });
+
+    it('writes code-mode agent overrides to deterministic per-agent files', async () => {
+      store.__registerMastra({
+        getAgentById: (id: string) =>
+          id === 'weatherAgent'
+            ? { source: 'code', __getEditorConfig: () => ({ instructions: true, tools: true }) }
+            : undefined,
+      });
+      const agents = await store.getStore('agents');
+      await agents!.create({
+        agent: {
+          id: 'weatherAgent',
+          name: 'Weather Agent',
+          instructions: 'Use the weather tools',
+          model: { provider: 'openai', name: 'gpt-4' },
+          tools: { getWeather: { description: 'Fetch weather' } },
+        },
+      });
+
+      const v1 = await agents!.getLatestVersion('weatherAgent');
+      await agents!.update({ id: 'weatherAgent', activeVersionId: v1!.id, status: 'published' });
+
+      // The shared agents.json should not be created for a code-mode-only
+      // workspace — only per-entity files. (If a shared file already exists
+      // from db-mode usage it would still be written and exclude the code
+      // agent.)
+      expect(existsSync(join(dir, 'agents.json'))).toBe(false);
+
+      const agentRaw = JSON.parse(readFileSync(join(dir, 'agents', 'weatherAgent.json'), 'utf-8'));
+      // Code-mode per-entity files exclude fields that are not editable from
+      // Studio (`name` and `model`) so the committed override JSON only carries
+      // user-controlled overrides.
+      expect(agentRaw).toEqual({
+        instructions: 'Use the weather tools',
+        tools: { getWeather: { description: 'Fetch weather' } },
+      });
+      expect(agentRaw).not.toHaveProperty('name');
+      expect(agentRaw).not.toHaveProperty('model');
+    });
+
+    it('hydrates code-mode agent overrides from per-agent files', async () => {
+      store.__registerMastra({
+        getAgentById: (id: string) =>
+          id === 'weatherAgent'
+            ? { source: 'code', __getEditorConfig: () => ({ instructions: true, tools: true }) }
+            : undefined,
+      });
+      const agents = await store.getStore('agents');
+      await agents!.create({
+        agent: {
+          id: 'weatherAgent',
+          name: 'Weather Agent',
+          instructions: 'Use the weather tools',
+          model: { provider: 'openai', name: 'gpt-4' },
+        },
+      });
+
+      const v1 = await agents!.getLatestVersion('weatherAgent');
+      await agents!.update({ id: 'weatherAgent', activeVersionId: v1!.id, status: 'published' });
+
+      const nextStore = new FilesystemStore({ dir });
+      await nextStore.init();
+      nextStore.__registerMastra({
+        getAgentById: (id: string) =>
+          id === 'weatherAgent'
+            ? { source: 'code', __getEditorConfig: () => ({ instructions: true, tools: true }) }
+            : undefined,
+      });
+      const nextAgents = await nextStore.getStore('agents');
+      const restored = await nextAgents!.getByIdResolved('weatherAgent', { status: 'published' });
+
+      expect(restored?.id).toBe('weatherAgent');
+      expect(restored?.instructions).toBe('Use the weather tools');
+    });
+
+    it('writes per-entity code-mode JSON with alphabetically sorted keys for stable diffs', async () => {
+      store.__registerMastra({
+        getAgentById: (id: string) =>
+          id === 'weatherAgent'
+            ? { source: 'code', __getEditorConfig: () => ({ instructions: true, tools: true }) }
+            : undefined,
+      });
+      const agents = await store.getStore('agents');
+      await agents!.create({
+        agent: {
+          id: 'weatherAgent',
+          name: 'Weather Agent',
+          // Build instructions with keys deliberately out of alphabetical order
+          // to confirm the on-disk JSON normalizes ordering.
+          instructions: [{ type: 'prompt_block', content: 'block content here' }] as unknown as string,
+          model: { provider: 'openai', name: 'gpt-4' },
+          tools: { getWeather: { description: 'Fetch weather' } },
+        },
+      });
+
+      const v1 = await agents!.getLatestVersion('weatherAgent');
+      await agents!.update({ id: 'weatherAgent', activeVersionId: v1!.id, status: 'published' });
+
+      const raw = readFileSync(join(dir, 'agents', 'weatherAgent.json'), 'utf-8');
+      const parsed = JSON.parse(raw);
+
+      // Top-level keys are alphabetical
+      expect(Object.keys(parsed)).toEqual([...Object.keys(parsed)].sort());
+      // Nested prompt-block keys are alphabetical (`content` before `type`)
+      expect(Object.keys(parsed.instructions[0])).toEqual(['content', 'type']);
+
+      // The shared agents.json should not be written when every published
+      // agent is stored in per-entity files — otherwise git tracks an
+      // always-empty stub file alongside the real per-agent files.
+      expect(existsSync(join(dir, 'agents.json'))).toBe(false);
+    });
+
+    it('removes per-agent files when code-mode overrides are deleted', async () => {
+      store.__registerMastra({
+        getAgentById: (id: string) =>
+          id === 'weatherAgent'
+            ? { source: 'code', __getEditorConfig: () => ({ instructions: true, tools: true }) }
+            : undefined,
+      });
+      const agents = await store.getStore('agents');
+      await agents!.create({
+        agent: {
+          id: 'weatherAgent',
+          name: 'Weather Agent',
+          instructions: 'Use the weather tools',
+          model: { provider: 'openai', name: 'gpt-4' },
+        },
+      });
+
+      const v1 = await agents!.getLatestVersion('weatherAgent');
+      await agents!.update({ id: 'weatherAgent', activeVersionId: v1!.id, status: 'published' });
+      const agentFile = join(dir, 'agents', 'weatherAgent.json');
+      expect(existsSync(agentFile)).toBe(true);
+
+      await agents!.delete('weatherAgent');
+
+      expect(existsSync(agentFile)).toBe(false);
     });
   });
 

--- a/packages/editor/src/apply-stored-overrides.test.ts
+++ b/packages/editor/src/apply-stored-overrides.test.ts
@@ -56,6 +56,108 @@ describe('applyStoredOverrides', () => {
     expect(instructions).toBe('You are a stored-config agent with updated instructions.');
   });
 
+  it('does not override anything when code agent disables editor overrides', async () => {
+    const storage = new InMemoryStore();
+    const editor = new MastraEditor();
+    const codeTool = createTool({
+      id: 'code-tool',
+      description: 'Code description',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ ok: z.boolean() }),
+      execute: async () => ({ ok: true }),
+    });
+    const storedTool = createTool({
+      id: 'stored-tool',
+      description: 'Stored description',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ ok: z.boolean() }),
+      execute: async () => ({ ok: true }),
+    });
+    const codeAgent = new Agent({
+      id: 'my-agent',
+      name: 'Code Agent',
+      instructions: 'Code instructions',
+      model: 'openai/gpt-4o',
+      tools: { 'code-tool': codeTool },
+      editor: false,
+    });
+    new Mastra({
+      storage,
+      editor,
+      agents: { 'my-agent': codeAgent },
+      tools: { 'stored-tool': storedTool },
+    });
+
+    const agentsStore = await storage.getStore('agents');
+    await agentsStore?.create({
+      agent: {
+        id: 'my-agent',
+        name: 'Stored Agent',
+        instructions: 'Stored instructions',
+        model: { provider: 'openai', name: 'gpt-4o' },
+        tools: { 'stored-tool': {} },
+      },
+    });
+
+    const result = await editor.agent.applyStoredOverrides(codeAgent);
+
+    expect(await result.getInstructions()).toBe('Code instructions');
+    const tools = await result.listTools();
+    expect(tools['code-tool']).toBeDefined();
+    expect(tools['stored-tool']).toBeUndefined();
+  });
+
+  it('only applies stored tool description overrides when code owns tool implementations', async () => {
+    const storage = new InMemoryStore();
+    const editor = new MastraEditor();
+    const codeTool = createTool({
+      id: 'code-tool',
+      description: 'Code description',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ ok: z.boolean() }),
+      execute: async () => ({ ok: true }),
+    });
+    const storedTool = createTool({
+      id: 'stored-tool',
+      description: 'Stored description',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ ok: z.boolean() }),
+      execute: async () => ({ ok: true }),
+    });
+    const codeAgent = new Agent({
+      id: 'my-agent',
+      name: 'Code Agent',
+      instructions: 'Code instructions',
+      model: 'openai/gpt-4o',
+      tools: { 'code-tool': codeTool },
+      editor: { tools: { description: true } },
+    });
+    new Mastra({
+      storage,
+      editor,
+      agents: { 'my-agent': codeAgent },
+      tools: { 'stored-tool': storedTool },
+    });
+
+    const agentsStore = await storage.getStore('agents');
+    await agentsStore?.create({
+      agent: {
+        id: 'my-agent',
+        name: 'Stored Agent',
+        instructions: 'Stored instructions',
+        model: { provider: 'openai', name: 'gpt-4o' },
+        tools: { 'code-tool': { description: 'Stored code-tool description' }, 'stored-tool': {} },
+      },
+    });
+
+    const result = await editor.agent.applyStoredOverrides(codeAgent);
+
+    expect(await result.getInstructions()).toBe('Code instructions');
+    const tools = await result.listTools();
+    expect(tools['code-tool']?.description).toBe('Stored code-tool description');
+    expect(tools['stored-tool']).toBeUndefined();
+  });
+
   it('does not override model from stored config (model is code-only)', async () => {
     const { editor, codeAgent } = await setup({
       name: 'Stored Agent',

--- a/packages/editor/src/ee/agent-builder-agent.ts
+++ b/packages/editor/src/ee/agent-builder-agent.ts
@@ -1,4 +1,5 @@
 import { Agent } from '@mastra/core/agent';
+import type { AgentConfig } from '@mastra/core/agent';
 import { Memory } from '@mastra/memory';
 import { Workspace, LocalFilesystem } from '@mastra/core/workspace';
 
@@ -35,11 +36,11 @@ const workspace = new Workspace({
  */
 
 export function createBuilderAgent(
-  args?: Partial<ConstructorParameters<typeof Agent<'builder-agent'>>[0]>,
+  args?: Partial<Omit<AgentConfig<'builder-agent'>, 'editor'>>,
 ): Agent<'builder-agent'> {
   const memory = new Memory();
 
-  return new Agent<'builder-agent'>({
+  const config: AgentConfig<'builder-agent'> = {
     instructions: `You are the Agent Builder.
 
 Your job: turn a non-technical user's plain-language request into a fully configured, production-quality agent in a single turn.
@@ -175,5 +176,7 @@ The system prompt written into \`set-agent-instructions\` MUST include all of th
     id: 'builder-agent',
     name: 'Agent Builder Agent',
     description: 'An agent that can build agents',
-  });
+  };
+
+  return new Agent<'builder-agent'>(config);
 }

--- a/packages/editor/src/ee/agent-builder-agent.ts
+++ b/packages/editor/src/ee/agent-builder-agent.ts
@@ -35,9 +35,7 @@ const workspace = new Workspace({
  * - createSkillTool (gated by features.skills) — only when a needed capability does not exist
  */
 
-export function createBuilderAgent(
-  args?: Partial<Omit<AgentConfig<'builder-agent'>, 'editor'>>,
-): Agent<'builder-agent'> {
+export function createBuilderAgent(args?: Partial<AgentConfig<'builder-agent'>>): Agent<'builder-agent'> {
   const memory = new Memory();
 
   const config: AgentConfig<'builder-agent'> = {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -58,7 +58,7 @@ export class MastraEditor implements IMastraEditor {
 
   private __toolProviders: Record<string, ToolProvider>;
   private __processorProviders: Record<string, ProcessorProvider>;
-  private __mode?: 'code' | 'db';
+  private __source?: 'code' | 'db';
   private __codePath: string;
   private readonly __builderConfig?: AgentBuilderOptions;
   private __builderInstance?: IAgentBuilder;
@@ -106,7 +106,7 @@ export class MastraEditor implements IMastraEditor {
     this.__logger = config?.logger;
     this.__toolProviders = config?.toolProviders ?? {};
     this.__processorProviders = { ...BUILT_IN_PROCESSOR_PROVIDERS, ...config?.processorProviders };
-    this.__mode = config?.mode;
+    this.__source = config?.source;
     this.__codePath = config?.codePath ?? './mastra/editor';
 
     // Built-in providers are always registered first, then merged with user-provided ones
@@ -161,7 +161,7 @@ export class MastraEditor implements IMastraEditor {
     // Code mode routes editor-owned domains to a FilesystemStore at `codePath`.
     // If app storage already exists, keep it as the default for non-editor domains
     // and overlay filesystem storage for editor saves.
-    if (this.__mode === 'code') {
+    if (this.__source === 'code') {
       const filesystemStore = new FilesystemStore({ dir: this.__codePath });
       const existingStorage = mastra.getStorage();
 
@@ -376,9 +376,9 @@ export class MastraEditor implements IMastraEditor {
     }
   }
 
-  /** Returns the editor's configured mode, or undefined if unset. */
-  getMode(): 'code' | 'db' | undefined {
-    return this.__mode;
+  /** Returns the editor's configured source, or undefined if unset. */
+  getSource(): 'code' | 'db' | undefined {
+    return this.__source;
   }
 
   /** Registered tool providers */

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -11,6 +11,7 @@ import type {
 import type { IMastraLogger as Logger } from '@mastra/core/logger';
 import { BUILT_IN_PROCESSOR_PROVIDERS } from '@mastra/core/processor-provider';
 import type { ProcessorProvider } from '@mastra/core/processor-provider';
+import { FilesystemStore, MastraCompositeStore } from '@mastra/core/storage';
 import type { BlobStore } from '@mastra/core/storage';
 import { UnknownToolProviderError } from '@mastra/core/tool-provider';
 import type { ToolProvider } from '@mastra/core/tool-provider';
@@ -57,6 +58,8 @@ export class MastraEditor implements IMastraEditor {
 
   private __toolProviders: Record<string, ToolProvider>;
   private __processorProviders: Record<string, ProcessorProvider>;
+  private __mode?: 'code' | 'db';
+  private __codePath: string;
   private readonly __builderConfig?: AgentBuilderOptions;
   private __builderInstance?: IAgentBuilder;
   private __builderResolved = false;
@@ -103,6 +106,8 @@ export class MastraEditor implements IMastraEditor {
     this.__logger = config?.logger;
     this.__toolProviders = config?.toolProviders ?? {};
     this.__processorProviders = { ...BUILT_IN_PROCESSOR_PROVIDERS, ...config?.processorProviders };
+    this.__mode = config?.mode;
+    this.__codePath = config?.codePath ?? './mastra/editor';
 
     // Built-in providers are always registered first, then merged with user-provided ones
     this.__filesystems = new Map<string, FilesystemProvider>();
@@ -151,6 +156,26 @@ export class MastraEditor implements IMastraEditor {
     this.__mastra = mastra;
     if (!this.__logger) {
       this.__logger = mastra.getLogger();
+    }
+
+    // Code mode routes editor-owned domains to a FilesystemStore at `codePath`.
+    // If app storage already exists, keep it as the default for non-editor domains
+    // and overlay filesystem storage for editor saves.
+    if (this.__mode === 'code') {
+      const filesystemStore = new FilesystemStore({ dir: this.__codePath });
+      const existingStorage = mastra.getStorage();
+
+      if (existingStorage) {
+        mastra.setStorage(
+          new MastraCompositeStore({
+            id: `${existingStorage.id}-with-editor-filesystem`,
+            default: existingStorage,
+            editor: filesystemStore,
+          }),
+        );
+      } else {
+        mastra.setStorage(filesystemStore);
+      }
     }
 
     // Fire-and-forget: persist builder default workspace to DB if configured,
@@ -349,6 +374,11 @@ export class MastraEditor implements IMastraEditor {
           'Ensure @mastra/core is updated to a version that includes EE support.',
       );
     }
+  }
+
+  /** Returns the editor's configured mode, or undefined if unset. */
+  getMode(): 'code' | 'db' | undefined {
+    return this.__mode;
   }
 
   /** Registered tool providers */

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -48,6 +48,8 @@ import { CrudEditorNamespace } from './base';
 import type { StorageAdapter } from './base';
 import { EditorMCPNamespace } from './mcp';
 
+type AgentEditorConfig = false | { instructions?: boolean; tools?: boolean | { description?: boolean } };
+
 // ============================================================================
 // Builder Defaults
 // ============================================================================
@@ -346,6 +348,19 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
     options?: { status?: 'draft' | 'published' } | { versionId: string },
     requestContext?: RequestContext,
   ): Promise<Agent> {
+    const editorConfig = (
+      agent as Agent & { __getEditorConfig?: () => AgentEditorConfig | undefined }
+    ).__getEditorConfig?.();
+    if (editorConfig === false) {
+      return agent;
+    }
+
+    const instructionsEditable = editorConfig === undefined ? true : editorConfig.instructions === true;
+    const toolsConfig = editorConfig === undefined ? true : editorConfig.tools;
+    const toolsEditable = toolsConfig === true;
+    const toolDescriptionsEditable =
+      typeof toolsConfig === 'object' && toolsConfig !== null && toolsConfig.description === true;
+
     let storedConfig: StorageResolvedAgentType | null = null;
     try {
       this.ensureRegistered();
@@ -380,7 +395,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
     this.logger?.debug(`[applyStoredOverrides] Applying stored overrides to code agent "${agent.id}"`);
 
     // --- Instructions ---
-    if (storedConfig.instructions !== undefined && storedConfig.instructions !== null) {
+    if (instructionsEditable && storedConfig.instructions !== undefined && storedConfig.instructions !== null) {
       const resolved = this.resolveStoredInstructions(storedConfig.instructions);
       if (resolved !== undefined) {
         fork.__updateInstructions(resolved);
@@ -394,7 +409,7 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
     const hasStoredToolProviders =
       storedConfig.toolProviders != null && Object.keys(storedConfig.toolProviders as object).length > 0;
 
-    if (hasStoredTools || hasStoredMCPClients || hasStoredIntegrationTools || hasStoredToolProviders) {
+    if (toolsEditable && (hasStoredTools || hasStoredMCPClients || hasStoredIntegrationTools || hasStoredToolProviders)) {
       const hasConditionalTools = this.isConditionalVariants(storedConfig.tools);
       const hasConditionalMCPClients =
         storedConfig.mcpClients != null && this.isConditionalVariants(storedConfig.mcpClients);
@@ -482,6 +497,30 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
           storedConfig.integrationTools as Record<string, StorageMCPClientToolsConfig> | undefined,
         );
         fork.__setTools({ ...codeTools, ...registryTools, ...mcpTools, ...integrationTools });
+      }
+    } else if (toolDescriptionsEditable && hasStoredTools) {
+      const hasConditionalTools = this.isConditionalVariants(storedConfig.tools);
+
+      if (hasConditionalTools) {
+        const originalTools = agent.listTools.bind(agent);
+        const toolsFn = async ({ requestContext }: { requestContext: RequestContext }): Promise<ToolsInput> => {
+          const codeTools = await originalTools({ requestContext });
+          const resolvedToolsConfig = this.accumulateObjectVariants(
+            storedConfig!.tools as StorageConditionalVariant<Record<string, StorageToolConfig>>[],
+            requestContext.toJSON(),
+          );
+
+          return this.applyStoredToolDescriptions(codeTools, resolvedToolsConfig);
+        };
+        fork.__setTools(toolsFn);
+      } else {
+        const codeTools = await fork.listTools();
+        fork.__setTools(
+          this.applyStoredToolDescriptions(
+            codeTools,
+            storedConfig.tools as Record<string, StorageToolConfig> | string[] | undefined,
+          ),
+        );
       }
     }
 
@@ -946,6 +985,27 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
       const context = requestContext.toJSON();
       return resolveInstructionBlocks(blocks, context, { promptBlocksStorage: promptBlocksStore });
     };
+  }
+
+  private applyStoredToolDescriptions(
+    codeTools: ToolsInput,
+    storedTools?: Record<string, StorageToolConfig> | string[],
+  ): ToolsInput {
+    if (!storedTools || Array.isArray(storedTools)) {
+      return codeTools;
+    }
+
+    let nextTools: ToolsInput | undefined;
+    for (const [toolKey, toolConfig] of Object.entries(storedTools)) {
+      if (!toolConfig.description || !(toolKey in codeTools)) {
+        continue;
+      }
+
+      nextTools ??= { ...codeTools };
+      nextTools[toolKey] = { ...codeTools[toolKey], description: toolConfig.description };
+    }
+
+    return nextTools ?? codeTools;
   }
 
   /**

--- a/packages/editor/src/namespaces/agent.ts
+++ b/packages/editor/src/namespaces/agent.ts
@@ -409,7 +409,10 @@ export class EditorAgentNamespace extends CrudEditorNamespace<
     const hasStoredToolProviders =
       storedConfig.toolProviders != null && Object.keys(storedConfig.toolProviders as object).length > 0;
 
-    if (toolsEditable && (hasStoredTools || hasStoredMCPClients || hasStoredIntegrationTools || hasStoredToolProviders)) {
+    if (
+      toolsEditable &&
+      (hasStoredTools || hasStoredMCPClients || hasStoredIntegrationTools || hasStoredToolProviders)
+    ) {
       const hasConditionalTools = this.isConditionalVariants(storedConfig.tools);
       const hasConditionalMCPClients =
         storedConfig.mcpClients != null && this.isConditionalVariants(storedConfig.mcpClients);


### PR DESCRIPTION
## Summary

Third in the code-mode override stack. Introduces the public API for code-mode agent overrides: a per-agent `editor` config that describes which fields Studio is allowed to override, and a `MastraEditor` `mode` config that toggles between db-backed versions and per-agent JSON files on disk.

### Why
Today Mastra agents are either fully code-defined (no editing in Studio) or stored entirely in the editor database. We want a third option: code-defined agents whose instructions/tools can be overridden via Studio, with overrides persisted as per-agent JSON files committed to git.

### What's in this PR
- `AgentEditorConfig` discriminated union: `false | { instructions?: boolean; tools?: boolean | { description?: boolean } }`. Used as the per-agent `editor` field.
- `Agent.__getEditorConfig()` and `Agent.__getOverridableFields()` so the editor and storage layers can read ownership and code-defined defaults.
- `MastraEditorConfig` gains `mode: 'code' | 'db'` and `codePath`. When `mode === 'code'` and no editor storage is provided, the editor auto-wires a `FilesystemStore` at `codePath` via `MastraCompositeStore`.
- `FilesystemAgentsStorage` becomes ownership-aware: reads the agent's editor config directly via the storage back-pointer (from PR #2) and strips unowned fields plus `model`/`name` from per-entity JSON.
- `applyStoredOverrides` (editor namespace) respects per-agent editor ownership when hydrating stored overrides.

### Stack
1. feat(core): per-entity filesystem storage + git history (#PR-A)
2. refactor(core): storage __registerMastra back-pointer (#PR-B)
3. **This PR** — MastraEditor mode + Agent editor ownership
4. feat(server): code-mode override export + ownership enforcement
5. feat(playground): code-mode Editor UI + db-mode chat fix

### Test plan
- `pnpm typecheck:core` clean
- `pnpm test:core -- src/storage/filesystem.test.ts` → 35 pass
- `pnpm --filter ./packages/editor test -- src/apply-stored-overrides.test.ts` → 13 pass
- Type tests for `AgentEditorConfig` discriminated union (`agent-types.test-d.ts`) pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets each agent say which parts of it Studio is allowed to edit, and adds a "code" editor mode that stores only those editable overrides as per-agent JSON files on disk (suitable for git) instead of in the DB.

## Overview

Adds per-agent editor ownership (which fields Studio may override) and a "code" editor source that auto-wires filesystem-backed storage for editor overrides. Code-owned agents keep locked fields at their code values (those fields are omitted from on-disk snapshots); owned fields can be overridden and are persisted as deterministic, per-agent JSON files. Editor hydration and storage flows respect per-agent ownership at runtime.

## Key Changes

- Agent editor ownership
  - New exported type: AgentEditorConfig = false | { instructions?: boolean; tools?: boolean | { description?: boolean } }.
  - Agent stores the editor config and exposes it via Agent.__getEditorConfig().
  - New helper Agent.__getOverridableFields() exposes which fields are editable / what defaults come from code (used by storage/hydration).
  - AgentConfig typing was refactored so compile-time checks forbid code-provided fields that the editor owns; type-tests added.

- MastraEditor "code" vs "db" source
  - MastraEditorConfig adds source?: 'code' | 'db' and codePath?: string; MastraEditor exposes getSource().
  - When source === 'code' and no editor storage is provided, a FilesystemStore at codePath (default ./mastra/editor/) is auto-wired via MastraCompositeStore so existing storage remains the default backend.

- Ownership-aware filesystem storage
  - FilesystemAgentsStorage is ownership-aware, holds a StorageMastraRef via __registerMastra to read agent editor configs at runtime, and omits unowned fields (and always model/name) from per-agent JSON snapshots for code-origin agents.
  - Per-agent files are deterministic (alphabetically sorted keys), are written/removed to reflect overrides for git, and contain only editable data.

- Apply stored overrides respects ownership
  - EditorAgentNamespace.applyStoredOverrides consults Agent.__getEditorConfig(); if editor === false, stored overrides are ignored.
  - Instructions and tools overrides apply only when owned. When only tool descriptions are owned, stored descriptions are merged into code-defined tools (via applyStoredToolDescriptions) without replacing the tool set.

- Misc / typing & API adjustments
  - StorageMastraRef updated to expose editor/source hooks used for wiring.
  - createBuilderAgent typing tightened.
  - Tests added/updated to validate behavior.

## Tests

- Filesystem store integration tests: per-agent JSON files for code-mode agents, deterministic key ordering, re-hydration into new store instances, and file removal when overrides deleted.
- applyStoredOverrides tests: ensure editor: false blocks overrides and that partial ownership (e.g., tool descriptions) only applies permitted overrides.
- Type-level tests updated to assert compile-time ownership constraints.

## Docs / Changeset

- Changeset updated for `@mastra/core` and `@mastra/editor` documenting agent/editor ownership and the editor "code" source behavior, including default codePath and intent for git-tracked per-agent JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->