### PR TITLE
01 feat(core): add message-first signal APIs

### DIFF
--- a/.changeset/clean-signals-message-api.md
+++ b/.changeset/clean-signals-message-api.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": minor
+---
+
+Add experimental `agent.sendMessage()` and `agent.queueMessage()` APIs for sending user-authored input into agent threads.
+
+This also normalizes signal categories so user messages use `type: 'user'` with `tagName: 'user'`, while preserving compatibility for legacy `user-message` and `system-reminder` signal payloads and stored records.

--- a/.changeset/harness-followups-queue-message.md
+++ b/.changeset/harness-followups-queue-message.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Use `queueMessage()` for Harness follow-up scheduling while preserving queued follow-up display state.

--- a/.changeset/soft-dogs-remind.md
+++ b/.changeset/soft-dogs-remind.md
@@ -1,0 +1,5 @@
+---
+"@mastra/memory": patch
+---
+
+Preserve system-reminder filtering for normalized reactive signal metadata.

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Signals | Agents"
-description: "Learn how to send real-time context into a Mastra agent thread."
+description: "Learn how to send real-time messages and context into a Mastra agent thread."
 packages:
   - "@mastra/core"
   - "@mastra/client-js"
@@ -14,13 +14,13 @@ This feature is in alpha. Breaking changes may occur without a major version bum
 
 :::
 
-Signals are a way to interact with an agent through a thread. Instead of starting every interaction with `agent.stream()`, subscribe to a thread and send signals. Mastra either wakes the agent when the thread is idle or drops the signal into the running agent loop.
+Signals are a way to interact with an agent through a thread. Instead of starting every interaction with `agent.stream()`, subscribe to a thread and send messages or signals. Mastra either wakes the agent when the thread is idle, drops input into the running agent loop, or queues input for the next turn.
 
-Signals are a context engineering tool for guiding the agent in real time as the agent loop progresses. Use them to add system-generated content from external event sources, such as incoming email notifications, GitHub pull request comments, background task notifications, and similar events.
+Use message APIs for user-authored input. Use `sendSignal()` for lower-level system context, such as background task notifications, policy reminders, or processor-generated context.
 
 ## Quickstart
 
-Subscribe to the thread before sending signals. The subscription receives the active stream when the signal wakes the agent or enters a running loop.
+Subscribe to the thread before sending messages. The subscription receives the active stream when the message wakes the agent or enters a running loop.
 
 ```typescript title="src/mastra/signals.ts"
 const subscription = await agent.subscribeToThread({
@@ -28,32 +28,65 @@ const subscription = await agent.subscribeToThread({
   threadId: 'thread_456',
 })
 
-agent.sendSignal(
-  {
-    type: 'user-message',
-    contents: 'Compare that with the previous option.',
-  },
-  {
-    resourceId: 'user_123',
-    threadId: 'thread_456',
-  },
-)
+agent.sendMessage('Compare that with the previous option.', {
+  resourceId: 'user_123',
+  threadId: 'thread_456',
+})
 
 for await (const chunk of subscription.stream) {
   console.log(chunk)
 }
 ```
 
-When the thread has a running agent stream, the signal becomes new input inside that agent loop. When the thread is idle, Mastra starts a stream with the signal as the first input.
+When the thread has a running agent stream, `sendMessage()` becomes new input inside that agent loop. When the thread is idle, Mastra starts a stream with the message as the first input.
 
-## Control signal behavior
+## Send a message now
 
-By default, Mastra delivers signals to active runs and wakes idle threads. Use `ifActive.behavior` and `ifIdle.behavior` to change that behavior.
+Use `sendMessage()` when the user expects the active agent to see the message immediately.
+
+```typescript title="src/mastra/signals.ts"
+agent.sendMessage(
+  {
+    contents: 'Use the latest customer note too.',
+    attributes: { name: 'Devin', sentFrom: 'slack' },
+  },
+  {
+    resourceId: 'user_123',
+    threadId: 'thread_456',
+  },
+)
+```
+
+The model receives attributed messages as XML-wrapped user input:
+
+```xml
+<user name="Devin" sentFrom="slack">Use the latest customer note too.</user>
+```
+
+Messages without attributes are sent as plain user input.
+
+## Queue a message for the next turn
+
+Use `queueMessage()` when a user sends a follow-up but the active model call should finish first. Mastra waits for the active run to complete, then starts a new run on the same thread.
+
+```typescript title="src/mastra/signals.ts"
+agent.queueMessage('Also check whether the tests need updates.', {
+  resourceId: 'user_123',
+  threadId: 'thread_456',
+})
+```
+
+When the thread is idle, `queueMessage()` starts a run immediately. When the thread is active, it preserves turn order by starting a new run after the active run completes.
+
+## Control low-level signal behavior
+
+Use `sendSignal()` when you need to send system-generated context instead of user-authored input. By default, Mastra delivers signals to active runs and wakes idle threads. Use `ifActive.behavior` and `ifIdle.behavior` to change that behavior.
 
 ```typescript title="src/mastra/signals.ts"
 const result = agent.sendSignal(
   {
-    type: 'user-message',
+    type: 'reactive',
+    tagName: 'system-reminder',
     contents: 'Store this for later, but do not wake the agent.',
   },
   {
@@ -70,68 +103,37 @@ await result.persisted
 
 The behavior options are:
 
-- `ifActive.behavior: 'deliver'`: Add the signal to the running agent loop. This is the default.
-- `ifActive.behavior: 'persist'`: Save the signal to memory without adding it to the running loop.
-- `ifActive.behavior: 'discard'`: Ignore the signal while the thread is active.
-- `ifIdle.behavior: 'wake'`: Start a stream with the signal as the first input. This is the default.
-- `ifIdle.behavior: 'persist'`: Save the signal to memory without starting a stream.
-- `ifIdle.behavior: 'discard'`: Ignore the signal while the thread is idle.
+- `ifActive.behavior: 'deliver'`: Add the signal or message to the running agent loop. This is the default.
+- `ifActive.behavior: 'persist'`: Save the signal or message to memory without adding it to the running loop.
+- `ifActive.behavior: 'discard'`: Ignore the signal or message while the thread is active.
+- `ifIdle.behavior: 'wake'`: Start a stream with the signal or message as the first input. This is the default.
+- `ifIdle.behavior: 'persist'`: Save the signal or message to memory without starting a stream.
+- `ifIdle.behavior: 'discard'`: Ignore the signal or message while the thread is idle.
 
 Pass `ifIdle.streamOptions` when the idle wake-up stream needs options such as model settings, tools, or runtime context. You do not need to repeat `memory.resource` or `memory.thread`; Mastra uses the top-level `resourceId` and `threadId` for the thread.
 
 ```typescript title="src/mastra/signals.ts"
-agent.sendSignal(
-  {
-    type: 'user-message',
-    contents: 'Continue with the next step.',
-  },
-  {
-    resourceId: 'user_123',
-    threadId: 'thread_456',
-    ifIdle: {
-      behavior: 'wake',
-      streamOptions: {
-        maxSteps: 3,
-      },
+agent.sendMessage('Continue with the next step.', {
+  resourceId: 'user_123',
+  threadId: 'thread_456',
+  ifIdle: {
+    behavior: 'wake',
+    streamOptions: {
+      maxSteps: 3,
     },
   },
-)
+})
 ```
-
-## Identify users with attributes
-
-Use `attributes` to tag each signal with user identity. The signal type and attributes are rendered as XML so the model can distinguish who said what in a multi-user thread:
-
-```typescript title="src/mastra/signals.ts"
-agent.sendSignal(
-  {
-    type: 'user',
-    contents: 'Can we simplify the API surface?',
-    attributes: { name: 'Devin', from: 'slack' },
-  },
-  {
-    resourceId: 'user_123',
-    threadId: 'thread_456',
-  },
-)
-```
-
-The model receives:
-
-```xml
-<user name="Devin" from="slack">Can we simplify the API surface?</user>
-```
-
-The UI sees just the message contents but can also read `attributes` and `metadata` off the signal message for custom rendering (e.g. showing user names, avatars, or platform badges).
 
 ## Send external event context
 
-Use custom signal types for system-generated context. Non-user signal types are rendered as XML-style user-role context so they can appear inside conversation history without looking like assistant output.
+Signals have a semantic `type` and an LLM-facing `tagName`. Use `type` to describe the signal category. Use `tagName` to control the XML tag the model sees.
 
 ```typescript title="src/mastra/signals.ts"
 agent.sendSignal(
   {
-    type: 'system-reminder',
+    type: 'reactive',
+    tagName: 'system-reminder',
     contents: 'User X has left a new PR comment asking for a smaller API surface.',
     attributes: {
       source: 'github',
@@ -145,22 +147,21 @@ agent.sendSignal(
 )
 ```
 
-The model receives the custom signal as context like this:
+The model receives the signal as context like this:
 
 ```xml
 <system-reminder source="github" pr="123">User X has left a new PR comment asking for a smaller API surface.</system-reminder>
 ```
 
-Use XML-safe signal type names and attribute names. Signal type names and attribute names can contain letters, numbers, underscores, periods, and hyphens. They must start with a letter or underscore.
+Use XML-safe `tagName` and attribute names. They can contain letters, numbers, underscores, periods, and hyphens. They must start with a letter or underscore.
 
 ## Delivery attributes
 
-Use `ifActive.attributes` and `ifIdle.attributes` to tag a signal with context that depends on whether the agent is active or idle at delivery time. Mastra resolves the correct branch when the signal is accepted.
+Use `ifActive.attributes` and `ifIdle.attributes` to tag input with context that depends on whether the agent is active or idle at delivery time. Mastra resolves the correct branch when the input is accepted.
 
 ```typescript title="src/mastra/signals.ts"
-agent.sendSignal(
+agent.sendMessage(
   {
-    type: 'user-message',
     contents: 'Also cover the edge cases.',
     attributes: { source: 'chat' },
   },
@@ -176,26 +177,33 @@ agent.sendSignal(
 When the agent is working, the model sees:
 
 ```xml
-<user-message source="chat" delivery="while-active">Also cover the edge cases.</user-message>
+<user source="chat" delivery="while-active">Also cover the edge cases.</user>
 ```
 
 When the agent is idle:
 
 ```xml
-<user-message source="chat" delivery="message">Also cover the edge cases.</user-message>
+<user source="chat" delivery="message">Also cover the edge cases.</user>
 ```
 
-Top-level `attributes` always apply. The selected branch's `attributes` are merged into them at delivery time. The `ifActive.attributes` branch merges when the signal is delivered to a running agent loop. The `ifIdle.attributes` branch merges when the signal wakes an idle thread. If the selected branch or its `attributes` field is `undefined`, no extra attributes are added.
+Top-level `attributes` always apply. The selected branch's `attributes` are merged into them at delivery time. The `delivery` name shown above is not a special Mastra API field. It is a custom attribute name used for this example.
 
-Delivery attributes work with any signal type and can carry any key-value pairs. The `delivery` name shown above is not a special Mastra API field. It is a custom attribute name used for this example; you can use any attribute names that fit your application.
+## Compatibility
+
+Mastra still accepts legacy signal payloads such as `type: 'user-message'` and `type: 'system-reminder'`. It normalizes them internally to the new category and tag shape:
+
+- `type: 'user-message'`: Normalizes to `type: 'user'` and `tagName: 'user'`
+- `type: 'system-reminder'`: Normalizes to `type: 'reactive'` and `tagName: 'system-reminder'`
+
+Existing stored signal rows and older clients continue to load through the compatibility layer.
 
 :::note
-Visit [Agent.sendSignal() reference](/reference/agents/agent#sendsignalsignal-options) for the full signal input and options types.
+Visit [Agent signals reference](/reference/agents/agent#thread-signals) for the full message, signal, and subscription types.
 :::
 
 ## Use the client SDK
 
-The JavaScript client exposes the same thread signal APIs. Use `subscribeToThread()` before `sendSignal()` so the client can render the stream that wakes from, or receives, the signal.
+The JavaScript client exposes thread signal APIs. Use `subscribeToThread()` before sending thread input so the client can render the stream that wakes from, or receives, the input.
 
 ```typescript title="src/app/chat.ts"
 const agent = client.getAgent('supportAgent')
@@ -244,6 +252,8 @@ Use heartbeats together with client-side reconnect logic. Heartbeats reduce idle
 
 ## Related
 
+- [`Agent.sendMessage()`](/reference/agents/agent#sendmessagemessage-options)
+- [`Agent.queueMessage()`](/reference/agents/agent#queuemessagemessage-options)
 - [`Agent.sendSignal()`](/reference/agents/agent#sendsignalsignal-options)
 - [`Agent.subscribeToThread()`](/reference/agents/agent#subscribetothreadoptions)
 - [`client.getAgent().sendSignal()`](/reference/client-js/agents#sendsignal)

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -48,7 +48,7 @@ Use `sendMessage()` when the user expects the active agent to see the message im
 agent.sendMessage(
   {
     contents: 'Use the latest customer note too.',
-    attributes: { name: 'Devin', sentFrom: 'slack' },
+    attributes: { name: 'Jane', sentFrom: 'slack' },
   },
   {
     resourceId: 'user_123',
@@ -60,7 +60,7 @@ agent.sendMessage(
 The model receives attributed messages as XML-wrapped user input:
 
 ```xml
-<user name="Devin" sentFrom="slack">Use the latest customer note too.</user>
+<user name="Jane" sentFrom="slack">Use the latest customer note too.</user>
 ```
 
 Messages without attributes are sent as plain user input.

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -110,9 +110,9 @@ export const agent = new Agent({
 
 ## Thread signals
 
-Use Agent signals to send real-time context into a memory thread. Signals are useful when a user adds input while an agent is already streaming, or when another process needs to add structured context to the thread.
+Use Agent signals to send real-time input and context into a memory thread. Message APIs are for user-authored input. `sendSignal()` is the lower-level API for system-generated context.
 
-A `user-message` signal represents user input. When the target thread is running, Mastra delivers the signal into the active agent loop. When the thread is idle, Mastra starts a stream with the signal as the first input by default.
+When the target thread is running, `sendMessage()` delivers the message into the active agent loop. When the thread is idle, Mastra starts a stream with the message as the first input by default.
 
 ```typescript title="src/mastra/signals.ts"
 const subscription = await agent.subscribeToThread({
@@ -126,26 +126,22 @@ void (async () => {
   }
 })()
 
-agent.sendSignal(
-  { type: 'user-message', contents: 'Use the latest customer note too.' },
-  {
-    resourceId: 'user-123',
-    threadId: 'thread-abc',
-    ifIdle: {
-      streamOptions: {
-        maxSteps: 3,
-      },
+agent.sendMessage('Use the latest customer note too.', {
+  resourceId: 'user-123',
+  threadId: 'thread-abc',
+  ifIdle: {
+    streamOptions: {
+      maxSteps: 3,
     },
   },
-)
+})
 ```
 
-Use `attributes` to identify different users in a shared thread. The signal type and attributes are rendered as XML so the model can distinguish who said what:
+Use `attributes` to identify different users in a shared thread. The attributes are rendered as XML so the model can distinguish who said what:
 
 ```typescript
-agent.sendSignal(
+agent.sendMessage(
   {
-    type: 'user',
     contents: 'Can we simplify the API surface?',
     attributes: { name: 'Devin', from: 'slack' },
   },
@@ -161,6 +157,73 @@ The model receives this as:
 
 The UI sees just the message contents but can also read `attributes` and `metadata` off the signal message for custom rendering (e.g. showing user names, avatars, or platform badges).
 
+### `sendMessage(message, options)`
+
+Sends a user message to an active run or memory thread. Use this when the active agent should receive the message immediately.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'message',
+    type: 'string | Array<TextPart | FilePart> | { contents: string | Array<TextPart | FilePart>; attributes?: Record<string, JSONValue>; metadata?: Record<string, unknown>; providerOptions?: ProviderMetadata }',
+    description:
+      'User-authored input. Bare strings and parts without attributes are sent to the model as normal user input. When `attributes` are present, Mastra renders the message as a `<user>` XML element with the attributes included.',
+  },
+  {
+    name: 'options.runId',
+    type: 'string',
+    isOptional: true,
+    description: 'Run ID to target directly. Use this when you already know the active run ID.',
+  },
+  {
+    name: 'options.resourceId',
+    type: 'string',
+    isOptional: true,
+    description: 'Resource ID for the memory thread. Required with `threadId` for thread-targeted messages.',
+  },
+  {
+    name: 'options.threadId',
+    type: 'string',
+    isOptional: true,
+    description: 'Thread ID to target. Required with `resourceId` for thread-targeted messages.',
+  },
+  {
+    name: 'options.ifActive.behavior',
+    type: "'deliver' | 'persist' | 'discard'",
+    isOptional: true,
+    description: 'Controls what happens when the target thread is active. Defaults to `deliver`.',
+  },
+  {
+    name: 'options.ifIdle.behavior',
+    type: "'wake' | 'persist' | 'discard'",
+    isOptional: true,
+    description: 'Controls what happens when the target thread is idle. Defaults to `wake`.',
+  },
+  {
+    name: 'options.ifIdle.streamOptions',
+    type: 'AgentExecutionOptions',
+    isOptional: true,
+    description:
+      'Options for the stream that starts when `ifIdle.behavior` is `wake`. Mastra uses the top-level `resourceId` and `threadId` for memory context.',
+  },
+]}
+/>
+
+Returns `{ accepted: true, runId: string, signal: CreatedAgentSignal, persisted?: Promise<void> }`. `persisted` is only present for `persist` behavior and resolves when Mastra finishes writing the message to memory.
+
+### `queueMessage(message, options)`
+
+Queues a user message for the next turn on a thread. If the thread is active, Mastra waits for the active run to finish, then starts a new run with the queued message. If the thread is idle, Mastra starts a run immediately.
+
+```typescript
+agent.queueMessage('Also check whether the tests need updates.', {
+  resourceId: 'user-123',
+  threadId: 'thread-abc',
+})
+```
+
+`queueMessage()` accepts the same `message` and `options` shape as `sendMessage()` and returns `{ accepted: true, runId: string, signal: CreatedAgentSignal, persisted?: Promise<void> }`.
+
 ### `sendSignal(signal, options)`
 
 Sends a signal to an active run or memory thread.
@@ -169,9 +232,9 @@ Sends a signal to an active run or memory thread.
   content={[
   {
     name: 'signal',
-    type: "{ type: 'user-message' | 'system-reminder' | string; contents: string | Array<TextPart | FilePart>; attributes?: Record<string, JSONValue>; metadata?: Record<string, unknown>; providerOptions?: ProviderMetadata }",
+    type: "{ type: 'user' | 'state' | 'reactive' | 'notification' | string; tagName?: string; contents: string | Array<TextPart | FilePart>; attributes?: Record<string, JSONValue>; metadata?: Record<string, unknown>; providerOptions?: ProviderMetadata }",
     description:
-      '`user-message` signals without attributes are treated as plain user input. All other signals — including `user-message` with `attributes`, `system-reminder`, and custom types — are wrapped in an XML element named after the signal type with `attributes` rendered as XML attributes (e.g. `<user name="Devin" from="slack">message</user>`). The model sees the XML; the UI sees the raw contents and can read `attributes` for custom rendering. `providerOptions` is attached to the resulting prompt turn and persisted on the stored signal message.',
+      "Signal context to send to the thread. `type` is the semantic signal category. `tagName` controls the XML tag the model sees. For example, `{ type: 'reactive', tagName: 'system-reminder' }` renders as `<system-reminder>...</system-reminder>`. Legacy `user-message` and `system-reminder` payloads are still accepted and normalized.",
   },
   {
     name: 'options.runId',
@@ -217,7 +280,7 @@ Returns `{ accepted: true, runId: string, signal: CreatedAgentSignal, persisted?
 
 ### `subscribeToThread(options)`
 
-Subscribes to raw stream chunks for a memory thread. Use this before calling `sendSignal()` when you need to render stream output, observe signal echoes, or abort the active run.
+Subscribes to raw stream chunks for a memory thread. Use this before calling `sendMessage()`, `queueMessage()`, or `sendSignal()` when you need to render stream output, observe signal echoes, or abort the active run.
 
 <PropertiesTable
   content={[

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -11,6 +11,7 @@ import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
 import { Agent } from '../agent';
 import {
+  createMessageSignal,
   createSignal,
   dataPartToSignal,
   mastraDBMessageToSignal,
@@ -127,13 +128,14 @@ describe('Agent signals', () => {
 
     expect(signal.toLLMMessage()).toEqual({
       role: 'user',
-      content: '<user-message priority="high">Signal contents</user-message>',
+      content: '<user priority="high">Signal contents</user>',
     });
     expect(signal.toDataPart()).toEqual({
       type: 'data-user-message',
       data: {
         id: 'signal-1',
-        type: 'user-message',
+        type: 'user',
+        tagName: 'user',
         contents: 'Signal contents',
         createdAt: '2026-01-01T00:00:00.000Z',
         acceptedAt: '2026-01-01T00:00:01.000Z',
@@ -149,7 +151,8 @@ describe('Agent signals', () => {
     expect(dbMessage.content.metadata).toEqual({
       signal: {
         id: 'signal-1',
-        type: 'user-message',
+        type: 'user',
+        tagName: 'user',
         createdAt: '2026-01-01T00:00:00.000Z',
         acceptedAt: '2026-01-01T00:00:01.000Z',
         attributes: { priority: 'high' },
@@ -239,6 +242,33 @@ describe('Agent signals', () => {
     expect(mastraDBMessageToSignal(fileSignal.toDBMessage()).contents).toEqual(fileContents);
   });
 
+  it('normalizes message signals and legacy signal types', () => {
+    const messageSignal = createMessageSignal({
+      contents: 'Hello',
+      attributes: { sentFrom: 'test' },
+    });
+    expect(messageSignal.type).toBe('user');
+    expect(messageSignal.tagName).toBe('user');
+    expect(messageSignal.toLLMMessage()).toEqual({ role: 'user', content: '<user sentFrom="test">Hello</user>' });
+
+    const legacyMessage = createSignal({ type: 'user-message', contents: 'Legacy message' });
+    expect(legacyMessage.type).toBe('user');
+    expect(legacyMessage.tagName).toBe('user');
+    expect(legacyMessage.toLLMMessage()).toEqual({ role: 'user', content: 'Legacy message' });
+
+    const legacyReminder = createSignal({ type: 'system-reminder', contents: 'Remember this' });
+    expect(legacyReminder.type).toBe('reactive');
+    expect(legacyReminder.tagName).toBe('system-reminder');
+    expect(legacyReminder.toLLMMessage()).toEqual({
+      role: 'user',
+      content: '<system-reminder>Remember this</system-reminder>',
+    });
+
+    const customLegacy = createSignal({ type: 'custom-reminder', contents: 'Legacy custom' });
+    expect(customLegacy.type).toBe('reactive');
+    expect(customLegacy.tagName).toBe('custom-reminder');
+  });
+
   it('renders user-message attributes inline-wrapped for text and multimodal contents', () => {
     const stringSignal = createSignal({
       type: 'user-message',
@@ -247,7 +277,7 @@ describe('Agent signals', () => {
     });
     expect(stringSignal.toLLMMessage()).toEqual({
       role: 'user',
-      content: '<user-message messageId="m-1" userId="u-1">Hello</user-message>',
+      content: '<user messageId="m-1" userId="u-1">Hello</user>',
     });
 
     const partsTextSignal = createSignal({
@@ -257,7 +287,7 @@ describe('Agent signals', () => {
     });
     expect(partsTextSignal.toLLMMessage()).toEqual({
       role: 'user',
-      content: '<user-message messageId="m-1b">Hello again</user-message>',
+      content: '<user messageId="m-1b">Hello again</user>',
     });
 
     const fileContents = [
@@ -280,7 +310,7 @@ describe('Agent signals', () => {
       expect.arrayContaining([
         expect.objectContaining({
           type: 'text',
-          text: '<user-message messageId="m-2">Look at this</user-message>',
+          text: '<user messageId="m-2">Look at this</user>',
         }),
         expect.objectContaining({
           type: 'file',
@@ -302,7 +332,7 @@ describe('Agent signals', () => {
     const fileOnlyResult = fileOnlySignal.toLLMMessage();
     expect(fileOnlyResult.role).toBe('user');
     expect(fileOnlyResult.content).toEqual([
-      expect.objectContaining({ type: 'text', text: '<user-message messageId="m-2d" />' }),
+      expect.objectContaining({ type: 'text', text: '<user messageId="m-2d" />' }),
       expect.objectContaining({ type: 'file', data: 'data:image/png;base64,aGVsbG8=' }),
     ]);
 
@@ -420,7 +450,7 @@ describe('Agent signals', () => {
     // Stash is dropped — metadata.signal carries only envelope fields (id/type/attributes/createdAt).
     const signalMeta = (userDb.content.metadata as { signal: Record<string, unknown> }).signal;
     expect(signalMeta).not.toHaveProperty('contents');
-    expect(signalMeta).toMatchObject({ type: 'user-message', attributes: { messageId: 'm-1' } });
+    expect(signalMeta).toMatchObject({ type: 'user', tagName: 'user', attributes: { messageId: 'm-1' } });
 
     const reminder = createSignal({
       type: 'system-reminder',
@@ -449,7 +479,8 @@ describe('Agent signals', () => {
       attributes: { kind: 'screenshot' },
     });
     const rehydrated = mastraDBMessageToSignal(reminder.toDBMessage());
-    expect(rehydrated.type).toBe('system-reminder');
+    expect(rehydrated.type).toBe('reactive');
+    expect(rehydrated.tagName).toBe('system-reminder');
     expect(rehydrated.contents).toEqual(screenshotContents);
     expect(rehydrated.attributes).toEqual({ kind: 'screenshot' });
 
@@ -855,6 +886,185 @@ describe('Agent signals', () => {
     subscription.unsubscribe();
   });
 
+  it('starts an idle thread run when sendMessage is called', async () => {
+    const agent = new Agent({
+      id: 'idle-message-agent',
+      name: 'Idle Message Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('message response'),
+    });
+
+    const subscription = await agent.subscribeToThread({
+      threadId: 'idle-message-thread',
+      resourceId: 'idle-message-user',
+    });
+    const nextRun = readNextRunWithParts(subscription.stream[Symbol.asyncIterator]());
+
+    const result = await agent.sendMessage(
+      { contents: 'Hello from sendMessage', attributes: { sentFrom: 'test' } },
+      {
+        resourceId: 'idle-message-user',
+        threadId: 'idle-message-thread',
+        ifIdle: { streamOptions: { memory: { resource: 'idle-message-user', thread: 'idle-message-thread' } } },
+      },
+    );
+
+    const subscribedRun = await nextRun;
+    expect(result).toEqual(expect.objectContaining({ accepted: true, runId: subscribedRun.value.runId }));
+    expect(result.signal).toMatchObject({ type: 'user', tagName: 'user', contents: 'Hello from sendMessage' });
+    const signalPart = subscribedRun.value.parts.find((part: any) => part.type === 'data-user-message');
+    expect(signalPart?.data).toMatchObject({
+      id: result.signal.id,
+      type: 'user',
+      tagName: 'user',
+      contents: 'Hello from sendMessage',
+      attributes: { sentFrom: 'test' },
+    });
+    expect(subscribedRun.value.text).toBe('message response');
+
+    subscription.unsubscribe();
+  });
+
+  it('delivers sendMessage into an active same-agent run', async () => {
+    let releaseFirst!: () => void;
+    const firstFinished = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    let streamCount = 0;
+    const prompts: any[][] = [];
+    const model = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        streamCount += 1;
+        prompts.push(prompt);
+        const responseText = streamCount === 1 ? 'first response' : 'message response';
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: new ReadableStream({
+            async start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+              controller.enqueue({
+                type: 'response-metadata',
+                id: `send-message-${streamCount}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              });
+              controller.enqueue({ type: 'text-start', id: 'text-1' });
+              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: responseText });
+              controller.enqueue({ type: 'text-end', id: 'text-1' });
+              if (streamCount === 1) {
+                await firstFinished;
+              }
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+              controller.close();
+            },
+          }),
+        };
+      },
+    });
+    const agent = new Agent({ id: 'active-message-agent', name: 'Active Message Agent', instructions: 'Test', model });
+    const subscription = await agent.subscribeToThread({
+      threadId: 'active-message-thread',
+      resourceId: 'active-message-user',
+    });
+
+    const stream = await agent.stream('Hello', {
+      memory: { thread: 'active-message-thread', resource: 'active-message-user' },
+    });
+    await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
+    const result = agent.sendMessage('Hello while active', {
+      resourceId: 'active-message-user',
+      threadId: 'active-message-thread',
+    });
+
+    expect(result).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+    releaseFirst();
+    await expect(stream.text).resolves.toBe('first responsemessage response');
+    expect(streamCount).toBe(2);
+    expect(JSON.stringify(prompts[1])).toContain('Hello while active');
+
+    subscription.unsubscribe();
+  });
+
+  it('queues queueMessage until the active run completes', async () => {
+    let releaseFirst!: () => void;
+    const firstFinished = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    let streamCount = 0;
+    const prompts: any[][] = [];
+    const model = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        streamCount += 1;
+        prompts.push(prompt);
+        const responseText = streamCount === 1 ? 'first response' : 'queued response';
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: new ReadableStream({
+            async start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+              controller.enqueue({
+                type: 'response-metadata',
+                id: `queue-message-${streamCount}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              });
+              controller.enqueue({ type: 'text-start', id: 'text-1' });
+              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: responseText });
+              controller.enqueue({ type: 'text-end', id: 'text-1' });
+              if (streamCount === 1) {
+                await firstFinished;
+              }
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+              controller.close();
+            },
+          }),
+        };
+      },
+    });
+    const agent = new Agent({ id: 'queue-message-agent', name: 'Queue Message Agent', instructions: 'Test', model });
+    const subscription = await agent.subscribeToThread({
+      threadId: 'queue-message-thread',
+      resourceId: 'queue-message-user',
+    });
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+    const firstRun = readNextRunWithParts(iterator);
+
+    const stream = await agent.stream('Hello', {
+      memory: { thread: 'queue-message-thread', resource: 'queue-message-user' },
+    });
+    await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
+    const result = agent.queueMessage('Queued follow-up', {
+      resourceId: 'queue-message-user',
+      threadId: 'queue-message-thread',
+    });
+
+    expect(result.accepted).toBe(true);
+    expect(result.runId).not.toBe(stream.runId);
+    await nextTick();
+    expect(streamCount).toBe(1);
+
+    releaseFirst();
+    await expect(stream.text).resolves.toBe('first response');
+    await firstRun;
+    const secondRun = await readNextRunWithParts(iterator);
+    expect(secondRun.value.runId).toBe(result.runId);
+    expect(secondRun.value.text).toBe('queued response');
+    expect(streamCount).toBe(2);
+    expect(JSON.stringify(prompts[1])).toContain('Queued follow-up');
+
+    subscription.unsubscribe();
+  });
+
   it('fans out sequential idle signal runs to many same-thread subscribers', async () => {
     const resourceId = 'share-resource';
     const threadId = 'share-thread';
@@ -1024,7 +1234,7 @@ describe('Agent signals', () => {
     expect(streamCount).toBe(0);
     expect(recalled.messages).toHaveLength(1);
     // Stash dropped; payload lives in content.parts now.
-    expect(recalled.messages[0]?.content.metadata?.signal).toMatchObject({ type: 'user-message' });
+    expect(recalled.messages[0]?.content.metadata?.signal).toMatchObject({ type: 'user', tagName: 'user' });
     expect(recalled.messages[0]?.content.parts).toEqual(
       expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'persist without waking' })]),
     );
@@ -1160,7 +1370,7 @@ describe('Agent signals', () => {
 
     const result = senderRuntime.sendSignal(
       sender,
-      { type: 'user-message', contents: [{ role: 'user', content: 'remote follow-up' }] },
+      { type: 'user-message', contents: 'remote follow-up' },
       { resourceId: 'remote-resource', threadId: 'remote-thread' },
       pubsub,
     );
@@ -2443,7 +2653,7 @@ describe('Agent signals', () => {
       const resolved = resolveDeliveryAttributes(signal, { delivery: 'while-active' });
       expect(resolved.toLLMMessage()).toEqual({
         role: 'user',
-        content: '<user-message delivery="while-active">fix the bug</user-message>',
+        content: '<user delivery="while-active">fix the bug</user>',
       });
     });
 

--- a/packages/core/src/agent/__tests__/prefill-error-recovery.test.ts
+++ b/packages/core/src/agent/__tests__/prefill-error-recovery.test.ts
@@ -202,7 +202,8 @@ describe('PrefillErrorHandler Recovery', () => {
       );
       expect(retryReminderMessage?.content.metadata).toEqual({
         signal: expect.objectContaining({
-          type: 'system-reminder',
+          type: 'reactive',
+          tagName: 'system-reminder',
           attributes: {
             type: ANTHROPIC_PREFILL_RETRY_SIGNAL_TYPE,
           },

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -118,11 +118,16 @@ import type {
   AgentCreateOptions,
   AgentExecuteOnFinishOptions,
   AgentInstructions,
+  AgentMessageInput,
   AgentMethodType,
   AgentSignal,
   AgentSubscribeToThreadOptions,
   AgentThreadSubscription,
   PublicStructuredOutputOptions,
+  QueueAgentMessageOptions,
+  QueueAgentMessageResult,
+  SendAgentMessageOptions,
+  SendAgentMessageResult,
   SendAgentSignalOptions,
   SendAgentSignalResult,
   StructuredOutputOptions,
@@ -6366,6 +6371,26 @@ export class Agent<
 
   abortRunStream(runId: string): boolean {
     return agentThreadStreamRuntime.abortRun(runId, this.getPubSub());
+  }
+
+  /**
+   * @experimental Agent message APIs are experimental and may change in a future release.
+   */
+  sendMessage<OUTPUT = TOutput>(
+    message: AgentMessageInput,
+    target: SendAgentMessageOptions<OUTPUT>,
+  ): SendAgentMessageResult {
+    return agentThreadStreamRuntime.sendMessage(this as Agent<any, any, any, any>, message, target, this.getPubSub());
+  }
+
+  /**
+   * @experimental Agent message APIs are experimental and may change in a future release.
+   */
+  queueMessage<OUTPUT = TOutput>(
+    message: AgentMessageInput,
+    target: QueueAgentMessageOptions<OUTPUT>,
+  ): QueueAgentMessageResult {
+    return agentThreadStreamRuntime.queueMessage(this as Agent<any, any, any, any>, message, target, this.getPubSub());
   }
 
   /**

--- a/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
@@ -90,6 +90,23 @@ function getSignalType(message: MastraDBMessage): string | undefined {
   return message.type;
 }
 
+function getSignalTagName(message: MastraDBMessage): string | undefined {
+  const signal = message.content.metadata?.signal;
+  if (signal && typeof signal === 'object' && !Array.isArray(signal)) {
+    const tagName = (signal as Record<string, unknown>).tagName;
+    if (typeof tagName === 'string') return tagName;
+  }
+
+  const type = getSignalType(message);
+  if (type === 'user') return 'user';
+  if (type === 'reactive') return message.type;
+  return type;
+}
+
+function isUserSignalType(type: string | undefined): boolean {
+  return type === 'user' || type === 'user-message';
+}
+
 function toSignalDataPart(message: MastraDBMessage, contents: string): MastraMessagePart {
   const signal =
     message.content.metadata?.signal && typeof message.content.metadata.signal === 'object'
@@ -100,11 +117,15 @@ function toSignalDataPart(message: MastraDBMessage, contents: string): MastraMes
       ? (signal.metadata as Record<string, unknown>)
       : {};
 
+  const type = getSignalType(message) ?? 'signal';
+  const tagName = getSignalTagName(message) ?? type;
+  const dataPartTagName = type === 'user' && tagName === 'user' ? 'user-message' : tagName;
   return {
-    type: `data-${getSignalType(message) ?? 'signal'}`,
+    type: `data-${dataPartTagName}`,
     data: {
       id: typeof signal.id === 'string' ? signal.id : message.id,
-      type: getSignalType(message) ?? 'signal',
+      type,
+      tagName,
       contents: 'contents' in signal ? signal.contents : contents,
       createdAt: typeof signal.createdAt === 'string' ? signal.createdAt : message.createdAt.toISOString(),
       ...(Object.keys(metadata).length ? { metadata } : {}),
@@ -249,7 +270,7 @@ export class AIV4Adapter {
     }
 
     const signalType = m.role === 'signal' ? getSignalType(m) : undefined;
-    const isUserMessageSignal = signalType === 'user-message';
+    const isUserMessageSignal = isUserSignalType(signalType);
     const v4Parts = preserveExtendedParts(
       m.role === 'signal' && !isUserMessageSignal ? [toSignalDataPart(m, m.content.content || contentString)] : parts,
     );

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
@@ -36,6 +36,23 @@ function getSignalType(message: MastraDBMessage): string | undefined {
   return message.type;
 }
 
+function getSignalTagName(message: MastraDBMessage): string | undefined {
+  const signal = message.content.metadata?.signal;
+  if (signal && typeof signal === 'object' && !Array.isArray(signal)) {
+    const tagName = (signal as Record<string, unknown>).tagName;
+    if (typeof tagName === 'string') return tagName;
+  }
+
+  const type = getSignalType(message);
+  if (type === 'user') return 'user';
+  if (type === 'reactive') return message.type;
+  return type;
+}
+
+function isUserSignalType(type: string | undefined): boolean {
+  return type === 'user' || type === 'user-message';
+}
+
 function getTextContent(message: MastraDBMessage): string {
   return typeof message.content.content === 'string'
     ? message.content.content
@@ -53,11 +70,14 @@ function toSignalDataPart(message: MastraDBMessage): AIV5Type.DataUIPart<AIV5.UI
       : {};
 
   const type = getSignalType(message) ?? 'signal';
+  const tagName = getSignalTagName(message) ?? type;
+  const dataPartTagName = type === 'user' && tagName === 'user' ? 'user-message' : tagName;
   return {
-    type: `data-${type}`,
+    type: `data-${dataPartTagName}`,
     data: {
       id: typeof signal.id === 'string' ? signal.id : message.id,
       type,
+      tagName,
       contents: 'contents' in signal ? signal.contents : getTextContent(message),
       createdAt: typeof signal.createdAt === 'string' ? signal.createdAt : message.createdAt.toISOString(),
       ...(Object.keys(metadata).length ? { metadata } : {}),
@@ -186,7 +206,7 @@ export class AIV5Adapter {
    */
   static toUIMessage(dbMsg: MastraDBMessage, options?: { transformToolPayloads?: boolean }): AIV5Type.UIMessage {
     const signalType = dbMsg.role === 'signal' ? getSignalType(dbMsg) : undefined;
-    const isUserMessageSignal = signalType === 'user-message';
+    const isUserMessageSignal = isUserSignalType(signalType);
     const transformToolPayloads = options?.transformToolPayloads ?? true;
     const parts: AIV5Type.UIMessage['parts'] = [];
     const metadata: Record<string, unknown> = { ...(dbMsg.content.metadata || {}) };

--- a/packages/core/src/agent/message-list/adapters/agent-signal-ui-conversion.test.ts
+++ b/packages/core/src/agent/message-list/adapters/agent-signal-ui-conversion.test.ts
@@ -52,7 +52,8 @@ describe('agent signal UI conversion', () => {
           type: 'data-system-reminder',
           data: {
             id: 'signal-system-1',
-            type: 'system-reminder',
+            type: 'reactive',
+            tagName: 'system-reminder',
             contents: 'continue',
             createdAt: '2024-01-01T00:00:00.000Z',
             metadata: { reminderType: 'anthropic-prefill-processor-retry' },

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -180,6 +180,7 @@ export class MessageList {
     const signalForTranscript = createSignal({
       id: signal.id,
       type: signal.type,
+      tagName: signal.tagName,
       contents: signal.contents,
       attributes: signal.attributes,
       metadata: signal.metadata,

--- a/packages/core/src/agent/signals.ts
+++ b/packages/core/src/agent/signals.ts
@@ -6,7 +6,14 @@ import type { MastraDBMessage, MastraMessagePart, MastraProviderMetadata } from 
 /**
  * @experimental Agent signals are experimental and may change in a future release.
  */
-export type AgentSignalType = 'user-message' | 'system-reminder' | string;
+export type AgentSignalCategory = 'user' | 'state' | 'reactive' | 'notification';
+
+/**
+ * @experimental Agent signals are experimental and may change in a future release.
+ */
+export type AgentSignalType = AgentSignalCategory | 'user-message' | 'system-reminder' | string;
+
+export type AgentSignalTagName = string;
 
 export type SignalPart = TextPart | SignalFilePart;
 type SignalFilePart = {
@@ -23,11 +30,21 @@ type SignalFilePart = {
 export type AgentSignalContents = string | Array<TextPart | FilePart>;
 export type AgentSignalAttributes = Record<string, string | number | boolean | null | undefined>;
 
+export type AgentMessageInput =
+  | AgentSignalContents
+  | {
+      contents: AgentSignalContents;
+      attributes?: AgentSignalAttributes;
+      metadata?: Record<string, unknown>;
+      providerOptions?: MastraProviderMetadata;
+    };
+
 export type AgentSignalInput = {
   id?: string;
   createdAt?: Date | string;
   acceptedAt?: Date | string;
   type: AgentSignalType;
+  tagName?: AgentSignalTagName;
   contents: AgentSignalContents;
   attributes?: AgentSignalAttributes;
   metadata?: Record<string, unknown>;
@@ -47,6 +64,7 @@ export type AgentSignalDataPart = {
   data: {
     id: string;
     type: AgentSignalType;
+    tagName?: AgentSignalTagName;
     contents: AgentSignalContents;
     createdAt: string;
     acceptedAt?: string;
@@ -73,9 +91,35 @@ export function isMastraSignalMessage(message: MastraDBMessage): message is Mast
   return message.role === 'signal';
 }
 
+function normalizeSignalType(input: Pick<AgentSignalInput, 'type' | 'tagName'>): {
+  type: AgentSignalCategory;
+  tagName: AgentSignalTagName;
+} {
+  if (input.type === 'user-message') {
+    return { type: 'user', tagName: input.tagName ?? 'user' };
+  }
+
+  if (input.type === 'system-reminder') {
+    return { type: 'reactive', tagName: input.tagName ?? 'system-reminder' };
+  }
+
+  if (input.type === 'user' || input.type === 'state' || input.type === 'notification') {
+    return { type: input.type, tagName: input.tagName ?? input.type };
+  }
+
+  if (input.type === 'reactive') {
+    return { type: 'reactive', tagName: input.tagName ?? 'reactive' };
+  }
+
+  return { type: 'reactive', tagName: input.tagName ?? input.type };
+}
+
 function normalizeSignal(signal: AgentSignalInput | CreatedAgentSignal) {
+  const { type, tagName } = normalizeSignalType(signal);
   return {
     ...signal,
+    type,
+    tagName,
     id: signal.id ?? crypto.randomUUID(),
     createdAt:
       signal.createdAt instanceof Date ? signal.createdAt : signal.createdAt ? new Date(signal.createdAt) : new Date(),
@@ -121,12 +165,13 @@ function signalAttributesToXml(attributes?: AgentSignalAttributes): string {
 }
 
 export function signalToXmlMarkup(
-  signal: Pick<AgentSignalInput, 'type' | 'attributes'> & { contents?: string },
+  signal: Pick<AgentSignalInput, 'type' | 'tagName' | 'attributes'> & { contents?: string },
 ): string {
-  assertXmlName(signal.type, 'tag name');
+  const tagName = signal.tagName ?? normalizeSignalType(signal).tagName;
+  assertXmlName(tagName, 'tag name');
   const attributesXml = signalAttributesToXml(signal.attributes);
-  if (!signal.contents) return `<${signal.type}${attributesXml} />`;
-  return `<${signal.type}${attributesXml}>${escapeXml(signal.contents)}</${signal.type}>`;
+  if (!signal.contents) return `<${tagName}${attributesXml} />`;
+  return `<${tagName}${attributesXml}>${escapeXml(signal.contents)}</${tagName}>`;
 }
 
 // Recover legacy metadata.signal.contents shapes (pre-narrowing) into the current
@@ -309,7 +354,10 @@ function hasMeaningfulAttributes(attributes?: AgentSignalAttributes): boolean {
 // Inline-wrap the first text part with the signal's XML tag. If there's no text part, prepend
 // a self-closing marker as a synthetic first part so attributes still surface alongside the
 // file/image payload on the same turn.
-function injectMarkerInline(signal: Pick<AgentSignalInput, 'type' | 'attributes'>, parts: SignalPart[]): SignalPart[] {
+function injectMarkerInline(
+  signal: Pick<AgentSignalInput, 'type' | 'tagName' | 'attributes'>,
+  parts: SignalPart[],
+): SignalPart[] {
   let wrapped = false;
   const out: SignalPart[] = [];
   for (const part of parts) {
@@ -321,7 +369,7 @@ function injectMarkerInline(signal: Pick<AgentSignalInput, 'type' | 'attributes'
     }
   }
   if (!wrapped) {
-    const markerText = signalToXmlMarkup({ type: signal.type, attributes: signal.attributes });
+    const markerText = signalToXmlMarkup({ type: signal.type, tagName: signal.tagName, attributes: signal.attributes });
     out.unshift({ type: 'text', text: markerText });
   }
   return out;
@@ -331,10 +379,10 @@ function injectMarkerInline(signal: Pick<AgentSignalInput, 'type' | 'attributes'
 // (a prompt turn the model sees, not a signal row). The XML wrapper carries the attributes
 // inline so there's no metadata.signal here.
 function signalToLLMMessage(
-  signal: Pick<AgentSignalInput, 'type' | 'attributes' | 'providerOptions'>,
+  signal: Pick<AgentSignalInput, 'type' | 'tagName' | 'attributes' | 'providerOptions'>,
   parts: SignalPart[],
 ): UserModelMessage {
-  const isUserMessage = signal.type === 'user-message';
+  const isUserMessage = signal.type === 'user';
   const hasAttrs = hasMeaningfulAttributes(signal.attributes);
 
   const anyPartProviderOptions = parts.some(part => part.providerOptions);
@@ -362,11 +410,13 @@ function signalToLLMMessage(
 }
 
 function signalToDataPart(signal: ReturnType<typeof normalizeSignal>, parts: SignalPart[]): AgentSignalDataPart {
+  const dataPartTagName = signal.type === 'user' && signal.tagName === 'user' ? 'user-message' : signal.tagName;
   return {
-    type: `data-${signal.type}`,
+    type: `data-${dataPartTagName}`,
     data: {
       id: signal.id,
       type: signal.type,
+      tagName: signal.tagName,
       contents: partsToSignalContents(parts),
       createdAt: signal.createdAt.toISOString(),
       ...(signal.acceptedAt ? { acceptedAt: signal.acceptedAt.toISOString() } : {}),
@@ -406,7 +456,7 @@ function signalToDBMessage(
     createdAt: signal.createdAt,
     threadId: options?.threadId,
     resourceId: options?.resourceId,
-    type: signal.type,
+    type: signal.tagName,
     content: {
       format: 2,
       parts: storageParts,
@@ -415,6 +465,7 @@ function signalToDBMessage(
         signal: {
           id: signal.id,
           type: signal.type,
+          tagName: signal.tagName,
           createdAt: signal.createdAt.toISOString(),
           ...(signal.acceptedAt ? { acceptedAt: signal.acceptedAt.toISOString() } : {}),
           ...(signal.attributes ? { attributes: signal.attributes } : {}),
@@ -486,7 +537,8 @@ export function mastraDBMessageToSignal(message: MastraDBMessage): CreatedAgentS
       ? (metadataSignal as Record<string, unknown>)
       : undefined;
 
-  const type = typeof signalMetadata?.type === 'string' ? signalMetadata.type : (message.type ?? 'user-message');
+  const rawType = typeof signalMetadata?.type === 'string' ? signalMetadata.type : (message.type ?? 'user-message');
+  const tagName = typeof signalMetadata?.tagName === 'string' ? signalMetadata.tagName : undefined;
   // Reconstruct contents from content.parts — the canonical source. Legacy rows (pre stash
   // removal) preserved the original input shape on metadata.signal.contents; recover whatever
   // we can from it (string, parts array, CoreUserMessage wrapper, CoreUserMessage[]) so files
@@ -517,7 +569,20 @@ export function mastraDBMessageToSignal(message: MastraDBMessage): CreatedAgentS
         : undefined,
   };
 
-  return createSignal({ ...base, type, contents });
+  return createSignal({ ...base, type: rawType, tagName, contents });
+}
+
+export function createMessageSignal(
+  input: AgentMessageInput,
+  options?: Pick<AgentSignalInput, 'id' | 'createdAt' | 'acceptedAt'>,
+): CreatedAgentSignal {
+  const message = typeof input === 'string' || Array.isArray(input) ? { contents: input } : input;
+  return createSignal({
+    ...message,
+    ...options,
+    type: 'user',
+    tagName: 'user',
+  });
 }
 
 export function dataPartToSignal(part: AgentSignalDataPart): CreatedAgentSignal {

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -8,12 +8,16 @@ import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context
 import type { MastraModelOutput } from '../stream/base/output';
 import type { Agent } from './agent';
 import type { AgentExecutionOptions } from './agent.types';
-import { createSignal, resolveDeliveryAttributes } from './signals';
-import type { CreatedAgentSignal } from './signals';
+import { createMessageSignal, createSignal, resolveDeliveryAttributes } from './signals';
+import type { AgentMessageInput, CreatedAgentSignal } from './signals';
 import type {
   AgentSignal,
   AgentSubscribeToThreadOptions,
   AgentThreadSubscription,
+  QueueAgentMessageOptions,
+  QueueAgentMessageResult,
+  SendAgentMessageOptions,
+  SendAgentMessageResult,
   SendAgentSignalOptions,
   SendAgentSignalResult,
 } from './types';
@@ -758,6 +762,72 @@ export class AgentThreadStreamRuntime {
         }
       })(),
     };
+  }
+
+  sendMessage<OUTPUT = unknown>(
+    agent: Agent<any, any, any, any>,
+    message: AgentMessageInput,
+    target: SendAgentMessageOptions<OUTPUT>,
+    pubsub?: PubSub,
+  ): SendAgentMessageResult {
+    return this.sendSignal(agent, createMessageSignal(message, { acceptedAt: new Date() }), target, pubsub);
+  }
+
+  queueMessage<OUTPUT = unknown>(
+    agent: Agent<any, any, any, any>,
+    message: AgentMessageInput,
+    target: QueueAgentMessageOptions<OUTPUT>,
+    pubsub?: PubSub,
+  ): QueueAgentMessageResult {
+    const state = this.#getState(pubsub);
+    const signal = createMessageSignal(message, { acceptedAt: new Date() });
+    let key: string | undefined;
+    let runId = target.runId;
+    let activeRecord: AgentThreadRunRecord<any> | undefined;
+
+    if (target.resourceId && target.threadId) {
+      key = this.#threadKey(target.resourceId, target.threadId);
+      const activeRunId = state.activeThreadRunIds.get(key);
+      activeRecord = activeRunId ? state.threadRunsById.get(activeRunId) : undefined;
+      if (activeRecord && activeRecord.output.status !== 'running') {
+        state.activeThreadRunIds.delete(key);
+        activeRecord = undefined;
+      }
+      runId ??= activeRunId;
+    }
+
+    if (runId) {
+      activeRecord ??= state.threadRunsById.get(runId);
+      if (activeRecord) {
+        key ??= this.#threadKey(activeRecord.resourceId, activeRecord.threadId);
+      }
+    }
+
+    const resourceId = target.resourceId ?? activeRecord?.resourceId;
+    const threadId = target.threadId ?? activeRecord?.threadId;
+    if (!resourceId || !threadId) {
+      throw new Error('resourceId and threadId are required to queue a message');
+    }
+
+    key ??= this.#threadKey(resourceId, threadId);
+    const queuedRunId = randomUUID();
+    const queuedStreamOptions = target.ifIdle?.streamOptions ?? activeRecord?.streamOptions;
+
+    if (activeRecord) {
+      const idleQueue = state.pendingIdleSignalsByThread.get(key) ?? [];
+      idleQueue.push({ agent, signal, runId: queuedRunId, resourceId, threadId, streamOptions: queuedStreamOptions });
+      state.pendingIdleSignalsByThread.set(key, idleQueue);
+      this.#watchThreadRunCompletion(state, pubsub, key, activeRecord);
+      return { accepted: true, runId: queuedRunId, signal };
+    }
+
+    state.activeThreadRunIds.delete(key);
+    return this.sendSignal(
+      agent,
+      signal,
+      { ...target, resourceId, threadId, ifIdle: { ...target.ifIdle, behavior: 'wake' } },
+      pubsub,
+    );
   }
 
   /**

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -82,6 +82,7 @@ export type ToolsInput = Record<
 export type AgentInstructions = SystemMessage;
 
 export type {
+  AgentMessageInput,
   AgentSignalAttributes,
   AgentSignalInput as AgentSignal,
   AgentSignalType,
@@ -132,6 +133,26 @@ export interface SendAgentSignalResult {
   /** Resolves when a `persist` behavior finishes writing the signal to memory. */
   persisted?: Promise<void>;
 }
+
+/**
+ * @experimental Agent message APIs are experimental and may change in a future release.
+ */
+export type SendAgentMessageOptions<OUTPUT = unknown> = SendAgentSignalOptions<OUTPUT>;
+
+/**
+ * @experimental Agent message APIs are experimental and may change in a future release.
+ */
+export type SendAgentMessageResult = SendAgentSignalResult;
+
+/**
+ * @experimental Agent message APIs are experimental and may change in a future release.
+ */
+export type QueueAgentMessageOptions<OUTPUT = unknown> = SendAgentSignalOptions<OUTPUT>;
+
+/**
+ * @experimental Agent message APIs are experimental and may change in a future release.
+ */
+export type QueueAgentMessageResult = SendAgentSignalResult;
 
 export interface AgentThreadRun<OUTPUT = unknown> {
   output: MastraModelOutput<OUTPUT>;

--- a/packages/core/src/browser/processor.test.ts
+++ b/packages/core/src/browser/processor.test.ts
@@ -154,7 +154,8 @@ describe('BrowserContextProcessor', () => {
       expect(addedMessage.content.metadata).toEqual(
         expect.objectContaining({
           signal: expect.objectContaining({
-            type: 'system-reminder',
+            type: 'reactive',
+            tagName: 'system-reminder',
             attributes: expect.objectContaining({ type: 'browser-context' }),
             metadata: expect.objectContaining({
               url: 'https://example.com/page',

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -113,7 +113,8 @@ export class BrowserContextProcessor {
     }
 
     await args.sendSignal?.({
-      type: 'system-reminder',
+      type: 'reactive',
+      tagName: 'system-reminder',
       contents: reminderText,
       attributes: {
         type: REMINDER_TYPE,

--- a/packages/core/src/channels/__tests__/agent-channels.test.ts
+++ b/packages/core/src/channels/__tests__/agent-channels.test.ts
@@ -40,6 +40,13 @@ function createMockAgent(name = 'test-agent') {
         },
       }),
     }),
+    sendMessage: vi.fn().mockResolvedValue({ accepted: true, runId: 'run-1' }),
+    subscribeToThread: vi.fn().mockResolvedValue({
+      stream: (async function* () {})(),
+      activeRunId: () => null,
+      abort: () => false,
+      unsubscribe: vi.fn(),
+    }),
     getMemory: vi.fn().mockResolvedValue(null),
     logger: { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
   } as any;
@@ -279,6 +286,77 @@ describe('AgentChannels', () => {
       expect(typeof agentChannels.sdk!.onNewMention).toBe('function');
       expect(typeof agentChannels.sdk!.onReaction).toBe('function');
       expect(typeof agentChannels.sdk!.onNewMessage).toBe('function');
+    });
+  });
+
+  describe('message routing', () => {
+    it('routes inbound channel messages through sendMessage with channel metadata', async () => {
+      const db = new InMemoryDB();
+      const memoryStore = new InMemoryMemory({ db });
+      const mockMastra = {
+        getStorage: () => ({ getStore: () => memoryStore }),
+        getServer: () => null,
+      } as any;
+
+      await agentChannels.initialize(mockMastra);
+
+      const chatThread = {
+        id: 'channel-1:thread-1',
+        channelId: 'channel-1',
+        isDM: false,
+        adapter: agentChannels.adapters.discord,
+        isSubscribed: vi.fn().mockResolvedValue(true),
+        subscribe: vi.fn().mockResolvedValue(undefined),
+        mentionUser: vi.fn((userId: string) => `<@${userId}>`),
+        messages: (async function* () {})(),
+      } as any;
+      const message = {
+        id: 'message-1',
+        text: 'hello from discord',
+        author: { userId: 'user-1', userName: 'tyler', fullName: 'Tyler Barnes' },
+        attachments: [],
+      } as any;
+
+      await (agentChannels as any).processChatMessage(chatThread, message, mockMastra);
+
+      expect(mockAgent.sendMessage).toHaveBeenCalledTimes(1);
+      expect(mockAgent.sendMessage).toHaveBeenCalledWith(
+        {
+          contents: 'hello from discord',
+          attributes: {
+            messageId: 'message-1',
+            authorName: 'Tyler Barnes',
+            authorId: 'user-1',
+            authorMention: '<@user-1>',
+          },
+          providerOptions: {
+            mastra: {
+              channels: {
+                discord: {
+                  messageId: 'message-1',
+                  author: {
+                    userId: 'user-1',
+                    userName: 'tyler',
+                    fullName: 'Tyler Barnes',
+                    mention: '<@user-1>',
+                  },
+                },
+              },
+            },
+          },
+        },
+        expect.objectContaining({
+          resourceId: 'discord:user-1',
+          threadId: expect.any(String),
+          ifIdle: expect.objectContaining({
+            behavior: 'wake',
+            streamOptions: expect.objectContaining({
+              requestContext: expect.any(Object),
+              memory: expect.objectContaining({ resource: 'discord:user-1' }),
+            }),
+          }),
+        }),
+      );
     });
   });
 

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -1049,7 +1049,8 @@ export class AgentChannels {
 
     this.agent.sendSignal(
       {
-        type: 'user-message',
+        type: 'user',
+        tagName: 'user',
         contents: signalContents,
         attributes,
         providerOptions,

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -732,8 +732,8 @@ export class AgentChannels {
    *
    *   - `channelContext` — goes on `requestContext` under the 'channel' key, consumed by
    *     `ChatChannelProcessor` and other input processors.
-   *   - `attributes` — serialized as XML on the signal element the LLM sees (e.g. on
-   *     `<user-message messageId=... authorId=... />`). Strings only.
+   *   - `attributes` — serialized as XML on the user message element the LLM sees (e.g. on
+   *     `<user messageId=... authorId=... />`). Strings only.
    *   - `providerOptions` — written to the stored message's `content.providerMetadata`
    *     under `mastra.channels.<platform>` so UI/query callers can read author/channel
    *     facts off the message (e.g. show a Slack icon + author name) without unpacking
@@ -1047,10 +1047,8 @@ export class AgentChannels {
     // Otherwise pass the parts array directly — both shapes match AgentSignalContents.
     const signalContents: AgentSignalContents = parts.length === 1 && parts[0]?.type === 'text' ? parts[0].text : parts;
 
-    this.agent.sendSignal(
+    this.agent.sendMessage(
       {
-        type: 'user',
-        tagName: 'user',
         contents: signalContents,
         attributes,
         providerOptions,

--- a/packages/core/src/harness/display-state-scheduler.ts
+++ b/packages/core/src/harness/display-state-scheduler.ts
@@ -8,6 +8,7 @@ export const DEFAULT_DISPLAY_STATE_SUBSCRIPTION_OPTIONS = {
 export const CRITICAL_DISPLAY_STATE_EVENT_TYPES: ReadonlySet<HarnessEvent['type']> = new Set([
   'agent_start',
   'agent_end',
+  'follow_up_queued',
   'error',
   'tool_approval_required',
   'tool_suspended',

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -32,6 +32,7 @@ describe('defaultDisplayState', () => {
     const ds = defaultDisplayState();
     expect(ds.isRunning).toBe(false);
     expect(ds.currentMessage).toBeNull();
+    expect(ds.queuedFollowUps).toBe(0);
     expect(ds.tokenUsage).toEqual(createEmptyTokenUsage());
     expect(ds.activeTools).toBeInstanceOf(Map);
     expect(ds.activeTools.size).toBe(0);

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -165,7 +165,8 @@ function toUserSignalMessage(payload: Record<string, unknown>): HarnessMessage |
 
   const signal = createSignal({
     id,
-    type: 'user-message',
+    type: 'user',
+    tagName: 'user',
     contents: rawContents as AgentSignalContents,
     attributes: getRecordValue(payload.attributes) as AgentSignalInput['attributes'],
     createdAt: getStringValue(payload.createdAt),
@@ -1609,30 +1610,104 @@ export class Harness<TState = {}> {
     await this.ensureAgentThreadSubscription(this.getCurrentAgent(), this.currentThreadId);
   }
 
+  private createMessageInput({
+    content,
+    files,
+  }: {
+    content: string;
+    files?: Array<{ data: string; mediaType: string; filename?: string }>;
+  }): AgentSignalContents {
+    if (!files?.length) return content;
+
+    const fileParts = files.map(f => {
+      const isText = f.mediaType.startsWith('text/') || f.mediaType === 'application/json';
+      if (isText) {
+        let textContent = f.data;
+        const base64Match = f.data.match(/^data:[^;]*;base64,(.*)$/);
+        if (base64Match) {
+          try {
+            textContent = Buffer.from(base64Match[1]!, 'base64').toString('utf-8');
+          } catch {
+            // Fall through with raw data
+          }
+        }
+        const label = f.filename ? `[File: ${f.filename}]` : '[Attached file]';
+        return { type: 'text' as const, text: `${label}\n\`\`\`\n${textContent}\n\`\`\`` };
+      }
+      return {
+        type: 'file' as const,
+        data: f.data,
+        mediaType: f.mediaType,
+        ...(f.filename ? { filename: f.filename } : {}),
+      };
+    });
+
+    return [{ type: 'text', text: content }, ...fileParts];
+  }
+
+  private async buildAgentMessageStreamOptions({
+    requestContext: requestContextInput,
+    tracingContext,
+    tracingOptions,
+  }: {
+    requestContext?: RequestContext;
+    tracingContext?: TracingContext;
+    tracingOptions?: TracingOptions;
+  }): Promise<Record<string, unknown>> {
+    if (!this.currentThreadId) {
+      throw new Error('Cannot build stream options without a current thread');
+    }
+
+    this.abortRequested = false;
+    this.abortController ??= new AbortController();
+    const requestContext = await this.buildRequestContext(requestContextInput);
+    const isYolo = (this.state as Record<string, unknown>).yolo === true;
+    const streamOptions: Record<string, unknown> = {
+      memory: { thread: this.currentThreadId, resource: this.resourceId },
+      abortSignal: this.abortController.signal,
+      requestContext,
+      maxSteps: 1000,
+      savePerStep: false,
+      requireToolApproval: !isYolo,
+      modelSettings: { temperature: 1 },
+      ...(tracingContext && { tracingContext }),
+      ...(tracingOptions && { tracingOptions }),
+    };
+    streamOptions.toolsets = await this.buildToolsets(requestContext);
+    return streamOptions;
+  }
+
   private async drainFollowUpQueue(options?: { tracingContext?: TracingContext; tracingOptions?: TracingOptions }) {
     if (this.followUpQueue.length === 0) return;
 
     const next = this.followUpQueue.shift()!;
-    if (this.agentThreadSubscription) {
-      // When called from processSubscribedThreadStream → finishSubscribedStreamRun,
-      // sendMessage would deadlock: it waits for the new run to finish via
-      // waitForCurrentThreadStreamIdle, but the subscription consumer is blocked
-      // here and cannot advance the generator to process that run. Send the
-      // signal directly and let the subscription handle the run lifecycle.
-      const signal = this.sendSignal({
-        content: next.content,
-        requestContext: next.requestContext,
-        tracingContext: options?.tracingContext,
-        tracingOptions: options?.tracingOptions,
-      });
-      await signal.accepted;
-    } else {
-      await this.sendMessage({
-        content: next.content,
-        requestContext: next.requestContext,
-        tracingContext: options?.tracingContext,
-        tracingOptions: options?.tracingOptions,
-      });
+    try {
+      if (this.agentThreadSubscription && this.currentThreadId) {
+        const agent = this.getCurrentAgent();
+        const streamOptions = await this.buildAgentMessageStreamOptions({
+          requestContext: next.requestContext,
+          tracingContext: options?.tracingContext,
+          tracingOptions: options?.tracingOptions,
+        });
+        const result = agent.queueMessage(this.createMessageInput({ content: next.content }), {
+          resourceId: this.resourceId,
+          threadId: this.currentThreadId,
+          ifIdle: { streamOptions: streamOptions as any },
+        });
+        this.emit({ type: 'follow_up_queued', count: this.followUpQueue.length, runId: result.runId });
+      } else {
+        this.emit({ type: 'follow_up_queued', count: this.followUpQueue.length });
+        await this.sendMessage({
+          content: next.content,
+          requestContext: next.requestContext,
+          tracingContext: options?.tracingContext,
+          tracingOptions: options?.tracingOptions,
+        });
+      }
+    } catch (error) {
+      this.followUpQueue.unshift(next);
+      this.emit({ type: 'follow_up_queued', count: this.followUpQueue.length });
+      throw error;
     }
   }
 
@@ -1756,7 +1831,9 @@ export class Harness<TState = {}> {
     const { tracingContext, tracingOptions, requestContext: requestContextInput } = 'content' in input ? input : {};
     const ifActive = 'content' in input ? input.ifActive : undefined;
     const ifIdle = 'content' in input ? input.ifIdle : undefined;
-    const signal = createSignal('content' in input ? { type: 'user-message', contents: input.content } : input);
+    const signal = createSignal(
+      'content' in input ? { type: 'user', tagName: 'user', contents: input.content } : input,
+    );
     const accepted = Promise.resolve().then(async () => {
       if (!this.currentThreadId) {
         const thread = await this.createThread();
@@ -1776,22 +1853,11 @@ export class Harness<TState = {}> {
         return { accepted: result.accepted, runId: result.runId };
       }
 
-      this.abortRequested = false;
-      this.abortController ??= new AbortController();
-      const requestContext = await this.buildRequestContext(requestContextInput);
-      const isYolo = (this.state as Record<string, unknown>).yolo === true;
-      const streamOptions: Record<string, unknown> = {
-        memory: { thread: this.currentThreadId, resource: this.resourceId },
-        abortSignal: this.abortController.signal,
-        requestContext,
-        maxSteps: 1000,
-        savePerStep: false,
-        requireToolApproval: !isYolo,
-        modelSettings: { temperature: 1 },
-        ...(tracingContext && { tracingContext }),
-        ...(tracingOptions && { tracingOptions }),
-      };
-      streamOptions.toolsets = await this.buildToolsets(requestContext);
+      const streamOptions = await this.buildAgentMessageStreamOptions({
+        requestContext: requestContextInput,
+        tracingContext,
+        tracingOptions,
+      });
 
       const result = agent.sendSignal(signal, {
         resourceId: this.resourceId,
@@ -1822,32 +1888,7 @@ export class Harness<TState = {}> {
     tracingOptions?: TracingOptions;
     requestContext?: RequestContext;
   }): Promise<void> {
-    let messageInput: AgentSignalContents = content;
-    if (files?.length) {
-      const fileParts = files.map(f => {
-        const isText = f.mediaType.startsWith('text/') || f.mediaType === 'application/json';
-        if (isText) {
-          let textContent = f.data;
-          const base64Match = f.data.match(/^data:[^;]*;base64,(.*)$/);
-          if (base64Match) {
-            try {
-              textContent = Buffer.from(base64Match[1]!, 'base64').toString('utf-8');
-            } catch {
-              // Fall through with raw data
-            }
-          }
-          const label = f.filename ? `[File: ${f.filename}]` : '[Attached file]';
-          return { type: 'text' as const, text: `${label}\n\`\`\`\n${textContent}\n\`\`\`` };
-        }
-        return {
-          type: 'file' as const,
-          data: f.data,
-          mediaType: f.mediaType,
-          ...(f.filename ? { filename: f.filename } : {}),
-        };
-      });
-      messageInput = [{ type: 'text', text: content }, ...fileParts];
-    }
+    const messageInput = this.createMessageInput({ content, files });
 
     const wasActive = this.isCurrentThreadStreamActive();
     let emittedAgentEnd = false;
@@ -2017,7 +2058,7 @@ export class Harness<TState = {}> {
     if (msg.role === 'signal') {
       const signal = mastraDBMessageToSignal(msg as MastraDBMessage);
 
-      if (signal.type === 'user-message') {
+      if (signal.type === 'user') {
         const signalContent = signalContentsToHarnessContent(signal.contents);
         if (signalContent.length > 0) {
           return {
@@ -2030,7 +2071,7 @@ export class Harness<TState = {}> {
         }
       }
 
-      if (signal.type === 'system-reminder') {
+      if (signal.type === 'reactive' && signal.tagName === 'system-reminder') {
         const reminder = toSystemReminderContent({
           type: signal.type,
           contents:
@@ -2814,6 +2855,7 @@ export class Harness<TState = {}> {
   async steer({ content, requestContext }: { content: string; requestContext?: RequestContext }): Promise<void> {
     this.abort();
     this.followUpQueue = [];
+    this.emit({ type: 'follow_up_queued', count: 0 });
     await this.sendMessage({ content, requestContext });
   }
 
@@ -2907,6 +2949,7 @@ export class Harness<TState = {}> {
     this.displayState.pendingPlanApproval = null;
     this.displayState.activeSubagents = new Map();
     this.displayState.currentMessage = null;
+    this.displayState.queuedFollowUps = 0;
     this.displayState.modifiedFiles = new Map();
     this.displayState.tasks = [];
     this.displayState.previousTasks = [];
@@ -3570,6 +3613,11 @@ export class Harness<TState = {}> {
       case 'task_updated':
         ds.previousTasks = [...ds.tasks];
         ds.tasks = event.tasks;
+        break;
+
+      // ── Follow-up queue ────────────────────────────────────────────────
+      case 'follow_up_queued':
+        ds.queuedFollowUps = event.count;
         break;
 
       // ── Thread lifecycle ───────────────────────────────────────────────

--- a/packages/core/src/harness/signal-messages.test.ts
+++ b/packages/core/src/harness/signal-messages.test.ts
@@ -177,12 +177,99 @@ describe('Harness signal messages', () => {
 
     expect(buildToolsets).not.toHaveBeenCalled();
     expect(sendSignal).toHaveBeenCalledWith(
-      expect.objectContaining({ id: signal.id, type: 'user-message', contents: 'active hello' }),
-      {
+      expect.objectContaining({ id: signal.id, type: 'user', tagName: 'user', contents: 'active hello' }),
+      expect.objectContaining({
         resourceId: thread.resourceId,
         threadId: thread.id,
-      },
+      }),
     );
+  });
+
+  it('tracks queued follow-ups in display state while running', async () => {
+    const storage = new InMemoryStore();
+    const harness = createHarness(storage);
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    (harness as any).abortController = new AbortController();
+
+    await harness.followUp({ content: 'queued follow-up' });
+
+    expect(harness.getFollowUpCount()).toBe(1);
+    expect(harness.getDisplayState().queuedFollowUps).toBe(1);
+    expect(events).toContainEqual({ type: 'follow_up_queued', count: 1 });
+  });
+
+  it('uses queueMessage when draining follow-ups for a subscribed thread', async () => {
+    const storage = new InMemoryStore();
+    const agent = new Agent({
+      id: 'follow-up-queue-agent',
+      name: 'follow-up-queue-agent',
+      instructions: 'You are a test agent.',
+      model: createTextStreamModel('Hello'),
+    });
+    const harness = createHarness(storage, agent);
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+    vi.spyOn(agent, 'subscribeToThread').mockResolvedValue({
+      stream: (async function* () {})(),
+      unsubscribe: vi.fn(),
+      abort: vi.fn(),
+      activeRunId: () => 'run-1',
+    });
+    const queueMessage = vi.spyOn(agent, 'queueMessage').mockReturnValue({
+      accepted: true,
+      runId: 'queued-run-id',
+      signal: createSignal({ type: 'user', contents: 'queued follow-up' }),
+    });
+    const sendSignal = vi.spyOn(agent, 'sendSignal');
+    const thread = await harness.createThread();
+    (harness as any).abortController = new AbortController();
+
+    await harness.followUp({ content: 'queued follow-up' });
+    await (harness as any).drainFollowUpQueue();
+
+    expect(queueMessage).toHaveBeenCalledWith(
+      'queued follow-up',
+      expect.objectContaining({
+        resourceId: thread.resourceId,
+        threadId: thread.id,
+        ifIdle: expect.objectContaining({
+          streamOptions: expect.objectContaining({
+            memory: { thread: thread.id, resource: thread.resourceId },
+            maxSteps: 1000,
+            savePerStep: false,
+            requireToolApproval: true,
+          }),
+        }),
+      }),
+    );
+    expect(sendSignal).not.toHaveBeenCalled();
+    expect(harness.getFollowUpCount()).toBe(0);
+    expect(harness.getDisplayState().queuedFollowUps).toBe(0);
+    expect(events).toContainEqual({ type: 'follow_up_queued', count: 1 });
+    expect(events).toContainEqual({ type: 'follow_up_queued', count: 0, runId: 'queued-run-id' });
+  });
+
+  it('sends idle follow-ups immediately without marking them queued', async () => {
+    const storage = new InMemoryStore();
+    const harness = createHarness(storage);
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+    const sendMessage = vi.spyOn(harness, 'sendMessage').mockResolvedValue(undefined);
+
+    await harness.followUp({ content: 'idle follow-up' });
+
+    expect(sendMessage).toHaveBeenCalledWith({ content: 'idle follow-up', requestContext: undefined });
+    expect(harness.getFollowUpCount()).toBe(0);
+    expect(harness.getDisplayState().queuedFollowUps).toBe(0);
+    expect(events.some(event => event.type === 'follow_up_queued')).toBe(false);
   });
 
   it('aborts the current thread stream through the active subscription', async () => {

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -587,6 +587,10 @@ export interface HarnessDisplayState {
   /** The message currently being streamed (null when idle) */
   currentMessage: HarnessMessage | null;
 
+  // ── Follow-up queue ──────────────────────────────────────────────────
+  /** Number of follow-up messages queued locally by the Harness */
+  queuedFollowUps: number;
+
   // ── Token usage ──────────────────────────────────────────────────────
   /** Cumulative token usage for the current thread */
   tokenUsage: TokenUsage;
@@ -666,6 +670,7 @@ export function defaultDisplayState(): HarnessDisplayState {
   return {
     isRunning: false,
     currentMessage: null,
+    queuedFollowUps: 0,
     tokenUsage: createEmptyTokenUsage(),
     activeTools: new Map(),
     toolInputBuffers: new Map(),
@@ -759,7 +764,7 @@ export type HarnessEvent =
   | { type: 'usage_update'; usage: TokenUsage }
   | { type: 'info'; message: string }
   | { type: 'error'; error: Error; errorType?: string; retryable?: boolean; retryDelay?: number }
-  | { type: 'follow_up_queued'; count: number }
+  | { type: 'follow_up_queued'; count: number; runId?: string }
   | { type: 'workspace_status_changed'; status: WorkspaceStatus; error?: Error }
   | { type: 'workspace_ready'; workspaceId: string; workspaceName: string }
   | { type: 'workspace_error'; error: Error }

--- a/packages/core/src/memory/system-reminders.test.ts
+++ b/packages/core/src/memory/system-reminders.test.ts
@@ -41,6 +41,18 @@ describe('system reminder filtering', () => {
         metadata: { signal: { type: 'system-reminder' } },
       },
     } as unknown as MastraDBMessage;
+    const reactiveSignalMessage = {
+      id: 'reactive-signal',
+      role: 'signal',
+      createdAt: new Date(),
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      content: {
+        format: 2 as const,
+        parts: [{ type: 'text' as const, text: 'continue' }],
+        metadata: { signal: { type: 'reactive', tagName: 'policy-reminder' } },
+      },
+    } as unknown as MastraDBMessage;
     const userSignalMessage = {
       id: 'user-signal',
       role: 'signal',
@@ -68,6 +80,7 @@ describe('system reminder filtering', () => {
     expect(isSystemReminderMessage(metadataReminderMessage)).toBe(true);
     expect(isSystemReminderMessage(textReminderMessage)).toBe(true);
     expect(isSystemReminderMessage(signalReminderMessage)).toBe(true);
+    expect(isSystemReminderMessage(reactiveSignalMessage)).toBe(true);
     expect(isSystemReminderMessage(userSignalMessage)).toBe(false);
     expect(isSystemReminderMessage(embeddedMarkupMessage)).toBe(false);
     expect(
@@ -75,6 +88,7 @@ describe('system reminder filtering', () => {
         metadataReminderMessage,
         textReminderMessage,
         signalReminderMessage,
+        reactiveSignalMessage,
         userSignalMessage,
         embeddedMarkupMessage,
       ]),

--- a/packages/core/src/memory/system-reminders.ts
+++ b/packages/core/src/memory/system-reminders.ts
@@ -24,8 +24,7 @@ export function isSystemReminderMessage(message: MastraDBMessage): boolean {
     return (
       isRecord(metadata) &&
       isRecord(metadata.signal) &&
-      (metadata.signal.type === 'system-reminder' ||
-        (metadata.signal.type === 'reactive' && metadata.signal.tagName === 'system-reminder'))
+      (metadata.signal.type === 'system-reminder' || metadata.signal.type === 'reactive')
     );
   }
 

--- a/packages/core/src/memory/system-reminders.ts
+++ b/packages/core/src/memory/system-reminders.ts
@@ -21,7 +21,12 @@ export function isSystemReminderMessage(message: MastraDBMessage): boolean {
 
   const metadata = message.content.metadata;
   if (message.role === 'signal') {
-    return isRecord(metadata) && isRecord(metadata.signal) && metadata.signal.type === 'system-reminder';
+    return (
+      isRecord(metadata) &&
+      isRecord(metadata.signal) &&
+      (metadata.signal.type === 'system-reminder' ||
+        (metadata.signal.type === 'reactive' && metadata.signal.tagName === 'system-reminder'))
+    );
   }
 
   if (message.role !== 'user') {

--- a/packages/core/src/processors/prefill-error-handler.test.ts
+++ b/packages/core/src/processors/prefill-error-handler.test.ts
@@ -132,7 +132,8 @@ describe('PrefillErrorHandler', () => {
     expect(lastMessage.content.metadata).toEqual(
       expect.objectContaining({
         signal: expect.objectContaining({
-          type: 'system-reminder',
+          type: 'reactive',
+          tagName: 'system-reminder',
           attributes: expect.objectContaining({ type: 'anthropic-prefill-processor-retry' }),
           metadata: expect.objectContaining({ message: 'Continuing after prefill error' }),
         }),

--- a/packages/core/src/processors/prefill-error-handler.ts
+++ b/packages/core/src/processors/prefill-error-handler.ts
@@ -62,7 +62,8 @@ export class PrefillErrorHandler implements Processor<'prefill-error-handler'> {
     if (!isPrefillError(error)) return;
 
     await sendSignal?.({
-      type: 'system-reminder',
+      type: 'reactive',
+      tagName: 'system-reminder',
       contents: 'continue',
       attributes: {
         type: 'anthropic-prefill-processor-retry',

--- a/packages/core/src/processors/tool-result-reminder.test.ts
+++ b/packages/core/src/processors/tool-result-reminder.test.ts
@@ -230,7 +230,8 @@ describe('AgentsMDInjector', () => {
     expect(injectedReminder?.content.metadata).toEqual(
       expect.objectContaining({
         signal: expect.objectContaining({
-          type: 'system-reminder',
+          type: 'reactive',
+          tagName: 'system-reminder',
           attributes: expect.objectContaining({ type: 'dynamic-agents-md' }),
           metadata: expect.objectContaining({ path: '/repo/src/agents/nested/AGENTS.md' }),
         }),
@@ -274,7 +275,8 @@ describe('AgentsMDInjector', () => {
       expect.objectContaining({
         type: 'data-system-reminder',
         data: expect.objectContaining({
-          type: 'system-reminder',
+          type: 'reactive',
+          tagName: 'system-reminder',
           contents: 'Project guidance from CLAUDE',
           metadata: {
             path: '/repo/CLAUDE.md',

--- a/packages/core/src/processors/tool-result-reminder.ts
+++ b/packages/core/src/processors/tool-result-reminder.ts
@@ -152,7 +152,8 @@ function extractReminderPathFromMetadata(message: MastraDBMessage): string | und
 
 function getReminderMarkup(reminderText: string, instructionPath: string): string {
   return signalToXmlMarkup({
-    type: 'system-reminder',
+    type: 'reactive',
+    tagName: 'system-reminder',
     contents: reminderText,
     attributes: { type: REMINDER_TYPE, path: instructionPath },
   });
@@ -281,7 +282,8 @@ export class AgentsMDInjector implements Processor<'agents-md-injector'> {
     }
 
     await args.sendSignal?.({
-      type: 'system-reminder',
+      type: 'reactive',
+      tagName: 'system-reminder',
       contents: reminderText,
       attributes: { type: REMINDER_TYPE, path: instructionPath },
       metadata: getReminderMetadata(instructionPath).systemReminder,

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -168,7 +168,12 @@ function isSystemReminderMessage(message: MastraDBMessage): boolean {
 
   const metadata = message.content.metadata;
   if (message.role === 'signal') {
-    return isRecord(metadata) && isRecord(metadata.signal) && metadata.signal.type === 'system-reminder';
+    return (
+      isRecord(metadata) &&
+      isRecord(metadata.signal) &&
+      (metadata.signal.type === 'system-reminder' ||
+        (metadata.signal.type === 'reactive' && metadata.signal.tagName === 'system-reminder'))
+    );
   }
 
   if (message.role !== 'user') {

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -171,8 +171,7 @@ function isSystemReminderMessage(message: MastraDBMessage): boolean {
     return (
       isRecord(metadata) &&
       isRecord(metadata.signal) &&
-      (metadata.signal.type === 'system-reminder' ||
-        (metadata.signal.type === 'reactive' && metadata.signal.tagName === 'system-reminder'))
+      (metadata.signal.type === 'system-reminder' || metadata.signal.type === 'reactive')
     );
   }
 

--- a/packages/memory/src/processors/observational-memory/__tests__/temporal-markers.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/temporal-markers.test.ts
@@ -260,7 +260,8 @@ describe('ObservationalMemoryProcessor temporal markers', () => {
     });
     expect(markers[0]!.content.metadata?.signal).toMatchObject({
       id: markers[0]!.id,
-      type: 'system-reminder',
+      type: 'reactive',
+      tagName: 'system-reminder',
       attributes: {
         type: 'temporal-gap',
         gapText: '30 minutes later',
@@ -291,7 +292,8 @@ describe('ObservationalMemoryProcessor temporal markers', () => {
       expect.objectContaining({
         type: 'data-system-reminder',
         data: expect.objectContaining({
-          type: 'system-reminder',
+          type: 'reactive',
+          tagName: 'system-reminder',
           contents: `30 minutes later — ${expectedTimestamp}`,
           attributes: expect.objectContaining({
             type: 'temporal-gap',

--- a/packages/memory/src/processors/observational-memory/temporal-markers.ts
+++ b/packages/memory/src/processors/observational-memory/temporal-markers.ts
@@ -109,7 +109,8 @@ export async function insertTemporalGapMarkers({
 
   await sendSignal?.({
     id: `__temporal_gap_${crypto.randomUUID()}`,
-    type: 'system-reminder',
+    type: 'reactive',
+    tagName: 'system-reminder',
     contents: getTemporalGapReminderText(gapText, timestamp),
     createdAt: new Date(timestamp - 1),
     acceptedAt: new Date(timestamp),


### PR DESCRIPTION
Stack 1 of the signals API cleanup. Adds message-first core signal APIs and compatibility normalization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds two new, easier methods (`sendMessage()` and `queueMessage()`) to send user messages into AI agents. Behind the scenes, it reorganizes how the system categorizes different types of signals (like user messages vs system reminders) to be cleaner and more consistent, while still supporting legacy message formats so existing code doesn't break.

---

## Overview

This PR implements the first phase of a signals API cleanup by introducing experimental `sendMessage()` and `queueMessage()` agent APIs as higher-level alternatives to the lower-level `sendSignal()` method. The implementation normalizes signal representation to use semantic categories (`user`, `state`, `reactive`, `notification`) with optional `tagName` metadata, while maintaining full backward compatibility with legacy `user-message` and `system-reminder` signal payloads across all wire payloads, persisted records, adapters, processors, and rendering.

## Key Changes

### New Agent Message APIs

Added two new experimental methods to the `Agent` class:
- **`sendMessage(message, options)`** – Sends a user message immediately; wakes an idle thread if not currently active
- **`queueMessage(message, options)`** – Queues a message for the next thread execution; prevents subscription deadlocks by queuing rather than sending during active runs

Both methods accept a unified `AgentMessageInput` (either raw content or a full message object with `contents`, `attributes`, and `metadata`), support targeting via `runId`/`resourceId`/`threadId`, and offer `ifActive`/`ifIdle` behavior controls.

The implementation wraps the existing `AgentThreadStreamRuntime.sendSignal()` infrastructure, converting `AgentMessageInput` into properly tagged `AgentSignal` objects internally.

### Signal Normalization

Signals are now represented with a two-part type system:
- **`type`**: Semantic category (`'user' | 'state' | 'reactive' | 'notification' | string`)
- **`tagName`** (optional): Specific tag for legacy compatibility and data-part serialization

Legacy signal types (`user-message`, `system-reminder`) are automatically normalized:
- User messages → `type: 'user'` with `tagName: 'user'`
- System reminders → `type: 'reactive'` with `tagName: 'system-reminder'`

XML markup and LLM-facing content generation use `tagName` to preserve the exact message element types seen by the model (e.g., `<user-message>` vs `<user>`). System-reminder filtering in memory modules now recognizes both legacy and normalized forms.

### Harness Follow-up Queueing

Updated `Harness.drainFollowUpQueue()` to prevent subscription deadlocks:
- When a thread subscription is active, follow-ups are now queued via `agent.queueMessage()` with stream options instead of immediately sent
- Added tracking of queued follow-ups in `HarnessDisplayState.queuedFollowUps` 
- Added `follow_up_queued` event (with optional `runId`) to harness event stream
- Idle follow-ups continue to send immediately via `sendMessage()`

### Channel Message Integration

Updated `AgentChannels` to route inbound channel messages through the new message API:
- Changed dispatch from `agent.sendSignal()` to `agent.sendMessage()`
- Preserves channel metadata, author/message attributes, and request context
- Maintains `resourceId`/`threadId` targeting and `ifIdle` wake behavior for message subscriptions

### Documentation and Changesets

- Updated `signals.mdx` guide to distinguish `sendMessage()` (user-authored input) from `sendSignal()` (low-level system context)
- Enhanced Agent reference docs with new `sendMessage()` and `queueMessage()` method signatures, examples, and compatibility notes
- Added signal type union documentation (`'user' | 'state' | 'reactive' | 'notification' | string`) with `tagName` optional field
- Updated example code to use `sendMessage()` with `ifIdle.streamOptions`
- Added three changesets (core, memory patches) documenting the message API and queuing behavior changes

## Backward Compatibility

The PR maintains full compatibility:
- Stored `user-message` and `system-reminder` payloads are automatically normalized on read
- Legacy metadata formats are rehydrated with the new `type`/`tagName` structure
- All adapters (AIV4, AIV5) detect and serialize user signals correctly with both old and new tag names
- System-reminder detection in memory and processors works with both legacy and reactive-wrapped forms
- Prefill error handlers, temporal gap markers, and tool result reminders updated to use normalized signal format

## Test Coverage

Expanded test suites verify:
- Message signal creation and normalization (`createMessageSignal`)
- Legacy signal rehydration with `tagName` metadata
- XML markup generation using `tagName`
- `sendMessage()` idle wake and active run injection
- `queueMessage()` behavior for subscribed threads
- Channel message routing through `sendMessage()`
- Follow-up queueing and display state tracking
- System-reminder filtering with normalized reactive signals

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->