### PR TITLE
04 docs: audit message-first signal docs

### DIFF
--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -241,7 +241,7 @@ Mastra still accepts legacy signal payloads such as `type: 'user-message'` and `
 - `type: 'user-message'`: Normalizes to `type: 'user'` and `tagName: 'user'`
 - `type: 'system-reminder'`: Normalizes to `type: 'reactive'` and `tagName: 'system-reminder'`
 
-Existing stored signal rows and older clients continue to load through the compatibility layer.
+Existing stored signal rows and older clients continue to load through the compatibility layer. New clients call the message routes when the server supports them; React's thread signal path falls back to the legacy `/signals` route when it detects an older server.
 
 :::note
 Visit [Agent signals reference](/reference/agents/agent#thread-signals) for the full message, signal, and subscription types.

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -293,7 +293,7 @@ Returns `{ accepted: true, runId: string }`.
 
 ### `subscribeToThread()`
 
-Subscribe to raw stream chunks for a memory thread. Use this to render output from a thread that may be started or continued by `sendSignal()`.
+Subscribe to raw stream chunks for a memory thread. Use this to render output from a thread that may be started or continued by `sendMessage()`, `queueMessage()`, or `sendSignal()`.
 
 ```typescript
 const agent = mastraClient.getAgent('support-agent')


### PR DESCRIPTION
## Stack position

Stack 4 of 8 in the signals API cleanup.

- Previous PR: #17238
- Next PR: #17240

## Summary

Performs the docs audit for the message-first signal API after the core, server, and SDK helpers are in place.

- Ensures the conceptual signals docs lead with `sendMessage()` / `queueMessage()`
- Keeps `sendSignal()` documented as the lower-level signal API for reactive, state, and notification primitives
- Updates client reference wording around `subscribeToThread()` to mention message helpers alongside signal helpers
- Fixes heading structure in the compatibility section
- Confirms the earlier stacks have package-scoped changesets

## Test plan

- `pnpm run prettier:changed`
