### PR TITLE
08 feat(playground): surface signal context panels

### DIFF
--- a/.changeset/ui-final-signal-panels.md
+++ b/.changeset/ui-final-signal-panels.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground': patch
+---
+
+Show state and notification signals as pinned thread context instead of normal chat messages.

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -371,6 +371,8 @@ Policy outcomes are `deliver`, `queue`, `persist`, `wake`, `summarize`, `discard
 
 Explicit message APIs stay predictable: `sendMessage()` still means immediate delivery by default, and `queueMessage()` still means next-turn queueing by default. Use `deliveryPolicy` only when you want to intentionally change those defaults for a category or source.
 
+Studio keeps state signals out of the normal transcript and shows them as pinned context above the thread instead. This keeps browser state and other processor state visible without turning every state refresh into chat noise.
+
 ## Notification signals
 
 Notification signals represent external events such as GitHub activity, email, Slack mentions, CI status, incidents, recordings, or direct messages. Notifications are durable and thread-scoped: each inbox record belongs to the conversation thread where it can be delivered, summarized, re-surfaced, and managed.
@@ -386,6 +388,8 @@ Mastra also supports lossy summaries that point back to full inbox records:
 ```
 
 Use `createNotificationInboxTool()` to give agents one flexible tool for `list`, `read`, `markSeen`, `dismiss`, `archive`, and `search` actions instead of many small CRUD tools. Source, resource, and agent ids are filters or routing metadata; `threadId` remains the primary inbox scope.
+
+Studio surfaces notification signals in a lightweight inbox panel above the thread. The panel groups the signal content with source, priority, and status metadata so notifications remain recoverable without being rendered as assistant chat bubbles.
 
 ## Delivery policy
 

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -371,6 +371,22 @@ Policy outcomes are `deliver`, `queue`, `persist`, `wake`, `summarize`, `discard
 
 Explicit message APIs stay predictable: `sendMessage()` still means immediate delivery by default, and `queueMessage()` still means next-turn queueing by default. Use `deliveryPolicy` only when you want to intentionally change those defaults for a category or source.
 
+## Notification signals
+
+Notification signals represent external events such as GitHub activity, email, Slack mentions, CI status, incidents, recordings, or direct messages. Notifications are durable and thread-scoped: each inbox record belongs to the conversation thread where it can be delivered, summarized, re-surfaced, and managed.
+
+```xml
+<notification source="github" type="ci-status" priority="high">CI failed on main: 3 tests</notification>
+```
+
+Mastra also supports lossy summaries that point back to full inbox records:
+
+```xml
+<notification-summary pending="10">GitHub: 3, Email: 5, Slack: 2</notification-summary>
+```
+
+Use `createNotificationInboxTool()` to give agents one flexible tool for `list`, `read`, `markSeen`, `dismiss`, `archive`, and `search` actions instead of many small CRUD tools. Source, resource, and agent ids are filters or routing metadata; `threadId` remains the primary inbox scope.
+
 ## Compatibility
 
 Mastra still accepts legacy signal payloads such as `type: 'user-message'` and `type: 'system-reminder'`. It normalizes them internally to the new category and tag shape:

--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -387,6 +387,33 @@ Mastra also supports lossy summaries that point back to full inbox records:
 
 Use `createNotificationInboxTool()` to give agents one flexible tool for `list`, `read`, `markSeen`, `dismiss`, `archive`, and `search` actions instead of many small CRUD tools. Source, resource, and agent ids are filters or routing metadata; `threadId` remains the primary inbox scope.
 
+## Delivery policy
+
+Agents can define an experimental `deliveryPolicy` when default routing is too noisy. The policy works by signal category (`user`, `reactive`, `state`, `notification`) instead of by XML tag name.
+
+```typescript title="src/mastra/agents/support-agent.ts"
+const agent = new Agent({
+  name: 'supportAgent',
+  instructions: 'Help users resolve support issues.',
+  model,
+  deliveryPolicy: {
+    categories: {
+      state: 'persist',
+      notification: 'summarize',
+    },
+    sources: {
+      pagerduty: {
+        notification: 'deliver',
+      },
+    },
+  },
+})
+```
+
+Policy outcomes are `deliver`, `queue`, `persist`, `wake`, `summarize`, `discard`, and `coalesce`. By default, user and reactive signals deliver to active runs and wake idle threads. State signals persist. Notifications summarize unless urgent; urgent notifications deliver immediately, and high-priority notifications can wake idle threads.
+
+Explicit message APIs stay predictable: `sendMessage()` still means immediate delivery by default, and `queueMessage()` still means next-turn queueing by default. Use `deliveryPolicy` only when you want to intentionally change those defaults for a category or source.
+
 ## Compatibility
 
 Mastra still accepts legacy signal payloads such as `type: 'user-message'` and `type: 'system-reminder'`. It normalizes them internally to the new category and tag shape:

--- a/packages/playground/src/lib/ai-ui/thread-runtime-state.ts
+++ b/packages/playground/src/lib/ai-ui/thread-runtime-state.ts
@@ -5,12 +5,33 @@ export type PendingSignalMessage = {
   preview: string;
 };
 
+export type ThreadStateSignal = {
+  id: string;
+  title: string;
+  preview: string;
+  source?: string;
+  updatedAt?: string;
+};
+
+export type ThreadNotificationSignal = {
+  id: string;
+  title: string;
+  preview: string;
+  source?: string;
+  priority?: string;
+  status?: string;
+  createdAt?: string;
+  count?: number;
+};
+
 export type ThreadRuntimeState = {
   isStreaming: boolean;
   canSendWhileStreaming: boolean;
   cancelStream: () => void | Promise<void>;
   pendingSignals: PendingSignalMessage[];
   hasPendingMessages: boolean;
+  stateSignals: ThreadStateSignal[];
+  notifications: ThreadNotificationSignal[];
 };
 
 const ThreadRuntimeStateContext = createContext<ThreadRuntimeState>({
@@ -19,6 +40,8 @@ const ThreadRuntimeStateContext = createContext<ThreadRuntimeState>({
   cancelStream: () => {},
   pendingSignals: [],
   hasPendingMessages: false,
+  stateSignals: [],
+  notifications: [],
 });
 
 export const ThreadRuntimeStateProvider = ThreadRuntimeStateContext.Provider;

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -1,7 +1,7 @@
 import type { MessagePrimitive } from '@assistant-ui/react';
 import { ComposerPrimitive, ThreadPrimitive, useComposer, useComposerRuntime } from '@assistant-ui/react';
 import { Avatar, Button, ButtonsGroup, cn, useAutoscroll } from '@mastra/playground-ui';
-import { ArrowUp, EyeIcon, Mic, PlusIcon } from 'lucide-react';
+import { ArrowUp, BellIcon, EyeIcon, Mic, PinIcon, PlusIcon } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { AttachFileDialog } from './attachments/attach-file-dialog';
 import { ComposerAttachments } from './attachments/attachment';
@@ -11,6 +11,7 @@ import { AssistantMessage } from './messages/assistant-message';
 import { SaveFullConversationAction } from './messages/dataset-save-action';
 import { UserMessage } from './messages/user-messages';
 import { useThreadRuntimeState } from './thread-runtime-state';
+import type { ThreadNotificationSignal, ThreadStateSignal } from './thread-runtime-state';
 import { BrowserThumbnail, useBrowserSession } from '@/domains/agents';
 import { ComposerModelSettings } from '@/domains/agents/components/composer-model-settings';
 import { ComposerModelSwitcher, ComposerModelWarning } from '@/domains/agents/components/composer-model-switcher';
@@ -34,6 +35,7 @@ export const Thread = ({ agentName, agentId, threadId, hasMemory, hasModelList, 
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   useAutoscroll(areaRef, { enabled: true });
   const { hasSession, viewMode, isInSidebar } = useBrowserSession();
+  const { stateSignals, notifications } = useThreadRuntimeState();
 
   // Show thumbnail in chat when:
   // 1. There's an active session
@@ -60,6 +62,7 @@ export const Thread = ({ agentName, agentId, threadId, hasMemory, hasModelList, 
           className="relative max-w-3xl w-full mx-auto px-4 pb-7 group-has-[[data-attachments-row]]/thread:pb-24"
         >
           <BracketOverlay containerRef={messagesContainerRef} />
+          <ThreadSignalContext stateSignals={stateSignals} notifications={notifications} />
           <ThreadPrimitive.Messages
             components={{
               UserMessage: UserMessage,
@@ -103,6 +106,69 @@ const ThreadWrapper = ({ children }: { children: React.ReactNode }) => {
     >
       {children}
     </ThreadPrimitive.Root>
+  );
+};
+
+const ThreadSignalContext = ({
+  stateSignals,
+  notifications,
+}: {
+  stateSignals: ThreadStateSignal[];
+  notifications: ThreadNotificationSignal[];
+}) => {
+  if (!stateSignals.length && !notifications.length) return null;
+
+  return (
+    <div className="mb-4 grid gap-2" data-testid="thread-signal-context">
+      {stateSignals.length ? (
+        <section className="rounded-lg border border-border2 bg-surface2 p-3" aria-label="Pinned state context">
+          <div className="mb-2 flex items-center gap-2 text-icon-sm font-medium text-icon6">
+            <PinIcon className="h-4 w-4" />
+            <span>Pinned state context</span>
+          </div>
+          <div className="grid gap-2">
+            {stateSignals.map(signal => (
+              <article
+                key={signal.id}
+                className="rounded-md bg-surface3 p-2 text-ui-sm"
+                data-testid="state-signal-card"
+              >
+                <div className="flex items-center justify-between gap-2 text-icon-xs text-icon3">
+                  <span>{signal.title}</span>
+                  {signal.updatedAt ? <time>{new Date(signal.updatedAt).toLocaleString()}</time> : null}
+                </div>
+                <p className="mt-1 text-icon5">{signal.preview}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {notifications.length ? (
+        <section className="rounded-lg border border-border2 bg-surface2 p-3" aria-label="Notification inbox">
+          <div className="mb-2 flex items-center gap-2 text-icon-sm font-medium text-icon6">
+            <BellIcon className="h-4 w-4" />
+            <span>Notification inbox</span>
+          </div>
+          <div className="grid gap-2">
+            {notifications.map(notification => (
+              <article
+                key={notification.id}
+                className="rounded-md bg-surface3 p-2 text-ui-sm"
+                data-testid="notification-signal-card"
+              >
+                <div className="flex items-center justify-between gap-2 text-icon-xs text-icon3">
+                  <span>{notification.source ?? notification.title}</span>
+                  {notification.priority ? <span>{notification.priority}</span> : null}
+                </div>
+                <p className="mt-1 text-icon5">{notification.preview}</p>
+                {notification.status ? <p className="mt-1 text-icon-xs text-icon3">{notification.status}</p> : null}
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </div>
   );
 };
 

--- a/packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx
+++ b/packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx
@@ -115,6 +115,84 @@ vi.mock('../tool-call-provider', () => ({
 }));
 
 import { MastraRuntimeProvider } from '../mastra-runtime-provider';
+import { extractThreadSignalPanels, removePinnedSignalParts } from '../signal-panels';
+
+describe('signal panel utilities', () => {
+  it('extracts state and notification signal panels from data parts', () => {
+    const messages = [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'data-state',
+            data: {
+              id: 'state-1',
+              type: 'state',
+              tagName: 'state',
+              contents: 'Browser is open. Active tab URL: https://example.com.',
+              createdAt: '2026-05-28T00:00:00.000Z',
+              attributes: { type: 'browser' },
+            },
+          },
+          {
+            type: 'data-notification',
+            data: {
+              id: 'notification-1',
+              type: 'notification',
+              tagName: 'notification',
+              contents: 'CI failed on main.',
+              createdAt: '2026-05-28T00:01:00.000Z',
+              attributes: { source: 'github', priority: 'high', status: 'pending' },
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(extractThreadSignalPanels(messages)).toEqual({
+      stateSignals: [
+        {
+          id: 'state-1',
+          title: 'browser state',
+          preview: 'Browser is open. Active tab URL: https://example.com.',
+          source: 'browser',
+          updatedAt: '2026-05-28T00:00:00.000Z',
+        },
+      ],
+      notifications: [
+        {
+          id: 'notification-1',
+          title: 'Notification',
+          preview: 'CI failed on main.',
+          source: 'github',
+          priority: 'high',
+          status: 'pending',
+          createdAt: '2026-05-28T00:01:00.000Z',
+          count: undefined,
+        },
+      ],
+    });
+  });
+
+  it('removes pinned state and notification parts from chat messages', () => {
+    const message = {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'Visible response' },
+        { type: 'data-state', data: { type: 'state', contents: 'Pinned context' } },
+        { type: 'data-notification', data: { type: 'notification', contents: 'Inbox event' } },
+      ],
+    };
+
+    expect(removePinnedSignalParts(message)).toEqual({
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Visible response' }],
+    });
+  });
+});
 
 describe('MastraRuntimeProvider', () => {
   beforeEach(() => {

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -8,6 +8,7 @@ import { toAssistantUIMessage, useMastraClient, useChat } from '@mastra/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
+import { extractThreadSignalPanels, removePinnedSignalParts } from './signal-panels';
 import {
   buildMaxStepsStreamErrorMessage,
   buildStreamErrorMessage,
@@ -854,14 +855,19 @@ export function MastraRuntimeProvider({
   // Build a global index of all OM cycle parts across all messages synchronously.
   // This gives each per-message converter the full picture of a cycle's state even when
   // parts are spread across messages (e.g., buffering-start on msg A, activation on msg B).
-  const globalOmParts = useMemo(() => buildGlobalOmPartsByCycleId(messages), [messages]);
+  const { stateSignals, notifications } = useMemo(() => extractThreadSignalPanels(messages), [messages]);
+  const chatMessages = useMemo(
+    () => messages.map(removePinnedSignalParts).filter((message): message is MastraUIMessage => Boolean(message)),
+    [messages],
+  );
+  const globalOmParts = useMemo(() => buildGlobalOmPartsByCycleId(chatMessages), [chatMessages]);
 
   // Convert data-om-* parts to dynamic-tool format BEFORE toAssistantUIMessage.
   // Strip transient error messages from `messages` because the same errors are
   // tracked in `streamErrors` (which survives the post-stream initialMessages
   // refresh). Without filtering here we would briefly render duplicate errors
   // during the streaming window.
-  const vnextmessages = [...messages.filter(msg => msg.metadata?.status !== 'error'), ...streamErrors].map(msg => {
+  const vnextmessages = [...chatMessages.filter(msg => msg.metadata?.status !== 'error'), ...streamErrors].map(msg => {
     const converted = convertOmPartsInMastraMessage(msg, globalOmParts);
     return toAssistantUIMessage(converted);
   });
@@ -890,6 +896,8 @@ export function MastraRuntimeProvider({
         cancelStream: onCancel,
         pendingSignals,
         hasPendingMessages: pendingSignals.length > 0,
+        stateSignals,
+        notifications,
       }}
     >
       <AssistantRuntimeProvider runtime={runtime}>

--- a/packages/playground/src/services/signal-panels.ts
+++ b/packages/playground/src/services/signal-panels.ts
@@ -1,0 +1,93 @@
+import type { ThreadNotificationSignal, ThreadStateSignal } from '@/lib/ai-ui/thread-runtime-state';
+
+type SignalDataPart = {
+  type?: string;
+  data?: {
+    id?: string;
+    type?: string;
+    tagName?: string;
+    contents?: unknown;
+    createdAt?: string;
+    attributes?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+  };
+};
+
+const signalContentsPreview = (contents: unknown): string => {
+  if (typeof contents === 'string') return contents;
+  if (Array.isArray(contents)) {
+    return contents
+      .map(part => (typeof part === 'object' && part !== null && 'text' in part ? String(part.text) : ''))
+      .filter(Boolean)
+      .join(' ');
+  }
+  return '';
+};
+
+const getSignalParts = (messages: Array<{ parts?: unknown[] }>): SignalDataPart[] => {
+  return messages.flatMap(message => {
+    const parts = message.parts ?? [];
+    return parts.filter(
+      (part): part is SignalDataPart =>
+        typeof part === 'object' && part !== null && typeof (part as SignalDataPart).type === 'string',
+    );
+  });
+};
+
+export const extractThreadSignalPanels = (messages: Array<{ parts?: unknown[] }>) => {
+  const stateSignals: ThreadStateSignal[] = [];
+  const notifications: ThreadNotificationSignal[] = [];
+
+  for (const part of getSignalParts(messages)) {
+    const category = part.data?.type;
+    if (category === 'state') {
+      const source =
+        typeof part.data?.attributes?.type === 'string'
+          ? part.data.attributes.type
+          : typeof part.data?.attributes?.source === 'string'
+            ? part.data.attributes.source
+            : undefined;
+      stateSignals.push({
+        id: part.data?.id ?? `state-${stateSignals.length}`,
+        title: source ? `${source} state` : 'State',
+        preview: signalContentsPreview(part.data?.contents),
+        source,
+        updatedAt: part.data?.createdAt,
+      });
+    } else if (category === 'notification') {
+      const attributes = part.data?.attributes ?? {};
+      const metadata = part.data?.metadata ?? {};
+      const notificationMetadata = metadata.notification as Record<string, unknown> | undefined;
+      notifications.push({
+        id: part.data?.id ?? `notification-${notifications.length}`,
+        title: part.data?.tagName === 'notification-summary' ? 'Notification summary' : 'Notification',
+        preview: signalContentsPreview(part.data?.contents),
+        source:
+          typeof attributes.source === 'string'
+            ? attributes.source
+            : typeof notificationMetadata?.source === 'string'
+              ? notificationMetadata.source
+              : undefined,
+        priority: typeof attributes.priority === 'string' ? attributes.priority : undefined,
+        status: typeof attributes.status === 'string' ? attributes.status : undefined,
+        createdAt: part.data?.createdAt,
+        count: typeof attributes.pending === 'number' ? attributes.pending : undefined,
+      });
+    }
+  }
+
+  return { stateSignals, notifications };
+};
+
+export const removePinnedSignalParts = <TMessage extends { role?: string; parts?: unknown[] }>(
+  message: TMessage,
+): TMessage | null => {
+  const parts = message.parts?.filter(part => {
+    const category = (part as SignalDataPart).data?.type;
+    return category !== 'state' && category !== 'notification';
+  });
+
+  if (!parts || parts.length === (message.parts?.length ?? 0)) return message;
+  if (parts.length === 0 && message.role === 'assistant') return null;
+  return { ...message, parts };
+};


### PR DESCRIPTION
## Stack position

Stack 8 of 8 in the signals API cleanup.

- Previous PR: #17242
- Next PR: none — final PR in this stack

## Summary

Surfaces non-chat signal context in the playground thread runtime so state and notification signals are visible without rendering them as normal chat messages.

- Adds state signal and notification collections to thread runtime state
- Extracts signal panel parsing helpers into a dedicated service module
- Surfaces state signal context and notification indicators in the thread UI
- Keeps user message echo handling and pending signal behavior intact
- Adds focused playground tests for signal panel extraction/runtime behavior
- Updates the final docs/examples and adds a UI changeset

## Test plan

- Playground MSW/unit tests for runtime provider signal panel behavior
- `pnpm --filter ./packages/playground check`
- `pnpm --filter ./packages/playground build`
- `pnpm run prettier:changed`
