### PR TITLE
refactor(observability): remove duplicate 'createRun' in workflow wrap list

### DIFF
--- a/packages/core/src/observability/context.ts
+++ b/packages/core/src/observability/context.ts
@@ -17,7 +17,7 @@ const AGENT_GETTERS = ['getAgent', 'getAgentById'];
 const AGENT_METHODS_TO_WRAP = ['generate', 'stream', 'generateLegacy', 'streamLegacy'];
 
 const WORKFLOW_GETTERS = ['getWorkflow', 'getWorkflowById'];
-const WORKFLOW_METHODS_TO_WRAP = ['execute', 'createRun', 'createRun'];
+const WORKFLOW_METHODS_TO_WRAP = ['execute', 'createRun'];
 
 /**
  * Helper function to detect NoOp spans to avoid unnecessary wrapping
@@ -146,8 +146,9 @@ function wrapWorkflow<T extends Workflow>(workflow: T, tracingContext: TracingCo
         try {
           // Wrap workflow execution methods with tracing context
           if (WORKFLOW_METHODS_TO_WRAP.includes(prop as string)) {
-            // Handle createRun and createRun methods differently
-            if (prop === 'createRun' || prop === 'createRun') {
+            // createRun returns a Run instance that must be wrapped to inject tracing
+            // context into its start() method.
+            if (prop === 'createRun') {
               return async (options: any = {}) => {
                 const run = await (target as any)[prop](options);
                 return run ? wrapRun(run, tracingContext) : run;


### PR DESCRIPTION
## Problem

In `packages/core/src/observability/context.ts`:

```ts
// line 20
const WORKFLOW_METHODS_TO_WRAP = ['execute', 'createRun', 'createRun'];

// line 149-150
// Handle createRun and createRun methods differently
if (prop === 'createRun' || prop === 'createRun') {
```

`'createRun'` appears twice in `WORKFLOW_METHODS_TO_WRAP`, and the condition that selects the wrapping branch compares `prop` against the same string on both sides of the `||`. The accompanying comment also references "createRun and createRun".

This was left over from the `createRunAsync` → `createRun` rename in #9663 — the automated replacement collapsed both entries to the same value but did not deduplicate them.

Runtime behavior is unchanged today (`Array.includes` works identically with or without the duplicate, and the `||` is a tautology), but the code reads as if two different methods are being handled.

## Solution

- Drop the duplicate from `WORKFLOW_METHODS_TO_WRAP` → `['execute', 'createRun']`.
- Simplify the condition to `if (prop === 'createRun')`.
- Update the comment to describe what the branch actually does (wraps the returned `Run` so `start()` carries tracing context).

No behavior change.

## Testing

Existing tests in `packages/core/src/observability/context.test.ts` cover the `createRun` wrapping path (`should wrap createRun to return run proxy` and surrounding cases at lines 153–201) and continue to pass with the simplified array and condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR cleans up duplicate code in the observability (monitoring/tracing) system. The code had the same method name listed twice in a list and was checking for it twice in an if-statement—kind of like saying "if it's a cat or a cat" instead of just "if it's a cat." The fix removes the duplicate so the code is simpler and clearer, but the program still works exactly the same way.

## Changes

**File: `packages/core/src/observability/context.ts`**

Removed redundant code from the workflow wrapping configuration:

- **`WORKFLOW_METHODS_TO_WRAP` array**: Now contains `['execute', 'createRun']`, removing the duplicate `'createRun'` entry that resulted from an earlier automated rename (`createRunAsync` → `createRun`).

- **Conditional logic**: Simplified the special-case handling for `createRun` from a redundant condition to a single, clear check (`if (prop === 'createRun')`).

- **Comment update**: Clarified the comment to accurately document that this branch wraps the returned Run instance so that tracing context can be properly injected into the Run's `start()` method.

## Impact

- **No behavioral changes**: The program's runtime behavior remains identical.
- **Code quality**: Eliminates confusing redundancy that resulted from an earlier automated rename.
- **Testing**: Existing tests in `packages/core/src/observability/context.test.ts`, including the "should wrap createRun to return run proxy" test, continue to pass with these changes.

**Lines changed**: +4/-3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->