### PR TITLE
fix(agent): persist tool approval state as output-denied on recall

### DIFF
--- a/.changeset/fix-tool-approval-round-trip.md
+++ b/.changeset/fix-tool-approval-round-trip.md
@@ -1,0 +1,10 @@
+---
+"@mastra/core": patch
+"@mastra/memory": patch
+---
+
+Fixed tool approval round-trip persistence for recalled messages.
+
+When a requireApproval tool call is declined or approved, the write path now correctly
+persists the approval object and output-denied state so memory.recall() +
+toAISdkMessages({ version: 'v6' }) reflects the decision correctly.

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -1036,31 +1036,17 @@ describe('Supervisor Pattern - Tool approval propagation', () => {
       toolCallId: approvalToolCallId,
     });
 
-    let toolDeclinedMessage = '';
-
     for await (const _chunk of resumeStream.fullStream) {
-      // consume
-      if (_chunk.type === 'tool-output') {
-        const output = _chunk.payload.output;
-        if (output.type === 'tool-result' && output.payload.toolName === 'find-user-tool-decline') {
-          toolDeclinedMessage = output.payload.result;
-        }
-      }
+      // consume — output-denied calls emit no tool-result chunk
     }
 
     const toolResults = await resumeStream.toolResults;
 
     // Verify tool was NOT executed
     expect(mockFindUser).not.toHaveBeenCalled();
-
-    // Verify we got tool results from the sub-agent delegation
+    // The supervisor gets a tool-result for the agent delegation itself,
+    // even though the sub-agent's tool was output-denied
     expect(toolResults.length).toBeGreaterThan(0);
-
-    // The supervisor's tool result for the agent delegation should contain the sub-agent's response
-    const subAgentResult = toolResults.find(tr => tr.payload?.toolName === 'agent-approvalDeclineSubAgent');
-    expect(subAgentResult).toBeDefined();
-    expect(subAgentResult?.payload?.result).toBeDefined();
-    expect(toolDeclinedMessage).toBe('Tool call was not approved by the user');
   });
 });
 

--- a/packages/core/src/agent/__tests__/tool-approval.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/tool-approval.e2e.test.ts
@@ -114,8 +114,7 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
         const toolResults = await resumeStream.toolResults;
 
         expect((await resumeStream.toolCalls).length).toBe(1);
-        expect(toolResults.length).toBe(1);
-        expect(toolResults[0].payload?.result).toBe('Tool call was not approved by the user');
+        expect(toolResults.length).toBe(0); // output-denied calls emit no tool-result chunk
         expect(mockFindUser).toHaveBeenCalledTimes(0);
       }, 500000);
 
@@ -481,8 +480,7 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
 
         const toolResults = resumeOutput.toolResults;
 
-        expect(toolResults.length).toBe(1);
-        expect(toolResults[0].payload?.result).toBe('Tool call was not approved by the user');
+        expect(toolResults.length).toBe(0); // output-denied calls emit no tool-result chunk
         expect(mockFindUser).toHaveBeenCalledTimes(0);
       }, 500000);
     });

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -349,6 +349,12 @@ export interface DurableToolCallOutput extends DurableToolCallInput {
     message: string;
     stack?: string;
   };
+  /** HITL approval decision, present when the tool required approval */
+  approval?: {
+    id: string;
+    approved: boolean;
+    reason?: string;
+  };
 }
 
 /**

--- a/packages/core/src/agent/durable/workflows/steps/llm-mapping-approval.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-mapping-approval.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import type { MastraToolInvocationPart } from '../../../message-list';
+import { MessageList } from '../../../message-list';
+import type { DurableToolCallOutput } from '../../types';
+import { createDurableLLMMappingStep } from './llm-mapping';
+
+const TOOL_CALL_ID = 'tc-denied-1';
+const TOOL_NAME = 'delete-file';
+
+function makeLlmOutput(messageListState: ReturnType<MessageList['serialize']>) {
+  return {
+    messageListState,
+    text: undefined,
+    toolCalls: [
+      {
+        toolCallId: TOOL_CALL_ID,
+        toolName: TOOL_NAME,
+        args: { path: '/tmp/test.txt' },
+      },
+    ],
+    stepResult: {
+      reason: 'tool-calls',
+      warnings: [],
+      isContinued: true,
+    },
+  };
+}
+
+async function executeMapping(toolResults: DurableToolCallOutput[]) {
+  const messageList = new MessageList({ threadId: 'thread-1', resourceId: 'user-1' });
+  messageList.add(
+    [
+      {
+        role: 'assistant' as const,
+        content: [
+          {
+            type: 'tool-call' as const,
+            toolCallId: TOOL_CALL_ID,
+            toolName: TOOL_NAME,
+            args: { path: '/tmp/test.txt' },
+          },
+        ],
+      },
+    ],
+    'response',
+  );
+
+  const step = createDurableLLMMappingStep();
+  const output = await (step as any).execute({
+    inputData: {
+      llmOutput: makeLlmOutput(messageList.serialize()),
+      toolResults,
+      runId: 'run-1',
+      agentId: 'agent-1',
+      messageId: 'msg-1',
+      state: { threadId: 'thread-1', resourceId: 'user-1' },
+    },
+  });
+
+  const resultList = new MessageList({ threadId: 'thread-1', resourceId: 'user-1' });
+  resultList.deserialize(output.messageListState);
+  return resultList;
+}
+
+describe('durable llm-mapping — tool approval persistence', () => {
+  it('persists a declined tool call as state: output-denied with approval metadata', async () => {
+    const resultList = await executeMapping([
+      {
+        toolCallId: TOOL_CALL_ID,
+        toolName: TOOL_NAME,
+        args: { path: '/tmp/test.txt' },
+        approval: {
+          id: TOOL_CALL_ID,
+          approved: false,
+          reason: 'Tool call was not approved by the user',
+        },
+      },
+    ]);
+
+    const messages = resultList.get.all.db();
+    const toolPart = messages
+      .flatMap(m => m.content.parts)
+      .find(
+        (p): p is MastraToolInvocationPart =>
+          p.type === 'tool-invocation' && (p as MastraToolInvocationPart).toolInvocation?.toolCallId === TOOL_CALL_ID,
+      );
+
+    expect(toolPart).toBeDefined();
+    expect(toolPart!.toolInvocation.state).toBe('output-denied');
+    const deniedInv = toolPart!.toolInvocation as MastraToolInvocationPart['toolInvocation'] & {
+      approval?: { id: string; approved: boolean; reason?: string };
+      result?: unknown;
+    };
+    expect(deniedInv.approval).toEqual({
+      id: TOOL_CALL_ID,
+      approved: false,
+      reason: 'Tool call was not approved by the user',
+    });
+    // No result should be persisted for a denied approval
+    expect(deniedInv.result).toBeUndefined();
+  });
+
+  it('persists an approved tool call as state: result with approval: { approved: true }', async () => {
+    const resultList = await executeMapping([
+      {
+        toolCallId: TOOL_CALL_ID,
+        toolName: TOOL_NAME,
+        args: { path: '/tmp/test.txt' },
+        result: { deleted: true },
+        approval: {
+          id: TOOL_CALL_ID,
+          approved: true,
+        },
+      },
+    ]);
+
+    const messages = resultList.get.all.db();
+    const toolPart = messages
+      .flatMap(m => m.content.parts)
+      .find(
+        (p): p is MastraToolInvocationPart =>
+          p.type === 'tool-invocation' && (p as MastraToolInvocationPart).toolInvocation?.toolCallId === TOOL_CALL_ID,
+      );
+
+    expect(toolPart).toBeDefined();
+    expect(toolPart!.toolInvocation.state).toBe('result');
+    const approvedInv = toolPart!.toolInvocation as MastraToolInvocationPart['toolInvocation'] & {
+      approval?: { id: string; approved: boolean; reason?: string };
+      result?: unknown;
+    };
+    expect(approvedInv.result).toEqual({ deleted: true });
+    expect(approvedInv.approval).toEqual({
+      id: TOOL_CALL_ID,
+      approved: true,
+    });
+  });
+});

--- a/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
@@ -86,16 +86,33 @@ export function createDurableLLMMappingStep() {
       // 2. Add tool results to message list
       if (toolResults.length > 0) {
         for (const toolResult of toolResults) {
-          const result = toolResult.error ? toolResult.error.message : toolResult.result;
+          const isDeniedApproval = toolResult.approval?.approved === false;
+          const result = toolResult.error
+            ? toolResult.error.message
+            : isDeniedApproval
+              ? (toolResult.approval?.reason ?? 'Tool call was not approved by the user')
+              : toolResult.result;
           const updated = messageList.updateToolInvocation({
             type: 'tool-invocation' as const,
-            toolInvocation: {
-              state: 'result' as const,
-              toolCallId: toolResult.toolCallId,
-              toolName: toolResult.toolName,
-              args: toolResult.args,
-              result,
-            },
+            toolInvocation: isDeniedApproval
+              ? {
+                  state: 'output-denied' as const,
+                  toolCallId: toolResult.toolCallId,
+                  toolName: toolResult.toolName,
+                  args: toolResult.args,
+                  approval: {
+                    ...toolResult.approval!,
+                    reason: toolResult.approval?.reason ?? 'Tool call was not approved by the user',
+                  },
+                }
+              : {
+                  state: 'result' as const,
+                  toolCallId: toolResult.toolCallId,
+                  toolName: toolResult.toolName,
+                  args: toolResult.args,
+                  result,
+                  ...(toolResult.approval ? { approval: toolResult.approval } : {}),
+                },
           });
 
           if (!updated) {

--- a/packages/core/src/agent/durable/workflows/steps/tool-call-approval.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call-approval.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
+import { globalRunRegistry } from '../../run-registry';
+import { createDurableToolCallStep } from './tool-call';
+
+vi.mock('../../../../background-tasks/create', () => ({
+  createBackgroundTask: vi.fn(),
+}));
+vi.mock('../../../../background-tasks/resolve-config', () => ({
+  resolveBackgroundConfig: vi.fn(),
+}));
+vi.mock('../../utils/resolve-runtime', () => ({
+  resolveTool: vi.fn(),
+  toolRequiresApproval: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('../../stream-adapter', () => ({
+  emitChunkEvent: vi.fn().mockResolvedValue(undefined),
+  emitSuspendedEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const RUN_ID = 'run-approval-1';
+const AGENT_ID = 'agent-1';
+const TOOL_NAME = 'delete-file';
+const TOOL_CALL_ID = 'call-approval-1';
+
+function mockPubsub() {
+  return { publish: vi.fn(), subscribe: vi.fn(), unsubscribe: vi.fn(), flush: vi.fn() };
+}
+
+function baseInput() {
+  return {
+    toolCallId: TOOL_CALL_ID,
+    toolName: TOOL_NAME,
+    args: { path: '/tmp/test.txt' },
+  };
+}
+
+function makeInitData(overrides: Record<string, any> = {}) {
+  return {
+    runId: RUN_ID,
+    agentId: AGENT_ID,
+    options: { requireToolApproval: true },
+    state: {
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+      memoryConfig: undefined,
+      threadExists: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeMessageList() {
+  return {
+    updateToolInvocation: vi.fn().mockReturnValue(true),
+    add: vi.fn(),
+  };
+}
+
+function makeSaveQueueManager() {
+  return { flushMessages: vi.fn().mockResolvedValue(undefined) };
+}
+
+function setupRegistry(overrides: Record<string, any> = {}) {
+  const messageList = makeMessageList();
+  const saveQueueManager = makeSaveQueueManager();
+  const entry = {
+    tools: {
+      [TOOL_NAME]: {
+        execute: vi.fn().mockResolvedValue({ deleted: true }),
+      },
+    },
+    model: {} as any,
+    messageList,
+    saveQueueManager,
+    ...overrides,
+  };
+  globalRunRegistry.set(RUN_ID, entry as any);
+  return { messageList, saveQueueManager, entry };
+}
+
+function executeStep(pubsub: any, initData: any, input: any, resumeData?: any) {
+  const step = createDurableToolCallStep();
+  return (step as any).execute({
+    inputData: input,
+    mastra: { getLogger: () => undefined },
+    suspend: vi.fn(),
+    resumeData,
+    requestContext: new Map(),
+    getInitData: () => initData,
+    [PUBSUB_SYMBOL]: pubsub,
+  });
+}
+
+afterEach(() => {
+  if (globalRunRegistry.has(RUN_ID)) {
+    globalRunRegistry.delete(RUN_ID);
+  }
+  vi.clearAllMocks();
+});
+
+describe('durable tool-call approval round-trip', () => {
+  it('returns a structured approval object (no result) when the tool call is declined', async () => {
+    const pubsub = mockPubsub();
+    setupRegistry();
+    const initData = makeInitData();
+
+    const output = await executeStep(pubsub, initData, baseInput(), { approved: false });
+
+    expect(output.result).toBeUndefined();
+    expect(output.approval).toEqual({
+      id: TOOL_CALL_ID,
+      approved: false,
+      reason: 'Tool call was not approved by the user',
+    });
+  });
+
+  it('returns an approval: { approved: true } alongside the result when the tool call is approved', async () => {
+    const pubsub = mockPubsub();
+    setupRegistry();
+    const initData = makeInitData();
+
+    const output = await executeStep(pubsub, initData, baseInput(), { approved: true });
+
+    expect(output.result).toEqual({ deleted: true });
+    expect(output.approval).toEqual({
+      id: TOOL_CALL_ID,
+      approved: true,
+    });
+  });
+});

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -49,6 +49,13 @@ const durableToolCallOutputSchema = durableToolCallInputSchema.extend({
       stack: z.string().optional(),
     })
     .optional(),
+  approval: z
+    .object({
+      id: z.string(),
+      approved: z.boolean(),
+      reason: z.string().optional(),
+    })
+    .optional(),
 });
 
 /**
@@ -329,7 +336,11 @@ export function createDurableToolCallStep() {
         if (!(resumeData as { approved: boolean }).approved) {
           return {
             ...typedInput,
-            result: 'Tool call was not approved by the user',
+            approval: {
+              id: typedInput.toolCallId,
+              approved: false,
+              reason: 'Tool call was not approved by the user',
+            },
           };
         }
       }
@@ -676,6 +687,12 @@ export function createDurableToolCallStep() {
                   ...typedInput,
                   args: cleanedArgs,
                   result: `Background task resumed. Task ID: ${task.id}. The tool "${toolName}" is running in the background. You will be notified when it completes.`,
+                  ...(requiresApproval &&
+                  resumeData &&
+                  typeof resumeData === 'object' &&
+                  (resumeData as any).approved === true
+                    ? { approval: { id: toolCallId, approved: true as const } }
+                    : {}),
                 };
               }
             }
@@ -702,6 +719,12 @@ export function createDurableToolCallStep() {
                 ...typedInput,
                 args: cleanedArgs,
                 result: `Background task started. Task ID: ${task.id}. The tool "${toolName}" is running in the background. You will be notified when it completes.`,
+                ...(requiresApproval &&
+                resumeData &&
+                typeof resumeData === 'object' &&
+                (resumeData as any).approved === true
+                  ? { approval: { id: toolCallId, approved: true as const } }
+                  : {}),
               };
             }
             // fallbackToSync: concurrency limit hit, fall through to synchronous execution
@@ -741,6 +764,9 @@ export function createDurableToolCallStep() {
         return {
           ...typedInput,
           result,
+          ...(requiresApproval && resumeData && typeof resumeData === 'object' && (resumeData as any).approved === true
+            ? { approval: { id: toolCallId, approved: true as const } }
+            : {}),
         };
       } catch (error) {
         const toolError = serializeError(error);

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter-suspended-parts.test.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter-suspended-parts.test.ts
@@ -225,6 +225,84 @@ describe('AIV5Adapter — suspended tool state rehydration', () => {
     expect(approvalParts).toHaveLength(1);
   });
 
+  it('should downgrade output-denied state to output-available with approval.reason as output', () => {
+    const dbMessage: MastraDBMessage = {
+      id: 'msg-denied',
+      role: 'assistant',
+      createdAt: new Date('2024-01-01'),
+      content: {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              toolCallId: 'tc-denied',
+              toolName: 'delete-file',
+              args: { path: '/tmp/test.txt' },
+              state: 'output-denied',
+              approval: {
+                id: 'tc-denied',
+                approved: false,
+                reason: 'Tool call was not approved by the user',
+              },
+            } as any,
+          },
+        ] as any,
+        metadata: {},
+      },
+    };
+
+    const uiMessage = AIV5Adapter.toUIMessage(dbMessage);
+
+    const toolParts = uiMessage.parts.filter(p => p.type.startsWith('tool-'));
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0]).toMatchObject({
+      type: 'tool-delete-file',
+      toolCallId: 'tc-denied',
+      input: { path: '/tmp/test.txt' },
+      state: 'output-available',
+      output: 'Tool call was not approved by the user',
+    });
+    // approval must not leak onto the V5 part
+    expect((toolParts[0] as any).approval).toBeUndefined();
+  });
+
+  it('should fall back to a default denial message when output-denied has no approval.reason', () => {
+    const dbMessage: MastraDBMessage = {
+      id: 'msg-denied-no-reason',
+      role: 'assistant',
+      createdAt: new Date('2024-01-01'),
+      content: {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              toolCallId: 'tc-denied-2',
+              toolName: 'delete-file',
+              args: { path: '/tmp/test2.txt' },
+              state: 'output-denied',
+              approval: {
+                id: 'tc-denied-2',
+                approved: false,
+              },
+            } as any,
+          },
+        ] as any,
+        metadata: {},
+      },
+    };
+
+    const uiMessage = AIV5Adapter.toUIMessage(dbMessage);
+
+    const toolParts = uiMessage.parts.filter(p => p.type.startsWith('tool-'));
+    expect(toolParts[0]).toMatchObject({
+      type: 'tool-delete-file',
+      state: 'output-available',
+      output: 'Tool call was not approved by the user',
+    });
+  });
+
   it('should NOT produce data-tool-call-suspended parts for already-resumed tools', () => {
     // When a tool has been resumed/completed, metadata.suspendedTools is cleared,
     // so no data-tool-call-suspended parts should be synthesized

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
@@ -331,6 +331,16 @@ export class AIV5Adapter {
               callProviderMetadata: mergeMastraCreatedAt(part.providerMetadata, part.createdAt),
               providerExecuted: (part as { providerExecuted?: boolean }).providerExecuted,
             } satisfies AIV5Type.ToolUIPart);
+          } else if (inv.state === 'output-denied') {
+            parts.push({
+              type: `tool-${inv.toolName}`,
+              toolCallId: inv.toolCallId,
+              input: getDisplayTransform(part.providerMetadata, 'input-available', inv.args, transformToolPayloads),
+              output: inv.approval?.reason ?? 'Tool call was not approved by the user',
+              state: 'output-available',
+              callProviderMetadata: mergeMastraCreatedAt(part.providerMetadata, part.createdAt),
+              providerExecuted: (part as { providerExecuted?: boolean }).providerExecuted,
+            } satisfies AIV5Type.ToolUIPart);
           } else {
             parts.push({
               type: `tool-${inv.toolName}`,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -1515,3 +1515,164 @@ describe('createLLMMappingStep toModelOutput', () => {
     expect(span.errorOptions).toEqual({ error: failure, endSpan: true });
   });
 });
+
+describe('createLLMMappingStep tool approval persistence', () => {
+  let controller: { enqueue: Mock };
+  let messageList: MessageList;
+  let llmExecutionStep: any;
+  let bail: Mock;
+  let getStepResult: Mock;
+  let llmMappingStep: ReturnType<typeof createLLMMappingStep>;
+
+  const createExecuteParams = (
+    inputData: ToolCallOutput[],
+  ): ExecuteFunctionParams<{}, ToolCallOutput[], any, any, any> => ({
+    runId: 'test-run',
+    workflowId: 'test-workflow',
+    mastra: {} as any,
+    requestContext: new RequestContext(),
+    state: {},
+    setState: vi.fn(),
+    retryCount: 1,
+    tracingContext: {} as any,
+    getInitData: vi.fn(),
+    getStepResult,
+    suspend: vi.fn(),
+    bail,
+    abort: vi.fn(),
+    engine: 'default' as any,
+    abortSignal: new AbortController().signal,
+    writer: new ToolStream({
+      prefix: 'tool',
+      callId: 'test-call-id',
+      name: 'test-tool',
+      runId: 'test-run',
+    }),
+    validateSchemas: false,
+    inputData,
+    [PUBSUB_SYMBOL]: {} as any,
+    [STREAM_FORMAT_SYMBOL]: undefined,
+  });
+
+  beforeEach(() => {
+    controller = { enqueue: vi.fn() };
+    messageList = {
+      get: {
+        all: { aiV5: { model: () => [] } },
+        input: { aiV5: { model: () => [] } },
+        response: { aiV5: { model: () => [] } },
+      },
+      add: vi.fn(),
+      updateToolInvocation: vi.fn(),
+    } as unknown as MessageList;
+
+    llmExecutionStep = createStep({
+      id: 'test-llm-execution',
+      inputSchema: z.any(),
+      outputSchema: z.any(),
+      execute: async () => ({
+        stepResult: { isContinued: true, reason: undefined },
+        metadata: {},
+      }),
+    });
+
+    bail = vi.fn(data => data);
+    getStepResult = vi.fn(() => ({
+      stepResult: {
+        isContinued: true,
+        reason: undefined,
+      },
+      metadata: {},
+    }));
+
+    llmMappingStep = createLLMMappingStep(
+      {
+        models: {} as any,
+        controller,
+        messageList,
+        runId: 'test-run',
+        _internal: {
+          generateId: () => 'test-message-id',
+        },
+      } as any,
+      llmExecutionStep,
+    );
+  });
+
+  it('should persist declined tool call as output-denied and not bail', async () => {
+    // Arrange: declined tool call has approval.approved === false and no result
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-declined',
+        toolName: 'someApprovalTool',
+        args: { value: 'test' },
+        result: undefined,
+        approval: {
+          id: 'call-declined',
+          approved: false,
+          reason: 'Tool call was not approved by the user',
+        },
+      } as any,
+    ];
+
+    // Act
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    // Assert: should NOT bail (declined approval bypasses the HITL bail path)
+    expect(bail).not.toHaveBeenCalled();
+
+    // Assert: updateToolInvocation called with output-denied state
+    expect(messageList.updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-invocation',
+        toolInvocation: expect.objectContaining({
+          state: 'output-denied',
+          toolCallId: 'call-declined',
+          approval: expect.objectContaining({
+            approved: false,
+            reason: 'Tool call was not approved by the user',
+          }),
+        }),
+      }),
+    );
+
+    // Assert: no tool-result chunk emitted for denied call
+    expect(controller.enqueue).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'tool-result' }));
+  });
+
+  it('should persist approval metadata in mixed turn (one approved success + one error)', async () => {
+    // Arrange: one tool approved+succeeded, one tool errored
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-approved',
+        toolName: 'approvedTool',
+        args: { value: 'test' },
+        result: { success: true },
+        approval: { id: 'call-approved', approved: true },
+      } as any,
+      {
+        toolCallId: 'call-error',
+        toolName: 'errorTool',
+        args: { value: 'bad' },
+        result: undefined,
+        error: new Error('tool-not-found'),
+      } as any,
+    ];
+
+    // Act
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    // Assert: approved tool persisted with approval metadata intact
+    expect(messageList.updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-invocation',
+        toolInvocation: expect.objectContaining({
+          state: 'result',
+          toolCallId: 'call-approved',
+          result: { success: true },
+          approval: expect.objectContaining({ approved: true }),
+        }),
+      }),
+    );
+  });
+});

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -293,7 +293,12 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
         return withToolPayloadTransformMetadata(withToolPayloadTransformMetadata(chunk, inputTransform), transform);
       }
 
-      if (inputData?.some(toolCall => toolCall?.result === undefined && !toolCall.providerExecuted)) {
+      const isDeniedApproval = (tc: any) => tc.approval?.approved === false;
+      if (
+        inputData?.some(
+          toolCall => toolCall?.result === undefined && !toolCall.providerExecuted && !isDeniedApproval(toolCall),
+        )
+      ) {
         const errorResults = inputData.filter(toolCall => toolCall?.error && !toolCall.providerExecuted);
 
         if (errorResults?.length) {
@@ -358,7 +363,9 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
         // Check for pending HITL tool calls (tools with no result and no error).
         // In mixed turns with errors and pending HITL tools,
         // the HITL suspension path should take priority over continuing the loop.
-        const hasPendingHITL = inputData.some(tc => tc.result === undefined && !tc.error && !tc.providerExecuted);
+        const hasPendingHITL = inputData.some(
+          tc => tc.result === undefined && !tc.error && !tc.providerExecuted && !isDeniedApproval(tc),
+        );
 
         if (errorResults?.length > 0 && !hasPendingHITL) {
           // Process any successful tool results from this turn before continuing.
@@ -408,6 +415,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
                     toolName: sanitizeToolName(toolCall.toolName),
                     args: toolCall.args,
                     result: toolCall.result,
+                    ...(toolCall.approval ? { approval: toolCall.approval } : {}),
                   },
                   ...(withToolPayloadTransformProviderMetadata(providerMetadata, chunk.metadata)
                     ? {
@@ -459,6 +467,23 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           // No result yet — skip emitting a chunk. For deferred provider-executed tools
           // (e.g. Anthropic web_search), the result arrives in a later step and is handled
           // by processOutputStream's 'tool-result' case in llm-execution-step.
+          if (toolCall.approval?.approved === false) {
+            rest.messageList.updateToolInvocation({
+              type: 'tool-invocation' as const,
+              toolInvocation: {
+                state: 'output-denied' as const,
+                toolCallId: toolCall.toolCallId,
+                toolName: sanitizeToolName(toolCall.toolName),
+                args: toolCall.args,
+                approval: {
+                  id: toolCall.approval.id,
+                  approved: false,
+                  reason: toolCall.approval.reason,
+                },
+              },
+            });
+            continue;
+          }
           if (toolCall.result === undefined) continue;
 
           // Compute modelOutput before emitting the chunk so consumers (e.g. harness)
@@ -501,6 +526,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
                 toolName: sanitizeToolName(toolCall.toolName),
                 args: toolCall.args,
                 result: toolCall.result,
+                ...(toolCall.approval ? { approval: toolCall.approval } : {}),
               },
               ...(withToolPayloadTransformProviderMetadata(providerMetadata, chunk.metadata)
                 ? {

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -427,8 +427,12 @@ describe('createToolCallStep tool approval workflow', () => {
     const result = await toolCallStep.execute(makeExecuteParams({ inputData, resumeData }));
 
     expect(result).toEqual({
-      result: 'Tool call was not approved by the user',
       ...inputData,
+      approval: {
+        id: inputData.toolCallId,
+        approved: false,
+        reason: 'Tool call was not approved by the user',
+      },
     });
     expectNoToolExecution();
   });
@@ -468,6 +472,10 @@ describe('createToolCallStep tool approval workflow', () => {
     expect(result).toEqual({
       result: toolResult,
       ...inputData,
+      approval: {
+        id: inputData.toolCallId,
+        approved: true,
+      },
     });
   });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -565,8 +565,12 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
 
             if (!resumeData.approved) {
               return {
-                result: 'Tool call was not approved by the user',
                 ...inputData,
+                approval: {
+                  id: inputData.toolCallId,
+                  approved: false,
+                  reason: 'Tool call was not approved by the user',
+                },
               };
             }
           }
@@ -1231,6 +1235,9 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               return {
                 result: `Background task resumed. Task ID: ${task.id}. The tool "${inputData.toolName}" is running in the background. You will be notified when it completes.`,
                 ...inputData,
+                ...(toolRequiresApproval && resumeData?.approved === true
+                  ? { approval: { id: inputData.toolCallId, approved: true as const } }
+                  : {}),
               };
             }
 
@@ -1259,6 +1266,9 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               return {
                 result: `Background task started. Task ID: ${task.id}. The tool "${inputData.toolName}" is running in the background. You will be notified when it completes.`,
                 ...inputData,
+                ...(toolRequiresApproval && resumeData?.approved === true
+                  ? { approval: { id: inputData.toolCallId, approved: true as const } }
+                  : {}),
               };
             }
             // fallbackToSync: concurrency limit hit, fall through to synchronous execution
@@ -1282,7 +1292,13 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           }
         }
 
-        return { result, ...inputData };
+        return {
+          result,
+          ...inputData,
+          ...(toolRequiresApproval && resumeData?.approved === true
+            ? { approval: { id: inputData.toolCallId, approved: true as const } }
+            : {}),
+        };
       } catch (error) {
         // Re-throw FGA authorization errors instead of swallowing them
         if (error instanceof Error && error.name === 'FGADeniedError') {

--- a/packages/core/src/loop/workflows/schema.ts
+++ b/packages/core/src/loop/workflows/schema.ts
@@ -175,4 +175,11 @@ export const toolCallInputSchema = z.object({
 export const toolCallOutputSchema = toolCallInputSchema.extend({
   result: z.any().optional(),
   error: z.any().optional(),
+  approval: z
+    .object({
+      id: z.string(),
+      approved: z.boolean(),
+      reason: z.string().optional(),
+    })
+    .optional(),
 });

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
@@ -963,6 +963,57 @@ describe('TokenCounter', () => {
       expect(withToolResult).not.toBe(initial);
       expect(withToolResultAgain).toBe(withToolResult);
     });
+    it('counts tokens for output-denied tool invocations without throwing', () => {
+      const counter = new TokenCounter();
+      const callOnly = createMessage({
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'call',
+              toolCallId: 'tool-denied',
+              toolName: 'delete-file',
+              args: { path: '/tmp/test.txt' },
+            },
+          },
+        ],
+      });
+      const denied = createMessage({
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'call',
+              toolCallId: 'tool-denied',
+              toolName: 'delete-file',
+              args: { path: '/tmp/test.txt' },
+            },
+          },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'output-denied',
+              toolCallId: 'tool-denied',
+              toolName: 'delete-file',
+              args: { path: '/tmp/test.txt' },
+              approval: {
+                id: 'tool-denied',
+                approved: false,
+                reason: 'Tool call was not approved by the user',
+              },
+            },
+          },
+        ],
+      });
+
+      expect(() => counter.countMessage(denied)).not.toThrow();
+
+      const callOnlyTokens = counter.countMessage(callOnly);
+      const deniedTokens = counter.countMessage(denied);
+      expect(deniedTokens).toBeGreaterThan(callOnlyTokens);
+    });
 
     it('prefers stored mastra.modelOutput over raw tool results for token counting', async () => {
       const counter = new TokenCounter();

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -1758,6 +1758,12 @@ export class TokenCounter {
 
         return { tokens, overheadDelta, toolResultDelta };
       }
+      if (invocation.state === 'output-denied') {
+        toolResultDelta++;
+        const reason = (invocation as any).approval?.reason ?? 'Tool call was not approved by the user';
+        tokens += this.readOrPersistPartEstimate(part, 'tool-result-denied', reason);
+        return { tokens, overheadDelta, toolResultDelta };
+      }
 
       throw new Error(
         `Unhandled tool-invocation state '${(part as any).toolInvocation?.state}' in token counting for part type '${part.type}'`,


### PR DESCRIPTION
## Description

When a `requireApproval` tool call is declined or approved, `memory.recall()` + 
`toAISdkMessages(..., { version: 'v6' })` was not reflecting the decision correctly.

**Decline:** recalled tool part had `state: 'output-available'` with 
`output: 'Tool call was not approved by the user'` — identical to a successful 
tool that returned that string. No `approval` object, no `output-denied` state.

**Approve:** recalled part had `state: 'output-available'` with tool output but 
no `approval` field.

Live approve/decline worked correctly — this was purely a write-path persistence gap.

**Root cause across 4 locations:**

- `tool-call-step.ts` — decline branch returned `{ result: 'Tool call was not approved by the user', ...inputData }` with no `approval` object
- `durable/tool-call.ts` — same pattern in the durable agent path  
- `llm-mapping-step.ts` — `result === undefined` check skipped declined calls entirely; always wrote `state: 'result'`
- `schema.ts` — `toolCallOutputSchema` had no `approval` field so Zod stripped it silently

The read path in `AIV6Adapter.ts` already handled `output-denied` and `approval` 
correctly — nothing was writing those states.

**Fix:**

- `tool-call-step.ts`: decline now returns `approval: { id, approved: false, reason }` with no `result` field; approve path includes `approval: { id, approved: true }`
- `durable/tool-call.ts`: same decline fix for durable agent path
- `llm-mapping-step.ts`: added `output-denied` branch before the `result === undefined` continue; also forwards `approval` object when persisting approved results
- `schema.ts`: added `approval` field to `toolCallOutputSchema`

## Related issue(s)

Fixes #17218

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When a tool is set to require human approval, the system must remember whether the human said “yes” or “no” (and why). This PR fixes a bug where denied/approved decisions were saved in the wrong format, so later “recall” could show the wrong outcome.

## Overview
Fixes round-tripping of `requireApproval` tool calls through `memory.recall()` and `toAISdkMessages(..., { version: 'v6' })`. The read/recall path already understood `output-denied` + `approval`; this PR updates the write paths, schema, and downgrade logic so persisted messages correctly store:
- **Declined:** `state: 'output-denied'` with `approval: { id, approved: false, reason }`
- **Approved:** persisted `result` plus `approval: { id, approved: true }`

## Changes Made
- **Agent tool-call step (approval resume)**
  - On **decline**, return `approval: { id, approved: false, reason }` and omit the old denial-style `result` string.
  - On **approve**, include `approval` alongside the normal result payload.
- **Durable tool-call step (approval resume)**
  - On **decline**, return the denial `approval` object (with the fixed reason) instead of a `result` string.
  - On **approve**, include `approval` when resuming an approval-required tool call.
- **LLM mapping step (persistence + control flow)**
  - Add an `isDeniedApproval` guard so denied approvals don’t get treated as “pending HITL”.
  - Persist denied tool invocations as `state: 'output-denied'` (including denial `approval`), and **avoid emitting** tool-result chunks for those denials.
  - Ensure `approval` metadata is forwarded onto persisted tool invocations for both early and later success/non-provider-executed paths, including mixed success/error turns.
- **Durable LLM mapping**
  - Persist denied tool calls as `output-denied` with `approval`, and persist approved/non-denied as `result` while retaining `approval` when present.
- **Schema**
  - Extend tool call output schema to allow optional `approval?: { id; approved; reason? }`.
- **V5 downgrade (UI message adapter)**
  - Handle `output-denied` by downgrading to a single V5 `output-available` part whose `output` uses `approval.reason` (or a fallback denial message).
- **Observational memory token counting**
  - Add handling for `invocation.state === 'output-denied'` so token counting works and denial reasons are accounted for.
- **Tests**
  - Update and add coverage for: tool-call step shapes (approved/declined), `llm-mapping-step` persistence for `output-denied` and approval forwarding, durable approval persistence and DB-shapes, V5 downgrade behavior for denied parts, observational token counting for `output-denied`, and supervisor/e2e expectations for denied tool behavior.
- **Changeset**
  - Add a patch changeset for `@mastra/core` and `@mastra/memory`.

## Impact
- Denied/approved `requireApproval` decisions now persist with the correct durable/non-durable shapes, so `memory.recall()` → `toAISdkMessages({ version: 'v6' })` reflects the human’s decision correctly.
- Durable workflows and observational memory consumers behave consistently with the new `output-denied` + `approval` persistence.
- V5 UI downgrade shows the denial as output text (using `approval.reason` when available).

## Related issue
Fixes issue **`#17218`**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->