### PR TITLE
Promote agent channels to a top-level tab

### DIFF
--- a/packages/playground/e2e/tests/agents/$agentId/ime-composition.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/ime-composition.spec.ts
@@ -40,8 +40,9 @@ test.afterEach(async () => {
 test('Enter during IME composition does not submit, Enter after composition does submit', async () => {
   await selectFixture(page, 'text-stream');
   await page.goto(`/agents/weather-agent/chat/new`);
-  await page.click('text=Model settings');
+  await page.getByTestId('composer-model-settings-trigger').click();
   await page.click('text=Stream');
+  await page.keyboard.press('Escape');
 
   const chatInput = page.getByPlaceholder('Enter your message...');
   await chatInput.click();
@@ -108,8 +109,9 @@ test('Enter after IME switch (no compositionend) still submits — #16464 regres
   //    the next Enter (with isComposing=false) submits normally.
   await selectFixture(page, 'text-stream');
   await page.goto(`/agents/weather-agent/chat/new`);
-  await page.click('text=Model settings');
+  await page.getByTestId('composer-model-settings-trigger').click();
   await page.click('text=Stream');
+  await page.keyboard.press('Escape');
 
   const chatInput = page.getByPlaceholder('Enter your message...');
   await chatInput.click();

--- a/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
@@ -26,8 +26,6 @@ test('overall layout information', async ({ page }) => {
   await expect(page.locator('button:has-text("weather-agent")')).toBeVisible();
   const overviewPane = await page.locator('button:has-text("Overview")');
   await expect(overviewPane).toHaveAttribute('aria-selected', 'true');
-  const modelSettingsPane = await page.locator('button:has-text("Model Settings")');
-  await expect(modelSettingsPane).toHaveAttribute('aria-selected', 'false');
   const memoryPane = await page.locator('button:has-text("Memory")');
   await expect(memoryPane).toHaveAttribute('aria-selected', 'false');
 });
@@ -41,75 +39,80 @@ test.describe('agent panels', () => {
       await expect(overview).toMatchAriaSnapshot();
     });
   });
+});
 
-  test.describe('model settings', () => {
-    test.beforeEach(async ({ page }) => {
-      await page.goto('/agents/weather-agent/chat/new');
-      await page.click('text=Model settings');
-    });
+test.describe('composer model settings', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/agents/weather-agent/chat/new');
+    await page.getByTestId('composer-model-settings-trigger').click();
+  });
 
-    test('model trigger modes', async ({ page }) => {
-      const generateRadio = page.getByRole('radio', { name: 'Generate' });
-      await page.click('text=Model settings');
+  test('model trigger modes', async ({ page }) => {
+    const generateRadio = page.getByRole('radio', { name: 'Generate' });
 
-      await expect(generateRadio).toBeVisible();
-      await expect(generateRadio).toHaveAttribute('aria-checked', 'false');
-      const streamRadio = page.getByRole('radio', { name: 'Stream' });
-      await expect(streamRadio).toBeVisible();
-      await expect(streamRadio).toHaveAttribute('aria-checked', 'true');
+    await expect(generateRadio).toBeVisible();
+    await expect(generateRadio).toHaveAttribute('aria-checked', 'false');
+    const streamRadio = page.getByRole('radio', { name: 'Stream' });
+    await expect(streamRadio).toBeVisible();
+    await expect(streamRadio).toHaveAttribute('aria-checked', 'true');
 
-      const networkRadio = page.getByRole('radio', { name: 'Network' });
-      await expect(networkRadio).toBeVisible();
-    });
+    const networkRadio = page.getByRole('radio', { name: 'Network' });
+    await expect(networkRadio).toBeVisible();
+  });
 
-    test('verfied persistent model settings', async ({ page }) => {
-      // Arrange
-      await page.isVisible('text=Chat Method');
-      await page.click('text=Generate');
-      await page.click('text=Advanced Settings');
-      await page.getByLabel('Top K').fill('9');
-      await page.getByLabel('Frequency Penalty').fill('0.7');
-      await page.getByLabel('Presence Penalty').fill('0.6');
-      await page.getByLabel('Max Tokens').fill('44');
-      await page.getByLabel('Max Steps').fill('3');
-      await page.getByLabel('Max Retries').fill('2');
+  test('verfied persistent model settings', async ({ page }) => {
+    // Arrange
+    await page.isVisible('text=Chat Method');
+    await page.click('text=Generate');
+    await page.click('text=Advanced Settings');
+    await page.getByLabel('Top K').fill('9');
+    await page.getByLabel('Frequency Penalty').fill('0.7');
+    await page.getByLabel('Presence Penalty').fill('0.6');
+    await page.getByLabel('Max Tokens').fill('44');
+    await page.getByLabel('Max Steps').fill('3');
+    await page.getByLabel('Max Retries').fill('2');
 
-      // Act
-      await page.reload();
-      await page.click('text=Model settings');
-      await page.click('text=Advanced Settings');
+    // Act
+    await page.reload();
+    await page.getByTestId('composer-model-settings-trigger').click();
+    await page.click('text=Advanced Settings');
 
-      // Assert
-      await expect(page.getByLabel('Top K')).toHaveValue('9');
-      await expect(page.getByLabel('Frequency Penalty')).toHaveValue('0.7');
-      await expect(page.getByLabel('Presence Penalty')).toHaveValue('0.6');
-      await expect(page.getByLabel('Max Tokens')).toHaveValue('44');
-      await expect(page.getByLabel('Max Steps')).toHaveValue('3');
-      await expect(page.getByLabel('Max Retries')).toHaveValue('2');
-    });
+    // Assert
+    await expect(page.getByLabel('Top K')).toHaveValue('9');
+    await expect(page.getByLabel('Frequency Penalty')).toHaveValue('0.7');
+    await expect(page.getByLabel('Presence Penalty')).toHaveValue('0.6');
+    await expect(page.getByLabel('Max Tokens')).toHaveValue('44');
+    await expect(page.getByLabel('Max Steps')).toHaveValue('3');
+    await expect(page.getByLabel('Max Retries')).toHaveValue('2');
+  });
 
-    test('resets the form values when pressing "reset" button', async ({ page }) => {
-      // Arrange
-      await page.isVisible('text=Chat Method');
-      await page.click('text=Generate');
-      await page.click('text=Advanced Settings');
-      await page.getByLabel('Top K').fill('9');
-      await page.getByLabel('Frequency Penalty').fill('0.7');
-      await page.getByLabel('Presence Penalty').fill('0.6');
-      await page.getByLabel('Max Tokens').fill('44');
-      await page.getByLabel('Max Steps').fill('3');
-      await page.getByLabel('Max Retries').fill('2');
+  test('resets the form values when pressing "reset" button', async ({ page }) => {
+    // Arrange
+    await page.isVisible('text=Chat Method');
+    await page.click('text=Generate');
+    await page.click('text=Advanced Settings');
+    await page.getByLabel('Top K').fill('9');
+    await page.getByLabel('Frequency Penalty').fill('0.7');
+    await page.getByLabel('Presence Penalty').fill('0.6');
+    await page.getByLabel('Max Tokens').fill('44');
+    await page.getByLabel('Max Steps').fill('3');
+    await page.getByLabel('Max Retries').fill('2');
 
-      // Act
-      await page.click('text=Reset');
+    // Close the Advanced Settings dialog before clicking Reset (Reset lives in the composer popover)
+    await page.keyboard.press('Escape');
 
-      // Assert - values reset to defaults (maxSteps: 5, maxRetries: 2 are fallback defaults)
-      await expect(page.getByLabel('Top K')).toHaveValue('');
-      await expect(page.getByLabel('Frequency Penalty')).toHaveValue('');
-      await expect(page.getByLabel('Presence Penalty')).toHaveValue('');
-      await expect(page.getByLabel('Max Tokens')).toHaveValue('');
-      await expect(page.getByLabel('Max Steps')).toHaveValue('5');
-      await expect(page.getByLabel('Max Retries')).toHaveValue('2');
-    });
+    // Act
+    await page.click('text=Reset');
+
+    // Reopen Advanced Settings to inspect the reset field values
+    await page.click('text=Advanced Settings');
+
+    // Assert - values reset to defaults (maxSteps: 5, maxRetries: 2 are fallback defaults)
+    await expect(page.getByLabel('Top K')).toHaveValue('');
+    await expect(page.getByLabel('Frequency Penalty')).toHaveValue('');
+    await expect(page.getByLabel('Presence Penalty')).toHaveValue('');
+    await expect(page.getByLabel('Max Tokens')).toHaveValue('');
+    await expect(page.getByLabel('Max Steps')).toHaveValue('5');
+    await expect(page.getByLabel('Max Retries')).toHaveValue('2');
   });
 });

--- a/packages/playground/e2e/tests/agents/$agentId/stream.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/stream.spec.ts
@@ -37,8 +37,9 @@ test('text stream', async () => {
 
   await selectFixture(page, 'text-stream');
   await page.goto(`/agents/weather-agent/chat/new`);
-  await page.click('text=Model settings');
+  await page.getByTestId('composer-model-settings-trigger').click();
   await page.click('text=Stream');
+  await page.keyboard.press('Escape');
 
   await fillAndSend(page, 'Give me the Lorem Ipsum thing');
 
@@ -68,8 +69,9 @@ test('text stream', async () => {
 test('tool stream', async () => {
   await selectFixture(page, 'tool-stream');
   await page.goto(`/agents/weather-agent/chat/new`);
-  await page.click('text=Model settings');
+  await page.getByTestId('composer-model-settings-trigger').click();
   await page.click('text=Stream');
+  await page.keyboard.press('Escape');
 
   await fillAndSend(page, 'Give me the weather in Paris');
 
@@ -107,8 +109,9 @@ async function assertToolStream(page: Page) {
 test('workflow stream', async () => {
   await selectFixture(page, 'workflow-stream');
   await page.goto(`/agents/weather-agent/chat/new`);
-  await page.click('text=Model settings');
+  await page.getByTestId('composer-model-settings-trigger').click();
   await page.click('text=Stream');
+  await page.keyboard.press('Escape');
 
   await fillAndSend(page, 'Give me the weather in Paris');
 

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -27,6 +27,7 @@ import AgentBuilderSkillsView from './pages/agent-builder/skills/view';
 import Agents from './pages/agents';
 import Agent from './pages/agents/agent';
 import AgentSession from './pages/agents/agent/session';
+import AgentChannelsPage from './pages/agents/agent-channels';
 import AgentEvaluate from './pages/agents/agent-evaluate';
 import AgentPlayground from './pages/agents/agent-playground';
 import AgentReview from './pages/agents/agent-review';
@@ -445,6 +446,7 @@ export const routes: RouteObject[] = [
               ]
             : []),
           { path: 'traces', element: <AgentTraces /> },
+          { path: 'channels', element: <AgentChannelsPage /> },
         ],
       },
 

--- a/packages/playground/src/domains/agents/agent-layout.tsx
+++ b/packages/playground/src/domains/agents/agent-layout.tsx
@@ -7,6 +7,7 @@ import { AgentTopBarControls } from '@/domains/agents/components/agent-top-bar-c
 import { PlaygroundModelProvider } from '@/domains/agents/context/playground-model-context';
 import { ReviewQueueProvider } from '@/domains/agents/context/review-queue-context';
 import { useAgent } from '@/domains/agents/hooks/use-agent';
+import { useChannelPlatforms } from '@/domains/agents/hooks/use-channels';
 import { useIsCmsAvailable } from '@/domains/cms/hooks/use-is-cms-available';
 import { useHasObservability } from '@/domains/configuration/hooks/use-has-observability';
 import { GenerationProvider } from '@/domains/datasets/context/generation-context';
@@ -18,6 +19,8 @@ export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
   const location = useLocation();
   const { isCmsAvailable } = useIsCmsAvailable();
   const { hasObservability } = useHasObservability();
+  const { data: channelPlatforms } = useChannelPlatforms();
+  const hasChannels = Boolean(channelPlatforms?.length);
 
   const isExperimentalFeatures = coreFeatures.has('datasets');
   const showPlayground = isCmsAvailable && isExperimentalFeatures;
@@ -37,7 +40,9 @@ export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
         ? 'review'
         : location.pathname.includes('/traces')
           ? 'traces'
-          : 'chat';
+          : location.pathname.includes('/channels')
+            ? 'channels'
+            : 'chat';
 
   const showTopBarControls =
     (activeTab === 'versions' || activeTab === 'evaluate' || activeTab === 'review') &&
@@ -50,6 +55,7 @@ export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
         activeTab={activeTab}
         showPlayground={showPlayground}
         showObservability={showObservability}
+        showChannels={hasChannels}
         rightSlot={showTopBarControls ? <AgentTopBarControls requestContextSchema={requestContextSchema} /> : undefined}
       />
       {children}

--- a/packages/playground/src/domains/agents/components/__tests__/agent-page-tabs.msw.test.tsx
+++ b/packages/playground/src/domains/agents/components/__tests__/agent-page-tabs.msw.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentLayout } from '../../agent-layout';
+import { emptyPlatforms, slackPlatform, systemPackages } from './fixtures/channels';
+import { v2Agent } from './fixtures/composer-model-settings';
+import { LinkComponentProvider } from '@/lib/framework';
+import { server } from '@/test/msw-server';
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
+const BASE_URL = 'http://localhost:4111';
+
+const StubLink = ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a {...props}>{children}</a>
+);
+
+const navigateSpy = vi.fn();
+
+const noopPaths = {
+  agentLink: () => '',
+  agentMessageLink: () => '',
+  workflowLink: () => '',
+  toolLink: () => '',
+  scoreLink: () => '',
+  scorerLink: () => '',
+  toolByAgentLink: () => '',
+  toolByWorkflowLink: () => '',
+  promptLink: () => '',
+  legacyWorkflowLink: () => '',
+  policyLink: () => '',
+  vNextNetworkLink: () => '',
+  agentBuilderLink: () => '',
+  mcpServerLink: () => '',
+  mcpServerToolLink: () => '',
+  workflowRunLink: () => '',
+  datasetLink: () => '',
+  datasetItemLink: () => '',
+  datasetExperimentLink: () => '',
+  experimentLink: () => '',
+} as never;
+
+function renderLayout() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <LinkComponentProvider Link={StubLink as never} navigate={navigateSpy} paths={noopPaths}>
+          <TooltipProvider>
+            <MemoryRouter initialEntries={['/agents/agent-1/chat/new']}>
+              <Routes>
+                <Route
+                  path="/agents/:agentId/*"
+                  element={
+                    <AgentLayout>
+                      <div data-testid="agent-child" />
+                    </AgentLayout>
+                  }
+                />
+              </Routes>
+            </MemoryRouter>
+          </TooltipProvider>
+        </LinkComponentProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+}
+
+function commonHandlers() {
+  return [
+    http.get(`${BASE_URL}/api/agents/agent-1`, () => HttpResponse.json(v2Agent)),
+    http.get(`${BASE_URL}/api/system/packages`, () => HttpResponse.json(systemPackages)),
+  ];
+}
+
+afterEach(() => {
+  cleanup();
+  navigateSpy.mockReset();
+});
+
+describe('AgentLayout channels tab', () => {
+  it('shows the Channels tab when channel platforms exist', async () => {
+    server.use(
+      ...commonHandlers(),
+      http.get(`${BASE_URL}/api/channels/platforms`, () => HttpResponse.json(slackPlatform)),
+    );
+
+    renderLayout();
+
+    expect(await screen.findByText('Channels')).not.toBeNull();
+  });
+
+  it('hides the Channels tab when no channel platforms exist', async () => {
+    server.use(
+      ...commonHandlers(),
+      http.get(`${BASE_URL}/api/channels/platforms`, () => HttpResponse.json(emptyPlatforms)),
+    );
+
+    renderLayout();
+
+    // Chat tab always renders; wait for it to confirm the layout mounted.
+    expect(await screen.findByText('Chat')).not.toBeNull();
+    await waitFor(() => expect(screen.queryByText('Channels')).toBeNull());
+  });
+
+  it('navigates to the channels route when the Channels tab is clicked', async () => {
+    server.use(
+      ...commonHandlers(),
+      http.get(`${BASE_URL}/api/channels/platforms`, () => HttpResponse.json(slackPlatform)),
+    );
+
+    renderLayout();
+
+    const channelsTab = await screen.findByText('Channels');
+    fireEvent.click(channelsTab);
+
+    expect(navigateSpy).toHaveBeenCalledWith('/agents/agent-1/channels');
+  });
+});

--- a/packages/playground/src/domains/agents/components/__tests__/fixtures/channels.ts
+++ b/packages/playground/src/domains/agents/components/__tests__/fixtures/channels.ts
@@ -1,0 +1,43 @@
+import type { ChannelPlatformInfo, ChannelInstallationInfo, GetSystemPackagesResponse } from '@mastra/client-js';
+
+export const systemPackages: GetSystemPackagesResponse = {
+  packages: [],
+  isDev: false,
+  cmsEnabled: false,
+  observabilityEnabled: false,
+};
+
+export const emptyPlatforms: ChannelPlatformInfo[] = [];
+
+export const slackPlatform: ChannelPlatformInfo[] = [
+  {
+    id: 'slack',
+    name: 'Slack',
+    isConfigured: true,
+  },
+];
+
+export const slackAndDiscordPlatforms: ChannelPlatformInfo[] = [
+  {
+    id: 'slack',
+    name: 'Slack',
+    isConfigured: true,
+  },
+  {
+    id: 'discord',
+    name: 'Discord',
+    isConfigured: false,
+  },
+];
+
+export const slackInstallations: ChannelInstallationInfo[] = [
+  {
+    id: 'install-1',
+    platform: 'slack',
+    agentId: 'agent-1',
+    status: 'active',
+    displayName: 'Workspace',
+  },
+];
+
+export const noSlackInstallations: ChannelInstallationInfo[] = [];

--- a/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
+++ b/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
@@ -1,4 +1,15 @@
-import { Button, Skeleton, StatusBadge, Txt, toast } from '@mastra/playground-ui';
+import {
+  Button,
+  DataList,
+  DataListSkeleton,
+  ListSearch,
+  NoDataPageLayout,
+  PageLayout,
+  StatusBadge,
+  Txt,
+  toast,
+} from '@mastra/playground-ui';
+import { useMemo, useState } from 'react';
 import {
   useChannelPlatforms,
   useChannelInstallations,
@@ -8,42 +19,79 @@ import {
 import type { ChannelPlatformInfo } from '../../hooks/use-channels';
 import { PlatformIcon } from './platform-icons';
 
+const COLUMNS = '1fr auto auto';
+
 export interface AgentChannelsProps {
   agentId: string;
 }
 
 export const AgentChannels = ({ agentId }: AgentChannelsProps) => {
   const { data: platforms, isLoading } = useChannelPlatforms();
+  const [search, setSearch] = useState('');
 
-  if (isLoading) {
-    return <Skeleton className="h-full" />;
-  }
-
-  if (!platforms || platforms.length === 0) {
+  if (!isLoading && (!platforms || platforms.length === 0)) {
     return (
-      <div className="py-2 overflow-y-auto h-full px-5">
+      <NoDataPageLayout>
         <Txt variant="ui-sm" className="text-neutral6">
           No channel platforms configured.
         </Txt>
-      </div>
+      </NoDataPageLayout>
     );
   }
 
   return (
-    <div className="py-2 overflow-y-auto h-full px-5 space-y-3">
-      {platforms.map(platform => (
-        <PlatformSection key={platform.id} platform={platform} agentId={agentId} />
-      ))}
-    </div>
+    <PageLayout>
+      <PageLayout.TopArea>
+        <div className="max-w-120">
+          <ListSearch onSearch={setSearch} label="Filter channels" placeholder="Filter by platform name" />
+        </div>
+      </PageLayout.TopArea>
+
+      <ChannelsList platforms={platforms ?? []} isLoading={isLoading} agentId={agentId} search={search} />
+    </PageLayout>
   );
 };
 
-interface PlatformSectionProps {
+interface ChannelsListProps {
+  platforms: ChannelPlatformInfo[];
+  isLoading: boolean;
+  agentId: string;
+  search: string;
+}
+
+function ChannelsList({ platforms, isLoading, agentId, search }: ChannelsListProps) {
+  const filtered = useMemo(() => {
+    const term = search.toLowerCase();
+    return platforms.filter(platform => platform.name.toLowerCase().includes(term));
+  }, [platforms, search]);
+
+  if (isLoading) {
+    return <DataListSkeleton columns={COLUMNS} />;
+  }
+
+  return (
+    <DataList columns={COLUMNS}>
+      <DataList.Top>
+        <DataList.TopCell className="">Platform</DataList.TopCell>
+        <DataList.TopCell className="justify-end text-right">Status</DataList.TopCell>
+        <DataList.TopCell className="">{''}</DataList.TopCell>
+      </DataList.Top>
+
+      {filtered.length === 0 && search ? <DataList.NoMatch message="No channels match your search" /> : null}
+
+      {filtered.map(platform => (
+        <ChannelRow key={platform.id} platform={platform} agentId={agentId} />
+      ))}
+    </DataList>
+  );
+}
+
+interface ChannelRowProps {
   platform: ChannelPlatformInfo;
   agentId: string;
 }
 
-function PlatformSection({ platform, agentId }: PlatformSectionProps) {
+function ChannelRow({ platform, agentId }: ChannelRowProps) {
   const { data: installations, isLoading } = useChannelInstallations(platform.id, agentId);
   const { connect, isConnecting } = useConnectChannelAction(platform.id);
   const { mutate: disconnect, isPending: isDisconnecting } = useDisconnectChannel(platform.id);
@@ -63,25 +111,35 @@ function PlatformSection({ platform, agentId }: PlatformSectionProps) {
   };
 
   return (
-    <section className="rounded-md border border-border1 p-3">
-      {isLoading ? (
-        <Skeleton className="h-10" />
-      ) : activeInstallation ? (
-        <div className="flex items-center gap-2.5">
+    <DataList.RowStatic>
+      <DataList.Cell className="text-left text-neutral4">
+        <span className="flex items-center gap-3 min-w-0">
           <PlatformIcon platform={platform.id} className="h-5 w-5 shrink-0" />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5">
-              <Txt variant="ui-sm" className="text-neutral3 truncate">
-                {platform.name}
+          <span className="flex flex-col min-w-0">
+            <span className="truncate">{platform.name}</span>
+            {activeInstallation ? (
+              <Txt variant="ui-xs" className="text-neutral5 truncate">
+                {activeInstallation.displayName || 'Workspace'}
               </Txt>
-              <StatusBadge variant="success" size="sm">
-                Connected
-              </StatusBadge>
-            </div>
-            <Txt variant="ui-xs" className="text-neutral5 truncate">
-              {activeInstallation.displayName || 'Workspace'}
-            </Txt>
-          </div>
+            ) : null}
+          </span>
+        </span>
+      </DataList.Cell>
+
+      <DataList.Cell className="flex justify-end">
+        {isLoading ? null : activeInstallation ? (
+          <StatusBadge variant="success" size="sm">
+            Connected
+          </StatusBadge>
+        ) : !platform.isConfigured ? (
+          <StatusBadge variant="warning" size="sm">
+            Not configured
+          </StatusBadge>
+        ) : null}
+      </DataList.Cell>
+
+      <DataList.Cell className="justify-end text-right">
+        {isLoading ? null : activeInstallation ? (
           <button
             type="button"
             onClick={handleDisconnect}
@@ -90,24 +148,12 @@ function PlatformSection({ platform, agentId }: PlatformSectionProps) {
           >
             {isDisconnecting ? 'Removing...' : 'Remove'}
           </button>
-        </div>
-      ) : (
-        <div className="flex items-center gap-2.5">
-          <PlatformIcon platform={platform.id} className="h-5 w-5 shrink-0" />
-          <Txt variant="ui-sm" className="text-neutral3 flex-1">
-            {platform.name}
-          </Txt>
-          {!platform.isConfigured ? (
-            <StatusBadge variant="warning" size="sm">
-              Not configured
-            </StatusBadge>
-          ) : (
-            <Button size="sm" variant="default" onClick={handleConnect} disabled={isConnecting}>
-              {isConnecting ? 'Connecting...' : 'Connect'}
-            </Button>
-          )}
-        </div>
-      )}
-    </section>
+        ) : platform.isConfigured ? (
+          <Button size="sm" variant="default" onClick={handleConnect} disabled={isConnecting}>
+            {isConnecting ? 'Connecting...' : 'Connect'}
+          </Button>
+        ) : null}
+      </DataList.Cell>
+    </DataList.RowStatic>
   );
 }

--- a/packages/playground/src/domains/agents/components/agent-information/agent-information.tsx
+++ b/packages/playground/src/domains/agents/components/agent-information/agent-information.tsx
@@ -1,8 +1,6 @@
 import { ScrollArea, Tabs, Tab, TabContent, TabList } from '@mastra/playground-ui';
 import { useBrowserSession } from '../../context/browser-session-context';
 import { useAgent } from '../../hooks/use-agent';
-import { useChannelPlatforms } from '../../hooks/use-channels';
-import { AgentChannels } from '../agent-channels';
 import { AgentEntityHeader } from '../agent-entity-header';
 import { AgentMetadata } from '../agent-metadata';
 import { BrowserSidebarTab } from '../browser-view/browser-sidebar-tab';
@@ -20,15 +18,12 @@ export interface AgentInformationProps {
 export function AgentInformation({ agentId, threadId }: AgentInformationProps) {
   const { data: agent } = useAgent(agentId);
   const { data: memory, isLoading: isMemoryLoading } = useMemory(agentId);
-  const { data: platforms } = useChannelPlatforms();
   const { hasSession, isInSidebar } = useBrowserSession();
   const hasMemory = !isMemoryLoading && Boolean(memory?.result);
-  const hasChannels = Boolean(platforms && platforms.length > 0);
 
   const { selectedTab, handleTabChange } = useAgentInformationTab({
     isMemoryLoading,
     hasMemory,
-    hasChannels,
   });
 
   return (
@@ -40,7 +35,6 @@ export function AgentInformation({ agentId, threadId }: AgentInformationProps) {
             <TabList>
               <Tab value="overview">Overview</Tab>
               {hasMemory && <Tab value="memory">Memory</Tab>}
-              {hasChannels && <Tab value="channels">Channels</Tab>}
               {agent?.requestContextSchema && <Tab value="request-context">Request Context</Tab>}
               <Tab value="tracing-options">Tracing Options</Tab>
             </TabList>
@@ -69,12 +63,6 @@ export function AgentInformation({ agentId, threadId }: AgentInformationProps) {
             {hasMemory && (
               <TabContent value="memory">
                 <AgentMemory agentId={agentId} threadId={threadId} memoryType={memory?.memoryType} />
-              </TabContent>
-            )}
-
-            {hasChannels && (
-              <TabContent value="channels">
-                <AgentChannels agentId={agentId} />
               </TabContent>
             )}
 
@@ -108,14 +96,11 @@ export interface AgentInformationTabLayoutProps {
 }
 export const AgentInformationTabLayout = ({ children, agentId }: AgentInformationTabLayoutProps) => {
   const { data: memory, isLoading: isMemoryLoading } = useMemory(agentId);
-  const { data: platforms } = useChannelPlatforms();
   const hasMemory = Boolean(memory?.result);
-  const hasChannels = Boolean(platforms && platforms.length > 0);
 
   const { selectedTab, handleTabChange } = useAgentInformationTab({
     isMemoryLoading,
     hasMemory,
-    hasChannels,
   });
 
   return (

--- a/packages/playground/src/domains/agents/components/agent-information/use-agent-information-tab.ts
+++ b/packages/playground/src/domains/agents/components/agent-information/use-agent-information-tab.ts
@@ -5,13 +5,12 @@ const STORAGE_KEY = 'agent-info-selected-tab';
 export interface UseAgentInformationTabArgs {
   isMemoryLoading: boolean;
   hasMemory: boolean;
-  hasChannels: boolean;
 }
 
 // Valid tab values that can be persisted
-const VALID_TABS = new Set(['overview', 'memory', 'channels', 'request-context', 'tracing-options']);
+const VALID_TABS = new Set(['overview', 'memory', 'request-context', 'tracing-options']);
 
-export const useAgentInformationTab = ({ isMemoryLoading, hasMemory, hasChannels }: UseAgentInformationTabArgs) => {
+export const useAgentInformationTab = ({ isMemoryLoading, hasMemory }: UseAgentInformationTabArgs) => {
   const [selectedTab, setSelectedTab] = useState<string>(() => {
     const stored = sessionStorage.getItem(STORAGE_KEY) || 'overview';
     // Validate stored tab is a known valid tab
@@ -25,10 +24,6 @@ export const useAgentInformationTab = ({ isMemoryLoading, hasMemory, hasChannels
     if (!VALID_TABS.has(selectedTab)) return 'overview';
     // Memory tab requires memory to be available
     if (selectedTab === 'memory' && !isMemoryLoading && !hasMemory) {
-      return 'overview';
-    }
-    // Channels tab requires channels to be available
-    if (selectedTab === 'channels' && !hasChannels) {
       return 'overview';
     }
     return selectedTab;

--- a/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
+++ b/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
@@ -1,15 +1,16 @@
 import { Tab, TabList, Tabs, Tooltip, TooltipContent, TooltipTrigger, Txt, Icon } from '@mastra/playground-ui';
-import { ExternalLink, EyeIcon, FlaskConical, MessageSquare, ClipboardCheck, GitBranch } from 'lucide-react';
+import { ExternalLink, EyeIcon, FlaskConical, MessageSquare, ClipboardCheck, GitBranch, Radio } from 'lucide-react';
 
 import { useLinkComponent } from '@/lib/framework';
 
-export type AgentPageTab = 'chat' | 'versions' | 'evaluate' | 'review' | 'traces';
+export type AgentPageTab = 'chat' | 'versions' | 'evaluate' | 'review' | 'traces' | 'channels';
 
 interface AgentPageTabsProps {
   agentId: string;
   activeTab: AgentPageTab;
   showPlayground?: boolean;
   showObservability?: boolean;
+  showChannels?: boolean;
   reviewBadge?: number;
   rightSlot?: React.ReactNode;
 }
@@ -84,6 +85,7 @@ export function AgentPageTabs({
   activeTab,
   showPlayground = false,
   showObservability = false,
+  showChannels = false,
   reviewBadge,
   rightSlot,
 }: AgentPageTabsProps) {
@@ -108,6 +110,7 @@ export function AgentPageTabs({
     evaluate: `/agents/${agentId}/evaluate`,
     review: `/agents/${agentId}/review`,
     traces: `/agents/${agentId}/traces`,
+    channels: `/agents/${agentId}/channels`,
   };
 
   const handleTabChange = (value: AgentPageTab) => {
@@ -148,6 +151,7 @@ export function AgentPageTabs({
             disabled={!showObservability}
             disabledReason={observabilityDisabledReason}
           />
+          {showChannels && <AgentTab value="channels" icon={<Radio />} label="Channels" />}
         </TabList>
       </Tabs>
       {rightSlot && <div className="flex items-center gap-2">{rightSlot}</div>}

--- a/packages/playground/src/pages/agents/agent-channels/__tests__/agent-channels-page.msw.test.tsx
+++ b/packages/playground/src/pages/agents/agent-channels/__tests__/agent-channels-page.msw.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import type * as PlaygroundUi from '@mastra/playground-ui';
+import { TooltipProvider } from '@mastra/playground-ui';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import AgentChannelsPage from '../index';
+import {
+  emptyPlatforms,
+  noSlackInstallations,
+  slackAndDiscordPlatforms,
+  slackInstallations,
+  slackPlatform,
+} from '@/domains/agents/components/__tests__/fixtures/channels';
+import { v2Agent } from '@/domains/agents/components/__tests__/fixtures/composer-model-settings';
+import { server } from '@/test/msw-server';
+
+vi.mock('@mastra/playground-ui', async () => {
+  const actual = await vi.importActual<typeof PlaygroundUi>('@mastra/playground-ui');
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
+const BASE_URL = 'http://localhost:4111';
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={['/agents/agent-1/channels']}>
+            <Routes>
+              <Route path="/agents/:agentId/channels" element={<AgentChannelsPage />} />
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe('AgentChannelsPage MSW integration', () => {
+  it('renders a connected platform when installations are active', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/agents/agent-1`, () => HttpResponse.json(v2Agent)),
+      http.get(`${BASE_URL}/api/channels/platforms`, () => HttpResponse.json(slackPlatform)),
+      http.get(`${BASE_URL}/api/channels/slack/installations`, () => HttpResponse.json(slackInstallations)),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('Slack')).not.toBeNull();
+    expect(await screen.findByText('Connected')).not.toBeNull();
+  });
+
+  it('renders the empty state when no platforms are configured', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/agents/agent-1`, () => HttpResponse.json(v2Agent)),
+      http.get(`${BASE_URL}/api/channels/platforms`, () => HttpResponse.json(emptyPlatforms)),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('No channel platforms configured.')).not.toBeNull();
+  });
+
+  it('shows a loading state while the agent is being fetched', async () => {
+    const gate = (() => {
+      let resolve: () => void = () => {};
+      const promise = new Promise<void>(r => {
+        resolve = r;
+      });
+      return { promise, resolve };
+    })();
+
+    server.use(
+      http.get(`${BASE_URL}/api/agents/agent-1`, async () => {
+        await gate.promise;
+        return HttpResponse.json(v2Agent);
+      }),
+      http.get(`${BASE_URL}/api/channels/platforms`, () => HttpResponse.json(emptyPlatforms)),
+    );
+
+    const { container } = renderPage();
+
+    expect(container.querySelector('.animate-spin')).not.toBeNull();
+
+    gate.resolve();
+
+    await waitFor(() => expect(screen.queryByText('No channel platforms configured.')).not.toBeNull());
+  });
+
+  it('filters platform rows by the search input', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/agents/agent-1`, () => HttpResponse.json(v2Agent)),
+      http.get(`${BASE_URL}/api/channels/platforms`, () => HttpResponse.json(slackAndDiscordPlatforms)),
+      http.get(`${BASE_URL}/api/channels/slack/installations`, () => HttpResponse.json(slackInstallations)),
+      http.get(`${BASE_URL}/api/channels/discord/installations`, () => HttpResponse.json(noSlackInstallations)),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('Slack')).not.toBeNull();
+    expect(await screen.findByText('Discord')).not.toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText('Filter by platform name'), { target: { value: 'slack' } });
+
+    await waitFor(() => expect(screen.queryByText('Discord')).toBeNull());
+    expect(screen.queryByText('Slack')).not.toBeNull();
+  });
+
+  it('shows a no-match message when the search matches nothing', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/agents/agent-1`, () => HttpResponse.json(v2Agent)),
+      http.get(`${BASE_URL}/api/channels/platforms`, () => HttpResponse.json(slackAndDiscordPlatforms)),
+      http.get(`${BASE_URL}/api/channels/slack/installations`, () => HttpResponse.json(slackInstallations)),
+      http.get(`${BASE_URL}/api/channels/discord/installations`, () => HttpResponse.json(noSlackInstallations)),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('Slack')).not.toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText('Filter by platform name'), { target: { value: 'nonexistent' } });
+
+    await waitFor(() => expect(screen.queryByText('No channels match your search')).not.toBeNull());
+    expect(screen.queryByText('Slack')).toBeNull();
+    expect(screen.queryByText('Discord')).toBeNull();
+  });
+});

--- a/packages/playground/src/pages/agents/agent-channels/index.tsx
+++ b/packages/playground/src/pages/agents/agent-channels/index.tsx
@@ -1,0 +1,48 @@
+import {
+  PermissionDenied,
+  SessionExpired,
+  Spinner,
+  is401UnauthorizedError,
+  is403ForbiddenError,
+} from '@mastra/playground-ui';
+import { useParams } from 'react-router';
+import { AgentChannels } from '@/domains/agents/components/agent-channels';
+import { useAgent } from '@/domains/agents/hooks/use-agent';
+
+function AgentChannelsPage() {
+  const { agentId } = useParams();
+
+  const { data: codeAgent, isLoading, error } = useAgent(agentId!);
+
+  if (error && is401UnauthorizedError(error)) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <SessionExpired />
+      </div>
+    );
+  }
+
+  if (error && is403ForbiddenError(error)) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <PermissionDenied resource="agents" />
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner className="h-6 w-6" />
+      </div>
+    );
+  }
+
+  if (!codeAgent) {
+    return <div className="text-center py-4">Agent not found</div>;
+  }
+
+  return <AgentChannels agentId={agentId!} />;
+}
+
+export default AgentChannelsPage;


### PR DESCRIPTION
## Summary

Channels were previously buried in the agent right-side information panel as a conditional sub-tab. This change promotes channels to a first-class, URL-routed destination in the main agent tab row (alongside Chat, Editor, Evaluate, and Traces) and rebuilds the page to match the agents-list pattern.

What changed:
- Added a **Channels** tab to the main agent tab row, gated on whether any channel platforms are configured, navigating to `/agents/:agentId/channels`.
- Added the new route and a routed `AgentChannelsPage` with the standard auth/loading/not-found guards.
- Removed the channels entry from the agent info panel and its persisted tab handling.
- Rebuilt the channels page to use `PageLayout` + `ListSearch` + `DataList`: platforms can be filtered by name, with aligned headers, a right-aligned status column, an empty state, a no-match state, and inline Connect/Remove actions.

No changeset added: only `@internal/playground` (private package) is modified.

## Test plan
- `pnpm --filter ./packages/playground typecheck` — clean.
- `pnpm --filter ./packages/playground test src/pages/agents/agent-channels` — 5 MSW tests pass (Slack name, Connected status, empty state, loading, search filtering, no-match).
- `pnpm --filter ./packages/playground test src/domains/agents/components/__tests__/agent-page-tabs.msw.test.tsx` — 3 tests pass (tab rendering + routed navigation).
- Manual: open `/agents/:id/channels` — search filters rows; connected rows show a Connected badge + Remove; configured-inactive show Connect; unconfigured show Not configured; titles align with their columns.

🤖 Generated with Mastra Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR moves the agent "Channels" feature from a hidden side panel into its own visible tab on the agent page, so users can open Channels like any other top-level agent tab and navigate to it via URL.

## Summary of Changes

Channels promoted to a top-level, URL-routed agent tab and rebuilt with a list/table UX:

- Tab & routing
  - Added a new "Channels" tab shown when any channel platforms exist.
  - New route: /agents/:agentId/channels → AgentChannelsPage.
  - Registered AgentChannelsPage in playground routing (packages/playground/src/App.tsx).

- Page & guards
  - Added AgentChannelsPage component that reads agentId, fetches agent, and shows standard guards/flows: SessionExpired (401), PermissionDenied (403 for "agents"), loading Spinner, and "Agent not found" handling (packages/playground/src/pages/agents/agent-channels/index.tsx).

- UI & layout
  - Rebuilt channels UI using PageLayout + ListSearch + DataList to match agents-list pattern.
  - Search/filter by platform name, empty-state and no-match state supported.
  - Platform rows show icon, truncated name, workspace for active installation, and a right-aligned status column.
  - Inline Connect / Remove actions; connected rows show Connected badge; configured-inactive rows show Connect; unconfigured show Not configured (packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx).

- Agent layout & tabs
  - AgentLayout now uses useChannelPlatforms to compute hasChannels and passes showChannels to AgentPageTabs; activeTab logic recognizes the channels path (packages/playground/src/domains/agents/agent-layout.tsx).
  - AgentPageTabs: added 'channels' to AgentPageTab union and optional showChannels prop to conditionally render the Channels tab and link to /agents/{agentId}/channels (packages/playground/src/domains/agents/components/agent-page-tabs.tsx).

- Removal from info panel
  - Removed Channels UI and persisted tab handling from AgentInformation and AgentInformationTabLayout; useAgentInformationTab hook no longer accepts hasChannels and tab persistence logic adjusted accordingly (packages/playground/src/domains/agents/components/agent-information/* and use-agent-information-tab.ts).

- Tests & fixtures
  - Added MSW tests for AgentChannelsPage (filtering, empty state, connected platform, loading/no-match) and agent-page-tabs behavior (visibility and navigation) (packages/playground/src/pages/agents/agent-channels/__tests__/* and packages/playground/src/domains/agents/components/__tests__/*).
  - Added channel fixture data for tests (packages/playground/src/domains/agents/components/__tests__/fixtures/channels.ts).
  - All playground typecheck/test runs referenced in PR notes pass locally in the author’s verification; toast functions mocked in tests.

- E2E adjustments
  - Minor Playwright test updates for composer model settings trigger usage across several agent e2e tests (packages/playground/e2e/tests/agents/$agentId/*).

## Scope & Notes

- Only modified package: `@internal/playground` (packages/playground).
- No changeset added.
- Tests: playground typecheck clean; MSW tests for agent-channels (5) and agent-page-tabs (3) included and passing per PR notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->