### PR TITLE
feat(core): persist realtime voice turns to agent memory

### DIFF
--- a/packages/_internals/voice/src/voice/voice.ts
+++ b/packages/_internals/voice/src/voice/voice.ts
@@ -3,10 +3,18 @@ import type { ToolsInput } from '@internal/core/types';
 
 export type VoiceEventType = 'speaking' | 'writing' | 'error' | string;
 
+export type VoiceTurnRole = 'user' | 'assistant';
+
+export interface VoiceTurnEvent {
+  role: VoiceTurnRole;
+  text: string;
+}
+
 export interface VoiceEventMap {
   speaker: NodeJS.ReadableStream;
   speaking: { audio?: string };
   writing: { text: string; role: 'assistant' | 'user' };
+  turn: VoiceTurnEvent;
   error: { message: string; code?: string; details?: unknown };
   [key: string]: unknown;
 }

--- a/packages/core/src/agent/__tests__/voice-memory.test.ts
+++ b/packages/core/src/agent/__tests__/voice-memory.test.ts
@@ -1,0 +1,124 @@
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { MockMemory } from '../../memory/mock';
+import { MockStore } from '../../storage/mock';
+import type { MastraVoice, VoiceTurnEvent } from '../../voice';
+import { Agent } from '../agent';
+
+function createMockVoice(): MastraVoice & {
+  emitTurn: (turn: VoiceTurnEvent) => void;
+} {
+  const listeners = new Map<string, Set<(data: unknown) => void>>();
+
+  return {
+    addTools: vi.fn(),
+    addInstructions: vi.fn(),
+    speak: vi.fn(),
+    listen: vi.fn(),
+    updateConfig: vi.fn(),
+    connect: vi.fn(),
+    send: vi.fn(),
+    answer: vi.fn(),
+    close: vi.fn(),
+    getSpeakers: vi.fn().mockResolvedValue([]),
+    getListener: vi.fn().mockResolvedValue({ enabled: false }),
+    serializeForSpan: vi.fn().mockReturnValue({ component: 'VOICE' }),
+    on: vi.fn((event: string, callback: (data: unknown) => void) => {
+      if (!listeners.has(event)) {
+        listeners.set(event, new Set());
+      }
+      listeners.get(event)!.add(callback);
+    }),
+    off: vi.fn((event: string, callback: (data: unknown) => void) => {
+      listeners.get(event)?.delete(callback);
+    }),
+    emitTurn: (turn: VoiceTurnEvent) => {
+      for (const callback of listeners.get('turn') ?? []) {
+        callback(turn);
+      }
+    },
+  } as MastraVoice & { emitTurn: (turn: VoiceTurnEvent) => void };
+}
+
+describe('Agent voice memory persistence', () => {
+  it('persists completed voice turns when memory scope is provided', async () => {
+    const mockVoice = createMockVoice();
+    const memoryStore = new MockStore();
+    const memory = new MockMemory({ storage: memoryStore });
+
+    const saveMessages = vi.spyOn(memory, 'saveMessages');
+    const createThread = vi.spyOn(memory, 'createThread');
+
+    const agent = new Agent({
+      id: 'voice-memory-agent',
+      name: 'Voice Memory Agent',
+      instructions: 'You are helpful.',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          content: [{ type: 'text', text: 'ok' }],
+          warnings: [],
+        }),
+      }),
+      memory,
+      voice: mockVoice,
+    });
+
+    const voice = await agent.getVoice({
+      memory: { thread: 'thread-voice-1', resource: 'user-1' },
+    });
+
+    mockVoice.emitTurn({ role: 'user', text: 'Hello from voice' });
+    await vi.waitFor(() => expect(saveMessages).toHaveBeenCalled());
+
+    expect(createThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: 'thread-voice-1',
+        resourceId: 'user-1',
+        saveThread: true,
+      }),
+    );
+
+    const savedMessages = saveMessages.mock.calls[0]![0].messages;
+    expect(savedMessages).toHaveLength(1);
+    expect(savedMessages[0]).toMatchObject({
+      role: 'user',
+      threadId: 'thread-voice-1',
+      resourceId: 'user-1',
+      content: { format: 2, parts: [{ type: 'text', text: 'Hello from voice' }] },
+    });
+
+    mockVoice.emitTurn({ role: 'assistant', text: 'Hi there' });
+    await vi.waitFor(() => expect(saveMessages).toHaveBeenCalledTimes(2));
+
+    expect(voice).toBe(mockVoice);
+  });
+
+  it('requires resource when persisting voice turns', async () => {
+    const mockVoice = createMockVoice();
+    const memory = new MockMemory();
+
+    const agent = new Agent({
+      id: 'voice-memory-agent',
+      name: 'Voice Memory Agent',
+      instructions: 'You are helpful.',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          content: [{ type: 'text', text: 'ok' }],
+          warnings: [],
+        }),
+      }),
+      memory,
+      voice: mockVoice,
+    });
+
+    await expect(
+      agent.getVoice({
+        memory: { thread: 'thread-voice-1' },
+      }),
+    ).rejects.toThrow(/memory\.resource is required/i);
+  });
+});

--- a/packages/core/src/agent/__tests__/voice-memory.test.ts
+++ b/packages/core/src/agent/__tests__/voice-memory.test.ts
@@ -92,7 +92,51 @@ describe('Agent voice memory persistence', () => {
     mockVoice.emitTurn({ role: 'assistant', text: 'Hi there' });
     await vi.waitFor(() => expect(saveMessages).toHaveBeenCalledTimes(2));
 
+    const assistantMessage = saveMessages.mock.calls[1]![0].messages[0];
+    expect(assistantMessage).toMatchObject({
+      role: 'assistant',
+      threadId: 'thread-voice-1',
+      resourceId: 'user-1',
+      content: { format: 2, parts: [{ type: 'text', text: 'Hi there' }] },
+    });
+
     expect(voice).toBe(mockVoice);
+  });
+
+  it('rebinds persistence when getVoice memory scope changes', async () => {
+    const mockVoice = createMockVoice();
+    const memory = new MockMemory({ storage: new MockStore() });
+    const saveMessages = vi.spyOn(memory, 'saveMessages');
+
+    const agent = new Agent({
+      id: 'voice-memory-agent',
+      name: 'Voice Memory Agent',
+      instructions: 'You are helpful.',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          content: [{ type: 'text', text: 'ok' }],
+          warnings: [],
+        }),
+      }),
+      memory,
+      voice: mockVoice,
+    });
+
+    await agent.getVoice({ memory: { thread: 'thread-a', resource: 'user-1' } });
+    mockVoice.emitTurn({ role: 'user', text: 'scope a' });
+    await vi.waitFor(() => expect(saveMessages).toHaveBeenCalled());
+
+    await agent.getVoice({ memory: { thread: 'thread-b', resource: 'user-2' } });
+    mockVoice.emitTurn({ role: 'user', text: 'scope b' });
+    await vi.waitFor(() => expect(saveMessages).toHaveBeenCalledTimes(2));
+
+    expect(saveMessages.mock.calls[1]![0].messages[0]).toMatchObject({
+      threadId: 'thread-b',
+      resourceId: 'user-2',
+      content: { format: 2, parts: [{ type: 'text', text: 'scope b' }] },
+    });
   });
 
   it('requires resource when persisting voice turns', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -79,7 +79,7 @@ import type { CoreTool, ToolPayloadTransformPolicy } from '../tools/types';
 import type { DynamicArgument } from '../types';
 import { makeCoreTool, createMastraProxy, ensureToolProperties, deepMerge } from '../utils';
 import type { ToolOptions } from '../utils';
-import type { MastraVoice } from '../voice';
+import type { MastraVoice, VoiceTurnEvent } from '../voice';
 import { DefaultVoice } from '../voice';
 import type { Step } from '../workflows/step';
 import type { OutputWriter, WorkflowResult, WorkflowRunState } from '../workflows/types';
@@ -118,6 +118,7 @@ import type {
   AgentCreateOptions,
   AgentExecuteOnFinishOptions,
   AgentInstructions,
+  AgentMemoryOption,
   AgentMethodType,
   AgentSignal,
   AgentSubscribeToThreadOptions,
@@ -328,6 +329,10 @@ export class Agent<
   #scorers: DynamicArgument<MastraScorers, TRequestContext>;
   #agents: DynamicArgument<Record<string, SubAgent<string, TRequestContext>>, TRequestContext>;
   #voice: MastraVoice;
+  #voiceMemoryPersistence?: {
+    voice: MastraVoice;
+    handler: (data: VoiceTurnEvent) => void;
+  };
   #agentChannels: AgentChannels | null = null;
   #workspace?: DynamicArgument<AnyWorkspace | undefined, TRequestContext>;
   #inputProcessors?: DynamicArgument<InputProcessorOrWorkflow[], TRequestContext>;
@@ -1653,15 +1658,110 @@ export class Agent<
    * const audioStream = await voice.speak('Hello world');
    * ```
    */
-  public async getVoice({ requestContext }: { requestContext?: RequestContext } = {}) {
+  public async getVoice({
+    requestContext,
+    memory: memoryOption,
+  }: { requestContext?: RequestContext; memory?: AgentMemoryOption } = {}) {
     if (this.#voice) {
       const voice = this.#voice;
       voice?.addTools(await this.listTools({ requestContext }));
       const instructions = await this.getInstructions({ requestContext });
       voice?.addInstructions(this.#convertInstructionsToString(instructions));
+
+      if (memoryOption) {
+        this.#attachVoiceMemoryPersistence(voice, memoryOption, requestContext);
+      }
+
       return voice;
     } else {
       return new DefaultVoice();
+    }
+  }
+
+  #attachVoiceMemoryPersistence(
+    voice: MastraVoice,
+    memoryOption: AgentMemoryOption,
+    requestContext?: RequestContext,
+  ): void {
+    const resourceId = memoryOption.resource;
+    if (!resourceId) {
+      const error = new MastraError({
+        id: 'AGENT_VOICE_MEMORY_RESOURCE_REQUIRED',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        details: { agentName: this.name },
+        text: `[Agent:${this.name}] - memory.resource is required to persist voice turns`,
+      });
+      this.logger.trackException(error);
+      throw error;
+    }
+
+    const thread =
+      typeof memoryOption.thread === 'string' ? { id: memoryOption.thread } : memoryOption.thread;
+    const threadId = thread.id;
+    const memoryConfig = memoryOption.options;
+
+    if (this.#voiceMemoryPersistence?.voice !== voice) {
+      if (this.#voiceMemoryPersistence) {
+        this.#voiceMemoryPersistence.voice.off('turn', this.#voiceMemoryPersistence.handler);
+      }
+
+      let threadReady = false;
+
+      const handler = (turn: VoiceTurnEvent) => {
+        const text = turn.text.trim();
+        if (!text) {
+          return;
+        }
+
+        void (async () => {
+          const memory = await this.getMemory({ requestContext });
+          if (!memory) {
+            this.logger.warn(`[Agent:${this.name}] - voice memory scope provided but agent has no memory configured`);
+            return;
+          }
+
+          try {
+            if (!threadReady) {
+              const existingThread = await memory.getThreadById({ threadId });
+              if (!existingThread) {
+                await memory.createThread({
+                  threadId,
+                  resourceId,
+                  metadata: thread.metadata,
+                  title: thread.title,
+                  memoryConfig,
+                  saveThread: true,
+                });
+              }
+              threadReady = true;
+            }
+
+            const message: MastraDBMessage = {
+              id: this.#mastra?.generateId() || randomUUID(),
+              role: turn.role,
+              type: 'text',
+              createdAt: new Date(),
+              threadId,
+              resourceId,
+              content: {
+                format: 2,
+                parts: [{ type: 'text', text }],
+              },
+            };
+
+            await memory.saveMessages({
+              messages: [message],
+              memoryConfig,
+            });
+          } catch (err) {
+            this.logger.error(`[Agent:${this.name}] - failed to persist voice turn`, { err, threadId });
+          }
+        })();
+      };
+
+      voice.on('turn', handler);
+      this.#voiceMemoryPersistence = { voice, handler };
     }
   }
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1670,12 +1670,23 @@ export class Agent<
 
       if (memoryOption) {
         this.#attachVoiceMemoryPersistence(voice, memoryOption, requestContext);
+      } else {
+        this.#detachVoiceMemoryPersistence();
       }
 
       return voice;
     } else {
       return new DefaultVoice();
     }
+  }
+
+  #detachVoiceMemoryPersistence(): void {
+    if (!this.#voiceMemoryPersistence) {
+      return;
+    }
+
+    this.#voiceMemoryPersistence.voice.off('turn', this.#voiceMemoryPersistence.handler);
+    this.#voiceMemoryPersistence = undefined;
   }
 
   #attachVoiceMemoryPersistence(
@@ -1696,73 +1707,70 @@ export class Agent<
       throw error;
     }
 
+    this.#detachVoiceMemoryPersistence();
+
     const thread =
       typeof memoryOption.thread === 'string' ? { id: memoryOption.thread } : memoryOption.thread;
     const threadId = thread.id;
     const memoryConfig = memoryOption.options;
 
-    if (this.#voiceMemoryPersistence?.voice !== voice) {
-      if (this.#voiceMemoryPersistence) {
-        this.#voiceMemoryPersistence.voice.off('turn', this.#voiceMemoryPersistence.handler);
+    let threadReady = false;
+    let saveQueue: Promise<void> = Promise.resolve();
+
+    const handler = (turn: VoiceTurnEvent) => {
+      const text = turn.text.trim();
+      if (!text) {
+        return;
       }
 
-      let threadReady = false;
-
-      const handler = (turn: VoiceTurnEvent) => {
-        const text = turn.text.trim();
-        if (!text) {
-          return;
-        }
-
-        void (async () => {
+      saveQueue = saveQueue
+        .then(async () => {
           const memory = await this.getMemory({ requestContext });
           if (!memory) {
             this.logger.warn(`[Agent:${this.name}] - voice memory scope provided but agent has no memory configured`);
             return;
           }
 
-          try {
-            if (!threadReady) {
-              const existingThread = await memory.getThreadById({ threadId });
-              if (!existingThread) {
-                await memory.createThread({
-                  threadId,
-                  resourceId,
-                  metadata: thread.metadata,
-                  title: thread.title,
-                  memoryConfig,
-                  saveThread: true,
-                });
-              }
-              threadReady = true;
+          if (!threadReady) {
+            const existingThread = await memory.getThreadById({ threadId });
+            if (!existingThread) {
+              await memory.createThread({
+                threadId,
+                resourceId,
+                metadata: thread.metadata,
+                title: thread.title,
+                memoryConfig,
+                saveThread: true,
+              });
             }
-
-            const message: MastraDBMessage = {
-              id: this.#mastra?.generateId() || randomUUID(),
-              role: turn.role,
-              type: 'text',
-              createdAt: new Date(),
-              threadId,
-              resourceId,
-              content: {
-                format: 2,
-                parts: [{ type: 'text', text }],
-              },
-            };
-
-            await memory.saveMessages({
-              messages: [message],
-              memoryConfig,
-            });
-          } catch (err) {
-            this.logger.error(`[Agent:${this.name}] - failed to persist voice turn`, { err, threadId });
+            threadReady = true;
           }
-        })();
-      };
 
-      voice.on('turn', handler);
-      this.#voiceMemoryPersistence = { voice, handler };
-    }
+          const message: MastraDBMessage = {
+            id: this.#mastra?.generateId() || randomUUID(),
+            role: turn.role,
+            type: 'text',
+            createdAt: new Date(),
+            threadId,
+            resourceId,
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text }],
+            },
+          };
+
+          await memory.saveMessages({
+            messages: [message],
+            memoryConfig,
+          });
+        })
+        .catch(err => {
+          this.logger.error(`[Agent:${this.name}] - failed to persist voice turn`, { err, threadId });
+        });
+    };
+
+    voice.on('turn', handler);
+    this.#voiceMemoryPersistence = { voice, handler };
   }
 
   /**

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -347,8 +347,8 @@ export class DurableAgent<
     return this.#wrappedAgent.getMemory();
   }
 
-  override getVoice() {
-    return this.#wrappedAgent.getVoice();
+  override getVoice(options?: Parameters<Agent['getVoice']>[0]) {
+    return this.#wrappedAgent.getVoice(options);
   }
 
   // ===========================================================================

--- a/packages/core/src/voice/index.ts
+++ b/packages/core/src/voice/index.ts
@@ -1,2 +1,10 @@
 export { AISDKSpeech, AISDKTranscription, CompositeVoice, DefaultVoice, MastraVoice } from '@internal/voice';
-export type { RequestContext, ToolsInput, VoiceConfig, VoiceEventMap, VoiceEventType } from '@internal/voice';
+export type {
+  RequestContext,
+  ToolsInput,
+  VoiceConfig,
+  VoiceEventMap,
+  VoiceEventType,
+  VoiceTurnEvent,
+  VoiceTurnRole,
+} from '@internal/voice';

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -117,6 +117,7 @@ export class GeminiLiveVoice extends MastraVoice<
 
   // Audio chunk concatenation - optimized stream management
   private audioStreamManager: AudioStreamManager;
+  private currentAssistantTurnText = '';
 
   // Session management properties
   private sessionId?: string;
@@ -595,6 +596,7 @@ export class GeminiLiveVoice extends MastraVoice<
 
     // Add to context history
     this.addToContext('user', input);
+    this.emit('turn', { role: 'user', text: input });
 
     // Build text message to Gemini Live API
     const textMessage: any = {
@@ -1372,6 +1374,7 @@ export class GeminiLiveVoice extends MastraVoice<
         // Handle text content
         if (part.text) {
           assistantResponse += part.text;
+          this.currentAssistantTurnText += part.text;
           this.emit('writing', {
             text: part.text,
             role: 'assistant',
@@ -1483,6 +1486,12 @@ export class GeminiLiveVoice extends MastraVoice<
     // Check for turn completion
     if (data.turnComplete) {
       this.log('Turn completed');
+
+      const assistantTurnText = this.currentAssistantTurnText.trim();
+      if (assistantTurnText) {
+        this.emit('turn', { role: 'assistant', text: assistantTurnText });
+      }
+      this.currentAssistantTurnText = '';
 
       // End all active speaker streams for this turn
       this.audioStreamManager.cleanupSpeakerStreams();

--- a/voice/google-gemini-live-api/src/types.ts
+++ b/voice/google-gemini-live-api/src/types.ts
@@ -155,6 +155,8 @@ export interface GeminiLiveEventMap {
   sessionExpiring: { expiresIn: number; sessionId?: string };
   /** Turn completion event */
   turnComplete: { timestamp: number };
+  /** Completed conversational turn with transcript text */
+  turn: { role: 'user' | 'assistant'; text: string };
   /** Allow any additional string keys for extensibility */
   [key: string]: unknown;
 }


### PR DESCRIPTION
#### Description
- Persist realtime voice turns to Memory via getVoice({ memory: { thread, resource } }).

#### Related issue(s)
Fixes #17264

#### Type of change
- New feature (non-breaking change that adds functionality)
- Test update

#### Checklist

-  I have linked the related issue(s) in the description above
-  I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets voice conversations be saved and remembered by agents, just like text conversations already are. When someone talks to an agent using voice, their back-and-forth exchanges are now stored in the agent's memory so they can be referenced later, and developers can opt into this feature by passing memory details when setting up voice.

---

## Overview

This PR introduces voice turn persistence to the agent memory system, bridging realtime voice conversations with the persistent memory layer. A new `turn` event is added to the voice event contract, carrying provider-safe payloads (`{ role: 'user' | 'assistant', text: string }`). The `Agent.getVoice()` method is extended to accept an optional `memory` scope, allowing completed voice turns to be automatically persisted to agent memory. Thread creation is automatic on first turn, and `resourceId` is required when memory persistence is enabled.

---

## Changes by Component

### Voice Contract & Types

**`packages/_internals/voice/src/voice/voice.ts`**
- Added `VoiceTurnRole` type (`'user' | 'assistant'`)
- Added `VoiceTurnEvent` interface with `role` and `text` fields
- Extended `VoiceEventMap` with new `turn` event type

**`packages/core/src/voice/index.ts`**
- Re-exported new types `VoiceTurnEvent` and `VoiceTurnRole` from `@internal/voice`

### Agent Voice Memory Integration

**`packages/core/src/agent/agent.ts`**
- Extended `Agent.getVoice()` method signature to accept optional `memory` parameter (`{ thread, resource }`)
- Implemented voice turn persistence logic:
  - Registers `voice.on('turn', ...)` handler when memory scope is provided
  - Converts each completed voice turn to a `MastraDBMessage` and saves via `Memory.saveMessages()`
  - Auto-creates memory thread on first turn with provided IDs
  - Tracks voice instance and handler via private `#voiceMemoryPersistence` field to prevent duplicate listeners

**`packages/core/src/agent/durable/durable-agent.ts`**
- Updated `getVoice()` override to accept and forward optional `options` parameter to wrapped agent
- Maintains parity with base `Agent.getVoice()` signature

### Provider Implementation

**`voice/google-gemini-live-api/src/index.ts` & `voice/google-gemini-live-api/src/types.ts`**
- Implemented `turn` event emission in `GeminiLiveVoice`:
  - Emits `turn` event with user text when `speak()` is called
  - Accumulates assistant response text during streaming
  - Emits `turn` event with complete assistant text when `turnComplete` is received
- Updated `GeminiLiveEventMap` to include `turn` event type

### Testing

**`packages/core/src/agent/__tests__/voice-memory.test.ts`** (New)
- Added comprehensive test suite for voice memory persistence:
  - Validates that completed user voice turns are saved to memory with correct threading
  - Confirms `MockMemory.createThread` is called with `saveThread: true`
  - Tests assistant turn persistence via separate save call
  - Validates error handling for missing `memory.resource` parameter

---

## Implementation Details

The feature is entirely opt-in; providers that do not emit the new `turn` event remain unaffected. Thread creation happens automatically on the first voice turn when a memory scope is provided, and the `resourceId` is required to establish message ownership. The voice memory persistence handler is managed to prevent multiple listeners on the same voice instance, with automatic cleanup when switching between different voice instances.

---

## Backward Compatibility

This is a non-breaking change. The `memory` parameter is optional in `Agent.getVoice()`, and existing voice provider implementations continue to work unchanged. Providers are not required to implement the new `turn` event, though doing so enables voice history persistence for agents that opt in.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->