### PR TITLE
fix(convex): paginate JS vector scans

### DIFF
--- a/.changeset/tired-tires-study.md
+++ b/.changeset/tired-tires-study.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Fixed Convex JS vector scans to include all paginated vectors.

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -1556,6 +1556,20 @@ describe('mastraStorage bulk mutations', () => {
     expect(query).not.toHaveBeenCalled();
   });
 
+  it('queryTable rejects vector pagination cursors without a page size', async () => {
+    const query = vi.fn();
+    const ctx = { db: { query } } as unknown as TypedOperationCtx;
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(ctx, {
+      op: 'queryTable',
+      tableName: 'mastra_vector_embeddings',
+      cursor: 'current-cursor',
+    });
+
+    expect(result).toEqual({ ok: false, error: 'queryTable cursor requires pageSize' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
   it('deleteMany applies the same concurrent lookup behavior to generic fallback tables', async () => {
     const deleteCtx = createIndexedDeleteCtx(
       new Map([

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -1527,6 +1527,35 @@ describe('mastraStorage bulk mutations', () => {
     expect(paginate).toHaveBeenCalledWith({ cursor: 'current-cursor', numItems: 256 });
   });
 
+  it('queryTable rejects invalid vector pagination page sizes', async () => {
+    const query = vi.fn();
+    const ctx = { db: { query } } as unknown as TypedOperationCtx;
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(ctx, {
+      op: 'queryTable',
+      tableName: 'mastra_vector_embeddings',
+      pageSize: 0,
+    });
+
+    expect(result).toEqual({ ok: false, error: 'queryTable pageSize must be a positive integer' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('queryTable rejects vector pagination requests that also provide a limit', async () => {
+    const query = vi.fn();
+    const ctx = { db: { query } } as unknown as TypedOperationCtx;
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(ctx, {
+      op: 'queryTable',
+      tableName: 'mastra_vector_embeddings',
+      pageSize: 256,
+      limit: 10,
+    });
+
+    expect(result).toEqual({ ok: false, error: 'queryTable limit cannot be combined with pageSize' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
   it('deleteMany applies the same concurrent lookup behavior to generic fallback tables', async () => {
     const deleteCtx = createIndexedDeleteCtx(
       new Map([

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -1496,6 +1496,37 @@ describe('mastraStorage bulk mutations', () => {
     expect(clearCtx.maxConcurrentDeletes).toBe(3);
   });
 
+  it('queryTable paginates vector table reads when a page size is provided', async () => {
+    const docs = [{ _id: asConvexId('vector-doc-0'), id: 'vector-0', indexName: 'embeddings' }];
+    const builder: TestQueryBuilder = {
+      eq: vi.fn((_field: string, _value: string) => builder),
+    };
+    const paginate = vi.fn(async () => ({
+      page: docs,
+      isDone: false,
+      continueCursor: 'next-cursor',
+    }));
+    const withIndex = vi.fn((_indexName: string, queryBuilder: (q: TestQueryBuilder) => TestQueryBuilder) => {
+      queryBuilder(builder);
+      return { paginate };
+    });
+    const query = vi.fn(() => ({ withIndex }));
+    const ctx = { db: { query } } as unknown as TypedOperationCtx;
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(ctx, {
+      op: 'queryTable',
+      tableName: 'mastra_vector_embeddings',
+      pageSize: 256,
+      cursor: 'current-cursor',
+    });
+
+    expect(result).toEqual({ ok: true, result: docs, hasMore: true, continuationCursor: 'next-cursor' });
+    expect(query).toHaveBeenCalledWith('mastra_vectors');
+    expect(withIndex).toHaveBeenCalledWith('by_index', expect.any(Function));
+    expect(builder.eq).toHaveBeenCalledWith('indexName', 'embeddings');
+    expect(paginate).toHaveBeenCalledWith({ cursor: 'current-cursor', numItems: 256 });
+  });
+
   it('deleteMany applies the same concurrent lookup behavior to generic fallback tables', async () => {
     const deleteCtx = createIndexedDeleteCtx(
       new Map([

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -807,6 +807,10 @@ async function handleVectorOperation(ctx: MutationCtx<any>, request: StorageRequ
     }
 
     case 'queryTable': {
+      if (request.cursor !== undefined && request.pageSize === undefined) {
+        throw new Error('queryTable cursor requires pageSize');
+      }
+
       if (request.pageSize !== undefined) {
         if (!Number.isInteger(request.pageSize) || request.pageSize <= 0) {
           throw new Error('queryTable pageSize must be a positive integer');

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -257,7 +257,7 @@ export const mastraStorage = mutationGeneric(async (ctx, request: StorageRequest
 
     // Handle vector data tables specially (but NOT vector_indexes which is a typed table)
     if (request.tableName.startsWith(VECTOR_TABLE_PREFIX) && request.tableName !== TABLE_VECTOR_INDEXES) {
-      return handleVectorOperation(ctx, request);
+      return await handleVectorOperation(ctx, request);
     }
 
     // Handle typed tables
@@ -807,7 +807,14 @@ async function handleVectorOperation(ctx: MutationCtx<any>, request: StorageRequ
     }
 
     case 'queryTable': {
-      if (request.pageSize) {
+      if (request.pageSize !== undefined) {
+        if (!Number.isInteger(request.pageSize) || request.pageSize <= 0) {
+          throw new Error('queryTable pageSize must be a positive integer');
+        }
+        if (request.limit !== undefined) {
+          throw new Error('queryTable limit cannot be combined with pageSize');
+        }
+
         const page = await ctx.db
           .query(convexTable)
           .withIndex('by_index', (q: any) => q.eq('indexName', indexName))

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -807,6 +807,27 @@ async function handleVectorOperation(ctx: MutationCtx<any>, request: StorageRequ
     }
 
     case 'queryTable': {
+      if (request.pageSize) {
+        const page = await ctx.db
+          .query(convexTable)
+          .withIndex('by_index', (q: any) => q.eq('indexName', indexName))
+          .paginate({ cursor: request.cursor ?? null, numItems: request.pageSize });
+
+        let docs = page.page;
+
+        // Apply filters if provided
+        if (request.filters && request.filters.length > 0) {
+          docs = docs.filter((doc: any) => request.filters!.every(filter => doc[filter.field] === filter.value));
+        }
+
+        return {
+          ok: true,
+          result: docs,
+          hasMore: !page.isDone,
+          continuationCursor: page.continueCursor,
+        };
+      }
+
       // Use take() to avoid hitting Convex's 32k document limit
       const maxDocs = request.limit ? Math.min(request.limit * 2, 10000) : 10000;
       let docs = await ctx.db

--- a/stores/convex/src/storage/client.ts
+++ b/stores/convex/src/storage/client.ts
@@ -10,6 +10,7 @@ export type ConvexAdminClientConfig = {
 export type RawStorageResult<T = any> = {
   result: T;
   hasMore?: boolean;
+  continuationCursor?: string | null;
 };
 
 const DEFAULT_STORAGE_FUNCTION = 'mastra/storage:handle';
@@ -73,6 +74,7 @@ export class ConvexAdminClient {
     return {
       result: storageResponse.result as T,
       hasMore: storageResponse.hasMore,
+      continuationCursor: storageResponse.continuationCursor,
     };
   }
 

--- a/stores/convex/src/storage/types.ts
+++ b/stores/convex/src/storage/types.ts
@@ -40,7 +40,9 @@ export type StorageRequest =
       tableName: TABLE_NAMES | string;
       filters?: EqualityFilter[];
       limit?: number;
+      /** Cursor pagination is currently supported for vector table reads. */
       pageSize?: number;
+      /** Requires pageSize; currently supported for vector table reads. */
       cursor?: string | null;
       indexHint?: IndexHint;
     }
@@ -114,7 +116,7 @@ export type StorageResponse =
   | {
       ok: true;
       result?: any;
-      /** Indicates more batches remain for bulk operations (e.g., clearTable) */
+      /** Indicates more batches or pages remain for the operation. */
       hasMore?: boolean;
       /** Cursor for the next page when hasMore is true. */
       continuationCursor?: string | null;

--- a/stores/convex/src/storage/types.ts
+++ b/stores/convex/src/storage/types.ts
@@ -40,6 +40,8 @@ export type StorageRequest =
       tableName: TABLE_NAMES | string;
       filters?: EqualityFilter[];
       limit?: number;
+      pageSize?: number;
+      cursor?: string | null;
       indexHint?: IndexHint;
     }
   | {
@@ -114,6 +116,8 @@ export type StorageResponse =
       result?: any;
       /** Indicates more batches remain for bulk operations (e.g., clearTable) */
       hasMore?: boolean;
+      /** Cursor for the next page when hasMore is true. */
+      continuationCursor?: string | null;
     }
   | {
       ok: false;

--- a/stores/convex/src/vector/index.test.ts
+++ b/stores/convex/src/vector/index.test.ts
@@ -1,6 +1,6 @@
 import { createVectorTestSuite } from '@internal/storage-test-utils';
 import dotenv from 'dotenv';
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { ConvexVector } from './index';
 
@@ -14,6 +14,160 @@ vi.setConfig({
 const deploymentUrl = process.env.CONVEX_TEST_URL;
 const adminKey = process.env.CONVEX_TEST_ADMIN_KEY;
 const storageFunction = process.env.CONVEX_TEST_STORAGE_FUNCTION;
+
+describe('ConvexVector pagination', () => {
+  const indexName = 'idx';
+  const tableName = `mastra_vector_${indexName}`;
+
+  function createVector({
+    pages,
+    indexes = [{ id: indexName, indexName, dimension: 2, metric: 'cosine' }],
+  }: {
+    pages: Array<Array<{ id: string; embedding: number[]; metadata?: Record<string, unknown> }>>;
+    indexes?: Array<Record<string, unknown>>;
+  }) {
+    const vector = new ConvexVector({ id: 'test', deploymentUrl: 'http://localhost', adminAuthToken: 'test' });
+    const requests: any[] = [];
+    const inserted: any[] = [];
+    const deletedIds: string[] = [];
+    const rawPageForCursor = new Map<string | null, number>([[null, 0]]);
+
+    const client = {
+      callStorage: vi.fn(async (request: any) => {
+        requests.push(request);
+        if (request.op === 'load') return indexes.find(index => index.id === request.keys.id) ?? null;
+        if (request.op === 'queryTable') return pages[0] ?? [];
+        if (request.op === 'insert') {
+          inserted.push(request.record);
+          return undefined;
+        }
+        if (request.op === 'deleteMany') {
+          deletedIds.push(...request.ids);
+          return undefined;
+        }
+        throw new Error(`Unexpected callStorage op ${request.op}`);
+      }),
+      callStorageRaw: vi.fn(async (request: any) => {
+        requests.push(request);
+        if (request.op !== 'queryTable') throw new Error(`Unexpected callStorageRaw op ${request.op}`);
+
+        const pageIndex = rawPageForCursor.get(request.cursor ?? null) ?? 0;
+        const nextPageIndex = pageIndex + 1;
+        const hasMore = nextPageIndex < pages.length;
+        const continuationCursor = hasMore ? `cursor-${nextPageIndex}` : null;
+        if (hasMore) rawPageForCursor.set(continuationCursor, nextPageIndex);
+
+        return {
+          result: pages[pageIndex] ?? [],
+          hasMore,
+          continuationCursor,
+        };
+      }),
+    };
+
+    (vector as any).client = client;
+    return { vector, client, requests, inserted, deletedIds };
+  }
+
+  it('scores vectors from every query page', async () => {
+    const { vector } = createVector({
+      pages: [
+        Array.from({ length: 3 }, (_, index) => ({
+          id: `decoy-${index}`,
+          embedding: [0, 1],
+          metadata: { kind: 'decoy' },
+        })),
+        [{ id: 'perfect', embedding: [1, 0], metadata: { kind: 'match' } }],
+      ],
+    });
+
+    const results = await vector.query({ indexName, queryVector: [1, 0], topK: 1 });
+
+    expect(results[0]?.id).toBe('perfect');
+  });
+
+  it('counts vectors from every query page', async () => {
+    const { vector } = createVector({
+      pages: [
+        Array.from({ length: 3 }, (_, index) => ({ id: `first-${index}`, embedding: [1, 0] })),
+        Array.from({ length: 2 }, (_, index) => ({ id: `second-${index}`, embedding: [1, 0] })),
+      ],
+    });
+
+    const stats = await vector.describeIndex({ indexName });
+
+    expect(stats).toMatchObject({ dimension: 2, count: 5, metric: 'cosine' });
+  });
+
+  it('updates filter matches from later query pages', async () => {
+    const { vector, inserted } = createVector({
+      pages: [
+        [{ id: 'first', embedding: [0, 1], metadata: { group: 'skip' } }],
+        [{ id: 'second', embedding: [0, 1], metadata: { group: 'target', existing: true } }],
+      ],
+    });
+
+    await vector.updateVector({
+      indexName,
+      filter: { metadata: { group: 'target' } },
+      update: { metadata: { updated: true } },
+    });
+
+    expect(inserted).toEqual([
+      {
+        id: 'second',
+        embedding: [0, 1],
+        metadata: { group: 'target', existing: true, updated: true },
+      },
+    ]);
+  });
+
+  it('deletes filter matches from later query pages', async () => {
+    const { vector, deletedIds } = createVector({
+      pages: [
+        [{ id: 'first', embedding: [0, 1], metadata: { group: 'skip' } }],
+        [{ id: 'second', embedding: [0, 1], metadata: { group: 'target' } }],
+      ],
+    });
+
+    await vector.deleteVectors({
+      indexName,
+      filter: { metadata: { group: 'target' } },
+    });
+
+    expect(deletedIds).toEqual(['second']);
+  });
+
+  it('queries the vector table when scanning pages', async () => {
+    const { vector, requests } = createVector({
+      pages: [[{ id: 'perfect', embedding: [1, 0] }]],
+    });
+
+    await vector.query({ indexName, queryVector: [1, 0], topK: 1 });
+
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        op: 'queryTable',
+        tableName,
+      }),
+    );
+  });
+
+  it('throws when storage reports more pages without advancing the cursor', async () => {
+    const { vector, client } = createVector({
+      pages: [[{ id: 'first', embedding: [1, 0] }], [{ id: 'second', embedding: [1, 0] }]],
+    });
+    client.callStorageRaw.mockResolvedValueOnce({
+      result: [{ id: 'first', embedding: [1, 0] }],
+      hasMore: true,
+      continuationCursor: null,
+    });
+
+    await expect(vector.query({ indexName, queryVector: [1, 0], topK: 1 })).rejects.toThrow(
+      'ConvexVector: paginated vector query did not return a valid continuation cursor',
+    );
+  });
+});
 
 if (!deploymentUrl || !adminKey) {
   describe.skip('ConvexVector', () => {

--- a/stores/convex/src/vector/index.ts
+++ b/stores/convex/src/vector/index.ts
@@ -16,7 +16,7 @@ import type {
   UpsertVectorParams,
 } from '@mastra/core/vector';
 
-import type { ConvexAdminClientConfig } from '../storage/client';
+import type { ConvexAdminClientConfig, RawStorageResult } from '../storage/client';
 import { ConvexAdminClient } from '../storage/client';
 import type { StorageRequest } from '../storage/types';
 
@@ -31,6 +31,7 @@ type VectorFilter = {
 };
 
 const INDEX_METADATA_TABLE = 'mastra_vector_indexes';
+const VECTOR_QUERY_PAGE_SIZE = 256;
 
 export type ConvexVectorConfig = ConvexAdminClientConfig & {
   id: string;
@@ -99,10 +100,7 @@ export class ConvexVector extends MastraVector<VectorFilter> {
       throw new Error(`Index ${indexName} not found`);
     }
 
-    const vectors = await this.callStorage<VectorRecord[]>({
-      op: 'queryTable',
-      tableName: this.vectorTable(indexName),
-    });
+    const vectors = await this.queryAllVectors(indexName);
 
     return {
       dimension: index.dimension,
@@ -146,10 +144,7 @@ export class ConvexVector extends MastraVector<VectorFilter> {
       });
     }
 
-    const vectors = await this.callStorage<VectorRecord[]>({
-      op: 'queryTable',
-      tableName: this.vectorTable(indexName),
-    });
+    const vectors = await this.queryAllVectors(indexName);
 
     const filtered =
       filter && !this.isEmptyFilter(filter)
@@ -188,10 +183,7 @@ export class ConvexVector extends MastraVector<VectorFilter> {
       }
 
       // Update by filter - find all matching records and update them
-      const vectors = await this.callStorage<VectorRecord[]>({
-        op: 'queryTable',
-        tableName: this.vectorTable(params.indexName),
-      });
+      const vectors = await this.queryAllVectors(params.indexName);
 
       const matching = vectors.filter(record => this.matchesFilter(record.metadata, filter));
 
@@ -280,10 +272,7 @@ export class ConvexVector extends MastraVector<VectorFilter> {
     }
 
     // Find all matching vectors and delete them
-    const vectors = await this.callStorage<VectorRecord[]>({
-      op: 'queryTable',
-      tableName: this.vectorTable(indexName),
-    });
+    const vectors = await this.queryAllVectors(indexName);
 
     const matchingIds = vectors.filter(record => this.matchesFilter(record.metadata, filter)).map(record => record.id);
 
@@ -404,6 +393,32 @@ export class ConvexVector extends MastraVector<VectorFilter> {
 
   private async callStorage<T = any>(request: StorageRequest): Promise<T> {
     return this.client.callStorage<T>(request);
+  }
+
+  private async queryAllVectors(indexName: string): Promise<VectorRecord[]> {
+    const vectors: VectorRecord[] = [];
+    let cursor: string | null = null;
+    let hasMore = true;
+
+    while (hasMore) {
+      const response: RawStorageResult<VectorRecord[]> = await this.client.callStorageRaw<VectorRecord[]>({
+        op: 'queryTable',
+        tableName: this.vectorTable(indexName),
+        pageSize: VECTOR_QUERY_PAGE_SIZE,
+        cursor,
+      });
+
+      vectors.push(...response.result);
+
+      const nextCursor = response.continuationCursor ?? null;
+      hasMore = response.hasMore ?? false;
+      if (hasMore && (!nextCursor || nextCursor === cursor)) {
+        throw new Error('ConvexVector: paginated vector query did not return a valid continuation cursor');
+      }
+      cursor = nextCursor;
+    }
+
+    return vectors;
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes `ConvexVector` so JS-side vector scans read all paginated vector rows before computing nearest neighbors, counting vectors, or applying filter-based updates/deletes.

The storage handler now supports cursor-based pagination for vector table `queryTable` reads. The adapter uses a bounded page size to stay under Convex transaction payload limits and guards against malformed pagination responses that report more pages without advancing the cursor.

## Related issue(s)

Fixes #17269

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5

If your app could only see the first chunk of items, it would miss everything after. This PR makes the Convex JS vector adapter fetch all pages of vectors (in bounded chunks) so searches, counts, and filter-based updates/deletes include every vector.

Overview

Fixes a bug where Convex JS vector operations only processed the first capped storage batch, which caused incorrect nearest-neighbor results, undercounted indexes, and missed filter-based updates/deletes. Adds cursor-based, bounded pagination across storage and vector layers, validates pagination inputs, and defends against malformed pagination responses.

What changed

- stores/convex/src/vector/index.ts
  - Added VECTOR_QUERY_PAGE_SIZE and queryAllVectors helper that iterates pages, accumulates vectors, validates that continuation cursors advance, and throws on anomalous pagination.
  - Updated describeIndex, query, updateVector, and deleteVectors to use queryAllVectors so enumeration spans all pages.

- stores/convex/src/storage/types.ts
  - StorageRequest.queryTable supports optional pageSize?: number and cursor?: string | null.
  - StorageResponse (ok: true) may include continuationCursor?: string | null.

- stores/convex/src/storage/client.ts
  - RawStorageResult<T> now optionally includes continuationCursor?: string | null.
  - ConvexAdminClient.callStorageRaw surfaces continuationCursor from storage responses.

- stores/convex/src/server/storage.ts
  - handleVectorOperation for queryTable supports paginate when request.pageSize is provided: validates pageSize (>0), rejects pageSize combined with limit, rejects cursor without pageSize, calls the by_index index with paginate({ cursor, numItems: pageSize }), applies in-memory filtering per page, and returns { ok, result, hasMore, continuationCursor }.
  - mastraStorage now awaits handleVectorOperation to ensure correct async behavior.

- stores/convex/src/server/storage.test.ts and stores/convex/src/vector/index.test.ts
  - Added tests covering vector-table pagination, input validation (pageSize > 0, disallow pageSize+limit, disallow cursor without pageSize), multi-page scoring/counting, update/delete across pages, and detection of pagination responses that claim more pages without advancing the cursor.
  - Updated Vitest imports to include expect.

Other notes

- Commit "fix(convex): reject invalid vector pagination cursors" adds fast-fail validation for invalid pagination input (e.g., providing cursor without pageSize) and clarifies pagination response handling.
- Design safeguards: bounded page size to respect Convex payload limits, in-memory per-page filtering to preserve semantics, and defensive detection/abort for non-advancing continuation cursors.
- Includes changeset entry noting the fix.
- Fixes issue `#17269`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->