### PR TITLE
fix(core): merge grep context hunks

### DIFF
--- a/.changeset/salty-rules-scream.md
+++ b/.changeset/salty-rules-scream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed grep context output so overlapping matches are shown once.

--- a/packages/core/src/workspace/tools/__tests__/grep.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/grep.test.ts
@@ -129,6 +129,91 @@ describe('workspace_grep', () => {
     expect(result).toContain('ctx.ts:5- line5');
   });
 
+  it('should merge overlapping context windows without duplicating lines', async () => {
+    await fs.writeFile(path.join(tempDir, 'f.ts'), 'MATCH_A\nx\nMATCH_B\ny\nz');
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.GREP].execute(
+      {
+        pattern: 'MATCH',
+        path: 'f.ts',
+        contextLines: 2,
+      },
+      { workspace },
+    );
+
+    expect(result).toBe(
+      [
+        '2 matches across 1 file',
+        '---',
+        'f.ts:1:1: MATCH_A',
+        'f.ts:2- x',
+        'f.ts:3:1: MATCH_B',
+        'f.ts:4- y',
+        'f.ts:5- z',
+      ].join('\n'),
+    );
+  });
+
+  it('should normalize fractional context lines before rendering context', async () => {
+    await fs.writeFile(path.join(tempDir, 'fractional.ts'), 'before\nTARGET\nafter\nextra');
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.GREP].execute(
+      {
+        pattern: 'TARGET',
+        path: 'fractional.ts',
+        contextLines: 1.5,
+      },
+      { workspace },
+    );
+
+    expect(result).toBe(
+      [
+        '1 match across 1 file',
+        '---',
+        'fractional.ts:1- before',
+        'fractional.ts:2:1: TARGET',
+        'fractional.ts:3- after',
+      ].join('\n'),
+    );
+  });
+
+  it('should separate distinct context hunks without a trailing separator', async () => {
+    await fs.writeFile(path.join(tempDir, 'split.ts'), 'TARGET_A\nctxA\ngap1\ngap2\nctxB\nTARGET_B');
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.GREP].execute(
+      {
+        pattern: 'TARGET',
+        path: 'split.ts',
+        contextLines: 1,
+      },
+      { workspace },
+    );
+
+    expect(result).toBe(
+      [
+        '2 matches across 1 file',
+        '---',
+        'split.ts:1:1: TARGET_A',
+        'split.ts:2- ctxA',
+        '--',
+        'split.ts:5- ctxB',
+        'split.ts:6:1: TARGET_B',
+      ].join('\n'),
+    );
+  });
+
   it('should limit matches per file with maxCount', async () => {
     const lines = Array.from({ length: 200 }, (_, i) => `match_${i}`).join('\n');
     await fs.writeFile(path.join(tempDir, 'big.ts'), lines);

--- a/packages/core/src/workspace/tools/grep.ts
+++ b/packages/core/src/workspace/tools/grep.ts
@@ -166,6 +166,8 @@ Usage:
       let truncated = false;
       const MAX_LINE_LENGTH = 500;
       const GLOBAL_CAP = 1000;
+      const normalizedContextLines = Math.max(0, Math.floor(contextLines));
+      let emittedContextHunk = false;
 
       for (const filePath of filePaths) {
         if (truncated) break;
@@ -181,6 +183,7 @@ Usage:
 
         const lines = content.split('\n');
         let fileMatchCount = 0;
+        const fileMatches: Array<{ lineIndex: number; columnIndex: number }> = [];
 
         for (let i = 0; i < lines.length; i++) {
           const currentLine = lines[i]!;
@@ -191,31 +194,7 @@ Usage:
 
           filesWithMatches.add(filePath);
 
-          let lineContent = currentLine;
-          if (lineContent.length > MAX_LINE_LENGTH) {
-            lineContent = lineContent.slice(0, MAX_LINE_LENGTH) + '...';
-          }
-
-          // Add context lines before the match
-          if (contextLines > 0) {
-            const beforeStart = Math.max(0, i - contextLines);
-            for (let b = beforeStart; b < i; b++) {
-              outputLines.push(`${filePath}:${b + 1}- ${lines[b]}`);
-            }
-          }
-
-          // Add the matching line
-          outputLines.push(`${filePath}:${i + 1}:${lineMatch.index + 1}: ${lineContent}`);
-
-          // Add context lines after the match
-          if (contextLines > 0) {
-            const afterEnd = Math.min(lines.length - 1, i + contextLines);
-            for (let a = i + 1; a <= afterEnd; a++) {
-              outputLines.push(`${filePath}:${a + 1}- ${lines[a]}`);
-            }
-            // Separator between context groups
-            outputLines.push('--');
-          }
+          fileMatches.push({ lineIndex: i, columnIndex: lineMatch.index });
 
           totalMatchCount++;
           fileMatchCount++;
@@ -227,6 +206,60 @@ Usage:
           if (totalMatchCount >= GLOBAL_CAP) {
             truncated = true;
             break;
+          }
+        }
+
+        if (normalizedContextLines > 0) {
+          const hunks: Array<{
+            start: number;
+            end: number;
+            matchesByLine: Map<number, number>;
+          }> = [];
+
+          for (const match of fileMatches) {
+            const start = Math.max(0, match.lineIndex - normalizedContextLines);
+            const end = Math.min(lines.length - 1, match.lineIndex + normalizedContextLines);
+            const previousHunk = hunks[hunks.length - 1];
+
+            if (previousHunk && start <= previousHunk.end + 1) {
+              previousHunk.end = Math.max(previousHunk.end, end);
+              previousHunk.matchesByLine.set(match.lineIndex, match.columnIndex);
+            } else {
+              hunks.push({
+                start,
+                end,
+                matchesByLine: new Map([[match.lineIndex, match.columnIndex]]),
+              });
+            }
+          }
+
+          for (const hunk of hunks) {
+            if (emittedContextHunk) {
+              outputLines.push('--');
+            }
+            emittedContextHunk = true;
+
+            for (let i = hunk.start; i <= hunk.end; i++) {
+              const columnIndex = hunk.matchesByLine.get(i);
+
+              if (columnIndex !== undefined) {
+                let lineContent = lines[i]!;
+                if (lineContent.length > MAX_LINE_LENGTH) {
+                  lineContent = lineContent.slice(0, MAX_LINE_LENGTH) + '...';
+                }
+                outputLines.push(`${filePath}:${i + 1}:${columnIndex + 1}: ${lineContent}`);
+              } else {
+                outputLines.push(`${filePath}:${i + 1}- ${lines[i]}`);
+              }
+            }
+          }
+        } else {
+          for (const match of fileMatches) {
+            let lineContent = lines[match.lineIndex]!;
+            if (lineContent.length > MAX_LINE_LENGTH) {
+              lineContent = lineContent.slice(0, MAX_LINE_LENGTH) + '...';
+            }
+            outputLines.push(`${filePath}:${match.lineIndex + 1}:${match.columnIndex + 1}: ${lineContent}`);
           }
         }
       }


### PR DESCRIPTION
## Description

Fixes workspace grep context output so overlapping or adjacent context windows are merged before rendering. This prevents the same line from appearing multiple times when matches are near each other.

The grep tool now collects matches for each file, builds merged context hunks, and renders separators only between distinct hunks. It also normalizes fractional `contextLines` values before calculating line indexes.

## Related issue(s)

Fixes #17273

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Validation

- `pnpm --filter ./packages/core test src/workspace/tools/__tests__/grep.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm build:core`
- `pnpm prettier --check packages/core/src/workspace/tools/grep.ts packages/core/src/workspace/tools/__tests__/grep.test.ts .changeset/salty-rules-scream.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Imagine you're searching a document for specific words. The tool shows you the words you found plus some extra lines around them for context. The bug was: if you have two search results close to each other, those extra "context" lines would get shown twice because each result was showing its own separate context. This PR fixes it by smart merging—now when context windows overlap, the tool shows those lines just once instead of duplicating them.

---

## Overview
This PR fixes a bug in the `workspace_grep` tool where overlapping or adjacent context windows caused the same source lines to appear multiple times in the output. The solution collects all matches in a file first, then merges nearby matches into unified context "hunks" before rendering output, ensuring each line appears only once and separators (`--`) only appear between distinct hunks.

## Changes

### Core Implementation
**packages/core/src/workspace/tools/grep.ts** — Refactored match output generation:
- Changed from emitting context immediately per match during line scanning to collecting all matches first
- Normalizes `contextLines` values (converting fractional values to integers)
- Groups nearby matches into merged context hunks when `contextLines > 0`
- Renders separators only between distinct hunks (not before first or after last)
- When `contextLines` is 0, emits only matched lines
- Maintains line truncation (`MAX_LINE_LENGTH`) behavior

### Tests
**packages/core/src/workspace/tools/__tests__/grep.test.ts** — Added three new test cases:
1. Verifies overlapping context windows are merged without duplicating context lines
2. Verifies fractional `contextLines` values are normalized before rendering
3. Verifies separate context hunks are rendered with separators between them (and no trailing separator)

### Documentation
**.changeset/salty-rules-scream.md** — Added changeset entry marking this as a patch release for `@mastra/core` with note: "Fixed grep context output so overlapping matches are shown once."

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->