### PR TITLE
fix(core): normalize read_file ranges past EOF

### DIFF
--- a/.changeset/mighty-humans-raise.md
+++ b/.changeset/mighty-humans-raise.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed read_file line ranges when offsets are past the end of a file

--- a/packages/core/src/workspace/line-utils.test.ts
+++ b/packages/core/src/workspace/line-utils.test.ts
@@ -43,6 +43,20 @@ describe('extractLines', () => {
     const result = extractLines(content, -5, 100);
     expect(result.lines).toEqual({ start: 1, end: 5 });
   });
+
+  it('should preserve an empty line within a valid range', () => {
+    const result = extractLines('Line 1\n\nLine 3', 2, 2);
+    expect(result.content).toBe('');
+    expect(result.lines).toEqual({ start: 2, end: 2 });
+    expect(result.totalLines).toBe(3);
+  });
+
+  it('should return an empty range when startLine is past the end', () => {
+    const result = extractLines(content, 10, 12);
+    expect(result.content).toBe('');
+    expect(result.lines).toEqual({ start: 0, end: 0 });
+    expect(result.totalLines).toBe(5);
+  });
 });
 
 describe('extractLinesWithLimit', () => {
@@ -66,6 +80,20 @@ describe('extractLinesWithLimit', () => {
     expect(result.content).toBe('Line 1\nLine 2');
     expect(result.lines).toEqual({ start: 1, end: 2 });
   });
+
+  it('should return an empty range when offset is past the end', () => {
+    const result = extractLinesWithLimit('a\nb\nc', 10, 5);
+    expect(result.content).toBe('');
+    expect(result.lines).toEqual({ start: 0, end: 0 });
+    expect(result.totalLines).toBe(3);
+  });
+
+  it('should return an empty range when offset without limit is past the end', () => {
+    const result = extractLinesWithLimit('a\nb\nc', 10);
+    expect(result.content).toBe('');
+    expect(result.lines).toEqual({ start: 0, end: 0 });
+    expect(result.totalLines).toBe(3);
+  });
 });
 
 describe('formatWithLineNumbers', () => {
@@ -87,6 +115,11 @@ describe('formatWithLineNumbers', () => {
   it('should adjust padding for large line numbers', () => {
     const result = formatWithLineNumbers('Line', 999);
     expect(result).toBe('   999→Line');
+  });
+
+  it('should format an empty line', () => {
+    const result = formatWithLineNumbers('', 10);
+    expect(result).toBe('    10→');
   });
 });
 

--- a/packages/core/src/workspace/line-utils.ts
+++ b/packages/core/src/workspace/line-utils.ts
@@ -41,6 +41,14 @@ export function extractLines(
   const start = Math.max(1, startLine ?? 1);
   const end = Math.min(totalLines, endLine ?? totalLines);
 
+  if (start > end) {
+    return {
+      content: '',
+      lines: { start: 0, end: 0 },
+      totalLines,
+    };
+  }
+
   // Extract the requested range (convert to 0-indexed)
   const extractedLines = allLines.slice(start - 1, end);
 

--- a/packages/core/src/workspace/tools/__tests__/read-file.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/read-file.test.ts
@@ -71,6 +71,45 @@ describe('workspace_read_file', () => {
     expect(result).toContain('Line 2\nLine 3');
   });
 
+  it('should report an empty range when offset is past the end of the file', async () => {
+    await fs.writeFile(path.join(tempDir, 'test.txt'), 'Line 1\nLine 2\nLine 3');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      {
+        path: 'test.txt',
+        offset: 10,
+        limit: 5,
+      },
+      { workspace },
+    );
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('lines 0-0 of 3');
+    expect(result).not.toContain('lines 10-3 of 3');
+    expect(result).not.toContain('10→');
+  });
+
+  it('should preserve line numbers for real blank lines', async () => {
+    await fs.writeFile(path.join(tempDir, 'test.txt'), 'Line 1\n\nLine 3');
+    const workspace = new Workspace({ filesystem: new LocalFilesystem({ basePath: tempDir }) });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      {
+        path: 'test.txt',
+        offset: 2,
+        limit: 1,
+      },
+      { workspace },
+    );
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('lines 2-2 of 3');
+    expect(result).toContain('2→');
+  });
+
   it('should handle binary content', async () => {
     const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47]); // PNG header bytes
     await fs.writeFile(path.join(tempDir, 'binary.bin'), buffer);

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -245,9 +245,11 @@ export const readFileTool = createTool({
       const result = extractLinesWithLimit(fullContent, offset, limit);
 
       const shouldShowLineNumbers = showLineNumbers !== false;
-      const formattedContent = shouldShowLineNumbers
-        ? formatWithLineNumbers(result.content, result.lines.start)
-        : result.content;
+      const hasExtractedLines = result.lines.start !== 0 || result.lines.end !== 0;
+      const formattedContent =
+        shouldShowLineNumbers && hasExtractedLines
+          ? formatWithLineNumbers(result.content, result.lines.start)
+          : result.content;
 
       let header: string;
       if (hasLineRange) {


### PR DESCRIPTION
Fixes #17277.

Fixes `read_file` output when a requested offset starts past EOF.

Previously, an offset beyond the file length could produce an inverted header like:

```txt
test.txt (lines 10-3 of 3, 20 bytes)
    10→
```

Now `extractLines` normalizes that empty result to `lines 0-0 of N`, and `read_file` skips phantom line-number formatting for that synthetic empty range. Real blank lines still keep their line number marker.

Added regression coverage for:
- `extractLines` ranges past EOF
- `extractLinesWithLimit` offsets past EOF, with and without `limit`
- `read_file` output past EOF
- preserving line numbers for real blank lines

Validation:
- `pnpm --filter ./packages/core exec vitest run src/workspace/line-utils.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/workspace/tools/__tests__/read-file.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core lint`
- `pnpm build:core`
- targeted Prettier check
