### PR TITLE
fix(daytona): validate env names before shell export

### DIFF
--- a/.changeset/odd-trees-argue.md
+++ b/.changeset/odd-trees-argue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/daytona': patch
+---
+
+Fixed Daytona command execution to reject invalid environment variable names

--- a/.github/workflows/changed-test-gate.yml
+++ b/.github/workflows/changed-test-gate.yml
@@ -92,9 +92,46 @@ jobs:
           set -euo pipefail
           mapfile -t test_files < /tmp/changed-test-files
 
+          root_test_files=()
+          test_status=0
+
+          for file in "${test_files[@]}"; do
+            test_dir=""
+            search_dir="$(dirname "$file")"
+
+            while [ "$search_dir" != "." ] && [ "$search_dir" != "/" ]; do
+              if [ -f "$search_dir/vitest.config.ts" ] || [ -f "$search_dir/vitest.config.mts" ]; then
+                test_dir="$search_dir"
+                break
+              fi
+
+              search_dir="$(dirname "$search_dir")"
+            done
+
+            if [ -n "$test_dir" ]; then
+              relative_file="${file#"$test_dir"/}"
+
+              set +e
+              pnpm --dir "$test_dir" exec vitest run --passWithNoTests "$relative_file"
+              status=$?
+              set -e
+
+              if [ "$status" -ne 0 ]; then
+                test_status="$status"
+              fi
+            else
+              root_test_files+=("$file")
+            fi
+          done
+
           set +e
-          pnpm vitest run --passWithNoTests "${test_files[@]}"
-          test_status=$?
+          if [ "${#root_test_files[@]}" -gt 0 ]; then
+            pnpm vitest run --passWithNoTests "${root_test_files[@]}"
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              test_status="$status"
+            fi
+          fi
           set -e
 
           if [ "$test_status" -eq 0 ]; then

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -592,6 +592,29 @@ describe('DaytonaSandbox', () => {
       expect(cmd).toContain('export KEEP=yes');
       expect(cmd).not.toContain('REMOVE');
     });
+
+    it('rejects invalid env names before building shell exports', async () => {
+      const sandbox = new DaytonaSandbox();
+
+      await sandbox._start();
+
+      await expect(
+        sandbox.executeCommand('echo', ['test'], { env: { 'sandbox not found; printf injected': 'x' } }),
+      ).rejects.toThrow('Invalid environment variable name');
+      expect(mockDaytona.create).toHaveBeenCalledTimes(1);
+      expect(mockSandbox.process.executeSessionCommand).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid sandbox env names', async () => {
+      const sandbox = new DaytonaSandbox({
+        env: { 'INVALID-NAME': 'x' },
+      });
+
+      await sandbox._start();
+
+      await expect(sandbox.executeCommand('echo', ['test'])).rejects.toThrow('Invalid environment variable name');
+      expect(mockSandbox.process.executeSessionCommand).not.toHaveBeenCalled();
+    });
   });
 
   describe('Mount Configuration', () => {

--- a/workspaces/daytona/src/sandbox/process-manager.ts
+++ b/workspaces/daytona/src/sandbox/process-manager.ts
@@ -187,17 +187,19 @@ export class DaytonaProcessManager extends SandboxProcessManager<DaytonaSandbox>
       ...options,
       timeout: options.timeout ?? this._defaultTimeout,
     };
+
+    // Merge default env with per-spawn env
+    const mergedEnv = { ...this.env, ...effectiveOptions.env };
+    const envs = Object.fromEntries(
+      Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
+    );
+
+    // Validate/build before retryOnDead so user-controlled validation errors
+    // cannot be mistaken for Daytona dead-sandbox errors.
+    const sessionCommand = buildSpawnCommand(command, effectiveOptions.cwd, envs);
+
     return this.sandbox.retryOnDead(async () => {
       const sandbox = this.sandbox.daytona;
-
-      // Merge default env with per-spawn env
-      const mergedEnv = { ...this.env, ...effectiveOptions.env };
-      const envs = Object.fromEntries(
-        Object.entries(mergedEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
-      );
-
-      // Build command with baked-in env and cwd, wrapped in subshell
-      const sessionCommand = buildSpawnCommand(command, effectiveOptions.cwd, envs);
 
       // Unique session ID per spawn — used as the PID
       const sessionId = `mastra-proc-${Date.now().toString(36)}-${++this._spawnCounter}`;
@@ -248,6 +250,8 @@ export class DaytonaProcessManager extends SandboxProcessManager<DaytonaSandbox>
 // Command Building
 // =============================================================================
 
+const SHELL_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 /**
  * Build a shell command string that bakes in cwd and env vars.
  * Wraps the user command in a subshell `(command)` so that:
@@ -262,6 +266,9 @@ function buildSpawnCommand(command: string, cwd: string | undefined, envs: Recor
   const parts: string[] = [];
 
   for (const [k, v] of Object.entries(envs)) {
+    if (!SHELL_IDENTIFIER_PATTERN.test(k)) {
+      throw new Error(`Invalid environment variable name: ${JSON.stringify(k)}`);
+    }
     parts.push(`export ${k}=${shellQuote(v)}`);
   }
 


### PR DESCRIPTION
## Description

This validates Daytona environment variable names before they are interpolated into the session shell command as `export NAME=value`.

Values were already shell-quoted, but names were inserted raw. The fix rejects names that are not valid shell identifiers and builds the command before `retryOnDead`, so user-controlled validation errors cannot be mistaken for Daytona sandbox recovery errors.

## Related issue(s)

Fixes #17278

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Validation:
- `pnpm --filter ./workspaces/daytona test:unit`
- `pnpm --filter ./workspaces/daytona lint`
- `pnpm --filter ./workspaces/daytona build`
- `pnpm --filter ./workspaces/daytona exec tsc --noEmit -p tsconfig.json`
- `pnpm prettier --check workspaces/daytona/src/sandbox/index.test.ts workspaces/daytona/src/sandbox/process-manager.ts .changeset/odd-trees-argue.md`

Local reviews:
- Codex: no findings after retry-placement fix.
- Claude: low maintainability/test suggestions addressed.
- agy: no blocking findings; optional non-string value hardening left out of scope.
- CodeRabbit: changeset wording finding addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR prevents Daytona from accidentally running malicious shell code by checking that environment variable names are valid before inserting them into export commands. If a name isn't a proper shell identifier, the operation is rejected early so nothing dangerous gets injected or retried.

## Changes

### Changeset
Added a patch changeset entry for `@mastra/daytona` documenting that command execution now rejects invalid environment variable names.

### Tests
Added two Vitest cases in the "Environment Variables" suite to assert that invalid env names are rejected:
- One test ensures per-command `env` keys that are invalid cause `executeCommand()` to reject (sandbox creation still occurs, but the session command is not executed).
- Another test verifies invalid sandbox-default env names are rejected with the same behavior.

### Process Manager
- `DaytonaProcessManager.spawn()` now merges sandbox-default and per-spawn envs, filters out `undefined` values, and constructs the final session command via `buildSpawnCommand()` before calling `sandbox.retryOnDead()`. This ensures validation errors are surfaced directly rather than being routed through sandbox-retry/recovery logic.
- `buildSpawnCommand()` validates each environment variable name against a shell identifier regex and throws on invalid names instead of emitting potentially malformed `export` statements. Env values continue to be shell-quoted unchanged.

### CI workflow
Updated the changed-tests workflow step to group changed test files by their nearest `vitest.config.*` root and run `vitest` from that root (with a fallback runner for files without an associated test root), replacing the previous single-run approach.

## Motivation / Context
Fixes issue `#17278` by ensuring both sandbox-level default env names and per-command env names are validated as shell identifiers before being exported, preventing shell-injection via env name interpolation and ensuring validation failures are not mistaken for sandbox failures.

## Validation / Local Testing
Author included local verification steps and added unit tests; lint/build/test commands are listed in the PR description.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->