### PR TITLE
fix(workspaces): report sandbox kill and timeout flags

### DIFF
--- a/.changeset/tender-areas-brake.md
+++ b/.changeset/tender-areas-brake.md
@@ -1,0 +1,7 @@
+---
+'@mastra/daytona': patch
+'@mastra/docker': patch
+'@mastra/modal': patch
+---
+
+Fixed sandbox execution results to report killed and timed out commands.

--- a/workspaces/daytona/src/sandbox/index.test.ts
+++ b/workspaces/daytona/src/sandbox/index.test.ts
@@ -1196,6 +1196,8 @@ describe('DaytonaSandbox', () => {
       expect(result.success).toBe(true);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toBe('hello world');
+      expect(result.killed).toBeUndefined();
+      expect(result.timedOut).toBeUndefined();
       expect(result.executionTimeMs).toBeGreaterThanOrEqual(0);
     });
 
@@ -1258,7 +1260,34 @@ describe('DaytonaSandbox', () => {
       const result = await sandbox.executeCommand('sleep', ['9999']);
 
       expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(124);
       expect(result.stderr).toContain('timed out');
+      expect(result.killed).toBe(true);
+      expect(result.timedOut).toBe(true);
+    });
+
+    it('marks explicit kill results as killed without timeout', async () => {
+      let finishLogs!: (error: Error) => void;
+      mockSandbox.process.getSessionCommandLogs.mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            finishLogs = reject;
+          }),
+      );
+
+      const sandbox = new DaytonaSandbox();
+      await sandbox._start();
+
+      const handle = await sandbox.processes.spawn('sleep 9999');
+      await handle.kill();
+      finishLogs(new Error('session deleted'));
+
+      const result = await handle.wait();
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(137);
+      expect(result.killed).toBe(true);
+      expect(result.timedOut).toBe(false);
     });
 
     it('wraps command in subshell', async () => {

--- a/workspaces/daytona/src/sandbox/process-manager.ts
+++ b/workspaces/daytona/src/sandbox/process-manager.ts
@@ -104,6 +104,8 @@ class DaytonaProcessHandle extends ProcessHandle {
             stdout: this.stdout,
             stderr: this.stderr || error.message,
             executionTimeMs: Date.now() - this._startTime,
+            killed: true,
+            timedOut: true,
           };
         }
         throw error;
@@ -123,6 +125,8 @@ class DaytonaProcessHandle extends ProcessHandle {
         stdout: this.stdout,
         stderr: this.stderr,
         executionTimeMs: Date.now() - this._startTime,
+        killed: true,
+        timedOut: false,
       };
     }
 

--- a/workspaces/docker/src/sandbox/index.test.ts
+++ b/workspaces/docker/src/sandbox/index.test.ts
@@ -26,7 +26,7 @@ import { DockerSandbox } from './index';
 // Mock Setup
 // =============================================================================
 
-const { mockContainer, mockExec, mockDocker, resetMockDefaults } = vi.hoisted(() => {
+const { mockContainer, mockExec, mockStream, mockDocker, resetMockDefaults } = vi.hoisted(() => {
   const mockStream = {
     on: vi.fn(),
     write: vi.fn(),
@@ -902,6 +902,24 @@ describe('DockerSandbox', () => {
       );
     });
 
+    it('should leave kill and timeout flags unset for natural exits', async () => {
+      const sandbox = new DockerSandbox();
+      await sandbox._start();
+
+      const handle = await sandbox.processes!.spawn('echo hello');
+      const waitPromise = handle.wait();
+
+      const endHandler = mockStream.on.mock.calls.find(([event]) => event === 'end')?.[1] as () => Promise<void>;
+      await endHandler();
+
+      const result = await waitPromise;
+
+      expect(result.success).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(result.killed).toBeUndefined();
+      expect(result.timedOut).toBeUndefined();
+    });
+
     it('should use process group kill (negative PID)', async () => {
       mockExec.inspect.mockResolvedValue({
         Running: true,
@@ -925,6 +943,56 @@ describe('DockerSandbox', () => {
       // The second exec call should be the kill command with negative PID
       const killCall = mockContainer.exec.mock.calls[1]?.[0];
       expect(killCall.Cmd).toEqual(['sh', '-c', 'kill -9 -42 2>/dev/null || kill -9 42']);
+    });
+
+    it('should mark explicit kill results as killed without timeout', async () => {
+      mockExec.inspect.mockResolvedValue({
+        Running: true,
+        ExitCode: null,
+        Pid: 42,
+      });
+
+      const sandbox = new DockerSandbox();
+      await sandbox._start();
+
+      const handle = await sandbox.processes!.spawn('sleep 100');
+      const waitPromise = handle.wait();
+      await handle.kill();
+
+      const closeHandler = mockStream.on.mock.calls.find(([event]) => event === 'close')?.[1] as () => void;
+      closeHandler();
+
+      const result = await waitPromise;
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(137);
+      expect(result.killed).toBe(true);
+      expect(result.timedOut).toBe(false);
+    });
+
+    it('should mark timeout results as killed and timed out', async () => {
+      vi.useFakeTimers();
+      try {
+        const sandbox = new DockerSandbox();
+        await sandbox._start();
+
+        const handle = await sandbox.processes!.spawn('sleep 100', { timeout: 50 });
+        const waitPromise = handle.wait();
+
+        vi.advanceTimersByTime(50);
+
+        const closeHandler = mockStream.on.mock.calls.find(([event]) => event === 'close')?.[1] as () => void;
+        closeHandler();
+
+        const result = await waitPromise;
+
+        expect(result.success).toBe(false);
+        expect(result.exitCode).toBe(137);
+        expect(result.killed).toBe(true);
+        expect(result.timedOut).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should track spawned processes in list()', async () => {

--- a/workspaces/docker/src/sandbox/process-manager.ts
+++ b/workspaces/docker/src/sandbox/process-manager.ts
@@ -31,6 +31,8 @@ class DockerProcessHandle extends ProcessHandle {
   private _exitCode: number | undefined;
   /** @internal Set by kill() and timeout to distinguish forced termination from natural exit */
   _killed = false;
+  /** @internal Set by the timeout path to distinguish timeout kills from explicit kills */
+  _timedOut = false;
   private _waitPromise: Promise<CommandResult> | null = null;
   private _stdinStream: NodeJS.WritableStream | null = null;
   private _execStream: NodeJS.ReadWriteStream | null = null;
@@ -298,6 +300,8 @@ export class DockerProcessManager extends SandboxProcessManager {
           stdout: handle.stdout,
           stderr: handle.stderr,
           executionTimeMs: Date.now() - startTime,
+          killed: true,
+          timedOut: handle._timedOut,
         });
       });
 
@@ -322,6 +326,7 @@ export class DockerProcessManager extends SandboxProcessManager {
       const timer = setTimeout(() => {
         if (handle.exitCode === undefined) {
           handle._killed = true;
+          handle._timedOut = true;
           handle.kill().catch(() => {});
           // Ensure stream is destroyed even if kill() fails (e.g., PID not found)
           handle._destroyStream();

--- a/workspaces/modal/src/sandbox/process-manager.ts
+++ b/workspaces/modal/src/sandbox/process-manager.ts
@@ -99,6 +99,8 @@ class ModalProcessHandle extends ProcessHandle {
             stdout: this.stdout,
             stderr: this.stderr || error.message,
             executionTimeMs: Date.now() - this._startTime,
+            killed: true,
+            timedOut: true,
           };
         }
         throw error;
@@ -116,6 +118,8 @@ class ModalProcessHandle extends ProcessHandle {
         stdout: this.stdout,
         stderr: this.stderr,
         executionTimeMs: Date.now() - this._startTime,
+        killed: true,
+        timedOut: false,
       };
     }
 

--- a/workspaces/modal/src/sandbox/sandbox.test.ts
+++ b/workspaces/modal/src/sandbox/sandbox.test.ts
@@ -355,6 +355,8 @@ describe('ModalProcessManager', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe('hello\n');
     expect(result.stderr).toBe('warning\n');
+    expect(result.killed).toBeUndefined();
+    expect(result.timedOut).toBeUndefined();
   });
 
   it('wait() returns failure for non-zero exit code', async () => {
@@ -462,6 +464,8 @@ describe('ModalProcessManager', () => {
     const result = await handle.wait();
     expect(result.success).toBe(false);
     expect(result.exitCode).toBe(137);
+    expect(result.killed).toBe(true);
+    expect(result.timedOut).toBe(false);
   });
 
   it('sendStdin() throws not supported', async () => {
@@ -483,6 +487,8 @@ describe('ModalProcessManager', () => {
 
     expect(result.exitCode).toBe(124);
     expect(result.success).toBe(false);
+    expect(result.killed).toBe(true);
+    expect(result.timedOut).toBe(true);
   }, 5000);
 
   it('list() returns tracked processes', async () => {


### PR DESCRIPTION
## Description

This fixes sandbox execution results for Docker, Daytona, and Modal so callers can distinguish natural exit codes from commands terminated by Mastra.

Timeout-triggered termination now reports `killed: true` and `timedOut: true`. Explicit kill paths report `killed: true` and `timedOut: false`. Natural exits keep the optional flags unset.

Added regression coverage for natural exits, explicit kills, and timeout paths, plus a patch changeset for the affected packages.

## Related issue(s)

Fixes #17280

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

When Mastra runs commands in a sandbox (like Docker or a cloud environment), it sometimes stops them early due to timeout or an explicit kill request. Before this PR, the code would return an exit code but wouldn't clearly say "Mastra stopped this" — it was hard for callers to tell if a command finished on its own or was forcefully terminated. This PR fixes that by always setting proper flags (`killed` and `timedOut`) so callers can now clearly distinguish natural exits from forced terminations.

## Changes Overview

This PR ensures consistent reporting of sandbox execution termination across three execution backends: Docker, Daytona, and Modal. It establishes a clear contract for execution results:

- **Natural exits**: Leave `killed` and `timedOut` flags undefined
- **Timeout-triggered terminations**: Set both `killed: true` and `timedOut: true`
- **Explicit kills**: Set `killed: true` and `timedOut: false`

## Detailed Changes by Package

### `@mastra/daytona`
- **`workspaces/daytona/src/sandbox/process-manager.ts`**: Updated `DaytonaProcessHandle.wait()` to set `killed: true` and `timedOut: true` on timeout, and `killed: true` with `timedOut: false` on explicit kill.
- **`workspaces/daytona/src/sandbox/index.test.ts`**: Added comprehensive tests validating that natural execution leaves flags undefined, timeouts set both flags to true, and explicit kills set killed to true and timedOut to false.

### `@mastra/docker`
- **`workspaces/docker/src/sandbox/process-manager.ts`**: Added internal `_timedOut` flag to `DockerProcessHandle` to distinguish timeout-triggered termination from explicit kills. Updated stream close handler to include proper `killed` and `timedOut` status in results.
- **`workspaces/docker/src/sandbox/index.test.ts`**: Refactored test suite to expose `mockStream` from hoisted factory, removing process-group kill test and replacing with targeted tests for natural exits, explicit kills, and timeout scenarios with fake timers.

### `@mastra/modal`
- **`workspaces/modal/src/sandbox/process-manager.ts`**: Updated `ModalProcessHandle.wait()` to return `killed: true, timedOut: true` on timeout and `killed: true, timedOut: false` on local kill.
- **`workspaces/modal/src/sandbox/sandbox.test.ts`**: Updated unit tests to verify proper flag values in successful waits, kill scenarios, and Mastra-level timeouts.

### Documentation
- **`.changeset/tender-areas-brake.md`**: Added changeset entry documenting patch releases for the three affected packages with note on improved execution result reporting.

## Testing
All three backends now include regression test coverage for:
- Natural command completion (flags undefined)
- Explicit termination via handle.kill() (killed: true, timedOut: false)
- Timeout-triggered termination (killed: true, timedOut: true)

Fixes `#17280`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->