### PR TITLE
feat(core): add harness v1 events

### DIFF
--- a/.changeset/eager-beers-sip.md
+++ b/.changeset/eager-beers-sip.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/core': minor
-'mastracode': patch
 ---
 
 Added harness events for session lifecycle updates, mode changes, model changes, and cloned threads.

--- a/.changeset/eager-beers-sip.md
+++ b/.changeset/eager-beers-sip.md
@@ -5,18 +5,11 @@
 
 Added harness events for session lifecycle updates, mode changes, model changes, and cloned threads.
 
-Users can now subscribe to harness events or provide an onEvent handler when creating a harness.
+Users can now subscribe to harness events to observe harness activity.
 
 **Example**
 
 ```ts
-const harness = new Harness({
-  modes,
-  onEvent: event => {
-    console.log(event.type);
-  },
-});
-
 const unsubscribe = harness.subscribe(event => {
   console.log(event.id, event.type);
 });

--- a/.changeset/eager-beers-sip.md
+++ b/.changeset/eager-beers-sip.md
@@ -1,0 +1,23 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Added harness events for session lifecycle updates, mode changes, model changes, and cloned threads.
+
+Users can now subscribe to harness events or provide an onEvent handler when creating a harness.
+
+**Example**
+
+```ts
+const harness = new Harness({
+  modes,
+  onEvent: event => {
+    console.log(event.type);
+  },
+});
+
+const unsubscribe = harness.subscribe(event => {
+  console.log(event.id, event.type);
+});
+```

--- a/packages/core/src/harness/v1/events.test.ts
+++ b/packages/core/src/harness/v1/events.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  EventEmitter,
+  HarnessEventSerializationError,
+  HarnessValidationError,
+  formatHarnessEventId,
+  parseHarnessEventId,
+} from './events';
+
+const expectEventShell = (event: { id: string; timestamp: number }) => {
+  expect(event.id).toMatch(/^harness-v1:[0-9a-f-]{36}:\d+$/);
+  expect(event.timestamp).toEqual(expect.any(Number));
+};
+
+describe('EventEmitter', () => {
+  it('stamps events with monotonic ids and scope', () => {
+    const emitter = new EventEmitter({ sessionId: 'session-1' }, { epoch: 'epoch-1' });
+    const listener = vi.fn();
+    emitter.subscribe(listener);
+
+    const first = emitter.emit({ type: 'model_changed', modelId: 'model-2', previousModelId: 'model-1' });
+    const second = emitter.emit({ type: 'mode_changed', modeId: 'plan', previousModeId: 'build' });
+
+    expect(first).toMatchObject({ id: 'harness-v1:epoch-1:0', sessionId: 'session-1' });
+    expect(second).toMatchObject({ id: 'harness-v1:epoch-1:1', sessionId: 'session-1' });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not skip listeners when one unsubscribes during dispatch', () => {
+    const emitter = new EventEmitter();
+    const second = vi.fn();
+    let unsubscribeFirst = () => {};
+    const first = vi.fn(() => unsubscribeFirst());
+    unsubscribeFirst = emitter.subscribe(first);
+    emitter.subscribe(second);
+
+    emitter.emit({ type: 'model_changed', modelId: 'model-2', previousModelId: 'model-1' });
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards scoped events to the parent emitter without restamping', () => {
+    const parent = new EventEmitter({}, { epoch: 'parent' });
+    const child = parent.scoped({ sessionId: 'session-1' });
+    const listener = vi.fn();
+    parent.subscribe(listener);
+
+    const event = child.emit({
+      type: 'thread_cloned',
+      threadId: 'thread-2',
+      resourceId: 'resource-1',
+      sourceThreadId: 'thread-1',
+    });
+
+    expectEventShell(event);
+    expect(event.sessionId).toBe('session-1');
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it('requires custom event types to be namespaced and JSON-serializable', () => {
+    const emitter = new EventEmitter();
+
+    expect(() => emitter.emit({ type: 'thread_custom', payload: null })).toThrow(HarnessValidationError);
+    expect(() => emitter.emit({ type: 'custom', payload: null })).toThrow(HarnessValidationError);
+    expect(() => emitter.emit({ type: 'app.event', payload: { date: new Date() } as never })).toThrow(
+      HarnessEventSerializationError,
+    );
+
+    expect(emitter.emit({ type: 'app.event', payload: { ok: true, nested: ['value'] } })).toMatchObject({
+      type: 'app.event',
+      payload: { ok: true, nested: ['value'] },
+    });
+  });
+});
+
+describe('harness event ids', () => {
+  it('formats and parses event ids', () => {
+    expect(formatHarnessEventId('epoch', 12)).toBe('harness-v1:epoch:12');
+    expect(parseHarnessEventId('harness-v1:epoch:12')).toEqual({ epoch: 'epoch', sequence: 12 });
+  });
+});

--- a/packages/core/src/harness/v1/events.ts
+++ b/packages/core/src/harness/v1/events.ts
@@ -1,0 +1,291 @@
+import { randomUUID } from 'node:crypto';
+
+import type { SessionRecord } from '../../storage/domains/harness';
+
+export interface HarnessEventBase {
+  id: string;
+  timestamp: number;
+  sessionId?: string;
+  subagentSessionId?: string;
+  runId?: string;
+  signalId?: string;
+  queuedItemId?: string;
+}
+
+export interface SessionCreatedEvent extends HarnessEventBase {
+  type: 'session_created';
+  resourceId: string;
+  threadId: string;
+  parentSessionId?: string;
+  modeId: string;
+  modelId: string;
+}
+
+export interface ModeChangedEvent extends HarnessEventBase {
+  type: 'mode_changed';
+  modeId: string;
+  previousModeId: string;
+}
+
+export interface ModelChangedEvent extends HarnessEventBase {
+  type: 'model_changed';
+  modelId: string;
+  previousModelId: string;
+}
+
+export interface ThreadClonedEvent extends HarnessEventBase {
+  type: 'thread_cloned';
+  threadId: string;
+  resourceId: string;
+  sourceThreadId: string;
+  title?: string;
+}
+
+export interface CustomEvent extends HarnessEventBase {
+  type: string;
+  payload?: JsonSerializable;
+}
+
+export type HarnessEvent = SessionCreatedEvent | ModeChangedEvent | ModelChangedEvent | ThreadClonedEvent | CustomEvent;
+export type HarnessEventListener = (event: HarnessEvent) => void | Promise<void>;
+export type HarnessEventUnsubscribe = () => void;
+
+export const HARNESS_EVENT_ID_PREFIX = 'harness-v1';
+
+export interface ParsedHarnessEventId {
+  epoch: string;
+  sequence: number;
+}
+
+export class HarnessValidationError extends Error {
+  constructor(
+    readonly path: string,
+    message: string,
+  ) {
+    super(`${path}: ${message}`);
+    this.name = 'HarnessValidationError';
+  }
+}
+
+export class HarnessEventSerializationError extends HarnessValidationError {
+  constructor(
+    readonly eventType: string,
+    readonly reason: EventSerializationReason,
+    readonly sessionId?: string,
+  ) {
+    super('event.payload', `custom event "${eventType}" payload is not JSON-serializable: ${reason}`);
+    this.name = 'HarnessEventSerializationError';
+  }
+}
+
+export type EventSerializationReason =
+  | 'undefined'
+  | 'function'
+  | 'symbol'
+  | 'bigint'
+  | 'date'
+  | 'map'
+  | 'set'
+  | 'typed-array'
+  | 'non-plain-object'
+  | 'cycle';
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonSerializable = JsonPrimitive | JsonSerializable[] | { [key: string]: JsonSerializable };
+
+type DistributiveOmit<T, K extends keyof never> = T extends unknown ? Omit<T, K> : never;
+export type EmitInput = DistributiveOmit<HarnessEvent, 'id' | 'timestamp' | 'sessionId'>;
+
+export interface EmitterScope {
+  sessionId?: string;
+}
+
+export function formatHarnessEventId(epoch: string, sequence: number): string {
+  if (epoch.length === 0 || epoch.includes(':')) {
+    throw new HarnessValidationError('eventId.epoch', 'epoch must be non-empty and must not contain ":"');
+  }
+  if (!Number.isSafeInteger(sequence) || sequence < 0) {
+    throw new HarnessValidationError('eventId.sequence', 'sequence must be a non-negative safe integer');
+  }
+  return `${HARNESS_EVENT_ID_PREFIX}:${epoch}:${sequence}`;
+}
+
+export function parseHarnessEventId(eventId: string): ParsedHarnessEventId {
+  const parts = eventId.split(':');
+  if (parts.length !== 3 || parts[0] !== HARNESS_EVENT_ID_PREFIX || parts[1] === '' || parts[2] === '') {
+    throw new HarnessValidationError('lastEventId', 'expected event id grammar harness-v1:<epoch>:<seq>');
+  }
+
+  const sequenceText = parts[2]!;
+  if (!/^(0|[1-9][0-9]*)$/.test(sequenceText)) {
+    throw new HarnessValidationError('lastEventId', 'event id sequence must be an unsigned decimal integer');
+  }
+
+  const sequence = Number(sequenceText);
+  if (!Number.isSafeInteger(sequence)) {
+    throw new HarnessValidationError('lastEventId', 'event id sequence must be within JavaScript safe integer range');
+  }
+
+  return { epoch: parts[1]!, sequence };
+}
+
+export function sessionCreatedPayload(
+  record: SessionRecord,
+): Omit<SessionCreatedEvent, keyof HarnessEventBase | 'type'> {
+  return {
+    resourceId: record.resourceId,
+    threadId: record.threadId,
+    parentSessionId: record.parentSessionId,
+    modeId: record.modeId,
+    modelId: record.modelId,
+  };
+}
+
+export function assertCustomEventType(eventType: string): void {
+  if (RESERVED_EVENT_TYPES.has(eventType) || RESERVED_EVENT_PREFIXES.some(prefix => eventType.startsWith(prefix))) {
+    throw new HarnessValidationError('event.type', `"${eventType}" is reserved by the harness`);
+  }
+  if (!eventType.includes('.')) {
+    throw new HarnessValidationError('event.type', 'custom event types must be namespaced with a dot');
+  }
+}
+
+export function assertJsonSerializable(eventType: string, sessionId: string | undefined, value: unknown): void {
+  visitJsonValue(eventType, sessionId, value, new WeakSet<object>());
+}
+
+export class EventEmitter {
+  private readonly listeners: HarnessEventListener[] = [];
+  private epoch?: string;
+  private seq: number;
+  private readonly scope: EmitterScope;
+  private readonly onEvent?: HarnessEventListener;
+
+  constructor(
+    scope: EmitterScope = {},
+    opts: { onEvent?: HarnessEventListener; epoch?: string; nextSequence?: number } = {},
+  ) {
+    this.scope = scope;
+    this.onEvent = opts.onEvent;
+    this.epoch = opts.epoch;
+    this.seq = opts.nextSequence ?? 0;
+    formatHarnessEventId(this.epoch ?? 'pending-epoch', this.seq);
+  }
+
+  scoped(scope: EmitterScope): EventEmitter {
+    return new EventEmitter(
+      { ...this.scope, ...scope },
+      {
+        onEvent: event => this.forward(event),
+      },
+    );
+  }
+
+  subscribe(listener: HarnessEventListener): HarnessEventUnsubscribe {
+    this.listeners.push(listener);
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index !== -1) this.listeners.splice(index, 1);
+    };
+  }
+
+  emit(event: EmitInput, overrides?: { sessionId?: string }): HarnessEvent {
+    const sessionId = overrides?.sessionId ?? this.scope.sessionId;
+    this.validateCustomEvent(event, sessionId);
+    const stamped = {
+      ...event,
+      id: formatHarnessEventId(this.epochId, this.seq++),
+      timestamp: Date.now(),
+      ...(sessionId !== undefined && { sessionId }),
+    } as HarnessEvent;
+    this.dispatch(stamped);
+    return stamped;
+  }
+
+  forward(event: HarnessEvent): void {
+    this.dispatch(event);
+  }
+
+  get listenerCount(): number {
+    return this.listeners.length;
+  }
+
+  get epochId(): string {
+    this.epoch ??= randomUUID();
+    return this.epoch;
+  }
+
+  private validateCustomEvent(event: EmitInput, sessionId: string | undefined): void {
+    const eventType = (event as { type?: unknown }).type;
+    if (typeof eventType !== 'string' || RESERVED_EVENT_TYPES.has(eventType)) return;
+
+    assertCustomEventType(eventType);
+    if (Object.prototype.hasOwnProperty.call(event, 'payload')) {
+      assertJsonSerializable(eventType, sessionId, (event as { payload?: unknown }).payload);
+    }
+  }
+
+  private dispatch(event: HarnessEvent): void {
+    if (this.onEvent) {
+      try {
+        const result = this.onEvent(event);
+        if (result && typeof (result as Promise<void>).catch === 'function') {
+          (result as Promise<void>).catch(err => console.error('[harness/v1] event persistence rejected:', err));
+        }
+      } catch (err) {
+        console.error('[harness/v1] event persistence threw:', err);
+      }
+    }
+
+    for (const listener of [...this.listeners]) {
+      try {
+        const result = listener(event);
+        if (result && typeof (result as Promise<void>).catch === 'function') {
+          (result as Promise<void>).catch(err => console.error('[harness/v1] event listener rejected:', err));
+        }
+      } catch (err) {
+        console.error('[harness/v1] event listener threw:', err);
+      }
+    }
+  }
+}
+
+const RESERVED_EVENT_TYPES = new Set(['session_created', 'mode_changed', 'model_changed', 'thread_cloned']);
+
+const RESERVED_EVENT_PREFIXES = ['session_', 'thread_'];
+
+function visitJsonValue(eventType: string, sessionId: string | undefined, value: unknown, seen: WeakSet<object>): void {
+  if (value === undefined) throwSerialization(eventType, sessionId, 'undefined');
+  if (typeof value === 'function') throwSerialization(eventType, sessionId, 'function');
+  if (typeof value === 'symbol') throwSerialization(eventType, sessionId, 'symbol');
+  if (typeof value === 'bigint') throwSerialization(eventType, sessionId, 'bigint');
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return;
+  if (value instanceof Date) throwSerialization(eventType, sessionId, 'date');
+  if (value instanceof Map) throwSerialization(eventType, sessionId, 'map');
+  if (value instanceof Set) throwSerialization(eventType, sessionId, 'set');
+  if (ArrayBuffer.isView(value)) throwSerialization(eventType, sessionId, 'typed-array');
+  if (typeof value !== 'object') return;
+
+  if (seen.has(value)) throwSerialization(eventType, sessionId, 'cycle');
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) visitJsonValue(eventType, sessionId, item, seen);
+    seen.delete(value);
+    return;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throwSerialization(eventType, sessionId, 'non-plain-object');
+  }
+
+  for (const item of Object.values(value)) {
+    visitJsonValue(eventType, sessionId, item, seen);
+  }
+  seen.delete(value);
+}
+
+function throwSerialization(eventType: string, sessionId: string | undefined, reason: EventSerializationReason): never {
+  throw new HarnessEventSerializationError(eventType, reason, sessionId);
+}

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -45,7 +45,7 @@ export class Harness<MODES extends HarnessMode[]> {
     this.#storage = config.storage;
     this.#compositeStorage = config.mastra?.getStorage();
     this.#memory = config.memory;
-    this.#events = new EventEmitter({}, { onEvent: config.onEvent });
+    this.#events = new EventEmitter();
 
     const modes = config.modes ?? [];
     for (const mode of modes) {

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -4,6 +4,8 @@ import type { MastraMemory } from '../../memory';
 import type { MastraCompositeStore } from '../../storage';
 import type { HarnessStorage, SessionRecord } from '../../storage/domains/harness';
 import type { DynamicArgument } from '../../types';
+import { EventEmitter, sessionCreatedPayload } from './events';
+import type { HarnessEventListener, HarnessEventUnsubscribe } from './events';
 import type { HarnessConfig } from './harness.types';
 import type { HarnessMode } from './mode';
 import { Session } from './session';
@@ -31,6 +33,7 @@ export class Harness<MODES extends HarnessMode[]> {
   readonly #storage?: HarnessStorage;
   readonly #compositeStorage?: MastraCompositeStore;
   readonly #memory: MastraMemory | DynamicArgument<MastraMemory>;
+  readonly #events: EventEmitter;
 
   constructor(config: HarnessConfig<MODES>) {
     if (!config.modes.length) {
@@ -42,6 +45,7 @@ export class Harness<MODES extends HarnessMode[]> {
     this.#storage = config.storage;
     this.#compositeStorage = config.mastra?.getStorage();
     this.#memory = config.memory;
+    this.#events = new EventEmitter({}, { onEvent: config.onEvent });
 
     const modes = config.modes ?? [];
     for (const mode of modes) {
@@ -58,6 +62,14 @@ export class Harness<MODES extends HarnessMode[]> {
 
   get ownerId(): string {
     return this.#ownerId;
+  }
+
+  subscribe(listener: HarnessEventListener): HarnessEventUnsubscribe {
+    return this.#events.subscribe(listener);
+  }
+
+  emit(event: Parameters<EventEmitter['emit']>[0]): ReturnType<EventEmitter['emit']> {
+    return this.#events.emit(event);
   }
 
   listModes(): HarnessMode[] {
@@ -117,6 +129,7 @@ export class Harness<MODES extends HarnessMode[]> {
     };
 
     await storage.saveSession(record);
+    this.#events.emit({ type: 'session_created', ...sessionCreatedPayload(record) });
     return this.#sessionFromRecord(record);
   }
 
@@ -146,6 +159,7 @@ export class Harness<MODES extends HarnessMode[]> {
     };
 
     await storage.saveSession(record);
+    this.#events.emit({ type: 'session_created', ...sessionCreatedPayload(record) });
     return this.#sessionFromRecord(record);
   }
 
@@ -188,6 +202,7 @@ export class Harness<MODES extends HarnessMode[]> {
       createdAt: record.createdAt,
       lastActivityAt: record.lastActivityAt,
       memory: this.#memory,
+      events: this.#events.scoped({ sessionId: record.id }),
     });
   }
 

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -1,3 +1,5 @@
 export { Harness } from './harness';
 export { Session } from './session';
+export { EventEmitter, formatHarnessEventId, parseHarnessEventId } from './events';
+export type { HarnessEvent, HarnessEventListener, HarnessEventUnsubscribe } from './events';
 export type { HarnessMode } from './mode';

--- a/packages/core/src/harness/v1/session.test.ts
+++ b/packages/core/src/harness/v1/session.test.ts
@@ -327,7 +327,7 @@ describe('Harness events', () => {
     events.length = 0;
 
     session.setModelId('model-2');
-    session.setMode({ id: 'plan', agentId: 'default', defaultModelId: 'zai-coding-plan/glm-5-turbo' });
+    session.setMode({ id: 'plan', agentId: 'default', defaultModelId: 'test-plan-model' });
 
     expect(events).toEqual([
       expect.objectContaining({

--- a/packages/core/src/harness/v1/session.test.ts
+++ b/packages/core/src/harness/v1/session.test.ts
@@ -5,6 +5,7 @@ import type { MastraMemory } from '../../memory';
 import type { StorageCloneThreadInput } from '../../storage';
 import { HarnessStorage } from '../../storage/domains/harness';
 import type { SessionRecord } from '../../storage/domains/harness';
+import type { HarnessEvent } from './events';
 import { Harness } from './harness';
 
 class RecordingHarnessStorage extends HarnessStorage {
@@ -274,6 +275,111 @@ describe('Harness.session()', () => {
 
     expect(memory.saveMessages).toHaveBeenCalledWith({ messages });
     expect(result.messages).toEqual(messages);
+  });
+});
+
+describe('Harness events', () => {
+  it('emits session_created only for newly persisted sessions', async () => {
+    const { harness } = createHarness(createMemory());
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    const session = await harness.session({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      modeId: 'plan',
+      modelId: 'test-model',
+    });
+    await harness.session({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      modeId: 'build',
+      modelId: 'ignored-model',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'session_created',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      modeId: 'plan',
+      modelId: 'test-model',
+    });
+    expect(events[0]?.id).toMatch(/^harness-v1:[0-9a-f-]{36}:0$/);
+    expect(events[0]?.timestamp).toEqual(expect.any(Number));
+    expect(session.id).toMatch(/^sess-[a-f0-9]{32}$/);
+  });
+
+  it('emits mode and model changes from sessions', async () => {
+    const { harness } = createHarness(createMemory());
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+    const session = await harness.session({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      modeId: 'build',
+      modelId: 'model-1',
+    });
+    events.length = 0;
+
+    session.setModelId('model-2');
+    session.setMode({ id: 'plan', agentId: 'default', defaultModelId: 'zai-coding-plan/glm-5-turbo' });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'model_changed',
+        sessionId: session.id,
+        modelId: 'model-2',
+        previousModelId: 'model-1',
+      }),
+      expect.objectContaining({
+        type: 'mode_changed',
+        sessionId: session.id,
+        modeId: 'plan',
+        previousModeId: 'build',
+      }),
+    ]);
+  });
+
+  it('emits thread_cloned from session.clone and session_created from harness.cloneSession', async () => {
+    const { harness } = createHarness(createMemory());
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+    const session = await harness.session({ threadId: 'thread-1', resourceId: 'resource-1' });
+    events.length = 0;
+
+    await session.clone({ threadId: 'thread-2', title: 'Clone' });
+    await harness.cloneSession(session, { sessionId: 'session-2', threadId: 'thread-3' });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'thread_cloned',
+        sessionId: session.id,
+        threadId: 'thread-2',
+        resourceId: 'resource-1',
+        sourceThreadId: 'thread-1',
+        title: 'Clone',
+      }),
+      expect.objectContaining({
+        type: 'thread_cloned',
+        sessionId: session.id,
+        threadId: 'thread-3',
+        resourceId: 'resource-1',
+        sourceThreadId: 'thread-1',
+      }),
+      expect.objectContaining({
+        type: 'session_created',
+        threadId: 'thread-3',
+        resourceId: 'resource-1',
+        parentSessionId: session.id,
+      }),
+    ]);
   });
 });
 

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -4,6 +4,7 @@ import { RequestContext } from '@internal/core/request-context';
 import type { MastraDBMessage } from '../../agent/message-list';
 import type { MastraMemory, StorageThreadType } from '../../memory';
 import type { DynamicArgument } from '../../types';
+import type { EventEmitter } from './events';
 import type { HarnessMode } from './mode';
 import type { CloneSessionOptions, SessionConfig } from './session.types';
 
@@ -16,6 +17,7 @@ export class Session {
   readonly #createdAt: Date;
   readonly #lastActivityAt: Date;
   readonly #memory: MastraMemory | DynamicArgument<MastraMemory>;
+  readonly #events: EventEmitter;
   // readonly parentSessionId?: string;
   // readonly subagentDepth: number;
 
@@ -32,6 +34,7 @@ export class Session {
     this.#createdAt = config.createdAt;
     this.#lastActivityAt = config.lastActivityAt;
     this.#memory = config.memory;
+    this.#events = config.events;
   }
 
   get id(): string {
@@ -66,8 +69,9 @@ export class Session {
       options: opts.messageLimit !== undefined ? { messageLimit: opts.messageLimit } : undefined,
     });
 
-    return new Session({
-      id: opts.sessionId ?? randomUUID(),
+    const cloneId = opts.sessionId ?? randomUUID();
+    const clone = new Session({
+      id: cloneId,
       ownerId: this.#ownerId,
       threadId: result.thread.id,
       resourceId: result.thread.resourceId,
@@ -76,7 +80,18 @@ export class Session {
       createdAt: result.thread.createdAt,
       lastActivityAt: result.thread.updatedAt,
       memory: this.#memory,
+      events: this.#events.scoped({ sessionId: cloneId }),
     });
+
+    this.#events.emit({
+      type: 'thread_cloned',
+      threadId: clone.threadId,
+      resourceId: clone.resourceId,
+      sourceThreadId: this.#threadId,
+      title: opts.title,
+    });
+
+    return clone;
   }
 
   async getThread(): Promise<StorageThreadType | null> {
@@ -101,7 +116,11 @@ export class Session {
   }
 
   setModelId(modelId: string) {
+    const previousModelId = this.#modelId;
     this.#modelId = modelId;
+    if (modelId !== previousModelId) {
+      this.#events.emit({ type: 'model_changed', modelId, previousModelId });
+    }
   }
 
   getMode(): HarnessMode {
@@ -109,7 +128,11 @@ export class Session {
   }
 
   setMode(mode: HarnessMode) {
+    const previousModeId = this.#mode.id;
     this.#mode = mode;
+    if (mode.id !== previousModeId) {
+      this.#events.emit({ type: 'mode_changed', modeId: mode.id, previousModeId });
+    }
   }
 
   async #buildRequestContext(requestContext?: RequestContext): Promise<RequestContext> {

--- a/packages/core/src/harness/v1/session.types.ts
+++ b/packages/core/src/harness/v1/session.types.ts
@@ -1,5 +1,6 @@
 import type { MastraMemory } from '../../memory';
 import type { DynamicArgument } from '../../types';
+import type { EventEmitter } from './events';
 import type { HarnessMode } from './mode';
 
 export type CloneSessionOptions = {
@@ -18,6 +19,7 @@ export type CloneSessionOptions = {
 
 export interface SessionConfig {
   memory: MastraMemory | DynamicArgument<MastraMemory>;
+  events: EventEmitter;
   // storage: HarnessStorage;
   /** Identifier of the Harness instance that owns this session. */
   ownerId: string;


### PR DESCRIPTION
Adds harness v1 events for session creation, mode changes, model changes, and cloned threads. This exposes `harness.subscribe()` so callers can observe harness activity without reaching into internals.

```ts
const unsubscribe = harness.subscribe(event => {
  console.log(event.id, event.type);
});
```

Verified with focused harness unit tests and `pnpm --filter ./packages/core check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a lightweight notification system to the Harness so external code can watch when sessions are created, modes/models change, or threads are cloned — you can subscribe and get events instead of poking inside internals.

## Overview

Implements a Harness v1 event model and emitter, integrates it into Harness/Session, and exposes a public subscription API (harness.subscribe()) so callers can observe harness lifecycle and activity without accessing internals.

## Key Changes

- Event model & emitter (packages/core/src/harness/v1/events.ts)
  - New typed event interfaces: SessionCreatedEvent, ModeChangedEvent, ModelChangedEvent, ThreadClonedEvent, CustomEvent, and common HarnessEventBase.
  - Event id utilities: formatHarnessEventId / parseHarnessEventId using harness-v1:<epoch>:<sequence>.
  - EventEmitter class:
    - subscribe/unsubscribe API and listener dispatch.
    - Deterministic id stamping, per-emitter epoch, sequence numbering.
    - scoped() to create child emitters that forward to parent without restamping (preserves session scoping).
    - forward() to accept externally formed events.
    - Optional onEvent persistence hook with safe error handling.
    - Validation: reserved type checks and strict JSON-serializability checks for custom payloads (throws HarnessValidationError / HarnessEventSerializationError).
  - Errors: HarnessValidationError, HarnessEventSerializationError.
  - Helpers: sessionCreatedPayload(), assertCustomEventType(), assertJsonSerializable().

- Harness integration (packages/core/src/harness/v1/harness.ts)
  - New Harness class holds an internal EventEmitter and exposes subscribe(listener) and emit(event).
  - Emits session_created when sessions are newly persisted (both top-level session creation and cloneSession persistence).
  - cloneSession persists cloned session records and emits session_created with parentSessionId tracking.
  - Sessions returned from storage are constructed with events scoped to the session id.

- Session behavior (packages/core/src/harness/v1/session.ts / session.types.ts)
  - Session now receives an EventEmitter instance via SessionConfig (events dependency).
  - clone() emits thread_cloned and constructs the cloned Session with a scoped emitter (clone id).
  - setModelId() and setMode() emit model_changed and mode_changed only when values actually change and include previous values.

- Public surface (packages/core/src/harness/v1/index.ts)
  - Re-exports EventEmitter, formatHarnessEventId, parseHarnessEventId, and event-related types alongside Harness/Session exports.

## Testing

- EventEmitter tests (events.test.ts)
  - Verify monotonic id stamping with epoch/session scope, listener unsubscribe behavior during dispatch, child→parent forwarding without restamping, custom event namespacing and JSON-serializability enforcement, and id format round-trip.

- Harness/session tests (session.test.ts)
  - Verify session creation persistence, loading by thread/id, cloning behavior, and that harness emits session_created, model_changed, mode_changed, and thread_cloned appropriately with correct previous/parent metadata.

- CI check command noted: pnpm --filter ./packages/core check (tests added and pass locally as part of change verification).

## Release Notes / Changeset

- Changeset updates `@mastra/core` (minor) and documents the new harness events and public subscription API with a TypeScript usage example (subscribe/unsubscribe handle).

## Small follow-ups in commits

- Scope narrowed to `@mastra/core` for the changeset.
- Test model id replaced with the existing placeholder pattern in a follow-up commit.
- Co-authored metadata added in commit history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->