### PR TITLE
fix: sanitize tool errors to prevent circular JSON serialization crash

### DIFF
--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -240,6 +240,58 @@ describe('createToolCallStep tool execution error handling', () => {
     expect(result).not.toHaveProperty('result');
     expect(result.error).toBeInstanceOf(Error);
   });
+
+  it('should sanitize errors with circular references (e.g. AWS SDK network errors)', async () => {
+    // Simulate an AWS SDK-style error with circular TLSSocket→ClientRequest→Agent references
+    const circularError = new Error('connect ECONNREFUSED 127.0.0.1:443') as any;
+    const fakeSocket = { _httpMessage: null as any };
+    const fakeRequest = { agent: { sockets: { 'host:443': [fakeSocket] } }, socket: fakeSocket };
+    fakeSocket._httpMessage = fakeRequest; // circular!
+    circularError.$metadata = { httpStatusCode: undefined };
+    circularError.request = fakeRequest;
+
+    const failingTool = createTool({
+      id: 'circular-error-tool',
+      description: 'A tool that throws a circular error',
+      inputSchema: z.object({ param: z.string() }),
+      execute: async () => {
+        throw circularError;
+      },
+    });
+
+    const builder = new CoreToolBuilder({
+      originalTool: failingTool,
+      options: {
+        name: 'circular-error-tool',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        description: 'A tool that throws a circular error',
+        requestContext: new RequestContext(),
+      },
+    });
+
+    const builtTool = builder.build();
+    const tools = { 'circular-error-tool': builtTool };
+
+    const toolCallStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'test-run',
+      streamState,
+    } as any);
+
+    const inputData = { toolCallId: 'test-call-id', toolName: 'circular-error-tool', args: { param: 'test' } };
+    const result = await toolCallStep.execute(makeExecuteParams({ inputData }));
+
+    expect(result).toHaveProperty('error');
+    // The key assertion: JSON.stringify should not throw on the sanitized error
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
 });
 
 describe('createToolCallStep tool approval workflow', () => {

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -1127,8 +1127,12 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         if (error instanceof Error && error.name === 'FGADeniedError') {
           throw error;
         }
+        // Sanitize error to prevent "Converting circular structure to JSON" crashes downstream.
+        // AWS SDK errors (and similar) hold references to TLSSocket/ClientRequest/Agent objects
+        // that form circular reference chains. ensureSerializable strips those.
+        const sanitizedError = ensureSerializable(error) as Error;
         return {
-          error: error as Error,
+          error: sanitizedError,
           ...inputData,
         };
       }


### PR DESCRIPTION
## Problem

When a tool throws an error that contains circular object references, Mastra crashes with:

```
Converting circular structure to JSON
    --> starting at object with constructor 'TLSSocket'
    |     property '_httpMessage' -> object with constructor 'ClientRequest'
    |     property 'agent' -> object with constructor 'Agent'
    --- property 'armis-cms-artifacts-test.s3.us-east-1.amazonaws.com:443:::::' -> object with constructor 'Array'
    --- index 0 closes the circle
```

This happens because AWS SDK errors (and similar HTTP client errors) hold references to the underlying `TLSSocket` → `ClientRequest` → `https.Agent` → connection pool, which forms a circular chain.

## Root Cause

PR #14535 correctly added `ensureSerializable()` to the **success path** in `tool-call-step.ts`:

```typescript
const rawResult = await tool.execute(args, toolOptions);
const result = ensureSerializable(rawResult);  // ✅ sanitized
```

But the **error path** in the same `catch` block was missed:

```typescript
} catch (error) {
  return {
    error: error as Error,  // ❌ not sanitized — circular refs crash JSON.stringify
    ...inputData,
  };
}
```

## Fix

Apply the same `ensureSerializable()` treatment to the error before returning it:

```typescript
const sanitizedError = ensureSerializable(error) as Error;
return { error: sanitizedError, ...inputData };
```

## How to Reproduce

1. Create a tool that makes an AWS SDK S3 call
2. Trigger a network error (e.g., ECONNREFUSED, TLS timeout)
3. The AWS SDK error object contains `error.request` → `ClientRequest` → `Agent` → `TLSSocket` circular chain
4. Mastra tries to serialize the tool result for memory/logging → crash

## Test

Added a test case that creates a simulated AWS SDK error with circular `TLSSocket` → `ClientRequest` → `Agent` references, verifies the result can be safely `JSON.stringify`'d.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a tool crashes with an error (especially from AWS), Mastra was trying to save that error but would crash itself because the error object had "circular references" (parts that point back to themselves like a snake eating its tail). This fix cleans up errors before saving them, just like it already does for successful results, so Mastra stops crashing.

## Changes

### Core Fix
Modified `packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts` to sanitize caught errors using `ensureSerializable()` before returning them in the catch block. This mirrors the existing sanitization applied to successful tool results and prevents circular reference errors from reaching `JSON.stringify()`.

### Testing
Added a test case in `packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts` that simulates an AWS SDK error with circular references (TLSSocket → ClientRequest → Agent pattern). The test verifies that `toolCallStep.execute` returns an object with a sanitized `error` field that can be safely serialized to JSON without throwing.

## Impact
Prevents Mastra from crashing when tools throw errors containing circular object references, such as those from AWS SDK calls that fail at the network level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->