### PR TITLE
fix: cache loaded FastEmbed models

### DIFF
--- a/.changeset/fair-kings-raise.md
+++ b/.changeset/fair-kings-raise.md
@@ -1,0 +1,5 @@
+---
+'@mastra/fastembed': patch
+---
+
+Fixed FastEmbed so repeated embedding calls reuse loaded models instead of loading a new model each time.

--- a/packages/fastembed/src/index.ts
+++ b/packages/fastembed/src/index.ts
@@ -1,13 +1,10 @@
-import fsp from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
 import { customProvider as customProviderV2 } from '@internal/ai-sdk-v5';
 import { customProvider as customProviderLegacy } from '@internal/ai-sdk-v4';
 import type { EmbeddingModelV3 } from '@internal/ai-v6';
 import type { EmbeddingModel as EmbeddingModelV2 } from '@internal/ai-sdk-v5';
 import type { EmbeddingModel as EmbeddingModelV1 } from '@internal/ai-sdk-v4';
 import { customProvider as customProviderV3 } from '@internal/ai-v6';
-import { FlagEmbedding, EmbeddingModel } from './fastembed.js';
+import { getCachedModel, warmupFastEmbedModels, type FastEmbedModelType } from './model-cache.js';
 
 export {
   EmbeddingModel,
@@ -22,28 +19,17 @@ export type { EmbeddingModel as EmbeddingModelV1 } from '@internal/ai-sdk-v4';
 export type { EmbeddingModel as EmbeddingModelV2 } from '@internal/ai-sdk-v5';
 export type { EmbeddingModel as EmbeddingModelV3 } from '@internal/ai-v6';
 
-async function getModelCachePath() {
-  const cachePath = path.join(os.homedir(), '.cache', 'mastra', 'fastembed-models');
-  await fsp.mkdir(cachePath, { recursive: true });
-  return cachePath;
-}
-
 /**
  * Pre-download fastembed models without creating ONNX sessions.
  * Call this before running tests in parallel to avoid concurrent download races.
  */
 export async function warmup() {
-  const cacheDir = await getModelCachePath();
-  await FlagEmbedding.retrieveModel(EmbeddingModel.BGESmallENV15, cacheDir, false);
-  await FlagEmbedding.retrieveModel(EmbeddingModel.BGEBaseENV15, cacheDir, false);
+  await warmupFastEmbedModels();
 }
 
 // Shared function to generate embeddings using fastembed
-async function generateEmbeddings(values: string[], modelType: 'BGESmallENV15' | 'BGEBaseENV15') {
-  const model = await FlagEmbedding.init({
-    model: EmbeddingModel[modelType],
-    cacheDir: await getModelCachePath(),
-  });
+async function generateEmbeddings(values: string[], modelType: FastEmbedModelType) {
+  const model = await getCachedModel(modelType);
 
   // model.embed() returns an AsyncGenerator that processes texts in batches (default size 256)
   const embeddings = model.embed(values);

--- a/packages/fastembed/src/model-cache.test.ts
+++ b/packages/fastembed/src/model-cache.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const embed = vi.fn((values: string[]) =>
+    (async function* () {
+      yield values.map((_, index) => [index + 1, index + 2, index + 3]);
+    })(),
+  );
+  const model = { embed };
+  const retrieveModel = vi.fn(async () => '/tmp/fastembed-model');
+
+  return {
+    embed,
+    init: vi.fn(async () => model),
+    mkdir: vi.fn(async () => undefined),
+    model,
+    retrieveModel,
+  };
+});
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    mkdir: mocks.mkdir,
+  },
+}));
+
+vi.mock('./fastembed.js', () => ({
+  EmbeddingModel: {
+    BGESmallENV15: 'fast-bge-small-en-v1.5',
+    BGEBaseENV15: 'fast-bge-base-en-v1.5',
+  },
+  FlagEmbedding: {
+    init: mocks.init,
+    retrieveModel: mocks.retrieveModel,
+  },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  mocks.embed.mockClear();
+  mocks.init.mockReset();
+  mocks.mkdir.mockClear();
+  mocks.retrieveModel.mockClear();
+  mocks.init.mockResolvedValue(mocks.model);
+});
+
+test('reuses the initialized small model across embedding calls', async () => {
+  const { getCachedModel } = await import('./model-cache.js');
+
+  await getCachedModel('BGESmallENV15');
+  await getCachedModel('BGESmallENV15');
+
+  expect(mocks.init).toHaveBeenCalledTimes(1);
+  expect(mocks.init).toHaveBeenCalledWith({
+    model: 'fast-bge-small-en-v1.5',
+    cacheDir: expect.stringContaining('fastembed-models'),
+  });
+});
+
+test('shares pending initialization across concurrent requests', async () => {
+  let resolveInit!: (model: typeof mocks.model) => void;
+  mocks.init.mockReturnValueOnce(
+    new Promise(resolve => {
+      resolveInit = resolve;
+    }),
+  );
+  const { getCachedModel } = await import('./model-cache.js');
+
+  const first = getCachedModel('BGESmallENV15');
+  const second = getCachedModel('BGESmallENV15');
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  expect(mocks.init).toHaveBeenCalledTimes(1);
+  resolveInit(mocks.model);
+  expect(await Promise.all([first, second])).toEqual([mocks.model, mocks.model]);
+});
+
+test('keeps separate cached models for small and base embeddings', async () => {
+  const { getCachedModel } = await import('./model-cache.js');
+
+  await getCachedModel('BGESmallENV15');
+  await getCachedModel('BGEBaseENV15');
+  await getCachedModel('BGESmallENV15');
+
+  expect(mocks.init).toHaveBeenCalledTimes(2);
+  expect(mocks.init).toHaveBeenNthCalledWith(1, {
+    model: 'fast-bge-small-en-v1.5',
+    cacheDir: expect.stringContaining('fastembed-models'),
+  });
+  expect(mocks.init).toHaveBeenNthCalledWith(2, {
+    model: 'fast-bge-base-en-v1.5',
+    cacheDir: expect.stringContaining('fastembed-models'),
+  });
+});
+
+test('warmup downloads models without initializing ONNX sessions', async () => {
+  const { warmupFastEmbedModels } = await import('./model-cache.js');
+
+  await warmupFastEmbedModels();
+
+  expect(mocks.retrieveModel).toHaveBeenCalledTimes(2);
+  expect(mocks.init).not.toHaveBeenCalled();
+});

--- a/packages/fastembed/src/model-cache.ts
+++ b/packages/fastembed/src/model-cache.ts
@@ -1,0 +1,44 @@
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { FlagEmbedding, EmbeddingModel } from './fastembed.js';
+
+export type FastEmbedModelType = 'BGESmallENV15' | 'BGEBaseENV15';
+
+let modelCachePathPromise: Promise<string> | undefined;
+
+async function getModelCachePath() {
+  modelCachePathPromise ??= (async () => {
+    const cachePath = path.join(os.homedir(), '.cache', 'mastra', 'fastembed-models');
+    await fsp.mkdir(cachePath, { recursive: true });
+    return cachePath;
+  })().catch(error => {
+    modelCachePathPromise = undefined;
+    throw error;
+  });
+  return modelCachePathPromise;
+}
+
+const modelCache = new Map<FastEmbedModelType, Promise<FlagEmbedding>>();
+
+export function getCachedModel(modelType: FastEmbedModelType) {
+  let modelPromise = modelCache.get(modelType);
+  if (!modelPromise) {
+    modelPromise = (async () =>
+      FlagEmbedding.init({
+        model: EmbeddingModel[modelType],
+        cacheDir: await getModelCachePath(),
+      }))();
+    void modelPromise.catch(() => {
+      modelCache.delete(modelType);
+    });
+    modelCache.set(modelType, modelPromise);
+  }
+  return modelPromise;
+}
+
+export async function warmupFastEmbedModels() {
+  const cacheDir = await getModelCachePath();
+  await FlagEmbedding.retrieveModel(EmbeddingModel.BGESmallENV15, cacheDir, false);
+  await FlagEmbedding.retrieveModel(EmbeddingModel.BGEBaseENV15, cacheDir, false);
+}


### PR DESCRIPTION
Possibly related to https://github.com/mastra-ai/mastra/issues/17055

This fixes FastEmbed repeatedly loading a new tokenizer and ONNX session for every embedding request. It now caches one loaded model per model type, so repeated message embedding work can reuse the same initialized model instead of growing memory and swap through repeated setup.

I added unit coverage for repeated calls, concurrent pending initialization, separate small/base caches, and warmup staying download-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Instead of loading a fresh copy of the embedding model every time you need to embed text, this fix saves the loaded model and reuses it. Think of it like ordering coffee—before, you'd throw away your coffee and buy a new one each time you wanted a sip; now, you just keep the same cup and refill it. This saves memory and makes things faster.

## Changes

### New Model Caching Infrastructure

Added `packages/fastembed/src/model-cache.ts` that introduces:
- **In-memory caching**: Models are cached per model type (`BGESmallENV15` and `BGEBaseENV15`) with separate cache entries for each variant
- **Filesystem cache**: Uses `~/.cache/mastra/fastembed-models` as a shared cache directory
- **Promise-based initialization**: Uses cached promises to ensure concurrent requests for the same model share a single initialization operation rather than creating duplicate instances
- **Graceful cleanup**: Removes cached promises if initialization fails, allowing retry on the next request
- **`getCachedModel(modelType)`**: Returns a cached model promise, initializing `FlagEmbedding` only once per model type
- **`warmupFastEmbedModels()`**: Proactively downloads both supported embedding models via `retrieveModel`

### Refactored Main Module

Updated `packages/fastembed/src/index.ts`:
- **Removed direct model management**: Deleted direct filesystem path handling and `FlagEmbedding` initialization logic
- **Delegated to cache helpers**: `warmup()` now calls `warmupFastEmbedModels()` instead of manually initializing models
- **Simplified embedding**: `generateEmbeddings()` calls `getCachedModel()` to retrieve cached models rather than creating new instances

### Comprehensive Test Coverage

Added `packages/fastembed/src/model-cache.test.ts` validating:
- Sequential calls to the same model reuse the cached instance
- Concurrent requests share a single pending initialization promise
- Different model types maintain separate caches
- Warmup triggers downloads via `retrieveModel` without calling model initialization
- Mock-based testing with proper module reset between tests

### Documentation

Updated `.changeset/fair-kings-raise.md` documenting the patch release with the caching fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->