### PR TITLE
fix(evals): read tool calls from V2 content.parts in extractToolCalls and extractToolResults

### DIFF
--- a/.changeset/spicy-jokes-nail.md
+++ b/.changeset/spicy-jokes-nail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed `extractToolCalls` and `extractToolResults` in `@mastra/evals` to also read tool invocations from V2 `content.parts` when `toolInvocations` is absent. Previously both functions only checked `message.content.toolInvocations`, which missed tool calls stored in `content.parts` as `tool-invocation` parts — the format used when observable memory is enabled. This caused hallucination and tool-usage scorers to receive empty tool data, producing incorrect scores.

--- a/packages/evals/src/scorers/utils.test.ts
+++ b/packages/evals/src/scorers/utils.test.ts
@@ -15,6 +15,7 @@ import {
   getReasoningFromRunOutput,
   createTestMessage,
   createToolInvocation,
+  extractToolCalls,
   extractToolResults,
   extractTrajectory,
   compareTrajectories,
@@ -452,6 +453,188 @@ describe('Scorer Utils', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0]?.toolName).toBe('hasResultTool');
+    });
+
+    it('should extract tool results from V2 content.parts when toolInvocations is absent', () => {
+      const output = [
+        {
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  state: 'result',
+                  toolCallId: 'call-1',
+                  toolName: 'weatherTool',
+                  args: { city: 'Seoul' },
+                  result: { temperature: 22 },
+                },
+              },
+            ],
+          },
+        },
+      ] as any;
+
+      const results = extractToolResults(output);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({
+        toolName: 'weatherTool',
+        toolCallId: 'call-1',
+        args: { city: 'Seoul' },
+        result: { temperature: 22 },
+      });
+    });
+
+    it('should prefer content.toolInvocations over content.parts when both are present', () => {
+      const output = [
+        {
+          role: 'assistant',
+          content: {
+            toolInvocations: [
+              { state: 'result', toolCallId: 'legacy-1', toolName: 'legacyTool', args: { x: 1 }, result: { ok: true } },
+            ],
+            format: 2,
+            parts: [
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  state: 'result',
+                  toolCallId: 'parts-1',
+                  toolName: 'partsTool',
+                  args: { y: 2 },
+                  result: { ok: false },
+                },
+              },
+            ],
+          },
+        },
+      ] as any;
+
+      const results = extractToolResults(output);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.toolName).toBe('legacyTool');
+    });
+  });
+
+  describe('extractToolCalls', () => {
+    it('should extract tool calls from legacy toolInvocations', () => {
+      const output: ScorerRunOutputForAgent = [
+        createTestMessage({
+          content: 'Calling a tool.',
+          role: 'assistant',
+          toolInvocations: [
+            createToolInvocation({
+              toolCallId: 'call-1',
+              toolName: 'searchTool',
+              args: { query: 'test' },
+              result: { hits: [] },
+              state: 'result',
+            }),
+          ],
+        }),
+      ];
+
+      const { tools, toolCallInfos } = extractToolCalls(output);
+
+      expect(tools).toEqual(['searchTool']);
+      expect(toolCallInfos).toHaveLength(1);
+      expect(toolCallInfos[0]?.toolName).toBe('searchTool');
+      expect(toolCallInfos[0]?.toolCallId).toBe('call-1');
+    });
+
+    it('should extract tool calls from V2 content.parts when toolInvocations is absent', () => {
+      const output = [
+        {
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  state: 'result',
+                  toolCallId: 'c1',
+                  toolName: 'weatherTool',
+                  args: { city: 'Seoul' },
+                  result: { temperature: 22 },
+                },
+              },
+            ],
+          },
+        },
+      ] as any;
+
+      const { tools, toolCallInfos } = extractToolCalls(output);
+
+      expect(tools).toEqual(['weatherTool']);
+      expect(toolCallInfos).toHaveLength(1);
+      expect(toolCallInfos[0]?.toolName).toBe('weatherTool');
+      expect(toolCallInfos[0]?.toolCallId).toBe('c1');
+    });
+
+    it('should extract multiple tool calls from V2 parts in a single message', () => {
+      const output = [
+        {
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: 'tool-invocation',
+                toolInvocation: { state: 'result', toolCallId: 'c1', toolName: 'toolA', args: { a: 1 }, result: 'ok' },
+              },
+              { type: 'text', text: 'some text' },
+              {
+                type: 'tool-invocation',
+                toolInvocation: { state: 'call', toolCallId: 'c2', toolName: 'toolB', args: { b: 2 } },
+              },
+            ],
+          },
+        },
+      ] as any;
+
+      const { tools } = extractToolCalls(output);
+
+      expect(tools).toEqual(['toolA', 'toolB']);
+    });
+
+    it('should prefer content.toolInvocations over content.parts when both are present', () => {
+      const output = [
+        {
+          role: 'assistant',
+          content: {
+            toolInvocations: [
+              { state: 'result', toolCallId: 'top-1', toolName: 'legacyTool', args: {}, result: {} },
+            ],
+            format: 2,
+            parts: [
+              {
+                type: 'tool-invocation',
+                toolInvocation: { state: 'result', toolCallId: 'p-1', toolName: 'partsTool', args: {}, result: {} },
+              },
+            ],
+          },
+        },
+      ] as any;
+
+      const { tools } = extractToolCalls(output);
+
+      expect(tools).toEqual(['legacyTool']);
+    });
+
+    it('should return empty arrays when no tool calls are present', () => {
+      const output: ScorerRunOutputForAgent = [
+        createTestMessage({ content: 'No tools used.', role: 'assistant' }),
+      ];
+
+      const { tools, toolCallInfos } = extractToolCalls(output);
+
+      expect(tools).toEqual([]);
+      expect(toolCallInfos).toEqual([]);
     });
   });
 

--- a/packages/evals/src/scorers/utils.ts
+++ b/packages/evals/src/scorers/utils.ts
@@ -597,19 +597,27 @@ export function extractToolCalls(output: ScorerRunOutputForAgent): { tools: stri
 
   for (let messageIndex = 0; messageIndex < output.length; messageIndex++) {
     const message = output[messageIndex];
-    // Tool invocations are now nested under content
-    if (message?.content?.toolInvocations) {
-      for (let invocationIndex = 0; invocationIndex < message.content.toolInvocations.length; invocationIndex++) {
-        const invocation = message.content.toolInvocations[invocationIndex];
-        if (invocation && invocation.toolName && (invocation.state === 'result' || invocation.state === 'call')) {
-          toolCalls.push(invocation.toolName);
-          toolCallInfos.push({
-            toolName: invocation.toolName,
-            toolCallId: invocation.toolCallId || `${messageIndex}-${invocationIndex}`,
-            messageIndex,
-            invocationIndex,
-          });
-        }
+    // Prefer the legacy toolInvocations array when present; fall back to
+    // V2 content.parts for messages that only store tool calls there.
+    const legacy = message?.content?.toolInvocations;
+    const fromParts = legacy
+      ? undefined
+      : message?.content?.parts
+          ?.filter((p): p is Extract<typeof p, { type: 'tool-invocation' }> => p.type === 'tool-invocation')
+          .map(p => p.toolInvocation);
+    const toolInvocations = legacy ?? fromParts;
+    if (!toolInvocations?.length) continue;
+
+    for (let invocationIndex = 0; invocationIndex < toolInvocations.length; invocationIndex++) {
+      const invocation = toolInvocations[invocationIndex];
+      if (invocation && invocation.toolName && (invocation.state === 'result' || invocation.state === 'call')) {
+        toolCalls.push(invocation.toolName);
+        toolCallInfos.push({
+          toolName: invocation.toolName,
+          toolCallId: invocation.toolCallId || `${messageIndex}-${invocationIndex}`,
+          messageIndex,
+          invocationIndex,
+        });
       }
     }
   }
@@ -700,8 +708,16 @@ export function extractToolResults(output: ScorerRunOutputForAgent): ToolResultI
   const results: ToolResultInfo[] = [];
 
   for (const message of output) {
-    const toolInvocations = message?.content?.toolInvocations;
-    if (!toolInvocations) continue;
+    // Prefer the legacy toolInvocations array when present; fall back to
+    // V2 content.parts for messages that only store tool calls there.
+    const legacy = message?.content?.toolInvocations;
+    const fromParts = legacy
+      ? undefined
+      : message?.content?.parts
+          ?.filter((p): p is Extract<typeof p, { type: 'tool-invocation' }> => p.type === 'tool-invocation')
+          .map(p => p.toolInvocation);
+    const toolInvocations = legacy ?? fromParts;
+    if (!toolInvocations?.length) continue;
 
     for (const invocation of toolInvocations) {
       if (invocation.state === 'result' && invocation.result !== undefined) {


### PR DESCRIPTION
## Problem

`extractToolCalls()` and `extractToolResults()` in `@mastra/evals` only read `message.content.toolInvocations` when extracting tool data for scorers.

This misses valid tool calls when an assistant message stores them only in V2 `content.parts` as `tool-invocation` entries — which is the format used when observable memory is enabled.

This is the same class of bug as #15438 / PR #15439, which fixed `extractTrajectory()` in `@mastra/core` but did not address the equivalent functions in `@mastra/evals`.

### Impact

When observable memory is enabled:
- **Hallucination scorer** with `getContext` using `extractToolResults()` always receives empty context → scores all responses as 100% hallucinated (score=1.0)
- **Tool-usage scorer** using `extractToolCalls()` always sees 0 tools → scores all tool-using responses as 0

## Solution

Applied the same fallback pattern already used in `extractTrajectory()` (from PR #15439) to both functions: prefer `content.toolInvocations` when present, fall back to `content.parts` filtered for `tool-invocation` entries when not.

## Testing

Added regression tests covering:
- `extractToolResults`: V2 parts fallback, precedence over `toolInvocations`
- `extractToolCalls`: legacy path, V2 parts fallback, multiple V2 parts, precedence, empty case

Existing tests continue to pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
The code that scores AI responses was looking for tool usage information in the wrong place when a feature called "observable memory" was turned on. This PR fixes two functions to look in both the old location AND the new location for that tool information, so the scoring works correctly.

## Changes Made

### Updated Functions: `extractToolCalls` and `extractToolResults`

Both functions in `packages/evals/src/scorers/utils.ts` now support dual formats for reading tool invocation data:

**`extractToolCalls`**: Now extracts tool calls from two sources:
- Prefers legacy `message.content.toolInvocations` array when present
- Falls back to filtering `message.content.parts` for `tool-invocation` entries and mapping them to the `toolInvocation` format
- Records tool names and generates default `toolCallId` values (`${messageIndex}-${invocationIndex}`) when not provided
- Includes tool calls in both 'result' and 'call' states

**`extractToolResults`**: Similarly updated to extract tool results:
- Prefers legacy `message.content.toolInvocations` array when present
- Falls back to extracting from `message.content.parts` entries of type `tool-invocation`
- Only includes invocations with `state === 'result'` and a defined `result` property

Both functions apply the same fallback pattern already used in `extractTrajectory()`, ensuring consistent handling across the codebase.

### Test Coverage

Comprehensive regression tests were added to `packages/evals/src/scorers/utils.test.ts`:

**`extractToolResults` tests**:
- Extract tool results from V2 content.parts when legacy toolInvocations is absent
- Prefer legacy toolInvocations over content.parts when both are present

**`extractToolCalls` tests**:
- Extract from legacy toolInvocations (existing behavior)
- Extract from V2 content.parts when toolInvocations is absent
- Extract multiple tool calls within a single message (including non-result states like 'call')
- Prefer legacy toolInvocations over parts when both exist
- Return empty arrays when no tool calls are present

### Changeset

A patch-level changeset for `@mastra/evals` documents the fix for improved transparency in release notes.

## Impact

Fixes scoring bugs where:
- The hallucination scorer received empty tool context and incorrectly scored all responses as fully hallucinated
- The tool-usage scorer reported zero tools when observable memory was enabled

The changes enable proper scoring when messages use V2 content format (the format used by observable memory) while maintaining backward compatibility with the legacy format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->