### PR TITLE
fix(react): render canonical user signal echoes

### DIFF
--- a/.changeset/afraid-banks-juggle.md
+++ b/.changeset/afraid-banks-juggle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Fixed canonical user signal echoes so messages sent through the agent-signals path appear in chat history when they move from pending to active.

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.test.ts
@@ -562,6 +562,31 @@ describe('toUIMessage', () => {
       ]);
     });
 
+    it('should append echoed canonical user signals as user messages', () => {
+      const chunk: ChunkType = {
+        type: 'data-user-message',
+        data: {
+          id: 'signal-1',
+          type: 'user',
+          tagName: 'user',
+          contents: { role: 'user', content: [{ type: 'text', text: 'hello from signal' }] },
+        },
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+      } as any;
+
+      const result = toUIMessage({ chunk, conversation: [], metadata: baseMetadata });
+
+      expect(result).toEqual([
+        {
+          id: 'signal-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'hello from signal' }],
+          metadata: baseMetadata,
+        },
+      ]);
+    });
+
     it('should dedupe echoed user-message signals by signal id', () => {
       const chunk: ChunkType = {
         type: 'data-user-message',

--- a/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts
+++ b/client-sdks/react/src/lib/ai-sdk/utils/toUIMessage.ts
@@ -270,7 +270,11 @@ export const toUIMessage = ({ chunk, conversation, metadata }: ToUIMessageArgs):
 
   // Handle data-* chunks (custom data chunks from writer.custom())
   if (chunk.type.startsWith('data-')) {
-    if (chunk.type === 'data-user-message' && 'data' in chunk && chunk.data?.type === 'user-message') {
+    if (
+      chunk.type === 'data-user-message' &&
+      'data' in chunk &&
+      (chunk.data?.type === 'user-message' || chunk.data?.type === 'user')
+    ) {
       const signalId = chunk.data.id;
       if (typeof signalId === 'string' && result.some(message => message.id === signalId)) {
         return result;


### PR DESCRIPTION
## Summary

- Render canonical `{ type: 'user' }` signal echoes as user messages in the React SDK UI-message adapter.
- Keep legacy `{ type: 'user-message' }` echo handling for existing streams.
- Add regression coverage for pending-to-active signal echoes appearing in chat history.

## Stack navigation

Stack position: 1/5. This is the base PR for the subscription chat stabilization split.

- Previous: none
- Next: #17310

## Test plan

- `pnpm --filter @mastra/react test src/lib/ai-sdk/utils/toUIMessage.test.ts --bail 1 --reporter=dot`
- `pnpm --filter @mastra/react build`
- `pnpm run prettier:changed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The React chat interface wasn't recognizing messages that came back from the AI agent in a certain format. This fix teaches it to recognize both the old and new ways that these "user message echoes" can be formatted, so they show up correctly in the chat history when they transition from waiting to active.

---

## Changes

### Canonical User Signal Echo Support

Added support for rendering canonical user signal echoes with `data.type: 'user'` in the React SDK's `toUIMessage` adapter, while preserving backward compatibility with legacy echoes that use `data.type: 'user-message'`.

The implementation now accepts both formats when deciding whether to convert `data-user-message` chunks into UI user messages:

- **Canonical format**: `{ type: 'user', tagName: 'user', contents: ... }`
- **Legacy format**: `{ type: 'user-message', contents: ... }`

Both formats result in the same UI output: a user message with the echoed content appearing in chat history with stable signal IDs preserved.

### Test Coverage

Added regression test for pending-to-active signal echoes in chat history that specifically validates the canonical user signal echo format is correctly converted to UI messages with proper role assignment and metadata handling.

### Release Notes

Changeset added to `@mastra/react` bumping to patch version documenting the fix for canonical user signal echoing through the agent-signals path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->