### PR TITLE
fix(playground): add legacy stream fallback

### DIFF
--- a/.changeset/quiet-rings-stream.md
+++ b/.changeset/quiet-rings-stream.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Added an explicit legacy Stream chat method in Playground agent settings so users can fall back from stream subscriptions while debugging.

--- a/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/page.spec.ts
@@ -52,9 +52,13 @@ test.describe('composer model settings', () => {
 
     await expect(generateRadio).toBeVisible();
     await expect(generateRadio).toHaveAttribute('aria-checked', 'false');
-    const streamRadio = page.getByRole('radio', { name: 'Stream' });
+    const streamSubscriptionRadio = page.getByRole('radio', { name: 'Stream subscription (default)' });
+    await expect(streamSubscriptionRadio).toBeVisible();
+    await expect(streamSubscriptionRadio).toHaveAttribute('aria-checked', 'true');
+
+    const streamRadio = page.getByRole('radio', { name: 'Stream', exact: true });
     await expect(streamRadio).toBeVisible();
-    await expect(streamRadio).toHaveAttribute('aria-checked', 'true');
+    await expect(streamRadio).toHaveAttribute('aria-checked', 'false');
 
     const networkRadio = page.getByRole('radio', { name: 'Network' });
     await expect(networkRadio).toBeVisible();

--- a/packages/playground/src/domains/agents/components/__tests__/composer-model-settings.test.tsx
+++ b/packages/playground/src/domains/agents/components/__tests__/composer-model-settings.test.tsx
@@ -99,11 +99,29 @@ describe('ComposerModelSettings', () => {
     await openPopover();
 
     expect(await screen.findByText('Chat Method')).not.toBeNull();
-    // v2 model defaults to the modern Generate/Stream options (no Legacy variants).
+    // v2 model defaults to the modern Generate/Stream Subscription/Stream options (no Legacy variants).
     expect(document.getElementById('generate')).not.toBeNull();
+    expect(document.getElementById('streamSubscription')).not.toBeNull();
     expect(document.getElementById('stream')).not.toBeNull();
     expect(document.getElementById('generateLegacy')).toBeNull();
     expect(document.getElementById('streamLegacy')).toBeNull();
+  });
+
+  it('persists legacy stream as an explicit no-subscription fallback', async () => {
+    useDefaultHandlers();
+    renderSettings();
+    await openPopover();
+
+    const legacyStream = document.getElementById('stream');
+    expect(legacyStream).not.toBeNull();
+    await act(async () => {
+      fireEvent.click(legacyStream!);
+    });
+
+    const stored = JSON.parse(window.localStorage.getItem(`mastra-agent-store-${AGENT_ID}`) ?? '{}');
+    expect(stored.modelSettings.chatWithLegacyStream).toBe(true);
+    expect(stored.modelSettings.chatWithGenerate).toBe(false);
+    expect(stored.modelSettings.chatWithNetwork).toBe(false);
   });
 
   it('keeps the popover open when the Advanced Settings dialog is dismissed via its built-in close button', async () => {

--- a/packages/playground/src/domains/agents/components/composer-model-settings.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-settings.tsx
@@ -111,8 +111,12 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
     if (isSupportedModel) {
       if (settings?.modelSettings?.chatWithNetwork) {
         radioValue = 'network';
+      } else if (settings?.modelSettings?.chatWithGenerate) {
+        radioValue = 'generate';
+      } else if (settings?.modelSettings?.chatWithLegacyStream) {
+        radioValue = 'stream';
       } else {
-        radioValue = settings?.modelSettings?.chatWithGenerate ? 'generate' : 'stream';
+        radioValue = 'streamSubscription';
       }
     } else {
       radioValue = settings?.modelSettings?.chatWithGenerateLegacy ? 'generateLegacy' : 'streamLegacy';
@@ -167,6 +171,7 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
                         ...settings?.modelSettings,
                         chatWithGenerateLegacy: value === 'generateLegacy',
                         chatWithGenerate: value === 'generate',
+                        chatWithLegacyStream: value === 'stream',
                         chatWithNetwork: value === 'network',
                       },
                     })
@@ -209,6 +214,19 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
                       />
                       <Label className="text-neutral6 text-ui-md" htmlFor="streamLegacy">
                         Stream (Legacy)
+                      </Label>
+                    </div>
+                  )}
+                  {isSupportedModel && (
+                    <div className="flex items-center gap-2">
+                      <RadioGroupItem
+                        value="streamSubscription"
+                        id="streamSubscription"
+                        className="text-neutral6"
+                        disabled={!canEditSettings}
+                      />
+                      <Label className="text-neutral6 text-ui-md" htmlFor="streamSubscription">
+                        Stream subscription (default)
                       </Label>
                     </div>
                   )}

--- a/packages/playground/src/domains/agents/hooks/use-agent-settings-state.ts
+++ b/packages/playground/src/domains/agents/hooks/use-agent-settings-state.ts
@@ -12,6 +12,7 @@ export const defaultSettings: AgentSettings = {
     maxSteps: 5,
     chatWithGenerateLegacy: false,
     chatWithGenerate: false,
+    chatWithLegacyStream: false,
   },
 };
 

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -310,7 +310,7 @@ export function MastraRuntimeProvider({
   const [pendingSignals, setPendingSignals] = useState<{ id: string; preview: string }[]>([]);
   const [threadSignalsUnsupported, setThreadSignalsUnsupported] = useState(false);
   const threadSignalsUnsupportedRef = useRef(false);
-  const threadSignalsEnabled = window.MASTRA_AGENT_SIGNALS === 'true';
+  const threadSignalsEnabled = window.MASTRA_AGENT_SIGNALS === 'true' && !settings?.modelSettings?.chatWithLegacyStream;
 
   const addPendingSignal = useCallback((signalId: string, preview: string) => {
     setPendingSignals(prev => [...prev.filter(signal => signal.id !== signalId), { id: signalId, preview }]);

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -44,6 +44,7 @@ export interface ModelSettings {
   providerOptions?: LLMStepResult['providerMetadata'];
   chatWithGenerateLegacy?: boolean;
   chatWithGenerate?: boolean;
+  chatWithLegacyStream?: boolean;
   chatWithNetwork?: boolean;
   requireToolApproval?: boolean;
 }


### PR DESCRIPTION
## Summary

- Add **Stream subscription (default)** and explicit legacy **Stream** choices to Playground agent settings.
- Persist `chatWithLegacyStream` as an opt-out from thread signals for the current agent settings.
- Update component and E2E expectations so the fallback UI exists before the default-on rollout.

## Stack navigation

Stack position: 4/5.

- Previous: #17311
- Next: #17313

## Test plan

- `pnpm --filter ./packages/playground exec vitest run src/domains/agents/components/__tests__/composer-model-settings.test.tsx src/services/__tests__/mastra-runtime-provider.test.tsx --bail 1 --reporter=dot`
- `pnpm --filter ./packages/playground test:e2e -- page.spec.ts --grep 'model trigger modes'` *(timed out after broader suite reached 75 passing tests; no assertion failure observed)*
- `pnpm --filter ./packages/playground build`
- `pnpm run prettier:changed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

This PR adds a fallback option to the Playground that lets you switch from the new "Stream subscription" chat method back to the older "Stream" chat method when debugging. Think of it like having two different ways to send messages—a new, preferred way and an old, reliable way. The PR prepares the UI for this choice ahead of time so that when the new method becomes the default, users can easily switch back to the old one if needed.

## Summary of Changes

### Type Definitions & Defaults
- Added `chatWithLegacyStream?: boolean` optional flag to the `ModelSettings` interface
- Set `chatWithLegacyStream: false` as the default in agent settings state

### Component Updates
- **ComposerModelSettings**: Updated the chat method selection logic to:
  - Add a new default "Stream subscription (default)" radio option
  - Persist the legacy stream selection to localStorage when the "Stream" radio option is selected
  - Adjust `radioValue` computation to prioritize: network → generate → legacy stream → stream subscription fallback

### Runtime Configuration
- **MastraRuntimeProvider**: Made `threadSignalsEnabled` conditional on the `chatWithLegacyStream` setting—thread signals are now only enabled when both the global flag is set AND legacy stream mode is not opted into

### Testing
- Added E2E test assertion updates to expect both the new "Stream subscription (default)" option and the explicit "Stream" option, with the former checked by default
- Added unit test case verifying that selecting the legacy stream control persists `chatWithLegacyStream: true` to localStorage

### Changeset
- Documented patch-level change for `@internal/playground` package noting the addition of explicit "legacy Stream chat" method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->