### PR TITLE
fix(playground): default chat to signal subscriptions

### DIFF
--- a/.changeset/upset-frogs-sit.md
+++ b/.changeset/upset-frogs-sit.md
@@ -1,0 +1,8 @@
+---
+'mastra': patch
+'@mastra/react': patch
+'@mastra/deployer': patch
+'@mastra/deployer-vercel': patch
+---
+
+Enabled Studio, Playground, deployers, and `useChat()` to use agent signal subscriptions by default while preserving `MASTRA_AGENT_SIGNALS=false` and explicit legacy Stream as opt-outs.

--- a/client-sdks/react/src/agent/hooks.test.ts
+++ b/client-sdks/react/src/agent/hooks.test.ts
@@ -133,6 +133,30 @@ describe('useChat forwards clientTools', () => {
     vi.clearAllMocks();
   });
 
+  it('uses thread signals by default when threadId is provided', async () => {
+    const { result } = renderHook(
+      () =>
+        useChat({
+          agentId: 'test-agent',
+          resourceId: 'resource-1',
+          threadId: 'thread-1',
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.sendMessage({
+        mode: 'stream',
+        message: 'hi',
+        threadId: 'thread-1',
+      });
+    });
+
+    expect(subscribeToThreadMock).toHaveBeenCalledTimes(1);
+    expect(sendSignalMock).toHaveBeenCalledTimes(1);
+    expect(streamUntilIdleMock).not.toHaveBeenCalled();
+  });
+
   it('marks subscription streams idle while waiting for tool approval', async () => {
     nextSubscribeChunks = [
       {
@@ -516,6 +540,31 @@ describe('useChat forwards clientTools', () => {
 
     expect(threadSubscriptionAbortMock).toHaveBeenCalledTimes(1);
     expect(threadSubscriptionUnsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the legacy stream path when thread signals are explicitly disabled', async () => {
+    const { result } = renderHook(
+      () =>
+        useChat({
+          agentId: 'test-agent',
+          resourceId: 'resource-1',
+          threadId: 'thread-1',
+          enableThreadSignals: false,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.sendMessage({
+        mode: 'stream',
+        message: 'hi',
+        threadId: 'thread-1',
+      });
+    });
+
+    expect(subscribeToThreadMock).not.toHaveBeenCalled();
+    expect(sendSignalMock).not.toHaveBeenCalled();
+    expect(streamUntilIdleMock).toHaveBeenCalledTimes(1);
   });
 
   it('keeps hook-prop clientTools on sendSignal when threadId is provided', async () => {

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -78,9 +78,8 @@ export interface MastraChatProps {
   onSignalEcho?: (signalId: string) => void;
   onThreadSignalsUnsupported?: () => void;
   /**
-   * Opt into the agent-signals streaming path (sendSignal + subscribeToThread).
-   * Defaults to `false` so consumers stay on the legacy `streamUntilIdle` route
-   * unless they explicitly enable the signals path.
+   * Use the agent-signals streaming path (sendSignal + subscribeToThread).
+   * Defaults to `true`; set to `false` to force the legacy `streamUntilIdle` route.
    */
   enableThreadSignals?: boolean;
 }
@@ -136,7 +135,7 @@ export const useChat = ({
   onSignalSent,
   onSignalEcho,
   onThreadSignalsUnsupported,
-  enableThreadSignals = false,
+  enableThreadSignals = true,
 }: MastraChatProps) => {
   const threadSignalsDisabled = enableThreadSignals === false;
   const _currentRunId = useRef<string | undefined>(undefined);

--- a/deployers/vercel/src/index.ts
+++ b/deployers/vercel/src/index.ts
@@ -109,7 +109,7 @@ export const HEAD = handle(app);
       telemetryDisabled: `''`,
       requestContextPresets: `''`,
       experimentalUI: `'false'`,
-      agentSignals: `'false'`,
+      agentSignals: `'true'`,
     });
 
     writeFileSync(indexPath, html);

--- a/packages/cli/src/commands/studio/studio.test.ts
+++ b/packages/cli/src/commands/studio/studio.test.ts
@@ -23,6 +23,7 @@ function createStudioFixture() {
     <script>
       window.MASTRA_STUDIO_BASE_PATH = '%%MASTRA_STUDIO_BASE_PATH%%';
       window.MASTRA_TEMPLATES = '%%MASTRA_TEMPLATES%%';
+      window.MASTRA_AGENT_SIGNALS = '%%MASTRA_AGENT_SIGNALS%%';
     </script>
   </head>
   <body>studio</body>
@@ -53,6 +54,7 @@ function request(url: string): Promise<{ status: number; body: string }> {
 afterEach(() => {
   delete process.env.MASTRA_STUDIO_BASE_PATH;
   delete process.env.MASTRA_TEMPLATES;
+  delete process.env.MASTRA_AGENT_SIGNALS;
 
   for (const dir of createdDirs.splice(0, createdDirs.length)) {
     rmSync(dir, { recursive: true, force: true });
@@ -102,6 +104,41 @@ describe('studio base path support', () => {
       expect(htmlResponse.body).toContain("window.MASTRA_TEMPLATES = 'true'");
     } finally {
       await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('enables agent signals by default and preserves the explicit opt-out', async () => {
+    process.env.MASTRA_STUDIO_BASE_PATH = '/agents';
+    const studioDir = createStudioFixture();
+    const defaultServer = createServer(studioDir, {}, '');
+
+    await new Promise<void>(resolve => defaultServer.listen(0, resolve));
+    const defaultAddress = defaultServer.address();
+    const defaultPort = typeof defaultAddress === 'object' && defaultAddress ? defaultAddress.port : 0;
+
+    try {
+      const htmlResponse = await request(`http://127.0.0.1:${defaultPort}/agents`);
+
+      expect(htmlResponse.status).toBe(200);
+      expect(htmlResponse.body).toContain("window.MASTRA_AGENT_SIGNALS = 'true'");
+    } finally {
+      await new Promise<void>((resolve, reject) => defaultServer.close(err => (err ? reject(err) : resolve())));
+    }
+
+    process.env.MASTRA_AGENT_SIGNALS = 'false';
+    const optOutServer = createServer(studioDir, {}, '');
+
+    await new Promise<void>(resolve => optOutServer.listen(0, resolve));
+    const optOutAddress = optOutServer.address();
+    const optOutPort = typeof optOutAddress === 'object' && optOutAddress ? optOutAddress.port : 0;
+
+    try {
+      const htmlResponse = await request(`http://127.0.0.1:${optOutPort}/agents`);
+
+      expect(htmlResponse.status).toBe(200);
+      expect(htmlResponse.body).toContain("window.MASTRA_AGENT_SIGNALS = 'false'");
+    } finally {
+      await new Promise<void>((resolve, reject) => optOutServer.close(err => (err ? reject(err) : resolve())));
     }
   });
 

--- a/packages/cli/src/commands/studio/studio.ts
+++ b/packages/cli/src/commands/studio/studio.ts
@@ -102,7 +102,7 @@ export const createServer = (builtStudioPath: string, options: StudioOptions, re
   const experimentalFeatures = process.env.EXPERIMENTAL_FEATURES === 'true' ? 'true' : 'false';
   const experimentalUI = process.env.MASTRA_EXPERIMENTAL_UI === 'true' ? 'true' : 'false';
   const templatesEnabled = process.env.MASTRA_TEMPLATES === 'true' ? 'true' : 'false';
-  const agentSignals = process.env.MASTRA_AGENT_SIGNALS === 'true' ? 'true' : 'false';
+  const agentSignals = process.env.MASTRA_AGENT_SIGNALS === 'false' ? 'false' : 'true';
 
   let html = readFileSync(indexHtmlPath, 'utf8')
     .replaceAll('%%MASTRA_STUDIO_BASE_PATH%%', basePath)

--- a/packages/deployer/src/build/utils.test.ts
+++ b/packages/deployer/src/build/utils.test.ts
@@ -595,7 +595,7 @@ describe('injectStudioHtmlConfig', () => {
       telemetryDisabled: "''",
       requestContextPresets: "''",
       experimentalUI: "'true'",
-      agentSignals: "'false'",
+      agentSignals: "'true'",
       autoDetectUrl: "'false'",
     });
 

--- a/packages/deployer/src/server/__tests__/option-studio-base.test.ts
+++ b/packages/deployer/src/server/__tests__/option-studio-base.test.ts
@@ -82,6 +82,7 @@ describe('Mastra Studio "studioBase" functionality', () => {
     window.MASTRA_CLOUD_API_ENDPOINT = '%%MASTRA_CLOUD_API_ENDPOINT%%';
     window.MASTRA_EXPERIMENTAL_FEATURES = '%%MASTRA_EXPERIMENTAL_FEATURES%%';
     window.MASTRA_REQUEST_CONTEXT_PRESETS = '%%MASTRA_REQUEST_CONTEXT_PRESETS%%';
+    window.MASTRA_AGENT_SIGNALS = '%%MASTRA_AGENT_SIGNALS%%';
   </script>
 </body>
 </html>`;
@@ -366,6 +367,34 @@ describe('Mastra Studio "studioBase" functionality', () => {
           process.env.MASTRA_TEMPLATES = originalEnv;
         } else {
           delete process.env.MASTRA_TEMPLATES;
+        }
+      }
+    });
+
+    it('should enable agent signals by default and preserve explicit opt-out', async () => {
+      const originalEnv = process.env.MASTRA_AGENT_SIGNALS;
+      try {
+        delete process.env.MASTRA_AGENT_SIGNALS;
+        vi.mocked(mockMastra.getServer).mockReturnValue({ studioBase: '/admin', port: 4111, host: 'localhost' });
+        const defaultApp = await createHonoServer(mockMastra, { tools: {}, studio: true });
+
+        const defaultResponse = await defaultApp.request('/admin');
+        const defaultHtml = await defaultResponse.text();
+
+        expect(defaultHtml).toContain("window.MASTRA_AGENT_SIGNALS = 'true'");
+
+        process.env.MASTRA_AGENT_SIGNALS = 'false';
+        const optOutApp = await createHonoServer(mockMastra, { tools: {}, studio: true });
+
+        const optOutResponse = await optOutApp.request('/admin');
+        const optOutHtml = await optOutResponse.text();
+
+        expect(optOutHtml).toContain("window.MASTRA_AGENT_SIGNALS = 'false'");
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.MASTRA_AGENT_SIGNALS = originalEnv;
+        } else {
+          delete process.env.MASTRA_AGENT_SIGNALS;
         }
       }
     });

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -459,7 +459,7 @@ export async function createHonoServer(
       const experimentalFeatures = process.env.EXPERIMENTAL_FEATURES === 'true' ? 'true' : 'false';
       const experimentalUI = process.env.MASTRA_EXPERIMENTAL_UI === 'true' ? 'true' : 'false';
       const templatesEnabled = process.env.MASTRA_TEMPLATES === 'true' ? 'true' : 'false';
-      const agentSignals = process.env.MASTRA_AGENT_SIGNALS === 'true' ? 'true' : 'false';
+      const agentSignals = process.env.MASTRA_AGENT_SIGNALS === 'false' ? 'false' : 'true';
       const requestContextPresets = process.env.MASTRA_REQUEST_CONTEXT_PRESETS || '';
 
       // Helper function to escape JSON for embedding in HTML/JavaScript

--- a/packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx
+++ b/packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { useChat } from '@mastra/react';
 import { act, render, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -127,13 +128,36 @@ import { MastraRuntimeProvider } from '../mastra-runtime-provider';
 
 describe('MastraRuntimeProvider', () => {
   beforeEach(() => {
+    vi.mocked(useChat).mockClear();
     mocks.cancelRun.mockReset();
     mocks.runtimeProps = undefined;
     mocks.threadRuntimeState = undefined;
     mocks.chatState.isAwaitingToolApproval = false;
     mocks.chatState.isRunning = false;
     mocks.sendMessage.mockReset();
+    delete (window as any).MASTRA_AGENT_SIGNALS;
+  });
+
+  it('enables thread signals by default', () => {
+    render(
+      <MastraRuntimeProvider agentId="agent-1" threadId="thread-1" initialMessages={[]} modelVersion="v2">
+        <div />
+      </MastraRuntimeProvider>,
+    );
+
+    expect(useChat).toHaveBeenCalledWith(expect.objectContaining({ enableThreadSignals: true }));
+  });
+
+  it('preserves the explicit thread signals opt-out', () => {
     (window as any).MASTRA_AGENT_SIGNALS = 'false';
+
+    render(
+      <MastraRuntimeProvider agentId="agent-1" threadId="thread-1" initialMessages={[]} modelVersion="v2">
+        <div />
+      </MastraRuntimeProvider>,
+    );
+
+    expect(useChat).toHaveBeenCalledWith(expect.objectContaining({ enableThreadSignals: false }));
   });
 
   it('persists a visible error when a vNext stream finishes with pending tool calls', async () => {

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -310,7 +310,8 @@ export function MastraRuntimeProvider({
   const [pendingSignals, setPendingSignals] = useState<{ id: string; preview: string }[]>([]);
   const [threadSignalsUnsupported, setThreadSignalsUnsupported] = useState(false);
   const threadSignalsUnsupportedRef = useRef(false);
-  const threadSignalsEnabled = window.MASTRA_AGENT_SIGNALS === 'true' && !settings?.modelSettings?.chatWithLegacyStream;
+  const threadSignalsEnabled =
+    window.MASTRA_AGENT_SIGNALS !== 'false' && !settings?.modelSettings?.chatWithLegacyStream;
 
   const addPendingSignal = useCallback((signalId: string, preview: string) => {
     setPendingSignals(prev => [...prev.filter(signal => signal.id !== signalId), { id: signalId, preview }]);

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -21,7 +21,7 @@ const studioStandalonePlugin = (targetPort: string, targetHost: string): PluginO
       .replace(/%%MASTRA_AUTO_DETECT_URL%%/g, 'true')
       .replace(/%%MASTRA_EXPERIMENTAL_FEATURES%%/g, process.env.EXPERIMENTAL_FEATURES || 'false')
       .replace(/%%MASTRA_EXPERIMENTAL_UI%%/g, process.env.MASTRA_EXPERIMENTAL_UI || 'false')
-      .replace(/%%MASTRA_AGENT_SIGNALS%%/g, process.env.MASTRA_AGENT_SIGNALS || 'false');
+      .replace(/%%MASTRA_AGENT_SIGNALS%%/g, process.env.MASTRA_AGENT_SIGNALS ?? 'true');
   },
 });
 


### PR DESCRIPTION
## Summary

- Default React `useChat()` to the agent-signals subscription path while preserving `enableThreadSignals: false` as an opt-out.
- Default Studio, Playground, and deployer HTML injection to `MASTRA_AGENT_SIGNALS=true` unless explicitly set to `false`.
- Keep the PR 4 legacy **Stream** setting as an in-product fallback after rollout.

## Stack navigation

Stack position: 5/5. This is the final default-on rollout after the safety fixes and fallback controls.

- Previous: #17312
- Next: none

## Test plan

- `pnpm --filter @mastra/react test src/agent/hooks.test.ts --bail 1 --reporter=dot`
- `pnpm --filter ./packages/playground exec vitest run src/services/__tests__/mastra-runtime-provider.test.tsx --bail 1 --reporter=dot`
- `pnpm --filter mastra test src/commands/studio/studio.test.ts --bail 1 --reporter=dot`
- `pnpm --filter @mastra/deployer test src/server/__tests__/option-studio-base.test.ts src/build/utils.test.ts --bail 1 --reporter=dot`
- `pnpm --filter @mastra/react build`
- `pnpm --filter ./packages/playground build`
- `pnpm run prettier:changed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the Mastra chat system use a faster, more responsive "signal subscriptions" method by default instead of the older "streaming" method. If you don't want the new behavior, you can turn it off by setting a flag to `false`, but most users will automatically get the better experience without having to do anything.

## Changes Summary

This PR implements the final rollout step to make agent signal subscriptions the default behavior across React hooks, Studio, Playground, and deployers, while maintaining backward compatibility through explicit opt-out mechanisms.

### Core Hook Changes

- **`useChat()` Hook Default**: Changed `enableThreadSignals` from `false` to `true` by default, so thread signals are now the primary behavior for agent communication.
- **Hook Tests**: Added two new test cases: one verifying default thread signal behavior when `threadId` is provided, and another confirming the legacy `streamUntilIdle` path when `enableThreadSignals` is explicitly set to `false`.

### Studio & Deployment Configuration

- **Studio HTML Injection**: Updated `packages/cli/src/commands/studio/studio.ts` to treat `MASTRA_AGENT_SIGNALS` as enabled by default (any value other than `'false'` enables signals). Added corresponding test coverage verifying this behavior and the opt-out path.
- **Playground Runtime Provider**: Changed `MastraRuntimeProvider` logic so `threadSignalsEnabled` defaults to `true` when `window.MASTRA_AGENT_SIGNALS` is not explicitly `'false'`. Updated tests to validate this new default and the opt-out mechanism.
- **Playground Vite Config**: Updated template substitution to default `MASTRA_AGENT_SIGNALS` to `'true'` when the environment variable is unset.
- **Vercel Deployer**: Changed `agentSignals` flag from `'false'` to `'true'` in the SPA HTML injection.
- **Generic Deployer**: Updated `createHonoServer` to treat `MASTRA_AGENT_SIGNALS` as enabled by default. Updated test fixtures to use `agentSignals: "'true'"` as the default.

### Release Metadata

- Added `.changeset/upset-frogs-sit.md` documenting the patch update for `mastra`, `@mastra/react`, `@mastra/deployer`, and `@mastra/deployer-vercel` packages with the behavior change details.

### Backward Compatibility

All changes preserve the ability to opt out by:
- Setting `enableThreadSignals: false` in the `useChat()` hook
- Setting `MASTRA_AGENT_SIGNALS='false'` in environment variables (Studio/deployers)
- Setting `window.MASTRA_AGENT_SIGNALS = 'false'` (Playground)
- Using legacy Stream wiring as an in-product fallback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->