### PR TITLE
fix(core): fix TS2589 depth error, storage debug spam, and MCP const-field validation

### DIFF
--- a/.changeset/mcp-const-field-auto-inject.md
+++ b/.changeset/mcp-const-field-auto-inject.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed MCP tools with `const`-constrained or single-value `enum` discriminator fields (e.g. `"@type": { "const": "com.SomeSpec" }`) always failing validation. Mastra now automatically injects these predetermined values before validation runs.

--- a/.changeset/storage-not-initialized-debug-spam.md
+++ b/.changeset/storage-not-initialized-debug-spam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed "Mastra storage is not initialized" debug messages appearing on every `agent.generate()` call when no storage backend is configured.

--- a/.changeset/ts2589-mastra-message-part-type.md
+++ b/.changeset/ts2589-mastra-message-part-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a TypeScript TS2589 "type instantiation is excessively deep" error when using Mastra alongside deeply-generic libraries such as @hono/zod-openapi.

--- a/packages/core/src/agent/message-list/state/types.ts
+++ b/packages/core/src/agent/message-list/state/types.ts
@@ -73,13 +73,18 @@ export type MastraSourceUrlPart = Omit<LegacySourcePart, 'providerMetadata'> & {
   createdAt?: number;
 };
 
+// Named alias so TypeScript caches the Exclude expansion and avoids TS2589 when
+// MastraMessagePart is used alongside deeply-generic libraries like @hono/zod-openapi.
+type UIV4NonMastraPart = Exclude<
+  UIMessageV4['parts'][number],
+  { type: 'tool-invocation' | 'source' | 'step-start' }
+>;
+
 // Canonical stored part type. It starts from the v4 UI part model and extends
 // it with provider metadata, AI SDK v5 data parts, and v6-only persisted parts
 // such as approval-aware tool invocations and source documents.
 export type MastraMessagePart =
-  | PartWithProviderMetadata<
-      Exclude<UIMessageV4['parts'][number], { type: 'tool-invocation' | 'source' | 'step-start' }>
-    >
+  | PartWithProviderMetadata<UIV4NonMastraPart>
   | MastraStepStartPart
   | MastraToolInvocationPart
   | MastraSourceUrlPart

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -64,10 +64,10 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
         internal: InternalSpans.WORKFLOW,
       },
       shouldPersistSnapshot: params => {
-        // We need a persisted snapshot record to support `resumeStream()`.
-        // - Create the initial record early ("pending")
-        // - Update it when execution is suspended ("paused"/"suspended")
-        // Avoid persisting "running" snapshots so we don't overwrite an existing suspended snapshot.
+        // Skip when no storage is configured to avoid debug spam on every generate() call.
+        if (!rest.mastra?.getStorage()) return false;
+        // Persist pending/suspended snapshots to support resumeStream(); skip "running"
+        // to avoid overwriting an existing suspended snapshot.
         return (
           params.workflowStatus === 'pending' ||
           params.workflowStatus === 'paused' ||

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -201,6 +201,34 @@ function normalizeNullishInput(schema: StandardSchemaWithJSON<any>, input: unkno
 }
 
 /**
+ * Auto-injects const-constrained field values into input before validation (GitHub #16444).
+ * JSON Schema `const` and single-value `enum` properties have a fixed predetermined value
+ * that LLMs cannot know to supply (e.g. discriminator fields like `"@type": {"const": "..."}`).
+ * Injecting them here lets the tool schema validate successfully without requiring the LLM
+ * to guess opaque constant values.
+ */
+function injectConstValues(schema: StandardSchemaWithJSON<unknown>, input: unknown): unknown {
+  if (!isPlainObject(input)) return input;
+  const jsonSchema = standardSchemaToJSONSchema(schema, { io: 'input' });
+  if (jsonSchema.type !== 'object' || !jsonSchema.properties) return input;
+
+  let injected = false;
+  const result: Record<string, unknown> = { ...(input as Record<string, unknown>) };
+  for (const [key, rawProp] of Object.entries(jsonSchema.properties)) {
+    if (result[key] !== undefined) continue;
+    const prop = rawProp as Record<string, unknown>;
+    if ('const' in prop) {
+      result[key] = prop['const'];
+      injected = true;
+    } else if (Array.isArray(prop['enum']) && prop['enum'].length === 1) {
+      result[key] = prop['enum'][0];
+      injected = true;
+    }
+  }
+  return injected ? result : input;
+}
+
+/**
  * Checks if a value is a plain object (created by {} or new Object()).
  * This excludes class instances, built-in objects like Date/Map/URL, etc.
  *
@@ -462,6 +490,10 @@ export function validateToolInput<T = unknown>(
   //    strict mode compliance. The schema's transform converts null back to undefined.
   //    (GitHub #11457)
   //
+  // 2.5. injectConstValues: Auto-inject JSON Schema `const` / single-value `enum` fields
+  //    whose fixed value an LLM cannot know to supply (e.g. MCP discriminator fields).
+  //    (GitHub #16444)
+  //
   // 3. First validation attempt with null values preserved. This handles .nullable()
   //    schemas correctly (where null is a valid value).
   //
@@ -478,6 +510,11 @@ export function validateToolInput<T = unknown>(
 
   // Step 2: Convert undefined values to null recursively (GitHub #11457)
   normalizedInput = convertUndefinedToNull(normalizedInput);
+
+  // Step 2.5: Auto-inject const-constrained field values (GitHub #16444)
+  // Fields with a JSON Schema `const` or single-value `enum` have a fixed value the LLM
+  // cannot know to supply (e.g. MCP discriminator fields). Inject them before validation.
+  normalizedInput = injectConstValues(schema, normalizedInput);
 
   // Step 3: Validate the normalized input
   const validation = safeValidate(schema, normalizedInput);


### PR DESCRIPTION
## Summary
- Fix TS2589 "type instantiation is excessively deep" error when `MastraMessagePart` is used alongside deeply-generic libraries like `@hono/zod-openapi` — extract the `Exclude<UIMessageV4['parts'][number], ...>` union into a named type alias so TypeScript caches the expansion instead of re-evaluating it per use site. (#17047)
- Fix `"Mastra storage is not initialized"` debug spam appearing on every `agent.generate()` call when no storage backend is configured — guard `shouldPersistSnapshot` in `createAgenticLoopWorkflow` with a storage availability check before attempting persistence. (#17137)
- Fix MCP tools with `const`-constrained or single-value `enum` discriminator fields always failing validation — auto-inject these predetermined values into tool input before the validation pipeline runs so the LLM does not need to supply them. (#16444)

## Test plan
```
pnpm --filter @mastra/core exec vitest run src/tools/validation.test.ts --bail 1 --reporter=dot
pnpm --filter @mastra/core typecheck
```

Closes #17047
Closes #17137
Closes #16444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes three separate bugs in the Mastra core library: (1) a TypeScript error that happens when Mastra is used with certain other libraries (fixed by reorganizing type definitions), (2) annoying repeated debug messages appearing when storage isn't set up (fixed by only checking for storage when needed), and (3) MCP tools failing validation when they have required fixed-value fields (fixed by automatically filling in those fixed values before validation runs).

## Changes

### Type System Optimization (TS2589 Fix)
- **File:** `packages/core/src/agent/message-list/state/types.ts`
- Introduces a new internal type alias `UIV4NonMastraPart` to extract the complex `Exclude<UIMessageV4['parts'][number], ...>` expression
- Updates `MastraMessagePart` to use the precomputed alias instead of the inline complex expression
- Resolves TypeScript's "type instantiation is excessively deep" error (TS2589) when Mastra is used alongside deeply generic libraries like `@hono/zod-openapi`

### Storage Debug Spam Fix
- **File:** `packages/core/src/loop/workflows/agentic-loop/index.ts`
- Adds a storage-availability check before attempting to persist snapshots in `shouldPersistSnapshot` logic
- Prevents repeated "Mastra storage is not initialized" debug messages when no storage backend is configured
- Updated inline documentation to reflect the new persistence guard

### MCP Tool Const-Field Auto-Injection
- **File:** `packages/core/src/tools/validation.ts`
- Adds new `injectConstValues` helper function that auto-injects JSON-schema `const` values and single-value `enum` values into tool input before validation
- Runs as a normalization step (Step 2.5) in the validation pipeline
- Ensures discriminator fields with fixed values are automatically populated, allowing MCP tools with `const` or single-value enum fields to pass validation without requiring the LLM to provide the predetermined values

### Changelog Entries
- Three changeset files added to document these fixes for `@mastra/core` patch release

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->