### PR TITLE
feat(server): add Standard Schema validators to custom API routes

### DIFF
--- a/.changeset/custom-route-validators.md
+++ b/.changeset/custom-route-validators.md
@@ -1,0 +1,25 @@
+---
+'@mastra/core': minor
+'@mastra/deployer': patch
+---
+
+Added `validators` option to `registerApiRoute` for automatic request validation using any [Standard Schema](https://standardschema.dev/)-compatible library (Zod, Valibot, ArkType, etc.). When validators are provided for a target (`json`, `query`, `param`, `header`, or `form`), the server validates the corresponding part of the request before calling the handler and returns a structured 400 response on failure.
+
+**Example:**
+```ts
+import { z } from 'zod';
+import { registerApiRoute } from '@mastra/core/server';
+
+registerApiRoute('/items', {
+  method: 'POST',
+  validators: {
+    json: z.object({ name: z.string(), price: z.number() }),
+    query: z.object({ currency: z.string().optional() }),
+  },
+  handler: async (c) => {
+    const body = c.req.valid('json');    // validated + typed
+    const query = c.req.valid('query'); // validated + typed
+    return c.json({ id: 1, ...body });
+  },
+});
+```

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -3,7 +3,7 @@ import type { DescribeRouteOptions } from 'hono-openapi';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
 import type { Mastra } from '../mastra';
 import type { RequestContext } from '../request-context';
-import type { ApiRoute, MastraAuthConfig, Methods } from './types';
+import type { ApiRoute, MastraAuthConfig, Methods, RouteValidators } from './types';
 
 export type {
   MastraAuthConfig,
@@ -12,6 +12,7 @@ export type {
   ContextWithMastra,
   CorsOptions,
   ApiRoute,
+  RouteValidators,
   HttpLoggingConfig,
   ValidationErrorContext,
   ValidationErrorResponse,
@@ -41,6 +42,13 @@ type CustomRouteVariables = {
 type RegisterApiRouteOptions<P extends string> = {
   method: Methods;
   openapi?: DescribeRouteOptions;
+  /**
+   * Per-target Standard Schema validators (Zod, Valibot, ArkType, etc.).
+   * The server automatically validates the matching request part and returns
+   * a 400 with structured errors on failure. Access validated data in the
+   * handler via `c.req.valid('json')`, `c.req.valid('query')`, etc.
+   */
+  validators?: RouteValidators;
   handler?: Handler<
     {
       Variables: CustomRouteVariables;
@@ -114,6 +122,7 @@ export function registerApiRoute<P extends string>(path: P, options: RegisterApi
     handler: options.handler,
     createHandler: options.createHandler,
     openapi: options.openapi,
+    validators: options.validators,
     middleware: options.middleware,
     cors: options.cors,
     requiresAuth: options.requiresAuth,

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { Handler, MiddlewareHandler, HonoRequest, Context } from 'hono';
 import type { cors } from 'hono/cors';
 import type { DescribeRouteOptions } from 'hono-openapi';
@@ -13,6 +14,28 @@ type RouteFGAConfig = FGARouteConfig;
 
 export type Methods = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'ALL';
 
+/**
+ * Per-target Standard Schema validators for a route. When present, the server
+ * automatically validates the corresponding part of the request before invoking
+ * the route handler, returning a structured 400 error on failure.
+ *
+ * Use any Standard Schema-compatible library (Zod, Valibot, ArkType, etc.).
+ *
+ * @example
+ * ```ts
+ * import { z } from 'zod';
+ * registerApiRoute('/items', {
+ *   method: 'POST',
+ *   validators: { json: z.object({ name: z.string() }) },
+ *   handler: async (c) => {
+ *     const body = c.req.valid('json');
+ *     return c.json({ id: 1, ...body });
+ *   },
+ * });
+ * ```
+ */
+export type RouteValidators = Partial<Record<'json' | 'query' | 'param' | 'header' | 'form', StandardSchemaV1>>;
+
 export type ApiRoute =
   | {
       path: string;
@@ -20,6 +43,7 @@ export type ApiRoute =
       handler: Handler;
       middleware?: MiddlewareHandler | MiddlewareHandler[];
       openapi?: DescribeRouteOptions;
+      validators?: RouteValidators;
       cors?: CorsOptions;
       requiresAuth?: boolean;
       requiresPermission?: MastraFGAPermissionInput | MastraFGAPermissionInput[];
@@ -33,6 +57,7 @@ export type ApiRoute =
       createHandler: ({ mastra }: { mastra: Mastra }) => Promise<Handler>;
       middleware?: MiddlewareHandler | MiddlewareHandler[];
       openapi?: DescribeRouteOptions;
+      validators?: RouteValidators;
       cors?: CorsOptions;
       requiresAuth?: boolean;
       requiresPermission?: MastraFGAPermissionInput | MastraFGAPermissionInput[];

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -4,6 +4,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
+import { sValidator } from '@hono/standard-validator';
 import { swaggerUI } from '@hono/swagger-ui';
 import type { Mastra } from '@mastra/core/mastra';
 import type { ApiRoute, CorsOptions } from '@mastra/core/server';
@@ -18,7 +19,6 @@ import { compress } from 'hono/compress';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { timeout } from 'hono/timeout';
-import { sValidator } from '@hono/standard-validator';
 import { describeRoute } from 'hono-openapi';
 import { injectStudioHtmlConfig, normalizeStudioBase } from '../build/utils';
 import { handleClientsRefresh, handleTriggerClientsRefresh, isHotReloadDisabled } from './handlers/client';
@@ -145,8 +145,22 @@ export async function createHonoServer(
     }
 
     if ('validators' in route && route.validators) {
-      for (const [target, schema] of Object.entries(route.validators) as [ValidatorTarget, NonNullable<(typeof route.validators)[ValidatorTarget]>][]) {
-        injected.push(sValidator(target, schema));
+      for (const [target, schema] of Object.entries(route.validators) as [
+        ValidatorTarget,
+        NonNullable<(typeof route.validators)[ValidatorTarget]>,
+      ][]) {
+        if (!schema) continue;
+        injected.push(
+          sValidator(target, schema, (result, c) => {
+            if (!result.success) {
+              const issues = (result as any).error ?? [];
+              const message = (Array.isArray(issues) ? issues : [])
+                .map((i: any) => `- ${i.path?.join('.') || 'root'}: ${i.message}`)
+                .join('\n');
+              return c.json({ error: `Validation failed:\n${message}` }, 400);
+            }
+          }) as unknown as MiddlewareHandler,
+        );
       }
     }
 

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -12,12 +12,13 @@ import { MastraServer, setupBrowserStream } from '@mastra/hono';
 import type { HonoBindings, HonoVariables } from '@mastra/hono';
 import { InMemoryTaskStore } from '@mastra/server/a2a/store';
 import { findMatchingCustomRoute } from '@mastra/server/auth';
-import type { Context } from 'hono';
+import type { Context, MiddlewareHandler } from 'hono';
 import { Hono } from 'hono';
 import { compress } from 'hono/compress';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { timeout } from 'hono/timeout';
+import { sValidator } from '@hono/standard-validator';
 import { describeRoute } from 'hono-openapi';
 import { injectStudioHtmlConfig, normalizeStudioBase } from '../build/utils';
 import { handleClientsRefresh, handleTriggerClientsRefresh, isHotReloadDisabled } from './handlers/client';
@@ -127,18 +128,30 @@ export async function createHonoServer(
   const a2aTaskStore = new InMemoryTaskStore();
   const routes = server?.apiRoutes;
 
-  // Pre-process routes: bake hono-openapi describeRoute into route middleware
-  // so the adapter handles it as normal middleware without needing to know about hono-openapi
+  // Pre-process routes: bake hono-openapi describeRoute and sValidator middleware into the
+  // route's middleware array so the adapter handles them as normal middleware.
+  type ValidatorTarget = 'json' | 'query' | 'param' | 'header' | 'form';
+
+  function toArray<T>(v: T | T[] | undefined): T[] {
+    if (!v) return [];
+    return Array.isArray(v) ? v : [v];
+  }
+
   const processedRoutes = routes?.map(route => {
+    const injected: MiddlewareHandler[] = [];
+
     if ('openapi' in route && route.openapi) {
-      const existingMiddleware = route.middleware
-        ? Array.isArray(route.middleware)
-          ? route.middleware
-          : [route.middleware]
-        : [];
-      return { ...route, middleware: [describeRoute(route.openapi), ...existingMiddleware] };
+      injected.push(describeRoute(route.openapi));
     }
-    return route;
+
+    if ('validators' in route && route.validators) {
+      for (const [target, schema] of Object.entries(route.validators) as [ValidatorTarget, NonNullable<(typeof route.validators)[ValidatorTarget]>][]) {
+        injected.push(sValidator(target, schema));
+      }
+    }
+
+    if (injected.length === 0) return route;
+    return { ...route, middleware: [...injected, ...toArray(route.middleware)] };
   });
 
   // Store custom route auth configurations


### PR DESCRIPTION
## Summary
- Add `validators` option to `registerApiRoute` and `ApiRoute` accepting per-target Standard Schema validators (`json`, `query`, `param`, `header`, `form`) via any Standard Schema-compatible library (Zod, Valibot, ArkType, etc.).
- Inject `sValidator` middleware in the deployer for each configured target, returning a structured 400 response on failure.
- No new package dependencies — `@hono/standard-validator` is already a direct dependency of `@mastra/deployer`.

## Test plan
```
pnpm --filter @mastra/core typecheck
pnpm --filter @mastra/deployer typecheck
```

Closes #5454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes API routes automatically check incoming requests (body, query, params, headers, form) against developer-provided validators like Zod, and rejects bad requests with a clear 400 error before your handler runs.

## Overview

Adds a `validators` option to route registration so routes can declare per-target Standard Schema–compatible validators (`json`, `query`, `param`, `header`, `form`). The deployer injects `sValidator` middleware for each configured target to perform runtime validation and return structured 400 responses on failure. No new package dependencies are introduced (uses existing `@hono/standard-validator` in `@mastra/deployer`). Typecheck test commands were also added for `@mastra/core` and `@mastra/deployer`.

## What changed

- packages/core/src/server/types.ts
  - New exported type `RouteValidators = Partial<Record<'json' | 'query' | 'param' | 'header' | 'form', StandardSchemaV1>>`.
  - `ApiRoute` now includes `validators?: RouteValidators`.

- packages/core/src/server/index.ts
  - Re-exports `RouteValidators`.
  - `registerApiRoute` options accept `validators?: RouteValidators` and the returned `ApiRoute` carries through `validators`.

- packages/deployer/src/server/index.ts
  - Preprocesses `server.apiRoutes` to inject `describeRoute(route.openapi)` (when present) and `sValidator` middleware for each configured validator target.
  - Injected `sValidator` includes an error callback that returns a structured 400 (formats errors from `result.error`).
  - Normalizes existing route middleware and appends it after injected validators.
  - Adds imports for `sValidator` and Hono middleware types.

- .changeset/custom-route-validators.md
  - Changeset documenting the feature, TypeScript example (Zod), notes on `c.req.valid(...)`, and dependency bump entries for `@mastra/core` (minor) and `@mastra/deployer` (patch).

- Additional runtime robustness (from commit notes)
  - Guard added to handle undefined validators and an error hook on `sValidator` to centralize validation error handling.

## Impact

- Implements feature requested in issue `#5454`: let custom API routes declare Standard Schema–backed validators (e.g., Zod) for params, body, query, headers, and forms.
- Enables deterministic, typed request validation in custom routes without adding dependencies or forcing alternate routing patterns.
- Surface change: `registerApiRoute` options now accept `validators`; `ApiRoute` includes `validators` in its config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->