### PR TITLE
fix: chat regressions from MastraDBMessage unification (render boundary, network approvals, reload)

### DIFF
--- a/.changeset/ten-boats-jog.md
+++ b/.changeset/ten-boats-jog.md
@@ -1,0 +1,11 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/react': patch
+---
+
+Fixed Studio chat rendering regressions:
+
+- Streamed and uploaded files and images render again — the converter now reads the `mediaType`/`url` shape the SDK emits (with a fallback to the persisted `mimeType`/`data`).
+- Reasoning blocks keep their text after a page reload by reading `details` when `reasoning` is empty.
+- A message whose `dynamic-tool` failed is marked incomplete instead of complete.
+- Observational Memory badges update correctly on stream interruption and reload — the helpers now read the nested `content.parts` shape of stored messages.

--- a/.changeset/ten-donkeys-design.md
+++ b/.changeset/ten-donkeys-design.md
@@ -1,0 +1,10 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/react': patch
+---
+
+Fixed chat regressions in `useChat` and the message accumulator:
+
+- Network sub-agent approvals and suspensions are surfaced again — the `agent-execution-approval` and `agent-execution-suspended` stream chunks now populate `requireApprovalMetadata`/`suspendedTools`, so a suspended or approval-gated child agent shows its Approve/Decline UI and stays resumable.
+- A sub-agent's streamed child messages are preserved through the terminal tool result instead of being dropped at completion.
+- Reloading a thread restores pending tool approvals (the Approve/Decline buttons no longer vanish on refresh) and hides completion-feedback messages flagged `suppressFeedback`, matching live-stream behavior.

--- a/client-sdks/react/src/agent/hooks.test.ts
+++ b/client-sdks/react/src/agent/hooks.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { createElement } from 'react';
@@ -346,5 +347,90 @@ describe('useChat forwards clientTools', () => {
     const firstUserPart = userMessages[0]?.content.parts[0] as Record<string, unknown>;
     expect(firstUserPart.type).toBe('text');
     expect(firstUserPart.text).toBe('what is the weather');
+  });
+});
+
+// =============================================================================
+// INITIAL-MESSAGE RELOAD — REGRESSIONS
+// =============================================================================
+//
+// The deleted `resolveInitialMessages` normalized persisted (reloaded) messages
+// before they entered chat state. `useChat` now passes `initialMessages` through
+// untouched, dropping two behaviors that the playground render layer still
+// depends on.
+
+describe('useChat initial-message reload', () => {
+  it('exposes requireApprovalMetadata for a reloaded message with persisted pendingToolApprovals', async () => {
+    // The server persists a pending tool approval as content.metadata.pendingToolApprovals
+    // (no requireApprovalMetadata, no mode). The approval UI (tool-fallback) only reads
+    // requireApprovalMetadata, so the reload path must derive it — otherwise the
+    // Approve/Decline buttons vanish on refresh and the run cannot be resumed.
+    const initial: MastraDBMessage[] = [
+      {
+        id: 'm-approval',
+        role: 'assistant',
+        createdAt: new Date(),
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                toolCallId: 'tc-1',
+                toolName: 'sendEmail',
+                state: 'approval-requested',
+                args: { to: 'x' },
+              },
+            } as unknown as MastraDBMessage['content']['parts'][number],
+          ],
+          metadata: {
+            pendingToolApprovals: {
+              sendEmail: { toolCallId: 'tc-1', toolName: 'sendEmail', args: { to: 'x' }, runId: 'run-1' },
+            },
+          },
+        },
+      },
+    ];
+
+    const { result } = renderHook(() => useChat({ agentId: 'test-agent', initialMessages: initial }), { wrapper });
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+    const metadata = result.current.messages[0]?.content.metadata as Record<string, any> | undefined;
+    expect(metadata?.requireApprovalMetadata?.sendEmail?.toolCallId).toBe('tc-1');
+  });
+
+  it('drops a persisted assistant message flagged completionResult.suppressFeedback on reload', async () => {
+    const initial: MastraDBMessage[] = [
+      {
+        id: 'u-1',
+        role: 'user',
+        createdAt: new Date(),
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+        content: { format: 2, parts: [{ type: 'text', text: 'hi' }] },
+      },
+      {
+        id: 'm-suppressed',
+        role: 'assistant',
+        createdAt: new Date(),
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'internal completion feedback' }],
+          metadata: { completionResult: { passed: true, suppressFeedback: true } },
+        },
+      },
+    ];
+
+    const { result } = renderHook(() => useChat({ agentId: 'test-agent', initialMessages: initial }), { wrapper });
+
+    await waitFor(() => expect(result.current.messages.length).toBeGreaterThan(0));
+    const texts = result.current.messages.flatMap(m =>
+      m.content.parts.filter((p: any) => p.type === 'text').map((p: any) => p.text as string),
+    );
+    expect(texts).not.toContain('internal completion feedback');
   });
 });

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -12,6 +12,7 @@ import {
   accumulateNetworkChunk,
   finishStreamingAssistantMessage,
   fromCoreUserMessageToMastraDBMessage,
+  normalizeReloadedMessages,
 } from '../lib/mastra-db';
 import type { MastraDBMessageMetadata } from '../lib/mastra-db';
 import { useMastraClient } from '../mastra-client-context';
@@ -171,7 +172,7 @@ export const useChat = ({
   const [isRunning, setIsRunning] = useState(false);
 
   useEffect(() => {
-    const formattedMessages = initialMessages ?? [];
+    const formattedMessages = normalizeReloadedMessages(initialMessages ?? []);
     setMessages(formattedMessages);
     _currentRunId.current = extractRunIdFromMessages(formattedMessages);
   }, [initialMessages]);

--- a/client-sdks/react/src/lib/mastra-db/accumulator-network.test.ts
+++ b/client-sdks/react/src/lib/mastra-db/accumulator-network.test.ts
@@ -79,6 +79,24 @@ const toolExecutionApprovalChunk = (toolName: string, toolCallId: string, runId:
     payload: { toolName, toolCallId, args: { a: 1 }, runId },
   }) as unknown as NetworkChunkType;
 
+// Core emits these distinct top-level chunks when a child AGENT (agent-as-tool)
+// in a network suspends or requires approval (see packages/core/src/loop/network).
+const agentExecutionSuspendedChunk = (toolName: string, toolCallId: string, runId: string): NetworkChunkType =>
+  ({
+    type: 'agent-execution-suspended',
+    runId,
+    from: 'AGENT',
+    payload: { toolName, toolCallId, args: { a: 1 }, suspendPayload: { reason: 'await input' }, runId },
+  }) as unknown as NetworkChunkType;
+
+const agentExecutionApprovalChunk = (toolName: string, toolCallId: string, runId: string): NetworkChunkType =>
+  ({
+    type: 'agent-execution-approval',
+    runId,
+    from: 'AGENT',
+    payload: { toolName, toolCallId, args: { a: 1 }, runId },
+  }) as unknown as NetworkChunkType;
+
 const networkValidationEndChunk = (runId: string, passed: boolean): NetworkChunkType =>
   ({
     type: 'network-validation-end',
@@ -261,6 +279,21 @@ describe('accumulateNetworkChunk', () => {
     const approval = meta(lastMessage(result)).requireApprovalMetadata;
     expect(approval?.sendEmail?.toolCallId).toBe('tc-3');
     expect(approval?.sendEmail?.toolName).toBe('sendEmail');
+  });
+
+  it('writes suspendedTools metadata on agent-execution-suspended', () => {
+    const result = run([agentExecutionSuspendedChunk('subAgent', 'ac-sus', RUN_ID)], seedAssistant());
+    const suspended = meta(lastMessage(result)).suspendedTools;
+    expect(suspended?.subAgent?.toolCallId).toBe('ac-sus');
+    expect(suspended?.subAgent?.toolName).toBe('subAgent');
+    expect(suspended?.subAgent?.suspendPayload).toEqual({ reason: 'await input' });
+  });
+
+  it('writes requireApprovalMetadata on agent-execution-approval', () => {
+    const result = run([agentExecutionApprovalChunk('subAgent', 'ac-app', RUN_ID)], seedAssistant());
+    const approval = meta(lastMessage(result)).requireApprovalMetadata;
+    expect(approval?.subAgent?.toolCallId).toBe('ac-app');
+    expect(approval?.subAgent?.toolName).toBe('subAgent');
   });
 
   it('accumulates an approval continuation after requireApprovalMetadata', () => {

--- a/client-sdks/react/src/lib/mastra-db/accumulator.test.ts
+++ b/client-sdks/react/src/lib/mastra-db/accumulator.test.ts
@@ -1138,3 +1138,45 @@ describe('accumulateChunk - workflow tool finish', () => {
     expect((toolPart.toolInvocation as { result: unknown }).result).toEqual({ hits: 3 });
   });
 });
+
+// =============================================================================
+// SUB-AGENT (agent-as-tool) CHILD MESSAGES — REGRESSION
+// =============================================================================
+//
+// When a child AGENT streams (nested tool-calls + text) into a parent
+// agent-as-tool part, `accumulateAgentChunk` accumulates them into
+// `result.childMessages` while the parent part stays `state: 'call'`. The
+// terminal `tool-result` must preserve those accumulated childMessages — but the
+// terminal `isAgent` branch only merges them when `state === 'result'`, which
+// never holds during sub-agent streaming, so they are dropped.
+
+describe('accumulateChunk - sub-agent child messages', () => {
+  const agentNestedChunk = (parentToolCallId: string, type: string, payload: Record<string, unknown>): ChunkType =>
+    toolOutputChunk(parentToolCallId, { type, runId: RUN_ID, from: 'AGENT', payload });
+
+  it('preserves accumulated sub-agent childMessages through the terminal tool-result', () => {
+    const out = reduce([
+      startChunk(),
+      toolCallChunk('agent-1', 'weatherAgent', { city: 'sf' }),
+      // Child agent streams a nested tool-call and its text answer -> childMessages
+      agentNestedChunk('agent-1', 'tool-call', {
+        toolCallId: 'child-tc',
+        toolName: 'getWeather',
+        args: { city: 'sf' },
+      }),
+      agentNestedChunk('agent-1', 'text-delta', { text: 'It is sunny in SF.' }),
+      // Terminal agent tool-result
+      toolResultChunk('agent-1', { text: 'It is sunny in SF.' }),
+    ]);
+
+    const toolPart = out
+      .flatMap(m => m.content.parts)
+      .find(p => p.type === 'tool-invocation') as MastraToolInvocationPart;
+    expect(toolPart.toolInvocation.state).toBe('result');
+
+    const result = toolPart.toolInvocation.result as { childMessages?: Array<Record<string, unknown>> };
+    expect(result.childMessages).toBeDefined();
+    expect(result.childMessages?.some(c => c.type === 'tool' && c.toolName === 'getWeather')).toBe(true);
+    expect(result.childMessages?.some(c => c.type === 'text')).toBe(true);
+  });
+});

--- a/client-sdks/react/src/lib/mastra-db/accumulator.ts
+++ b/client-sdks/react/src/lib/mastra-db/accumulator.ts
@@ -1002,8 +1002,11 @@ export const accumulateChunk = ({ chunk, conversation, metadata }: AccumulateChu
               output = payloadResult;
             }
           } else if (isAgent) {
-            const existingOutput =
-              toolPart.toolInvocation.state === 'result' ? toolPart.toolInvocation.result : undefined;
+            // The parent agent tool part stays in state 'call' while the sub-agent
+            // streams (accumulateAgentChunk preserves the state), so read its
+            // accumulated result regardless of state — otherwise the streamed
+            // childMessages are dropped at finalization.
+            const existingOutput = toolPart.toolInvocation.result;
             const existingChild = (existingOutput as { childMessages?: unknown[] } | undefined)?.childMessages;
             output = existingOutput
               ? {
@@ -1687,6 +1690,51 @@ const handleAgentNetworkChunk = (
     }
 
     return replaceLast(conversation, withParts(lastMessage, parts));
+  }
+
+  if (chunk.type === 'agent-execution-approval') {
+    const lastMessage = lastAssistant(conversation);
+    if (!lastMessage) return conversation;
+    const existing = lastMessage.content.metadata?.requireApprovalMetadata ?? {};
+    return replaceLast(
+      conversation,
+      withMetadata(lastMessage, {
+        ...cloneMetadata(lastMessage.content.metadata),
+        mode: 'network',
+        requireApprovalMetadata: {
+          ...existing,
+          [(chunk.payload as any).toolName]: {
+            toolCallId: (chunk.payload as any).toolCallId,
+            toolName: (chunk.payload as any).toolName,
+            args: (chunk.payload as any).args,
+            runId: (chunk.payload as any).runId,
+          },
+        },
+      }),
+    );
+  }
+
+  if (chunk.type === 'agent-execution-suspended') {
+    const lastMessage = lastAssistant(conversation);
+    if (!lastMessage) return conversation;
+    const existing = lastMessage.content.metadata?.suspendedTools ?? {};
+    return replaceLast(
+      conversation,
+      withMetadata(lastMessage, {
+        ...cloneMetadata(lastMessage.content.metadata),
+        mode: 'network',
+        suspendedTools: {
+          ...existing,
+          [(chunk.payload as any).toolName]: {
+            toolCallId: (chunk.payload as any).toolCallId,
+            toolName: (chunk.payload as any).toolName,
+            args: (chunk.payload as any).args,
+            suspendPayload: (chunk.payload as any).suspendPayload,
+            runId: (chunk.payload as any).runId,
+          },
+        },
+      }),
+    );
   }
 
   if (chunk.type.startsWith('agent-execution-event-')) {

--- a/client-sdks/react/src/lib/mastra-db/index.ts
+++ b/client-sdks/react/src/lib/mastra-db/index.ts
@@ -6,6 +6,7 @@ export {
 } from './accumulator';
 export type { AccumulateChunkArgs, AccumulateNetworkChunkArgs } from './accumulator';
 export { fromCoreUserMessageToMastraDBMessage } from './fromCoreUserMessage';
+export { normalizeReloadedMessages } from './reload';
 export type {
   AccumulatorPart,
   BackgroundTaskEntry,

--- a/client-sdks/react/src/lib/mastra-db/reload.ts
+++ b/client-sdks/react/src/lib/mastra-db/reload.ts
@@ -1,0 +1,94 @@
+import type { MastraDBMessage } from '@mastra/core/agent/message-list';
+import type { MastraDBMessageMetadata } from './types';
+
+/**
+ * Reload normalization for persisted messages handed to `useChat` via
+ * `initialMessages`.
+ *
+ * The old `resolveInitialMessages` layer performed two reload-only conversions
+ * that the live streaming path does not cover. They are reinstated here so a
+ * reloaded thread behaves like a streamed one:
+ *
+ *  1. The server persists pending tool approvals as
+ *     `content.metadata.pendingToolApprovals`, but the approval UI reads
+ *     `content.metadata.requireApprovalMetadata` (gated on `mode`). Without the
+ *     conversion the Approve/Decline buttons vanish on refresh and the run cannot
+ *     be resumed.
+ *  2. Completion-feedback assistant messages flagged `suppressFeedback` are
+ *     persisted to memory but meant to stay hidden in the UI; without the filter
+ *     they reappear after a reload.
+ */
+
+type ApprovalEntry = { toolCallId?: string; toolName?: string; args?: unknown; runId?: string };
+
+const isToolResolved = (message: MastraDBMessage, toolCallId: string): boolean =>
+  message.content.parts.some(part => {
+    if (part.type === 'tool-invocation') {
+      const inv = part.toolInvocation as { toolCallId?: string; state?: string; result?: unknown };
+      return (
+        inv.toolCallId === toolCallId &&
+        (inv.state === 'result' || inv.state === 'output-error' || inv.state === 'output-denied' || inv.result != null)
+      );
+    }
+    const dyn = part as { type?: string; toolCallId?: string; output?: unknown };
+    return dyn.type === 'dynamic-tool' && dyn.toolCallId === toolCallId && dyn.output != null;
+  });
+
+const restorePendingApprovalMetadata = (message: MastraDBMessage): MastraDBMessage => {
+  if (message.role !== 'assistant') return message;
+
+  const metadata = message.content.metadata as
+    | (MastraDBMessageMetadata & { pendingToolApprovals?: Record<string, ApprovalEntry> })
+    | undefined;
+  if (!metadata) return message;
+
+  const pendingToolApprovals = metadata.pendingToolApprovals;
+  const suspendedTools = metadata.suspendedTools;
+  if (!pendingToolApprovals && !suspendedTools) return message;
+
+  const stillPending: Record<string, ApprovalEntry> = {};
+  if (pendingToolApprovals) {
+    for (const [key, approval] of Object.entries(pendingToolApprovals)) {
+      if (!approval || typeof approval !== 'object' || !approval.toolCallId) continue;
+      if (!isToolResolved(message, approval.toolCallId)) stillPending[key] = approval;
+    }
+  }
+
+  const hasPending = Object.keys(stillPending).length > 0;
+  if (!hasPending && !suspendedTools) return message;
+
+  return {
+    ...message,
+    content: {
+      ...message.content,
+      metadata: {
+        ...metadata,
+        mode: metadata.mode ?? 'stream',
+        ...(hasPending
+          ? {
+              requireApprovalMetadata: {
+                ...metadata.requireApprovalMetadata,
+                ...stillPending,
+              },
+            }
+          : {}),
+      },
+    },
+  };
+};
+
+const isSuppressedFeedbackMessage = (message: MastraDBMessage): boolean => {
+  if (message.role !== 'assistant') return false;
+  const metadata = message.content.metadata as
+    | { completionResult?: { suppressFeedback?: boolean }; isTaskCompleteResult?: { suppressFeedback?: boolean } }
+    | undefined;
+  return Boolean(metadata?.completionResult?.suppressFeedback || metadata?.isTaskCompleteResult?.suppressFeedback);
+};
+
+/**
+ * Apply the reload-only conversions to persisted `initialMessages`: drop
+ * suppressed completion-feedback messages and derive `requireApprovalMetadata`
+ * from persisted `pendingToolApprovals`.
+ */
+export const normalizeReloadedMessages = (messages: MastraDBMessage[]): MastraDBMessage[] =>
+  messages.filter(message => !isSuppressedFeedbackMessage(message)).map(restorePendingApprovalMetadata);

--- a/packages/playground/src/services/__tests__/om-parts-converter.test.ts
+++ b/packages/playground/src/services/__tests__/om-parts-converter.test.ts
@@ -1,0 +1,84 @@
+import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent/message-list';
+import { describe, expect, it } from 'vitest';
+
+import { injectBufferingEnds, markOmMarkersAsDisconnected, scanOmInitialState } from '../om-parts-converter';
+
+/**
+ * Build a `data-om-*` part. `data-${string}` parts are first-class
+ * `MastraMessagePart` union members, so no cast is needed.
+ */
+const omPart = (name: string, data: Record<string, unknown>): MastraMessagePart => ({
+  type: `data-${name}`,
+  data,
+});
+
+const assistantMessage = (parts: MastraMessagePart[], id = 'msg-1'): MastraDBMessage => ({
+  id,
+  role: 'assistant',
+  createdAt: new Date('2026-05-29T00:00:00.000Z'),
+  threadId: 'thread-1',
+  resourceId: 'resource-1',
+  content: { format: 2, parts, metadata: {} },
+});
+
+const partsOf = (message: MastraDBMessage) => message.content.parts as Array<{ type: string; data?: any }>;
+
+describe('markOmMarkersAsDisconnected', () => {
+  it('marks an in-progress observation-start marker as disconnected (reads content.parts)', () => {
+    const [message] = markOmMarkersAsDisconnected([
+      assistantMessage([omPart('om-observation-start', { cycleId: 'cycle-1' })]),
+    ]);
+
+    const part = partsOf(message)[0];
+    expect(part.type).toBe('data-om-observation-start');
+    expect(part.data?._state).toBe('disconnected');
+    expect(typeof part.data?.disconnectedAt).toBe('string');
+  });
+
+  it('leaves user messages untouched', () => {
+    const userMessage: MastraDBMessage = {
+      ...assistantMessage([omPart('om-observation-start', { cycleId: 'cycle-1' })], 'user-1'),
+      role: 'user',
+    };
+    const [message] = markOmMarkersAsDisconnected([userMessage]);
+    expect(partsOf(message)[0].data?._state).toBeUndefined();
+  });
+});
+
+describe('injectBufferingEnds', () => {
+  it('injects a synthetic buffering-end for an in-progress buffering-start (reads content.parts)', () => {
+    const [message] = injectBufferingEnds(
+      [assistantMessage([omPart('om-buffering-start', { cycleId: 'cycle-2', operationType: 'observation' })])],
+      { bufferedObservationChunks: [{ cycleId: 'cycle-2', messageTokens: 120, tokenCount: 40, observations: ['x'] }] },
+    );
+
+    const parts = partsOf(message);
+    expect(parts).toHaveLength(2);
+    expect(parts[1].type).toBe('data-om-buffering-end');
+    expect(parts[1].data?.cycleId).toBe('cycle-2');
+    expect(parts[1].data?.tokensBuffered).toBe(120);
+    expect(parts[1].data?.observations).toEqual(['x']);
+  });
+
+  it('does not inject an end for an already-disconnected buffering-start', () => {
+    const [message] = injectBufferingEnds([
+      assistantMessage([omPart('om-buffering-start', { cycleId: 'cycle-3', disconnectedAt: 'yes' })]),
+    ]);
+    expect(partsOf(message)).toHaveLength(1);
+  });
+});
+
+describe('scanOmInitialState', () => {
+  it('collects activation cycle ids and the last progress part from content.parts', () => {
+    const { activatedCycleIds, lastProgress } = scanOmInitialState([
+      assistantMessage([
+        omPart('om-activation', { cycleId: 'cycle-a' }),
+        omPart('om-status', { tokensObserved: 100 }),
+        omPart('om-status', { tokensObserved: 250 }),
+      ]),
+    ]);
+
+    expect(activatedCycleIds).toEqual(['cycle-a']);
+    expect(lastProgress).toEqual({ tokensObserved: 250 });
+  });
+});

--- a/packages/playground/src/services/__tests__/to-assistant-ui-message.test.ts
+++ b/packages/playground/src/services/__tests__/to-assistant-ui-message.test.ts
@@ -253,3 +253,87 @@ describe('toAssistantUIMessage network routing JSON reconstruction', () => {
     expect(invalid.content[0]).toMatchObject({ type: 'text', text: '{"isNetwork": true' });
   });
 });
+
+describe('toAssistantUIMessage file and image parts', () => {
+  /**
+   * The stream accumulator emits file parts in the V5 shape `{ mediaType, url }`
+   * (see client-sdks/react/src/lib/mastra-db/accumulator.ts: it casts to
+   * `MastraMessagePart` because the V4-typed union describes `{ mimeType, data }`).
+   * User uploads via `fromCoreUserMessage` produce the same V5 shape. The converter
+   * receives exactly this at render time, so we build it with a single narrow
+   * boundary cast (mirroring the accumulator) to reflect the real runtime input.
+   */
+  const streamedFilePart = (part: { mediaType: string; url: string; filename?: string }): MastraMessagePart =>
+    ({ type: 'file', ...part }) as unknown as MastraMessagePart;
+
+  it('renders a streamed image file part (mediaType/url) as an image content part', () => {
+    const dataUrl =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
+    const { content } = toAssistantUIMessage(
+      assistantMessage([streamedFilePart({ mediaType: 'image/png', url: dataUrl })]),
+    );
+    if (typeof content === 'string') throw new Error('expected structured content parts');
+
+    const part = content[0];
+    expect(part.type).toBe('image');
+    if (part.type !== 'image') throw new Error('expected image');
+    expect(part.image).toBe(dataUrl);
+  });
+
+  it('renders a streamed non-image file part with its media type and data', () => {
+    const dataUrl = 'data:application/pdf;base64,JVBERi0xLjQ=';
+    const { content } = toAssistantUIMessage(
+      assistantMessage([streamedFilePart({ mediaType: 'application/pdf', url: dataUrl, filename: 'doc.pdf' })]),
+    );
+    if (typeof content === 'string') throw new Error('expected structured content parts');
+
+    const part = content[0];
+    expect(part.type).toBe('file');
+    if (part.type !== 'file') throw new Error('expected file');
+    expect(part.mimeType).toBe('application/pdf');
+    expect(part.data).toBe(dataUrl);
+  });
+});
+
+describe('toAssistantUIMessage reasoning reload', () => {
+  /**
+   * Persisted reasoning parts arrive from the DB with an empty `reasoning` string
+   * and the actual thinking text inside `details` (AIV5Adapter writes
+   * `reasoning: '', details: [{ type: 'text', text }]`, and core's own reader
+   * falls back to `details` when `reasoning` is empty). On reload the converter
+   * receives this shape, so the visible reasoning text must come from `details`.
+   */
+  const persistedReasoningPart = (text: string): MastraMessagePart =>
+    ({ type: 'reasoning', reasoning: '', details: [{ type: 'text', text }] }) as MastraMessagePart;
+
+  it('renders persisted reasoning text from details when reasoning is empty', () => {
+    const { content } = toAssistantUIMessage(
+      assistantMessage([persistedReasoningPart('Let me think about this step by step.')]),
+    );
+    if (typeof content === 'string') throw new Error('expected structured content parts');
+
+    const part = content[0];
+    expect(part.type).toBe('reasoning');
+    if (part.type !== 'reasoning') throw new Error('expected reasoning');
+    expect(part.text).toBe('Let me think about this step by step.');
+  });
+});
+
+describe('toAssistantUIMessage status from dynamic-tool errors', () => {
+  it('marks a message with a failed dynamic-tool as incomplete', () => {
+    const message = assistantMessage([
+      dynamicToolPart({
+        type: 'dynamic-tool',
+        toolCallId: 'call-dyn-err',
+        toolName: 'some-network-tool',
+        input: {},
+        state: 'output-error',
+        errorText: 'sub-agent failed',
+      }),
+    ]);
+
+    const { status } = toAssistantUIMessage(message);
+
+    expect(status).toEqual({ type: 'incomplete', reason: 'error' });
+  });
+});

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -8,7 +8,13 @@ import { useMastraClient, useChat } from '@mastra/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
-import { buildGlobalOmPartsByCycleId, convertOmPartsInMastraMessage } from './om-parts-converter';
+import {
+  buildGlobalOmPartsByCycleId,
+  convertOmPartsInMastraMessage,
+  injectBufferingEnds,
+  markOmMarkersAsDisconnected,
+  scanOmInitialState,
+} from './om-parts-converter';
 import {
   buildMaxStepsStreamErrorMessage,
   buildStreamErrorMessage,
@@ -235,118 +241,6 @@ export function MastraRuntimeProvider({
     }
   };
 
-  // Helper to mark in-progress OM markers as disconnected in messages.
-  // Preserves the original part type (keeps start markers as start markers)
-  // so the badge stays anchored at the correct position. Only adds disconnection
-  // metadata to the data payload.
-  const markOmMarkersAsDisconnected = (msgs: any[]) => {
-    return msgs.map(msg => {
-      if (msg.role !== 'assistant') return msg;
-
-      // Handle both 'parts' (v2/v3) and 'content' (legacy) message formats
-      const partsKey = msg.parts ? 'parts' : msg.content ? 'content' : null;
-      if (!partsKey || !Array.isArray(msg[partsKey])) return msg;
-
-      const updatedParts = msg[partsKey].map((part: any) => {
-        // Mark raw start markers as disconnected (keep original type for badge anchoring)
-        if (part.type === 'data-om-observation-start' || part.type === 'data-om-buffering-start') {
-          return {
-            ...part,
-            data: {
-              ...part.data,
-              disconnectedAt: new Date().toISOString(),
-              _state: 'disconnected',
-            },
-          };
-        }
-        // Also check for already-converted tool-call format
-        if (part.type === 'tool-call' && part.toolName === 'mastra-memory-om-observation') {
-          const omData = part.metadata?.omData || part.args;
-          // If it's in loading state (no completedAt, failedAt, or disconnectedAt), mark as disconnected
-          if (!omData?.completedAt && !omData?.failedAt && !omData?.disconnectedAt) {
-            return {
-              ...part,
-              metadata: {
-                ...part.metadata,
-                omData: {
-                  ...omData,
-                  disconnectedAt: new Date().toISOString(),
-                  _state: 'disconnected',
-                },
-              },
-            };
-          }
-        }
-        return part;
-      });
-
-      return { ...msg, [partsKey]: updatedParts };
-    });
-  };
-
-  // Mark in-progress buffering badges as complete after buffer-status resolves.
-  // Injects synthetic data-om-buffering-end parts so convertOmPartsInMastraMessage
-  // sees a matching end for each in-progress start. Uses the record from awaitBufferStatus
-  // to populate token counts and observations for the badge display.
-  const markBufferingBadgesAsComplete = (msgs: any[], record?: any) => {
-    // Build a lookup from cycleId to chunk data for observation buffering
-    const chunksByCycleId = new Map<string, any>();
-    if (record?.bufferedObservationChunks) {
-      for (const chunk of record.bufferedObservationChunks) {
-        if (chunk.cycleId) {
-          chunksByCycleId.set(chunk.cycleId, chunk);
-        }
-      }
-    }
-
-    return msgs.map(msg => {
-      if (msg.role !== 'assistant') return msg;
-
-      const partsKey = msg.parts ? 'parts' : msg.content ? 'content' : null;
-      if (!partsKey || !Array.isArray(msg[partsKey])) return msg;
-
-      const newParts: any[] = [];
-      let changed = false;
-
-      for (const part of msg[partsKey]) {
-        newParts.push(part);
-        // For each buffering-start that isn't already disconnected, inject a synthetic buffering-end
-        if (part.type === 'data-om-buffering-start' && part.data?.cycleId && !part.data?.disconnectedAt) {
-          const cycleId = part.data.cycleId;
-          const opType = part.data.operationType;
-
-          let endData: Record<string, any> = {
-            cycleId,
-            operationType: opType,
-            completedAt: new Date().toISOString(),
-          };
-
-          if (opType === 'observation') {
-            // Match chunk by cycleId for observation buffering
-            const chunk = chunksByCycleId.get(cycleId);
-            if (chunk) {
-              endData.tokensBuffered = chunk.messageTokens;
-              endData.bufferedTokens = chunk.tokenCount;
-              endData.observations = chunk.observations;
-            }
-          } else if (opType === 'reflection') {
-            // Use aggregate reflection data from the record
-            if (record) {
-              endData.tokensBuffered = record.bufferedReflectionInputTokens;
-              endData.bufferedTokens = record.bufferedReflectionTokens;
-              endData.observations = record.bufferedReflection;
-            }
-          }
-
-          newParts.push({ type: 'data-om-buffering-end', data: endData });
-          changed = true;
-        }
-      }
-
-      return changed ? { ...msg, [partsKey]: newParts } : msg;
-    });
-  };
-
   // Helper to reset OM streaming state when stream is interrupted
   // (user cancel, network error, process exit, etc.)
   const resetObservationalMemoryStreamState = () => {
@@ -367,19 +261,9 @@ export function MastraRuntimeProvider({
   // On initial load, scan messages for activation markers and the last progress part.
   // This ensures buffering badges show as activated and token counts are accurate on reload.
   useEffect(() => {
-    const allMessages = [...(initialMessages || [])];
-    let lastProgress: any = null;
-    for (const msg of allMessages) {
-      const parts = (msg as any).parts || (msg as any).content || [];
-      if (!Array.isArray(parts)) continue;
-      for (const part of parts) {
-        if (part?.type === 'data-om-activation' && part?.data?.cycleId) {
-          markCycleIdActivated(part.data.cycleId);
-        }
-        if (part?.type === 'data-om-status' && part?.data) {
-          lastProgress = part.data;
-        }
-      }
+    const { activatedCycleIds, lastProgress } = scanOmInitialState(initialMessages || []);
+    for (const cycleId of activatedCycleIds) {
+      markCycleIdActivated(cycleId);
     }
     // Restore the last known progress so sidebar shows accurate token counts on load
     if (lastProgress) {
@@ -580,7 +464,7 @@ export function MastraRuntimeProvider({
             baseClient
               .awaitBufferStatus({ agentId, resourceId: agentId, threadId })
               .then(result => {
-                setMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
+                setMessages(prev => injectBufferingEnds(prev, result?.record));
                 void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
                 void queryClient.invalidateQueries({ queryKey: ['memory-status', agentId] });
               })
@@ -600,7 +484,7 @@ export function MastraRuntimeProvider({
         baseClient
           .awaitBufferStatus({ agentId, resourceId: agentId, threadId })
           .then(result => {
-            setMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
+            setMessages(prev => injectBufferingEnds(prev, result?.record));
 
             void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
             void queryClient.invalidateQueries({ queryKey: ['memory-status', agentId] });
@@ -640,7 +524,7 @@ export function MastraRuntimeProvider({
       baseClient
         .awaitBufferStatus({ agentId, resourceId: agentId, threadId })
         .then(result => {
-          setMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
+          setMessages(prev => injectBufferingEnds(prev, result?.record));
 
           void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
           void queryClient.invalidateQueries({ queryKey: ['memory-status', agentId] });

--- a/packages/playground/src/services/om-parts-converter.ts
+++ b/packages/playground/src/services/om-parts-converter.ts
@@ -205,3 +205,145 @@ export const convertOmPartsInMastraMessage = (
     },
   };
 };
+
+// -----------------------------------------------------------------------------
+// Reload / interruption helpers for OM badges.
+//
+// `useChat` returns canonical `MastraDBMessage`s, where parts live at
+// `message.content.parts` (and `content` is an object, not an array). These
+// helpers therefore read/write `content.parts` directly. They are typed against
+// `MastraDBMessage[]` on purpose: the previous in-provider versions were typed
+// `any[]` and silently no-oped on the nested shape.
+// -----------------------------------------------------------------------------
+
+const mapAssistantParts = (
+  messages: MastraDBMessage[],
+  mapParts: (parts: any[]) => { parts: any[]; changed: boolean },
+): MastraDBMessage[] =>
+  messages.map(msg => {
+    if (msg.role !== 'assistant') return msg;
+    const parts = msg.content?.parts;
+    if (!Array.isArray(parts)) return msg;
+
+    const { parts: nextParts, changed } = mapParts(parts as any[]);
+    if (!changed) return msg;
+
+    return {
+      ...msg,
+      content: { ...msg.content, parts: nextParts as MastraDBMessage['content']['parts'] },
+    };
+  });
+
+/**
+ * Mark in-progress OM markers as disconnected when a stream is interrupted
+ * (user cancel, network error, process exit). Preserves the original part type so
+ * the badge stays anchored, only adding disconnection metadata to the data payload.
+ */
+export const markOmMarkersAsDisconnected = (messages: MastraDBMessage[]): MastraDBMessage[] =>
+  mapAssistantParts(messages, parts => {
+    let changed = false;
+    const nextParts = parts.map((part: any) => {
+      // Raw start markers (keep original type for badge anchoring).
+      if (part.type === 'data-om-observation-start' || part.type === 'data-om-buffering-start') {
+        changed = true;
+        return {
+          ...part,
+          data: { ...part.data, disconnectedAt: new Date().toISOString(), _state: 'disconnected' },
+        };
+      }
+      // Already-converted tool-call format still in a loading state.
+      if (part.type === 'tool-call' && part.toolName === OM_TOOL_NAME) {
+        const omData = part.metadata?.omData || part.args;
+        if (!omData?.completedAt && !omData?.failedAt && !omData?.disconnectedAt) {
+          changed = true;
+          return {
+            ...part,
+            metadata: {
+              ...part.metadata,
+              omData: { ...omData, disconnectedAt: new Date().toISOString(), _state: 'disconnected' },
+            },
+          };
+        }
+      }
+      return part;
+    });
+    return { parts: nextParts, changed };
+  });
+
+/**
+ * Inject synthetic `data-om-buffering-end` parts after buffer-status resolves so
+ * `convertOmPartsInMastraMessage` sees a matching end for each in-progress start.
+ * Uses the record from `awaitBufferStatus` to populate token counts/observations.
+ */
+export const injectBufferingEnds = (messages: MastraDBMessage[], record?: any): MastraDBMessage[] => {
+  const chunksByCycleId = new Map<string, any>();
+  if (record?.bufferedObservationChunks) {
+    for (const chunk of record.bufferedObservationChunks) {
+      if (chunk.cycleId) chunksByCycleId.set(chunk.cycleId, chunk);
+    }
+  }
+
+  return mapAssistantParts(messages, parts => {
+    const newParts: any[] = [];
+    let changed = false;
+
+    for (const part of parts) {
+      newParts.push(part);
+      if (part.type === 'data-om-buffering-start' && part.data?.cycleId && !part.data?.disconnectedAt) {
+        const cycleId = part.data.cycleId;
+        const opType = part.data.operationType;
+
+        const endData: Record<string, any> = {
+          cycleId,
+          operationType: opType,
+          completedAt: new Date().toISOString(),
+        };
+
+        if (opType === 'observation') {
+          const chunk = chunksByCycleId.get(cycleId);
+          if (chunk) {
+            endData.tokensBuffered = chunk.messageTokens;
+            endData.bufferedTokens = chunk.tokenCount;
+            endData.observations = chunk.observations;
+          }
+        } else if (opType === 'reflection' && record) {
+          endData.tokensBuffered = record.bufferedReflectionInputTokens;
+          endData.bufferedTokens = record.bufferedReflectionTokens;
+          endData.observations = record.bufferedReflection;
+        }
+
+        newParts.push({ type: 'data-om-buffering-end', data: endData });
+        changed = true;
+      }
+    }
+
+    return { parts: newParts, changed };
+  });
+};
+
+/**
+ * Scan persisted messages on initial load for OM activation markers and the last
+ * progress part, so buffering badges show as activated and token counts are
+ * accurate after a reload.
+ */
+export const scanOmInitialState = (
+  messages: MastraDBMessage[],
+): { activatedCycleIds: string[]; lastProgress: Record<string, unknown> | null } => {
+  const activatedCycleIds: string[] = [];
+  let lastProgress: Record<string, unknown> | null = null;
+
+  for (const msg of messages) {
+    const parts = msg?.content?.parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts as any[]) {
+      if (part?.type === 'data-om-activation' && part?.data?.cycleId) {
+        activatedCycleIds.push(part.data.cycleId);
+      }
+      if (part?.type === 'data-om-status' && part?.data) {
+        lastProgress = part.data;
+      }
+    }
+  }
+
+  return { activatedCycleIds, lastProgress };
+};

--- a/packages/playground/src/services/to-assistant-ui-message.ts
+++ b/packages/playground/src/services/to-assistant-ui-message.ts
@@ -214,7 +214,20 @@ const toContentPart = (message: MastraDBMessage, part: MastraMessagePart): Conte
   }
 
   if (part.type === 'reasoning') {
-    return { type: 'reasoning', text: part.reasoning, metadata: getPartMetadata(message, part) } as ContentPart;
+    // Persisted reasoning parts arrive with an empty `reasoning` string and the
+    // text in `details` (AIV5Adapter writes `reasoning: '', details: [...]`), so
+    // fall back to the joined `details` text on reload, mirroring core's reader.
+    const reasoningPart = part as typeof part & { details?: Array<{ type?: string; text?: string }> };
+    const text =
+      reasoningPart.reasoning ||
+      (reasoningPart.details ?? [])
+        .filter(
+          (detail): detail is { type: 'text'; text: string } =>
+            detail?.type === 'text' && typeof detail.text === 'string',
+        )
+        .map(detail => detail.text)
+        .join('');
+    return { type: 'reasoning', text, metadata: getPartMetadata(message, part) } as ContentPart;
   }
 
   if (part.type === 'source') {
@@ -239,14 +252,22 @@ const toContentPart = (message: MastraDBMessage, part: MastraMessagePart): Conte
   }
 
   if (part.type === 'file') {
-    if (part.mimeType?.includes('image/')) {
-      return { type: 'image', image: part.data, metadata: getPartMetadata(message, part) } as ContentPart;
+    // The stream accumulator and `fromCoreUserMessage` emit V5-shaped file parts
+    // (`{ mediaType, url }`), while persisted/reloaded parts keep the V4 shape
+    // (`{ mimeType, data }`). The union is typed V4, so read both with a fallback
+    // to render streamed and persisted files/images consistently.
+    const filePart = part as typeof part & { mediaType?: string; url?: string };
+    const mediaType = filePart.mediaType ?? filePart.mimeType;
+    const fileData = filePart.url ?? filePart.data;
+
+    if (mediaType?.includes('image/')) {
+      return { type: 'image', image: fileData, metadata: getPartMetadata(message, part) } as ContentPart;
     }
 
     return {
       type: 'file',
-      mimeType: part.mimeType,
-      data: part.data,
+      mimeType: mediaType,
+      data: fileData,
       metadata: getPartMetadata(message, part),
     } as ContentPart;
   }
@@ -305,16 +326,23 @@ const toStatus = (message: MastraDBMessage): MessageStatus | undefined => {
   );
   if (hasStreamingText) return { type: 'running' };
 
-  const hasApprovalTool = message.content.parts.some(
-    part => part.type === 'tool-invocation' && part.toolInvocation.state === 'approval-requested',
-  );
+  // A tool part's state lives on `toolInvocation.state` for `tool-invocation`
+  // parts and directly on the part for runtime-only `dynamic-tool` parts (network
+  // sub-agents, OM badges). Read both so a failed/pending dynamic-tool drives the
+  // message status instead of being silently marked complete.
+  const toolState = (part: MastraMessagePart): string | undefined => {
+    if (part.type === 'tool-invocation') return part.toolInvocation.state;
+    if ((part.type as string) === 'dynamic-tool') return (part as { state?: string }).state;
+    return undefined;
+  };
+
+  const hasApprovalTool = message.content.parts.some(part => toolState(part) === 'approval-requested');
   if (hasApprovalTool) return { type: 'requires-action', reason: 'tool-calls' };
 
-  const hasErrorTool = message.content.parts.some(
-    part =>
-      part.type === 'tool-invocation' &&
-      (part.toolInvocation.state === 'output-error' || part.toolInvocation.state === 'output-denied'),
-  );
+  const hasErrorTool = message.content.parts.some(part => {
+    const state = toolState(part);
+    return state === 'output-error' || state === 'output-denied';
+  });
   if (hasErrorTool) return { type: 'incomplete', reason: 'error' };
 
   return { type: 'complete', reason: 'stop' };


### PR DESCRIPTION
Fixes for the chat/`useChat` scope of #17208 (MastraDBMessage unification), so it can be merged into that PR. Each fix is driven by a failing test first (TDD red → green). All tests in `@mastra/react` and `@internal/playground` pass.

## Regressions fixed

**Render boundary — `packages/playground/src/services/to-assistant-ui-message.ts`**
- **Files/images rendered blank.** The converter read `part.mimeType`/`part.data`, but the accumulator and `fromCoreUserMessage` emit V5-shaped `{ mediaType, url }`. Now reads `mediaType`/`url` with a fallback to the persisted `mimeType`/`data`, so streamed and uploaded files/images render again.
- **Reasoning empty after reload.** Persisted reasoning parts carry `reasoning: ''` with the text in `details[]`. Now falls back to the joined `details` text, matching core's own reader.
- **`dynamic-tool` errors marked complete.** `toStatus` only inspected `tool-invocation`; a failed `dynamic-tool` is now marked `incomplete`.

**Stream accumulator — `client-sdks/react/src/lib/mastra-db/accumulator.ts`**
- **Network sub-agent approvals/suspensions dropped.** `agent-execution-approval` / `agent-execution-suspended` fell through to a no-op (only the tool/workflow variants were handled). They now populate `requireApprovalMetadata` / `suspendedTools`, mirroring `handleToolNetworkChunk`, so a suspended or approval-gated child agent surfaces its Approve/Decline UI and stays resumable.
- **Sub-agent `childMessages` dropped at finalization.** The terminal AGENT `tool-result` only merged accumulated `childMessages` when the part state was `result`, but the parent agent part stays in state `call` during the sub-stream. It now reads the accumulated result regardless of state.

**Reload normalization — `client-sdks/react/src/agent/hooks.ts` + new `lib/mastra-db/reload.ts`**
- **Approval buttons lost on reload.** The deleted `resolveInitialMessages` conversion is reinstated in `useChat`: persisted `pendingToolApprovals` are converted to `requireApprovalMetadata` (filtering already-resolved tools, stamping `mode: 'stream'`), so a thread reloaded mid-approval keeps its Approve/Decline buttons.
- **Suppressed completion feedback reappeared on reload.** Assistant messages flagged `completionResult.suppressFeedback` are dropped on reload.

**Observational Memory — `packages/playground/src/services/om-parts-converter.ts` + `mastra-runtime-provider.tsx`**
- Three OM helpers (disconnect markers, inject buffering-ends, mount-scan) still read top-level `msg.parts` and silently no-oped on `MastraDBMessage` (parts live under `content.parts`, and they were typed `any[]`). Extracted to pure, `MastraDBMessage[]`-typed, exported helpers (`markOmMarkersAsDisconnected`, `injectBufferingEnds`, `scanOmInitialState`) so the compiler guards the shape, and wired them into the provider. OM badges now update on stream interruption and reload.

## Tests
- New unit coverage for the converter (file/image, reasoning reload, dynamic-tool status), the OM helpers, and the SDK accumulator/hooks regressions (network agent approvals, childMessages preservation, reload approvals/suppressFeedback).
- `pnpm --filter @mastra/react test` → 148 passing
- `pnpm --filter @internal/playground typecheck` → clean; chat/services/badge suites → 62 passing
- `pnpm --filter @mastra/react build:js` → builds

## Not addressed here (follow-ups, mostly from CodeRabbit)
- `accumulator.ts` large `Uint8Array` binary encoding via `String.fromCharCode(...)` (RangeError risk).
- `fromCoreUserMessage.ts` non-string/non-URL image/file payloads → `url: ''` (silent drop).
- `stream-error-message.ts` collision-prone IDs.
- `accumulator.ts` network step-finish `findIndex` finalizing the wrong text part.

## Notes
- Two changesets are included (`@mastra/react`, `@internal/playground`); feel free to fold the `@mastra/react` one into the consolidated branch changeset.
- The Observational Memory fixes are verifiable against the kitchen-sink OM agents; the file/image, reasoning, and approval fixes need a Studio reload check.
