### PR TITLE
fix(mcp): close stale transport on connection close to prevent SSE session leak

### DIFF
--- a/.changeset/fluffy-garlics-admire.md
+++ b/.changeset/fluffy-garlics-admire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Close the stale MCP transport before reconnecting so SSE connections no longer leak orphaned EventSource instances and accumulate server-side sessions on implicit reconnect.

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -3101,3 +3101,50 @@ describe('MastraMCPClient - custom fetch failure modes (auth-token loop)', () =>
     tokenWaiters.forEach(cancel => cancel());
   }, 20000);
 });
+
+describe('InternalMastraMCPClient - transport cleanup on close (issue #16693)', () => {
+  let testServer: Awaited<ReturnType<typeof setupTestServer>>;
+  let client: InternalMastraMCPClient;
+
+  beforeEach(async () => {
+    testServer = await setupTestServer(false);
+    client = new InternalMastraMCPClient({
+      name: 'test-close-cleanup-client',
+      server: { url: testServer.baseUrl },
+    });
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    await client?.disconnect().catch(() => {});
+    await testServer?.mcpServer.close().catch(() => {});
+    await testServer?.serverTransport?.close().catch(() => {});
+    testServer?.httpServer.close();
+  });
+
+  it('closes and clears the stale transport when the connection closes', async () => {
+    const staleTransport = (client as any).transport;
+    expect(staleTransport).toBeDefined();
+    const closeSpy = vi.spyOn(staleTransport, 'close');
+
+    // Simulate a server-initiated close firing the SDK client's onclose handler.
+    (client as any).client.onclose?.();
+
+    expect((client as any).transport).toBeUndefined();
+    expect((client as any).isConnected).toBeNull();
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+
+    // Let the fire-and-forget close settle.
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+
+  it('does not throw when the stale transport close rejects', async () => {
+    const staleTransport = (client as any).transport;
+    vi.spyOn(staleTransport, 'close').mockRejectedValueOnce(new Error('already closed'));
+
+    expect(() => (client as any).client.onclose?.()).not.toThrow();
+    expect((client as any).transport).toBeUndefined();
+    expect((client as any).isConnected).toBeNull();
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+});

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -499,7 +499,15 @@ export class InternalMastraMCPClient extends MastraBase {
         const originalOnClose = this.client.onclose;
         this.client.onclose = () => {
           this.log('debug', `MCP server connection closed`);
+          // Close the stale transport before any reconnect so its EventSource/session
+          // can't keep retrying and leak server-side sessions (issue #16693). Clear
+          // synchronously first so a concurrent connect() sees a clean slate.
+          const staleTransport = this.transport;
+          this.transport = undefined;
           this.isConnected = null;
+          if (staleTransport) {
+            void staleTransport.close().catch(() => {});
+          }
           if (typeof originalOnClose === 'function') {
             originalOnClose();
           }


### PR DESCRIPTION
## Summary

- Close and clear the stale MCP transport in the `onclose` handler before any reconnect, so the previous SSE `EventSource` (or StreamableHTTP session) no longer keeps its built-in retry loop alive and accumulates orphaned server-side sessions.
- Mirrors the existing cleanup in `forceReconnect()`; clears `transport`/`isConnected` synchronously so a concurrent `connect()` sees a clean slate, then closes the old transport fire-and-forget.

## Test plan

- `pnpm --filter ./packages/mcp test:client`

Closes #16693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an MCP server connection closes unexpectedly, the client used to leave the old connection handler running in the background, which kept retrying and creating new orphaned sessions on the server. This PR fixes that by properly shutting down the old connection handler before attempting to reconnect, preventing the accumulation of abandoned server-side sessions.

## Overview

This PR fixes an SSE (Server-Sent Events) transport leak in `InternalMastraMCPClient` that was causing server-side session map growth when connections closed unexpectedly.

**Issue:** When the server triggered a connection close (due to restart, network timeout, etc.), the `onclose` handler would reset the `isConnected` flag but fail to close or clear the `transport` reference. The orphaned `EventSource` remained in CONNECTING state with its built-in retry loop still active, continuously creating new SSE handshakes and accumulating orphaned server sessions.

**Solution:** The `onclose` handler now performs cleanup that mirrors the existing `forceReconnect()` behavior:
1. Synchronously clear `this.transport` and capture it as `staleTransport`
2. Reset `this.isConnected` to `null`
3. Asynchronously close the stale transport (fire-and-forget, suppressing any errors)

This ensures the implicit reconnect path presents a clean slate to concurrent `connect()` calls, preventing the retry loop from creating additional orphaned sessions.

## Changes

- **packages/mcp/src/client/client.ts:** Updated the `onclose` handler in `InternalMastraMCPClient.connect()` to explicitly close the stale transport before triggering reconnect behavior, with synchronous reference clearing followed by asynchronous transport closure.

- **packages/mcp/src/client/client.test.ts:** Added a new test suite verifying that `InternalMastraMCPClient` properly closes stale transport on connection close, including tests for successful closure and error handling when the transport close fails.

- **.changeset/fluffy-garlics-admire.md:** Patch release entry documenting the fix for the EventSource leak.

## Related Issues

Closes `#16693`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->