### PR TITLE
fix(memory): include role, content, and created_at in vector metadata

### DIFF
--- a/.changeset/blue-crabs-repeat.md
+++ b/.changeset/blue-crabs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Include role, content, and created_at in vector embedding metadata when saving and updating messages, so consumers that build search results directly from vector metadata get complete message data instead of only the lookup ids.

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -1766,6 +1766,94 @@ describe('Memory', () => {
     });
   });
 
+  describe('vector metadata completeness (issue #16380)', () => {
+    const embeddingDim = 384;
+    const fakeEmbedding = new Array(embeddingDim).fill(0.1);
+
+    function setup() {
+      const mockVector: MastraVector = {
+        createIndex: vi.fn().mockResolvedValue(undefined),
+        upsert: vi.fn().mockResolvedValue(undefined),
+        query: vi.fn().mockResolvedValue([]),
+        listIndexes: vi.fn().mockResolvedValue([]),
+        deleteVectors: vi.fn().mockResolvedValue(undefined),
+        describeIndex: vi.fn().mockResolvedValue({ dimension: embeddingDim }),
+        id: 'mock-vector',
+      } as any;
+      const mockEmbedder = {
+        doEmbed: vi.fn().mockResolvedValue({ embeddings: [fakeEmbedding] }),
+        modelId: 'mock-384-embedder',
+        specificationVersion: 'v1',
+        provider: 'mock',
+      } as any;
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        vector: mockVector,
+        embedder: mockEmbedder,
+        options: { semanticRecall: { scope: 'thread' }, lastMessages: 10, generateTitle: false },
+      });
+      return { memory, mockVector };
+    }
+
+    it('saveMessages writes role, content, and created_at to vector metadata', async () => {
+      const { memory, mockVector } = setup();
+      await memory.createThread({ threadId: 'meta-thread', resourceId: 'meta-resource' });
+
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'meta-msg-1',
+            role: 'user',
+            content: { format: 2, parts: [{ type: 'text', text: 'hello world' }], content: 'hello world' },
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            threadId: 'meta-thread',
+            resourceId: 'meta-resource',
+          } as MastraDBMessage,
+        ],
+      });
+
+      expect(mockVector.upsert).toHaveBeenCalled();
+      const metadata = vi.mocked(mockVector.upsert).mock.calls[0]![0].metadata[0] as Record<string, unknown>;
+      expect(metadata.message_id).toBe('meta-msg-1');
+      expect(metadata.thread_id).toBe('meta-thread');
+      expect(metadata.resource_id).toBe('meta-resource');
+      expect(metadata.role).toBe('user');
+      expect(metadata.content).toBe('hello world');
+      expect(metadata.created_at).toBe('2024-01-01T00:00:00.000Z');
+    });
+
+    it('updateMessages writes role, content, and created_at from the stored message', async () => {
+      const { memory, mockVector } = setup();
+      await memory.createThread({ threadId: 'meta-thread-2', resourceId: 'meta-resource-2' });
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'meta-msg-2',
+            role: 'user',
+            content: { format: 2, parts: [{ type: 'text', text: 'original' }], content: 'original' },
+            createdAt: new Date('2024-02-02T00:00:00.000Z'),
+            threadId: 'meta-thread-2',
+            resourceId: 'meta-resource-2',
+          } as MastraDBMessage,
+        ],
+      });
+      vi.mocked(mockVector.upsert).mockClear();
+
+      await memory.updateMessages({
+        messages: [
+          { id: 'meta-msg-2', content: { format: 2, parts: [{ type: 'text', text: 'updated text' }] } } as any,
+        ],
+      });
+
+      expect(mockVector.upsert).toHaveBeenCalled();
+      const metadata = vi.mocked(mockVector.upsert).mock.calls[0]![0].metadata[0] as Record<string, unknown>;
+      expect(metadata.message_id).toBe('meta-msg-2');
+      expect(metadata.role).toBe('user');
+      expect(metadata.content).toBe('updated text');
+      expect(metadata.created_at).toBe('2024-02-02T00:00:00.000Z');
+    });
+  });
+
   describe('toModelOutput persistence', () => {
     it('should preserve raw tool result and stored modelOutput through save/load cycle', async () => {
       const memory = new Memory({

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -214,6 +214,26 @@ const DEFAULT_TOP_K = 4;
 const VECTOR_DELETE_BATCH_SIZE = 100;
 
 /**
+ * Builds the metadata stored alongside a message's vector embedding. Includes
+ * role/content/created_at (not just the lookup keys) so consumers can build a
+ * search result directly from vector metadata, matching the semantic-recall processor.
+ */
+function buildVectorMessageMetadata(
+  id: string,
+  source: { threadId?: string; resourceId?: string; role?: string; createdAt?: Date | string },
+  content: string,
+): Record<string, unknown> & { message_id: string; thread_id: string | undefined; resource_id: string | undefined } {
+  return {
+    message_id: id,
+    thread_id: source.threadId,
+    resource_id: source.resourceId,
+    role: source.role,
+    content,
+    created_at: source.createdAt instanceof Date ? source.createdAt.toISOString() : String(source.createdAt ?? ''),
+  };
+}
+
+/**
  * Concrete implementation of MastraMemory that adds support for thread configuration
  * and message injection.
  */
@@ -1150,9 +1170,7 @@ ${workingMemory}`;
               embeddings: result.embeddings,
               metadata: result.chunks.map(() => ({
                 ...threadMetadata,
-                message_id: message.id,
-                thread_id: message.threadId,
-                resource_id: message.resourceId,
+                ...buildVectorMessageMetadata(message.id, message, textForEmbedding),
               })),
             });
           }),
@@ -2023,11 +2041,7 @@ Notes:
 
         embeddingData.push({
           embeddings: embedResult.embeddings,
-          metadata: embedResult.chunks.map(() => ({
-            message_id: message.id,
-            thread_id: message.threadId,
-            resource_id: message.resourceId,
-          })),
+          metadata: embedResult.chunks.map(() => buildVectorMessageMetadata(message.id, message, textForEmbedding)),
         });
       }),
     );
@@ -2168,11 +2182,9 @@ Notes:
 
               embeddingData.push({
                 embeddings: result.embeddings,
-                metadata: result.chunks.map(() => ({
-                  message_id: message.id,
-                  thread_id: existingMessage.threadId,
-                  resource_id: existingMessage.resourceId,
-                })),
+                metadata: result.chunks.map(() =>
+                  buildVectorMessageMetadata(message.id, existingMessage, textForEmbedding),
+                ),
               });
               messageIdsWithNewEmbeddings.add(message.id);
             } else {
@@ -2616,11 +2628,7 @@ Notes:
 
         embeddingData.push({
           embeddings: result.embeddings,
-          metadata: result.chunks.map(() => ({
-            message_id: message.id,
-            thread_id: message.threadId,
-            resource_id: message.resourceId,
-          })),
+          metadata: result.chunks.map(() => buildVectorMessageMetadata(message.id, message, textForEmbedding)),
         });
       }),
     );


### PR DESCRIPTION
## Summary

- Write `role`, `content`, and `created_at` (alongside the existing `message_id`/`thread_id`/`resource_id`) into the metadata stored with each message's vector embedding, so consumers reading directly from vector search results get complete message data instead of only the lookup ids.
- Applied consistently across all four embedding paths (`saveMessages`, `updateMessages`, `indexMessagesList`, `embedClonedMessages`) via a shared `buildVectorMessageMetadata` helper that also normalizes `created_at` to an ISO string. Matches the metadata already written by the semantic-recall processor in `@mastra/core`.

## Test plan

- `pnpm --filter ./packages/memory test` (see new `vector metadata completeness` tests in `src/index.test.ts`)

Closes #16380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When messages are saved with vector embeddings (a way to make text searchable), the system used to only store the message's ID number in the metadata. Now it also stores the actual message content, who wrote it, and when it was created—so someone searching through vectors can get the complete message information without having to look it up separately.

## Overview

This PR enriches vector embedding metadata for messages in the `@mastra/memory` package by including role, content, and created_at fields alongside existing identifiers. Previously, vector metadata contained only message_id, thread_id, and resource_id, leaving consumers unable to reconstruct complete message data from vector metadata alone. The fix aligns the package with what the semantic-recall processor in `@mastra/core` expects.

## Changes Made

### Core Implementation (packages/memory/src/index.ts)

- Introduced a new `buildVectorMessageMetadata` helper function that standardizes the construction of vector embedding metadata
- The helper enriches metadata with:
  - `message_id`, `thread_id`, `resource_id` (existing identifiers)
  - `role` (message sender role)
  - `content` (the text used for embedding)
  - `created_at` (normalized to ISO string format)

- Applied this metadata generation consistently across all embedding paths:
  - `saveMessages`: When saving messages for semantic recall
  - `updateMessages`: When updating messages and syncing semantic-recall vectors
  - `indexMessagesList`: When indexing a list of messages directly
  - `embedClonedMessages`: When embedding cloned thread messages

### Tests (packages/memory/src/index.test.ts)

- Added a new test suite "vector metadata completeness (issue `#16380`)" with 88 new lines
- Tests validate that `Memory.saveMessages` and `Memory.updateMessages` correctly include all required metadata fields
- `updateMessages` test verifies that metadata fields are sourced from the stored message (not the partial update input)
- Tests use mocked vector client and embedder (384-dim)

### Changeset

- Updated `@mastra/memory` with a patch version bump documenting the functional change

## Technical Details

- Metadata is stored as JSONB in pgvector, making this change backward-compatible
- Existing consumers that only use identifiers will continue to work
- The metadata shape now matches what `@mastra/core`'s SemanticRecall processor already expects
- `created_at` is normalized to ISO string format for consistency

## Related Issue

Closes issue `#16380`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->