### PR TITLE
fix(e2b): use stable Sandbox.create() for e2b SDK >= 2.24.0

### DIFF
--- a/.changeset/seven-mirrors-jump.md
+++ b/.changeset/seven-mirrors-jump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/e2b': patch
+---
+
+Fix sandbox creation crash on e2b SDK >= 2.24.0 by using the stable Sandbox.create() and lifecycle: { onTimeout: 'pause' } instead of the removed betaCreate()/autoPause.

--- a/workspaces/e2b/package.json
+++ b/workspaces/e2b/package.json
@@ -30,7 +30,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "e2b": "^2.14.1"
+    "e2b": "^2.24.0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/workspaces/e2b/src/sandbox/index.test.ts
+++ b/workspaces/e2b/src/sandbox/index.test.ts
@@ -96,7 +96,7 @@ const { mockSandbox, createMockSandboxApi, resetMockDefaults, createMockCommandH
 
   const createMockSandboxApi = () => ({
     Sandbox: {
-      betaCreate: vi.fn().mockResolvedValue(mockSandbox),
+      create: vi.fn().mockResolvedValue(mockSandbox),
       connect: vi.fn().mockResolvedValue(mockSandbox),
       list: vi.fn().mockReturnValue({
         nextItems: vi.fn().mockResolvedValue([]),
@@ -113,7 +113,7 @@ const { mockSandbox, createMockSandboxApi, resetMockDefaults, createMockCommandH
    */
   const resetMockDefaults = async () => {
     const { Sandbox, Template } = await import('e2b');
-    (Sandbox.betaCreate as any).mockResolvedValue(mockSandbox);
+    (Sandbox.create as any).mockResolvedValue(mockSandbox);
     (Sandbox.connect as any).mockResolvedValue(mockSandbox);
     (Sandbox.list as any).mockReturnValue({
       nextItems: vi.fn().mockResolvedValue([]),
@@ -203,8 +203,8 @@ describe('E2BSandbox', () => {
       // Both promises should resolve to the same value (void)
       expect(result1).toBe(result2);
 
-      // betaCreate should only be called once
-      expect(Sandbox.betaCreate).toHaveBeenCalledTimes(1);
+      // create should only be called once
+      expect(Sandbox.create).toHaveBeenCalledTimes(1);
     });
 
     it('start() is idempotent when already running', async () => {
@@ -212,11 +212,11 @@ describe('E2BSandbox', () => {
       const sandbox = new E2BSandbox();
 
       await sandbox._start();
-      expect(Sandbox.betaCreate).toHaveBeenCalledTimes(1);
+      expect(Sandbox.create).toHaveBeenCalledTimes(1);
 
       // Second start should not create another sandbox
       await sandbox._start();
-      expect(Sandbox.betaCreate).toHaveBeenCalledTimes(1);
+      expect(Sandbox.create).toHaveBeenCalledTimes(1);
     });
 
     it('status transitions through starting to running', async () => {
@@ -237,19 +237,19 @@ describe('E2BSandbox', () => {
 
       await sandbox._start();
 
-      expect(Sandbox.betaCreate).toHaveBeenCalled();
+      expect(Sandbox.create).toHaveBeenCalled();
     });
 
-    it('uses autoPause for sandbox persistence', async () => {
+    it('uses lifecycle.onTimeout=pause for sandbox persistence', async () => {
       const { Sandbox } = await import('e2b');
       const sandbox = new E2BSandbox();
 
       await sandbox._start();
 
-      expect(Sandbox.betaCreate).toHaveBeenCalledWith(
+      expect(Sandbox.create).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          autoPause: true,
+          lifecycle: { onTimeout: 'pause' },
         }),
       );
     });
@@ -260,7 +260,7 @@ describe('E2BSandbox', () => {
 
       await sandbox._start();
 
-      expect(Sandbox.betaCreate).toHaveBeenCalledWith(
+      expect(Sandbox.create).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
           metadata: expect.objectContaining({
@@ -319,8 +319,8 @@ describe('E2BSandbox', () => {
       const sandbox = new E2BSandbox({ template: 'my-custom-template' });
       await sandbox._start();
 
-      // betaCreate should be called with the custom template ID
-      expect(Sandbox.betaCreate).toHaveBeenCalledWith('my-custom-template', expect.any(Object));
+      // create should be called with the custom template ID
+      expect(Sandbox.create).toHaveBeenCalledWith('my-custom-template', expect.any(Object));
     });
   });
 
@@ -352,14 +352,14 @@ describe('E2BSandbox', () => {
   });
 
   describe('Environment Variables', () => {
-    it('env vars not passed to Sandbox.betaCreate', async () => {
+    it('env vars not passed to Sandbox.create', async () => {
       const { Sandbox } = await import('e2b');
       const sandbox = new E2BSandbox({ env: { KEY: 'value' } });
 
       await sandbox._start();
 
-      // betaCreate should NOT have envs option
-      expect(Sandbox.betaCreate).toHaveBeenCalledWith(
+      // create should NOT have envs option
+      expect(Sandbox.create).toHaveBeenCalledWith(
         expect.any(String),
         expect.not.objectContaining({
           envs: expect.any(Object),
@@ -584,7 +584,7 @@ describe('E2BSandbox Race Conditions', () => {
 
   it('start() clears _startPromise after error', async () => {
     const { Sandbox } = await import('e2b');
-    (Sandbox.betaCreate as any).mockRejectedValueOnce(new Error('Creation failed'));
+    (Sandbox.create as any).mockRejectedValueOnce(new Error('Creation failed'));
 
     const sandbox = new E2BSandbox();
 
@@ -613,7 +613,7 @@ describe('E2BSandbox Template Handling', () => {
 
     // First call fails with 404 error (matching the implementation check), second succeeds
     let callCount = 0;
-    (Sandbox.betaCreate as any).mockImplementation(() => {
+    (Sandbox.create as any).mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
         // Error message must include both '404' and 'not found' to trigger rebuild
@@ -627,7 +627,7 @@ describe('E2BSandbox Template Handling', () => {
 
     // Template.build should be called to rebuild after 404
     expect(Template.build).toHaveBeenCalled();
-    // And betaCreate should be called twice (retry after rebuild)
+    // And create should be called twice (retry after rebuild)
     expect(callCount).toBe(2);
   });
 
@@ -2105,8 +2105,8 @@ describe('E2BSandbox Internal Methods', () => {
 
       // Should succeed on retry (auto-restarts sandbox)
       expect(result.success).toBe(true);
-      // betaCreate called once in initial start(), once in retry start()
-      expect(Sandbox.betaCreate).toHaveBeenCalledTimes(2);
+      // create called once in initial start(), once in retry start()
+      expect(Sandbox.create).toHaveBeenCalledTimes(2);
     });
 
     it('does not retry infinitely (only once)', async () => {
@@ -2209,7 +2209,7 @@ describe('E2BSandbox Self-Hosted Connection Options', () => {
     await resetMockDefaults();
   });
 
-  it('forwards domain/apiUrl/apiKey/accessToken to Sandbox.betaCreate', async () => {
+  it('forwards domain/apiUrl/apiKey/accessToken to Sandbox.create', async () => {
     const { Sandbox } = await import('e2b');
     const sandbox = new E2BSandbox({
       domain: 'custom.dev',
@@ -2220,7 +2220,7 @@ describe('E2BSandbox Self-Hosted Connection Options', () => {
 
     await sandbox._start();
 
-    expect(Sandbox.betaCreate).toHaveBeenCalledWith(
+    expect(Sandbox.create).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
         domain: 'custom.dev',
@@ -2317,12 +2317,12 @@ describe('E2BSandbox Self-Hosted Connection Options', () => {
     const sandbox = new E2BSandbox();
     await sandbox._start();
 
-    // betaCreate should not contain domain/apiUrl/apiKey/accessToken
-    const betaCreateOpts = (Sandbox.betaCreate as any).mock.calls[0][1];
-    expect(betaCreateOpts).not.toHaveProperty('domain');
-    expect(betaCreateOpts).not.toHaveProperty('apiUrl');
-    expect(betaCreateOpts).not.toHaveProperty('apiKey');
-    expect(betaCreateOpts).not.toHaveProperty('accessToken');
+    // create should not contain domain/apiUrl/apiKey/accessToken
+    const createOpts = (Sandbox.create as any).mock.calls[0][1];
+    expect(createOpts).not.toHaveProperty('domain');
+    expect(createOpts).not.toHaveProperty('apiUrl');
+    expect(createOpts).not.toHaveProperty('apiKey');
+    expect(createOpts).not.toHaveProperty('accessToken');
 
     // list should not contain connection opts
     const listOpts = (Sandbox.list as any).mock.calls[0][0];

--- a/workspaces/e2b/src/sandbox/index.ts
+++ b/workspaces/e2b/src/sandbox/index.ts
@@ -274,18 +274,22 @@ export class E2BSandbox extends MastraSandbox {
     }
 
     // Create a new sandbox with our logical ID in metadata
-    // Using betaCreate with autoPause so sandbox pauses on timeout instead of being destroyed
+    // Using lifecycle: { onTimeout: 'pause' } so sandbox pauses on timeout instead of being destroyed
     this.logger.debug(`${LOG_PREFIX} Creating new sandbox for: ${this.id} with template: ${resolvedTemplateId}`);
 
+    const sandboxCreateOpts = {
+      lifecycle: { onTimeout: 'pause' as const },
+      metadata: {
+        ...this.metadata,
+        'mastra-sandbox-id': this.id,
+      },
+      timeoutMs: this.timeout,
+    };
+
     try {
-      this._sandbox = await Sandbox.betaCreate(resolvedTemplateId, {
+      this._sandbox = await Sandbox.create(resolvedTemplateId, {
         ...this.connectionOpts,
-        autoPause: true,
-        metadata: {
-          ...this.metadata,
-          'mastra-sandbox-id': this.id,
-        },
-        timeoutMs: this.timeout,
+        ...sandboxCreateOpts,
       });
     } catch (createError) {
       // If template not found (404), rebuild it and retry
@@ -296,14 +300,9 @@ export class E2BSandbox extends MastraSandbox {
         const rebuiltTemplateId = await this.buildDefaultTemplate();
 
         this.logger.debug(`${LOG_PREFIX} Retrying sandbox creation with rebuilt template: ${rebuiltTemplateId}`);
-        this._sandbox = await Sandbox.betaCreate(rebuiltTemplateId, {
+        this._sandbox = await Sandbox.create(rebuiltTemplateId, {
           ...this.connectionOpts,
-          autoPause: true,
-          metadata: {
-            ...this.metadata,
-            'mastra-sandbox-id': this.id,
-          },
-          timeoutMs: this.timeout,
+          ...sandboxCreateOpts,
         });
       } else {
         throw createError;


### PR DESCRIPTION
## Summary

- Replace the removed `Sandbox.betaCreate()` with the stable `Sandbox.create()` and swap the deprecated `autoPause: true` option for `lifecycle: { onTimeout: 'pause' }`. In e2b SDK 2.24.0 `betaCreate()` was promoted to `create()` and removed, so sandbox creation crashed with "Sandbox.betaCreate is not a function".
- Bump the `e2b` dependency range to `^2.24.0` so fresh installs resolve a compatible SDK.

## Test plan

- `pnpm --filter ./workspaces/e2b test:unit`

Closes #17258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a crash that happens when using the newer e2b library. The code was trying to use an old function that doesn't exist anymore (`Sandbox.betaCreate`), so we updated it to use the new official function (`Sandbox.create`). We also updated how we tell the sandbox to pause when it times out, so the code works the same way as before but with the new library.

## Changes

Updated the `@mastra/e2b` package to work with e2b SDK v2.24.0 and later by migrating from the deprecated `Sandbox.betaCreate()` API to the stable `Sandbox.create()` API, and replacing the deprecated `autoPause: true` option with the new `lifecycle: { onTimeout: 'pause' }` configuration.

### Files Changed

- **workspaces/e2b/package.json**: Updated e2b dependency from `^2.14.1` to `^2.24.0`
- **workspaces/e2b/src/sandbox/index.ts**: Migrated sandbox creation logic from `Sandbox.betaCreate()` to `Sandbox.create()`, updated timeout configuration to use `lifecycle: { onTimeout: 'pause' }`, and refactored creation options into a reusable `sandboxCreateOpts` object
- **workspaces/e2b/src/sandbox/index.test.ts**: Updated all test mocks and assertions to target `Sandbox.create` instead of `Sandbox.betaCreate`, including template rebuild retry logic, custom template handling, connection options forwarding, and error path tests
- **.changeset/seven-mirrors-jump.md**: Added changeset entry documenting the patch-level fix

## Testing

Unit tests for the e2b workspace have been updated to verify:
- Sandbox creation with the new `Sandbox.create()` API
- Correct timeout behavior via `lifecycle: { onTimeout: 'pause' }`
- Template preparation and rebuild edge cases
- Custom template and connection option forwarding
- Retry logic on dead sandbox scenarios

Run tests via: `pnpm --filter ./workspaces/e2b test:unit`

## Related Issue

Closes `#17258` - Fixes "Sandbox.betaCreate is not a function" error that occurred with e2b SDK >= 2.24.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->