### PR TITLE
fix(voice-openai-realtime): remove deprecated OpenAI-Beta realtime header

### DIFF
--- a/.changeset/yummy-actors-smile.md
+++ b/.changeset/yummy-actors-smile.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-openai-realtime': patch
+---
+
+Remove the deprecated `OpenAI-Beta: realtime=v1` header from realtime voice connections. OpenAI removed the beta realtime interface, so sending this header broke all realtime voice connections.

--- a/voice/openai-realtime-api/src/index.test.ts
+++ b/voice/openai-realtime-api/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WebSocket } from 'ws';
 import { OpenAIRealtimeVoice } from './index';
 
 // Mock RealtimeClient
@@ -74,6 +75,17 @@ describe('OpenAIRealtimeVoice', () => {
 
     it('should throw error on empty input', async () => {
       await expect(voice.speak('')).rejects.toThrow('Input text is empty');
+    });
+  });
+
+  describe('connect', () => {
+    it('should not send the deprecated OpenAI-Beta header', async () => {
+      await voice.connect();
+
+      expect(WebSocket).toHaveBeenCalledTimes(1);
+      const headers = (vi.mocked(WebSocket).mock.calls[0]![2] as { headers: Record<string, string> }).headers;
+      expect(headers.Authorization).toBe('Bearer test-api-key');
+      expect(headers).not.toHaveProperty('OpenAI-Beta');
     });
   });
 

--- a/voice/openai-realtime-api/src/index.ts
+++ b/voice/openai-realtime-api/src/index.ts
@@ -386,7 +386,6 @@ export class OpenAIRealtimeVoice extends MastraVoice {
     this.ws = new WebSocket(url, undefined, {
       headers: {
         Authorization: 'Bearer ' + apiKey,
-        'OpenAI-Beta': 'realtime=v1',
       },
     });
 


### PR DESCRIPTION
## Summary

- Stop sending the `OpenAI-Beta: realtime=v1` header when opening the realtime WebSocket connection. OpenAI removed the beta realtime interface, so sending this header broke all realtime voice connections.

## Test plan

- `pnpm --filter ./voice/openai-realtime-api test` (includes a regression test asserting `connect()` no longer sends the `OpenAI-Beta` header)

Closes #16875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation
OpenAI changed how their real-time voice API works and stopped using a special "beta" label for it. This PR removes the outdated label that our code was still sending, which was causing voice connections to fail. Now the code just sends the basic authentication information without the old beta label.

## Overview
This PR removes the deprecated `OpenAI-Beta: realtime=v1` header from WebSocket connections to the OpenAI Realtime API. OpenAI removed support for this beta interface, causing voice connections to fail when the header was present.

## Changes Made

**voice/openai-realtime-api/src/index.ts:**
- Removed the `OpenAI-Beta: realtime=v1` header from the WebSocket connection initialization in `OpenAIRealtimeVoice.connect()`
- The connection now uses only the `Authorization: Bearer <apiKey>` header

**voice/openai-realtime-api/src/index.test.ts:**
- Added WebSocket import from the `ws` library
- Added a regression test that verifies `OpenAIRealtimeVoice.connect()` sends the `Authorization` header but does NOT send the deprecated `OpenAI-Beta` header

**.changeset/yummy-actors-smile.md:**
- Documents a patch release for `@mastra/voice-openai-realtime` explaining the removal of the deprecated header

## Testing
A new test in the suite explicitly asserts that the `connect()` method no longer includes the `OpenAI-Beta` header, serving as a regression test to prevent this issue from reoccurring.

## Related Issue
Closes issue `#16875`, which reported connection failures when using the OpenAI Realtime API with certain model IDs after OpenAI removed the beta interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->