### PR TITLE
test(core): guard createTool execute inputData type inference (#16528)

### DIFF
--- a/packages/core/src/tools/createtool-input-types.test-d.ts
+++ b/packages/core/src/tools/createtool-input-types.test-d.ts
@@ -1,0 +1,69 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import zDefault from 'zod';
+import { z } from 'zod/v4';
+
+import { createTool } from './tool';
+
+/**
+ * Regression tests for issue #16528: `createTool`'s `execute` callback `inputData`
+ * parameter was typed as `any` regardless of the provided `inputSchema`, instead of
+ * the inferred schema type. These are type-level assertions only.
+ */
+describe('createTool execute inputData type inference (issue #16528)', () => {
+  it('infers inputData with the default `import z from "zod"` (exact issue repro)', () => {
+    const schema = zDefault.object({ name: zDefault.string() });
+    createTool({
+      id: 'test',
+      description: 'test',
+      inputSchema: schema,
+      execute: async inputData => {
+        expectTypeOf(inputData).not.toBeAny();
+        expectTypeOf(inputData).toEqualTypeOf<{ name: string }>();
+        // @ts-expect-error - `this_does_not_exist` is not a property of the inferred input type
+        inputData.this_does_not_exist;
+        return {};
+      },
+    });
+  });
+
+  it('infers inputData from a Zod inputSchema and does not widen to any', () => {
+    createTool({
+      id: 'typed-input',
+      description: 'Test',
+      inputSchema: z.object({ name: z.string(), age: z.number() }),
+      execute: async inputData => {
+        expectTypeOf(inputData).not.toBeAny();
+        expectTypeOf(inputData).toEqualTypeOf<{ name: string; age: number }>();
+        expectTypeOf(inputData.name).toBeString();
+        expectTypeOf(inputData.age).toBeNumber();
+        // @ts-expect-error - `missing` is not a property of the inferred input type
+        inputData.missing;
+        return undefined;
+      },
+    });
+  });
+
+  it('infers optional fields from the inputSchema', () => {
+    createTool({
+      id: 'optional-input',
+      description: 'Test',
+      inputSchema: z.object({ name: z.string(), email: z.string().optional() }),
+      execute: async inputData => {
+        expectTypeOf(inputData).not.toBeAny();
+        expectTypeOf(inputData).toEqualTypeOf<{ name: string; email?: string | undefined }>();
+        return undefined;
+      },
+    });
+  });
+
+  it('does not break tools without an inputSchema', () => {
+    createTool({
+      id: 'no-input',
+      description: 'Test',
+      execute: async inputData => {
+        expectTypeOf(inputData).toBeUnknown();
+        return undefined;
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add type-level regression tests confirming that `createTool`'s `execute` `inputData` parameter is inferred from `inputSchema` (not `any`), covering the exact reproduction from #16528 (`import z from 'zod'` + an extracted schema), inline schemas, optional fields, and the no-`inputSchema` case.
- This behavior already works on `main` (the `InferSchema` generics were restructured by the Standard Schema work in #12238); the issue was filed against an older `@mastra/core`. These tests lock the behavior in so it can't regress. Test-only change — no runtime/API change and no changeset.

## Test plan

- `pnpm --filter ./packages/core test -- --project 'typecheck:packages/core' src/tools/createtool-input-types.test-d.ts`

Closes #16528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds tests to make sure that when you set up a tool with a form (schema) that says what kind of data it expects, TypeScript automatically knows what type of data the tool receives. It's like labeling the shape of puzzle pieces before using them—the tests just verify the labels work correctly.

## Overview

This is a test-only PR that adds type-level regression tests for `createTool` to verify that the `execute` callback's `inputData` parameter is properly inferred from the provided `inputSchema`, rather than defaulting to `any`. These tests are regression guards for issue `#16528` and lock in behavior that already works on main (enabled by prior Standard Schema changes in `#12238`).

## Test Coverage

The new test file adds assertions covering:

- **Zod imports**: Verifies `inputData` type inference works with both `import z from 'zod'` (with extracted schema) and `zod/v4` imports
- **Inline and extracted schemas**: Tests both inline schema definitions and extracted schema constants
- **Optional fields**: Confirms that optional schema fields are correctly reflected as optional/possibly-undefined in `inputData`
- **No inputSchema case**: Verifies that when no `inputSchema` is provided, `inputData` remains `unknown`

The tests also validate that the inferred shape exactly matches the object schema fields with correct property types.

## Impact

- **No runtime changes**: This is strictly a test-addition PR
- **No API changes**: No modifications to exported declarations or public entities
- **No changeset**: Not needed for a test-only PR
- **File modified**: `packages/core/src/tools/createtool-input-types.test-d.ts` (+69 lines)

## Validation

Tests should be run using:
```
pnpm --filter ./packages/core test -- --project 'typecheck:packages/core' src/tools/createtool-input-types.test-d.ts
```

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->