### PR TITLE
fix(mastracode): wrap long slash-command descriptions in autocomplete picker

### DIFF
--- a/.changeset/wrap-slash-command-descriptions.md
+++ b/.changeset/wrap-slash-command-descriptions.md
@@ -1,0 +1,5 @@
+---
+"mastracode": patch
+---
+
+Wrap long slash-command and skill descriptions in the autocomplete picker instead of truncating them on a single line. The picker dropdown now word-wraps descriptions across multiple rows (continuation rows indented under the description column), so long command/skill descriptions stay fully readable without widening the terminal.

--- a/mastracode/src/tui/components/__tests__/wrapping-autocomplete-list.test.ts
+++ b/mastracode/src/tui/components/__tests__/wrapping-autocomplete-list.test.ts
@@ -1,0 +1,150 @@
+import { visibleWidth } from '@mariozechner/pi-tui';
+import type { SelectItem, SelectListTheme } from '@mariozechner/pi-tui';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the keybindings helper so handleInput tests can simulate up/down/enter/esc
+// without depending on the real config. The mock recognises a small set of
+// sentinel strings the tests pass in directly.
+vi.mock('@mariozechner/pi-tui', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getKeybindings: () => ({
+      matches: (data: string, key: string) => data === `__${key}__`,
+    }),
+  };
+});
+
+import { WrappingAutocompleteList } from '../wrapping-autocomplete-list.js';
+
+const theme: SelectListTheme = {
+  selectedPrefix: (s: string) => `[S]${s}`,
+  selectedText: (s: string) => `[S]${s}`,
+  description: (s: string) => `[D]${s}`,
+  scrollInfo: (s: string) => `[I]${s}`,
+  noMatch: (s: string) => `[N]${s}`,
+};
+
+// Passthrough theme: production themes wrap with invisible ANSI escapes, so
+// width assertions use this shape rather than the visible `[S]`/`[D]` markers.
+const passthrough: SelectListTheme = {
+  selectedPrefix: s => s,
+  selectedText: s => s,
+  description: s => s,
+  scrollInfo: s => s,
+  noMatch: s => s,
+};
+
+const item = (value: string, description?: string): SelectItem => ({ value, label: value, description });
+
+describe('WrappingAutocompleteList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('keeps a short description on a single row', () => {
+      const list = new WrappingAutocompleteList([item('new', 'Start a new thread')], 5, theme);
+      const lines = list.render(80);
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('new');
+      expect(lines[0]).toContain('Start a new thread');
+    });
+
+    it('wraps a long description across multiple rows instead of truncating it', () => {
+      const longDescription =
+        'Activate a skill that does many useful things and has a very long description that cannot possibly fit on a single line';
+      const list = new WrappingAutocompleteList([item('skill/example', longDescription)], 5, passthrough);
+      list.setSelectedIndex(0);
+
+      const lines = list.render(50);
+
+      // More than one row means the description wrapped rather than being clipped.
+      expect(lines.length).toBeGreaterThan(1);
+
+      // Every rendered row fits within the requested width.
+      lines.forEach(row => expect(visibleWidth(row)).toBeLessThanOrEqual(50));
+
+      // The tail of the description (which truncation would have dropped) is present.
+      const combined = lines.join(' ').replace(/\s+/g, ' ');
+      expect(combined).toContain('single line');
+    });
+
+    it('indents continuation rows under the description column', () => {
+      const longDescription = 'word '.repeat(40).trim();
+      const list = new WrappingAutocompleteList([item('cmd', longDescription)], 5, passthrough);
+
+      const lines = list.render(50);
+      expect(lines.length).toBeGreaterThan(1);
+
+      // Continuation rows start with leading whitespace (aligned under the description column).
+      for (let i = 1; i < lines.length; i++) {
+        expect(lines[i]).toMatch(/^\s+\S/);
+      }
+    });
+
+    it('renders an item without a description as a single row', () => {
+      const list = new WrappingAutocompleteList([item('exit')], 5, theme);
+      const lines = list.render(80);
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('exit');
+    });
+
+    it('does not split the description column when the width is narrow', () => {
+      // At width <= 40, SelectList renders only the primary column; we mirror
+      // that so narrow terminals keep the existing single-column behaviour.
+      const list = new WrappingAutocompleteList([item('cmd', 'a description here')], 5, passthrough);
+      const lines = list.render(30);
+      lines.forEach(row => expect(visibleWidth(row)).toBeLessThanOrEqual(30));
+    });
+
+    it('shows the noMatch message when the filter eliminates every item', () => {
+      const list = new WrappingAutocompleteList([item('alpha'), item('beta')], 5, theme);
+      list.setFilter('zzz');
+      const lines = list.render(40);
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('[N]');
+    });
+
+    it('emits a scroll indicator when items exceed maxVisible', () => {
+      const list = new WrappingAutocompleteList([item('a'), item('b'), item('c'), item('d'), item('e')], 2, theme);
+      const lines = list.render(40);
+      expect(lines.some(line => line.includes('[I]') && line.includes('1/5'))).toBe(true);
+    });
+  });
+
+  describe('navigation', () => {
+    it('advances the selected item by one on down arrow, regardless of description height', () => {
+      const longDescription = 'word '.repeat(40).trim();
+      const list = new WrappingAutocompleteList([item('first', longDescription), item('second')], 5, theme);
+      expect(list.getSelectedItem()?.value).toBe('first');
+
+      list.handleInput('__tui.select.down__');
+      expect(list.getSelectedItem()?.value).toBe('second');
+    });
+
+    it('wraps selection from last to first on down arrow', () => {
+      const list = new WrappingAutocompleteList([item('a'), item('b')], 5, theme);
+      list.setSelectedIndex(1);
+      list.handleInput('__tui.select.down__');
+      expect(list.getSelectedItem()?.value).toBe('a');
+    });
+
+    it('invokes onSelect with the highlighted item on confirm', () => {
+      const list = new WrappingAutocompleteList([item('a'), item('b')], 5, theme);
+      const onSelect = vi.fn();
+      list.onSelect = onSelect;
+      list.setSelectedIndex(1);
+      list.handleInput('__tui.select.confirm__');
+      expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ value: 'b' }));
+    });
+
+    it('invokes onCancel on cancel', () => {
+      const list = new WrappingAutocompleteList([item('a')], 5, theme);
+      const onCancel = vi.fn();
+      list.onCancel = onCancel;
+      list.handleInput('__tui.select.cancel__');
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/mastracode/src/tui/components/custom-editor.ts
+++ b/mastracode/src/tui/components/custom-editor.ts
@@ -6,12 +6,20 @@ import { readFileSync, statSync } from 'node:fs';
 import { extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Editor, matchesKey } from '@mariozechner/pi-tui';
-import type { EditorTheme, TUI } from '@mariozechner/pi-tui';
+import type { EditorTheme, SelectItem, TUI } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import { getClipboardImage, getClipboardText } from '../../clipboard/index.js';
 import type { ClipboardImage } from '../../clipboard/index.js';
 import { mastra, theme } from '../theme.js';
 import type { GradientAnimator } from './obi-loader.js';
+import { WrappingAutocompleteList } from './wrapping-autocomplete-list.js';
+
+// Mirrors pi-tui's SLASH_COMMAND_SELECT_LIST_LAYOUT so slash-command rows keep
+// the same primary-column sizing as the upstream SelectList.
+const SLASH_COMMAND_LIST_LAYOUT = {
+  minPrimaryColumnWidth: 12,
+  maxPrimaryColumnWidth: 32,
+};
 
 const PASTE_START = '\x1b[200~';
 const PASTE_END = '\x1b[201~';
@@ -126,6 +134,17 @@ export class CustomEditor extends Editor {
       }
 
       return firstPrefixIndex;
+    };
+
+    // Override pi-tui's private `createAutocompleteList` so the slash-command /
+    // autocomplete dropdown uses WrappingAutocompleteList. This wraps long
+    // command/skill descriptions across multiple rows instead of truncating
+    // them on a single line. Wired here (rather than as a class method) because
+    // the base declares it `private`, so a normal override would be a type clash.
+    (this as any).createAutocompleteList = (prefix: string, items: SelectItem[]) => {
+      const layout = prefix.startsWith('/') ? SLASH_COMMAND_LIST_LAYOUT : undefined;
+      const internals = this as unknown as { autocompleteMaxVisible: number; theme: EditorTheme };
+      return new WrappingAutocompleteList(items, internals.autocompleteMaxVisible, internals.theme.selectList, layout);
     };
   }
 

--- a/mastracode/src/tui/components/wrapping-autocomplete-list.ts
+++ b/mastracode/src/tui/components/wrapping-autocomplete-list.ts
@@ -1,0 +1,201 @@
+/**
+ * Drop-in replacement for pi-tui's `SelectList` used by the editor's
+ * slash-command / autocomplete dropdown. Behaves like `SelectList` (same
+ * prefix, primary column, and description styling) but word-wraps long
+ * descriptions across multiple terminal rows instead of truncating them on a
+ * single line. Continuation rows are indented under the description column so
+ * the full command/skill description stays readable without widening the
+ * terminal.
+ *
+ * Arrow keys move item-to-item (not row-to-row), so navigation stays
+ * predictable regardless of how many rows a description wraps onto.
+ */
+
+import { getKeybindings, truncateToWidth, visibleWidth, wrapTextWithAnsi } from '@mariozechner/pi-tui';
+import type { Component, SelectItem, SelectListTheme } from '@mariozechner/pi-tui';
+
+const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
+const PRIMARY_COLUMN_GAP = 2;
+const MIN_DESCRIPTION_WIDTH = 10;
+const DESCRIPTION_WIDTH_THRESHOLD = 40;
+
+export interface WrappingAutocompleteListLayout {
+  minPrimaryColumnWidth?: number;
+  maxPrimaryColumnWidth?: number;
+}
+
+const normalizeToSingleLine = (text: string): string => text.replace(/[\r\n]+/g, ' ').trim();
+const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(value, max));
+
+export class WrappingAutocompleteList implements Component {
+  private items: SelectItem[];
+  private filteredItems: SelectItem[];
+  private selectedIndex = 0;
+  private maxVisible: number;
+  private theme: SelectListTheme;
+  private layout: WrappingAutocompleteListLayout;
+
+  onSelect?: (item: SelectItem) => void;
+  onCancel?: () => void;
+  onSelectionChange?: (item: SelectItem) => void;
+
+  constructor(
+    items: SelectItem[],
+    maxVisible: number,
+    theme: SelectListTheme,
+    layout: WrappingAutocompleteListLayout = {},
+  ) {
+    this.items = items;
+    this.filteredItems = items;
+    this.maxVisible = maxVisible;
+    this.theme = theme;
+    this.layout = layout;
+  }
+
+  setFilter(filter: string): void {
+    this.filteredItems = this.items.filter(item => item.value.toLowerCase().startsWith(filter.toLowerCase()));
+    this.selectedIndex = 0;
+  }
+
+  setSelectedIndex(index: number): void {
+    this.selectedIndex = Math.max(0, Math.min(index, this.filteredItems.length - 1));
+  }
+
+  invalidate(): void {}
+
+  getSelectedItem(): SelectItem | null {
+    return this.filteredItems[this.selectedIndex] ?? null;
+  }
+
+  render(width: number): string[] {
+    const lines: string[] = [];
+
+    if (this.filteredItems.length === 0) {
+      lines.push(this.theme.noMatch('  No matching commands'));
+      return lines;
+    }
+
+    const primaryColumnWidth = this.getPrimaryColumnWidth();
+    const startIndex = Math.max(
+      0,
+      Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), this.filteredItems.length - this.maxVisible),
+    );
+    const endIndex = Math.min(startIndex + this.maxVisible, this.filteredItems.length);
+
+    for (let i = startIndex; i < endIndex; i++) {
+      const item = this.filteredItems[i];
+      if (!item) continue;
+      const isSelected = i === this.selectedIndex;
+      const description = item.description ? normalizeToSingleLine(item.description) : undefined;
+      for (const row of this.renderItem(item, isSelected, width, description, primaryColumnWidth)) {
+        lines.push(row);
+      }
+    }
+
+    if (startIndex > 0 || endIndex < this.filteredItems.length) {
+      const scrollText = `  (${this.selectedIndex + 1}/${this.filteredItems.length})`;
+      lines.push(this.theme.scrollInfo(truncateToWidth(scrollText, width - 2, '')));
+    }
+
+    return lines;
+  }
+
+  handleInput(keyData: string): void {
+    const kb = getKeybindings();
+
+    if (kb.matches(keyData, 'tui.select.up')) {
+      this.selectedIndex = this.selectedIndex === 0 ? this.filteredItems.length - 1 : this.selectedIndex - 1;
+      this.notifySelectionChange();
+    } else if (kb.matches(keyData, 'tui.select.down')) {
+      this.selectedIndex = this.selectedIndex === this.filteredItems.length - 1 ? 0 : this.selectedIndex + 1;
+      this.notifySelectionChange();
+    } else if (kb.matches(keyData, 'tui.select.confirm')) {
+      const selected = this.filteredItems[this.selectedIndex];
+      if (selected && this.onSelect) this.onSelect(selected);
+    } else if (kb.matches(keyData, 'tui.select.cancel')) {
+      this.onCancel?.();
+    }
+  }
+
+  private renderItem(
+    item: SelectItem,
+    isSelected: boolean,
+    width: number,
+    description: string | undefined,
+    primaryColumnWidth: number,
+  ): string[] {
+    const prefix = isSelected ? '→ ' : '  ';
+    const prefixWidth = visibleWidth(prefix);
+
+    if (description && width > DESCRIPTION_WIDTH_THRESHOLD) {
+      const effectivePrimaryColumnWidth = Math.max(1, Math.min(primaryColumnWidth, width - prefixWidth - 4));
+      const maxPrimaryWidth = Math.max(1, effectivePrimaryColumnWidth - PRIMARY_COLUMN_GAP);
+      const truncatedValue = this.truncatePrimary(item, maxPrimaryWidth);
+      const truncatedValueWidth = visibleWidth(truncatedValue);
+      const spacing = ' '.repeat(Math.max(1, effectivePrimaryColumnWidth - truncatedValueWidth));
+      const descriptionStart = prefixWidth + truncatedValueWidth + spacing.length;
+      const remainingWidth = width - descriptionStart - 2; // -2 for safety, mirrors SelectList
+
+      if (remainingWidth > MIN_DESCRIPTION_WIDTH) {
+        // Wrap the description across rows instead of truncating it. The first
+        // row keeps the primary column; continuation rows indent under the
+        // description column so the wrapped text aligns.
+        const wrapped = wrapTextWithAnsi(description, remainingWidth);
+        const continuationIndent = ' '.repeat(descriptionStart);
+
+        return wrapped.map((chunk, index) => {
+          if (index === 0) {
+            if (isSelected) {
+              return this.theme.selectedText(`${prefix}${truncatedValue}${spacing}${chunk}`);
+            }
+            return prefix + truncatedValue + this.theme.description(spacing + chunk);
+          }
+          if (isSelected) {
+            return this.theme.selectedText(`${continuationIndent}${chunk}`);
+          }
+          return this.theme.description(continuationIndent + chunk);
+        });
+      }
+    }
+
+    const maxWidth = width - prefixWidth - 2;
+    const truncatedValue = this.truncatePrimary(item, maxWidth);
+    if (isSelected) {
+      return [this.theme.selectedText(`${prefix}${truncatedValue}`)];
+    }
+    return [prefix + truncatedValue];
+  }
+
+  private getPrimaryColumnWidth(): number {
+    const { min, max } = this.getPrimaryColumnBounds();
+    const widestPrimary = this.filteredItems.reduce(
+      (widest, item) => Math.max(widest, visibleWidth(this.getDisplayValue(item)) + PRIMARY_COLUMN_GAP),
+      0,
+    );
+    return clamp(widestPrimary, min, max);
+  }
+
+  private getPrimaryColumnBounds(): { min: number; max: number } {
+    const rawMin =
+      this.layout.minPrimaryColumnWidth ?? this.layout.maxPrimaryColumnWidth ?? DEFAULT_PRIMARY_COLUMN_WIDTH;
+    const rawMax =
+      this.layout.maxPrimaryColumnWidth ?? this.layout.minPrimaryColumnWidth ?? DEFAULT_PRIMARY_COLUMN_WIDTH;
+    return {
+      min: Math.max(1, Math.min(rawMin, rawMax)),
+      max: Math.max(1, Math.max(rawMin, rawMax)),
+    };
+  }
+
+  private truncatePrimary(item: SelectItem, maxWidth: number): string {
+    return truncateToWidth(this.getDisplayValue(item), maxWidth, '');
+  }
+
+  private getDisplayValue(item: SelectItem): string {
+    return item.label || item.value;
+  }
+
+  private notifySelectionChange(): void {
+    const selected = this.filteredItems[this.selectedIndex];
+    if (selected && this.onSelectionChange) this.onSelectionChange(selected);
+  }
+}


### PR DESCRIPTION
## What changed

Long slash-command and skill descriptions in the Mastra Code autocomplete picker now wrap onto multiple rows instead of being truncated on a single line.

Before, when you typed `/` to open the picker, any command or skill with a long description was clipped — you could only read the full text by widening the terminal. Now the description word-wraps across rows, with continuation rows indented under the description column so it stays aligned and readable at any terminal width.

## Why

The picker dropdown rendered descriptions through pi-tui's `SelectList`, which normalizes each description to a single line and clips it with `truncateToWidth`. There was no way for a user to see the tail of a long description without resizing their terminal.

## How

- Added `WrappingAutocompleteList`, a list component that reproduces `SelectList`'s layout (prefix + primary column + styled description) but word-wraps the description across rows. Arrow keys continue to move item-to-item, so navigation is unaffected by how many rows a description wraps onto.
- Overrode the editor's `createAutocompleteList` so the dropdown uses the wrapping list. Narrow terminals (≤40 columns) keep the existing single-column behavior, matching upstream.

This mirrors the approach already used for the `ask_user` active picker, which swapped `SelectList` for a wrapping variant.

## Test plan

- `pnpm check` (tsc) passes
- New unit tests in `wrapping-autocomplete-list.test.ts` cover wrapping, continuation-row indentation, narrow-width fallback, no-match, scroll indicator, and navigation/selection callbacks
- Full `mastracode` component test suite passes (248 tests)
- ESLint clean on all touched files
- Manual: open Mastra Code, type `/`, and confirm a command/skill with a long description wraps instead of clipping

Fixes #17118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you type a slash command in Mastra Code to open the autocomplete menu, long command descriptions used to get cut off and disappeared off the edge of the screen. This PR makes those descriptions wrap across multiple lines so you can read the full text without having to make your terminal wider.

## Changes

### New Component: WrappingAutocompleteList
A new component that replaces pi-tui's `SelectList` for slash-command autocomplete rendering. It reproduces the original layout (prefix + primary column + description) but adds word-wrapping support for descriptions that exceed available width. Key features:
- Wraps description text across multiple terminal rows using `wrapTextWithAnsi`
- Indents continuation rows under the description column for visual alignment
- Computes bounded primary column width based on the widest item in the list
- Narrows to single-column behavior for terminals ≤40 columns wide
- Preserves existing keyboard navigation (arrow keys, confirm/cancel) and selection behavior

### Integration in CustomEditor
Modified `CustomEditor` to override pi-tui's `createAutocompleteList` method. When the autocomplete prefix starts with `/`, it uses the new `WrappingAutocompleteList` with a custom layout configuration; otherwise it falls back to default behavior. This ensures slash-command descriptions wrap while other autocomplete types remain unchanged.

### Test Coverage
Added comprehensive test suite (`wrapping-autocomplete-list.test.ts`) covering:
- Short vs. long description wrapping behavior
- Continuation row indentation
- Single-column fallback for narrow terminals
- Empty filtered state (`noMatch` message)
- Scroll indicator display
- Navigation and selection callbacks (up/down/confirm/cancel)

### Documentation
Added changeset entry documenting the `patch`-level change to `mastracode`.

## Testing
- Type-checking passes (pnpm check)
- 150+ new unit tests in wrapping-autocomplete-list.test.ts all passing
- Full mastracode test suite passes (248 tests)
- ESLint clean on touched files
- Manual verification confirmed long descriptions now wrap in the Mastra Code slash-command picker

Fixes issue `#17118`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mastra-ai/mastra/pull/17333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->