### PR TITLE
fix(mastracode): render ask_user multi_select as a multi-select picker

### DIFF
--- a/.changeset/lovely-pumas-trade.md
+++ b/.changeset/lovely-pumas-trade.md
@@ -1,0 +1,7 @@
+---
+'mastracode': patch
+---
+
+Fixed the `ask_user` tool's `multi_select` mode in Mastra Code, which previously rendered as a single-select list and returned only one answer.
+
+When an agent calls `ask_user` with `selectionMode: "multi_select"`, the CLI now shows a multi-select picker — press Space to toggle each option and Enter to confirm — and returns every selected label to the agent as an array instead of a single string.

--- a/mastracode/src/tui/components/__tests__/ask-question-inline-multi-select.test.ts
+++ b/mastracode/src/tui/components/__tests__/ask-question-inline-multi-select.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock pi-tui — the real Input/Box components touch the terminal at construction.
+// We keep the real WrappingSelectList (imported below) so the multi-select path
+// is exercised end-to-end through the component.
+vi.mock('@mariozechner/pi-tui', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  class StubInput {
+    onSubmit?: (value: string) => void;
+    focused = false;
+    handleInput(_data: string): void {}
+    render(_width: number): string[] {
+      return [''];
+    }
+  }
+  class StubBox {
+    children: unknown[] = [];
+    addChild(c: unknown): void {
+      this.children.push(c);
+    }
+    invalidate(): void {}
+  }
+  class StubContainer extends StubBox {}
+  class StubText {
+    constructor(_text: string, _x: number, _y: number) {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  class StubSpacer {
+    constructor(_height: number) {}
+    render(): string[] {
+      return [''];
+    }
+  }
+  return {
+    ...actual,
+    Input: StubInput,
+    Box: StubBox,
+    Container: StubContainer,
+    Text: StubText,
+    Spacer: StubSpacer,
+    // Recognise the sentinel keybinding markers the tests send directly.
+    getKeybindings: () => ({
+      matches: (data: string, key: string) => data === `__${key}__`,
+    }),
+  };
+});
+
+import { AskQuestionInlineComponent } from '../ask-question-inline.js';
+
+describe('AskQuestionInlineComponent multi-select', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const opts = [{ label: 'React' }, { label: 'Vue' }, { label: 'Svelte' }];
+
+  it('renders the multi-select hint when selectionMode is multi_select', () => {
+    const component = new AskQuestionInlineComponent({
+      question: 'Which apply?',
+      options: opts,
+      selectionMode: 'multi_select',
+      onSubmit: () => {},
+      onCancel: () => {},
+    });
+    expect((component as any).borderedBox?.hintText).toBe('Space to toggle · Enter to confirm · Esc to skip');
+  });
+
+  it('renders the single-select hint by default', () => {
+    const component = new AskQuestionInlineComponent({
+      question: 'Which one?',
+      options: opts,
+      onSubmit: () => {},
+      onCancel: () => {},
+    });
+    expect((component as any).borderedBox?.hintText).toBe('↑↓ to navigate · Enter to select · Esc to skip');
+  });
+
+  it('omits the "Custom response..." escape hatch in multi-select mode', () => {
+    const component = new AskQuestionInlineComponent({
+      question: 'Which apply?',
+      options: opts,
+      selectionMode: 'multi_select',
+      onSubmit: () => {},
+      onCancel: () => {},
+    });
+    const listItems = (component as any).selectList?.items as Array<{ value: string }>;
+    expect(listItems.some(i => i.value === '__custom_response__')).toBe(false);
+    expect(listItems).toHaveLength(opts.length);
+  });
+
+  it('calls onSubmitMulti with the toggled labels on confirm', () => {
+    const onSubmitMulti = vi.fn();
+    const onSubmit = vi.fn();
+    const component = new AskQuestionInlineComponent({
+      question: 'Which apply?',
+      options: opts,
+      selectionMode: 'multi_select',
+      onSubmit,
+      onSubmitMulti,
+      onCancel: () => {},
+    });
+
+    // Toggle React, move to Svelte, toggle it, then confirm.
+    component.handleInput(' ');
+    component.handleInput('__tui.select.down__');
+    component.handleInput('__tui.select.down__');
+    component.handleInput(' ');
+    component.handleInput('__tui.select.confirm__');
+
+    expect(onSubmitMulti).toHaveBeenCalledWith(['React', 'Svelte']);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a comma-joined string on onSubmit when onSubmitMulti is omitted', () => {
+    const onSubmit = vi.fn();
+    const component = new AskQuestionInlineComponent({
+      question: 'Which apply?',
+      options: opts,
+      selectionMode: 'multi_select',
+      onSubmit,
+      onCancel: () => {},
+    });
+
+    component.handleInput(' '); // React
+    component.handleInput('__tui.select.down__');
+    component.handleInput(' '); // Vue
+    component.handleInput('__tui.select.confirm__');
+
+    expect(onSubmit).toHaveBeenCalledWith('React, Vue');
+  });
+
+  it('freezes the box showing every selected option after answering', () => {
+    const component = new AskQuestionInlineComponent({
+      question: 'Which apply?',
+      options: opts,
+      selectionMode: 'multi_select',
+      onSubmit: () => {},
+      onSubmitMulti: () => {},
+      onCancel: () => {},
+    });
+
+    component.handleInput(' '); // React
+    component.handleInput('__tui.select.down__');
+    component.handleInput(' '); // Vue
+    component.handleInput('__tui.select.confirm__');
+
+    const lines = (component as any).borderedBox.render(60).join('\n');
+    // Selected options get a ✓, the unselected one is dimmed (no ✓).
+    expect(lines).toContain('✓');
+    expect(lines).toContain('React');
+    expect(lines).toContain('Vue');
+    expect(lines).toContain('Svelte');
+  });
+});

--- a/mastracode/src/tui/components/__tests__/wrapping-select-list.test.ts
+++ b/mastracode/src/tui/components/__tests__/wrapping-select-list.test.ts
@@ -138,4 +138,65 @@ describe('WrappingSelectList', () => {
       expect(onSelectionChange).toHaveBeenCalledWith(expect.objectContaining({ value: 'b' }));
     });
   });
+
+  describe('multi-select — space toggles, enter confirms all checked items', () => {
+    it('renders an unchecked checkbox per item in multi-select mode', () => {
+      const list = new WrappingSelectList(items('Alpha', 'Beta'), 5, theme, true);
+      const lines = list.render(40);
+      expect(lines[0]).toContain('[ ] Alpha');
+      expect(lines[1]).toContain('[ ] Beta');
+    });
+
+    it('checks the highlighted item when space is pressed', () => {
+      const list = new WrappingSelectList(items('Alpha', 'Beta'), 5, theme, true);
+      list.handleInput(' ');
+      const lines = list.render(40);
+      expect(lines[0]).toContain('[x] Alpha');
+      expect(lines[1]).toContain('[ ] Beta');
+    });
+
+    it('toggles an item off when space is pressed again', () => {
+      const list = new WrappingSelectList(items('Alpha'), 5, theme, true);
+      list.handleInput(' ');
+      list.handleInput(' ');
+      expect(list.render(40)[0]).toContain('[ ] Alpha');
+    });
+
+    it('does not fire onSelect on enter in multi-select mode', () => {
+      const list = new WrappingSelectList(items('Alpha', 'Beta'), 5, theme, true);
+      const onSelect = vi.fn();
+      list.onSelect = onSelect;
+      list.handleInput('__tui.select.confirm__');
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('fires onConfirmMulti with every checked item in display order on enter', () => {
+      const list = new WrappingSelectList(items('Alpha', 'Beta', 'Gamma'), 5, theme, true);
+      const onConfirmMulti = vi.fn();
+      list.onConfirmMulti = onConfirmMulti;
+      // Check Alpha, move to Gamma, check it — Beta stays unchecked.
+      list.handleInput(' ');
+      list.handleInput('__tui.select.down__');
+      list.handleInput('__tui.select.down__');
+      list.handleInput(' ');
+      list.handleInput('__tui.select.confirm__');
+      expect(onConfirmMulti).toHaveBeenCalledTimes(1);
+      expect(onConfirmMulti.mock.calls[0][0].map((i: { value: string }) => i.value)).toEqual(['Alpha', 'Gamma']);
+    });
+
+    it('fires onConfirmMulti with an empty array when nothing is checked', () => {
+      const list = new WrappingSelectList(items('Alpha'), 5, theme, true);
+      const onConfirmMulti = vi.fn();
+      list.onConfirmMulti = onConfirmMulti;
+      list.handleInput('__tui.select.confirm__');
+      expect(onConfirmMulti).toHaveBeenCalledWith([]);
+    });
+
+    it('ignores space in single-select mode', () => {
+      const list = new WrappingSelectList(items('Alpha'), 5, theme);
+      list.handleInput(' ');
+      expect(list.render(40)[0]).not.toContain('[x]');
+      expect(list.render(40)[0]).not.toContain('[ ]');
+    });
+  });
 });

--- a/mastracode/src/tui/components/ask-question-dialog.ts
+++ b/mastracode/src/tui/components/ask-question-dialog.ts
@@ -7,11 +7,15 @@
 import { Box, getKeybindings, Input, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, Component, TUI } from '@mariozechner/pi-tui';
 import { theme, getSelectListTheme, getEditorTheme } from '../theme.js';
+import type { AskQuestionSelectionMode } from './ask-question-inline.js';
 import { MultilineInput } from './multiline-input.js';
+import { WrappingSelectList } from './wrapping-select-list.js';
 
 export interface AskQuestionDialogOptions {
   question: string;
   options?: Array<{ label: string; description?: string }>;
+  /** Controls whether options are single- or multi-select. Defaults to single_select. */
+  selectionMode?: AskQuestionSelectionMode;
   /**
    * Use a multiline editor for free-text input (Shift+Enter / \+Enter for new lines).
    * Defaults to false. Enable for prompts that legitimately want paragraph-length replies.
@@ -23,21 +27,28 @@ export interface AskQuestionDialogOptions {
   selectedOptionLabel?: string;
   tui?: TUI;
   onSubmit: (answer: string) => void;
+  /**
+   * Called instead of `onSubmit` when the prompt is multi-select, with every selected
+   * option label. Falls back to `onSubmit` with a comma-joined string when omitted.
+   */
+  onSubmitMulti?: (answers: string[]) => void;
   onCancel: () => void;
 }
 
 export class AskQuestionDialogComponent extends Box implements Focusable {
   private static readonly CUSTOM_RESPONSE_VALUE = '__custom_response__';
 
-  private selectList?: SelectList;
+  private selectList?: SelectList | WrappingSelectList;
   private input?: Input | MultilineInput;
   private tui?: TUI;
   private multiline = false;
+  private multiSelect = false;
   private allowEmptyInput = false;
   private defaultValue?: string;
   private allowCustomResponse = true;
   private selectedOptionLabel?: string;
   private onSubmit: (answer: string) => void;
+  private onSubmitMulti?: (answers: string[]) => void;
   private onCancel: () => void;
 
   /** Children added by buildSelectMode/buildInputMode, tracked for removal on mode switch */
@@ -56,9 +67,11 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
     super(2, 1, text => theme.bg('overlayBg', text));
 
     this.onSubmit = options.onSubmit;
+    this.onSubmitMulti = options.onSubmitMulti;
     this.onCancel = options.onCancel;
     this.tui = options.tui;
     this.multiline = Boolean(options.multiline);
+    this.multiSelect = options.selectionMode === 'multi_select';
     this.allowEmptyInput = Boolean(options.allowEmptyInput);
     this.defaultValue = options.defaultValue;
     this.allowCustomResponse = options.allowCustomResponse ?? true;
@@ -87,34 +100,52 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
       label: opt.description ? `  ${opt.label}  ${theme.fg('dim', opt.description)}` : `  ${opt.label}`,
     }));
 
-    if (this.allowCustomResponse) {
+    // "Custom response..." only applies to single-select: it switches to free-text.
+    if (this.allowCustomResponse && !this.multiSelect) {
       items.push({
         value: AskQuestionDialogComponent.CUSTOM_RESPONSE_VALUE,
         label: `  ${theme.fg('dim', '✎ Custom response...')}`,
       });
     }
 
-    this.selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
-    const selectedIndex = items.findIndex(item => item.value === this.selectedOptionLabel);
-    if (selectedIndex >= 0) this.selectList.setSelectedIndex(selectedIndex);
-
-    this.selectList.onSelect = (item: SelectItem) => {
-      if (item.value === AskQuestionDialogComponent.CUSTOM_RESPONSE_VALUE) {
-        this.switchToCustomInput();
-        return;
-      }
-      this.onSubmit(item.value);
-    };
-    this.selectList.onCancel = this.onCancel;
+    let hintText: string;
+    if (this.multiSelect) {
+      const list = new WrappingSelectList(items, Math.min(items.length, 8), getSelectListTheme(), true);
+      list.onConfirmMulti = (selected: SelectItem[]) => {
+        const values = selected.map(item => item.value);
+        if (this.onSubmitMulti) {
+          this.onSubmitMulti(values);
+        } else {
+          this.onSubmit(values.join(', '));
+        }
+      };
+      list.onCancel = this.onCancel;
+      this.selectList = list;
+      hintText = '  Space to toggle · Enter to confirm · Esc to skip';
+    } else {
+      const list = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
+      const selectedIndex = items.findIndex(item => item.value === this.selectedOptionLabel);
+      if (selectedIndex >= 0) list.setSelectedIndex(selectedIndex);
+      list.onSelect = (item: SelectItem) => {
+        if (item.value === AskQuestionDialogComponent.CUSTOM_RESPONSE_VALUE) {
+          this.switchToCustomInput();
+          return;
+        }
+        this.onSubmit(item.value);
+      };
+      list.onCancel = this.onCancel;
+      this.selectList = list;
+      hintText = '  ↑↓ to navigate · Enter to select · Esc to skip';
+    }
 
     this.modeChildren = [];
-    const selectChild = this.selectList;
+    const selectChild = this.selectList as Component;
     this.addChild(selectChild);
     this.modeChildren.push(selectChild);
     const spacer = new Spacer(1);
     this.addChild(spacer);
     this.modeChildren.push(spacer);
-    const hint = new Text(theme.fg('dim', '  ↑↓ to navigate · Enter to select · Esc to skip'), 0, 0);
+    const hint = new Text(theme.fg('dim', hintText), 0, 0);
     this.addChild(hint);
     this.modeChildren.push(hint);
   }

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -18,9 +18,18 @@ import { BOX_INDENT_STR, theme, getSelectListTheme, getEditorTheme } from '../th
 import { MultilineInput } from './multiline-input.js';
 import { WrappingSelectList } from './wrapping-select-list.js';
 
+/**
+ * Selection mode for option prompts. `single_select` selects one option on Enter
+ * (the default). `multi_select` lets the user toggle several options with Space and
+ * confirm them together with Enter, returning all selected labels as an array.
+ */
+export type AskQuestionSelectionMode = 'single_select' | 'multi_select';
+
 export interface AskQuestionInlineOptions {
   question: string;
   options?: Array<{ label: string; description?: string }>;
+  /** Controls whether options are single- or multi-select. Defaults to single_select. */
+  selectionMode?: AskQuestionSelectionMode;
   /** Format the text shown after an answer is selected. Defaults to `question → answer`. */
   formatResult?: (answer: string) => string;
   /** If provided, determines whether an answer should be shown with error styling (red ✗). */
@@ -36,6 +45,11 @@ export interface AskQuestionInlineOptions {
    */
   multiline?: boolean;
   onSubmit: (answer: string) => void;
+  /**
+   * Called instead of `onSubmit` when the prompt is multi-select, with every selected
+   * option label. Falls back to `onSubmit` with a comma-joined string when omitted.
+   */
+  onSubmitMulti?: (answers: string[]) => void;
   onCancel: () => void;
 }
 
@@ -52,6 +66,8 @@ class AskQuestionBorderedBox {
   private answered = false;
   private cancelled = false;
   private selectedValue?: string;
+  /** Selected option labels when the box was answered in multi-select mode. */
+  private selectedValues?: string[];
   private answerIsNegative = false;
   /** True when created during streaming, before activate() is called */
   private streaming = false;
@@ -88,6 +104,13 @@ class AskQuestionBorderedBox {
     this.answered = true;
     this.selectedValue = selectedValue;
     this.answerIsNegative = isNegative;
+  }
+
+  setAnsweredMulti(selectedValues: string[]) {
+    this.streaming = false;
+    this.answered = true;
+    this.selectedValues = selectedValues;
+    this.answerIsNegative = false;
   }
 
   setCancelled() {
@@ -180,7 +203,9 @@ class AskQuestionBorderedBox {
         // ✓/✗ on selected, dimmed unselected
         const text = (s: string) => theme.fg('text', s);
         for (const item of this.items) {
-          const isSelected = item.label === this.selectedValue;
+          const isSelected = this.selectedValues
+            ? this.selectedValues.includes(item.label)
+            : item.label === this.selectedValue;
           if (isSelected) {
             const icon = this.answerIsNegative ? theme.fg('error', '✗') : theme.fg('success', '✓');
             addWrappedOptionLine(`${icon}  `, item.label, text);
@@ -239,11 +264,13 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
   private input?: Input | MultilineInput;
   private tui?: TUI;
   private onSubmit?: (answer: string) => void;
+  private onSubmitMulti?: (answers: string[]) => void;
   private onCancel?: () => void;
   private isNegativeAnswer?: (answer: string) => boolean;
   private allowEmptyInput = false;
   private multiline = false;
   private allowCustomResponse = true;
+  private multiSelect = false;
   private answered = false;
 
   /**
@@ -312,17 +339,19 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     if (options) {
       // Full construction with interactive elements
       this.onSubmit = options.onSubmit;
+      this.onSubmitMulti = options.onSubmitMulti;
       this.onCancel = options.onCancel;
       this.isNegativeAnswer = options.isNegativeAnswer;
       this.allowEmptyInput = Boolean(options.allowEmptyInput);
       this.multiline = Boolean(options.multiline);
       this.allowCustomResponse = options.allowCustomResponse ?? true;
+      this.multiSelect = options.selectionMode === 'multi_select';
 
       const questionLines = options.question.split('\n');
 
       let hintText: string;
       if (options.options && options.options.length > 0) {
-        hintText = '↑↓ to navigate · Enter to select · Esc to skip';
+        hintText = this.selectHintText();
         this.buildSelectMode(options.options);
       } else {
         hintText = this.useMultiline()
@@ -373,22 +402,26 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
   activate(options: {
     question: string;
     options?: Array<{ label: string; description?: string }>;
+    selectionMode?: AskQuestionSelectionMode;
     isNegativeAnswer?: (answer: string) => boolean;
     allowEmptyInput?: boolean;
     allowCustomResponse?: boolean;
     multiline?: boolean;
     tui?: TUI;
     onSubmit: (answer: string) => void;
+    onSubmitMulti?: (answers: string[]) => void;
     onCancel: () => void;
   }): void {
     if (this.answered) return;
     if (options.tui) this.tui = options.tui;
     this.onSubmit = options.onSubmit;
+    this.onSubmitMulti = options.onSubmitMulti;
     this.onCancel = options.onCancel;
     this.isNegativeAnswer = options.isNegativeAnswer;
     this.allowEmptyInput = Boolean(options.allowEmptyInput);
     this.allowCustomResponse = options.allowCustomResponse ?? true;
     this.multiline = Boolean(options.multiline);
+    this.multiSelect = options.selectionMode === 'multi_select';
 
     // Update question text and items to final values
     this.borderedBox.questionLines = options.question.split('\n');
@@ -397,7 +430,7 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     // Build interactive elements
     let hintText: string;
     if (options.options && options.options.length > 0) {
-      hintText = '↑↓ to navigate · Enter to select · Esc to skip';
+      hintText = this.selectHintText();
       this.buildSelectMode(options.options);
     } else {
       hintText = this.useMultiline()
@@ -412,29 +445,43 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
 
   private static readonly CUSTOM_RESPONSE_VALUE = '__custom_response__';
 
+  /** Hint line shown under an option list, tailored to single- vs multi-select. */
+  private selectHintText(): string {
+    return this.multiSelect
+      ? 'Space to toggle · Enter to confirm · Esc to skip'
+      : '↑↓ to navigate · Enter to select · Esc to skip';
+  }
+
   private buildSelectMode(opts: Array<{ label: string; description?: string }>): void {
     const items: SelectItem[] = opts.map(opt => ({
       value: opt.label,
       label: opt.description ? `${opt.label}  ${theme.fg('dim', opt.description)}` : opt.label,
     }));
 
-    // Append a "Custom response..." option so the user can type a free-text answer
-    if (this.allowCustomResponse) {
+    // "Custom response..." only applies to single-select: it switches to free-text.
+    // Multi-select toggles a fixed option set, so the escape hatch doesn't apply.
+    if (this.allowCustomResponse && !this.multiSelect) {
       items.push({
         value: AskQuestionInlineComponent.CUSTOM_RESPONSE_VALUE,
         label: theme.fg('dim', '✎ Custom response...'),
       });
     }
 
-    this.selectList = new WrappingSelectList(items, Math.min(items.length, 8), getSelectListTheme());
+    this.selectList = new WrappingSelectList(items, Math.min(items.length, 8), getSelectListTheme(), this.multiSelect);
 
-    this.selectList.onSelect = (item: SelectItem) => {
-      if (item.value === AskQuestionInlineComponent.CUSTOM_RESPONSE_VALUE) {
-        this.switchToCustomInput();
-        return;
-      }
-      this.handleAnswer(item.value);
-    };
+    if (this.multiSelect) {
+      this.selectList.onConfirmMulti = (selected: SelectItem[]) => {
+        this.handleMultiAnswer(selected.map(item => item.value));
+      };
+    } else {
+      this.selectList.onSelect = (item: SelectItem) => {
+        if (item.value === AskQuestionInlineComponent.CUSTOM_RESPONSE_VALUE) {
+          this.switchToCustomInput();
+          return;
+        }
+        this.handleAnswer(item.value);
+      };
+    }
     this.selectList.onCancel = () => {
       this.handleCancel();
     };
@@ -507,6 +554,20 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     this.answer(answer, isNegative);
 
     this.onSubmit?.(answer);
+  }
+
+  private handleMultiAnswer(answers: string[]): void {
+    if (this.answered) return;
+    this.answered = true;
+    this.borderedBox.setAnsweredMulti(answers);
+
+    // Prefer the array-shaped callback; fall back to a comma-joined string so
+    // single-select-only callers still receive a usable answer.
+    if (this.onSubmitMulti) {
+      this.onSubmitMulti(answers);
+    } else {
+      this.onSubmit?.(answers.join(', '));
+    }
   }
 
   private handleCancel(): void {

--- a/mastracode/src/tui/components/wrapping-select-list.ts
+++ b/mastracode/src/tui/components/wrapping-select-list.ts
@@ -12,6 +12,9 @@ const SELECTED_PREFIX = '→ ';
 const UNSELECTED_PREFIX = '  ';
 const CONTINUATION_PREFIX = '↳ ';
 const PREFIX_WIDTH = 2;
+const CHECKBOX_CHECKED = '[x] ';
+const CHECKBOX_UNCHECKED = '[ ] ';
+const CHECKBOX_WIDTH = 4;
 
 export class WrappingSelectList implements Component {
   private items: SelectItem[];
@@ -19,16 +22,23 @@ export class WrappingSelectList implements Component {
   private selectedIndex = 0;
   private maxVisible: number;
   private theme: SelectListTheme;
+  /** When true, items are toggled (space) and confirmed together (enter) instead of selected one at a time. */
+  private multiSelect: boolean;
+  /** Values toggled on in multi-select mode. */
+  private checkedValues = new Set<string>();
 
   onSelect?: (item: SelectItem) => void;
   onCancel?: () => void;
   onSelectionChange?: (item: SelectItem) => void;
+  /** Called when the user confirms a multi-select list with Enter; receives all checked items in display order. */
+  onConfirmMulti?: (items: SelectItem[]) => void;
 
-  constructor(items: SelectItem[], maxVisible: number, theme: SelectListTheme) {
+  constructor(items: SelectItem[], maxVisible: number, theme: SelectListTheme, multiSelect = false) {
     this.items = items;
     this.filteredItems = items;
     this.maxVisible = maxVisible;
     this.theme = theme;
+    this.multiSelect = multiSelect;
   }
 
   setFilter(filter: string): void {
@@ -85,7 +95,21 @@ export class WrappingSelectList implements Component {
     } else if (kb.matches(keyData, 'tui.select.down')) {
       this.selectedIndex = this.selectedIndex === this.filteredItems.length - 1 ? 0 : this.selectedIndex + 1;
       this.notifySelectionChange();
+    } else if (this.multiSelect && keyData === ' ') {
+      const current = this.filteredItems[this.selectedIndex];
+      if (current) {
+        if (this.checkedValues.has(current.value)) {
+          this.checkedValues.delete(current.value);
+        } else {
+          this.checkedValues.add(current.value);
+        }
+      }
     } else if (kb.matches(keyData, 'tui.select.confirm')) {
+      if (this.multiSelect) {
+        const checked = this.items.filter(item => this.checkedValues.has(item.value));
+        this.onConfirmMulti?.(checked);
+        return;
+      }
       const selected = this.filteredItems[this.selectedIndex];
       if (selected && this.onSelect) this.onSelect(selected);
     } else if (kb.matches(keyData, 'tui.select.cancel')) {
@@ -95,20 +119,30 @@ export class WrappingSelectList implements Component {
 
   private renderItem(item: SelectItem, isSelected: boolean, width: number): string[] {
     const labelText = this.getDisplayValue(item);
-    const labelWidth = Math.max(1, width - PREFIX_WIDTH);
+    // In multi-select mode each row carries a `[x] `/`[ ] ` checkbox after the
+    // cursor prefix, so reserve that extra width when wrapping the label.
+    const checkboxWidth = this.multiSelect ? CHECKBOX_WIDTH : 0;
+    const labelWidth = Math.max(1, width - PREFIX_WIDTH - checkboxWidth);
     const wrapped = wrapTextWithAnsi(labelText, labelWidth);
+    const checkbox = this.multiSelect
+      ? this.checkedValues.has(item.value)
+        ? CHECKBOX_CHECKED
+        : CHECKBOX_UNCHECKED
+      : '';
 
     if (wrapped.length === 0) {
       const prefix = isSelected ? SELECTED_PREFIX : UNSELECTED_PREFIX;
-      const rendered = `${prefix}`;
+      const rendered = `${prefix}${checkbox}`;
       return [isSelected ? this.theme.selectedText(rendered) : rendered];
     }
 
     return wrapped.map((chunk, index) => {
-      const prefix = index === 0 ? (isSelected ? SELECTED_PREFIX : UNSELECTED_PREFIX) : CONTINUATION_PREFIX;
-      const rendered = `${prefix}${chunk}`;
+      const cursorPrefix = index === 0 ? (isSelected ? SELECTED_PREFIX : UNSELECTED_PREFIX) : CONTINUATION_PREFIX;
+      // Only the first row shows the checkbox; continuation rows indent to align.
+      const boxPart = index === 0 ? checkbox : ' '.repeat(checkbox.length);
+      const rendered = `${cursorPrefix}${boxPart}${chunk}`;
       if (isSelected) return this.theme.selectedText(rendered);
-      if (prefix === CONTINUATION_PREFIX) return this.theme.description(rendered);
+      if (cursorPrefix === CONTINUATION_PREFIX) return this.theme.description(rendered);
       return rendered;
     });
   }

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -362,7 +362,7 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
     }
 
     case 'ask_question':
-      await handleAskQuestion(ectx, event.questionId, event.question, event.options);
+      await handleAskQuestion(ectx, event.questionId, event.question, event.options, event.selectionMode);
       break;
 
     case 'sandbox_access_request':

--- a/mastracode/src/tui/handlers/__tests__/prompts.test.ts
+++ b/mastracode/src/tui/handlers/__tests__/prompts.test.ts
@@ -57,6 +57,28 @@ describe('handleAskQuestion goal mode', () => {
     state.activeInlineQuestion!.handleInput('\r');
     await promise;
   });
+
+  it('resolves a multi_select prompt with an array of every toggled option label', async () => {
+    const { ctx, state } = createCtx();
+    const options = [{ label: 'React' }, { label: 'Vue' }, { label: 'Svelte' }];
+
+    const promise = handleAskQuestion(ctx, 'q1', 'Which apply?', options, 'multi_select');
+
+    const component = state.activeInlineQuestion!;
+    // Toggle React (space), move down twice to Svelte, toggle it, then confirm (enter).
+    component.handleInput(' ');
+    component.handleInput('\x1b[B');
+    component.handleInput('\x1b[B');
+    component.handleInput(' ');
+    component.handleInput('\r');
+
+    await promise;
+
+    expect(state.harness.respondToQuestion).toHaveBeenCalledWith({
+      questionId: 'q1',
+      answer: ['React', 'Svelte'],
+    });
+  });
 });
 
 function createPlanApprovalCtx() {

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -2,6 +2,7 @@
  * Event handlers for interactive prompt events:
  * ask_question, sandbox_access_request, plan_approval_required.
  */
+import type { HarnessQuestionSelectionMode } from '@mastra/core/harness';
 import { savePlanToDisk } from '../../utils/plans.js';
 import { AskQuestionDialogComponent } from '../components/ask-question-dialog.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
@@ -35,6 +36,7 @@ export async function handleAskQuestion(
   questionId: string,
   question: string,
   options?: Array<{ label: string; description?: string }>,
+  selectionMode?: HarnessQuestionSelectionMode,
 ): Promise<void> {
   const { state } = ctx;
 
@@ -55,11 +57,18 @@ export async function handleAskQuestion(
             askUserComponent.activate({
               question,
               options,
+              selectionMode,
               multiline: true,
               tui: state.ui,
               onSubmit: answer => {
                 state.activeInlineQuestion = undefined;
                 state.harness.respondToQuestion({ questionId, answer });
+                resolve();
+                processNextInlineQuestion(state);
+              },
+              onSubmitMulti: answers => {
+                state.activeInlineQuestion = undefined;
+                state.harness.respondToQuestion({ questionId, answer: answers });
                 resolve();
                 processNextInlineQuestion(state);
               },
@@ -78,10 +87,17 @@ export async function handleAskQuestion(
               {
                 question,
                 options,
+                selectionMode,
                 multiline: true,
                 onSubmit: answer => {
                   state.activeInlineQuestion = undefined;
                   state.harness.respondToQuestion({ questionId, answer });
+                  resolve();
+                  processNextInlineQuestion(state);
+                },
+                onSubmitMulti: answers => {
+                  state.activeInlineQuestion = undefined;
+                  state.harness.respondToQuestion({ questionId, answer: answers });
                   resolve();
                   processNextInlineQuestion(state);
                 },
@@ -127,11 +143,17 @@ export async function handleAskQuestion(
       const dialog = new AskQuestionDialogComponent({
         question,
         options,
+        selectionMode,
         multiline: true,
         tui: state.ui,
         onSubmit: answer => {
           state.ui.hideOverlay();
           state.harness.respondToQuestion({ questionId, answer });
+          resolve();
+        },
+        onSubmitMulti: answers => {
+          state.ui.hideOverlay();
+          state.harness.respondToQuestion({ questionId, answer: answers });
           resolve();
         },
         onCancel: () => {


### PR DESCRIPTION
## Summary

Closes #17004.

The `ask_user` tool exposes a `selectionMode` parameter with `single_select` and `multi_select` values, but Mastra Code always rendered option prompts as single-select. When an agent called `ask_user` with `selectionMode: "multi_select"`, the user could only pick one option and the agent got a single string back instead of the full set of selected answers.

This change makes `multi_select` work end-to-end in the CLI:

- When `selectionMode: "multi_select"` is passed, the prompt renders a multi-select picker — **Space** toggles each option's checkbox, **Enter** confirms all checked options.
- The agent now receives **every selected option label as an array**, instead of a single collapsed string.
- Single-select prompts are unchanged: Enter still selects the highlighted option immediately, and the "Custom response…" free-text escape hatch is still offered (it's intentionally omitted in multi-select, which toggles a fixed option set).

The harness side already supported this fully — the `ask_question` event carried `selectionMode` and `respondToQuestion` already accepted `string[]`. The gap was entirely in the TUI, which never read `selectionMode`. This PR threads it from the event dispatcher through `handleAskQuestion` into the inline and dialog components, and adds a multi-select mode to the shared `WrappingSelectList`.

## Test plan

- New unit tests:
  - `wrapping-select-list.test.ts` — checkbox rendering, Space toggling on/off, Enter firing `onConfirmMulti` with checked items in display order, and that Space/Enter are inert in single-select mode.
  - `ask-question-inline-multi-select.test.ts` — multi-select hint, omission of the custom-response option, array answer via `onSubmitMulti`, comma-joined fallback, and the frozen answered box showing every selection.
  - `prompts.test.ts` — end-to-end: a `multi_select` prompt resolves `respondToQuestion` with an array of selected labels.
- `tsc --noEmit`, `tsup` build, and ESLint all pass.
- Manually verified in the local CLI: the picker shows checkboxes, Space toggles, Enter confirms, and the agent receives the array of selected labels.

A `mastracode` patch changeset is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Mastra Code CLI had a feature that was supposed to let users pick multiple options from a list, but it wasn't actually working—users could only pick one. This PR fixes it by making sure the "allow multiple picks" setting gets passed through all the right places in the code, and by adding checkboxes so users can toggle their choices with the spacebar and confirm them with Enter.

## Overview

This PR fixes a bug in Mastra Code's `ask_user` tool where the `selectionMode: "multi_select"` option was being ignored. Previously, prompts always rendered as single-select, allowing users to pick only one option and returning a single string to the agent. After this fix, multi-select mode displays a proper picker with checkboxes (toggled via Space, confirmed via Enter) and returns all selected option labels as an array.

## Key Changes

**Threading `selectionMode` through the event pipeline:**
- `event-dispatch.ts`: Passes `event.selectionMode` into `handleAskQuestion`
- `prompts.ts`: `handleAskQuestion` now accepts an optional `selectionMode` parameter and wires it to inline and dialog components
- Both inline and dialog components now support `onSubmitMulti(answers: string[])` callbacks alongside the existing `onSubmit`

**Multi-select UI implementation:**
- `wrapping-select-list.ts`: Added checkbox rendering (`[x]`/`[ ]`), spacebar toggling, and `onConfirmMulti` callback for gathering all checked items in display order
- `ask-question-inline.ts`: Added `AskQuestionSelectionMode` type export, `selectionMode` and `onSubmitMulti` options to `AskQuestionInlineOptions`, and tracks multiple selections via a `selectedValues` set
- `ask-question-dialog.ts`: Updated `AskQuestionDialogOptions` with `selectionMode` and `onSubmitMulti` support; routes multi-select confirmations appropriately
- "Custom response..." escape hatch is now single-select only; removed from multi-select prompts

**Behavioral changes:**
- Single-select mode: unchanged (Enter selects highlighted option, custom-response option available)
- Multi-select mode: Space toggles checkboxes, Enter confirms all checked options; agents receive an array of selected labels; if `onSubmitMulti` is omitted, falls back to `onSubmit` with comma-joined string

## Testing

Added comprehensive test coverage:
- `wrapping-select-list.test.ts`: Verifies checkbox rendering, space-key toggling, enter-to-confirm, `onConfirmMulti` invocation with all checked items, and that space is ignored in single-select mode
- `ask-question-inline-multi-select.test.ts`: Covers multi-select hint text, absence of custom-response option, `onSubmitMulti` invocation with toggled labels, fallback to `onSubmit` when `onSubmitMulti` is omitted, and rendered state after confirmation
- `prompts.test.ts`: End-to-end test verifying `handleAskQuestion` with `selectionMode: 'multi_select'` resolves to an array of selected labels

## Validation

- TypeScript: `tsc --noEmit` passes
- Build: `tsup` completes successfully
- Linting: ESLint passes
- Manual CLI verification performed
- Includes a changeset for Mastra Code package version bump

Closes `#17004`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->