### PR TITLE
feat(core): support conditional, function-based tool approvals

### DIFF
--- a/.changeset/conditional-tool-approvals.md
+++ b/.changeset/conditional-tool-approvals.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': minor
+'@mastra/mcp': patch
+---
+
+Support conditional, function-based tool approvals.
+
+- MCP tools that wrap a server-level `requireToolApproval` function are now honored end-to-end. The per-tool approval function was previously dropped when the agent converted MCP tools (it kept only the boolean flag), so conditional approval silently fell back to always-on. `CoreToolBuilder` now preserves a `needsApprovalFn` attached directly to a tool instance.
+- The global `requireToolApproval` option on `agent.stream`/`agent.generate` now accepts a function in addition to a boolean. It is evaluated per tool call with the tool name, arguments, and request context, enabling policies such as regex allowlists on tool names. Returning `true` requires approval for that call; `false` allows it. On error the call defaults to requiring approval. When a function policy is set, tool calls run sequentially so approval suspensions don't race. Durable agents and stored agents continue to accept only a boolean (a function degrades to requiring approval for every call, since their options must be serializable).
+```ts
+// Approve only tool calls whose name is not on an allowlist.
+const allowlist = /^(get|list|search)_/;
+await agent.generate('...', {
+  requireToolApproval: ({ toolName }) => !allowlist.test(toolName),
+});
+```
+
+- Precedence is unchanged from before: a per-tool approval function (`createTool({ requireApproval: fn })` or an MCP-derived `needsApprovalFn`) is authoritative for that tool and overrides the global setting, so a tool can still opt out of approval by returning `false` even when the global option is on. The only new behavior is that the global option may now be a function in addition to a boolean.
+- The previously implicit, runtime-attached per-tool approval predicate is now a typed contract: `@mastra/core` exports `NeedsApprovalFn` and declares the optional `needsApprovalFn` property on the `Tool` class. The MCP client and the agent runtime now share this typed contract instead of reaching through `any`. This is additive — no public API changes.

--- a/docs/src/content/en/docs/agents/agent-approval.mdx
+++ b/docs/src/content/en/docs/agents/agent-approval.mdx
@@ -99,6 +99,24 @@ for await (const chunk of stream.fullStream) {
 }
 ```
 
+#### Conditional approval with a function
+
+Instead of a boolean, `requireToolApproval` accepts a function that decides per tool call. It receives the `toolName`, the `args` the model passed, the `requestContext`, and the `workspace`. Return `true` to require approval for that call, or `false` to allow it. This lets you gate approval dynamically — for example, only for tools whose name matches a pattern:
+
+```typescript
+const stream = await agent.stream('Clean up old records', {
+  requireToolApproval: ({ toolName }) => /^delete_/.test(toolName),
+})
+```
+
+A tool's own `requireApproval` setting still takes precedence: if a tool defines its own approval rule, that rule decides for that tool and the function above does not override it. If the function throws, the call requires approval (fail-safe).
+
+:::note
+
+Function-based `requireToolApproval` is only available on regular `stream()` / `generate()` calls. Durable agents and stored agents persist their options, and a function can't be serialized, so they accept only a boolean. If you pass a function in those contexts it falls back to requiring approval for every tool call.
+
+:::
+
 ### Runtime suspension with `suspend()`
 
 A tool can also pause _during_ its `execute` function by calling `suspend()`. This is useful when the tool starts running and then discovers it needs additional user input or confirmation before it can finish.

--- a/packages/core/src/agent/__tests__/tool-approval.test.ts
+++ b/packages/core/src/agent/__tests__/tool-approval.test.ts
@@ -159,6 +159,190 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
           expect(toolName).toBe('findUserTool');
         }
       }, 500000);
+
+      it('should evaluate a function-valued global requireToolApproval per tool call', async () => {
+        const execute = vi.fn().mockResolvedValue({ name: 'Dero Israel', email: 'dero@mail.com' });
+        const findUserTool = createTool({
+          id: 'find-user-tool',
+          description: 'Returns the name and email for a user',
+          inputSchema: z.object({ name: z.string() }),
+          execute: async () => execute(),
+        });
+
+        const makeModel = () =>
+          new MockLanguageModelV2({
+            doStream: async () => ({
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              warnings: [],
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'findUserTool',
+                  input: '{"name":"Dero Israel"}',
+                  providerExecuted: false,
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                },
+              ]),
+            }),
+          });
+
+        const makeAgent = () =>
+          new Agent({
+            id: 'global-approval-agent',
+            name: 'Global Approval Agent',
+            instructions: 'You can look up users.',
+            model: makeModel(),
+            tools: { findUserTool },
+            memory: new MockMemory(),
+          });
+
+        // Case 1: the policy returns true → the tool call suspends for approval and does not execute.
+        const approveAll = vi.fn().mockReturnValue(true);
+        const suspendingAgent = makeAgent();
+        const suspendStream = await suspendingAgent.stream('Find the user with name - Dero Israel', {
+          memory: { thread: randomUUID(), resource: randomUUID() },
+          requireToolApproval: approveAll,
+        });
+        let approvedToolName = '';
+        for await (const chunk of suspendStream.fullStream) {
+          if (chunk.type === 'tool-call-approval') {
+            approvedToolName = chunk.payload.toolName;
+          }
+        }
+        expect(approveAll).toHaveBeenCalledWith(
+          expect.objectContaining({ toolName: 'findUserTool', args: { name: 'Dero Israel' } }),
+        );
+        expect(approvedToolName).toBe('findUserTool');
+        expect(execute).not.toHaveBeenCalled();
+
+        // Case 2: the policy returns false → the tool runs without requiring approval.
+        const denyApproval = vi.fn().mockReturnValue(false);
+        const runningAgent = makeAgent();
+        const runStream = await runningAgent.stream('Find the user with name - Dero Israel', {
+          memory: { thread: randomUUID(), resource: randomUUID() },
+          requireToolApproval: denyApproval,
+        });
+        let sawApproval = false;
+        for await (const chunk of runStream.fullStream) {
+          if (chunk.type === 'tool-call-approval') {
+            sawApproval = true;
+          }
+        }
+        expect(denyApproval).toHaveBeenCalled();
+        expect(sawApproval).toBe(false);
+        expect(execute).toHaveBeenCalled();
+      }, 500000);
+
+      it('honors a function-valued global requireToolApproval across suspend and resume', async () => {
+        // The function policy lives only in the live JS call (RequestContext.toJSON strips it from
+        // the persisted suspend snapshot). This proves the resume call re-supplies and re-evaluates
+        // the function, so approval survives a real suspend -> resume cycle without serialization.
+        let callCount = 0;
+        const mockModel = new MockLanguageModelV2({
+          doStream: async () => {
+            callCount++;
+            if (callCount === 1) {
+              return {
+                rawCall: { rawPrompt: null, rawSettings: {} },
+                warnings: [],
+                stream: convertArrayToReadableStream([
+                  { type: 'stream-start', warnings: [] },
+                  { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+                  {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolName: 'findUserTool',
+                    input: '{"name":"Dero Israel"}',
+                    providerExecuted: false,
+                  },
+                  {
+                    type: 'finish',
+                    finishReason: 'tool-calls',
+                    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                  },
+                ]),
+              };
+            }
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              warnings: [],
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-2',
+                  toolName: 'findUserTool',
+                  input: '{"name":"Dero Israel", "resumeData": { "approved": true }}',
+                  providerExecuted: false,
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+                },
+              ]),
+            };
+          },
+        });
+
+        const findUserTool = createTool({
+          id: 'find-user-tool',
+          description: 'Returns the name and email for a user',
+          inputSchema: z.object({ name: z.string() }),
+          execute: async input => mockFindUser(input) as Promise<Record<string, any>>,
+        });
+
+        const resumeAgent = new Agent({
+          id: 'resume-approval-agent',
+          name: 'Resume Approval Agent',
+          instructions: 'You can look up users.',
+          model: mockModel,
+          tools: { findUserTool },
+          memory: new MockMemory(),
+        });
+
+        const mastra = new Mastra({ agents: { resumeAgent }, logger: false, storage: mockStorage });
+        const agent = mastra.getAgent('resumeAgent');
+        const memory = { thread: randomUUID(), resource: randomUUID() };
+        const requireToolApproval = vi.fn().mockReturnValue(true);
+
+        mockFindUser.mockClear();
+
+        // First call: the function policy requires approval, so the tool suspends.
+        const suspendStream = await agent.stream('Find the user with name - Dero Israel', {
+          memory,
+          requireToolApproval,
+        });
+        let toolName = '';
+        for await (const chunk of suspendStream.fullStream) {
+          if (chunk.type === 'tool-call-approval') {
+            toolName = chunk.payload.toolName;
+          }
+        }
+        expect(toolName).toBe('findUserTool');
+        expect(mockFindUser).not.toHaveBeenCalled();
+
+        // Resume call: re-supplies the same function policy. Approval is granted, tool executes.
+        const resumeStream = await agent.stream('Approve', { memory, requireToolApproval });
+        for await (const _chunk of resumeStream.fullStream) {
+          // drain
+        }
+        const toolResults = await resumeStream.toolResults;
+        const toolCall = toolResults?.find((result: any) => result.payload.toolName === 'findUserTool')?.payload;
+
+        // The policy was evaluated on both the suspend and resume passes (function survived resume).
+        expect(requireToolApproval.mock.calls.length).toBeGreaterThanOrEqual(2);
+        expect(mockFindUser).toHaveBeenCalled();
+        expect((toolCall?.result as any)?.name).toBe('Dero Israel');
+      }, 500000);
     });
   });
 }

--- a/packages/core/src/agent/__tests__/tools.test.ts
+++ b/packages/core/src/agent/__tests__/tools.test.ts
@@ -1387,6 +1387,54 @@ describe('requireApproval property preservation', () => {
       }
     }
   });
+
+  it('should preserve a needsApprovalFn attached directly to a tool (MCP shape) through convertTools', async () => {
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        text: 'ok',
+        content: [{ type: 'text', text: 'ok' }],
+        warnings: [],
+      }),
+    });
+
+    // Mirror how the MCP client builds tools: boolean requireApproval plus a
+    // server-level approval function attached directly as needsApprovalFn.
+    const needsApprovalFn = (args: any) => args.amount > 100;
+    const mcpStyleTool = createTool({
+      id: 'transfer-funds',
+      description: 'Transfer funds',
+      inputSchema: z.object({ amount: z.number() }),
+      requireApproval: true,
+      execute: async ({ amount }) => ({ success: true, amount }),
+    });
+    mcpStyleTool.needsApprovalFn = needsApprovalFn;
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent for conditional approval',
+      model: mockModel,
+    });
+
+    const tools = await agent['convertTools']({
+      requestContext: new RequestContext(),
+      methodType: 'generate',
+      toolsets: {
+        banking: {
+          transferFunds: mcpStyleTool,
+        },
+      },
+    });
+
+    expect(tools.transferFunds).toBeDefined();
+    expect((tools.transferFunds as any).requireApproval).toBe(true);
+    // The conditional approval function must survive conversion so tool-call-step
+    // can evaluate it per call instead of falling back to the boolean flag.
+    expect((tools.transferFunds as any).needsApprovalFn).toBe(needsApprovalFn);
+  });
 });
 
 describe('sub-agent prompt input normalization (GitHub #14154)', () => {

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -9,7 +9,7 @@ import type { VersionOverrides } from '../mastra/types';
 import type { ObservabilityContext, TracingOptions } from '../observability';
 import type { ErrorProcessorOrWorkflow, InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors';
 import type { RequestContext } from '../request-context';
-import type { ToolPayloadTransformPolicy } from '../tools';
+import type { RequireToolApproval, ToolPayloadTransformPolicy } from '../tools';
 import type { OutputWriter, WorkflowRunState } from '../workflows/types';
 import type { MessageListInput } from './message-list';
 import type {
@@ -568,8 +568,12 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
    */
   isTaskComplete?: StreamIsTaskCompleteConfig;
 
-  /** Require approval for all tool calls */
-  requireToolApproval?: boolean;
+  /**
+   * Require approval for tool calls. Pass `true` to require approval for every tool call,
+   * or a function evaluated per call (with the tool name, args, and request context) to
+   * decide conditionally — e.g. to gate approval by a regex on the tool name.
+   */
+  requireToolApproval?: RequireToolApproval;
 
   /** Automatically resume suspended tools */
   autoResumeSuspendedTools?: boolean;

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -327,7 +327,10 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
       toolChoice: execOptions?.toolChoice as any,
       activeTools: execOptions?.activeTools,
       temperature: execOptions?.modelSettings?.temperature,
-      requireToolApproval: execOptions?.requireToolApproval,
+      // Durable runs serialize their options, so a function-valued global approval policy
+      // can't be persisted. Degrade safely by requiring approval for every tool call.
+      requireToolApproval:
+        typeof execOptions?.requireToolApproval === 'function' ? true : execOptions?.requireToolApproval,
       toolCallConcurrency: execOptions?.toolCallConcurrency,
       autoResumeSuspendedTools: execOptions?.autoResumeSuspendedTools,
       maxProcessorRetries: execOptions?.maxProcessorRetries,

--- a/packages/core/src/agent/durable/utils/resolve-runtime.ts
+++ b/packages/core/src/agent/durable/utils/resolve-runtime.ts
@@ -5,6 +5,7 @@ import type { StreamInternal } from '../../../loop/types';
 import type { Mastra } from '../../../mastra';
 import type { MastraMemory } from '../../../memory/memory';
 import { RequestContext } from '../../../request-context';
+import { getNeedsApprovalFn } from '../../../tools/toolchecks';
 import type { CoreTool } from '../../../tools/types';
 import type { Workspace } from '../../../workspace';
 import { MessageList } from '../../message-list';
@@ -246,8 +247,9 @@ export function resolveTool(toolName: string, mastra?: Mastra): CoreTool | undef
  * Check if a tool requires human approval.
  *
  * If the tool has a `needsApprovalFn`, it takes precedence over both the
- * global `requireToolApproval` flag and the tool-level `requireApproval` flag.
- * This matches the behavior of the non-durable agent's tool-call-step.
+ * global `requireToolApproval` flag and the tool-level `requireApproval` flag
+ * (e.g. skill tools return `false` to suppress approval). On error the call
+ * defaults to requiring approval (safe default).
  */
 export async function toolRequiresApproval(
   tool: CoreTool,
@@ -257,9 +259,10 @@ export async function toolRequiresApproval(
   let requires = !!(globalRequireApproval || (tool as any).requireApproval);
 
   // needsApprovalFn overrides all other flags (e.g., skill tools return false)
-  if ((tool as any).needsApprovalFn) {
+  const needsApprovalFn = getNeedsApprovalFn(tool);
+  if (needsApprovalFn) {
     try {
-      requires = await (tool as any).needsApprovalFn(args ?? {});
+      requires = !!(await needsApprovalFn(args ?? {}));
     } catch {
       // On error, default to requiring approval (safe default)
       requires = true;

--- a/packages/core/src/agent/workflows/prepare-stream/index.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/index.ts
@@ -8,7 +8,7 @@ import type { Span, SpanType } from '../../../observability';
 import { InternalSpans } from '../../../observability';
 import type { RequestContext } from '../../../request-context';
 import { MastraModelOutput } from '../../../stream';
-import type { ToolPayloadTransformPolicy } from '../../../tools';
+import type { RequireToolApproval, ToolPayloadTransformPolicy } from '../../../tools';
 import { createWorkflow } from '../../../workflows/workflow';
 import type { Workspace } from '../../../workspace/workspace';
 import type { InnerAgentExecutionOptions } from '../../agent.types';
@@ -35,7 +35,7 @@ interface CreatePrepareStreamWorkflowOptions<OUTPUT = undefined> {
   memory?: MastraMemory;
   returnScorerData?: boolean;
   saveQueueManager?: SaveQueueManager;
-  requireToolApproval?: boolean;
+  requireToolApproval?: RequireToolApproval;
   toolCallConcurrency?: number;
   resumeContext?: {
     resumeData: any;

--- a/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
@@ -8,7 +8,7 @@ import type { MemoryConfigInternal } from '../../../memory/types';
 import { resolveObservabilityContext } from '../../../observability';
 import { RequestContext } from '../../../request-context';
 import { MastraModelOutput } from '../../../stream';
-import type { ToolPayloadTransformPolicy } from '../../../tools';
+import type { RequireToolApproval, ToolPayloadTransformPolicy } from '../../../tools';
 import { createStep } from '../../../workflows/workflow';
 import type { Workspace } from '../../../workspace/workspace';
 import type { SaveQueueManager } from '../../save-queue';
@@ -20,7 +20,7 @@ interface StreamStepOptions {
   capabilities: AgentCapabilities;
   runId: string;
   returnScorerData?: boolean;
-  requireToolApproval?: boolean;
+  requireToolApproval?: RequireToolApproval;
   toolCallConcurrency?: number;
   resumeContext?: {
     resumeData: any;

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -20,6 +20,7 @@ import { ChunkFrom } from '../../stream';
 import type { ChunkType } from '../../stream';
 import { escapeUnescapedControlCharsInJsonStrings } from '../../stream/base/output-format-handlers';
 import { MastraAgentNetworkStream } from '../../stream/MastraAgentNetworkStream';
+import { getNeedsApprovalFn } from '../../tools/toolchecks';
 import type { IdGeneratorContext } from '../../types';
 import type { Step, SuspendOptions } from '../../workflows/step';
 import { createStep, createWorkflow } from '../../workflows/workflow';
@@ -1578,10 +1579,11 @@ export async function createNetworkLoop({
       // - undefined (no approval needed)
       // If needsApprovalFn exists, evaluate it with the tool args
       let toolRequiresApproval = (tool as any).requireApproval;
-      if ((tool as any).needsApprovalFn) {
+      const needsApprovalFn = getNeedsApprovalFn(tool);
+      if (needsApprovalFn) {
         // Evaluate the function with the parsed args
         try {
-          const needsApprovalResult = await (tool as any).needsApprovalFn(inputDataToUse);
+          const needsApprovalResult = await needsApprovalFn(inputDataToUse);
           toolRequiresApproval = needsApprovalResult;
         } catch (error) {
           // Log error to help developers debug faulty needsApprovalFn implementations

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -38,7 +38,7 @@ import type {
   StreamChunkType,
   StreamTransportRef,
 } from '../stream/types';
-import type { ToolPayloadTransformPolicy } from '../tools';
+import type { RequireToolApproval, ToolPayloadTransformPolicy } from '../tools';
 import type { MastraIdGenerator } from '../types';
 import type { OutputWriter } from '../workflows/types';
 import type { Workspace } from '../workspace/workspace';
@@ -148,7 +148,7 @@ export type LoopOptions<TOOLS extends ToolSet = ToolSet, OUTPUT = undefined> = {
   downloadRetries?: number;
   downloadConcurrency?: number;
   modelSpanTracker?: IModelSpanTracker;
-  requireToolApproval?: boolean;
+  requireToolApproval?: RequireToolApproval;
   autoResumeSuspendedTools?: boolean;
   agentId: string;
   toolCallConcurrency?: number;

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.test.ts
@@ -22,6 +22,20 @@ describe('tool call concurrency resolution', () => {
     ).toBe(true);
   });
 
+  it('requires sequential execution when global approval is a function', () => {
+    // A function policy can only be evaluated per call once args are known, so before
+    // execution we conservatively force sequential to avoid approval suspensions racing.
+    expect(
+      effectiveToolSetRequiresSequentialExecution({
+        requireToolApproval: () => false,
+        tools: {
+          safe: safeTool,
+        },
+        activeTools: ['safe'],
+      }),
+    ).toBe(true);
+  });
+
   it('scans all current tools when activeTools is undefined', () => {
     expect(
       effectiveToolSetRequiresSequentialExecution({

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-concurrency.ts
@@ -1,4 +1,5 @@
 import type { ToolSet } from '@internal/ai-sdk-v5';
+import type { RequireToolApproval } from '../../../tools';
 
 export type ToolCallForeachOptions = {
   concurrency: number;
@@ -13,7 +14,10 @@ export function effectiveToolSetRequiresSequentialExecution({
   tools,
   activeTools,
 }: {
-  requireToolApproval?: boolean;
+  // A function-valued global approval policy is evaluated per call at execution time;
+  // before args are known we conservatively treat it like `true` and force sequential
+  // execution so approval suspensions never race with concurrent tool calls.
+  requireToolApproval?: RequireToolApproval;
   tools?: ToolSet;
   activeTools?: readonly string[];
 }): boolean {
@@ -45,7 +49,7 @@ export function resolveToolCallConcurrency({
   activeTools,
   configuredConcurrency,
 }: {
-  requireToolApproval?: boolean;
+  requireToolApproval?: RequireToolApproval;
   tools?: ToolSet;
   activeTools?: readonly string[];
   configuredConcurrency: number;

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -494,6 +494,132 @@ describe('createToolCallStep needsApprovalFn enriched context', () => {
   });
 });
 
+describe('createToolCallStep global requireToolApproval function', () => {
+  let controller: { enqueue: Mock };
+  let suspend: Mock;
+  let streamState: { serialize: Mock };
+  let messageList: MessageList;
+  let neverResolve: Promise<never>;
+
+  const makeInputData = () => ({
+    toolCallId: 'global-call-id',
+    toolName: 'transfer-funds',
+    args: { amount: 500 },
+  });
+
+  const makeExecuteParams = (requireToolApproval: unknown, overrides: any = {}) => {
+    const requestContext = new RequestContext();
+    if (requireToolApproval !== undefined) {
+      requestContext.set('__mastra_requireToolApproval', requireToolApproval as any);
+    }
+    return {
+      ...makeBaseExecuteParams(suspend, { requestContext }),
+      writer: new ToolStream({
+        prefix: 'tool',
+        callId: 'global-call-id',
+        name: 'transfer-funds',
+        runId: 'global-run-id',
+      }),
+      inputData: makeInputData(),
+      ...overrides,
+    };
+  };
+
+  beforeEach(() => {
+    controller = { enqueue: vi.fn() };
+    neverResolve = new Promise(() => {});
+    suspend = vi.fn().mockReturnValue(neverResolve);
+    streamState = { serialize: vi.fn().mockReturnValue('serialized-state') };
+    messageList = createMessageList();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('should require approval when the global function returns true', async () => {
+    const requireToolApproval = vi.fn().mockReturnValue(true);
+    const tools = { 'transfer-funds': { execute: vi.fn() } };
+
+    const toolCallStep = createToolCallStep({ tools, messageList, controller, runId: 'global-run-id', streamState });
+    const executePromise = toolCallStep.execute(makeExecuteParams(requireToolApproval));
+    await new Promise(resolve => setImmediate(resolve));
+
+    // The policy is evaluated with the tool name and args.
+    expect(requireToolApproval).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: 'transfer-funds', args: { amount: 500 } }),
+    );
+    expect(suspend).toHaveBeenCalled();
+    expect(tools['transfer-funds'].execute).not.toHaveBeenCalled();
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('should skip approval when the global function returns false', async () => {
+    const requireToolApproval = vi.fn().mockReturnValue(false);
+    const toolResult = { transferred: true };
+    const tools = { 'transfer-funds': { execute: vi.fn().mockResolvedValue(toolResult) } };
+
+    const toolCallStep = createToolCallStep({ tools, messageList, controller, runId: 'global-run-id', streamState });
+    const result = await toolCallStep.execute(makeExecuteParams(requireToolApproval));
+
+    expect(requireToolApproval).toHaveBeenCalled();
+    expect(suspend).not.toHaveBeenCalled();
+    expect(result).toEqual({ result: toolResult, ...makeInputData() });
+  });
+
+  it('should default to requiring approval when the global function throws', async () => {
+    const requireToolApproval = vi.fn().mockImplementation(() => {
+      throw new Error('policy error');
+    });
+    const tools = { 'transfer-funds': { execute: vi.fn() } };
+
+    const toolCallStep = createToolCallStep({ tools, messageList, controller, runId: 'global-run-id', streamState });
+    const executePromise = toolCallStep.execute(makeExecuteParams(requireToolApproval));
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(suspend).toHaveBeenCalled();
+    expect(tools['transfer-funds'].execute).not.toHaveBeenCalled();
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('lets a per-tool needsApprovalFn override a global function that requires approval', async () => {
+    // Global policy requires approval, but the tool's needsApprovalFn returns false. The
+    // per-tool function is authoritative (long-standing precedence), so the call runs without
+    // approval — the global must not be able to force approval on a tool that opts out.
+    const requireToolApproval = vi.fn().mockReturnValue(true);
+    const needsApprovalFn = vi.fn().mockReturnValue(false);
+    const toolResult = { transferred: true };
+    const tools = { 'transfer-funds': { execute: vi.fn().mockResolvedValue(toolResult), needsApprovalFn } };
+
+    const toolCallStep = createToolCallStep({ tools, messageList, controller, runId: 'global-run-id', streamState });
+    const result = await toolCallStep.execute(makeExecuteParams(requireToolApproval));
+
+    expect(needsApprovalFn).toHaveBeenCalled();
+    expect(suspend).not.toHaveBeenCalled();
+    expect(result).toEqual({ result: toolResult, ...makeInputData() });
+  });
+
+  it('lets a per-tool needsApprovalFn require approval the global function allowed', async () => {
+    // Global policy allows the call, but the tool's needsApprovalFn requires approval.
+    const requireToolApproval = vi.fn().mockReturnValue(false);
+    const needsApprovalFn = vi.fn().mockReturnValue(true);
+    const tools = { 'transfer-funds': { execute: vi.fn(), needsApprovalFn } };
+
+    const toolCallStep = createToolCallStep({ tools, messageList, controller, runId: 'global-run-id', streamState });
+    const executePromise = toolCallStep.execute(makeExecuteParams(requireToolApproval));
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(needsApprovalFn).toHaveBeenCalled();
+    expect(suspend).toHaveBeenCalled();
+    expect(tools['transfer-funds'].execute).not.toHaveBeenCalled();
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+});
+
 describe('createToolCallStep provider-executed tools', () => {
   let controller: ReadableStreamDefaultController;
   let suspend: Mock;

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -18,7 +18,8 @@ import {
   withToolPayloadTransformProviderMetadata,
 } from '../../../tools/payload-transform';
 import { findProviderToolByName } from '../../../tools/provider-tool-utils';
-import type { MastraToolInvocationOptions } from '../../../tools/types';
+import { getNeedsApprovalFn } from '../../../tools/toolchecks';
+import type { MastraToolInvocationOptions, ToolApprovalContext } from '../../../tools/types';
 import { noopObserve } from '../../../tools/types';
 import { ensureSerializable } from '../../../utils';
 import type { SuspendOptions } from '../../../workflows/step';
@@ -365,20 +366,51 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
 
         const isResumeToolCall = !!resumeDataFromArgs;
 
-        // Check if approval is required
-        // requireApproval can be:
-        // - boolean (from Mastra createTool or mapped from AI SDK needsApproval: true)
-        // - undefined (no approval needed)
-        // If needsApprovalFn exists, evaluate it with the tool args and context
-        let toolRequiresApproval = requireToolApproval || (tool as any).requireApproval;
-        if ((tool as any).needsApprovalFn) {
-          // Evaluate the function with parsed args and available context
+        // Check if approval is required.
+        //
+        // The global `requireToolApproval` option (boolean, or — new — a function evaluated per
+        // call so policies can inspect the tool name and args, e.g. regex allowlists) and the
+        // tool's own boolean `requireApproval` flag seed the decision: the call requires approval
+        // if either is truthy.
+        //
+        // A per-tool `needsApprovalFn` (from `createTool({ requireApproval: fn })` or an
+        // MCP-derived tool) is authoritative when present and OVERRIDES the seed — it may return
+        // `false` to allow a call the global policy/flag would otherwise gate. This preserves the
+        // long-standing precedence; the only new behavior is that the global may now be a function.
+        // Any policy that throws defaults to requiring approval, to be safe.
+        const buildApprovalContext = (): ToolApprovalContext => ({
+          toolName: inputData.toolName,
+          args,
+          // Exclude the internal approval hook so policies only see public request-context entries.
+          requestContext: requestContext
+            ? Object.fromEntries(
+                [...requestContext.entries()].filter(([key]) => key !== '__mastra_requireToolApproval'),
+              )
+            : {},
+          workspace: _internal?.stepWorkspace,
+        });
+
+        let globalRequiresApproval: boolean;
+        if (typeof requireToolApproval === 'function') {
           try {
-            const needsApprovalResult = await (tool as any).needsApprovalFn(args, {
-              requestContext: requestContext ? Object.fromEntries(requestContext.entries()) : {},
-              workspace: _internal?.stepWorkspace,
-            });
-            toolRequiresApproval = needsApprovalResult;
+            globalRequiresApproval = !!(await requireToolApproval(buildApprovalContext()));
+          } catch (error) {
+            logger?.error(`Error evaluating global requireToolApproval for tool ${inputData.toolName}:`, error);
+            // On error, default to requiring approval to be safe.
+            globalRequiresApproval = true;
+          }
+        } else {
+          globalRequiresApproval = !!requireToolApproval;
+        }
+
+        let toolRequiresApproval: boolean = globalRequiresApproval || !!(tool as any).requireApproval;
+
+        const needsApprovalFn = getNeedsApprovalFn(tool);
+        if (needsApprovalFn) {
+          // Per-tool needsApprovalFn overrides the seed (matches prior behavior).
+          try {
+            const { toolName: _toolName, ...needsApprovalCtx } = buildApprovalContext();
+            toolRequiresApproval = !!(await needsApprovalFn(args, needsApprovalCtx));
           } catch (error) {
             // Log error to help developers debug faulty needsApprovalFn implementations
             logger?.error(`Error evaluating needsApprovalFn for tool ${inputData.toolName}:`, error);

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -234,8 +234,17 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
         resourceId: _internal?.resourceId,
       });
 
-      if (requireToolApproval) {
+      if (typeof requireToolApproval === 'function') {
+        // Store the function so the tool-call-step can evaluate it per call. RequestContext.toJSON()
+        // strips non-serializable values, so this never reaches the persisted suspend snapshot — that
+        // is fine because approval is only decided at call time, before any suspend/resume.
+        requestContext.set('__mastra_requireToolApproval', requireToolApproval);
+      } else if (requireToolApproval) {
         requestContext.set('__mastra_requireToolApproval', true);
+      } else {
+        // Clear any value left over from a prior call so a reused RequestContext can't leak a
+        // stale function/`true` into a call where approval is no longer required.
+        requestContext.delete('__mastra_requireToolApproval');
       }
 
       const executionResult = resumeContext

--- a/packages/core/src/storage/default-options-types.test-d.ts
+++ b/packages/core/src/storage/default-options-types.test-d.ts
@@ -1,0 +1,20 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { RequireToolApprovalFn } from '../tools';
+import type { StorageDefaultOptions } from './types';
+
+/**
+ * Stored agent default options must be serializable. `requireToolApproval` can be a function at
+ * runtime (a per-call approval policy), but a function cannot be persisted, so the stored shape is
+ * intentionally narrowed to `boolean`. This test guards against accidentally re-widening the field
+ * to the runtime union — doing so previously broke `@mastra/server`'s build, which consumes
+ * `StorageDefaultOptions` as a serializable shape.
+ */
+describe('StorageDefaultOptions serialization constraints', () => {
+  it('keeps requireToolApproval boolean-only (no function policies in stored options)', () => {
+    expectTypeOf<StorageDefaultOptions['requireToolApproval']>().toEqualTypeOf<boolean | undefined>();
+  });
+
+  it('is not assignable from a function-valued requireToolApproval policy', () => {
+    expectTypeOf<RequireToolApprovalFn>().not.toExtend<StorageDefaultOptions['requireToolApproval']>();
+  });
+});

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -397,7 +397,14 @@ export type StorageDefaultOptions = Omit<
   | 'system' // SystemMessage can be arrays or complex message objects
   | 'stopWhen' // StopCondition is a complex union type from AI SDK
   | 'providerOptions' // ProviderOptions includes provider-specific types from external packages
->;
+  | 'requireToolApproval' // can be a function at runtime; stored options must be serializable
+> & {
+  /**
+   * Stored agents only support a boolean here. Function-based approval policies are runtime-only
+   * and cannot be serialized, so they are intentionally excluded from stored default options.
+   */
+  requireToolApproval?: boolean;
+};
 
 /**
  * A conditional variant: a value paired with an optional RuleGroup.

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -397,6 +397,62 @@ describe('MCP Tool Tracing', () => {
       expect(builtTool.requireApproval).toBe(true);
       expect((builtTool as any).needsApprovalFn).toBeUndefined();
     });
+
+    it('should preserve a needsApprovalFn attached directly to the tool instance (MCP shape)', () => {
+      // MCP tools wrap a server-level requireToolApproval function and attach it as
+      // `needsApprovalFn` on the tool while keeping `requireApproval` as a boolean.
+      const needsApprovalFn = (args: any) => args.value === 'secret';
+      const testTool = {
+        id: 'mcp-test-tool',
+        description: 'An MCP-style test tool',
+        inputSchema: z.object({ value: z.string() }),
+        execute: async (input: any) => input,
+        requireApproval: true,
+        needsApprovalFn,
+      };
+
+      const builder = new CoreToolBuilder({
+        originalTool: testTool as any,
+        options: {
+          name: 'mcp-test-tool',
+          // Mirrors the agent passing the tool's boolean requireApproval into options.
+          requireApproval: true,
+        },
+      });
+
+      const builtTool = builder.build();
+
+      // requireApproval stays true so tool-call-step evaluates the function.
+      expect(builtTool.requireApproval).toBe(true);
+      // The directly-attached function must survive conversion.
+      expect((builtTool as any).needsApprovalFn).toBe(needsApprovalFn);
+    });
+
+    it('should not override an options-derived needsApprovalFn with the instance one', () => {
+      const optionsFn = (input: any) => input.value === 'fromOptions';
+      const instanceFn = (input: any) => input.value === 'fromInstance';
+      const testTool = {
+        id: 'precedence-tool',
+        description: 'A tool with both function sources',
+        inputSchema: z.object({ value: z.string() }),
+        execute: async (input: any) => input,
+        needsApprovalFn: instanceFn,
+      };
+
+      const builder = new CoreToolBuilder({
+        originalTool: testTool as any,
+        options: {
+          name: 'precedence-tool',
+          requireApproval: optionsFn,
+        },
+      });
+
+      const builtTool = builder.build();
+
+      expect(builtTool.requireApproval).toBe(true);
+      // Options-derived function wins; the instance fallback only fills gaps.
+      expect((builtTool as any).needsApprovalFn).toBe(optionsFn);
+    });
   });
 });
 

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -24,7 +24,7 @@ import { executeWithContext } from '../../observability/utils';
 import { RequestContext } from '../../request-context';
 import { isStandardSchemaWithJSON, toStandardSchema, standardSchemaToJSONSchema } from '../../schema';
 import type { StandardSchemaWithJSON } from '../../schema';
-import { isVercelTool, isProviderDefinedTool } from '../../tools/toolchecks';
+import { getNeedsApprovalFn, isVercelTool, isProviderDefinedTool } from '../../tools/toolchecks';
 import type { ToolOptions } from '../../utils';
 import { safeStringify } from '../../utils';
 import { isZodObject, safeExtendZodObject } from '../../utils/zod-utils';
@@ -35,6 +35,7 @@ import type {
   CoreTool,
   McpMetadata,
   MastraToolInvocationOptions,
+  NeedsApprovalFn,
   ToolAction,
   VercelTool,
   VercelToolV5,
@@ -947,7 +948,7 @@ export class CoreToolBuilder extends MastraBase {
     // Map AI SDK's needsApproval to our requireApproval
     // needsApproval can be boolean or a function that takes input and returns boolean
     let requireApproval = false;
-    let needsApprovalFn: ((input: any) => boolean | Promise<boolean>) | undefined;
+    let needsApprovalFn: NeedsApprovalFn | undefined;
 
     if (typeof this.options.requireApproval === 'function') {
       requireApproval = true;
@@ -968,6 +969,19 @@ export class CoreToolBuilder extends MastraBase {
         // Set requireApproval to true so the tool-call-step knows to check the function
         requireApproval = true;
       }
+    }
+
+    // Preserve a needsApprovalFn that was attached directly to the tool instance
+    // (e.g. MCP tools wrap a server-level `requireToolApproval` function and set
+    // `needsApprovalFn` on the tool while keeping `requireApproval` as a boolean).
+    // The branches above only derive needsApprovalFn from options/AI SDK shapes, so
+    // without this it would be dropped during conversion and conditional approval
+    // would silently fall back to the boolean flag.
+    const instanceNeedsApprovalFn = getNeedsApprovalFn(this.originalTool);
+    if (!needsApprovalFn && instanceNeedsApprovalFn) {
+      needsApprovalFn = instanceNeedsApprovalFn;
+      // Ensure the tool-call-step knows to evaluate the function per call.
+      requireApproval = true;
     }
 
     const definition = {

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -3,7 +3,14 @@ import { RequestContext } from '../request-context';
 import { toStandardSchema } from '../schema';
 import type { PublicSchema, StandardSchemaWithJSON, InferPublicSchema } from '../schema';
 import type { SuspendOptions } from '../workflows';
-import type { McpMetadata, MCPToolProperties, ToolAction, ToolExecutionContext, ToolPayloadTransform } from './types';
+import type {
+  McpMetadata,
+  MCPToolProperties,
+  NeedsApprovalFn,
+  ToolAction,
+  ToolExecutionContext,
+  ToolPayloadTransform,
+} from './types';
 import { validateToolInput, validateToolOutput, validateToolSuspendData, validateRequestContext } from './validation';
 
 /**
@@ -136,6 +143,16 @@ export class Tool<
     TId,
     TRequestContext
   >['requireApproval'];
+
+  /**
+   * Runtime-resolved per-tool approval predicate, evaluated per call.
+   *
+   * This is set automatically when a tool's `requireApproval` is a function, or by the
+   * MCP client when wrapping a server-level `requireToolApproval` function — not something
+   * you normally set yourself (prefer the `requireApproval` option). When present it is the
+   * authoritative per-tool approval decision and is always evaluated by the agent runtime.
+   */
+  needsApprovalFn?: NeedsApprovalFn;
 
   /**
    * Enables strict tool input generation for providers that support it.

--- a/packages/core/src/tools/toolchecks.ts
+++ b/packages/core/src/tools/toolchecks.ts
@@ -1,6 +1,6 @@
 import { Tool, MASTRA_TOOL_MARKER } from './tool';
 import type { ToolToConvert } from './tool-builder/builder';
-import type { VercelTool } from './types';
+import type { NeedsApprovalFn, VercelTool } from './types';
 
 /**
  * Checks if a tool is a Mastra Tool, using both instanceof and marker.
@@ -64,4 +64,18 @@ export const isProviderTool = isProviderDefinedTool;
  */
 export function getProviderToolName(providerId: string): string {
   return providerId.split('.').slice(1).join('.');
+}
+
+/**
+ * Reads a per-tool {@link NeedsApprovalFn} attached to a tool instance, if present.
+ *
+ * Runtime tool maps are loosely typed (AI SDK `ToolSet` shape plus Mastra extras), so the
+ * `needsApprovalFn` decided by {@link CoreToolBuilder} / the MCP client is read off an
+ * arbitrary tool-like value. This helper centralizes that access with a typed result so the
+ * runtime never has to reach through `any` for it.
+ */
+export function getNeedsApprovalFn(tool: unknown): NeedsApprovalFn | undefined {
+  if (typeof tool !== 'object' || tool === null) return undefined;
+  const fn = (tool as { needsApprovalFn?: unknown }).needsApprovalFn;
+  return typeof fn === 'function' ? (fn as NeedsApprovalFn) : undefined;
 }

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -28,6 +28,58 @@ export type VercelToolV5 = ToolV5;
 
 export type ToolInvocationOptions = ToolExecutionOptions | ToolCallOptions;
 
+/**
+ * Context passed to a global `requireToolApproval` function, evaluated per tool call.
+ */
+export type ToolApprovalContext = {
+  /** Name of the tool being called. */
+  toolName: string;
+  /** Arguments the model is passing to the tool. */
+  args: Record<string, unknown>;
+  /** Plain object view of the request context, when available. */
+  requestContext?: Record<string, unknown>;
+  /** Active workspace, when the run is bound to one. */
+  workspace?: Workspace;
+};
+
+/**
+ * Function form of the global `requireToolApproval` option. Evaluated per tool call;
+ * return `true` to require approval for that call, `false` to allow it. Enables
+ * conditional, per-call approval policies (e.g. regex matching on `toolName`).
+ */
+export type RequireToolApprovalFn = (ctx: ToolApprovalContext) => boolean | Promise<boolean>;
+
+/**
+ * Global tool approval setting. `true` requires approval for every tool call,
+ * `false`/omitted requires none, and a function decides per call.
+ */
+export type RequireToolApproval = boolean | RequireToolApprovalFn;
+
+/**
+ * Context passed to a per-tool `needsApprovalFn` alongside the parsed tool input.
+ * This is the same context surfaced to a tool-level `requireApproval` function.
+ */
+export type NeedsApprovalContext = {
+  /** Plain object view of the request context, when available. */
+  requestContext?: Record<string, unknown>;
+  /** Active workspace, when the run is bound to one. */
+  workspace?: Workspace;
+};
+
+/**
+ * Per-tool approval predicate attached to a tool instance.
+ *
+ * This is the runtime-resolved form of a tool's `requireApproval` function (or of an
+ * MCP server-level `requireToolApproval` function wrapped by the MCP client). It is
+ * evaluated per tool call with the parsed input and the available context; return
+ * `true` to require approval for that call, `false` to allow it.
+ *
+ * It is attached to the tool instance by {@link CoreToolBuilder} / the MCP client and
+ * read by the agent runtime. Prefer the public `requireApproval` option on
+ * `createTool` over setting this directly.
+ */
+export type NeedsApprovalFn = (input: any, ctx?: NeedsApprovalContext) => boolean | Promise<boolean>;
+
 export type ToolPayloadTransformTarget = 'display' | 'transcript';
 
 export type ToolPayloadTransformPhase =

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -4,7 +4,7 @@ import type { Stream } from 'node:stream';
 import { MastraBase } from '@mastra/core/base';
 import type { RequestContext } from '@mastra/core/di';
 import { createTool } from '@mastra/core/tools';
-import type { Tool } from '@mastra/core/tools';
+import type { NeedsApprovalFn, Tool } from '@mastra/core/tools';
 
 import type { JSONSchema7 } from '@mastra/schema-compat';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -755,7 +755,7 @@ export class InternalMastraMCPClient extends MastraBase {
       try {
         // Resolve requireToolApproval for this tool
         let requireApproval: boolean | undefined;
-        let needsApprovalFn: ((args: any, ctx: any) => boolean | Promise<boolean>) | undefined;
+        let needsApprovalFn: NeedsApprovalFn | undefined;
 
         // Capture server-advertised annotations (title, readOnlyHint, destructiveHint, ...).
         // These are exposed on the tool's `mcp.annotations` field and forwarded to the
@@ -899,9 +899,9 @@ export class InternalMastraMCPClient extends MastraBase {
         });
 
         // Set needsApprovalFn directly on the tool instance (same pattern as tool-builder).
-        // This is accessed via (tool as any).needsApprovalFn in tool-call-step.ts.
+        // The agent runtime reads it back via the typed `getNeedsApprovalFn` helper.
         if (needsApprovalFn) {
-          (mastraTool as any).needsApprovalFn = needsApprovalFn;
+          mastraTool.needsApprovalFn = needsApprovalFn;
         }
 
         if (tool.name) {


### PR DESCRIPTION
## Summary

Closes #16506.

Tool approvals could only be turned on or off with a boolean, so there was no way to express "require approval conditionally" — e.g. only for destructive tools, or based on a regex over the tool name. This PR adds function-based approval support in the two places it was missing, without changing any existing approval behavior.

### 1. MCP per-tool approval functions are honored end-to-end

The MCP client already supports a server-level `requireToolApproval` function and attaches the resulting per-tool policy to the tool as `needsApprovalFn` (while keeping `requireApproval` as a boolean). But when an agent converted that tool, `CoreToolBuilder` derived `needsApprovalFn` only from its options / AI SDK shapes and never copied a `needsApprovalFn` set directly on the tool instance. The function was dropped during conversion, so conditional approval silently fell back to always requiring approval.

`CoreToolBuilder` now preserves a `needsApprovalFn` that is attached directly to a tool instance, so MCP `requireToolApproval` functions work through the full agent path.

### 2. Global `requireToolApproval` accepts a function

`agent.stream` / `agent.generate` `requireToolApproval` now accepts a function in addition to a boolean:

```ts
await agent.stream('...', {
  requireToolApproval: ({ toolName, args, requestContext }) => /^delete_/.test(toolName),
});
```

- Evaluated per tool call with `{ toolName, args, requestContext, workspace }`. Return `true` to require approval for that call, `false` to allow it.
- **Precedence is unchanged.** A per-tool approval function (`createTool({ requireApproval: fn })` or an MCP-derived `needsApprovalFn`) is authoritative for that tool and **overrides** the global setting, exactly as before — a tool can return `false` to opt out of approval even when the global option is on. Without a per-tool function, the call requires approval if the global option or the tool's boolean `requireApproval` flag requires it. The only new behavior is that the global option may now be a function.
- On error, the call defaults to requiring approval (safe default).
- When a function policy is set, tool calls run sequentially so approval suspensions don't race with concurrent calls.
- The function is stored on the request context, which strips non-serializable values when serialized, so suspend/resume is unaffected.
- Durable agents keep accepting only a boolean; a function passed there degrades to requiring approval for every call, since durable state must be serializable.

### 3. The per-tool `needsApprovalFn` is now a typed contract

The per-tool approval predicate was an implicit, runtime-attached property read/written via `(tool as any).needsApprovalFn` across `@mastra/core` and `@mastra/mcp`. It is now typed: `@mastra/core` exports `NeedsApprovalFn` and declares the optional `needsApprovalFn` property on the `Tool` class, and both packages share a typed `getNeedsApprovalFn` helper instead of reaching through `any`. Additive only — no public API changes.

## No-regression notes

- For the pre-existing boolean `requireToolApproval` path, the approval decision is equivalent to `main` (per-tool function overrides; otherwise `global || tool.requireApproval`).
- The durable and network code paths are unchanged except for swapping the `any` cast for the typed helper.

## Test plan

- `tool-builder/builder.test.ts` — preserves an instance `needsApprovalFn` (MCP shape); options-derived function still wins over the instance one.
- `agent/__tests__/tools.test.ts` — an MCP-shaped tool's `needsApprovalFn` survives `agent.convertTools`.
- `tool-call-step.test.ts` — global function evaluated per call (requires approval on `true`, runs on `false`, defaults to requiring approval when it throws, receives `toolName` + `args`); per-tool function overrides the global in both directions (global `true` + per-tool `false` runs; global `false` + per-tool `true` suspends); the canonical MCP shape (`requireApproval: true` + `needsApprovalFn` returning `false`) still runs.
- `tool-call-concurrency.test.ts` — a function policy forces sequential execution.
- `agent/__tests__/tool-approval.test.ts` — end-to-end through `agent.stream`: function policy suspends on `true` and executes on `false`, receiving the tool name and args.
- `durable-agent-tool-approval.test.ts` and `packages/mcp` `requireToolApproval` client tests still pass.
- `tsc --noEmit` and ESLint pass for `@mastra/core` and `@mastra/mcp`.

`@mastra/core` minor + `@mastra/mcp` patch changeset included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR lets you write a small function to decide, for each tool call, whether the system should pause and ask for approval (instead of only "always" or "never"). It also fixes a bug where those functions were dropped when converting tools from the MCP, and keeps durable/stored agents safe by falling back to conservative boolean behavior.

---

## Overview

Implements end-to-end conditional, function-based tool approvals across Mastra: global agent options, per-call evaluation during stream/generate, per-tool predicates preserved from MCP tools, typed contracts for approval functions, sequential execution when function policies are used, and safe degradation for durable/storage contexts.

## Key Changes

- Core types and helpers
  - Adds approval types: ToolApprovalContext, RequireToolApprovalFn/RequireToolApproval, NeedsApprovalContext, NeedsApprovalFn (packages/core/src/tools/types.ts).
  - Adds getNeedsApprovalFn(tool) helper to safely extract a needsApprovalFn (packages/core/src/tools/toolchecks.ts).

- Tool API & builder
  - Tool class gains optional needsApprovalFn?: NeedsApprovalFn (packages/core/src/tools/tool.ts).
  - CoreToolBuilder.build() preserves instance-attached needsApprovalFn and sets requireApproval = true when present to ensure evaluation at call time (packages/core/src/tools/tool-builder/builder.ts and tests).

- Global & per-tool evaluation
  - agent.stream / agent.generate global requireToolApproval now accepts boolean or function evaluated per tool call with { toolName, args, requestContext, workspace } (typed as RequireToolApproval).
  - Tool-call logic builds a ToolApprovalContext and evaluates: (1) global policy (requestContext.__mastra_requireToolApproval) — function errors default to true; (2) seed from global || tool.requireApproval; (3) per-tool needsApprovalFn (from getNeedsApprovalFn) — if present it overrides seed, errors default to true. Implementation in tool-call-step and related tests (packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts and tests).

- Concurrency & sequencing
  - When requireToolApproval is a function, the system conservatively treats the policy as requiring approval until args are known, forcing sequential tool-call execution to avoid approval-race conditions (tool-call-concurrency changes + tests).

- RequestContext & serialization
  - If requireToolApproval is a function, it’s stored on requestContext.__mastra_requireToolApproval for per-call evaluation; non-serializable values are stripped during serialization (stream/workflow changes).
  - Durable/preparation step coerces function-valued requireToolApproval to true for durable workflows (persistable boolean-only), preserving boolean values otherwise (packages/core/src/agent/durable/preparation.ts).
  - Storage default options keep requireToolApproval as boolean-only in persisted defaults (packages/core/src/storage/types.ts and type tests).

- MCP integration
  - MCP client now wires per-tool needsApprovalFn using the shared NeedsApprovalFn type so MCP-provided predicates are preserved (packages/mcp/src/client/client.ts).
  - Tests added to verify MCP-style tools preserve needsApprovalFn through convert/build flows.

- Tests & docs
  - Extensive tests added/updated across tool-builder, agent stream/generate approvals, tool-call-step, concurrency, durable-agent behavior, and MCP client.
  - Documentation page clarifies function-based requireToolApproval usage, precedence, error defaults, and durable-agent constraints.

## Behavior & Semantics

- Per-tool precedence: per-tool needsApprovalFn (from createTool options or MCP-derived) is authoritative and overrides global settings.
- Global function: evaluated per tool call with toolName, parsed args, requestContext, workspace; return true to require approval, false to allow execution.
- Error handling: if a function throws, the call defaults to requiring approval (fail-safe).
- Sequential execution: function policies cause sequential tool calls to avoid races during approval suspension.
- Durable degradation: functions cannot be serialized; durable agents treat function-valued policies as requiring approval for every call (coerced to true).
- No-regression: existing boolean approval behavior and durable/network serialization semantics preserved.

## Public API / Type surface

- Agent/loop/workflow option types updated to accept RequireToolApproval where appropriate (AgentExecutionOptionsBase, LoopOptions, stream/prepare types).
- Added exported NeedsApprovalFn and related types; exported helper getNeedsApprovalFn.
- Storage/persisted default options continue to accept only boolean requireToolApproval.

## Tests & Validation

- Added/updated unit tests covering per-call global functions, per-tool predicate preservation (MCP), suspend/resume flows, precedence, error defaults, concurrency sequencing, durable/preparation serialization, and type-only serialization constraints.
- tsc --noEmit and ESLint pass for affected packages per PR description.

## Changeset

- `@mastra/core`: minor — adds conditional, function-based tool approval support end-to-end, preserves MCP-derived per-tool predicates, typed contracts, and safe execution semantics.
- `@mastra/mcp`: patch — wires typed per-tool needsApprovalFn from MCP client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->