### PR TITLE
fix(core): extract MastraMessagePart part-union alias to prevent TS2589 depth error

### DIFF
--- a/.changeset/ts2589-mastra-message-part-type.md
+++ b/.changeset/ts2589-mastra-message-part-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a TypeScript TS2589 "type instantiation is excessively deep" error when using Mastra alongside deeply-generic libraries such as @hono/zod-openapi.

--- a/packages/core/src/agent/message-list/state/types.ts
+++ b/packages/core/src/agent/message-list/state/types.ts
@@ -73,13 +73,15 @@ export type MastraSourceUrlPart = Omit<LegacySourcePart, 'providerMetadata'> & {
   createdAt?: number;
 };
 
+// Named alias so TypeScript caches the Exclude expansion and avoids TS2589 when
+// MastraMessagePart is used alongside deeply-generic libraries like @hono/zod-openapi.
+type UIV4NonMastraPart = Exclude<UIMessageV4['parts'][number], { type: 'tool-invocation' | 'source' | 'step-start' }>;
+
 // Canonical stored part type. It starts from the v4 UI part model and extends
 // it with provider metadata, AI SDK v5 data parts, and v6-only persisted parts
 // such as approval-aware tool invocations and source documents.
 export type MastraMessagePart =
-  | PartWithProviderMetadata<
-      Exclude<UIMessageV4['parts'][number], { type: 'tool-invocation' | 'source' | 'step-start' }>
-    >
+  | PartWithProviderMetadata<UIV4NonMastraPart>
   | MastraStepStartPart
   | MastraToolInvocationPart
   | MastraSourceUrlPart


### PR DESCRIPTION
## Summary

- Extract the `Exclude<UIMessageV4['parts'][number], ...>` union in `MastraMessagePart` into a named type alias `UIV4NonMastraPart` so TypeScript caches the expansion instead of re-evaluating it per use site, eliminating TS2589 \"type instantiation is excessively deep\" errors when Mastra types are used alongside deeply-generic libraries like `@hono/zod-openapi`.

## Test plan

```
pnpm --filter @mastra/core typecheck
```

Closes #17047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation
TypeScript was getting confused and crashing when Mastra types were used alongside other complex libraries because a type definition was too complicated and deeply nested. The fix gives that complicated type definition a simple name so TypeScript can remember and reuse it instead of having to re-evaluate it over and over, which was making it hit its depth limit.

## Overview
This PR resolves a TypeScript compilation error (TS2589: "type instantiation is excessively deep") that was introduced in v1.24.0 when `MastraMessagePart` was expanded to support AI SDK v6 approval flows. The error occurred when Mastra types were used alongside deeply generic libraries such as `@hono/zod-openapi`.

## Root Cause
The `MastraMessagePart` type contained an inline complex union expression (`Exclude<UIMessageV4['parts'][number], { type: 'tool-invocation' | 'source' | 'step-start' }>`) nested within `PartWithProviderMetadata`. When TypeScript encountered this type in contexts involving deeply generic type resolution, it exceeded its instantiation depth limit.

## Solution
The PR extracts the inline union into a named type alias (`UIV4NonMastraPart`), allowing TypeScript to cache the expansion and reuse it at each site rather than re-evaluating it recursively. This is a pure type-level refactoring that maintains the same public API while improving type system performance.

## Changes
- **New file**: `.changeset/ts2589-mastra-message-part-type.md` – Documents the patch-level fix for the TS2589 error.
- **Modified**: `packages/core/src/agent/message-list/state/types.ts`
  - Introduced `UIV4NonMastraPart` as an intermediate type alias (line 78) for v4 UI parts excluding tool-invocation, source, and step-start types.
  - Updated `MastraMessagePart` (lines 83-89) to use `PartWithProviderMetadata<UIV4NonMastraPart>` instead of the inlined `Exclude<...>` expression.

## Testing
Run type checking via: `pnpm --filter `@mastra/core` typecheck`

## Related Issue
Closes `#17047`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->