### PR TITLE
fix(core): auto-inject JSON Schema const and single-enum fields before MCP tool validation

### DIFF
--- a/.changeset/mcp-const-field-auto-inject.md
+++ b/.changeset/mcp-const-field-auto-inject.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed MCP tools with `const`-constrained or single-value `enum` discriminator fields (e.g. `"@type": { "const": "com.SomeSpec" }`) always failing validation. Mastra now automatically injects these predetermined values before validation runs.

--- a/packages/core/src/tools/validation.test.ts
+++ b/packages/core/src/tools/validation.test.ts
@@ -2207,6 +2207,38 @@ describe('validateToolInput - Stringified JSON Coercion (GitHub #12757)', () => 
   });
 });
 
+describe('validateToolInput - const/enum auto-injection (GitHub #16444)', () => {
+  it('should inject missing const field value', () => {
+    const schema = z.object({
+      '@type': z.literal('MyType'),
+      name: z.string(),
+    });
+    const result = validateToolInput(schema, { name: 'foo' });
+    expect(result.error).toBeUndefined();
+    expect((result.data as any)['@type']).toBe('MyType');
+  });
+
+  it('should overwrite incorrect const field value', () => {
+    const schema = z.object({
+      '@type': z.literal('MyType'),
+      name: z.string(),
+    });
+    const result = validateToolInput(schema, { '@type': 'wrong', name: 'foo' });
+    expect(result.error).toBeUndefined();
+    expect((result.data as any)['@type']).toBe('MyType');
+  });
+
+  it('should overwrite incorrect single-enum field value', () => {
+    const schema = z.object({
+      version: z.enum(['v2']),
+      query: z.string(),
+    });
+    const result = validateToolInput(schema, { version: 'v1', query: 'hello' });
+    expect(result.error).toBeUndefined();
+    expect((result.data as any)['version']).toBe('v2');
+  });
+});
+
 describe('prompt alias normalization (GitHub #14154)', () => {
   const promptSchema = z.object({
     prompt: z.string(),

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -201,6 +201,34 @@ function normalizeNullishInput(schema: StandardSchemaWithJSON<any>, input: unkno
 }
 
 /**
+ * Auto-injects const-constrained field values into input before validation (GitHub #16444).
+ * JSON Schema `const` and single-value `enum` properties have a fixed predetermined value
+ * that LLMs cannot know to supply (e.g. discriminator fields like `"@type": {"const": "..."}`).
+ * Injecting them here lets the tool schema validate successfully without requiring the LLM
+ * to guess opaque constant values.
+ */
+function injectConstValues(schema: StandardSchemaWithJSON<unknown>, input: unknown): unknown {
+  if (!isPlainObject(input)) return input;
+  const jsonSchema = standardSchemaToJSONSchema(schema, { io: 'input' });
+  if (jsonSchema.type !== 'object' || !jsonSchema.properties) return input;
+
+  let injected = false;
+  const result: Record<string, unknown> = { ...(input as Record<string, unknown>) };
+  for (const [key, rawProp] of Object.entries(jsonSchema.properties)) {
+    if (result[key] !== undefined) continue;
+    const prop = rawProp as Record<string, unknown>;
+    if ('const' in prop) {
+      result[key] = prop['const'];
+      injected = true;
+    } else if (Array.isArray(prop['enum']) && prop['enum'].length === 1) {
+      result[key] = prop['enum'][0];
+      injected = true;
+    }
+  }
+  return injected ? result : input;
+}
+
+/**
  * Checks if a value is a plain object (created by {} or new Object()).
  * This excludes class instances, built-in objects like Date/Map/URL, etc.
  *
@@ -462,6 +490,10 @@ export function validateToolInput<T = unknown>(
   //    strict mode compliance. The schema's transform converts null back to undefined.
   //    (GitHub #11457)
   //
+  // 2.5. injectConstValues: Auto-inject JSON Schema `const` / single-value `enum` fields
+  //    whose fixed value an LLM cannot know to supply (e.g. MCP discriminator fields).
+  //    (GitHub #16444)
+  //
   // 3. First validation attempt with null values preserved. This handles .nullable()
   //    schemas correctly (where null is a valid value).
   //
@@ -478,6 +510,11 @@ export function validateToolInput<T = unknown>(
 
   // Step 2: Convert undefined values to null recursively (GitHub #11457)
   normalizedInput = convertUndefinedToNull(normalizedInput);
+
+  // Step 2.5: Auto-inject const-constrained field values (GitHub #16444)
+  // Fields with a JSON Schema `const` or single-value `enum` have a fixed value the LLM
+  // cannot know to supply (e.g. MCP discriminator fields). Inject them before validation.
+  normalizedInput = injectConstValues(schema, normalizedInput);
 
   // Step 3: Validate the normalized input
   const validation = safeValidate(schema, normalizedInput);

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -215,14 +215,18 @@ function injectConstValues(schema: StandardSchemaWithJSON<unknown>, input: unkno
   let injected = false;
   const result: Record<string, unknown> = { ...(input as Record<string, unknown>) };
   for (const [key, rawProp] of Object.entries(jsonSchema.properties)) {
-    if (result[key] !== undefined) continue;
     const prop = rawProp as Record<string, unknown>;
     if ('const' in prop) {
-      result[key] = prop['const'];
-      injected = true;
+      if (result[key] !== prop['const']) {
+        result[key] = prop['const'];
+        injected = true;
+      }
     } else if (Array.isArray(prop['enum']) && prop['enum'].length === 1) {
-      result[key] = prop['enum'][0];
-      injected = true;
+      const onlyValue = prop['enum'][0];
+      if (result[key] !== onlyValue) {
+        result[key] = onlyValue;
+        injected = true;
+      }
     }
   }
   return injected ? result : input;


### PR DESCRIPTION
## Summary

- Add an `injectConstValues` normalization step in the tool validation pipeline that auto-populates fields whose JSON Schema declares a fixed `const` value or a single-item `enum` array before the validation check runs, so MCP tools with discriminator fields the LLM cannot supply no longer fail with \"invalid input\" errors.

## Test plan

```
pnpm --filter @mastra/core exec vitest run src/tools/validation.test.ts --reporter=dot
```

Closes #16444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Some tool inputs must always contain exact fixed values (like an "`@type`" tag). If the AI leaves them out or supplies the wrong value, validation fails — this PR makes Mastra automatically put the correct fixed values into inputs (and replace wrong ones) before validating, so tools don't fail when the LLM is wrong.

## Summary
Adds an input normalization step (injectConstValues) to the tool validation pipeline that discovers JSON Schema properties with `const` or an `enum` containing exactly one value and injects those canonical values into object inputs (overwriting incorrect values as well as filling missing ones) before validation runs. This prevents MCP tools with discriminator or other const-constrained fields from failing when the LLM omits or supplies incorrect constants.

### Changes
- packages/core/src/tools/validation.ts
  - New helper injectConstValues(schema, input) that:
    - Uses standardSchemaToJSONSchema(schema, { io: 'input' }) to find object properties with `const` or single-item `enum`.
    - Only processes plain objects (avoids class instances and built-ins).
    - Creates a shallow copy of the input and sets those property values to the canonical constant, marking the input as modified when changes occur.
    - Returns the original input if no injections/overwrites were needed.
  - Injects this helper into the validation normalization pipeline as step 2.5 (after undefined→null/empty normalization and before the first validation attempt).
- packages/core/src/tools/validation.test.ts
  - New test suite covering:
    - Injecting a missing const/literal field (e.g., `@type`).
    - Overwriting an incorrect const field value.
    - Injecting/overwriting a single-value z.enum field.
  - Test placement is before existing prompt alias normalization tests.
- .changeset/mcp-const-field-auto-inject.md
  - Changeset entry documenting the patch for `@mastra/core` and the bug fix.

### Technical details / notes
- The injection step runs only for JSON Schema object types with a `properties` map.
- The implementation overwrites incorrect values (per commit messages and tests), not just fill missing keys.
- No exported/public API changes; this is an internal validation pipeline enhancement.
- Test command: pnpm --filter `@mastra/core` exec vitest run src/tools/validation.test.ts --reporter=dot
- Closes issue `#16444`.

### Impact
Centralizes and hardens handling of const/discriminator fields so MCP tools no longer fail validation due to LLM omissions or incorrect constant values, removing fragile per-tool workarounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->