### PR TITLE
fix(brightdata): validate search language/country codes and honor raw format

### DIFF
--- a/.changeset/brightdata-language-validation.md
+++ b/.changeset/brightdata-language-validation.md
@@ -1,0 +1,5 @@
+---
+"@mastra/brightdata": patch
+---
+
+Harden Bright Data search input handling. Country and language codes are now validated as alphabetic two-letter codes, the `getBrightDataClient().search.google()` client validates and lowercase-normalizes `language` before the request, and structured JSON (`brd_json=1`) is only requested when the search `format` is `json` so callers can obtain a true raw SERP response.

--- a/integrations/brightdata/src/__tests__/client.test.ts
+++ b/integrations/brightdata/src/__tests__/client.test.ts
@@ -139,6 +139,33 @@ describe('getBrightDataClient', () => {
     expect(requestBody.url).toContain('hl=es');
   });
 
+  it('should normalize the language code to lowercase', async () => {
+    const client = getBrightDataClient({ apiKey: 'test-key' });
+
+    await client.search.google('pizza', { language: 'EN' });
+
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(requestBody.url).toContain('hl=en');
+  });
+
+  it('should reject an invalid language code before making a request', async () => {
+    const client = getBrightDataClient({ apiKey: 'test-key' });
+
+    await expect(client.search.google('pizza', { language: '1_' })).rejects.toThrow(
+      'language must be a two-letter code',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should not request structured JSON when raw format is requested', async () => {
+    const client = getBrightDataClient({ apiKey: 'test-key' });
+
+    await client.search.google('pizza', { format: 'raw' });
+
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(requestBody.url).not.toContain('brd_json');
+  });
+
   it('should return a client object', () => {
     const client = getBrightDataClient({ apiKey: 'test-key' });
     expect(client).toBeDefined();

--- a/integrations/brightdata/src/client.ts
+++ b/integrations/brightdata/src/client.ts
@@ -97,7 +97,9 @@ async function requestBrightData(
 function buildGoogleSearchUrl(query: string, options: SearchOptions = {}) {
   const url = new URL('https://www.google.com/search');
   url.searchParams.set('q', query.trim());
-  url.searchParams.set('brd_json', '1');
+  if ((options.format ?? 'json') === 'json') {
+    url.searchParams.set('brd_json', '1');
+  }
   url.searchParams.set('hl', options.language ?? 'en');
 
   if (options.country) {
@@ -146,15 +148,23 @@ export function getBrightDataClient(config?: BrightDataClientOptions): BrightDat
   return {
     search: {
       google: async (query: string, options: SearchOptions = {}) => {
-        const url = buildGoogleSearchUrl(query, options);
+        if (options.language && !/^[a-z]{2}$/i.test(options.language)) {
+          throw new Error('language must be a two-letter code (e.g. "en", "es")');
+        }
+
+        const normalizedOptions = options.language
+          ? { ...options, language: options.language.toLowerCase() }
+          : options;
+
+        const url = buildGoogleSearchUrl(query, normalizedOptions);
         return requestBrightData(
           apiKey,
-          toRequestBody(url, options.zone ?? serpZone, {
-            ...options,
-            format: options.format ?? 'json',
+          toRequestBody(url, normalizedOptions.zone ?? serpZone, {
+            ...normalizedOptions,
+            format: normalizedOptions.format ?? 'json',
             method: 'GET',
           }),
-          options.timeout ?? timeout,
+          normalizedOptions.timeout ?? timeout,
         );
       },
     },

--- a/integrations/brightdata/src/search.ts
+++ b/integrations/brightdata/src/search.ts
@@ -8,12 +8,12 @@ const inputSchema = z.object({
   query: z.string().describe('The search query'),
   country: z
     .string()
-    .length(2)
+    .regex(/^[a-z]{2}$/i, 'Country must be a 2-letter code')
     .optional()
     .describe('2-letter country code for geo-targeted results (e.g., "us", "gb")'),
   language: z
     .string()
-    .length(2)
+    .regex(/^[a-z]{2}$/i, 'Language must be a 2-letter code')
     .optional()
     .describe('Language code for localized Google results (e.g., "en", "es", "fr")'),
   start: z


### PR DESCRIPTION
## Summary

Follow-up hardening for the Bright Data tools, addressing CodeRabbit review feedback left on #16630 (merged). Builds on @Rohithmatham12's Bun-compatibility work.

- Validate `country` and `language` search inputs as alphabetic two-letter codes (was a bare length check, so values like `1_` passed).
- Validate and lowercase-normalize `language` in the public `getBrightDataClient().search.google()` so direct client consumers get the same two-letter contract instead of failing only after the network call.
- Only request structured JSON (`brd_json=1`) when the search `format` is `json`, so callers asking for `format: 'raw'` can obtain a true raw SERP response.

## Tests

- `vitest run` from `integrations/brightdata` — 35 passed (added coverage for language normalization, invalid-language rejection, and raw-format behavior).
- `pnpm lint` and `prettier --check` clean.

## Credit

Continuation of #16630 by @Rohithmatham12; co-authored to preserve attribution.

Relates to #16627.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes the Bright Data search integration stricter about validating country and language codes (they must now be exactly 2 alphabetic letters, not just any 2 characters) and fixes a bug where responses were being converted to JSON even when users asked for raw data. It also ensures the validation happens before making any network requests, so bad inputs fail early.

## Changes

### Input Validation Hardening

- `country` and `language` parameters now validate using alphabetic two-letter regex patterns (`/^[a-z]{2}$/i`) with explicit error messages, replacing the previous `.length(2)` checks that accepted invalid patterns like `1_`
- Validation occurs in the public `getBrightDataClient().search.google()` method before any network calls

### Language Normalization

- The public client method normalizes the `language` option to lowercase before building the request URL, ensuring consistent `hl=` parameter formatting in the underlying request

### Output Format Handling

- The `brd_json=1` structured JSON parameter is now only included in search requests when `format: 'json'` is specified
- Callers requesting `format: 'raw'` now receive the true raw SERP response instead of JSON-converted data

### Testing

- 35 integration tests passing in `integrations/brightdata`
- New test coverage for language code normalization, invalid language rejection (prevents `fetchMock` calls), and raw format preservation
- `pnpm lint` and `prettier --check` are clean

### Files Modified

- `.changeset/brightdata-language-validation.md` — Documents the changes
- `integrations/brightdata/src/search.ts` — Updated validation logic
- `integrations/brightdata/src/client.ts` — Implements language normalization and conditional `brd_json` parameter
- `integrations/brightdata/src/__tests__/client.test.ts` — New test coverage

### Context

This is a follow-up hardening effort addressing CodeRabbit review feedback on `#16630`. It builds on Bun-compatibility work and relates to `#16627`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->