### PR TITLE
fix(core): quiet storage-not-initialized log noise on agent generate/stream

### DIFF
--- a/.changeset/quiet-storage-execution-workflow.md
+++ b/.changeset/quiet-storage-execution-workflow.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed noisy "Cannot get workflow run. Mastra storage is not initialized" debug logs that appeared on every `agent.generate()` and `agent.stream()` call when the agent's Mastra instance had storage configured.
+
+The internal workflow that runs each agent call never received the parent Mastra instance, so it could not see configured storage and logged the warning before falling back to in-memory state. It now receives the Mastra instance. It still does not write any of its own snapshots to your storage, so no extra rows are created.

--- a/packages/core/src/agent/__tests__/execution-workflow-storage-noise.test.ts
+++ b/packages/core/src/agent/__tests__/execution-workflow-storage-noise.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/17137
+ *
+ * When an agent is registered to a Mastra instance that has storage configured,
+ * calling agent.generate()/stream() must:
+ *   1. NOT emit the debug log "Cannot get workflow run. Mastra storage is not initialized".
+ *      That log fired because the internal `execution-workflow` never received the parent's
+ *      Mastra reference, so its createRun() saw no storage and took the no-storage branch.
+ *   2. NOT persist a workflow snapshot for the throwaway internal `execution-workflow`.
+ *      The execution-workflow is an internal implementation detail and is not resumable, so
+ *      it must never write rows to the user's storage even after it can read storage.
+ */
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { Workflow } from '../../workflows/workflow';
+import { Agent } from '../agent';
+
+function createDummyModel() {
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop',
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: 'text', text: 'Dummy response' }],
+      warnings: [],
+    }),
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Dummy response' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+      ]),
+    }),
+  });
+}
+
+function buildAgentWithStorage() {
+  const storage = new InMemoryStore();
+  const agent = new Agent({
+    id: 'noise-agent',
+    name: 'noise-agent',
+    instructions: 'test',
+    model: createDummyModel(),
+  });
+  const mastra = new Mastra({
+    agents: { agent },
+    storage,
+    logger: false,
+  });
+  return { mastra, storage };
+}
+
+describe('agent execution-workflow storage noise (issue #17137)', () => {
+  it('gives the internal execution-workflow access to storage (no "storage is not initialized" branch)', async () => {
+    // The buggy execution-workflow used its own un-registered logger, so spying on the Mastra
+    // logger does not see the noise. Instead, assert the root cause directly: when
+    // getWorkflowRunById runs for the execution-workflow it now has storage, so the
+    // no-storage debug branch is unreachable.
+    const seen: Array<{ id: string; hasStorage: boolean }> = [];
+    const original = (Workflow.prototype as unknown as { getWorkflowRunById: (...a: unknown[]) => unknown })
+      .getWorkflowRunById;
+    const spy = vi
+      .spyOn(Workflow.prototype as unknown as Record<string, any>, 'getWorkflowRunById')
+      .mockImplementation(async function (this: any, ...args: unknown[]) {
+        seen.push({ id: this.id, hasStorage: Boolean(this.mastra?.getStorage?.()) });
+        return original.apply(this, args);
+      });
+
+    try {
+      const { mastra } = buildAgentWithStorage();
+      await mastra.getAgent('agent').generate('Hello!');
+    } finally {
+      spy.mockRestore();
+    }
+
+    const executionWorkflowLookups = seen.filter(s => s.id === 'execution-workflow');
+    expect(executionWorkflowLookups.length).toBeGreaterThan(0);
+    expect(executionWorkflowLookups.every(s => s.hasStorage)).toBe(true);
+  });
+
+  it('does not persist a snapshot for the internal execution-workflow on generate', async () => {
+    const { mastra, storage } = buildAgentWithStorage();
+
+    await mastra.getAgent('agent').generate('Hello!');
+
+    const workflowsStore = await storage.getStore('workflows');
+    const { runs, total } = await workflowsStore!.listWorkflowRuns({ workflowName: 'execution-workflow' });
+    expect(total).toBe(0);
+    expect(runs).toEqual([]);
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5917,6 +5917,14 @@ export class Agent<
       drainPendingSignals: runId => agentThreadStreamRuntime.drainPendingSignals(runId, threadStreamPubSub),
     });
 
+    // Register the parent Mastra instance on the internal execution workflow so it can read
+    // configured storage instead of logging "Mastra storage is not initialized" on every run.
+    // The workflow opts out of snapshot persistence (shouldPersistSnapshot returns false), so
+    // this does not write any execution-workflow rows to storage.
+    if (this.#mastra) {
+      executionWorkflow.__registerMastra(this.#mastra);
+    }
+
     const run = await executionWorkflow.createRun();
     const observabilityContext = createObservabilityContext({ currentSpan: agentSpan });
     const result = await run.start({ ...observabilityContext });

--- a/packages/core/src/agent/workflows/prepare-stream/index.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/index.ts
@@ -159,6 +159,10 @@ export function createPrepareStreamWorkflow<OUTPUT = undefined>({
       tracingPolicy: {
         internal: InternalSpans.WORKFLOW,
       },
+      // This is an internal, non-resumable workflow created per agent generate/stream call.
+      // It must never write snapshot rows to the user's storage. Registering Mastra (done by
+      // the agent) lets it read storage to suppress noise, while this keeps writes off.
+      shouldPersistSnapshot: () => false,
       validateInputs: false,
     },
   })


### PR DESCRIPTION
## What

Calling `agent.generate()` or `agent.stream()` on an agent whose Mastra instance has `storage` configured emitted the debug log `Cannot get workflow run. Mastra storage is not initialized` on every call. The output was correct (it falls back to in-memory state), but the noise scaled with call volume — live scorers at sampling rate 1, dataset experiments with many items — and was misleading when diagnosing real storage misconfigurations.

Closes #17137.

## Root cause

Each agent call builds an internal `execution-workflow`. Unlike the agent, memory, and other workflows, this internal workflow never received the parent Mastra instance, so `Workflow.getWorkflowRunById` saw no storage and took the no-storage debug branch on the happy path. This was verified empirically by spying on `getWorkflowRunById`: during one `generate()`, the `execution-workflow` lookup had `hasStorage: false` while the sibling `agentic-loop` / `executionWorkflow` lookups had `hasStorage: true`.

## Fix

- Register the parent Mastra instance on the internal `execution-workflow` before `createRun()`, so it can read configured storage and no longer logs the warning.
- Set `shouldPersistSnapshot: () => false` on that workflow. It is internal and non-resumable, so it must not write snapshot rows to the user's storage. This matches the deliberate persistence control already used by the sibling `agentic-loop` and `executionWorkflow` workflows.

Without the second part, simply registering Mastra would cause every agent call to persist an `execution-workflow` snapshot row — verified empirically: a register-only change produced 1 persisted `execution-workflow` row per `generate()`, where the fix produces 0.

## Tests

New `execution-workflow-storage-noise.test.ts` with two guards, both confirmed to fail without the corresponding part of the fix:

1. The `execution-workflow` lookup now has storage access (guards the original bug).
2. No `execution-workflow` snapshot is persisted to storage after `generate()` (guards the persistence side effect).

## Verification

- New tests pass; both proven to fail on the unfixed/partially-fixed code.
- `tool-approval.e2e`, `tool-approval-standalone-repro`, `resume-stream-no-snapshot`, `stream-id` suites pass (41 tests) — resume relies on the sibling workflows persisting, unaffected.
- `workflow.test.ts` + `save-and-errors.test.ts` pass (307 tests).
- `tsc --noEmit`, ESLint, and Prettier all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you use Mastra to run agents, it creates temporary workflows to handle each request. These internal workflows weren't being told about your Mastra storage setup, so they would complain with debug messages saying "storage isn't initialized" even though it actually was. This PR fixes that by passing the storage information to these internal workflows, so they stop complaining and work quietly.

## Overview

This PR resolves noisy debug logging that occurred when calling `agent.generate()` or `agent.stream()` on agents registered to a Mastra instance with storage configured (issue `#17137`). The internal execution-workflow created per agent call was not receiving the parent Mastra instance reference, causing it to repeatedly log "Cannot get workflow run. Mastra storage is not initialized" before falling back to in-memory state.

## Changes

### Core Fixes

**`packages/core/src/agent/agent.ts`**
- Modified `Agent.#execute()` to register the parent Mastra instance on the internal `executionWorkflow` before creating the run via `__registerMastra()`
- This allows the workflow to access configured storage and avoid the debug message
- Added clarifying comments that snapshot persistence is opted out for this workflow

**`packages/core/src/agent/workflows/prepare-stream/index.ts`**
- Updated `createPrepareStreamWorkflow()` to explicitly disable snapshot persistence by setting `shouldPersistSnapshot` to always return `false`
- Prevents persisted execution-workflow rows from being written to storage (one per generate() call)

### Testing & Verification

**`packages/core/src/agent/__tests__/execution-workflow-storage-noise.test.ts`** (new file)
- Added regression test suite with two guards:
  1. Verifies that the internal `execution-workflow` instance has storage access and can successfully lookup workflow runs (never hits the no-storage branch)
  2. Confirms that generating once does not persist workflow snapshot/run rows for the internal `execution-workflow` to the user's storage
- Both tests fail on unfixed code and pass with the applied fixes

### Changelog

**`.changeset/quiet-storage-execution-workflow.md`** (new file)
- Documents patch-level update to `@mastra/core`
- Describes suppression of repeated debug logs during `agent.generate()` and `agent.stream()` calls

## Verification

- New regression tests pass
- Related test suites pass (41 + 307 existing tests)
- No TypeScript or linting errors
- Closes issue `#17137`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->