### PR TITLE
feat(core): support per-request voice resolution on agents

### DIFF
--- a/.changeset/polite-ducks-glow.md
+++ b/.changeset/polite-ducks-glow.md
@@ -1,0 +1,32 @@
+---
+'@mastra/core': minor
+---
+
+Added support for resolving an agent's `voice` per request.
+
+You can now pass `voice` as a resolver, just like `instructions`, `tools`, and `model`. Mastra runs the resolver on each `getVoice()` call and returns a fresh, session-owned voice instance. This fixes concurrent realtime and speech-to-speech sessions on a single deployed agent, where a shared voice instance previously let one session overwrite another session's WebSocket, tools, and instructions.
+
+A static `voice` keeps its existing shared behavior, so this change is backward compatible.
+
+**Before**
+
+```typescript
+const agent = new Agent({
+  name: 'support-line',
+  voice: new GeminiLiveVoice({ apiKey: KEY }), // shared across every session
+});
+```
+
+**After**
+
+```typescript
+const agent = new Agent({
+  name: 'support-line',
+  voice: ({ requestContext }) => new GeminiLiveVoice({ apiKey: requestContext.get('apiKey') }),
+});
+
+const voice = await agent.getVoice({ requestContext }); // owns its own ws/tools/instructions
+await voice.connect();
+```
+
+The caller owns the lifecycle of a resolver instance and should call `disconnect()` when the session ends. The `agent.voice` getter throws when `voice` is a resolver because it has no request context; use `agent.getVoice({ requestContext })` instead.

--- a/docs/src/content/en/docs/agents/adding-voice.mdx
+++ b/docs/src/content/en/docs/agents/adding-voice.mdx
@@ -151,6 +151,37 @@ agent.voice.send(microphoneStream)
 agent.voice.close()
 ```
 
+### Per-session voice for concurrent sessions
+
+A static `voice` instance is shared across every request. For one-shot text-to-speech this is fine, but realtime and speech-to-speech providers store one WebSocket, one set of tools, and one request context per instance. If you deploy a single agent that handles several live sessions at once, a shared instance lets one session overwrite another session's tools, instructions, and request context.
+
+To give each session its own voice, provide `voice` as a resolver. Mastra runs the resolver on every `getVoice()` call and returns a fresh, session-owned instance:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { OpenAIRealtimeVoice } from '@mastra/voice-openai-realtime'
+
+export const agent = new Agent({
+  id: 'support-line',
+  name: 'Support Line',
+  instructions: ({ requestContext }) => `Help user ${requestContext.get('user')}.`,
+  model: '__GATEWAY_OPENAI_MODEL__',
+  voice: ({ requestContext }) => new OpenAIRealtimeVoice({ apiKey: requestContext.get('apiKey') }),
+})
+
+// Each concurrent session resolves its own voice instance
+const voice = await agent.getVoice({ requestContext })
+await voice.connect()
+```
+
+When you use a resolver:
+
+- Each call to `getVoice()` returns a new instance, so concurrent sessions never share state.
+- Mastra does not add tools or instructions to a resolver instance. Configure those inside the resolver or on the provider.
+- You own the lifecycle of the returned instance, so call `disconnect()` or `close()` when the session ends.
+
+The `agent.voice` getter has no request context, so it throws when `voice` is a resolver. Use `agent.getVoice({ requestContext })` instead.
+
 ### Event System
 
 The realtime voice provider emits several events you can listen for:

--- a/packages/core/src/agent/__tests__/voice.test.ts
+++ b/packages/core/src/agent/__tests__/voice.test.ts
@@ -1,6 +1,7 @@
 import { PassThrough } from 'node:stream';
 import { openai } from '@ai-sdk/openai-v5';
-import { beforeEach, describe, expect, it, expectTypeOf } from 'vitest';
+import { beforeEach, describe, expect, it, expectTypeOf, vi } from 'vitest';
+import { RequestContext } from '../../request-context';
 import { CompositeVoice } from '../../voice/composite-voice';
 import { MastraVoice } from '../../voice/voice';
 import { Agent } from '../agent';
@@ -177,6 +178,98 @@ describe('voice capabilities', () => {
 
       const audioStream = await agent.voice.speak('Hello');
       expect(audioStream).toBeDefined();
+    });
+  });
+
+  /**
+   * Per-session voice scope for realtime/STS agents (GitHub Issue #17262).
+   *
+   * When `voice` is a resolver, each getVoice() call must return a fresh,
+   * session-owned instance, and the agent must not post-mutate it via
+   * addTools/addInstructions.
+   */
+  describe('dynamic voice resolver (issue #17262)', () => {
+    it('AgentConfig.voice should accept a resolver returning MastraVoice', () => {
+      type VoiceConfigType = NonNullable<AgentConfig['voice']>;
+      expectTypeOf<({ requestContext }: { requestContext: any }) => MastraVoice>().toMatchTypeOf<VoiceConfigType>();
+    });
+
+    it('returns a fresh instance per call for a resolver', async () => {
+      const agent = new Agent({
+        id: 'dynamic-voice-agent',
+        name: 'Dynamic Voice Agent',
+        instructions: 'You are a voice assistant.',
+        model: openai('gpt-4o-mini'),
+        voice: () => new MockVoice({ speaker: 'mock-voice' }),
+      });
+
+      const voiceA = await agent.getVoice();
+      const voiceB = await agent.getVoice();
+
+      expect(voiceA).toBeInstanceOf(MockVoice);
+      expect(voiceB).toBeInstanceOf(MockVoice);
+      expect(voiceA).not.toBe(voiceB);
+    });
+
+    it('does not post-mutate a resolver-produced instance', async () => {
+      const addTools = vi.fn();
+      const addInstructions = vi.fn();
+
+      class SpyVoice extends MockVoice {
+        addTools = addTools;
+        addInstructions = addInstructions;
+      }
+
+      const agent = new Agent({
+        id: 'dynamic-voice-agent',
+        name: 'Dynamic Voice Agent',
+        instructions: 'You are a voice assistant.',
+        model: openai('gpt-4o-mini'),
+        voice: () => new SpyVoice({ speaker: 'mock-voice' }),
+      });
+
+      const voice = await agent.getVoice();
+
+      expect(voice).toBeInstanceOf(SpyVoice);
+      expect(addTools).not.toHaveBeenCalled();
+      expect(addInstructions).not.toHaveBeenCalled();
+    });
+
+    it('passes requestContext into the resolver', async () => {
+      const seen: string[] = [];
+
+      const agent = new Agent({
+        id: 'dynamic-voice-agent',
+        name: 'Dynamic Voice Agent',
+        instructions: 'You are a voice assistant.',
+        model: openai('gpt-4o-mini'),
+        voice: ({ requestContext }) => {
+          seen.push(String(requestContext.get('user')));
+          return new MockVoice({ speaker: 'mock-voice' });
+        },
+      });
+
+      const ctxA = new RequestContext();
+      ctxA.set('user', 'alice');
+      const ctxB = new RequestContext();
+      ctxB.set('user', 'bob');
+
+      await agent.getVoice({ requestContext: ctxA });
+      await agent.getVoice({ requestContext: ctxB });
+
+      expect(seen).toEqual(['alice', 'bob']);
+    });
+
+    it('the plain voice getter throws when voice is a resolver', () => {
+      const agent = new Agent({
+        id: 'dynamic-voice-agent',
+        name: 'Dynamic Voice Agent',
+        instructions: 'You are a voice assistant.',
+        model: openai('gpt-4o-mini'),
+        voice: () => new MockVoice({ speaker: 'mock-voice' }),
+      });
+
+      expect(() => agent.voice).toThrow('Voice is not compatible when voice is a function');
     });
   });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -332,7 +332,7 @@ export class Agent<
   #tools: DynamicArgument<TTools, TRequestContext>;
   #scorers: DynamicArgument<MastraScorers, TRequestContext>;
   #agents: DynamicArgument<Record<string, SubAgent<string, TRequestContext>>, TRequestContext>;
-  #voice: MastraVoice;
+  #voice: DynamicArgument<MastraVoice, TRequestContext>;
   #agentChannels: AgentChannels | null = null;
   #workspace?: DynamicArgument<AnyWorkspace | undefined, TRequestContext>;
   #inputProcessors?: DynamicArgument<InputProcessorOrWorkflow[], TRequestContext>;
@@ -468,11 +468,15 @@ export class Agent<
 
     if (config.voice) {
       this.#voice = config.voice;
-      if (typeof config.tools !== 'function') {
-        this.#voice?.addTools(this.#tools as TTools);
-      }
-      if (typeof config.instructions === 'string') {
-        this.#voice?.addInstructions(config.instructions);
+      // Only seed a static voice instance. A resolver is invoked per request in getVoice(),
+      // where its session-owned instance is configured, so we must not touch it here.
+      if (typeof this.#voice !== 'function') {
+        if (typeof config.tools !== 'function') {
+          this.#voice.addTools(this.#tools as TTools);
+        }
+        if (typeof config.instructions === 'string') {
+          this.#voice.addInstructions(config.instructions);
+        }
       }
     } else {
       this.#voice = new DefaultVoice();
@@ -1562,6 +1566,20 @@ export class Agent<
   }
 
   get voice() {
+    if (typeof this.#voice === 'function') {
+      const mastraError = new MastraError({
+        id: 'AGENT_VOICE_INCOMPATIBLE_WITH_FUNCTION_VOICE',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        details: {
+          agentName: this.name,
+        },
+        text: 'Voice is not compatible when voice is a function. Please use getVoice() instead.',
+      });
+      this.logger.trackException(mastraError);
+      throw mastraError;
+    }
+
     if (typeof this.#instructions === 'function') {
       const mastraError = new MastraError({
         id: 'AGENT_VOICE_INCOMPATIBLE_WITH_FUNCTION_INSTRUCTIONS',
@@ -1652,6 +1670,14 @@ export class Agent<
    * Gets the voice instance for this agent with tools and instructions configured.
    * The voice instance enables text-to-speech and speech-to-text capabilities.
    *
+   * When `voice` is configured as a resolver (`({ requestContext }) => new SomeVoice(...)`),
+   * each call resolves a fresh, session-owned instance. The resolver is responsible for
+   * configuring its own tools/instructions/request context, so this method does not mutate
+   * the resolved instance. The caller owns the lifecycle (e.g. `disconnect()`) of that instance.
+   *
+   * A static `MastraVoice` is shared across calls and is configured with the current
+   * tools/instructions on each call (appropriate for one-shot TTS).
+   *
    * @example
    * ```typescript
    * const voice = await agent.getVoice();
@@ -1659,15 +1685,23 @@ export class Agent<
    * ```
    */
   public async getVoice({ requestContext }: { requestContext?: RequestContext } = {}) {
-    if (this.#voice) {
-      const voice = this.#voice;
-      voice?.addTools(await this.listTools({ requestContext }));
-      const instructions = await this.getInstructions({ requestContext });
-      voice?.addInstructions(this.#convertInstructionsToString(instructions));
-      return voice;
-    } else {
+    if (!this.#voice) {
       return new DefaultVoice();
     }
+
+    if (typeof this.#voice === 'function') {
+      const resolved = await this.#voice({
+        requestContext: (requestContext ?? new RequestContext()) as RequestContext<TRequestContext>,
+        mastra: this.#mastra,
+      });
+      return resolved ?? new DefaultVoice();
+    }
+
+    const voice = this.#voice;
+    voice?.addTools(await this.listTools({ requestContext }));
+    const instructions = await this.getInstructions({ requestContext });
+    voice?.addInstructions(this.#convertInstructionsToString(instructions));
+    return voice;
   }
 
   /**

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -456,9 +456,16 @@ export interface AgentConfig<
    */
   browser?: MastraBrowser;
   /**
-   * Voice settings for speech input and output.
+   * Voice settings for speech input and output. Can be provided statically or resolved dynamically per request.
+   *
+   * Provide a resolver (`({ requestContext }) => new SomeVoice(...)`) to give each request/session its own
+   * voice instance. This is required for realtime / speech-to-speech providers, where concurrent live sessions
+   * must not share a single mutable instance (ws, tools, instructions, request context). The caller owns the
+   * lifecycle (e.g. `disconnect()`) of a resolver-produced instance.
+   *
+   * A static `MastraVoice` remains shared across requests, which is appropriate for one-shot TTS.
    */
-  voice?: MastraVoice;
+  voice?: DynamicArgument<MastraVoice, TRequestContext>;
   /**
    * Messaging channels the agent communicates over (e.g. Slack, Discord).
    *


### PR DESCRIPTION
## Summary

An agent's `voice` can now be configured as a resolver function, the same way `instructions`, `tools`, and `model` already work. Mastra runs the resolver on each `getVoice()` call and returns a fresh, session-owned voice instance rather than sharing a single mutable instance across all requests.

This makes it possible to run many concurrent realtime and speech-to-speech sessions against one deployed agent. Each session resolves its own voice provider, so it owns its own WebSocket, tools, and instructions. Previously a single shared voice instance meant concurrent sessions overwrote each other's connection state.

A static `voice` (`voice: new SomeVoice()`) keeps its existing shared behavior, so this is fully backward compatible.

### Before

```typescript
const agent = new Agent({
  name: 'support-line',
  voice: new GeminiLiveVoice({ apiKey: KEY }), // shared across every session
});
```

### After

```typescript
const agent = new Agent({
  name: 'support-line',
  voice: ({ requestContext }) =>
    new GeminiLiveVoice({ apiKey: requestContext.get('apiKey') }),
});

const voice = await agent.getVoice({ requestContext }); // owns its own ws/tools/instructions
await voice.connect();
```

When `voice` is a resolver, the caller owns the lifecycle of the resolved instance and should `disconnect()` when the session ends. The `agent.voice` getter throws when `voice` is a resolver because it has no request context — consistent with the existing function-instructions guard — and directs callers to `agent.getVoice({ requestContext })`.

Fixes #17262.

## Test plan

- `pnpm --filter ./packages/core check` — typecheck passes, no errors
- `pnpm --filter ./packages/core test src/agent/__tests__/voice.test.ts src/agent/__tests__/instructions.test.ts` — 66 tests pass
- New tests in `voice.test.ts` cover: resolver type acceptance, a fresh instance per `getVoice()` call, no post-mutation of resolver instances, `requestContext` passthrough, and the `agent.voice` getter throwing for resolvers
- Static-voice behavior verified unchanged by existing tests

## Docs

- Added a per-session voice section to `docs/src/content/en/docs/agents/adding-voice.mdx`

🤖 Generated with Mastra Code