### PR TITLE
fix(core): reduce streamed tool payload lookup overhead

### DIFF
--- a/.changeset/plain-monkeys-tap.md
+++ b/.changeset/plain-monkeys-tap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Reduced overhead when streaming tool calls in agentic workflows

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -3,6 +3,7 @@ import { convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Mock } from 'vitest';
 import { z } from 'zod/v4';
+import { MODEL_TOKENS } from '../../../../../../docs/src/plugins/remark-model-tokens/models';
 import { MessageList } from '../../../agent/message-list';
 import { SpanType } from '../../../observability';
 import { ProviderHistoryCompat } from '../../../processors/provider-history-compat';
@@ -499,7 +500,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
           model: {
             specificationVersion: 'v2' as const,
             provider: 'mock-provider',
-            modelId: 'mock-model-id',
+            modelId: MODEL_TOKENS.__GATEWAY_OPENAI_MODEL_BASE__,
             supportedUrls: {},
             doGenerate: vi.fn(),
             doStream: vi.fn(async () => ({

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -460,6 +460,109 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     });
   });
 
+  it('resolves streamed tool payload transforms without rescanning tools per delta', async () => {
+    const onInputDelta = vi.fn();
+    const rawTools = {
+      registeredLookup: {
+        id: 'lookup_by_model_name',
+        inputSchema: z.object({ query: z.string() }),
+        onInputDelta,
+        transform: {
+          display: {
+            inputDelta: ({ inputTextDelta }: { inputTextDelta?: string }) => inputTextDelta?.toUpperCase(),
+          },
+        },
+      },
+    };
+    let toolEnumerationCount = 0;
+    const tools = new Proxy(rawTools, {
+      ownKeys(target) {
+        toolEnumerationCount += 1;
+        return Reflect.ownKeys(target);
+      },
+    });
+    const toolInputDeltas = ['{"query":"', ...Array.from({ length: 12 }, (_, index) => `part-${index} `), '"}'];
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream: vi.fn(async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-input-start',
+                  id: 'call-1',
+                  toolName: 'lookup_by_model_name',
+                  providerExecuted: false,
+                },
+                ...toolInputDeltas.map(delta => ({
+                  type: 'tool-input-delta' as const,
+                  id: 'call-1',
+                  delta,
+                })),
+                {
+                  type: 'tool-input-end',
+                  id: 'call-1',
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: testUsage,
+                },
+              ]),
+              request: {},
+              response: {
+                headers: undefined,
+              },
+              warnings: [],
+            })),
+          } as any,
+        },
+      ],
+      tools,
+      toolCallStreaming: true,
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<typeof tools>);
+
+    await llmExecutionStep.execute(createExecuteParams(createIterationInput()));
+
+    const enqueuedChunks = (controller.enqueue as Mock).mock.calls.map(([chunk]) => chunk);
+    const deltaChunks = enqueuedChunks.filter(chunk => chunk.type === 'tool-call-delta');
+
+    expect(toolEnumerationCount).toBeLessThanOrEqual(5);
+    expect(onInputDelta).toHaveBeenCalledTimes(toolInputDeltas.length);
+    expect(deltaChunks).toHaveLength(toolInputDeltas.length);
+    expect(deltaChunks.map(chunk => chunk.metadata?.mastra?.toolPayloadTransform?.display?.['input-delta'])).toEqual(
+      toolInputDeltas.map(delta => ({ transformed: delta.toUpperCase() })),
+    );
+  });
+
   it('merges model config headers with explicit modelSettings headers and lets modelSettings override duplicates', async () => {
     const doStream = vi.fn(async () => ({
       stream: convertArrayToReadableStream([

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -43,7 +43,7 @@ import {
 } from '../../../tools/payload-transform';
 import { findProviderToolByName, inferProviderExecuted } from '../../../tools/provider-tool-utils';
 import type { ToolToConvert } from '../../../tools/tool-builder/builder';
-import { isMastraTool } from '../../../tools/toolchecks';
+import { getProviderToolName, isMastraTool, isProviderTool } from '../../../tools/toolchecks';
 import { makeCoreTool } from '../../../utils';
 import { createStep } from '../../../workflows/workflow';
 import type { Workspace } from '../../../workspace/workspace';
@@ -116,14 +116,90 @@ type ProcessOutputStreamOptions<OUTPUT = undefined> = {
   tracingContext?: TracingContext;
 };
 
+type ToolResolvers = {
+  resolveTool: (toolName: string) => ToolSet[string] | undefined;
+  resolveDirectOrProviderTool: (toolName: string) => ToolSet[string] | undefined;
+  resolveDirectOrIdTool: (toolName: string) => ToolSet[string] | undefined;
+};
+
+function createToolResolvers(tools?: ToolSet): ToolResolvers {
+  let providerToolsByName: Map<string, ToolSet[string]> | undefined;
+  let toolsById: Map<string, ToolSet[string]> | undefined;
+
+  const ensureToolIndexes = () => {
+    if (providerToolsByName && toolsById) {
+      return;
+    }
+
+    const nextProviderToolsByName = new Map<string, ToolSet[string]>();
+    const nextToolsById = new Map<string, ToolSet[string]>();
+
+    for (const tool of Object.values(tools || {})) {
+      if (!tool || typeof tool !== 'object') {
+        continue;
+      }
+
+      if (isProviderTool(tool)) {
+        const providerToolName = getProviderToolName(tool.id);
+        if (!nextProviderToolsByName.has(providerToolName)) {
+          nextProviderToolsByName.set(providerToolName, tool);
+        }
+
+        const explicitProviderName = (tool as { name?: unknown }).name;
+        if (typeof explicitProviderName === 'string' && !nextProviderToolsByName.has(explicitProviderName)) {
+          nextProviderToolsByName.set(explicitProviderName, tool);
+        }
+      }
+
+      const toolId = (tool as { id?: unknown }).id;
+      if (typeof toolId === 'string' && !nextToolsById.has(toolId)) {
+        nextToolsById.set(toolId, tool);
+      }
+    }
+
+    providerToolsByName = nextProviderToolsByName;
+    toolsById = nextToolsById;
+  };
+
+  const resolveDirectOrProviderTool = (toolName: string) => {
+    const directTool = tools?.[toolName];
+    if (directTool) {
+      return directTool;
+    }
+    ensureToolIndexes();
+    return providerToolsByName?.get(toolName);
+  };
+  const resolveDirectOrIdTool = (toolName: string) => {
+    const directTool = tools?.[toolName];
+    if (directTool) {
+      return directTool;
+    }
+    ensureToolIndexes();
+    return toolsById?.get(toolName);
+  };
+
+  return {
+    resolveTool: toolName => {
+      const tool = resolveDirectOrProviderTool(toolName);
+      if (tool) {
+        return tool;
+      }
+      ensureToolIndexes();
+      return toolsById?.get(toolName);
+    },
+    resolveDirectOrProviderTool,
+    resolveDirectOrIdTool,
+  };
+}
+
 async function addToolPayloadTransformToChunk<OUTPUT>(
   chunk: ChunkType<OUTPUT>,
   {
-    tools,
+    resolveTool,
     policy,
     logger,
   }: {
-    tools?: ToolSet;
+    resolveTool: ToolResolvers['resolveTool'];
     policy?: NonNullable<OuterLLMRun['_internal']>['toolPayloadTransform'];
     logger?: IMastraLogger;
   },
@@ -139,10 +215,7 @@ async function addToolPayloadTransformToChunk<OUTPUT>(
     return chunk;
   }
 
-  const tool =
-    tools?.[toolName] ||
-    findProviderToolByName(tools, toolName) ||
-    Object.values(tools || {}).find((candidate: any) => `id` in candidate && candidate.id === toolName);
+  const tool = resolveTool(toolName);
   const source = {
     policy,
     toolTransform: (tool as { transform?: unknown } | undefined)?.transform as any,
@@ -330,6 +403,7 @@ async function processOutputStream<OUTPUT = undefined>({
 }: ProcessOutputStreamOptions<OUTPUT>): Promise<ProcessOutputStreamResult> {
   let transportSet = false;
   const collectedChunks: CollectedChunk[] = [];
+  const { resolveTool, resolveDirectOrProviderTool, resolveDirectOrIdTool } = createToolResolvers(tools);
   const clientToolArgsTextByToolCallId = new Map<string, string[]>();
   const clientToolObservabilityByToolCallId = new Map<
     string,
@@ -383,7 +457,7 @@ async function processOutputStream<OUTPUT = undefined>({
     providerExecuted?: boolean;
     payload: Record<string, unknown> & { observability?: unknown };
   }) => {
-    const toolDef = tools?.[toolName] || findProviderToolByName(tools, toolName);
+    const toolDef = resolveDirectOrProviderTool(toolName);
     const inferredProviderExecuted = inferProviderExecuted(providerExecuted, toolDef);
     const isClientTool = !inferredProviderExecuted && !(toolDef as { execute?: unknown } | undefined)?.execute;
 
@@ -468,7 +542,7 @@ async function processOutputStream<OUTPUT = undefined>({
     }
 
     chunk = await addToolPayloadTransformToChunk(chunk, {
-      tools,
+      resolveTool,
       policy: toolPayloadTransform,
       logger,
     });
@@ -523,10 +597,7 @@ async function processOutputStream<OUTPUT = undefined>({
         break;
 
       case 'tool-call-input-streaming-start': {
-        const tool =
-          toolInputStartToolDef ||
-          tools?.[chunk.payload.toolName] ||
-          Object.values(tools || {})?.find(tool => `id` in tool && tool.id === chunk.payload.toolName);
+        const tool = toolInputStartToolDef || resolveDirectOrIdTool(chunk.payload.toolName);
 
         if (tool && 'onInputStart' in tool) {
           try {
@@ -545,9 +616,7 @@ async function processOutputStream<OUTPUT = undefined>({
       }
 
       case 'tool-call-delta': {
-        const tool =
-          tools?.[chunk.payload.toolName || ''] ||
-          Object.values(tools || {})?.find(tool => `id` in tool && tool.id === chunk.payload.toolName);
+        const tool = chunk.payload.toolName ? resolveDirectOrIdTool(chunk.payload.toolName) : undefined;
 
         if (tool && 'onInputDelta' in tool) {
           try {
@@ -616,8 +685,7 @@ async function processOutputStream<OUTPUT = undefined>({
         // For same-stream results (call + result in one step), no matching part exists yet
         // so updateToolInvocation returns false — buildMessagesFromChunks handles the merge.
         if (chunk.payload.result != null) {
-          const resultToolDef =
-            tools?.[chunk.payload.toolName] || findProviderToolByName(tools, chunk.payload.toolName);
+          const resultToolDef = resolveDirectOrProviderTool(chunk.payload.toolName);
           messageList.updateToolInvocation({
             type: 'tool-invocation',
             toolInvocation: {


### PR DESCRIPTION
## Description

This reduces overhead in the agentic stream processing path when tool payload transforms run on streamed tool input deltas. The stream now uses lazy per-stream tool indexes for fallback lookup instead of re-enumerating the tool registry on each matching chunk.

The lookup behavior stays scoped to the existing patterns at each call site:
- payload transforms: direct key, provider name, id
- observability/result paths: direct key, provider name
- streaming start/delta callbacks: direct key, id

I also added a regression test covering streamed tool payload transforms through the id fallback path, verifying that `onInputDelta` and display transforms still run for every delta while tool enumeration stays constant.

Benchmark shape:
- 2,000 registered tools
- 1,000 streamed tool input deltas
- real `createLLMExecutionStep` streaming flow
- payload transform and `onInputDelta` verified on every delta

Results on `origin/main`:
- p50: 1884.16 ms
- average: 1883.25 ms
- tool registry enumerations per run: 3011

Results with this change:
- p50: 26.16 ms
- average: 25.65 ms
- tool registry enumerations per run: 5

## Related issue(s)

Fixes https://github.com/mastra-ai/mastra/issues/17353

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When streaming tool input, the system used to re-search the whole list of tools for every little chunk. This PR builds a small lookup index once per stream so each chunk finds its tool quickly, making streaming much faster.

## Summary

This PR reduces overhead for streamed tool calls in agentic workflows by introducing lazy, per-stream tool resolvers so fallback lookups no longer re-enumerate the entire tool registry for every streamed delta.

### Problem
Fallback lookup paths (provider name, id) were causing repeated full tool-registry scans during a single model turn, e.g., 3,011 registry enumerations in a benchmark with 2,000 tools and 1,000 streamed deltas.

### Solution
Add a centralized createToolResolvers() helper in packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts that builds cached lookup indexes (direct by name/id and provider-tool names) once per step. All lookup sites now use these resolvers, preserving existing lookup semantics:
- payload transforms: direct key, provider name, id
- observability/result paths: direct key, provider name
- streaming start/delta callbacks: direct key, id

### Changes
- Refactor llm-execution-step.ts to use createToolResolvers() and route lookups through resolveTool helpers (affects addToolPayloadTransformToChunk, injectClientToolObservability, streaming lifecycle hooks, and deferred provider result handling). Replaced ad-hoc scans with resolver lookups and added getProviderToolName import usage.
- Add regression test in llm-execution-step.test.ts ("resolves streamed tool payload transforms without rescanning tools per delta") that imports MODEL_TOKENS, streams multiple tool-input-delta events, asserts per-delta transforms/onInputDelta execution, and verifies tool enumeration remains bounded (≤5 ownKeys calls).
- .changeset entry: patch bump for `@mastra/core`.
- Commit updates test to use shared model placeholder token per PR feedback.

### Performance Impact
Benchmark (2,000 tools, 1,000 deltas, real createLLMExecutionStep flow):
- origin/main: p50 1884.16 ms, avg 1883.25 ms, tool registry enumerations per run: 3,011
- With change: p50 26.16 ms, avg 25.65 ms, tool registry enumerations per run: 5
(≈72× p50 improvement)

Fixes https://github.com/mastra-ai/mastra/issues/17353.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
