### PR TITLE
feat(workflows): add metadata field to workflow definitions

### DIFF
--- a/.changeset/workflow-metadata-field.md
+++ b/.changeset/workflow-metadata-field.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": patch
+"@mastra/server": patch
+"@mastra/client-js": patch
+---
+
+Added optional metadata field to workflow definitions, mirroring the existing step metadata feature. Metadata is preserved through serialization and exposed via the Mastra Server API.

--- a/.changeset/workflow-metadata-field.md
+++ b/.changeset/workflow-metadata-field.md
@@ -4,4 +4,22 @@
 "@mastra/client-js": patch
 ---
 
-Added optional metadata field to workflow definitions, mirroring the existing step metadata feature. Metadata is preserved through serialization and exposed via the Mastra Server API.
+Workflows now support an optional `metadata` field for attaching custom key-value data such as `displayName`, `author`, or `category`. Metadata is preserved through serialization and returned in workflow info API responses.
+
+```typescript
+// Define a workflow with metadata
+const myWorkflow = createWorkflow({
+  id: 'data-processing',
+  metadata: {
+    displayName: 'Data Processing Pipeline',
+    author: 'team@example.com',
+    category: 'ETL',
+  },
+  inputSchema: z.object({ ... }),
+  outputSchema: z.object({ ... }),
+});
+
+// Retrieve workflow info with metadata via the Mastra Server API
+const workflowInfo = await mastraClient.getWorkflow('data-processing');
+console.log(workflowInfo.metadata?.displayName); // "Data Processing Pipeline"
+```

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -602,6 +602,7 @@ export type GetWorkflowRunByIdResponse = WorkflowState;
 export interface GetWorkflowResponse {
   name: string;
   description?: string;
+  metadata?: Record<string, unknown>;
   steps: {
     [key: string]: {
       id: string;

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -820,6 +820,7 @@ export type WorkflowConfig<
   mastra?: Mastra;
   id: TWorkflowId;
   description?: string | undefined;
+  metadata?: Record<string, unknown> | undefined;
   inputSchema: PublicSchema<TInput>;
   outputSchema: PublicSchema<TOutput>;
   stateSchema?: PublicSchema<TState>;

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1647,6 +1647,7 @@ export class Workflow<
 {
   public id: TWorkflowId;
   public description?: string | undefined;
+  public metadata?: Record<string, unknown> | undefined;
   public inputSchema: StandardSchemaWithJSON<TInput>;
   public outputSchema: StandardSchemaWithJSON<TOutput>;
   public stateSchema?: StandardSchemaWithJSON<TState>;
@@ -1681,6 +1682,7 @@ export class Workflow<
     stateSchema,
     requestContextSchema,
     description,
+    metadata,
     executionEngine,
     retryConfig,
     steps,
@@ -1690,6 +1692,7 @@ export class Workflow<
     super({ name: id, component: RegisteredLogger.WORKFLOW });
     this.id = id;
     this.description = description;
+    this.metadata = metadata;
     this.inputSchema = inputSchema ? toStandardSchema(inputSchema) : inputSchema;
     this.outputSchema = outputSchema ? toStandardSchema(outputSchema) : outputSchema;
     this.stateSchema = stateSchema ? toStandardSchema(stateSchema) : undefined;

--- a/packages/server/src/server/schemas/workflows.ts
+++ b/packages/server/src/server/schemas/workflows.ts
@@ -57,6 +57,7 @@ export const workflowInfoSchema = z.object({
   allSteps: z.record(z.string(), serializedStepSchema),
   name: z.string().optional(),
   description: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   stepGraph: z.array(serializedStepFlowEntrySchema),
   inputSchema: z.string().optional(),
   outputSchema: z.string().optional(),

--- a/packages/server/src/server/utils.ts
+++ b/packages/server/src/server/utils.ts
@@ -184,6 +184,7 @@ export function getWorkflowInfo(workflow: Workflow, partial: boolean = false): W
     return {
       name: workflow.name,
       description: workflow.description,
+      metadata: workflow.metadata,
       stepCount: Object.keys(workflow.steps).length,
       stepGraph: workflow.serializedStepGraph,
       options: workflow.options,
@@ -198,6 +199,7 @@ export function getWorkflowInfo(workflow: Workflow, partial: boolean = false): W
   return {
     name: workflow.name,
     description: workflow.description,
+    metadata: workflow.metadata,
     steps: Object.entries(workflow.steps).reduce<any>((acc, [key, step]) => {
       acc[key] = {
         id: step.id,


### PR DESCRIPTION
## Description

Workflows now support an optional `metadata` field for storing arbitrary key-value data, mirroring the existing step metadata feature added in #12508.

**Changes:**
- `WorkflowConfig` type accepts optional `metadata?: Record<string, unknown>`
- `Workflow` class stores and exposes `metadata` as a public field
- `getWorkflowInfo()` in server utils forwards `metadata` in both partial and full modes
- `workflowInfoSchema` in server schemas includes the `metadata` field
- `GetWorkflowResponse` in the client SDK exposes `metadata`

Metadata values must be serializable (no functions or circular references).

**Example:**
```typescript
const myWorkflow = createWorkflow({
  id: 'my-workflow',
  metadata: {
    displayName: 'My Workflow',
    author: 'team-name',
    category: 'data-processing',
  },
  inputSchema: z.object({ ... }),
  outputSchema: z.object({ ... }),
});
```

## Related issue(s)

Fixes #17349

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds an optional metadata field to workflows so you can attach simple extra info (like display name, author, category) to an entire workflow; that data is saved and returned by the server so frontends can show or use it.

## Changes

**Core Types and Classes**
- `WorkflowConfig` accepts optional `metadata?: Record<string, unknown>`.
- `Workflow` class exposes `public metadata?: Record<string, unknown>` and wires it through the constructor.

**Server Schema and Utilities**
- `workflowInfoSchema` includes optional `metadata: z.record(z.string(), z.unknown())`.
- `getWorkflowInfo()` now returns `metadata` in both partial and full modes.

**Client SDK**
- `GetWorkflowResponse` (client-js) includes optional `metadata?: Record<string, unknown>`.

**Changeset / Releases**
- Changeset added documenting patch releases for `@mastra/core`, `@mastra/server`, and `@mastra/client-js`.

## Design notes
- Mirrors existing step-level metadata behavior for consistency.
- Metadata values must be serializable (no functions or circular references).
- Non-breaking: optional fields only; existing APIs remain unchanged.

## Related
- Implements the request from issue `#17349`.

## Checklist / Outstanding
- Related issue linked and code comments addressed.
- Documentation update has not yet been completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->