### PR TITLE
fix(pg): honor explicit ssl over sslmode in connection string

### DIFF
--- a/.changeset/pg-ssl-connection-string-precedence.md
+++ b/.changeset/pg-ssl-connection-string-precedence.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed `PostgresStore` ignoring an explicit `ssl` option when the `connectionString` also carries an `sslmode=`/`ssl=` query param. node-postgres re-parses the connection string and `Object.assign`s the URL-derived `ssl` over the explicit one, so a config like `{ connectionString: '...?sslmode=require', ssl: { rejectUnauthorized: false } }` silently dropped `rejectUnauthorized: false` and failed with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` against self-signed CAs. The connection-string branch now parses the URL and applies the explicit `ssl` last, while still honoring URL-driven SSL when no `ssl` option is provided. Fixes #17307.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6204,6 +6204,9 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      pg-connection-string:
+        specifier: ^2.12.0
+        version: 2.12.0
       xxhash-wasm:
         specifier: ^1.1.0
         version: 1.1.0

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "async-mutex": "^0.5.0",
     "pg": "^8.20.0",
+    "pg-connection-string": "^2.12.0",
     "xxhash-wasm": "^1.1.0"
   },
   "devDependencies": {

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -33,6 +33,7 @@ import { ScoresPG } from './domains/scores';
 import { SkillsPG } from './domains/skills';
 import { WorkflowsPG } from './domains/workflows';
 import { WorkspacesPG } from './domains/workspaces';
+import { buildConnectionStringPoolConfig } from './pool-config';
 
 /** Default maximum number of connections in the pool */
 const DEFAULT_MAX_CONNECTIONS = 20;
@@ -194,12 +195,12 @@ export class PostgresStore extends MastraCompositeStore {
 
   private createPool(config: PostgresStoreConfig): Pool {
     if (isConnectionStringConfig(config)) {
-      return new Pool({
-        connectionString: config.connectionString,
-        ssl: config.ssl,
-        max: config.max ?? DEFAULT_MAX_CONNECTIONS,
-        idleTimeoutMillis: config.idleTimeoutMillis ?? DEFAULT_IDLE_TIMEOUT_MS,
-      });
+      return new Pool(
+        buildConnectionStringPoolConfig(config, {
+          max: DEFAULT_MAX_CONNECTIONS,
+          idleTimeoutMillis: DEFAULT_IDLE_TIMEOUT_MS,
+        }),
+      );
     }
 
     if (isHostConfig(config)) {

--- a/stores/pg/src/storage/pool-config.test.ts
+++ b/stores/pg/src/storage/pool-config.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildConnectionStringPoolConfig } from './pool-config';
+
+const defaults = { max: 20, idleTimeoutMillis: 30_000 };
+
+// Regression coverage for https://github.com/mastra-ai/mastra/issues/17307
+describe('buildConnectionStringPoolConfig', () => {
+  it('lets an explicit ssl object win over an sslmode= URL param', () => {
+    const cfg = buildConnectionStringPoolConfig(
+      {
+        connectionString: 'postgresql://user:pass@localhost:5432/db?sslmode=require',
+        ssl: { rejectUnauthorized: false },
+      },
+      defaults,
+    );
+
+    expect(cfg.ssl).toEqual({ rejectUnauthorized: false });
+    // The raw connectionString must not be forwarded, otherwise pg re-parses it
+    // and Object.assigns the URL-derived ssl back over our explicit one.
+    expect(cfg).not.toHaveProperty('connectionString');
+    expect(cfg.host).toBe('localhost');
+    expect(String(cfg.port)).toBe('5432');
+    expect(cfg.database).toBe('db');
+  });
+
+  it('lets an explicit ssl object win over an ssl= URL param', () => {
+    const cfg = buildConnectionStringPoolConfig(
+      {
+        connectionString: 'postgresql://user:pass@localhost:5432/db?ssl=no-verify',
+        ssl: { rejectUnauthorized: false },
+      },
+      defaults,
+    );
+
+    expect(cfg.ssl).toEqual({ rejectUnauthorized: false });
+  });
+
+  it('preserves URL-driven ssl when no explicit ssl is provided', () => {
+    const cfg = buildConnectionStringPoolConfig(
+      { connectionString: 'postgresql://user:pass@localhost:5432/db?sslmode=require' },
+      defaults,
+    );
+
+    // pg-connection-string maps sslmode=require to {}; this must be kept rather
+    // than clobbered to undefined.
+    expect(cfg.ssl).toEqual({});
+  });
+
+  it('leaves ssl undefined when neither the URL nor the config set it', () => {
+    const cfg = buildConnectionStringPoolConfig(
+      { connectionString: 'postgresql://user:pass@localhost:5432/db' },
+      defaults,
+    );
+
+    expect(cfg.ssl).toBeUndefined();
+  });
+
+  it('applies pool defaults and honors explicit overrides', () => {
+    const withDefaults = buildConnectionStringPoolConfig(
+      { connectionString: 'postgresql://user:pass@localhost:5432/db' },
+      defaults,
+    );
+    expect(withDefaults.max).toBe(20);
+    expect(withDefaults.idleTimeoutMillis).toBe(30_000);
+
+    const overridden = buildConnectionStringPoolConfig(
+      { connectionString: 'postgresql://user:pass@localhost:5432/db', max: 5, idleTimeoutMillis: 1_000 },
+      defaults,
+    );
+    expect(overridden.max).toBe(5);
+    expect(overridden.idleTimeoutMillis).toBe(1_000);
+  });
+});

--- a/stores/pg/src/storage/pool-config.ts
+++ b/stores/pg/src/storage/pool-config.ts
@@ -1,0 +1,38 @@
+import type { PoolConfig } from 'pg';
+import { parse } from 'pg-connection-string';
+
+import type { ConnectionStringConfig } from '../shared/config';
+
+/**
+ * Builds the `pg.Pool` options for a connection-string based config.
+ *
+ * node-postgres re-parses `connectionString` via `pg-connection-string` and
+ * `Object.assign`s the parsed result over any explicit options. As a result an
+ * `sslmode=` / `ssl=` query param in the URL silently overrides an explicit
+ * `ssl` object (e.g. `{ rejectUnauthorized: false }`), producing
+ * `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` against self-signed CAs even though the
+ * caller asked to skip verification.
+ *
+ * To avoid that we parse the connection string ourselves and forward the
+ * discrete fields, applying the explicit `ssl` last so it always wins. When no
+ * explicit `ssl` is provided we keep whatever the URL implied (`sslmode=...`),
+ * preserving backwards-compatible behaviour for connection-string-only SSL.
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/17307
+ */
+export function buildConnectionStringPoolConfig(
+  config: ConnectionStringConfig,
+  defaults: { max: number; idleTimeoutMillis: number },
+): PoolConfig {
+  // `parse` returns ports as strings and may include an `ssl` key derived from
+  // the URL; `pg` accepts these discrete fields the same way it would the raw
+  // string, minus the precedence quirk above.
+  const parsed = parse(config.connectionString) as unknown as PoolConfig;
+
+  return {
+    ...parsed,
+    ...(config.ssl !== undefined ? { ssl: config.ssl } : {}),
+    max: config.max ?? defaults.max,
+    idleTimeoutMillis: config.idleTimeoutMillis ?? defaults.idleTimeoutMillis,
+  };
+}


### PR DESCRIPTION
## What

Fixes `PostgresStore` ignoring an explicit `ssl` option when the `connectionString` carries an `sslmode=`/`ssl=` query param.

## Why

node-postgres builds `ConnectionParameters` via `Object.assign({}, config, parse(connectionString))`, so a URL SSL hint overrides the explicit `ssl` object. A config like:

```ts
new PostgresStore({
  id: 'store',
  connectionString: 'postgres://user:pass@host:5432/db?sslmode=require',
  ssl: { rejectUnauthorized: false },
});
```

therefore drops `rejectUnauthorized: false` and fails with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` against a self-signed CA. Reproduced in plain Node (no Next.js / Turbopack), which rules out the earlier bundler theory — credit to @suspect-47 in the issue thread for the root-cause analysis and minimal repro.

## How

`createPool`'s connection-string branch now parses the URL itself and forwards the discrete fields, applying the explicit `ssl` **last** so it always wins — while still honoring URL-driven SSL (`sslmode=...`) when no `ssl` option is provided. The logic is extracted into a small internal helper (`buildConnectionStringPoolConfig`) so it can be unit-tested without a live database.

`pg-connection-string` is added as a direct dependency since we now import it explicitly (it was already present transitively via `pg`).

## Tests

`stores/pg/src/storage/pool-config.test.ts` — 5 unit tests, no database required:
- explicit `ssl` wins over `sslmode=require`
- explicit `ssl` wins over `ssl=no-verify`
- URL-driven `ssl` preserved when no explicit `ssl`
- `ssl` stays undefined when neither sets it
- pool defaults applied / overrides honored

Fixes #17307


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When connecting to a PostgreSQL database with SSL, you can specify SSL settings in two ways: directly in code (explicit ssl option) or in the connection URL (sslmode parameter). The bug was that the URL settings were always overwriting your explicit settings, causing SSL connections to fail. This PR fixes it so that your explicit settings always win, but the URL settings still work if you don't explicitly set them.

## Changes Overview

This PR fixes `PostgresStore` to properly honor explicit SSL options when connecting to PostgreSQL, ensuring that an explicitly provided `ssl` config object takes precedence over any SSL-related query parameters in the connection string (`sslmode=` or `ssl=`).

### Problem Addressed

Previously, `PostgresStore` would accept an `ssl` configuration option but node-postgres's internal connection handling would re-parse the connection string, causing URL-derived SSL settings to override the explicit `ssl` object. This resulted in settings like `rejectUnauthorized: false` being silently dropped, causing certificate validation failures when connecting to databases with self-signed CAs (issue `#17307`).

### Implementation

**New dependency:**
- Added `pg-connection-string` (`^2.12.0`) to parse connection URLs separately from node-postgres's parsing

**New utility function:**
- Created `buildConnectionStringPoolConfig()` in `stores/pg/src/storage/pool-config.ts` that:
  - Parses the connection string using `pg-connection-string`
  - Returns discrete connection fields instead of passing the raw `connectionString` to node-postgres
  - Applies the explicit `ssl` option last when provided, ensuring it always takes precedence
  - Preserves URL-driven SSL settings when no explicit `ssl` is provided

**Updated connection logic:**
- Modified `createPool()` in `stores/pg/src/storage/index.ts` to use `buildConnectionStringPoolConfig()` instead of inline option construction
- Ensures pool defaults (`max`, `idleTimeoutMillis`) are still applied correctly

**Test coverage:**
- Added 5 unit tests in `stores/pg/src/storage/pool-config.test.ts` covering:
  - Explicit `ssl` object overriding URL `sslmode=require`
  - Explicit `ssl` object overriding URL `ssl=no-verify`
  - URL-driven SSL being preserved when no explicit `ssl` is provided
  - `ssl` remaining `undefined` when neither source sets it
  - Pool defaults and explicit overrides being applied correctly

### Impact

All internal PostgreSQL connections created by sub-stores (MemoryPG, WorkflowsPG, ScoresPG, etc.) will now properly inherit the SSL configuration passed to `PostgresStore`, enabling secure connections to PostgreSQL instances using self-signed CAs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->