### PR TITLE
fix(schema-compat): generate JSON Schema from pre-transform input shape

### DIFF
--- a/.changeset/yellow-chairs-move.md
+++ b/.changeset/yellow-chairs-move.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed Zod 4 schemas with `.transform()` producing the wrong JSON Schema for structured output and tool calling. The generated schema now describes the pre-transform input the model must produce instead of the post-transform output, so a field like `z.string().transform(JSON.parse)` is advertised as a `string` rather than `string | number | boolean | null`.

--- a/packages/schema-compat/src/zod-to-json.test.ts
+++ b/packages/schema-compat/src/zod-to-json.test.ts
@@ -723,4 +723,17 @@ describe('ensureAllPropertiesRequired', () => {
     expect(result.required).toContain('required');
     expect(result.required).not.toContain('optional');
   });
+
+  describe.runIf(isZodV4)('transforms (io: input)', () => {
+    it('describes the pre-transform input shape for transformed fields', () => {
+      const schema = z.object({
+        additionalData: z.string().transform(val => JSON.parse(val)),
+      });
+
+      const result = zodToJsonSchema(schema);
+      const additionalData = (result.properties as any).additionalData;
+
+      expect(additionalData.type).toBe('string');
+    });
+  });
 });

--- a/packages/schema-compat/src/zod-to-json.ts
+++ b/packages/schema-compat/src/zod-to-json.ts
@@ -295,6 +295,7 @@ export function zodToJsonSchema(
 
     const jsonSchema = zV4.toJSONSchema(zodSchema, {
       unrepresentable: 'any',
+      io: 'input',
       override: (ctx: any) => {
         // Handle both Zod v4 structures: _def directly or nested in _zod
         const def = ctx.zodSchema?._def || ctx.zodSchema?._zod?.def;


### PR DESCRIPTION
## Summary

`zodToJsonSchema` converted Zod 4 schemas with `zV4.toJSONSchema(...)` using the default `io: 'output'`, which describes the **post-transform** shape. For LLM structured output and tool calling the JSON Schema must describe the **pre-transform input** the model produces (which is then re-parsed, applying transforms).

As a result a field like `z.string().transform(val => JSON.parse(val))` was advertised to the model as `string | number | boolean | null` instead of the `string` it actually has to emit.

This passes `io: 'input'` so transformed fields advertise their input shape. Schemas without transforms are unaffected (input and output shapes are identical).

```ts
const schema = z.object({
  additionalData: z.string().transform(val => JSON.parse(val)),
});

// before: additionalData -> { type: ['string', 'number', 'boolean', 'null'] }
// after:  additionalData -> { type: 'string' }
```

## Test plan

- Added a Zod 4 regression test asserting a transformed field yields `type: 'string'`.
- `pnpm vitest run src/zod-to-json.test.ts` — 91 passed, 1 skipped (v3/v4 gate).
- Full package suite `pnpm test` — 793 passed; `tsc --noEmit` clean.

Closes #16377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When AI models need to produce structured data, they're told what types to generate using a JSON schema. This PR fixes a bug where transformed fields (like a string that gets converted to JSON) were incorrectly telling the model it could produce the final type directly, when it should have been asking for the input type (the string) that would then be transformed. Now the schema correctly describes what the model should actually emit.

## Changes

**packages/schema-compat/src/zod-to-json.ts**
- Updated the Zod v4 path to pass `io: 'input'` to `zV4.toJSONSchema()`, ensuring the generated JSON Schema describes the pre-transform input shape rather than the post-transform output shape
- This affects how transformed fields are represented; for example, `z.string().transform(JSON.parse)` now correctly advertises `type: 'string'` instead of `type: ['string','number','boolean','null']`

**packages/schema-compat/src/zod-to-json.test.ts**
- Added a new Zod v4-specific test suite under `describe.runIf(isZodV4)('transforms (io: input)')` that verifies transformed fields produce the correct pre-transform input shape
- The test creates a schema with `z.string().transform(JSON.parse)` and asserts that the generated `additionalData` property has `type: 'string'`

**.changeset/yellow-chairs-move.md**
- Created a patch-level changelog entry documenting the fix for Zod 4 schemas with `.transform()`

## Impact

This fix ensures that when `@mastra/schema-compat`'s `zodToJsonSchema` is used for LLM structured output and tool calling, the generated JSON Schema accurately describes what the model should produce (the pre-transform input), not what the application receives after parsing and transformation. This prevents LLMs from being instructed to emit values that don't match the parser's expectations.

Closes `#16377`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->