### PR TITLE
test(memory): guard assistant text persistence after tool call with observational memory

### DIFF
--- a/packages/memory/src/processors/observational-memory/__tests__/om-error-and-persistence.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/om-error-and-persistence.test.ts
@@ -548,6 +548,67 @@ describe('OM Persistence', () => {
     expect(hasOmParts).toBe(true);
   });
 
+  it('should persist the assistant text response that follows a tool call (issue #15078)', async () => {
+    const threadId = 'test-coordinator-text-thread';
+    const resourceId = 'test-resource';
+
+    const quietStore = new InMemoryStore();
+    const quietMemory = new Memory({
+      storage: quietStore,
+      options: {
+        observationalMemory: {
+          enabled: true,
+          observation: {
+            model: createMockObserverModel() as any,
+            messageTokens: 1_000_000,
+            bufferTokens: false,
+          },
+          reflection: {
+            model: createMockReflectorModel() as any,
+            observationTokens: 50_000,
+          },
+        },
+      },
+    });
+    const quietAgent = new Agent({
+      id: 'test-quiet-coordinator',
+      name: 'Test Quiet Coordinator',
+      instructions: 'You are a helpful assistant. Always use the test tool first.',
+      model: createMockOmModel(longResponseText) as any,
+      tools: { test: omTriggerTool },
+      memory: quietMemory,
+    });
+
+    const response = await quietAgent.stream('Please use the test tool and then answer.', {
+      memory: {
+        thread: threadId,
+        resource: resourceId,
+      },
+    });
+
+    const reader = response.fullStream.getReader();
+    try {
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const memoryStore = await quietStore.getStore('memory');
+    const result = await memoryStore!.listMessages({ threadId });
+    const assistantMessages = result.messages.filter((m: any) => m.role === 'assistant');
+
+    const persistedText = assistantMessages
+      .flatMap((m: any) => m.content?.parts ?? [])
+      .filter((p: any) => p.type === 'text')
+      .map((p: any) => p.text)
+      .join('');
+
+    expect(persistedText).toContain('I understand your request completely');
+  });
+
   it('should persist OM messages when a workflow processor runs before memory processors', async () => {
     const threadId = 'test-workflow-processor-thread';
     const resourceId = 'test-resource';


### PR DESCRIPTION
## Summary

Adds an end-to-end regression guard for #15078: with observational memory enabled, a multi-step turn (step 0 tool call → step 1 text) must persist the assistant text response, not just the tool invocation.

The reported data loss was filed against `@mastra/core` 1.21.0 and is **already resolved on `main`**: when step 1's text is merged into the assistant message, `MessageList` re-pushes it to its source bucket (`message-list.ts` `pushMessageToSource(existingMessage, messageSource)`), so the updated message lands back in the `response` bucket and `turn.end()` persists it with the text intact.

This PR adds a test that locks in that behavior so it can't silently regress. It covers the "quiet" path where no observation fires this turn (so there is no response-message-id rotation) and step 1's text appends to the assistant message that the step transition already moved into the `memory` bucket — the exact condition described in #15078.

## Test plan

- `pnpm vitest run src/processors/observational-memory/__tests__/om-error-and-persistence.test.ts` — 7 passed.
- The new test fails if the step-1 text is dropped from the persisted assistant message.

Closes #15078