### PR TITLE
fix(schema-compat): add strictMode to zodToJsonSchema for OpenAI structured outputs

### DIFF
--- a/.changeset/fine-ends-push.md
+++ b/.changeset/fine-ends-push.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fix Zod schema conversion to produce OpenAI strict-mode compatible JSON Schema (additionalProperties: false, required on all fields, no type arrays)

--- a/packages/schema-compat/src/zod-to-json.test.ts
+++ b/packages/schema-compat/src/zod-to-json.test.ts
@@ -658,9 +658,11 @@ describe('ensureAllPropertiesRequired', () => {
 
     expect(fixed.required).toContain('outer');
 
+    // `outer` was not in parent required[], so it's wrapped as anyOf[nullable]
     const outerProp = fixed.properties!.outer as any;
-    expect(outerProp.required).toContain('required');
-    expect(outerProp.required).toContain('optional');
+    const outerSchema = outerProp.anyOf ? outerProp.anyOf[0] : outerProp;
+    expect(outerSchema.required).toContain('required');
+    expect(outerSchema.required).toContain('optional');
   });
 
   it('should handle schemas without properties (no-op)', () => {
@@ -757,6 +759,8 @@ describe('zodToJsonSchema strictMode', () => {
     const nicknameProp = result.properties!.nickname as any;
     expect(nicknameProp).toBeDefined();
     expect(Array.isArray(nicknameProp.type)).toBe(false);
+    expect(Array.isArray(nicknameProp.anyOf)).toBe(true);
+    expect(nicknameProp.anyOf.some((s: any) => s?.type === 'null')).toBe(true);
   });
 
   it('should recursively apply additionalProperties: false on nested objects', () => {

--- a/packages/schema-compat/src/zod-to-json.test.ts
+++ b/packages/schema-compat/src/zod-to-json.test.ts
@@ -724,3 +724,69 @@ describe('ensureAllPropertiesRequired', () => {
     expect(result.required).not.toContain('optional');
   });
 });
+
+// =============================================================================
+// zodToJsonSchema strictMode — unit tests
+// =============================================================================
+
+describe('zodToJsonSchema strictMode', () => {
+  it('should add additionalProperties: false and all keys in required', () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const result = zodToJsonSchema(schema, 'jsonSchema7', 'relative', true);
+
+    expect(result.additionalProperties).toBe(false);
+    expect(result.required).toContain('name');
+    expect(result.required).toContain('age');
+  });
+
+  it('should include optional fields in required and represent them as anyOf with null', () => {
+    const schema = z.object({
+      name: z.string(),
+      nickname: z.string().optional(),
+    });
+
+    const result = zodToJsonSchema(schema, 'jsonSchema7', 'relative', true);
+
+    expect(result.required).toContain('name');
+    expect(result.required).toContain('nickname');
+
+    const nicknameProp = result.properties!.nickname as any;
+    expect(nicknameProp).toBeDefined();
+    expect(Array.isArray(nicknameProp.type)).toBe(false);
+  });
+
+  it('should recursively apply additionalProperties: false on nested objects', () => {
+    const schema = z.object({
+      user: z.object({
+        name: z.string(),
+        address: z.object({
+          city: z.string(),
+        }),
+      }),
+    });
+
+    const result = zodToJsonSchema(schema, 'jsonSchema7', 'relative', true);
+
+    expect(result.additionalProperties).toBe(false);
+    const userProp = result.properties!.user as any;
+    expect(userProp.additionalProperties).toBe(false);
+    const addressProp = userProp.properties.address as any;
+    expect(addressProp.additionalProperties).toBe(false);
+  });
+
+  it('should not apply strict mode transforms when strictMode is false (default)', () => {
+    const schema = z.object({
+      name: z.string(),
+      optional: z.string().optional(),
+    });
+
+    const result = zodToJsonSchema(schema);
+
+    expect(result.required).toContain('name');
+    expect(result.required).not.toContain('optional');
+  });
+});

--- a/packages/schema-compat/src/zod-to-json.ts
+++ b/packages/schema-compat/src/zod-to-json.ts
@@ -178,9 +178,16 @@ export function ensureAllPropertiesRequired(schema: JSONSchema7): JSONSchema7 {
   const result = { ...schema };
 
   if (result.type === 'object' && result.properties) {
+    const existingRequired = new Set(result.required ?? []);
     result.required = Object.keys(result.properties);
     result.properties = Object.fromEntries(
-      Object.entries(result.properties).map(([key, value]) => [key, ensureAllPropertiesRequired(value as JSONSchema7)]),
+      Object.entries(result.properties).map(([key, value]) => {
+        const processed = ensureAllPropertiesRequired(value as JSONSchema7);
+        if (!existingRequired.has(key)) {
+          return [key, { anyOf: [processed, { type: 'null' as const }] }];
+        }
+        return [key, processed];
+      }),
     );
   }
 

--- a/packages/schema-compat/src/zod-to-json.ts
+++ b/packages/schema-compat/src/zod-to-json.ts
@@ -283,6 +283,7 @@ export function zodToJsonSchema(
   zodSchema: any,
   target: Targets = 'jsonSchema7',
   strategy: 'none' | 'seen' | 'root' | 'relative' = 'relative',
+  strictMode: boolean = false,
 ): JSONSchema7 {
   // Route based on whether the schema is v4 (has _zod) or v3 (only has _def).
   // We use zV4.toJSONSchema (imported from 'zod/v4') for v4 schemas, since the
@@ -311,13 +312,23 @@ export function zodToJsonSchema(
       },
     }) as JSONSchema7;
 
+    if (strictMode) {
+      return prepareJsonSchemaForOpenAIStrictMode(jsonSchema);
+    }
+
     // Fix anyOf patterns for nullable fields - required for OpenAI compatibility
     return fixAnyOfNullable(jsonSchema);
   } else {
     // Zod v3 path - use the original converter
-    return zodToJsonSchemaOriginal(zodSchema as ZodSchemaV3, {
+    const jsonSchema = zodToJsonSchemaOriginal(zodSchema as ZodSchemaV3, {
       $refStrategy: strategy,
       target,
     }) as JSONSchema7;
+
+    if (strictMode) {
+      return prepareJsonSchemaForOpenAIStrictMode(jsonSchema);
+    }
+
+    return jsonSchema;
   }
 }


### PR DESCRIPTION
Fixes #16383

`zodToJsonSchema()` had no way to produce strict-mode-compatible JSON Schema for OpenAI structured outputs. The helper functions `prepareJsonSchemaForOpenAIStrictMode`, `ensureAllPropertiesRequired`, and `ensureAdditionalPropertiesFalse` already existed as exports but were never called internally.

This adds a `strictMode: boolean = false` 4th parameter:

- **Zod v4 path**: uses `prepareJsonSchemaForOpenAIStrictMode` instead of `fixAnyOfNullable`, preserving `anyOf` form for nullable fields (OpenAI rejects `type: ['string', 'null']` arrays)
- **Zod v3 path**: applies `prepareJsonSchemaForOpenAIStrictMode` before returning, adding `additionalProperties: false` and populating `required` for all properties (missing these caused HTTP 400 from OpenAI)

Default behavior (`strictMode=false`) is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a "strict mode" option to zodToJsonSchema so generated JSON Schemas can be accepted by OpenAI's strict structured-output mode: it marks all object properties as required and disallows extra properties, and preserves nullable fields in a form OpenAI accepts.

## Changes

### Implementation (packages/schema-compat/src/zod-to-json.ts)
- Added fourth parameter to zodToJsonSchema: strictMode: boolean = false.
- When strictMode=true:
  - Zod v4 conversion uses prepareJsonSchemaForOpenAIStrictMode instead of fixAnyOfNullable to preserve anyOf nullable forms (avoids converting nullable anyOf to type arrays).
  - Zod v3 conversion also runs prepareJsonSchemaForOpenAIStrictMode before returning, so object schemas get additionalProperties: false and required lists include every property.
- Implemented/used helpers:
  - ensureAllPropertiesRequired: sets required to all property keys and wraps properties not previously required in anyOf[..., { type: "null" }] so optional fields remain nullable in anyOf form.
  - ensureAdditionalPropertiesFalse and prepareJsonSchemaForOpenAIStrictMode: apply the OpenAI-compatible constraints recursively.
- Default behavior unchanged when strictMode is false (existing fixes like fixAnyOfNullable remain in non-strict path).

### Tests (packages/schema-compat/src/zod-to-json.test.ts)
- Added a strictMode test suite exercising:
  - additionalProperties: false is set on top-level and nested objects when strictMode=true.
  - All object keys are included in required.
  - Optional fields are still represented as nullable via anyOf that includes null.
  - Strict-mode transforms are applied recursively.
  - Default behavior (strictMode omitted) continues to exclude optional keys from required.
- Updated ensureAllPropertiesRequired related tests to accept cases where nested schemas may be wrapped in anyOf.

### Release (.changeset/fine-ends-push.md)
- Added a changeset marking a patch for `@mastra/schema-compat` describing the fix for OpenAI strict-mode compatibility (additionalProperties: false, required on all fields, and no type arrays).

## Fixes
- Addresses the OpenAI strict-mode incompatibilities reported in `#16383` by:
  - Ensuring every property in properties appears in required (Zod v3 path and via helper when strictMode=true).
  - Preserving anyOf-based nullable representations (Zod v4 path under strictMode), avoiding type-array forms that OpenAI rejects.
  - Disallowing additionalProperties on objects for strict-mode schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->