### PR TITLE
fix(server): add metadata to WorkflowInfo and requestContextSchema to partial workflow info

### DIFF
--- a/.changeset/fix-workflow-info-metadata.md
+++ b/.changeset/fix-workflow-info-metadata.md
@@ -1,8 +1,0 @@
----
-'@mastra/core': patch
-'@mastra/server': patch
----
-
-Fix build break in `@mastra/server` caused by a `WorkflowInfo` type mismatch.
-
-`getWorkflowInfo` was setting `metadata` on the serialized workflow info and omitting `requestContextSchema` in partial mode, but the `WorkflowInfo` type did not declare `metadata` and required `requestContextSchema`. Added `metadata` to `WorkflowInfo` and included `requestContextSchema` in the partial result so the package type-checks and builds.

--- a/.changeset/fix-workflow-info-metadata.md
+++ b/.changeset/fix-workflow-info-metadata.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': patch
+'@mastra/server': patch
+---
+
+Fix build break in `@mastra/server` caused by a `WorkflowInfo` type mismatch.
+
+`getWorkflowInfo` was setting `metadata` on the serialized workflow info and omitting `requestContextSchema` in partial mode, but the `WorkflowInfo` type did not declare `metadata` and required `requestContextSchema`. Added `metadata` to `WorkflowInfo` and included `requestContextSchema` in the partial result so the package type-checks and builds.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -8789,6 +8789,11 @@ export type GetWorkflows_Response = {
     };
     name?: string | undefined;
     description?: string | undefined;
+    metadata?:
+      | {
+          [key: string]: unknown;
+        }
+      | undefined;
     stepGraph: {
       type: 'step' | 'sleep' | 'sleepUntil' | 'waitForEvent' | 'parallel' | 'conditional' | 'loop' | 'foreach';
     }[];
@@ -8866,6 +8871,11 @@ export type GetWorkflowsWorkflowId_Response = {
   };
   name?: string | undefined;
   description?: string | undefined;
+  metadata?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
   stepGraph: {
     type: 'step' | 'sleep' | 'sleepUntil' | 'waitForEvent' | 'parallel' | 'conditional' | 'loop' | 'foreach';
   }[];
@@ -77519,6 +77529,11 @@ export type GetAgentBuilder_Response = {
     };
     name?: string | undefined;
     description?: string | undefined;
+    metadata?:
+      | {
+          [key: string]: unknown;
+        }
+      | undefined;
     stepGraph: {
       type: 'step' | 'sleep' | 'sleepUntil' | 'waitForEvent' | 'parallel' | 'conditional' | 'loop' | 'foreach';
     }[];
@@ -77592,6 +77607,11 @@ export type GetAgentBuilderActionId_Response = {
   };
   name?: string | undefined;
   description?: string | undefined;
+  metadata?:
+    | {
+        [key: string]: unknown;
+      }
+    | undefined;
   stepGraph: {
     type: 'step' | 'sleep' | 'sleepUntil' | 'waitForEvent' | 'parallel' | 'conditional' | 'loop' | 'foreach';
   }[];

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -101,6 +101,7 @@ import type {
   DelegationStartContext,
   DelegationCompleteContext,
 } from './agent.types';
+import { buildMcpServerGuidance } from './mcp-guidance';
 import { MessageList } from './message-list';
 import type { MessageInput, MessageListInput, UIMessageWithMetadata, MastraDBMessage } from './message-list';
 import { SaveQueueManager } from './save-queue';
@@ -138,7 +139,6 @@ import type {
 import { isSupportedLanguageModel, resolveThreadIdFromArgs, supportedLanguageModelSpecifications } from './utils';
 import { createPrepareStreamWorkflow } from './workflows/prepare-stream';
 import type { AgentCapabilities } from './workflows/prepare-stream/schema';
-import { buildMcpServerGuidance } from './mcp-guidance';
 
 export type MastraLLM = MastraLLMV1 | MastraLLMVNext;
 

--- a/packages/core/src/agent/mcp-guidance.test.ts
+++ b/packages/core/src/agent/mcp-guidance.test.ts
@@ -31,9 +31,7 @@ describe('buildMcpServerGuidance', () => {
   });
 
   it('does not forward when forwardInstructions is omitted (opt-in)', () => {
-    expect(
-      buildMcpServerGuidance([tool({ serverName: 'db', serverInstructions: 'Validate first.' })]),
-    ).toBeUndefined();
+    expect(buildMcpServerGuidance([tool({ serverName: 'db', serverInstructions: 'Validate first.' })])).toBeUndefined();
   });
 
   it('does not forward when forwardInstructions is false', () => {

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -486,6 +486,7 @@ export type WorkflowInfo = {
   allSteps: Record<string, SerializedStep>;
   name: string | undefined;
   description: string | undefined;
+  metadata?: Record<string, unknown> | undefined;
   stepGraph: SerializedStepFlowEntry[];
   inputSchema: string | undefined;
   outputSchema: string | undefined;

--- a/packages/server/src/server/utils.ts
+++ b/packages/server/src/server/utils.ts
@@ -193,6 +193,7 @@ export function getWorkflowInfo(workflow: Workflow, partial: boolean = false): W
       inputSchema: undefined,
       outputSchema: undefined,
       stateSchema: undefined,
+      requestContextSchema: undefined,
     } as WorkflowInfo;
   }
 


### PR DESCRIPTION
## Description

Fixes a `@mastra/server` build break caused by a type mismatch between the serialized workflow info produced in `getWorkflowInfo` and the `WorkflowInfo` type in `@mastra/core`.

`getWorkflowInfo` (`packages/server/src/server/utils.ts`) sets a `metadata` field on the returned workflow info and, in full mode, a `requestContextSchema` field. However, the `WorkflowInfo` type did not declare `metadata`, and its `requestContextSchema` field is required while the partial-mode result omitted it. This produced two compile errors and failed `@mastra/server#build:lib`:

```
src/server/utils.ts(184,12): error TS2352: ... Property 'requestContextSchema' is missing ...
src/server/utils.ts(202,5): error TS2353: ... 'metadata' does not exist in type 'WorkflowInfo'.
```

## Changes

- `packages/core/src/workflows/types.ts`: add `metadata?: Record<string, unknown> | undefined` to `WorkflowInfo`, matching the workflow definition config.
- `packages/server/src/server/utils.ts`: include `requestContextSchema: undefined` in the partial-mode result so it satisfies the required field.

## Verification

- Reproduced both TS errors with `tsc --noEmit` on `@mastra/server` before the fix.
- After the fix: full `@mastra/server` turbo build passes (including the previously-failing `build:lib`), `@mastra/core` typecheck is clean, and the workflow handler test suite (`packages/server/src/server/handlers/workflows.test.ts`, 50 tests) passes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The PR fixes a TypeScript mismatch between what the server returns for workflow info and what the core types expect: it adds the missing optional metadata type and makes partial responses include requestContextSchema so compilation succeeds.

## Overview

Address TS build errors in `@mastra/server` caused by a shape mismatch between getWorkflowInfo() runtime output and the WorkflowInfo type in `@mastra/core`. Runtime values included metadata and omitted requestContextSchema in partial mode; the type lacked metadata and required requestContextSchema. This PR adds metadata to the type and aligns the partial-mode return shape with the full-mode shape.

## Changes

- packages/core/src/workflows/types.ts
  - Added: metadata?: Record<string, unknown> | undefined to WorkflowInfo (optional).

- packages/server/src/server/utils.ts
  - getWorkflowInfo(workflow, partial = true): include metadata from the workflow in both full and partial returns.
  - In partial mode, explicitly set requestContextSchema: undefined so partial results satisfy the WorkflowInfo shape.
  - Ensure per-step metadata is passed through in step descriptors.

- client-sdks/client-js/src/route-types.generated.ts
  - Regenerated route types to include optional metadata fields in generated shapes that expose workflow/agent descriptors.

- packages/core/src/agent/agent.ts
  - Moved the import location for buildMcpServerGuidance (import order change only; no behavioral/API change).

- packages/core/src/agent/mcp-guidance.test.ts
  - Minor test assertion formatting change (no behavior change).

## Verification

- Reproduced TS errors (TS2352, TS2353) with tsc --noEmit on `@mastra/server` before the fix.
- After changes:
  - Full `@mastra/server` turbo build (including build:lib) passes.
  - `@mastra/core` typecheck is clean.
  - Workflow handler test suite (packages/server/src/server/handlers/workflows.test.ts, 50 tests) passes.

## Type of change

Bug fix (non-breaking): align runtime shapes with TypeScript definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->