### PR TITLE
fix(playground): type OM badge helpers against MastraDBMessage (fixes silent no-op)

### DIFF
--- a/.changeset/free-adults-cry.md
+++ b/.changeset/free-adults-cry.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/react': patch
+---
+
+Fixed Observational Memory badges not updating when a stream is interrupted or after a page reload. The helpers that mark badges disconnected, inject buffering completion, and restore activation on load were reading a flat message shape and silently did nothing on the canonical stored message; they now read `content.parts` and are typed against `MastraDBMessage` so the compiler enforces the shape.

--- a/packages/playground/src/services/__tests__/om-parts-converter.test.ts
+++ b/packages/playground/src/services/__tests__/om-parts-converter.test.ts
@@ -1,0 +1,84 @@
+import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent/message-list';
+import { describe, expect, it } from 'vitest';
+
+import { injectBufferingEnds, markOmMarkersAsDisconnected, scanOmInitialState } from '../om-parts-converter';
+
+/**
+ * Build a `data-om-*` part. `data-${string}` parts are first-class
+ * `MastraMessagePart` union members, so no cast is needed.
+ */
+const omPart = (name: string, data: Record<string, unknown>): MastraMessagePart => ({
+  type: `data-${name}`,
+  data,
+});
+
+const assistantMessage = (parts: MastraMessagePart[], id = 'msg-1'): MastraDBMessage => ({
+  id,
+  role: 'assistant',
+  createdAt: new Date('2026-05-29T00:00:00.000Z'),
+  threadId: 'thread-1',
+  resourceId: 'resource-1',
+  content: { format: 2, parts, metadata: {} },
+});
+
+const partsOf = (message: MastraDBMessage) => message.content.parts as Array<{ type: string; data?: any }>;
+
+describe('markOmMarkersAsDisconnected', () => {
+  it('marks an in-progress observation-start marker as disconnected (reads content.parts)', () => {
+    const [message] = markOmMarkersAsDisconnected([
+      assistantMessage([omPart('om-observation-start', { cycleId: 'cycle-1' })]),
+    ]);
+
+    const part = partsOf(message)[0];
+    expect(part.type).toBe('data-om-observation-start');
+    expect(part.data?._state).toBe('disconnected');
+    expect(typeof part.data?.disconnectedAt).toBe('string');
+  });
+
+  it('leaves user messages untouched', () => {
+    const userMessage: MastraDBMessage = {
+      ...assistantMessage([omPart('om-observation-start', { cycleId: 'cycle-1' })], 'user-1'),
+      role: 'user',
+    };
+    const [message] = markOmMarkersAsDisconnected([userMessage]);
+    expect(partsOf(message)[0].data?._state).toBeUndefined();
+  });
+});
+
+describe('injectBufferingEnds', () => {
+  it('injects a synthetic buffering-end for an in-progress buffering-start (reads content.parts)', () => {
+    const [message] = injectBufferingEnds(
+      [assistantMessage([omPart('om-buffering-start', { cycleId: 'cycle-2', operationType: 'observation' })])],
+      { bufferedObservationChunks: [{ cycleId: 'cycle-2', messageTokens: 120, tokenCount: 40, observations: ['x'] }] },
+    );
+
+    const parts = partsOf(message);
+    expect(parts).toHaveLength(2);
+    expect(parts[1].type).toBe('data-om-buffering-end');
+    expect(parts[1].data?.cycleId).toBe('cycle-2');
+    expect(parts[1].data?.tokensBuffered).toBe(120);
+    expect(parts[1].data?.observations).toEqual(['x']);
+  });
+
+  it('does not inject an end for an already-disconnected buffering-start', () => {
+    const [message] = injectBufferingEnds([
+      assistantMessage([omPart('om-buffering-start', { cycleId: 'cycle-3', disconnectedAt: 'yes' })]),
+    ]);
+    expect(partsOf(message)).toHaveLength(1);
+  });
+});
+
+describe('scanOmInitialState', () => {
+  it('collects activation cycle ids and the last progress part from content.parts', () => {
+    const { activatedCycleIds, lastProgress } = scanOmInitialState([
+      assistantMessage([
+        omPart('om-activation', { cycleId: 'cycle-a' }),
+        omPart('om-status', { tokensObserved: 100 }),
+        omPart('om-status', { tokensObserved: 250 }),
+      ]),
+    ]);
+
+    expect(activatedCycleIds).toEqual(['cycle-a']);
+    expect(lastProgress).toEqual({ tokensObserved: 250 });
+  });
+});

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -8,7 +8,13 @@ import { useMastraClient, useChat } from '@mastra/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
-import { buildGlobalOmPartsByCycleId, convertOmPartsInMastraMessage } from './om-parts-converter';
+import {
+  buildGlobalOmPartsByCycleId,
+  convertOmPartsInMastraMessage,
+  injectBufferingEnds,
+  markOmMarkersAsDisconnected,
+  scanOmInitialState,
+} from './om-parts-converter';
 import {
   buildMaxStepsStreamErrorMessage,
   buildStreamErrorMessage,
@@ -235,118 +241,6 @@ export function MastraRuntimeProvider({
     }
   };
 
-  // Helper to mark in-progress OM markers as disconnected in messages.
-  // Preserves the original part type (keeps start markers as start markers)
-  // so the badge stays anchored at the correct position. Only adds disconnection
-  // metadata to the data payload.
-  const markOmMarkersAsDisconnected = (msgs: any[]) => {
-    return msgs.map(msg => {
-      if (msg.role !== 'assistant') return msg;
-
-      // Handle both 'parts' (v2/v3) and 'content' (legacy) message formats
-      const partsKey = msg.parts ? 'parts' : msg.content ? 'content' : null;
-      if (!partsKey || !Array.isArray(msg[partsKey])) return msg;
-
-      const updatedParts = msg[partsKey].map((part: any) => {
-        // Mark raw start markers as disconnected (keep original type for badge anchoring)
-        if (part.type === 'data-om-observation-start' || part.type === 'data-om-buffering-start') {
-          return {
-            ...part,
-            data: {
-              ...part.data,
-              disconnectedAt: new Date().toISOString(),
-              _state: 'disconnected',
-            },
-          };
-        }
-        // Also check for already-converted tool-call format
-        if (part.type === 'tool-call' && part.toolName === 'mastra-memory-om-observation') {
-          const omData = part.metadata?.omData || part.args;
-          // If it's in loading state (no completedAt, failedAt, or disconnectedAt), mark as disconnected
-          if (!omData?.completedAt && !omData?.failedAt && !omData?.disconnectedAt) {
-            return {
-              ...part,
-              metadata: {
-                ...part.metadata,
-                omData: {
-                  ...omData,
-                  disconnectedAt: new Date().toISOString(),
-                  _state: 'disconnected',
-                },
-              },
-            };
-          }
-        }
-        return part;
-      });
-
-      return { ...msg, [partsKey]: updatedParts };
-    });
-  };
-
-  // Mark in-progress buffering badges as complete after buffer-status resolves.
-  // Injects synthetic data-om-buffering-end parts so convertOmPartsInMastraMessage
-  // sees a matching end for each in-progress start. Uses the record from awaitBufferStatus
-  // to populate token counts and observations for the badge display.
-  const markBufferingBadgesAsComplete = (msgs: any[], record?: any) => {
-    // Build a lookup from cycleId to chunk data for observation buffering
-    const chunksByCycleId = new Map<string, any>();
-    if (record?.bufferedObservationChunks) {
-      for (const chunk of record.bufferedObservationChunks) {
-        if (chunk.cycleId) {
-          chunksByCycleId.set(chunk.cycleId, chunk);
-        }
-      }
-    }
-
-    return msgs.map(msg => {
-      if (msg.role !== 'assistant') return msg;
-
-      const partsKey = msg.parts ? 'parts' : msg.content ? 'content' : null;
-      if (!partsKey || !Array.isArray(msg[partsKey])) return msg;
-
-      const newParts: any[] = [];
-      let changed = false;
-
-      for (const part of msg[partsKey]) {
-        newParts.push(part);
-        // For each buffering-start that isn't already disconnected, inject a synthetic buffering-end
-        if (part.type === 'data-om-buffering-start' && part.data?.cycleId && !part.data?.disconnectedAt) {
-          const cycleId = part.data.cycleId;
-          const opType = part.data.operationType;
-
-          let endData: Record<string, any> = {
-            cycleId,
-            operationType: opType,
-            completedAt: new Date().toISOString(),
-          };
-
-          if (opType === 'observation') {
-            // Match chunk by cycleId for observation buffering
-            const chunk = chunksByCycleId.get(cycleId);
-            if (chunk) {
-              endData.tokensBuffered = chunk.messageTokens;
-              endData.bufferedTokens = chunk.tokenCount;
-              endData.observations = chunk.observations;
-            }
-          } else if (opType === 'reflection') {
-            // Use aggregate reflection data from the record
-            if (record) {
-              endData.tokensBuffered = record.bufferedReflectionInputTokens;
-              endData.bufferedTokens = record.bufferedReflectionTokens;
-              endData.observations = record.bufferedReflection;
-            }
-          }
-
-          newParts.push({ type: 'data-om-buffering-end', data: endData });
-          changed = true;
-        }
-      }
-
-      return changed ? { ...msg, [partsKey]: newParts } : msg;
-    });
-  };
-
   // Helper to reset OM streaming state when stream is interrupted
   // (user cancel, network error, process exit, etc.)
   const resetObservationalMemoryStreamState = () => {
@@ -367,19 +261,9 @@ export function MastraRuntimeProvider({
   // On initial load, scan messages for activation markers and the last progress part.
   // This ensures buffering badges show as activated and token counts are accurate on reload.
   useEffect(() => {
-    const allMessages = [...(initialMessages || [])];
-    let lastProgress: any = null;
-    for (const msg of allMessages) {
-      const parts = (msg as any).parts || (msg as any).content || [];
-      if (!Array.isArray(parts)) continue;
-      for (const part of parts) {
-        if (part?.type === 'data-om-activation' && part?.data?.cycleId) {
-          markCycleIdActivated(part.data.cycleId);
-        }
-        if (part?.type === 'data-om-status' && part?.data) {
-          lastProgress = part.data;
-        }
-      }
+    const { activatedCycleIds, lastProgress } = scanOmInitialState(initialMessages || []);
+    for (const cycleId of activatedCycleIds) {
+      markCycleIdActivated(cycleId);
     }
     // Restore the last known progress so sidebar shows accurate token counts on load
     if (lastProgress) {
@@ -580,7 +464,7 @@ export function MastraRuntimeProvider({
             baseClient
               .awaitBufferStatus({ agentId, resourceId: agentId, threadId })
               .then(result => {
-                setMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
+                setMessages(prev => injectBufferingEnds(prev, result?.record));
                 void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
                 void queryClient.invalidateQueries({ queryKey: ['memory-status', agentId] });
               })
@@ -600,7 +484,7 @@ export function MastraRuntimeProvider({
         baseClient
           .awaitBufferStatus({ agentId, resourceId: agentId, threadId })
           .then(result => {
-            setMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
+            setMessages(prev => injectBufferingEnds(prev, result?.record));
 
             void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
             void queryClient.invalidateQueries({ queryKey: ['memory-status', agentId] });
@@ -640,7 +524,7 @@ export function MastraRuntimeProvider({
       baseClient
         .awaitBufferStatus({ agentId, resourceId: agentId, threadId })
         .then(result => {
-          setMessages(prev => markBufferingBadgesAsComplete(prev, result?.record));
+          setMessages(prev => injectBufferingEnds(prev, result?.record));
 
           void queryClient.invalidateQueries({ queryKey: ['observational-memory', agentId] });
           void queryClient.invalidateQueries({ queryKey: ['memory-status', agentId] });

--- a/packages/playground/src/services/om-parts-converter.ts
+++ b/packages/playground/src/services/om-parts-converter.ts
@@ -205,3 +205,145 @@ export const convertOmPartsInMastraMessage = (
     },
   };
 };
+
+// -----------------------------------------------------------------------------
+// Reload / interruption helpers for OM badges.
+//
+// `useChat` returns canonical `MastraDBMessage`s, where parts live at
+// `message.content.parts` (and `content` is an object, not an array). These
+// helpers therefore read/write `content.parts` directly. They are typed against
+// `MastraDBMessage[]` on purpose: the previous in-provider versions were typed
+// `any[]` and silently no-oped on the nested shape.
+// -----------------------------------------------------------------------------
+
+const mapAssistantParts = (
+  messages: MastraDBMessage[],
+  mapParts: (parts: any[]) => { parts: any[]; changed: boolean },
+): MastraDBMessage[] =>
+  messages.map(msg => {
+    if (msg.role !== 'assistant') return msg;
+    const parts = msg.content?.parts;
+    if (!Array.isArray(parts)) return msg;
+
+    const { parts: nextParts, changed } = mapParts(parts as any[]);
+    if (!changed) return msg;
+
+    return {
+      ...msg,
+      content: { ...msg.content, parts: nextParts as MastraDBMessage['content']['parts'] },
+    };
+  });
+
+/**
+ * Mark in-progress OM markers as disconnected when a stream is interrupted
+ * (user cancel, network error, process exit). Preserves the original part type so
+ * the badge stays anchored, only adding disconnection metadata to the data payload.
+ */
+export const markOmMarkersAsDisconnected = (messages: MastraDBMessage[]): MastraDBMessage[] =>
+  mapAssistantParts(messages, parts => {
+    let changed = false;
+    const nextParts = parts.map((part: any) => {
+      // Raw start markers (keep original type for badge anchoring).
+      if (part.type === 'data-om-observation-start' || part.type === 'data-om-buffering-start') {
+        changed = true;
+        return {
+          ...part,
+          data: { ...part.data, disconnectedAt: new Date().toISOString(), _state: 'disconnected' },
+        };
+      }
+      // Already-converted tool-call format still in a loading state.
+      if (part.type === 'tool-call' && part.toolName === OM_TOOL_NAME) {
+        const omData = part.metadata?.omData || part.args;
+        if (!omData?.completedAt && !omData?.failedAt && !omData?.disconnectedAt) {
+          changed = true;
+          return {
+            ...part,
+            metadata: {
+              ...part.metadata,
+              omData: { ...omData, disconnectedAt: new Date().toISOString(), _state: 'disconnected' },
+            },
+          };
+        }
+      }
+      return part;
+    });
+    return { parts: nextParts, changed };
+  });
+
+/**
+ * Inject synthetic `data-om-buffering-end` parts after buffer-status resolves so
+ * `convertOmPartsInMastraMessage` sees a matching end for each in-progress start.
+ * Uses the record from `awaitBufferStatus` to populate token counts/observations.
+ */
+export const injectBufferingEnds = (messages: MastraDBMessage[], record?: any): MastraDBMessage[] => {
+  const chunksByCycleId = new Map<string, any>();
+  if (record?.bufferedObservationChunks) {
+    for (const chunk of record.bufferedObservationChunks) {
+      if (chunk.cycleId) chunksByCycleId.set(chunk.cycleId, chunk);
+    }
+  }
+
+  return mapAssistantParts(messages, parts => {
+    const newParts: any[] = [];
+    let changed = false;
+
+    for (const part of parts) {
+      newParts.push(part);
+      if (part.type === 'data-om-buffering-start' && part.data?.cycleId && !part.data?.disconnectedAt) {
+        const cycleId = part.data.cycleId;
+        const opType = part.data.operationType;
+
+        const endData: Record<string, any> = {
+          cycleId,
+          operationType: opType,
+          completedAt: new Date().toISOString(),
+        };
+
+        if (opType === 'observation') {
+          const chunk = chunksByCycleId.get(cycleId);
+          if (chunk) {
+            endData.tokensBuffered = chunk.messageTokens;
+            endData.bufferedTokens = chunk.tokenCount;
+            endData.observations = chunk.observations;
+          }
+        } else if (opType === 'reflection' && record) {
+          endData.tokensBuffered = record.bufferedReflectionInputTokens;
+          endData.bufferedTokens = record.bufferedReflectionTokens;
+          endData.observations = record.bufferedReflection;
+        }
+
+        newParts.push({ type: 'data-om-buffering-end', data: endData });
+        changed = true;
+      }
+    }
+
+    return { parts: newParts, changed };
+  });
+};
+
+/**
+ * Scan persisted messages on initial load for OM activation markers and the last
+ * progress part, so buffering badges show as activated and token counts are
+ * accurate after a reload.
+ */
+export const scanOmInitialState = (
+  messages: MastraDBMessage[],
+): { activatedCycleIds: string[]; lastProgress: Record<string, unknown> | null } => {
+  const activatedCycleIds: string[] = [];
+  let lastProgress: Record<string, unknown> | null = null;
+
+  for (const msg of messages) {
+    const parts = msg?.content?.parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts as any[]) {
+      if (part?.type === 'data-om-activation' && part?.data?.cycleId) {
+        activatedCycleIds.push(part.data.cycleId);
+      }
+      if (part?.type === 'data-om-status' && part?.data) {
+        lastProgress = part.data;
+      }
+    }
+  }
+
+  return { activatedCycleIds, lastProgress };
+};


### PR DESCRIPTION
## Summary

PR 2 of a small split of chat fixes for #17208 (MastraDBMessage unification). This is the **type-safety** slice: removing `any` is what surfaces and fixes the bug.

`useChat` now returns `MastraDBMessage`, whose parts live under `content.parts` (and `content` is an object, not an array). Three Observational-Memory helpers in the runtime provider still read top-level `msg.parts` and were typed `any[]`, so they silently no-oped:
- on stream interruption, badges never went `disconnected` (stuck spinner),
- buffering badges never completed after `awaitBufferStatus`,
- activation / token progress was not restored on reload.

Because the helpers were `any[]`, the compiler couldn't catch the wrong access.

## Scope

- Extract the three helpers into pure, exported, `MastraDBMessage[]`-typed functions in `om-parts-converter.ts`: `markOmMarkersAsDisconnected`, `injectBufferingEnds`, `scanOmInitialState` — all reading `content.parts`.
- Wire `mastra-runtime-provider.tsx` to them and drop the in-provider `any[]` closures (−129 lines of duplicated logic).
- Unit tests for each helper (they exercise the nested `content.parts` shape the old closures no-oped on).

Typing the public signatures as `MastraDBMessage[]` is the fix: the provider call sites only typecheck against the correct shape now.

## Verification

- `pnpm --filter @internal/playground typecheck` — clean (the new signatures compile only because the access is correct)
- OM helper + runtime-provider tests pass (6)

## Intentionally excluded

- Reasoning-on-reload ships in its own PR (#17362).
- File/image rendering + `dynamic-tool` status, and SDK-side fixes, are separate.
