### PR TITLE
refactor(playground): drop redundant `as ContentPart` casts (re-enable type-checking)

### DIFF
--- a/.changeset/quiet-converter-casts.md
+++ b/.changeset/quiet-converter-casts.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: remove redundant `as ContentPart` casts in the Studio chat converter so its content-part returns are type-checked by inference. No behavior change.

--- a/packages/playground/src/services/to-assistant-ui-message.ts
+++ b/packages/playground/src/services/to-assistant-ui-message.ts
@@ -214,7 +214,7 @@ const toContentPart = (message: MastraDBMessage, part: MastraMessagePart): Conte
   }
 
   if (part.type === 'reasoning') {
-    return { type: 'reasoning', text: part.reasoning, metadata: getPartMetadata(message, part) } as ContentPart;
+    return { type: 'reasoning', text: part.reasoning, metadata: getPartMetadata(message, part) };
   }
 
   if (part.type === 'source') {
@@ -225,7 +225,7 @@ const toContentPart = (message: MastraDBMessage, part: MastraMessagePart): Conte
       url: part.source.url,
       title: part.source.title,
       metadata: getPartMetadata(message, part),
-    } as ContentPart;
+    };
   }
 
   if (part.type === 'source-document') {
@@ -240,7 +240,7 @@ const toContentPart = (message: MastraDBMessage, part: MastraMessagePart): Conte
 
   if (part.type === 'file') {
     if (part.mimeType?.includes('image/')) {
-      return { type: 'image', image: part.data, metadata: getPartMetadata(message, part) } as ContentPart;
+      return { type: 'image', image: part.data, metadata: getPartMetadata(message, part) };
     }
 
     return {
@@ -248,7 +248,7 @@ const toContentPart = (message: MastraDBMessage, part: MastraMessagePart): Conte
       mimeType: part.mimeType,
       data: part.data,
       metadata: getPartMetadata(message, part),
-    } as ContentPart;
+    };
   }
 
   if (part.type === 'tool-invocation') {
@@ -291,7 +291,7 @@ const toContentPart = (message: MastraDBMessage, part: MastraMessagePart): Conte
       name: part.type.substring(5),
       data: 'data' in part ? part.data : undefined,
       metadata: getPartMetadata(message, part),
-    } as ContentPart;
+    };
   }
 
   return { type: 'text', text: '', metadata: getPartMetadata(message, part) };


### PR DESCRIPTION
## Summary

Small type-safety cleanup of the Studio chat converter (`to-assistant-ui-message.ts`). **Stacked on #17362** (same file).

Every branch of `toContentPart` asserted its return `as ContentPart`. Empirically, those casts hid **nothing**: removing all five type-checks cleanly (the `source-document` branch already returned without one). They only **suppressed checking**.

Removing them means the converter's content-part returns are now checked by inference — a future field typo or shape mismatch (e.g. `image: ...` with the wrong value type) is caught at compile time instead of being silently cast away.

## Scope

- Drop the 5 redundant `as ContentPart` casts in `toContentPart`.

## Verification

- `pnpm --filter @internal/playground typecheck` — clean (proves the literals already satisfy `ContentPart`)
- Converter tests pass (9)
- No runtime change — `as` casts are compile-time only.

## Honest note

This does **not** fix a hidden bug — there wasn't one behind these casts. It re-enables type-checking on these returns. The deeper converter type smell (the V4-anchored `MastraMessagePart` vs the V5 runtime shape the accumulator emits) is upstream in `@mastra/core` and out of scope here.
