### PR TITLE
fix: replace Function() eval with CSP-safe runtime Zod converter

### DIFF
--- a/.changeset/wild-cloths-dig.md
+++ b/.changeset/wild-cloths-dig.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/schema-compat': patch
+---
+
+Replace Function() eval with CSP-safe runtime Zod converter to fix CSP violations in Mastra Studio

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import type { CoreMessage } from '@internal/ai-sdk-v4';
-import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
+import { jsonSchemaToZodRuntime } from '@mastra/schema-compat/json-to-zod';
 import { z } from 'zod/v4';
 import type { MastraPrimitives } from './action';
 import type { ToolsInput } from './agent';
@@ -465,7 +465,7 @@ function convertVercelToolParameters(tool: VercelTool): z.ZodType {
     schema = schema();
   }
 
-  return isZodType(schema) ? schema : resolveSerializedZodOutput(jsonSchemaToZod(schema));
+  return isZodType(schema) ? schema : jsonSchemaToZodRuntime(schema);
 }
 
 /**

--- a/packages/playground/src/lib/form/utils.ts
+++ b/packages/playground/src/lib/form/utils.ts
@@ -1,6 +1,6 @@
 import type { FieldConfig } from '@autoform/core';
 import { buildZodFieldConfig } from '@autoform/react';
-import { z } from 'zod';
+import { jsonSchemaToZodRuntime } from '@mastra/schema-compat/json-to-zod';
 import type { FieldTypes } from './auto-form';
 
 // @ts-expect-error - TODO
@@ -55,5 +55,5 @@ export function removeEmptyValues<T extends Record<string, any>>(values: T): Par
  * @returns resolved zod object
  */
 export function resolveSerializedZodOutput(obj: any) {
-  return Function('z', `"use strict";return (${obj});`)(z);
+  return jsonSchemaToZodRuntime(obj);
 }

--- a/packages/schema-compat/src/json-to-zod.ts
+++ b/packages/schema-compat/src/json-to-zod.ts
@@ -7,6 +7,7 @@ import jsonSchemaToZodOriginal, {
   parseOneOf,
   parseSchema,
 } from 'json-schema-to-zod';
+import { z } from 'zod';
 
 function parseObject(objectSchema: JsonSchemaObject & { type: 'object' }, refs: Refs): string {
   let properties: string | undefined = undefined;
@@ -342,3 +343,129 @@ export function jsonSchemaToZod(schema: JsonSchema, options: Options = {}): stri
 
 // Re-export all named exports from json-schema-to-zod (excluding the default export)
 export * from 'json-schema-to-zod';
+
+export function jsonSchemaToZodRuntime(schema: JsonSchema): z.ZodType {
+  return parseSchemaRuntime(schema, {});
+}
+
+function parseSchemaRuntime(schema: JsonSchema, defs: Record<string, z.ZodType>): z.ZodType {
+  if (typeof schema === 'boolean') {
+    return schema ? z.any() : z.never();
+  }
+
+  if ('$ref' in schema && typeof schema.$ref === 'string') {
+    const refName = schema.$ref.replace('#/$defs/', '').replace('#/definitions/', '');
+    if (defs[refName]) return defs[refName]!;
+    return z.any();
+  }
+
+  const localDefs = { ...defs };
+  const rawDefs = (schema as any).$defs ?? (schema as any).definitions;
+  if (rawDefs) {
+    for (const [key, defSchema] of Object.entries(rawDefs)) {
+      localDefs[key] = parseSchemaRuntime(defSchema as JsonSchema, localDefs);
+    }
+  }
+
+  if ('oneOf' in schema && Array.isArray(schema.oneOf)) {
+    const options = schema.oneOf.map(s => parseSchemaRuntime(s as JsonSchema, localDefs));
+    return z.union(options as [z.ZodType, z.ZodType, ...z.ZodType[]]);
+  }
+  if ('anyOf' in schema && Array.isArray(schema.anyOf)) {
+    const options = schema.anyOf.map(s => parseSchemaRuntime(s as JsonSchema, localDefs));
+    return z.union(options as [z.ZodType, z.ZodType, ...z.ZodType[]]);
+  }
+  if ('allOf' in schema && Array.isArray(schema.allOf)) {
+    const [first, ...rest] = schema.allOf.map(s => parseSchemaRuntime(s as JsonSchema, localDefs));
+    return rest.reduce((acc, s) => acc.and(s), first as z.ZodType);
+  }
+
+  if ('enum' in schema && Array.isArray(schema.enum)) {
+    const values = schema.enum as [unknown, ...unknown[]];
+    return z.enum(values.map(String) as [string, ...string[]]);
+  }
+
+  if ('const' in schema) {
+    return z.literal(schema.const as any);
+  }
+
+  const type = (schema as any).type;
+
+  if (Array.isArray(type)) {
+    const options = type.map(t => parseSchemaRuntime({ type: t } as JsonSchema, localDefs));
+    return z.union(options as [z.ZodType, z.ZodType, ...z.ZodType[]]);
+  }
+
+  switch (type) {
+    case 'string': {
+      let s = z.string();
+      if ((schema as any).minLength !== undefined) s = s.min((schema as any).minLength);
+      if ((schema as any).maxLength !== undefined) s = s.max((schema as any).maxLength);
+      return applyMeta(schema, s);
+    }
+    case 'number':
+    case 'integer': {
+      let n = z.number();
+      if ((schema as any).minimum !== undefined) n = n.min((schema as any).minimum);
+      if ((schema as any).maximum !== undefined) n = n.max((schema as any).maximum);
+      return applyMeta(schema, n);
+    }
+    case 'boolean':
+      return applyMeta(schema, z.boolean());
+    case 'null':
+      return z.null();
+    case 'array': {
+      const items = (schema as any).items;
+      const itemType = items ? parseSchemaRuntime(items as JsonSchema, localDefs) : z.any();
+      let arr = z.array(itemType);
+      if ((schema as any).minItems !== undefined) arr = arr.min((schema as any).minItems);
+      if ((schema as any).maxItems !== undefined) arr = arr.max((schema as any).maxItems);
+      return applyMeta(schema, arr);
+    }
+    case 'object': {
+      const properties = (schema as any).properties as Record<string, JsonSchema> | undefined;
+      const required: string[] = (schema as any).required ?? [];
+      const additionalProperties = (schema as any).additionalProperties;
+
+      if (!properties || Object.keys(properties).length === 0) {
+        if (additionalProperties !== undefined && additionalProperties !== false) {
+          const valueType =
+            typeof additionalProperties === 'boolean'
+              ? z.any()
+              : parseSchemaRuntime(additionalProperties as JsonSchema, localDefs);
+          return applyMeta(schema, z.record(z.string(), valueType));
+        }
+        return applyMeta(schema, z.record(z.string(), z.any()));
+      }
+
+      const shape: Record<string, z.ZodType> = {};
+      for (const [key, propSchema] of Object.entries(properties)) {
+        const isRequired = required.includes(key);
+        const parsed = parseSchemaRuntime(propSchema, localDefs);
+        shape[key] = isRequired ? parsed : parsed.optional();
+      }
+
+      let obj: z.ZodType = z.object(shape);
+
+      if (additionalProperties !== undefined && additionalProperties !== false) {
+        const valueType =
+          typeof additionalProperties === 'boolean'
+            ? z.any()
+            : parseSchemaRuntime(additionalProperties as JsonSchema, localDefs);
+        obj = (obj as z.ZodObject<any>).catchall(valueType);
+      }
+
+      return applyMeta(schema, obj);
+    }
+    default:
+      return z.any();
+  }
+}
+
+function applyMeta(schema: JsonSchema, zodType: z.ZodType): z.ZodType {
+  if (typeof schema === 'boolean') return zodType;
+  let t = zodType;
+  if ((schema as any).description) t = t.describe((schema as any).description);
+  if ((schema as any).default !== undefined) t = t.default((schema as any).default);
+  return t;
+}


### PR DESCRIPTION
Fixes #16992

## Problem
`resolveSerializedZodOutput` was using `new Function()` to evaluate serialized Zod schemas at runtime. This is equivalent to `eval()` and is blocked by Content Security Policy (CSP) headers, causing Mastra Studio to fail in CSP-enforcing environments.

## Solution
Added `jsonSchemaToZodRuntime()` to `@mastra/schema-compat` that converts JSON Schema directly to a Zod type at runtime without any code generation or eval.

- `packages/schema-compat/src/json-to-zod.ts`: Added `jsonSchemaToZodRuntime` and `parseSchemaRuntime` functions
- `packages/core/src/utils.ts`: Updated `convertVercelToolParameters` to use `jsonSchemaToZodRuntime` directly
- `packages/playground/src/lib/form/utils.ts`: Updated `resolveSerializedZodOutput` to delegate to `jsonSchemaToZodRuntime`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a security issue where Mastra Studio was using dangerous code evaluation (Function/eval) that violates strict Content Security Policies. Instead of generating JavaScript code as strings and executing them to build schema validators, the code now builds them directly in memory without any string evaluation.

## Overview

Replaces unsafe `Function()`-based evaluation with a CSP-compliant runtime converter for materializing Zod schemas from JSON Schema objects. This eliminates Content Security Policy violations that were causing Mastra Studio to fail in restrictive CSP environments.

## Problem Addressed

The original implementation used `resolveSerializedZodOutput`, which constructed Zod schemas via `new Function('z', `"use strict";return (${schema});`)(z)` — equivalent to eval() and blocked by strict CSPs disallowing 'unsafe-eval'. This caused schema-driven forms to fail across multiple surfaces: tools, agent tool forms, MCP tools, workflows, dataset validation, and request-context forms.

## Changes

### New Runtime Converter
**packages/schema-compat/src/json-to-zod.ts** (+127 lines)
- Added `jsonSchemaToZodRuntime(schema: JsonSchema): z.ZodType` — new public API for CSP-safe schema conversion
- Implemented `parseSchemaRuntime()` — recursive converter building Zod types directly from JSON Schema
- Handles:
  - Boolean schemas (`true` → `z.any()`, `false` → `z.never()`)
  - `$ref` resolution from local `#/$defs` / `#/definitions`
  - Combinators: `oneOf`/`anyOf` as `z.union()`, `allOf` as chained `.and()`
  - Keywords: `enum` → `z.enum()`, `const` → `z.literal()`
  - Primitive types: string, number, integer, boolean, null, array, object with constraints
  - Object properties with required/optional support and `additionalProperties` handling
  - Metadata: description via `.describe()`, defaults via `.default()`
- Existing `jsonSchemaToZod` string-generation API remains unchanged

### Updated Call Sites
**packages/core/src/utils.ts** (+2/-2)
- Updated `convertVercelToolParameters` to use `jsonSchemaToZodRuntime` directly instead of the serialized string reconstruction path
- Replaced import from `jsonSchemaToZod` with `jsonSchemaToZodRuntime`

**packages/playground/src/lib/form/utils.ts** (+2/-2)
- Updated `resolveSerializedZodOutput` to delegate to `jsonSchemaToZodRuntime`
- Removed unsafe `Function()` evaluation and direct `z` import

### Changeset
**.changeset/wild-cloths-dig.md** (+6/-0)
- Marked `@mastra/core` and `@mastra/schema-compat` as patch-level updates
- Documented fix: "Replace Function() eval with CSP-safe runtime Zod converter to fix CSP violations in Mastra Studio"

## Impact

- Eliminates CSP violations caused by runtime code evaluation
- Enables Mastra Studio to operate in strict CSP environments without requiring 'unsafe-eval' permission
- Maintains API compatibility while replacing unsafe implementation
- All schema-driven form surfaces now function safely under restrictive policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->