### PR TITLE
fix(core): share processor state across step lifecycle chunks during streaming

### DIFF
--- a/.changeset/lifecycle-chunk-processor-state.md
+++ b/.changeset/lifecycle-chunk-processor-state.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed output processor state continuity for step lifecycle chunks during streaming. Lifecycle chunks (e.g. `step-finish`) routed through the stream `outputWriter` now share the same per-processor state map as the main model-output path, so state set in `processOutputStream` while handling content chunks is visible when the lifecycle chunk is processed (and in `processOutputResult`). Previously these chunks were handled with an isolated, empty state.
+
+Note: as part of routing lifecycle chunks through output processors, an aborted stream now surfaces content the model produced before the abort (e.g. a `text-start` chunk and partial `text`) instead of dropping it. Consumers that assumed an aborted result always had empty text may now observe partial output.

--- a/observability/mastra/src/__snapshots__/agent-structured-output-trace-generate.json
+++ b/observability/mastra/src/__snapshots__/agent-structured-output-trace-generate.json
@@ -294,11 +294,11 @@
               "environment": "test"
             },
             "input": {
-              "totalChunks": 5,
+              "totalChunks": 6,
               "accumulatedText": "Mock V2 generate response"
             },
             "output": {
-              "totalChunks": 5,
+              "totalChunks": 6,
               "accumulatedText": "Mock V2 generate response"
             }
           }

--- a/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
@@ -292,11 +292,11 @@
               "environment": "test"
             },
             "input": {
-              "totalChunks": 3,
+              "totalChunks": 4,
               "accumulatedText": "Mock V2 stream response"
             },
             "output": {
-              "totalChunks": 3,
+              "totalChunks": 4,
               "accumulatedText": "Mock V2 stream response"
             }
           }

--- a/packages/core/src/agent/agent-stream-processor.test.ts
+++ b/packages/core/src/agent/agent-stream-processor.test.ts
@@ -217,6 +217,46 @@ describe('Processor state persistence across processOutputStream and processOutp
     expect(stateInOutputResult?.streamProcessed).toBe(true);
     expect(stateInOutputResult?.chunks).toEqual(['Hello ', 'World']);
   });
+
+  it('exposes prior processOutputStream state to the step-finish lifecycle chunk', async () => {
+    // Regression for #16687: lifecycle chunks (step-start/step-finish) are routed
+    // through output processors via a separate ProcessorRunner. That runner must share
+    // the same processorStates map as the main model-output path, otherwise the
+    // step-finish chunk is handled with a fresh, empty state and loses continuity.
+    const stateByChunkType: Record<string, Record<string, unknown>> = {};
+
+    class LifecycleStateProcessor implements Processor {
+      readonly id = 'lifecycle-state-processor';
+      readonly name = 'Lifecycle State Processor';
+
+      async processOutputStream({ part, state }: any) {
+        if (part.type === 'text-delta') {
+          state.sawText = true;
+        }
+        // Snapshot the state the processor sees for each chunk type
+        stateByChunkType[part.type] = { ...state };
+        return part;
+      }
+    }
+
+    const agent = new Agent({
+      id: 'lifecycle-agent',
+      name: 'lifecycle-agent',
+      instructions: 'Test agent',
+      model: mockModel as any,
+      outputProcessors: [new LifecycleStateProcessor()],
+    });
+
+    const stream = await agent.stream('test message');
+    for await (const _chunk of stream.textStream) {
+      // consume
+    }
+
+    // The processor must have observed the step-finish lifecycle chunk...
+    expect(stateByChunkType['step-finish']).toBeDefined();
+    // ...and at that point it must still see the state set while handling text-delta.
+    expect(stateByChunkType['step-finish']?.sawText).toBe(true);
+  });
 });
 
 describe('OutputProcessor Metadata with Streaming (Issue #11454)', () => {

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -8143,6 +8143,15 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
             },
             {
               "from": "AGENT",
+              "payload": {
+                "id": "id-2",
+                "providerMetadata": undefined,
+              },
+              "runId": "test-run-id",
+              "type": "text-start",
+            },
+            {
+              "from": "AGENT",
               "payload": {},
               "runId": "test-run-id",
               "type": "abort",
@@ -8203,7 +8212,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                 },
                 "output": {
                   "steps": [],
-                  "text": "",
+                  "text": "Hello",
                   "toolCalls": [],
                   "usage": {
                     "inputTokens": 0,
@@ -8694,6 +8703,15 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
             },
             {
               "from": "AGENT",
+              "payload": {
+                "id": "id-2",
+                "providerMetadata": undefined,
+              },
+              "runId": "test-run-id",
+              "type": "text-start",
+            },
+            {
+              "from": "AGENT",
               "payload": {},
               "runId": "test-run-id",
               "type": "abort",
@@ -8817,7 +8835,7 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                 },
                 "output": {
                   "steps": [],
-                  "text": "",
+                  "text": "Hello",
                   "toolCalls": [],
                   "usage": {
                     "inputTokens": 3,

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -35,16 +35,23 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
       // Normalize requestContext so data-chunk processors and the agentic loop share the same instance
       const requestContext = rest.requestContext ?? new RequestContext();
 
-      // Create a ProcessorRunner for data-* chunks so they go through output processors
+      // Create a ProcessorRunner for chunks routed through outputWriter (data-* custom
+      // chunks plus lifecycle chunks like step-finish) so they go through output processors.
+      // Share the loop's processorStates map so these chunks see the same per-processor state
+      // that the main model-output stream path populates; otherwise the runner would build an
+      // isolated empty state map and break state continuity across the step lifecycle.
       const hasOutputProcessors = rest.outputProcessors && rest.outputProcessors.length > 0;
+      const dataChunkProcessorStates = hasOutputProcessors
+        ? (rest.processorStates ?? new Map<string, ProcessorState>())
+        : undefined;
       const dataChunkProcessorRunner = hasOutputProcessors
         ? new ProcessorRunner({
             outputProcessors: rest.outputProcessors,
             logger: rest.logger || new ConsoleLogger({ level: 'error' }),
             agentName: agentId || 'unknown',
+            processorStates: dataChunkProcessorStates,
           })
         : undefined;
-      const dataChunkProcessorStates = hasOutputProcessors ? new Map<string, ProcessorState>() : undefined;
 
       // Create a ProcessorStreamWriter so output processors can emit custom chunks back to the stream
       const dataChunkStreamWriter = {
@@ -69,7 +76,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
               processorId,
             } = await dataChunkProcessorRunner.processPart(
               chunk,
-              (rest.processorStates ?? dataChunkProcessorStates!) as Map<string, ProcessorState<OUTPUT>>,
+              dataChunkProcessorStates! as Map<string, ProcessorState<OUTPUT>>,
               undefined, // observabilityContext
               requestContext,
               messageList,
@@ -143,7 +150,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
             processorId,
           } = await dataChunkProcessorRunner.processPart(
             chunk,
-            (rest.processorStates ?? dataChunkProcessorStates!) as Map<string, ProcessorState<OUTPUT>>,
+            dataChunkProcessorStates! as Map<string, ProcessorState<OUTPUT>>,
             undefined,
             requestContext,
             messageList,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When streaming data through processors (like filters or transformers) in a workflow, the processor was "forgetting" changes it made to its state when it moved from one part of the lifecycle to the next (like when finishing a step). This PR fixes it by making the processor remember its state throughout the entire process, so changes stick around. It also fixes a bug where if something got interrupted while streaming, all the data collected so far would be thrown away instead of partially returned.

## Summary

This PR fixes processor state continuity for streaming step lifecycle chunks in the core package. The main issue was that output processors' state wasn't being shared across different stages of the streaming pipeline—particularly when lifecycle chunks (like `step-finish` events) were being processed separately from the main model output stream.

### Changes Made

**Core streaming logic** (`packages/core/src/loop/workflows/stream.ts`):
- The `workflowLoopStream` function now constructs a shared `processorStates` map that's used across both the main stream path and the output-writer path
- Both data chunk persistence and injected chunks now pass this shared state map instead of using separate state instances

**Test coverage** (`packages/core/src/agent/agent-stream-processor.test.ts`):
- Added a regression test verifying that processor state is properly maintained when processing lifecycle chunks (`step-finish`)
- The test confirms that state changes made during normal output processing are visible when handling lifecycle events

**Abort behavior** (`packages/core/src/loop/test-utils/options.ts`):
- Updated expectations for abort-signal streaming scenarios
- When a stream is aborted, partial content collected before the abort is now surfaced instead of being dropped
- Previously empty text output is now expected to contain the content accumulated before abort

**Test snapshots** (`observability/mastra/src/__snapshots__/`):
- Updated structured output trace snapshots to reflect increased chunk counts due to additional lifecycle chunks now being properly counted

### Impact

- Processor state mutations are now visible throughout the entire step lifecycle
- Streaming workflows that abort will now surface partial output instead of losing all accumulated data
- Ensures consistent processor behavior across all streaming pathways

<!-- end of auto-generated comment: release notes by coderabbit.ai -->