### PR TITLE
docs(mcp): add local WorkPaper server example

### DIFF
--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -62,6 +62,42 @@ For connecting to OAuth-protected MCP servers, see the [OAuth Authentication](/r
 
 :::
 
+## Connect local project-file servers
+
+Some stdio MCP servers work against local files in your project instead of a remote API. For example, a formula workbook server can let an agent update input cells, recalculate outputs, and persist workbook state as JSON.
+
+The following example starts [Bilig WorkPaper](https://github.com/proompteng/bilig) as a local writable MCP server and stores the workbook at `./pricing.workpaper.json`:
+
+```typescript title="src/mastra/mcp/workpaper-mcp-client.ts"
+import { MCPClient } from '@mastra/mcp'
+
+export const workpaperMcpClient = new MCPClient({
+  id: 'workpaper-mcp-client',
+  servers: {
+    bilig: {
+      command: 'npm',
+      args: [
+        'exec',
+        '--yes',
+        '--package',
+        '@bilig/workpaper@0.131.2',
+        '--',
+        'bilig-workpaper-mcp',
+        '--workpaper',
+        './pricing.workpaper.json',
+        '--init-demo-workpaper',
+        '--writable',
+      ],
+      requireToolApproval: true,
+    },
+  },
+})
+```
+
+Because this server can write to disk, `requireToolApproval: true` keeps each workbook edit behind Mastra's human approval flow. Pass `await workpaperMcpClient.listTools()` to an agent, then ask it to update workbook inputs, read calculated outputs, and verify the persisted JSON before returning an answer.
+
+Use the same pattern for any local-file MCP server: keep the server command explicit, require approval when tools can mutate files, and ask the agent to return readback or persistence evidence.
+
 ## Using `MCPClient` with an agent
 
 To use tools from an MCP server in an agent, import your `MCPClient` and call `.listTools()` in the `tools` parameter. This loads from the defined MCP servers, making them available to the agent.


### PR DESCRIPTION
Closes #17371.

## Summary

- Adds a short `MCPClient` example for local stdio MCP servers that work on project files.
- Uses Bilig WorkPaper as the concrete example because it writes a local `pricing.workpaper.json` file, recalculates workbook formulas, and returns persisted readback evidence.
- Keeps file-mutating MCP tools behind `requireToolApproval: true`.

## Validation

```bash
git diff --check
pnpm dlx prettier@3.8.3 --check docs/src/content/en/docs/mcp/overview.mdx
npm view @bilig/workpaper@0.131.2 version
npm exec --yes --package @bilig/workpaper@0.131.2 -- bilig-evaluate --door agent-mcp --json
```

The Bilig evaluator returned `verified: true` with 8 MCP tools, `Inputs!B3` -> `Summary!B3` readback, persisted JSON, and restart readback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a helpful example to the documentation that shows how to connect a local tool (called a MCP server) that can save files to your project. It demonstrates how to set up a "WorkPaper" tool that performs calculations and saves results to a file, and how to make sure changes get human approval before they happen.

## Changes

Added documentation to `docs/src/content/en/docs/mcp/overview.mdx` explaining how to configure and use local stdio MCP servers that operate on project files.

The documentation includes:
- An `MCPClient` configuration example that starts the Bilig WorkPaper MCP server via `npm exec` command
- Configuration of `requireToolApproval: true` to route file-mutating operations through human approval
- Guidance on the recommended usage pattern for agents: listing available tools, updating inputs, reading outputs, and verifying persisted state in the generated JSON file
- Reference to Bilig WorkPaper as a concrete example that recalculates workbook formulas and persists data to `./pricing.workpaper.json`

## Scope

- Documentation-only change (no code modifications)
- Lines changed: +36/-0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->