### PR TITLE
fix(cli): add --skip-install flag to mastra migrate for immutable lockfile environments

### DIFF
--- a/.changeset/plain-aliens-cover.md
+++ b/.changeset/plain-aliens-cover.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Add --skip-install flag to migrate command to skip dependency installation in immutable lockfile environments (Yarn 4 --immutable, npm ci)

--- a/packages/cli/src/commands/actions/migrate.ts
+++ b/packages/cli/src/commands/actions/migrate.ts
@@ -1,7 +1,14 @@
 import { analytics, origin } from '../..';
 import { migrate as runMigrate } from '../migrate/migrate';
 
-export const migrate = async (args: { dir?: string; root?: string; env?: string; debug?: boolean; yes?: boolean }) => {
+export const migrate = async (args: {
+  dir?: string;
+  root?: string;
+  env?: string;
+  debug?: boolean;
+  yes?: boolean;
+  skipInstall?: boolean;
+}) => {
   await analytics.trackCommandExecution({
     command: 'mastra migrate',
     args: { ...args },
@@ -12,6 +19,7 @@ export const migrate = async (args: { dir?: string; root?: string; env?: string;
         env: args?.env,
         debug: args?.debug ?? false,
         yes: args?.yes ?? false,
+        skipInstall: args?.skipInstall,
       });
     },
     origin,

--- a/packages/cli/src/commands/migrate/MigrateBundler.test.ts
+++ b/packages/cli/src/commands/migrate/MigrateBundler.test.ts
@@ -11,6 +11,7 @@ vi.mock('@mastra/deployer/build', () => ({
 vi.mock('../build/BuildBundler.js', () => ({
   BuildBundler: class MockBuildBundler {
     protected platform = 'node';
+    protected logger: { info: (...args: unknown[]) => void } = { info: vi.fn() };
     constructor(_options?: { studio?: boolean }) {}
     __setLogger(_logger: unknown) {}
     getAllToolPaths(_dir: string, _extra: unknown[]) {
@@ -23,6 +24,9 @@ vi.mock('../build/BuildBundler.js', () => ({
       return Promise.resolve(new Map());
     }
     protected _bundle(_entry: string, _entryFile: string, _options: unknown, _toolsPaths: unknown): Promise<void> {
+      return Promise.resolve();
+    }
+    protected installDependencies(_outputDirectory: string, _rootDir?: string): Promise<void> {
       return Promise.resolve();
     }
   },
@@ -125,6 +129,60 @@ describe('MigrateBundler', () => {
 
       expect(entry).toContain('catch (error)');
       expect(entry).toContain('error instanceof Error ? error.message');
+    });
+  });
+
+  describe('installDependencies', () => {
+    it('should call super.installDependencies when no skip flags are set', async () => {
+      delete process.env.YARN_ENABLE_IMMUTABLE_INSTALLS;
+      delete process.env.npm_config_ci;
+      const bundler = new MigrateBundler(undefined, false);
+      const superInstall = vi.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(bundler)), 'installDependencies');
+      await (bundler as any).installDependencies('/out', '/root');
+      expect(superInstall).toHaveBeenCalledWith('/out', '/root');
+    });
+
+    it('should skip installDependencies when skipInstall is true', async () => {
+      delete process.env.YARN_ENABLE_IMMUTABLE_INSTALLS;
+      delete process.env.npm_config_ci;
+      const bundler = new MigrateBundler(undefined, true);
+      const superInstall = vi.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(bundler)), 'installDependencies');
+      await (bundler as any).installDependencies('/out', '/root');
+      expect(superInstall).not.toHaveBeenCalled();
+    });
+
+    it('should skip installDependencies when YARN_ENABLE_IMMUTABLE_INSTALLS=true', async () => {
+      process.env.YARN_ENABLE_IMMUTABLE_INSTALLS = 'true';
+      delete process.env.npm_config_ci;
+      const bundler = new MigrateBundler(undefined, false);
+      const superInstall = vi.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(bundler)), 'installDependencies');
+      const logSpy = vi.spyOn((bundler as any).logger, 'info');
+      await (bundler as any).installDependencies('/out', '/root');
+      expect(superInstall).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(
+        'Skipping dependency installation (immutable lockfile mode or --skip-install flag)',
+      );
+    });
+
+    it('should skip installDependencies when npm_command=ci', async () => {
+      delete process.env.YARN_ENABLE_IMMUTABLE_INSTALLS;
+      delete process.env.npm_config_ci;
+      process.env.npm_command = 'ci';
+      const bundler = new MigrateBundler(undefined, false);
+      const superInstall = vi.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(bundler)), 'installDependencies');
+      await (bundler as any).installDependencies('/out', '/root');
+      expect(superInstall).not.toHaveBeenCalled();
+      delete process.env.npm_command;
+    });
+
+    it('should skip installDependencies when npm_config_ci=true', async () => {
+      delete process.env.YARN_ENABLE_IMMUTABLE_INSTALLS;
+      delete process.env.npm_command;
+      process.env.npm_config_ci = 'true';
+      const bundler = new MigrateBundler(undefined, false);
+      const superInstall = vi.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(bundler)), 'installDependencies');
+      await (bundler as any).installDependencies('/out', '/root');
+      expect(superInstall).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/commands/migrate/MigrateBundler.ts
+++ b/packages/cli/src/commands/migrate/MigrateBundler.ts
@@ -5,10 +5,25 @@ import { shouldSkipDotenvLoading } from '../utils.js';
 
 export class MigrateBundler extends BuildBundler {
   private customEnvFile?: string;
+  private skipInstall: boolean;
 
-  constructor(customEnvFile?: string) {
+  constructor(customEnvFile?: string, skipInstall = false) {
     super({ studio: false });
     this.customEnvFile = customEnvFile;
+    this.skipInstall = skipInstall;
+  }
+
+  protected override async installDependencies(outputDirectory: string, rootDir?: string): Promise<void> {
+    if (
+      this.skipInstall ||
+      process.env['YARN_ENABLE_IMMUTABLE_INSTALLS'] === 'true' ||
+      process.env['npm_command'] === 'ci' ||
+      process.env['npm_config_ci'] === 'true'
+    ) {
+      this.logger?.info('Skipping dependency installation (immutable lockfile mode or --skip-install flag)');
+      return;
+    }
+    return super.installDependencies(outputDirectory, rootDir);
   }
 
   override getEnvFiles(): Promise<string[]> {

--- a/packages/cli/src/commands/migrate/migrate.ts
+++ b/packages/cli/src/commands/migrate/migrate.ts
@@ -31,12 +31,14 @@ export async function migrate({
   env,
   debug,
   yes,
+  skipInstall,
 }: {
   dir?: string;
   root?: string;
   env?: string;
   debug: boolean;
   yes: boolean;
+  skipInstall?: boolean;
 }) {
   const logger = createLogger(debug);
   const { rootDir, mastraDir } = resolveMigratePaths({
@@ -100,7 +102,7 @@ export async function migrate({
   }
 
   try {
-    const bundler = new MigrateBundler(env);
+    const bundler = new MigrateBundler(env, skipInstall);
     bundler.__setLogger(logger);
 
     logger.info('Building project for migration...');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -311,6 +311,7 @@ program
   .option('-e, --env <env>', 'Custom env file to include')
   .option('--debug', 'Enable debug logs', false)
   .option('-y, --yes', 'Skip confirmation prompt (for CI/automation)')
+  .option('--skip-install', 'Skip dependency installation (for immutable lockfile environments)')
   .action(migrate);
 
 const scorersCommand = program.command('scorers').description('Manage scorers for evaluating AI outputs');


### PR DESCRIPTION
Fixes #16957

`mastra migrate` always runs package installation internally, which breaks CI/CD pipelines that enforce immutable lockfiles (Yarn 4 `--immutable`, `npm ci`, `pnpm --frozen-lockfile`).

This adds a `--skip-install` flag and auto-detects common immutable-install environments:

- `--skip-install` CLI flag: explicit opt-out
- `YARN_ENABLE_IMMUTABLE_INSTALLS=true`: Yarn Berry's own env var
- `npm_command=ci`: set by npm v7+ when running `npm ci`
- `npm_config_ci=true`: manual fallback for older npm setups

When skipping, `MigrateBundler.installDependencies()` is a no-op and logs an info message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a `--skip-install` flag to the `mastra migrate` command so that it won't try to install packages during migration when you're in a strict CI environment that locks your dependencies (like Yarn 4 or npm ci). It also automatically detects these strict environments, so you don't even have to use the flag if you don't want to.

## Overview

This PR adds a `--skip-install` CLI flag to `mastra migrate` that prevents the command from running dependency installation in immutable lockfile environments, addressing CI/CD failures when strict lockfile policies are enforced.

## Changes

### CLI Interface
- Added `--skip-install` flag to the `migrate` command in the CLI
- Updated the `migrate` command interface to accept an optional `skipInstall` boolean parameter

### Core Implementation
- Extended `MigrateBundler` to accept a `skipInstall` constructor flag
- Modified `MigrateBundler.installDependencies()` to become a no-op when:
  - The `--skip-install` flag is explicitly set, OR
  - Immutable lockfile environments are detected via environment variables:
    - `YARN_ENABLE_IMMUTABLE_INSTALLS=true` (Yarn 4 immutable mode)
    - `npm_command=ci` (npm ci command)
    - `npm_config_ci=true` (npm ci configuration)
  - When skipping, logs an informational message
- Updated the `migrate` runner to pass the `skipInstall` flag through to `MigrateBundler`

### Testing
- Added comprehensive test suite for `MigrateBundler.installDependencies()` covering:
  - Cases where installation should be delegated to parent implementation
  - Cases where installation should be skipped based on the `skipInstall` flag
  - Auto-detection of immutable lockfile environments via each of the three environment variable patterns
  - Verification that informational logging occurs when skipping

### Documentation
- Updated changeset to document the new `--skip-install` flag for the `migrate` command

## Addresses

Fixes issue `#16957` by providing an explicit opt-out mechanism and auto-detection of immutable install modes to prevent `mastra migrate` from bypassing workspace lockfile guarantees and potential supply-chain issues in strict CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->