### PR TITLE
fix(pg): batch saveMessages into chunked multi-row INSERT

### DIFF
--- a/.changeset/better-buses-turn.md
+++ b/.changeset/better-buses-turn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fix Postgres saveMessages to use a single batched INSERT instead of one round trip per message

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -1212,7 +1212,6 @@ export class MemoryPG extends MemoryStorage {
     try {
       const tableName = getTableName({ indexName: TABLE_MESSAGES, schemaName: getSchemaName(this.#schema) });
       await this.#db.client.tx(async t => {
-        // Insert messages sequentially to avoid concurrent queries on the same pg client
         for (const message of messages) {
           if (!message.threadId) {
             throw new Error(
@@ -1224,25 +1223,39 @@ export class MemoryPG extends MemoryStorage {
               `Expected to find a resourceId for message, but couldn't find one. An unexpected error has occurred.`,
             );
           }
+        }
+
+        const PARAMS_PER_ROW = 8;
+        const CHUNK_SIZE = Math.floor(65535 / PARAMS_PER_ROW);
+
+        for (let i = 0; i < messages.length; i += CHUNK_SIZE) {
+          const chunk = messages.slice(i, i + CHUNK_SIZE);
+          const placeholders = chunk
+            .map((_, idx) => {
+              const base = idx * PARAMS_PER_ROW;
+              return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8})`;
+            })
+            .join(', ');
+          const values = chunk.flatMap(message => [
+            message.id,
+            message.threadId,
+            typeof message.content === 'string' ? message.content : JSON.stringify(message.content),
+            message.createdAt || new Date(),
+            message.createdAt || new Date(),
+            message.role,
+            message.type || 'v2',
+            message.resourceId,
+          ]);
           await t.none(
             `INSERT INTO ${tableName} (id, thread_id, content, "createdAt", "createdAtZ", role, type, "resourceId")
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             VALUES ${placeholders}
              ON CONFLICT (id) DO UPDATE SET
               thread_id = EXCLUDED.thread_id,
               content = EXCLUDED.content,
               role = EXCLUDED.role,
               type = EXCLUDED.type,
               "resourceId" = EXCLUDED."resourceId"`,
-            [
-              message.id,
-              message.threadId,
-              typeof message.content === 'string' ? message.content : JSON.stringify(message.content),
-              message.createdAt || new Date(),
-              message.createdAt || new Date(),
-              message.role,
-              message.type || 'v2',
-              message.resourceId,
-            ],
+            values,
           );
         }
 

--- a/stores/pg/src/storage/domains/memory/save-messages-batch.test.ts
+++ b/stores/pg/src/storage/domains/memory/save-messages-batch.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DbClient, TxClient } from '../../client';
+import { MemoryPG } from './index';
+
+function makeMessage(id: string, threadId = 'thread-1', resourceId = 'resource-1') {
+  return {
+    id,
+    threadId,
+    resourceId,
+    content: { text: `msg ${id}` },
+    role: 'user' as const,
+    type: 'v2' as const,
+    createdAt: new Date('2024-01-01'),
+  };
+}
+
+function makeThread(id = 'thread-1') {
+  return { id, resourceId: 'resource-1', title: 'Test', metadata: {}, createdAt: new Date(), updatedAt: new Date() };
+}
+
+function makeMockClient(): { client: DbClient; tNone: ReturnType<typeof vi.fn> } {
+  const tNone = vi.fn().mockResolvedValue(null);
+  const txClient = {
+    none: tNone,
+    one: vi.fn(),
+    oneOrNone: vi.fn(),
+    any: vi.fn(),
+    manyOrNone: vi.fn(),
+    many: vi.fn(),
+    query: vi.fn(),
+    result: vi.fn(),
+    tx: vi.fn(),
+  } as unknown as TxClient;
+  const client = {
+    none: vi.fn().mockResolvedValue(null),
+    one: vi.fn(),
+    oneOrNone: vi.fn(),
+    any: vi.fn(),
+    manyOrNone: vi.fn(),
+    many: vi.fn(),
+    query: vi.fn(),
+    result: vi.fn(),
+    tx: vi.fn().mockImplementation(async (cb: (t: TxClient) => Promise<unknown>) => cb(txClient)),
+  } as unknown as DbClient;
+  return { client, tNone };
+}
+
+const PARAMS_PER_ROW = 8;
+const CHUNK_SIZE = Math.floor(65535 / PARAMS_PER_ROW);
+
+describe('saveMessages batch INSERT', () => {
+  let memoryPG: MemoryPG;
+  let tNone: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    const mock = makeMockClient();
+    tNone = mock.tNone;
+    memoryPG = new MemoryPG({ client: mock.client });
+    vi.spyOn(memoryPG, 'getThreadById').mockResolvedValue(makeThread() as any);
+  });
+
+  it('inserts 10 messages in a single t.none call', async () => {
+    const messages = Array.from({ length: 10 }, (_, i) => makeMessage(`msg-${i}`));
+    await memoryPG.saveMessages({ messages: messages as any });
+    const insertCalls = tNone.mock.calls.filter(([sql]) => (sql as string).includes('INSERT INTO'));
+    expect(insertCalls).toHaveLength(1);
+    expect((insertCalls[0]![1] as unknown[]).length).toBe(10 * PARAMS_PER_ROW);
+  });
+
+  it('returns early without any INSERT when messages array is empty', async () => {
+    await memoryPG.saveMessages({ messages: [] });
+    expect(tNone).not.toHaveBeenCalled();
+  });
+
+  it('chunk size constant is 8191 (floor(65535 / 8))', () => {
+    expect(CHUNK_SIZE).toBe(8191);
+  });
+
+  it('splits messages exceeding chunk size into two INSERT calls', async () => {
+    const messages = Array.from({ length: CHUNK_SIZE + 1 }, (_, i) => makeMessage(`msg-${i}`));
+    await memoryPG.saveMessages({ messages: messages as any });
+    const insertCalls = tNone.mock.calls.filter(([sql]) => (sql as string).includes('INSERT INTO'));
+    expect(insertCalls).toHaveLength(2);
+    expect((insertCalls[0]![1] as unknown[]).length).toBe(CHUNK_SIZE * PARAMS_PER_ROW);
+    expect((insertCalls[1]![1] as unknown[]).length).toBe(1 * PARAMS_PER_ROW);
+  });
+
+  it('INSERT includes ON CONFLICT DO UPDATE clause', async () => {
+    await memoryPG.saveMessages({ messages: [makeMessage('id-1')] as any });
+    const insertCalls = tNone.mock.calls.filter(([sql]) => (sql as string).includes('INSERT INTO'));
+    expect(insertCalls[0]![0]).toContain('ON CONFLICT (id) DO UPDATE SET');
+  });
+
+  it('values are ordered: id, threadId, content, createdAt, createdAtZ, role, type, resourceId', async () => {
+    const msg = makeMessage('id-1');
+    await memoryPG.saveMessages({ messages: [msg] as any });
+    const insertCalls = tNone.mock.calls.filter(([sql]) => (sql as string).includes('INSERT INTO'));
+    const values = insertCalls[0]![1] as unknown[];
+    expect(values[0]).toBe('id-1');
+    expect(values[1]).toBe('thread-1');
+    expect(values[2]).toBe(JSON.stringify(msg.content));
+    expect(values[3]).toEqual(msg.createdAt);
+    expect(values[4]).toEqual(msg.createdAt);
+    expect(values[5]).toBe('user');
+    expect(values[6]).toBe('v2');
+    expect(values[7]).toBe('resource-1');
+  });
+});


### PR DESCRIPTION
Fixes #17350

`saveMessages()` was executing one `INSERT` per message inside a transaction, causing N sequential round trips for N messages.

This replaces the per-message loop with chunked multi-row `INSERT ... VALUES (...), (...), ...`. Chunk size is `floor(65535 / 8) = 8191` rows (Postgres bind-parameter cap at 8 params per row). For most workloads this reduces N round trips to 1.

The validation loop (checking `threadId`/`resourceId` on each message) still runs before the batch INSERT. The thread `updatedAt` UPDATE is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Instead of telling the database "insert this message" one at a time (which is slow because each message needs its own trip to the database), the code now groups messages together and says "insert all of these at once" in batches. This is much faster because it reduces the number of trips from many down to just a few.

## Summary

This PR optimizes the `saveMessages` method in the Postgres adapter by replacing per-message `INSERT ... ON CONFLICT` statements with chunked multi-row batch inserts.

### Changes

**Memory Storage Optimization** (`stores/pg/src/storage/domains/memory/index.ts`)
- Replaced sequential single-row INSERT statements inside a transaction with batched multi-row `INSERT ... VALUES (...), (...) ON CONFLICT (id) DO UPDATE` statements
- Chunk size set to 8,191 rows (computed as `floor(65535 / 8)`) to respect Postgres bind-parameter limits while maintaining 8 parameters per row
- Per-message validation for `threadId` and `resourceId` preserved before batch insertion
- Thread timestamp (`updatedAt`) updates remain unchanged
- Reduces database round trips from N (one per message) to approximately 1 for typical workloads

**Test Coverage** (`stores/pg/src/storage/domains/memory/save-messages-batch.test.ts`)
- Added comprehensive test suite validating batch insert behavior
- Confirms single `t.none` call for 10 messages with correct parameter binding
- Validates chunking logic when messages exceed chunk size (multiple `t.none` calls)
- Verifies `CHUNK_SIZE` constant equals 8,191
- Confirms `ON CONFLICT` clause preservation with correct column ordering
- Tests edge cases including empty message arrays

**Release Notes** (`.changeset/better-buses-turn.md`)
- Patch release entry documenting the optimization

### Impact

- Preserves existing upsert semantics (`ON CONFLICT (id)` updates for thread_id, content, role, type, and resourceId)
- Maintains transaction atomicity including thread timestamp updates
- Handles duplicate ids within single `saveMessages` calls correctly
- Reduces database latency for batch message persistence operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->