### PR TITLE
fix: sanitize OpenRouter Gemini tool schemas

### DIFF
--- a/.changeset/openrouter-gemini-tool-schema.md
+++ b/.changeset/openrouter-gemini-tool-schema.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Sanitize prepared tool schemas for Google/Gemini models, including OpenRouter-hosted Gemini models.
+Fixed OpenRouter Gemini supervisor failures by removing unsupported tool-schema fields from Gemini-compatible requests.

--- a/.changeset/openrouter-gemini-tool-schema.md
+++ b/.changeset/openrouter-gemini-tool-schema.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Sanitize prepared tool schemas for Google/Gemini models, including OpenRouter-hosted Gemini models.

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -1,6 +1,7 @@
 import { jsonSchema } from '@internal/ai-sdk-v5';
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod/v4';
+import { MODEL_TOKENS } from '../../../../../../../docs/src/plugins/remark-model-tokens/models';
 import { RequestContext } from '../../../../request-context';
 import { createTool } from '../../../../tools/tool';
 import { CoreToolBuilder } from '../../../../tools/tool-builder/builder';
@@ -493,6 +494,11 @@ describe('prepareToolsAndToolChoice', () => {
         toolChoice: undefined,
         activeTools: undefined,
         targetVersion: 'v2',
+        model: {
+          modelId: MODEL_TOKENS.__GATEWAY_GOOGLE_MODEL__,
+          provider: 'openrouter',
+          supportsStructuredOutputs: false,
+        },
       });
 
       expect(result.tools).toBeDefined();
@@ -582,7 +588,7 @@ describe('prepareToolsAndToolChoice', () => {
           requestContext: new RequestContext(),
           tracingContext: {},
           model: {
-            modelId: 'google/gemini-3.1-flash-lite',
+            modelId: MODEL_TOKENS.__GATEWAY_GOOGLE_MODEL__,
             provider: 'openrouter',
             specificationVersion: 'v2',
             supportsStructuredOutputs: false,
@@ -596,7 +602,7 @@ describe('prepareToolsAndToolChoice', () => {
         activeTools: undefined,
         targetVersion: 'v2',
         model: {
-          modelId: 'google/gemini-3.1-flash-lite',
+          modelId: MODEL_TOKENS.__GATEWAY_GOOGLE_MODEL__,
           provider: 'openrouter',
           supportsStructuredOutputs: false,
         },

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -1,7 +1,9 @@
 import { jsonSchema } from '@internal/ai-sdk-v5';
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod/v4';
+import { RequestContext } from '../../../../request-context';
 import { createTool } from '../../../../tools/tool';
+import { CoreToolBuilder } from '../../../../tools/tool-builder/builder';
 import { prepareToolsAndToolChoice } from './prepare-tools';
 
 describe('prepareToolsAndToolChoice', () => {
@@ -443,6 +445,30 @@ describe('prepareToolsAndToolChoice', () => {
   });
 
   describe('agent-as-tools schema serialization (#13324)', () => {
+    function expectRequiredKeysHaveProperties(schema: any) {
+      if (!schema || typeof schema !== 'object') return;
+
+      if (schema.properties && Array.isArray(schema.required)) {
+        const propertyKeys = new Set(Object.keys(schema.properties));
+        for (const requiredKey of schema.required) {
+          expect(
+            propertyKeys.has(requiredKey),
+            `Required key '${requiredKey}' must be present in properties. Got: ${JSON.stringify(schema)}`,
+          ).toBe(true);
+        }
+      }
+
+      for (const value of Object.values(schema)) {
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            expectRequiredKeysHaveProperties(item);
+          }
+        } else {
+          expectRequiredKeysHaveProperties(value);
+        }
+      }
+    }
+
     it('should produce valid JSON Schema with type keys for all properties including resumeData: z.any()', () => {
       // Simulate what CoreToolBuilder does: inject resumeData and suspendedToolRunId
       // into agent tool schemas. The resumeData field uses z.any() which serializes
@@ -531,6 +557,59 @@ describe('prepareToolsAndToolChoice', () => {
       expect(Array.isArray(resumeDataSchema.type)).toBe(true);
       expect(resumeDataSchema.type).not.toContain('array');
       expect(resumeDataSchema.items).toBeUndefined();
+    });
+
+    it('should not emit orphaned required keys for OpenRouter Gemini agent tools', () => {
+      const agentTool = createTool({
+        id: 'agent-subAgent',
+        description: 'A sub-agent tool',
+        inputSchema: z.object({
+          prompt: z.string().describe('The prompt to send to the agent'),
+          threadId: z.string().nullish().describe('Thread ID for conversation continuity for memory messages'),
+          resourceId: z.string().nullish().describe('Resource/user identifier for memory messages'),
+          instructions: z.string().nullish().describe('Additional instructions to append to the agent instructions.'),
+          maxSteps: z.number().min(3).nullish().describe('Maximum number of execution steps for the sub-agent'),
+        }),
+        execute: async () => 'result',
+      });
+
+      const builtTool = new CoreToolBuilder({
+        originalTool: agentTool,
+        options: {
+          name: 'agent-subAgent',
+          logger: console as any,
+          description: 'A sub-agent tool',
+          requestContext: new RequestContext(),
+          tracingContext: {},
+          model: {
+            modelId: 'google/gemini-3.1-flash-lite',
+            provider: 'openrouter',
+            specificationVersion: 'v2',
+            supportsStructuredOutputs: false,
+          } as any,
+        },
+      }).buildV5();
+
+      const result = prepareToolsAndToolChoice({
+        tools: { 'agent-subAgent': builtTool as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v2',
+        model: {
+          modelId: 'google/gemini-3.1-flash-lite',
+          provider: 'openrouter',
+          supportsStructuredOutputs: false,
+        },
+      });
+
+      const toolDef = result.tools![0] as { type: string; inputSchema: Record<string, any> };
+      expectRequiredKeysHaveProperties(toolDef.inputSchema);
+      expect(toolDef.inputSchema.$schema).toBeUndefined();
+      expect(toolDef.inputSchema.additionalProperties).toBeUndefined();
+      expect(toolDef.inputSchema.properties.threadId).toMatchObject({
+        type: 'string',
+        nullable: true,
+      });
     });
   });
 

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -10,6 +10,7 @@ import type {
 } from '@ai-sdk/provider-v6';
 import { asSchema, tool as toolFn } from '@internal/ai-sdk-v5';
 import type { Tool, ToolChoice } from '@internal/ai-sdk-v5';
+import { GoogleSchemaCompatLayer } from '@mastra/schema-compat';
 import { isStandardSchemaWithJSON, standardSchemaToJSONSchema } from '../../../../schema';
 import { isProviderDefinedTool } from '../../../../tools/toolchecks';
 
@@ -24,6 +25,12 @@ type PreparedTool =
   | LanguageModelV3ProviderTool;
 
 type PreparedToolChoice = LanguageModelV2ToolChoice | LanguageModelV3ToolChoice;
+
+type ToolPrepModelInfo = {
+  provider: string;
+  modelId: string;
+  supportsStructuredOutputs?: boolean;
+};
 
 /**
  * Recursively fixes JSON Schema properties that lack a 'type' key.
@@ -69,17 +76,99 @@ function fixTypelessProperties(schema: Record<string, unknown>): Record<string, 
 
   return result;
 }
+
+function applyGoogleSchemaCompat(schema: Record<string, unknown>, model?: ToolPrepModelInfo): Record<string, unknown> {
+  if (!model) return schema;
+
+  const layer = new GoogleSchemaCompatLayer({
+    provider: model.provider,
+    modelId: model.modelId,
+    supportsStructuredOutputs: model.supportsStructuredOutputs ?? false,
+  });
+
+  if (!layer.shouldApply()) return schema;
+
+  return stripGeminiUnsupportedJsonSchemaKeywords(
+    layer.processToJSONSchema(schema, 'input') as Record<string, unknown>,
+  );
+}
+
+function stripGeminiUnsupportedJsonSchemaKeywords(schema: Record<string, unknown>): Record<string, unknown> {
+  if (typeof schema !== 'object' || schema === null) return schema;
+
+  const result = { ...schema };
+  delete result.$schema;
+  delete result.additionalProperties;
+  delete result.propertyNames;
+
+  if (result.properties && typeof result.properties === 'object' && !Array.isArray(result.properties)) {
+    const properties = result.properties as Record<string, unknown>;
+    result.properties = Object.fromEntries(
+      Object.entries(properties).map(([key, value]) => [
+        key,
+        typeof value === 'object' && value !== null && !Array.isArray(value)
+          ? stripGeminiUnsupportedJsonSchemaKeywords(value as Record<string, unknown>)
+          : value,
+      ]),
+    );
+
+    if (Array.isArray(result.required)) {
+      const propertyKeys = new Set(Object.keys(result.properties as Record<string, unknown>));
+      result.required = result.required.filter(key => typeof key === 'string' && propertyKeys.has(key));
+    }
+  }
+
+  if (result.items) {
+    if (Array.isArray(result.items)) {
+      result.items = result.items.map(item =>
+        typeof item === 'object' && item !== null && !Array.isArray(item)
+          ? stripGeminiUnsupportedJsonSchemaKeywords(item as Record<string, unknown>)
+          : item,
+      );
+    } else if (typeof result.items === 'object') {
+      result.items = stripGeminiUnsupportedJsonSchemaKeywords(result.items as Record<string, unknown>);
+    }
+  }
+
+  for (const key of ['anyOf', 'oneOf', 'allOf'] as const) {
+    if (Array.isArray(result[key])) {
+      result[key] = result[key].map(item =>
+        typeof item === 'object' && item !== null && !Array.isArray(item)
+          ? stripGeminiUnsupportedJsonSchemaKeywords(item as Record<string, unknown>)
+          : item,
+      );
+    }
+  }
+
+  if (Array.isArray(result.anyOf)) {
+    const variants = result.anyOf as Record<string, unknown>[];
+    const nullVariant = variants.find(variant => variant && typeof variant === 'object' && variant.type === 'null');
+    const nonNullVariants = variants.filter(
+      variant => !(variant && typeof variant === 'object' && variant.type === 'null'),
+    );
+
+    if (nullVariant && nonNullVariants.length === 1) {
+      delete result.anyOf;
+      Object.assign(result, nonNullVariants[0], { nullable: true });
+    }
+  }
+
+  return result;
+}
+
 export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
   tools,
   toolChoice,
   activeTools,
   targetVersion = 'v2',
+  model,
 }: {
   tools: TOOLS | undefined;
   toolChoice: ToolChoice<TOOLS> | undefined;
   activeTools: Array<keyof TOOLS> | undefined;
   /** Target model version: 'v2' for AI SDK v5, 'v3' for AI SDK v6. Defaults to 'v2'. */
   targetVersion?: ModelSpecVersion;
+  model?: ToolPrepModelInfo;
 }): {
   tools: PreparedTool[] | undefined;
   toolChoice: PreparedToolChoice | undefined;
@@ -196,7 +285,10 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
                 type: 'function' as const,
                 name,
                 description: sdkTool.description,
-                inputSchema: fixTypelessProperties(parameters as Record<string, unknown>),
+                inputSchema: applyGoogleSchemaCompat(
+                  fixTypelessProperties(parameters as Record<string, unknown>),
+                  model,
+                ),
                 // Preserve strict through v2 preparation because the model router may
                 // still forward these tools to an AI SDK v6 / V3 model later. Actual
                 // V2 model calls strip this field at the AISDKV5LanguageModel boundary.

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -89,7 +89,7 @@ function applyGoogleSchemaCompat(schema: Record<string, unknown>, model?: ToolPr
   if (!layer.shouldApply()) return schema;
 
   return stripGeminiUnsupportedJsonSchemaKeywords(
-    layer.processToJSONSchema(schema, 'input') as Record<string, unknown>,
+    fixTypelessProperties(layer.processToJSONSchema(schema, 'input') as Record<string, unknown>),
   );
 }
 

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -79,6 +79,12 @@ export function execute<OUTPUT = undefined>({
     toolChoice,
     activeTools,
     targetVersion,
+    model: {
+      provider: model.provider,
+      modelId: model.modelId,
+      supportsStructuredOutputs:
+        'supportsStructuredOutputs' in model ? Boolean(model.supportsStructuredOutputs) : false,
+    },
   });
 
   const structuredOutputMode = structuredOutput?.schema


### PR DESCRIPTION
Summary
- apply Google/Gemini schema compatibility during final AI SDK v5 tool preparation, including OpenRouter-hosted Gemini models
- strip Gemini-rejected JSON Schema keywords from prepared tool schemas and collapse nullable anyOf shapes to OpenAPI-style nullable fields
- add a regression test for supervisor sub-agent tool schemas with `openrouter/google/gemini-3.1-flash-lite`
- add a patch changeset for `@mastra/core`

Fixes #17325

Tests
- `./node_modules/.bin/vitest run packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts`
- `./node_modules/.bin/vitest run packages/core/src/tools/tool-builder/builder.test.ts`
- `./node_modules/.bin/vitest run packages/core/src/stream/aisdk/v5/execute.test.ts`
- `./node_modules/.bin/vitest run packages/core/src/llm/model/router-provider-tools.test.ts`
- `git diff --check`

Note
- I also tried `./node_modules/.bin/tsc --noEmit -p packages/core/tsconfig.build.json`; it is blocked in this local workspace by missing built internal packages (`@internal/external-types`, `@internal/voice`), not by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR fixes a crash where the supervisor agent failed when using an OpenRouter-hosted Gemini model by cleaning up tool JSON schemas so they only include fields Gemini accepts.

## Summary of Changes

### Core Fix
- Add Google/Gemini compatibility during final AI SDK v5 tool preparation so OpenRouter-hosted Gemini models are treated the same as other Gemini endpoints.
- Introduce schema sanitization that:
  - Removes Gemini-unsupported JSON Schema keywords ($schema, additionalProperties, propertyNames).
  - Collapses nullable anyOf patterns (null + type) into OpenAPI-style nullable fields (nullable: true on the single type).
  - Preserves existing fixTypelessProperties normalization and runs sanitization after compat conversion.
- New helper wrapper applyGoogleSchemaCompat runs GoogleSchemaCompatLayer conversion (when appropriate) then strips Gemini-incompatible keywords.

Files changed:
- packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
  - prepareToolsAndToolChoice now accepts an optional model parameter (ToolPrepModelInfo) and applies Google/Gemini schema compatibility and sanitization to each tool inputSchema.
  - Adds stripGeminiUnsupportedJsonSchemaKeywords and applyGoogleSchemaCompat logic.
- packages/core/src/stream/aisdk/v5/execute.ts
  - Passes model metadata (provider, modelId, supportsStructuredOutputs) into prepareToolsAndToolChoice so provider-aware adjustments can be applied.

### Tests
- packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
  - Add regression test for supervisor sub-agent tool schemas with openrouter/google/gemini-3.1-flash-lite.
  - Add helper expectRequiredKeysHaveProperties to assert every required key exists in properties and validate nested schema integrity.
  - Verify schemas no longer contain $schema or additionalProperties and that nullable fields are collapsed correctly.

### Release / Meta
- .changeset/openrouter-gemini-tool-schema.md
  - Patch changeset for `@mastra/core` describing the fix that strips unsupported tool-schema fields for Gemini-compatible requests.

## Impact
- Fixes supervisor agent failure when using openrouter/google/gemini-3.1-flash-lite (fixes `#17325`).
- Applies only when Gemini compatibility is detected; non-Gemini flows unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->