### PR TITLE
fix(pg,deployer): eliminate ESM TLA deadlock from custom bundler.externals

### DIFF
--- a/.changeset/long-memes-battle.md
+++ b/.changeset/long-memes-battle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Added a belt-and-suspenders guardrail: when `@mastra/pg` appears in a user-supplied `bundler.externals` array, `@mastra/core/storage` is automatically added to the external list so the bundler never inlines the pg store's synchronous require of that subpath.

--- a/.changeset/tasty-sheep-dig.md
+++ b/.changeset/tasty-sheep-dig.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed a Top-Level Await deadlock in `MemoryPG.init()` that occurred when `@mastra/pg` was inlined by a custom `bundler.externals` config. The dynamic `await import('@mastra/core/storage')` call in `init()` is replaced with the synchronous `createRequire` path already established at module scope, so the module can never produce a TLA cycle in an ESM bundle.

--- a/packages/deployer/src/build/analyze-pg-tla-guard.test.ts
+++ b/packages/deployer/src/build/analyze-pg-tla-guard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { CO_EXTERNALS } from './analyze/constants';
+import { isDependencyPartOfPackage } from './utils';
+
+function applyCoExternals(userExternals: string[], externalsPreset: boolean): string[] {
+  const coRequired = externalsPreset
+    ? []
+    : CO_EXTERNALS.filter(r => userExternals.some(e => isDependencyPartOfPackage(e, r.trigger))).flatMap(
+        r => r.requires,
+      );
+  return coRequired.length ? [...userExternals, ...new Set(coRequired)] : userExternals;
+}
+
+describe('CO_EXTERNALS pg TLA guardrail', () => {
+  it('appends @mastra/core/storage when @mastra/pg is externalized', () => {
+    expect(applyCoExternals(['@mastra/pg'], false)).toContain('@mastra/core/storage');
+  });
+
+  it('appends @mastra/core/storage when @mastra/store-pg is externalized', () => {
+    expect(applyCoExternals(['@mastra/store-pg'], false)).toContain('@mastra/core/storage');
+  });
+
+  it('does not append when no pg package is present', () => {
+    expect(applyCoExternals(['some-other-package', '@mastra/core'], false)).not.toContain('@mastra/core/storage');
+    expect(applyCoExternals([], false)).not.toContain('@mastra/core/storage');
+  });
+
+  it('skips the guard when externalsPreset is true', () => {
+    expect(applyCoExternals(['@mastra/pg'], true)).not.toContain('@mastra/core/storage');
+  });
+
+  it('preserves original externals when guard entry is appended', () => {
+    const result = applyCoExternals(['@mastra/pg', 'some-other-package'], false);
+    expect(result).toContain('@mastra/pg');
+    expect(result).toContain('some-other-package');
+  });
+});

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -11,7 +11,7 @@ import type { WorkspacePackageInfo } from '../bundler/workspaceDependencies';
 import { validate, ValidationError } from '../validator/validate';
 import { analyzeEntry } from './analyze/analyzeEntry';
 import { bundleExternals } from './analyze/bundleExternals';
-import { DEPS_TO_IGNORE, GLOBAL_EXTERNALS } from './analyze/constants';
+import { CO_EXTERNALS, DEPS_TO_IGNORE, GLOBAL_EXTERNALS } from './analyze/constants';
 import { checkConfigExport } from './babel/check-config-export';
 import { detectPinoTransports } from './babel/detect-pino-transports';
 import type { BundlerOptions, DependencyMetadata, ExternalDependencyInfo } from './types';
@@ -345,11 +345,18 @@ export async function analyzeBundle(
 
   let externalsPreset = false;
 
-  const userExternals = Array.isArray(bundlerOptions?.externals) ? bundlerOptions?.externals : [];
+  const rawUserExternals = Array.isArray(bundlerOptions?.externals) ? bundlerOptions?.externals : [];
   const userDynamicPackages = bundlerOptions?.dynamicPackages ?? [];
   if (bundlerOptions?.externals === true) {
     externalsPreset = true;
   }
+
+  const coRequired = externalsPreset
+    ? []
+    : CO_EXTERNALS.filter(r => rawUserExternals.some(e => isDependencyPartOfPackage(e, r.trigger))).flatMap(
+        r => r.requires,
+      );
+  const userExternals = coRequired.length ? [...rawUserExternals, ...new Set(coRequired)] : rawUserExternals;
 
   let index = 0;
   const depsToOptimize = new Map<string, DependencyMetadata>();

--- a/packages/deployer/src/build/analyze/constants.ts
+++ b/packages/deployer/src/build/analyze/constants.ts
@@ -15,3 +15,8 @@ export const GLOBAL_EXTERNALS = [
   'execa',
 ];
 export const DEPRECATED_EXTERNALS = ['fastembed', 'nodemailer', 'jsdom', 'sqlite3'];
+
+export const CO_EXTERNALS: { trigger: string; requires: string[] }[] = [
+  { trigger: '@mastra/pg', requires: ['@mastra/core/storage'] },
+  { trigger: '@mastra/store-pg', requires: ['@mastra/core/storage'] },
+];

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -154,14 +154,7 @@ export class MemoryPG extends MemoryStorage {
     await this.#db.createTable({ tableName: TABLE_MESSAGES, schema: TABLE_SCHEMAS[TABLE_MESSAGES] });
     await this.#db.createTable({ tableName: TABLE_RESOURCES, schema: TABLE_SCHEMAS[TABLE_RESOURCES] });
 
-    // Dynamically import OM schema to avoid breaking older @mastra/core versions
-    let omSchema: Record<string, any> | undefined;
-    try {
-      const { OBSERVATIONAL_MEMORY_TABLE_SCHEMA } = await import('@mastra/core/storage');
-      omSchema = OBSERVATIONAL_MEMORY_TABLE_SCHEMA?.[OM_TABLE];
-    } catch {
-      // OM not available in this version of core
-    }
+    const omSchema = _omTableSchema?.[OM_TABLE];
 
     if (omSchema) {
       await this.#db.createTable({

--- a/stores/pg/src/storage/domains/memory/init-om-schema.test.ts
+++ b/stores/pg/src/storage/domains/memory/init-om-schema.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createTable = vi.fn().mockResolvedValue(undefined);
+const alterTable = vi.fn().mockResolvedValue(undefined);
+const noneQuery = vi.fn().mockResolvedValue(undefined);
+const createDefaultIndexes = vi.fn().mockResolvedValue(undefined);
+const createCustomIndexes = vi.fn().mockResolvedValue(undefined);
+
+const mockClient = { none: noneQuery };
+
+vi.mock('../../db', () => {
+  class PgDB {
+    createTable = createTable;
+    alterTable = alterTable;
+    client = mockClient;
+    constructor(_opts: any) {}
+  }
+
+  return {
+    PgDB,
+    resolvePgConfig: vi.fn(() => ({
+      client: mockClient,
+      schemaName: 'public',
+      skipDefaultIndexes: false,
+      indexes: [],
+    })),
+    generateTableSQL: vi.fn(),
+    generateIndexSQL: vi.fn(),
+    getSchemaName: vi.fn((s: string) => `"${s || 'public'}"`),
+    getTableName: vi.fn(({ indexName, schemaName }: { indexName: string; schemaName?: string }) =>
+      schemaName ? `${schemaName}."${indexName}"` : `"${indexName}"`,
+    ),
+  };
+});
+
+vi.mock('@mastra/core/storage', async () => {
+  const TABLE_SCHEMAS = {
+    mastra_messages: { id: { type: 'text', primaryKey: true } },
+    mastra_resources: { id: { type: 'text', primaryKey: true } },
+    mastra_threads: { id: { type: 'text', primaryKey: true } },
+    mastra_workflow_snapshot: {},
+    mastra_spans: {},
+  };
+
+  class MemoryStorage {
+    createDefaultIndexes = createDefaultIndexes;
+    createCustomIndexes = createCustomIndexes;
+  }
+
+  return {
+    MemoryStorage,
+    normalizePerPage: vi.fn(),
+    calculatePagination: vi.fn(),
+    TABLE_MESSAGES: 'mastra_messages',
+    TABLE_RESOURCES: 'mastra_resources',
+    TABLE_THREADS: 'mastra_threads',
+    TABLE_SCHEMAS,
+    TABLE_WORKFLOW_SNAPSHOT: 'mastra_workflow_snapshot',
+    TABLE_SPANS: 'mastra_spans',
+    createStorageErrorId: vi.fn((_a: string, _b: string, _c: string) => `${_a}_${_b}_${_c}`),
+    getSqlType: vi.fn(() => 'text'),
+    getDefaultValue: vi.fn(() => null),
+    OBSERVATIONAL_MEMORY_TABLE_SCHEMA: {
+      mastra_observational_memory: { id: { type: 'text', primaryKey: true } },
+    },
+  };
+});
+
+vi.mock('@mastra/core/error', () => ({
+  MastraError: class MastraError extends Error {
+    constructor(opts: any, cause?: any) {
+      super(opts.text ?? String(opts));
+      this.cause = cause;
+    }
+  },
+  ErrorDomain: { STORAGE: 'STORAGE' },
+  ErrorCategory: { USER: 'USER', THIRD_PARTY: 'THIRD_PARTY', SYSTEM: 'SYSTEM' },
+}));
+
+vi.mock('@mastra/core/agent', () => ({
+  MessageList: class MessageList {},
+}));
+
+vi.mock('@mastra/core/utils', () => ({
+  parseSqlIdentifier: vi.fn((x: string) => x),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createTable.mockResolvedValue(undefined);
+  alterTable.mockResolvedValue(undefined);
+  noneQuery.mockResolvedValue(undefined);
+  createDefaultIndexes.mockResolvedValue(undefined);
+  createCustomIndexes.mockResolvedValue(undefined);
+});
+
+describe('MemoryPG.init() uses module-level createRequire for OM schema (no dynamic import)', () => {
+  it('creates the OM table when OBSERVATIONAL_MEMORY_TABLE_SCHEMA is available', async () => {
+    const { MemoryPG } = await import('./index');
+    const instance = new MemoryPG({ client: mockClient as any });
+    await instance.init();
+
+    const tableNames = createTable.mock.calls.map((c: any[]) => c[0]?.tableName as string);
+    expect(tableNames).toContain('mastra_observational_memory');
+  });
+
+  it('calls alterTable for OM migration columns after creating the OM table', async () => {
+    const { MemoryPG } = await import('./index');
+    const instance = new MemoryPG({ client: mockClient as any });
+    await instance.init();
+    const alterCalls = alterTable.mock.calls.map((c: any[]) => c[0]?.tableName as string);
+    expect(alterCalls).toContain('mastra_observational_memory');
+  });
+});


### PR DESCRIPTION
Fixes #17115

When users set a custom `bundler.externals` array (e.g. `externals: ['@mastra/pg']`), the bundler was inlining `@mastra/pg`'s dynamic `await import('@mastra/core/storage')` call inside `MemoryPG.init()`. Because this uses top-level await semantics in an ESM chunk, it caused a TLA deadlock at bundle evaluation time.

**Part A — root fix (`@mastra/pg`):** Replace the `await import('@mastra/core/storage')` in `MemoryPG.init()` with the synchronous `createRequire` path already established at module scope (lines 57–64). `_omTableSchema` is now loaded once when the module loads; `init()` just reads it. No TLA is ever emitted.

**Part B — deployer guardrail (`@mastra/deployer`):** Add a `CO_EXTERNALS` policy table to `analyze/constants.ts`. When a user externalizes `@mastra/pg` or `@mastra/store-pg`, `@mastra/core/storage` is automatically added to the external list, preventing accidental bundling of that subpath even if the TLA were ever reintroduced. The table lives alongside `GLOBAL_EXTERNALS` and is data-driven, making future co-external relationships trivially maintainable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

When a user tells the bundler not to bundle a package (by putting it in `bundler.externals`), sometimes the bundler would still sneak code from that package into the bundle if it contained certain types of imports. This created a deadlock. The fix moves one problematic import to happen earlier (at module startup instead of during a function), and adds a smart helper that says "if someone excludes package A, you also need to exclude package B so the code doesn't get mixed in."

## Changes Made

### Part A: `@mastra/pg` — Root Fix

**MemoryPG initialization refactored** (`stores/pg/src/storage/domains/memory/index.ts`):
- Removed the dynamic `await import('`@mastra/core/storage`')` call from `MemoryPG.init()` that was producing a top-level await
- Replaced it with a module-level cached value (`_omTableSchema`) that is loaded synchronously once at import time
- OM (observational memory) table creation and schema operations now use the precomputed schema reference
- Added comprehensive test coverage (`stores/pg/src/storage/domains/memory/init-om-schema.test.ts`) verifying that `MemoryPG.init()` correctly creates and migrates the observational memory table

### Part B: `@mastra/deployer` — Guardrail Policy

**Co-external dependency tracking added** (`packages/deployer/src/build/analyze/constants.ts`):
- Introduced `CO_EXTERNALS` constant: a data-driven table mapping trigger packages (`@mastra/pg`, `@mastra/store-pg`) to their required co-external dependencies (`@mastra/core/storage`)
- Placed alongside `GLOBAL_EXTERNALS` for maintainability

**Bundle analysis updated** (`packages/deployer/src/build/analyze.ts`):
- Extended `analyzeBundle` to automatically include required externals from `CO_EXTERNALS` when a trigger package is user-specified
- Uses dependency resolution (`isDependencyPartOfPackage`) to check if user externals match any trigger
- Appends required externals while deduplicating

**Guard behavior validated** (`packages/deployer/src/build/analyze-pg-tla-guard.test.ts`):
- Added test suite verifying the guardrail correctly includes `@mastra/core/storage` when either pg-related package is externalized
- Confirms the guard respects `externalsPreset: true` to skip automatic inclusion
- Preserves user externals when no pg packages are detected

### Documentation

- Two changeset entries documenting the patch releases for `@mastra/pg` and `@mastra/deployer`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->