### PR TITLE
fix(pg): batch PgVector upserts

### DIFF
--- a/.changeset/thick-lands-shine.md
+++ b/.changeset/thick-lands-shine.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Improved performance when upserting multiple PgVector records

--- a/packages/memory/integration-tests/src/shared/with-pg-storage.ts
+++ b/packages/memory/integration-tests/src/shared/with-pg-storage.ts
@@ -967,6 +967,46 @@ export function getPgStorageTests(connectionString: string) {
     });
 
     describe('Observational memory standalone repro path', () => {
+      it('indexes and retrieves observational memory vectors with PgVector', async () => {
+        const testResourceId = `test-om-vector-${randomUUID()}`;
+        const threadId = randomUUID();
+        const groupId = randomUUID();
+        const observationIndexName = 'memory_observations_384';
+
+        try {
+          await memory.indexObservation({
+            text: 'The user prefers espresso, keyboard shortcuts, and concise technical answers.',
+            groupId,
+            range: 'messages:1-2',
+            threadId,
+            resourceId: testResourceId,
+            observedAt: new Date('2026-01-01T00:00:00.000Z'),
+          });
+
+          const { results } = await memory.searchMessages({
+            query: 'espresso keyboard shortcut preferences',
+            resourceId: testResourceId,
+            topK: 5,
+          });
+
+          expect(results.length).toBeGreaterThan(0);
+          expect(results[0]).toMatchObject({
+            groupId,
+            threadId,
+            range: 'messages:1-2',
+          });
+          expect(results[0]?.text).toContain('espresso');
+          expect(results[0]?.observedAt?.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+        } finally {
+          try {
+            await integrationVector.deleteVectors({
+              indexName: observationIndexName,
+              filter: { resource_id: testResourceId },
+            });
+          } catch {}
+        }
+      });
+
       // PR-added regression repro. Kept skipped by default because CI currently falls back to
       // fuzzy llm-recorder matches for this path, which makes the recorded tool-heavy run unstable.
       it.skip('splits buffered output into multiple assistant messages instead of one mega-message', async () => {

--- a/stores/pg/src/vector/index.schema-name.test.ts
+++ b/stores/pg/src/vector/index.schema-name.test.ts
@@ -13,6 +13,10 @@ vi.mock('@mastra/core/error', () => ({
   },
 }));
 
+vi.mock('@mastra/core/storage', () => ({
+  createVectorErrorId: vi.fn((...parts: string[]) => parts.join('_')),
+}));
+
 vi.mock('@mastra/core/utils', () => ({
   parseSqlIdentifier: (name: string) => name,
 }));
@@ -370,6 +374,115 @@ describe('PgVector custom schema sets search_path before index creation and quer
       .some(call => call.text.includes('search_path') && call.text.includes('myapp'));
 
     expect(searchPathBeforeInsert).toBe(true);
+  });
+
+  it('should upsert multiple vectors with one insert statement', async () => {
+    await vectorStore.createIndex({
+      indexName: 'bulkUpsertTest',
+      dimension: 3,
+      buildIndex: false,
+    });
+
+    queryHistory.length = 0;
+
+    await vectorStore.upsert({
+      indexName: 'bulkUpsertTest',
+      vectors: [
+        [0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6],
+        [0.7, 0.8, 0.9],
+      ],
+      metadata: [{ key: 'one' }, { key: 'two' }, { key: 'three' }],
+      ids: ['vec-1', 'vec-2', 'vec-3'],
+    });
+
+    const insertCalls = queryHistory.filter(call => call.text.includes('INSERT INTO'));
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]?.values).toHaveLength(9);
+    expect(insertCalls[0]?.text).toContain(
+      'VALUES ($1, $2::myapp.vector, $3::jsonb), ($4, $5::myapp.vector, $6::jsonb), ($7, $8::myapp.vector, $9::jsonb)',
+    );
+    expect(insertCalls[0]?.text).toContain('embedding = EXCLUDED.embedding');
+    expect(insertCalls[0]?.values).toEqual([
+      'vec-1',
+      '[0.1,0.2,0.3]',
+      '{"key":"one"}',
+      'vec-2',
+      '[0.4,0.5,0.6]',
+      '{"key":"two"}',
+      'vec-3',
+      '[0.7,0.8,0.9]',
+      '{"key":"three"}',
+    ]);
+  });
+
+  it('should split unique-id bulk upserts at the batch boundary', async () => {
+    await vectorStore.createIndex({
+      indexName: 'bulkUpsertBoundaryTest',
+      dimension: 3,
+      buildIndex: false,
+    });
+
+    queryHistory.length = 0;
+
+    const vectors = Array.from({ length: 1001 }, (_, index) => [index, index + 1, index + 2]);
+    const metadata = vectors.map((_, index) => ({ key: `value-${index}` }));
+    const ids = vectors.map((_, index) => `vec-${index}`);
+
+    await vectorStore.upsert({
+      indexName: 'bulkUpsertBoundaryTest',
+      vectors,
+      metadata,
+      ids,
+    });
+
+    const insertCalls = queryHistory.filter(call => call.text.includes('INSERT INTO'));
+    expect(insertCalls).toHaveLength(2);
+
+    expect(insertCalls[0]?.values).toHaveLength(3000);
+    expect(insertCalls[0]?.values?.slice(0, 6)).toEqual([
+      'vec-0',
+      '[0,1,2]',
+      '{"key":"value-0"}',
+      'vec-1',
+      '[1,2,3]',
+      '{"key":"value-1"}',
+    ]);
+    expect(insertCalls[0]?.values?.slice(-3)).toEqual(['vec-999', '[999,1000,1001]', '{"key":"value-999"}']);
+    expect(insertCalls[0]?.text).toContain('($2998, $2999::myapp.vector, $3000::jsonb)');
+
+    expect(insertCalls[1]?.values).toEqual(['vec-1000', '[1000,1001,1002]', '{"key":"value-1000"}']);
+    expect(insertCalls[1]?.text).toContain('VALUES ($1, $2::myapp.vector, $3::jsonb)');
+  });
+
+  it('should use serial upserts for duplicate ids', async () => {
+    await vectorStore.createIndex({
+      indexName: 'duplicateIdUpsertTest',
+      dimension: 3,
+      buildIndex: false,
+    });
+
+    queryHistory.length = 0;
+
+    const ids = await vectorStore.upsert({
+      indexName: 'duplicateIdUpsertTest',
+      vectors: [
+        [0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6],
+        [0.7, 0.8, 0.9],
+      ],
+      metadata: [{ key: 'first' }, { key: 'second' }, { key: 'last' }],
+      ids: ['same-id', 'other-id', 'same-id'],
+    });
+
+    const insertCalls = queryHistory.filter(call => call.text.includes('INSERT INTO'));
+    expect(ids).toEqual(['same-id', 'other-id', 'same-id']);
+    expect(insertCalls).toHaveLength(3);
+    expect(insertCalls.map(call => call.values)).toEqual([
+      ['same-id', '[0.1,0.2,0.3]', '{"key":"first"}'],
+      ['other-id', '[0.4,0.5,0.6]', '{"key":"second"}'],
+      ['same-id', '[0.7,0.8,0.9]', '{"key":"last"}'],
+    ]);
   });
 
   it('should set search_path before updateVector when extension is in custom schema', async () => {

--- a/stores/pg/src/vector/index.test.ts
+++ b/stores/pg/src/vector/index.test.ts
@@ -160,6 +160,90 @@ describe('PgVector', () => {
   });
 
   describe('PgVector Specific Tests', () => {
+    it('should atomically replace filtered vectors when bulk upserting with deleteFilter', async () => {
+      const replaceIndex = 'test_bulk_upsert_delete_filter';
+
+      try {
+        await vectorDB.createIndex({ indexName: replaceIndex, dimension: 3 });
+
+        await vectorDB.upsert({
+          indexName: replaceIndex,
+          vectors: [
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+          ],
+          metadata: [
+            { source: 'doc-a', revision: 'old' },
+            { source: 'doc-a', revision: 'old' },
+            { source: 'doc-b', revision: 'old' },
+          ],
+          ids: ['old-a-1', 'old-a-2', 'keep-b'],
+        });
+
+        const ids = await vectorDB.upsert({
+          indexName: replaceIndex,
+          vectors: [
+            [0.5, 0.5, 0],
+            [0.5, 0, 0.5],
+          ],
+          metadata: [
+            { source: 'doc-a', revision: 'new' },
+            { source: 'doc-a', revision: 'new' },
+          ],
+          ids: ['new-a-1', 'new-a-2'],
+          deleteFilter: { source: 'doc-a' },
+        });
+
+        expect(ids).toEqual(['new-a-1', 'new-a-2']);
+
+        const replaced = await vectorDB.query({
+          indexName: replaceIndex,
+          filter: { source: 'doc-a' },
+          topK: 10,
+        });
+        expect(replaced.map(result => result.id).sort()).toEqual(['new-a-1', 'new-a-2']);
+        expect(replaced.every(result => result.metadata?.revision === 'new')).toBe(true);
+
+        const untouched = await vectorDB.query({
+          indexName: replaceIndex,
+          filter: { source: 'doc-b' },
+          topK: 10,
+        });
+        expect(untouched.map(result => result.id)).toEqual(['keep-b']);
+      } finally {
+        await vectorDB.deleteIndex({ indexName: replaceIndex });
+      }
+    });
+
+    it('should roll back all chunks when a later bulk upsert chunk fails', async () => {
+      const rollbackIndex = 'test_bulk_upsert_chunk_rollback';
+      const vectors = Array.from({ length: 1001 }, (_, index) => (index === 1000 ? [1, 0] : [1, 0, 0]));
+
+      try {
+        await vectorDB.createIndex({ indexName: rollbackIndex, dimension: 3 });
+
+        await expect(
+          vectorDB.upsert({
+            indexName: rollbackIndex,
+            vectors,
+            metadata: vectors.map((_, index) => ({ source: 'rollback-test', index })),
+            ids: vectors.map((_, index) => `rollback-${index}`),
+          }),
+        ).rejects.toThrow(/Vector dimension mismatch|expected 3 dimensions/);
+
+        const results = await vectorDB.query({
+          indexName: rollbackIndex,
+          filter: { source: 'rollback-test' },
+          topK: 5,
+        });
+
+        expect(results).toHaveLength(0);
+      } finally {
+        await vectorDB.deleteIndex({ indexName: rollbackIndex });
+      }
+    });
+
     describe('Public Fields Access', () => {
       let testDB: PgVector;
       beforeAll(async () => {

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -26,6 +26,8 @@ import { buildFilterQuery, buildDeleteFilterQuery } from './sql-builder';
 import type { IndexConfig, IndexType, PgMetric, VectorOps, VectorType } from './types';
 export type { PgMetric, VectorOps, VectorType, IndexConfig, IndexType } from './types';
 
+const VECTOR_UPSERT_BATCH_SIZE = 1000;
+
 export interface PGIndexStats extends IndexStats {
   type: IndexType;
   /**
@@ -664,19 +666,49 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       const qualifiedVectorType = this.getVectorTypeName(indexInfo.vectorType, indexInfo.dimension);
       const ops = this.getVectorOps(indexInfo.vectorType, indexInfo.metric ?? 'cosine');
 
-      for (let i = 0; i < vectors.length; i++) {
-        const vectorStr = ops.formatVector(vectors[i]!, indexInfo.dimension);
-        const query = `
-          INSERT INTO ${tableName} (vector_id, embedding, metadata)
-          VALUES ($1, $2::${qualifiedVectorType}, $3::jsonb)
-          ON CONFLICT (vector_id)
-          DO UPDATE SET
-            embedding = $2::${qualifiedVectorType},
-            metadata = $3::jsonb
-          RETURNING embedding::text
-        `;
+      // Multi-row ON CONFLICT cannot update the same caller-provided id twice; use the old serial path for duplicates.
+      const hasDuplicateIds = ids ? new Set(vectorIds).size !== vectorIds.length : false;
+      if (hasDuplicateIds) {
+        for (let i = 0; i < vectors.length; i++) {
+          const vectorStr = ops.formatVector(vectors[i]!, indexInfo.dimension);
+          const query = `
+            INSERT INTO ${tableName} (vector_id, embedding, metadata)
+            VALUES ($1, $2::${qualifiedVectorType}, $3::jsonb)
+            ON CONFLICT (vector_id)
+            DO UPDATE SET
+              embedding = $2::${qualifiedVectorType},
+              metadata = $3::jsonb
+            RETURNING embedding::text
+          `;
 
-        await client.query(query, [vectorIds[i], vectorStr, JSON.stringify(metadata?.[i] || {})]);
+          await client.query(query, [vectorIds[i], vectorStr, JSON.stringify(metadata?.[i] || {})]);
+        }
+      } else {
+        for (let offset = 0; offset < vectors.length; offset += VECTOR_UPSERT_BATCH_SIZE) {
+          const batchVectors = vectors.slice(offset, offset + VECTOR_UPSERT_BATCH_SIZE);
+          const values: unknown[] = [];
+          const valueRows = batchVectors.map((vector, batchIndex) => {
+            const vectorIndex = offset + batchIndex;
+            const valueIndex = values.length + 1;
+            values.push(
+              vectorIds[vectorIndex],
+              ops.formatVector(vector, indexInfo.dimension),
+              JSON.stringify(metadata?.[vectorIndex] || {}),
+            );
+            return `($${valueIndex}, $${valueIndex + 1}::${qualifiedVectorType}, $${valueIndex + 2}::jsonb)`;
+          });
+
+          const query = `
+            INSERT INTO ${tableName} (vector_id, embedding, metadata)
+            VALUES ${valueRows.join(', ')}
+            ON CONFLICT (vector_id)
+            DO UPDATE SET
+              embedding = EXCLUDED.embedding,
+              metadata = EXCLUDED.metadata
+          `;
+
+          await client.query(query, values);
+        }
       }
 
       await client.query('COMMIT');


### PR DESCRIPTION
## Description

This updates `PgVector.upsert` so unique-id multi-vector upserts use chunked multi-row `INSERT ... ON CONFLICT` statements instead of issuing one awaited insert per vector.

The duplicate-id case keeps the previous serial insert behavior because Postgres multi-row `ON CONFLICT DO UPDATE` cannot update the same row twice in one statement. This preserves the old validation, casting, rollback, and last-write behavior for duplicate IDs while still improving the normal batched ingestion path.

This is intended to reduce database round trips and Postgres connection checkout time when PgVector receives many vectors in one `upsert`, such as document indexing, workspace indexing, or callers that batch precomputed embeddings.

## Related issue(s)

Fixes #17393

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Benchmark

Local benchmark against pgvector using compiled package code and 1536-dimensional vectors. The old path used one insert per vector; the new unique-id path uses one insert per chunk.

| vectors | old median | new median | saved | speedup |
|---:|---:|---:|---:|---:|
| 50 | 41.1ms | 19.8ms | 21.4ms | 2.08x |
| 200 | 161.7ms | 65.9ms | 95.8ms | 2.45x |
| 500 | 308.1ms | 144.3ms | 163.8ms | 2.14x |

## Notes

I kept the implementation to chunked multi-row inserts rather than parallel per-row inserts, `COPY`, or staging-table based bulk load. Parallel inserts would increase pool pressure and complicate transaction semantics. `COPY` or staging-table bulk load could be faster for very large imports, but would add more complexity than this adapter path needs.

Duplicate IDs keep the previous serial path because multi-row `ON CONFLICT DO UPDATE` cannot affect the same row twice in one statement.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Validation

- `pnpm --filter ./stores/pg exec vitest run src/vector/index.schema-name.test.ts`
- `pnpm --filter ./stores/pg build:lib`
- `pnpm --filter ./stores/pg lint`
- `pnpm prettier --check stores/pg/src/vector/index.ts stores/pg/src/vector/index.schema-name.test.ts .changeset/thick-lands-shine.md`
- `pnpm --filter ./stores/pg exec vitest run src/vector/index.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Instead of inserting each vector one at a time, this change groups many vectors into fewer batched database inserts so bulk uploads are much faster while keeping duplicate handling and transaction behavior the same.

## Summary

PgVector.upsert() now batches non-duplicate multi-vector upserts into chunked multi-row INSERT ... ON CONFLICT statements (controlled by VECTOR_UPSERT_BATCH_SIZE = 1000) to reduce DB round trips and Postgres client pool checkout time. If duplicate vector IDs are present in the input, the code falls back to the previous per-row INSERT ... ON CONFLICT ... DO UPDATE path because Postgres multi-row ON CONFLICT cannot update the same row twice. The batched path no longer reads embeddings back from SQL (the method still returns the provided/generated IDs).

### Key Changes

- stores/pg/src/vector/index.ts
  - Added VECTOR_UPSERT_BATCH_SIZE constant and chunked multi-row upsert path.
  - Detects duplicate IDs to preserve prior serial per-row upsert behavior for duplicates.
  - Multi-row INSERTs use EXCLUDED to update embedding and metadata on conflict; batching loops over vectors in chunks.

- stores/pg/src/vector/index.schema-name.test.ts
  - Added tests/mocks asserting batched multi-row INSERTs use correct casts/placeholders, verify chunk-splitting for large unique-id upserts, and ensure duplicate IDs trigger serial per-row INSERTs while preserving returned ID ordering.

- stores/pg/src/vector/index.test.ts
  - Added tests validating atomic filtered replacement with deleteFilter and rollback across bulk upsert chunks (ensuring no partial commits when a later chunk fails).

- packages/memory/integration-tests/src/shared/with-pg-storage.ts
  - Added an integration test exercising observational-memory indexing/search against the PG storage path.

- .changeset/thick-lands-shine.md
  - Added a patch changeset for `@mastra/pg` noting improved upsert performance.

### Performance Impact

Local benchmarks (1536-dim vectors) show roughly 2× median insert-phase speedup for typical batch sizes (~50–500) by reducing round trips and decreasing Postgres client pool checkout contention.

### Invariants & Behaviors Preserved

- Transaction and deleteFilter atomicity across upserts
- Generated ID return order preserved
- Vector type casts (vector, halfvec, bit, sparsevec) and metadata defaults preserved
- Serial per-row behavior for duplicate IDs retained to preserve validation, casting, rollback, and last-write semantics

### Tests & Release

- New unit and integration tests added to validate batched upserts, duplicate-ID fallback, schema/type casting, atomic deleteFilter behavior, and rollback across chunks.
- Changeset added to trigger a patch release for `@mastra/pg`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
