### PR TITLE
fix(@mastra/core): move hono from dependencies to peerDependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -766,7 +766,6 @@
     "execa": "^9.6.1",
     "fastq": "^1.19.1",
     "gray-matter": "^4.0.3",
-    "hono": "^4.12.8",
     "hono-openapi": "^1.3.0",
     "ignore": "^7.0.5",
     "json-schema": "^0.4.0",
@@ -780,6 +779,7 @@
     "xxhash-wasm": "^1.1.0"
   },
   "peerDependencies": {
+    "hono": "^4.12.8",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

Closes #17395

`@mastra/core` lists `hono` as a regular `dependency`. This causes a TypeScript type incompatibility when users register handlers from `chatRoute()` (via `@mastra/ai-sdk`) on their own Hono router instance:

```
No overload matches this call.
  Argument of type 'Handler' is not assignable to parameter of type 'H<...>'.
    Types of parameters 'c' and 'c' are incompatible.
      Property '[GET_MATCH_RESULT]' is missing in type 'HonoRequest<"/chat/:agentId", unknown>'
      but required in type 'HonoRequest<any, unknown>'.
```

The `GET_MATCH_RESULT` unique symbol defined in hono becomes incompatible when two separate hono instances are resolved, even if they are the same version.

## Fix

Move `hono` from `dependencies` to `peerDependencies`.

This is a 1-line change that ensures users share the same hono instance with `@mastra/core`, making `Handler` types fully compatible — eliminating the need for unsafe `as unknown as MiddlewareHandler` assertions.

## Before / After

```ts
// Before: forced to use unsafe double assertion
router.post('/chat/:agentId', chatRouteConfig.handler as unknown as MiddlewareHandler);

// After: works as-is
router.post('/chat/:agentId', chatRouteConfig.handler);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a problem where `@mastra/core` was providing its own copy of a tool called `hono`, which caused conflicts when developers tried to use it with their own copy of the same tool. Instead of the library providing the tool, it now asks users to provide it themselves, so everyone uses the same version and things work together properly.

## Problem

`@mastra/core` listed `hono` as a direct dependency, which caused TypeScript type incompatibility issues when users registered handlers from `@mastra/ai-sdk` (produced by `chatRoute()`) on their own Hono router. Even when `hono` versions matched, separate package manager resolutions created different instances with distinct unique symbols (`GET_MATCH_RESULT`), breaking type compatibility and forcing users to use unsafe `as unknown as MiddlewareHandler` type assertions.

## Solution

Moved `hono` from `dependencies` to `peerDependencies` in `packages/core/package.json`, ensuring that `@mastra/core` and consuming applications share the same `hono` instance rather than having separate resolutions.

## Impact

- Eliminates TypeScript type incompatibility errors when registering `chatRoute()` handlers on a consumer's Hono router
- Removes the need for unsafe type assertions
- Aligns with the pattern used in `@plaidev/hono-middleware` where `hono` was similarly moved to peerDependencies
- Consumers must now explicitly include `hono` as a dependency in their own `package.json`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->