### PR TITLE
perf(pg): batch Postgres storage inserts

### DIFF
--- a/.changeset/pg-batch-insert-throughput.md
+++ b/.changeset/pg-batch-insert-throughput.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Reduced Postgres round trips when batch inserting multiple storage records.

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -22,6 +22,10 @@ import type { DbClient, QueryValues, TxClient } from '../client';
 import { PoolAdapter } from '../client';
 import { buildConstraintName } from './constraint-utils';
 
+// PostgreSQL's extended query protocol supports at most 65,535 bind parameters.
+// Keep chunked batch inserts below that limit with some headroom.
+const BATCH_INSERT_MAX_PARAMETERS = 60_000;
+
 // Re-export DbClient for external use
 export type { DbClient } from '../client';
 
@@ -163,6 +167,11 @@ function mapToSqlType(type: StorageColumn['type']): string {
       return getSqlType(type);
   }
 }
+
+type PreparedInsertRecord = {
+  columns: string[];
+  values: QueryValues;
+};
 
 export function generateTableSQL({
   tableName,
@@ -441,8 +450,8 @@ export class PgDB extends MastraBase {
   /**
    * Prepares values for insertion, handling JSONB columns by stringifying them
    */
-  private prepareValuesForInsert(record: Record<string, any>, tableName: TABLE_NAMES): any[] {
-    return Object.entries(record).map(([key, value]) => {
+  private prepareValuesForInsert(entries: [string, any][], tableName: TABLE_NAMES): QueryValues {
+    return entries.map(([key, value]) => {
       const schema = TABLE_SCHEMAS[tableName];
       const columnSchema = schema?.[key];
 
@@ -466,6 +475,181 @@ export class PgDB extends MastraBase {
     if (record.updatedAt) {
       record.updatedAtZ = record.updatedAt;
     }
+  }
+
+  private async prepareInsertRecord(
+    tableName: TABLE_NAMES,
+    record: Record<string, any>,
+  ): Promise<PreparedInsertRecord> {
+    this.addTimestampZColumns(record);
+
+    const filteredRecord = await this.filterRecordToKnownColumns(tableName, record);
+    const entries = Object.entries(filteredRecord).sort(([left], [right]) => left.localeCompare(right));
+    const columns = entries.map(([col]) => parseSqlIdentifier(col, 'column name'));
+    const values = this.prepareValuesForInsert(entries, tableName);
+
+    return { columns, values };
+  }
+
+  private buildInsertQuery({
+    tableName,
+    columns,
+    rowCount,
+  }: {
+    tableName: TABLE_NAMES;
+    columns: string[];
+    rowCount: number;
+  }): string {
+    const schemaName = getSchemaName(this.schemaName);
+    const fullTableName = getTableName({ indexName: tableName, schemaName });
+    const columnList = columns.map(c => `"${c}"`).join(', ');
+    const valueRows = Array.from({ length: rowCount }, (_, rowIndex) => {
+      const offset = rowIndex * columns.length;
+      return `(${columns.map((_, columnIndex) => `$${offset + columnIndex + 1}`).join(', ')})`;
+    }).join(', ');
+
+    if (tableName === TABLE_SPANS) {
+      const updateColumns = columns.filter(c => c !== 'traceId' && c !== 'spanId');
+      if (updateColumns.length > 0) {
+        const updateClause = updateColumns.map(c => `"${c}" = EXCLUDED."${c}"`).join(', ');
+        return `INSERT INTO ${fullTableName} (${columnList}) VALUES ${valueRows}
+             ON CONFLICT ("traceId", "spanId") DO UPDATE SET ${updateClause}`;
+      }
+
+      return `INSERT INTO ${fullTableName} (${columnList}) VALUES ${valueRows}
+             ON CONFLICT ("traceId", "spanId") DO NOTHING`;
+    }
+
+    return `INSERT INTO ${fullTableName} (${columnList}) VALUES ${valueRows}`;
+  }
+
+  private async executeBatchInsert(
+    client: Pick<TxClient, 'none'>,
+    { tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] },
+  ): Promise<void> {
+    const preparedRecords: PreparedInsertRecord[] = [];
+    for (const record of records) {
+      const preparedRecord = await this.prepareInsertRecord(tableName, record);
+      if (preparedRecord.columns.length === 0) continue;
+      preparedRecords.push(preparedRecord);
+    }
+
+    const recordGroups =
+      tableName === TABLE_SPANS
+        ? this.groupConsecutiveRecordsByColumnShape(this.sortSpanRecordsByConflictKey(preparedRecords))
+        : this.groupRecordsByColumnShape(preparedRecords);
+
+    for (const groupedRecords of recordGroups) {
+      const columns = groupedRecords[0]!.columns;
+      const maxRowsPerInsert = Math.max(1, Math.floor(BATCH_INSERT_MAX_PARAMETERS / columns.length));
+
+      for (let offset = 0; offset < groupedRecords.length; offset += maxRowsPerInsert) {
+        const batch = groupedRecords.slice(offset, offset + maxRowsPerInsert);
+        const query = this.buildInsertQuery({ tableName, columns, rowCount: batch.length });
+        const values = batch.flatMap(record => record.values);
+
+        await client.none(query, values);
+      }
+    }
+  }
+
+  private getColumnShape(record: PreparedInsertRecord): string {
+    return record.columns.join('\0');
+  }
+
+  private groupRecordsByColumnShape(records: PreparedInsertRecord[]): PreparedInsertRecord[][] {
+    const recordsByColumnShape = new Map<string, PreparedInsertRecord[]>();
+    for (const record of records) {
+      // Non-span batch inserts favor fewer statements over preserving mixed-shape input order.
+      const columnShape = this.getColumnShape(record);
+      const groupedRecords = recordsByColumnShape.get(columnShape);
+      if (groupedRecords) {
+        groupedRecords.push(record);
+      } else {
+        recordsByColumnShape.set(columnShape, [record]);
+      }
+    }
+
+    return [...recordsByColumnShape.values()];
+  }
+
+  private groupConsecutiveRecordsByColumnShape(records: PreparedInsertRecord[]): PreparedInsertRecord[][] {
+    const groups: PreparedInsertRecord[][] = [];
+    let currentGroup: PreparedInsertRecord[] = [];
+    let currentColumnShape: string | undefined;
+
+    for (const record of records) {
+      const columnShape = this.getColumnShape(record);
+      if (currentColumnShape && currentColumnShape !== columnShape) {
+        groups.push(currentGroup);
+        currentGroup = [];
+      }
+
+      currentColumnShape = columnShape;
+      currentGroup.push(record);
+    }
+
+    if (currentGroup.length > 0) {
+      groups.push(currentGroup);
+    }
+
+    return groups;
+  }
+
+  private getPreparedValue(record: PreparedInsertRecord, columnName: string): string {
+    const columnIndex = record.columns.indexOf(columnName);
+    if (columnIndex === -1) return '';
+    return String(record.values[columnIndex] ?? '');
+  }
+
+  private getRecordValue(record: Record<string, any>, columnName: string): string {
+    return String(record[columnName] ?? '');
+  }
+
+  private comparePreparedValues(left: string, right: string): number {
+    if (left < right) return -1;
+    if (left > right) return 1;
+    return 0;
+  }
+
+  private sortSpanRecordsByConflictKey(records: PreparedInsertRecord[]): PreparedInsertRecord[] {
+    return [...records].sort((left, right) => {
+      const leftTraceId = this.getPreparedValue(left, 'traceId');
+      const rightTraceId = this.getPreparedValue(right, 'traceId');
+      const traceCompare = this.comparePreparedValues(leftTraceId, rightTraceId);
+      if (traceCompare !== 0) return traceCompare;
+
+      const leftSpanId = this.getPreparedValue(left, 'spanId');
+      const rightSpanId = this.getPreparedValue(right, 'spanId');
+      return this.comparePreparedValues(leftSpanId, rightSpanId);
+    });
+  }
+
+  private sortSpanInputRecordsByConflictKey(records: Record<string, any>[]): Record<string, any>[] {
+    return [...records].sort((left, right) => {
+      const traceCompare = this.comparePreparedValues(
+        this.getRecordValue(left, 'traceId'),
+        this.getRecordValue(right, 'traceId'),
+      );
+      if (traceCompare !== 0) return traceCompare;
+
+      return this.comparePreparedValues(this.getRecordValue(left, 'spanId'), this.getRecordValue(right, 'spanId'));
+    });
+  }
+
+  private hasDuplicateSpanIds(records: Record<string, any>[]): boolean {
+    const spanIds = new Set<string>();
+    for (const record of records) {
+      // Missing or null span keys are left to the database constraints; this guard only avoids
+      // Postgres's multi-row ON CONFLICT error for duplicate concrete keys in one statement.
+      if (record.traceId == null || record.spanId == null) continue;
+      const spanKey = `${String(record.traceId)}\0${String(record.spanId)}`;
+      if (spanIds.has(spanKey)) {
+        return true;
+      }
+      spanIds.add(spanKey);
+    }
+    return false;
   }
 
   /**
@@ -570,42 +754,9 @@ export class PgDB extends MastraBase {
     client: Pick<DbClient, 'none'> | Pick<TxClient, 'none'>,
     { tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> },
   ): Promise<void> {
-    this.addTimestampZColumns(record);
-
-    // Filter out columns that don't exist in the actual database table
-    const filteredRecord = await this.filterRecordToKnownColumns(tableName, record);
-
-    const schemaName = getSchemaName(this.schemaName);
-    const columns = Object.keys(filteredRecord).map(col => parseSqlIdentifier(col, 'column name'));
+    const { columns, values } = await this.prepareInsertRecord(tableName, record);
     if (columns.length === 0) return; // No known columns after filtering - skip insert
-    const values = this.prepareValuesForInsert(filteredRecord, tableName);
-    const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
-    const fullTableName = getTableName({ indexName: tableName, schemaName });
-    const columnList = columns.map(c => `"${c}"`).join(', ');
-
-    // For spans table, use ON CONFLICT to handle duplicate (traceId, spanId) gracefully
-    if (tableName === TABLE_SPANS) {
-      // Build update clause for all columns except the primary key columns
-      const updateColumns = columns.filter(c => c !== 'traceId' && c !== 'spanId');
-
-      if (updateColumns.length > 0) {
-        const updateClause = updateColumns.map(c => `"${c}" = EXCLUDED."${c}"`).join(', ');
-        await client.none(
-          `INSERT INTO ${fullTableName} (${columnList}) VALUES (${placeholders})
-             ON CONFLICT ("traceId", "spanId") DO UPDATE SET ${updateClause}`,
-          values,
-        );
-      } else {
-        // Only PK columns provided - use DO NOTHING to avoid invalid SQL
-        await client.none(
-          `INSERT INTO ${fullTableName} (${columnList}) VALUES (${placeholders})
-             ON CONFLICT ("traceId", "spanId") DO NOTHING`,
-          values,
-        );
-      }
-    } else {
-      await client.none(`INSERT INTO ${fullTableName} (${columnList}) VALUES (${placeholders})`, values);
-    }
+    await client.none(this.buildInsertQuery({ tableName, columns, rowCount: 1 }), values);
   }
 
   async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
@@ -1206,9 +1357,14 @@ export class PgDB extends MastraBase {
   async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
     try {
       await this.client.tx(async tx => {
-        for (const record of records) {
-          await this.executeInsert(tx, { tableName, record });
+        if (tableName === TABLE_SPANS && this.hasDuplicateSpanIds(records)) {
+          for (const record of this.sortSpanInputRecordsByConflictKey(records)) {
+            await this.executeInsert(tx, { tableName, record });
+          }
+          return;
         }
+
+        await this.executeBatchInsert(tx, { tableName, records });
       });
     } catch (error) {
       throw new MastraError(

--- a/stores/pg/src/storage/db/transaction-client.test.ts
+++ b/stores/pg/src/storage/db/transaction-client.test.ts
@@ -1,4 +1,4 @@
-import { TABLE_THREADS } from '@mastra/core/storage';
+import { TABLE_SPANS, TABLE_THREADS } from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { DbClient, QueryValues, TxClient } from '../client';
@@ -31,9 +31,15 @@ function createMockTxClient(onNone: (query: string, values?: QueryValues) => Pro
 
 function createMockDbClient(
   txClient: TxClient,
-): DbClient & { querySpy: ReturnType<typeof vi.fn>; txSpy: ReturnType<typeof vi.fn> } {
+  tableColumns: string[] = [],
+): DbClient & {
+  querySpy: ReturnType<typeof vi.fn>;
+  txSpy: ReturnType<typeof vi.fn>;
+  manyOrNoneSpy: ReturnType<typeof vi.fn>;
+} {
   const querySpy = vi.fn(async () => ({ rows: [] }) as any);
   const txSpy = vi.fn(async <T>(callback: (t: TxClient) => Promise<T>) => callback(txClient));
+  const manyOrNoneSpy = vi.fn(async () => tableColumns.map(column_name => ({ column_name })));
 
   return {
     $pool: {} as any,
@@ -48,24 +54,34 @@ function createMockDbClient(
     }),
     oneOrNone: vi.fn(async () => null),
     any: vi.fn(async () => []),
-    manyOrNone: vi.fn(async () => []),
+    manyOrNone: manyOrNoneSpy,
     many: vi.fn(async () => []),
     query: querySpy,
     tx: txSpy,
     querySpy,
     txSpy,
-  } as DbClient & { querySpy: ReturnType<typeof vi.fn>; txSpy: ReturnType<typeof vi.fn> };
+    manyOrNoneSpy,
+  } as DbClient & {
+    querySpy: ReturnType<typeof vi.fn>;
+    txSpy: ReturnType<typeof vi.fn>;
+    manyOrNoneSpy: ReturnType<typeof vi.fn>;
+  };
+}
+
+function setupBatchInsertHarness(tableColumns?: string[]) {
+  const txCalls: Array<{ query: string; values?: QueryValues }> = [];
+  const txClient = createMockTxClient(async (query, values) => {
+    txCalls.push({ query, values });
+    return null;
+  });
+  const client = createMockDbClient(txClient, tableColumns);
+  const db = new PgDB({ client });
+  return { txCalls, client, db };
 }
 
 describe('PgDB transaction handling', () => {
   it('uses tx() for batchInsert instead of manual BEGIN/COMMIT/ROLLBACK queries', async () => {
-    const txStatements: string[] = [];
-    const txClient = createMockTxClient(async query => {
-      txStatements.push(query);
-      return null;
-    });
-    const client = createMockDbClient(txClient);
-    const db = new PgDB({ client });
+    const { txCalls, client, db } = setupBatchInsertHarness();
 
     await db.batchInsert({
       tableName: TABLE_THREADS,
@@ -77,8 +93,250 @@ describe('PgDB transaction handling', () => {
 
     expect(client.txSpy).toHaveBeenCalledOnce();
     expect(client.querySpy).not.toHaveBeenCalled();
-    expect(txStatements).toHaveLength(2);
-    expect(txStatements.every(query => query.startsWith('INSERT INTO'))).toBe(true);
+    expect(txCalls).toHaveLength(1);
+    expect(txCalls[0]!.query).toContain('INSERT INTO');
+    expect(txCalls[0]!.query).toContain('VALUES ($1, $2, $3, $4, $5), ($6, $7, $8, $9, $10)');
+    expect(txCalls[0]!.values).toHaveLength(10);
+  });
+
+  it('uses the table column cache while preparing batchInsert records', async () => {
+    const { txCalls, client, db } = setupBatchInsertHarness([
+      'id',
+      'resourceId',
+      'title',
+      'createdAt',
+      'updatedAt',
+      'createdAtZ',
+      'updatedAtZ',
+    ]);
+
+    await db.batchInsert({
+      tableName: TABLE_THREADS,
+      records: [
+        {
+          id: 'thread-1',
+          resourceId: 'resource-1',
+          title: 'One',
+          createdAt: new Date('2024-01-01T00:00:00.000Z'),
+          updatedAt: new Date('2024-01-01T00:00:01.000Z'),
+          ignoredColumn: true,
+        },
+        {
+          id: 'thread-2',
+          resourceId: 'resource-1',
+          title: 'Two',
+          createdAt: new Date('2024-01-01T00:00:02.000Z'),
+          updatedAt: new Date('2024-01-01T00:00:03.000Z'),
+          ignoredColumn: true,
+        },
+      ],
+    });
+
+    expect(client.manyOrNoneSpy).toHaveBeenCalledOnce();
+    expect(txCalls).toHaveLength(1);
+    expect(txCalls[0]!.query).not.toContain('ignoredColumn');
+    expect(txCalls[0]!.values).toHaveLength(14);
+  });
+
+  it('keeps separate batchInsert statements for incompatible column shapes', async () => {
+    const { txCalls, client, db } = setupBatchInsertHarness();
+
+    await db.batchInsert({
+      tableName: TABLE_THREADS,
+      records: [
+        { id: 'thread-1', resourceId: 'resource-1', createdAt: new Date('2024-01-01T00:00:00.000Z') },
+        { id: 'thread-2', resourceId: 'resource-1', title: 'Two', createdAt: new Date('2024-01-01T00:00:01.000Z') },
+      ],
+    });
+
+    expect(client.txSpy).toHaveBeenCalledOnce();
+    expect(client.querySpy).not.toHaveBeenCalled();
+    expect(txCalls).toHaveLength(2);
+    expect(txCalls[0]!.query).toContain('VALUES ($1, $2, $3, $4)');
+    expect(txCalls[0]!.values).toHaveLength(4);
+    expect(txCalls[1]!.query).toContain('VALUES ($1, $2, $3, $4, $5)');
+    expect(txCalls[1]!.values).toHaveLength(5);
+  });
+
+  it('batches compatible records even when incompatible shapes are interleaved', async () => {
+    const { txCalls, db } = setupBatchInsertHarness();
+
+    await db.batchInsert({
+      tableName: TABLE_THREADS,
+      records: [
+        { id: 'thread-1', resourceId: 'resource-1', createdAt: new Date('2024-01-01T00:00:00.000Z') },
+        { id: 'thread-2', resourceId: 'resource-1', title: 'Two', createdAt: new Date('2024-01-01T00:00:01.000Z') },
+        { id: 'thread-3', resourceId: 'resource-1', createdAt: new Date('2024-01-01T00:00:02.000Z') },
+      ],
+    });
+
+    expect(txCalls).toHaveLength(2);
+    expect(txCalls[0]!.values).toContain('thread-1');
+    expect(txCalls[0]!.values).toContain('thread-3');
+    expect(txCalls[0]!.values).not.toContain('thread-2');
+    expect(txCalls[0]!.query).toContain('VALUES ($1, $2, $3, $4), ($5, $6, $7, $8)');
+    expect(txCalls[1]!.values).toContain('thread-2');
+    expect(txCalls[1]!.values).not.toContain('thread-1');
+    expect(txCalls[1]!.values).not.toContain('thread-3');
+    expect(txCalls[1]!.query).toContain('VALUES ($1, $2, $3, $4, $5)');
+  });
+
+  it('batches records with the same columns regardless of input key order', async () => {
+    const { txCalls, db } = setupBatchInsertHarness();
+
+    await db.batchInsert({
+      tableName: TABLE_THREADS,
+      records: [
+        { id: 'thread-1', resourceId: 'resource-1', title: 'One', createdAt: new Date('2024-01-01T00:00:00.000Z') },
+        { title: 'Two', resourceId: 'resource-1', createdAt: new Date('2024-01-01T00:00:01.000Z'), id: 'thread-2' },
+      ],
+    });
+
+    expect(txCalls).toHaveLength(1);
+    expect(txCalls[0]!.values).toHaveLength(10);
+  });
+
+  it('splits batchInsert statements at the Postgres parameter boundary', async () => {
+    const { txCalls, client, db } = setupBatchInsertHarness();
+
+    await db.batchInsert({
+      tableName: TABLE_THREADS,
+      records: Array.from({ length: 12_001 }, (_, index) => ({
+        id: `thread-${index}`,
+        resourceId: 'resource-1',
+        title: `Thread ${index}`,
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      })),
+    });
+
+    expect(client.txSpy).toHaveBeenCalledOnce();
+    expect(client.querySpy).not.toHaveBeenCalled();
+    expect(txCalls).toHaveLength(2);
+    expect(txCalls[0]!.query).toContain('VALUES ($1, $2, $3, $4, $5)');
+    expect(txCalls[0]!.values).toHaveLength(60_000);
+    expect(txCalls[1]!.query).toContain('VALUES ($1, $2, $3, $4, $5)');
+    expect(txCalls[1]!.values).toHaveLength(5);
+  });
+
+  it('batches distinct span inserts with the ON CONFLICT update clause', async () => {
+    const { txCalls, db } = setupBatchInsertHarness();
+
+    await db.batchInsert({
+      tableName: TABLE_SPANS,
+      records: [
+        { traceId: 'trace-1', spanId: 'span-1', name: 'first' },
+        { traceId: 'trace-1', spanId: 'span-2', name: 'second' },
+      ],
+    });
+
+    expect(txCalls).toHaveLength(1);
+    expect(txCalls[0]!.query).toContain('VALUES ($1, $2, $3), ($4, $5, $6)');
+    expect(txCalls[0]!.query).toContain('ON CONFLICT ("traceId", "spanId") DO UPDATE SET');
+    expect(txCalls[0]!.values).toHaveLength(6);
+  });
+
+  it('orders span batch rows by conflict key before upsert', async () => {
+    const { txCalls, db } = setupBatchInsertHarness();
+
+    await db.batchInsert({
+      tableName: TABLE_SPANS,
+      records: [
+        { traceId: 'trace-1', spanId: 'span-2', name: 'second' },
+        { traceId: 'trace-1', spanId: 'span-1', name: 'first' },
+      ],
+    });
+
+    expect(txCalls).toHaveLength(1);
+    expect(txCalls[0]!.values!.indexOf('span-1')).toBeLessThan(txCalls[0]!.values!.indexOf('span-2'));
+  });
+
+  it('orders mixed-shape span inserts by conflict key before grouping compatible rows', async () => {
+    const { txCalls, db } = setupBatchInsertHarness();
+
+    await db.batchInsert({
+      tableName: TABLE_SPANS,
+      records: [
+        { traceId: 'trace-1', spanId: 'span-1', name: 'first', startedAt: '2024-01-01T00:00:00.000Z' },
+        {
+          traceId: 'trace-1',
+          spanId: 'span-2',
+          name: 'second',
+          parentSpanId: 'span-1',
+          startedAt: '2024-01-01T00:00:01.000Z',
+        },
+        { traceId: 'trace-1', spanId: 'span-3', name: 'third', startedAt: '2024-01-01T00:00:02.000Z' },
+      ],
+    });
+
+    expect(txCalls).toHaveLength(3);
+    expect(txCalls[0]!.query).toContain('VALUES ($1, $2, $3, $4)');
+    expect(txCalls[0]!.query).toContain('ON CONFLICT ("traceId", "spanId") DO UPDATE SET');
+    expect(txCalls[0]!.values).toContain('span-1');
+    expect(txCalls[0]!.values).not.toContain('span-2');
+    expect(txCalls[0]!.values).not.toContain('span-3');
+    expect(txCalls[1]!.query).toContain('VALUES ($1, $2, $3, $4, $5)');
+    expect(txCalls[1]!.query).toContain('ON CONFLICT ("traceId", "spanId") DO UPDATE SET');
+    expect(txCalls[1]!.values).toContain('span-2');
+    expect(txCalls[2]!.query).toContain('VALUES ($1, $2, $3, $4)');
+    expect(txCalls[2]!.query).toContain('ON CONFLICT ("traceId", "spanId") DO UPDATE SET');
+    expect(txCalls[2]!.values).toContain('span-3');
+  });
+
+  it('uses DO NOTHING for span batches with only conflict key columns', async () => {
+    const { txCalls, db } = setupBatchInsertHarness(['traceId', 'spanId']);
+
+    await db.batchInsert({
+      tableName: TABLE_SPANS,
+      records: [
+        { traceId: 'trace-1', spanId: 'span-1', name: 'first' },
+        { traceId: 'trace-1', spanId: 'span-2', name: 'second' },
+      ],
+    });
+
+    expect(txCalls).toHaveLength(1);
+    expect(txCalls[0]!.query).toContain('VALUES ($1, $2), ($3, $4)');
+    expect(txCalls[0]!.query).toContain('ON CONFLICT ("traceId", "spanId") DO NOTHING');
+    expect(txCalls[0]!.values).toEqual(['span-1', 'trace-1', 'span-2', 'trace-1']);
+  });
+
+  it('falls back to serial span inserts for duplicate span ids in the same batch', async () => {
+    const { txCalls, client, db } = setupBatchInsertHarness();
+
+    await db.batchInsert({
+      tableName: TABLE_SPANS,
+      records: [
+        { traceId: 'trace-1', spanId: 'span-2', name: 'third' },
+        { traceId: 'trace-1', spanId: 'span-1', name: 'first' },
+        { traceId: 'trace-1', spanId: 'span-1', name: 'second' },
+      ],
+    });
+
+    expect(client.txSpy).toHaveBeenCalledOnce();
+    expect(client.querySpy).not.toHaveBeenCalled();
+    expect(txCalls).toHaveLength(3);
+    expect(txCalls.every(call => call.query.includes('ON CONFLICT ("traceId", "spanId") DO UPDATE'))).toBe(true);
+    expect(txCalls[0]!.query).toContain('VALUES ($1, $2, $3)');
+    expect(txCalls[1]!.query).toContain('VALUES ($1, $2, $3)');
+    expect(txCalls[2]!.query).toContain('VALUES ($1, $2, $3)');
+    expect(txCalls[0]!.values).toEqual(['first', 'span-1', 'trace-1']);
+    expect(txCalls[1]!.values).toEqual(['second', 'span-1', 'trace-1']);
+    expect(txCalls[2]!.values).toEqual(['third', 'span-2', 'trace-1']);
+  });
+
+  it('does not use the duplicate span fallback for null span keys', async () => {
+    const { txCalls, db } = setupBatchInsertHarness();
+
+    await db.batchInsert({
+      tableName: TABLE_SPANS,
+      records: [
+        { traceId: 'trace-1', spanId: null, name: 'first' },
+        { traceId: 'trace-1', spanId: null, name: 'second' },
+      ],
+    });
+
+    expect(txCalls).toHaveLength(1);
+    expect(txCalls[0]!.query).toContain('VALUES ($1, $2, $3), ($4, $5, $6)');
+    expect(txCalls[0]!.query).toContain('ON CONFLICT ("traceId", "spanId") DO UPDATE');
   });
 
   it('uses tx() for batchUpdate instead of manual BEGIN/COMMIT/ROLLBACK queries', async () => {

--- a/stores/pg/src/storage/migration.test.ts
+++ b/stores/pg/src/storage/migration.test.ts
@@ -1270,6 +1270,80 @@ describe('PostgreSQL Spans ON CONFLICT Handling', () => {
     );
     expect(Number(result.count)).toBe(2);
   }, 30000);
+
+  it('should handle duplicate span ids inside the same batch insert', async () => {
+    await expect(
+      observability.batchCreateSpans({
+        records: [
+          {
+            traceId: 'trace-same-batch-duplicate',
+            spanId: 'span-same-batch-2',
+            name: 'Other span',
+            spanType: SpanType.TOOL_CALL,
+            isEvent: false,
+            startedAt: new Date('2024-01-01T00:00:00Z'),
+          },
+          {
+            traceId: 'trace-same-batch-duplicate',
+            spanId: 'span-same-batch-1',
+            name: 'First duplicate write',
+            spanType: SpanType.AGENT_RUN,
+            isEvent: false,
+            startedAt: new Date('2024-01-01T00:00:00Z'),
+          },
+          {
+            traceId: 'trace-same-batch-duplicate',
+            spanId: 'span-same-batch-1',
+            name: 'Second duplicate write',
+            spanType: SpanType.AGENT_RUN,
+            isEvent: false,
+            startedAt: new Date('2024-01-01T00:00:01Z'),
+          },
+        ],
+      }),
+    ).resolves.not.toThrow();
+
+    const result = await store.db.one<{ count: string }>(
+      `SELECT COUNT(*) as count FROM ${testSchema}.${TABLE_SPANS}
+       WHERE "traceId" = 'trace-same-batch-duplicate'`,
+    );
+    expect(Number(result.count)).toBe(2);
+
+    const duplicate = await store.db.one<{ name: string }>(
+      `SELECT name FROM ${testSchema}.${TABLE_SPANS}
+       WHERE "traceId" = 'trace-same-batch-duplicate' AND "spanId" = 'span-same-batch-1'`,
+    );
+    expect(duplicate.name).toBe('Second duplicate write');
+  }, 30000);
+
+  it('should handle concurrent overlapping batch span upserts with divergent input order', async () => {
+    const batches = Array.from({ length: 5 }, (_, batchIndex) => {
+      const spans = Array.from({ length: 20 }, (_, spanIndex) => ({
+        traceId: 'trace-concurrent-conflict',
+        spanId: `span-concurrent-${spanIndex}`,
+        ...(spanIndex % 2 === 1 ? { parentSpanId: 'span-concurrent-0' } : {}),
+        name: `Concurrent span ${batchIndex}-${spanIndex}`,
+        spanType: SpanType.AGENT_RUN,
+        isEvent: false,
+        startedAt: new Date('2024-01-01T00:00:00Z'),
+      }));
+      return batchIndex % 2 === 0 ? spans : spans.reverse();
+    });
+
+    await Promise.all(batches.map(records => observability.batchCreateSpans({ records })));
+
+    const result = await store.db.one<{ count: string }>(
+      `SELECT COUNT(*) as count FROM ${testSchema}.${TABLE_SPANS}
+       WHERE "traceId" = 'trace-concurrent-conflict'`,
+    );
+    expect(Number(result.count)).toBe(20);
+
+    const sample = await store.db.one<{ name: string }>(
+      `SELECT name FROM ${testSchema}.${TABLE_SPANS}
+       WHERE "traceId" = 'trace-concurrent-conflict' AND "spanId" = 'span-concurrent-0'`,
+    );
+    expect(sample.name).toMatch(/^Concurrent span [0-4]-0$/);
+  }, 30000);
 });
 
 /**


### PR DESCRIPTION
## Description

Updates `PgDB.batchInsert` to group compatible records into multi-row parameterized `INSERT` statements instead of sending one insert statement per record.

This targets batched Postgres storage writes, especially observability span ingestion. The implementation keeps the existing transaction boundary and reuses the same record preparation path as single-row inserts.

The batching logic:

- filters records against known table columns before building SQL
- canonicalizes column order so equivalent records batch together
- chunks statements below PostgreSQL bind-parameter limits
- preserves span `ON CONFLICT ("traceId", "spanId")` upsert behavior
- falls back to serial span inserts when the same `(traceId, spanId)` appears more than once in a single input batch

Local Docker Postgres benchmark:

The old path sends one insert statement per record, so the record count is also the old statement count.

| records | new statements | old median | new median |
| ---: | ---: | ---: | ---: |
| 100 | 1 | 22.0ms | 2.9ms |
| 1,000 | 1 | 192.2ms | 12.9ms |
| 5,000 | 1 | 906.1ms | 62.6ms |
| 12,001 | 2 | 2138.2ms | 134.2ms |

## Related issue(s)

Fixes #17398

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Validation

- `pnpm --filter ./stores/pg exec vitest run src/storage/db/transaction-client.test.ts`
- `pnpm --filter ./stores/pg exec vitest run src/storage/migration.test.ts -t "batch insert"`
- `pnpm --filter ./stores/pg build:lib`
- `pnpm --filter ./stores/pg lint`
- `pnpm prettier --check stores/pg/src/storage/db/index.ts stores/pg/src/storage/db/transaction-client.test.ts .changeset/pg-batch-insert-throughput.md`
- `TZ=UTC pnpm --filter ./stores/pg test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Instead of saving each record with its own database request (like sending one letter per truck), this PR groups compatible records and inserts many at once (like loading many letters into one truck), making bulk saves much faster.

## Overview

This PR implements batching for Postgres storage inserts in PgDB.batchInsert: compatible records are grouped into multi-row parameterized INSERT statements rather than issuing one INSERT per record. The change preserves transaction boundaries, existing column-filtering behavior, and span upsert semantics, and it chunks statements to stay under PostgreSQL bind-parameter limits.

Performance (local Docker Postgres median latencies):
- 100 records: 22.0ms → 2.9ms (1 statement)
- 1,000 records: 192.2ms → 12.9ms (1 statement)
- 5,000 records: 906.1ms → 62.6ms (1 statement)
- 12,001 records: 2138.2ms → 134.2ms (2 statements)

Fixes: `#17398`

## Changes

stores/pg/src/storage/db/index.ts
- Added bind-parameter-limit-aware batching path and refactored single-row & batch insert flow into a shared "prepare → build query → execute" pipeline.
- New helpers: prepareInsertRecord, buildInsertQuery; introduced BATCH_INSERT_MAX_PARAMETERS and helpers for filtering/normalizing/sorting record columns and values.
- Filters records to known table columns and canonicalizes column order so equivalent records batch together.
- Generates multi-row INSERTs with:
  - ON CONFLICT ("traceId","spanId") DO UPDATE when non-PK columns exist,
  - DO NOTHING when only PK/conflict columns are present.
- Chunks multi-row statements to keep total bind parameters under PostgreSQL limits.
- For spans, detects duplicate (traceId, spanId) within the same input batch and falls back to serial inserts (after ordering by conflict key) to avoid invalid multi-row ON CONFLICT updates.
- executeInsert updated to use the new pipeline and skip inserts when no known columns remain; prepareValuesForInsert now operates on sorted key/value entries.
- No exported/public API changes.

stores/pg/src/storage/db/transaction-client.test.ts
- Expanded and revised tests to assert multi-row INSERT shapes, placeholder grouping, total bound parameter counts, filtering by cached table columns, batching across mixed/incompatible record shapes, parameter-limit splitting, and span-specific upsert behaviors.
- Tests for ordering by conflict keys, DO NOTHING behavior when only conflict-key columns are present, and fallback to serial inserts on duplicate span keys.
- Enhanced mock DbClient/TxClient harness with configurable cached tableColumns and query/tx spies to capture executed SQL and bound parameters.
- Test-only changes; no public API changes.

stores/pg/src/storage/migration.test.ts
- Added Vitest cases covering:
  - batchCreateSpans handling duplicate (traceId, spanId) within a single batch (deduplication, last-write retention).
  - Concurrent batch upserts with overlapping spans and differing record order resolving to a valid outcome.
- Test-only changes.

.changeset/pg-batch-insert-throughput.md
- Added changeset documenting a patch bump for `@mastra/pg` and noting reduced Postgres round trips from batched inserts.

## Impact

- Performance: Significant throughput improvement for bulk inserts (observed up to ~16x in local benchmarks).
- Backward compatibility: Transaction semantics, column filtering, and span upsert behavior preserved.
- Safety: Batches are chunked to respect parameter limits; duplicate span keys within a single input batch trigger a safe serial-insert fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->