### PR TITLE
fix(playground-ui): refine checkbox states

### DIFF
--- a/.changeset/upset-cats-sniff.md
+++ b/.changeset/upset-cats-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved Checkbox styling with neutral selected states, cleaner focus outlines, and smoother state transitions.

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx
@@ -13,7 +13,8 @@ const meta: Meta<typeof Checkbox> = {
       control: { type: 'boolean' },
     },
     checked: {
-      control: { type: 'boolean' },
+      control: { type: 'radio' },
+      options: [false, true, 'indeterminate'],
     },
   },
 };
@@ -42,6 +43,52 @@ export const DisabledChecked: Story = {
     disabled: true,
     checked: true,
   },
+};
+
+export const Indeterminate: Story = {
+  args: {
+    checked: 'indeterminate',
+  },
+};
+
+export const AllStates: Story = {
+  parameters: {
+    layout: 'centered',
+  },
+  render: () => (
+    <div className="grid min-w-[26rem] gap-4 rounded-lg border border-border1 bg-surface2 p-4">
+      <div className="grid grid-cols-[9rem_repeat(4,minmax(0,1fr))] items-center gap-x-5 gap-y-3 text-ui-sm text-neutral3">
+        <span />
+        <span>Default</span>
+        <span>Checked</span>
+        <span>Mixed</span>
+        <span>Focus</span>
+
+        <span className="text-neutral5">Enabled</span>
+        <Checkbox aria-label="enabled unchecked" />
+        <Checkbox aria-label="enabled checked" checked onCheckedChange={() => {}} />
+        <Checkbox aria-label="enabled mixed" checked="indeterminate" onCheckedChange={() => {}} />
+        <Checkbox
+          aria-label="focused checked"
+          checked
+          onCheckedChange={() => {}}
+          className="border-neutral5/60 outline outline-1 outline-offset-2 outline-neutral5/55"
+        />
+
+        <span className="text-neutral5">Disabled</span>
+        <Checkbox aria-label="disabled unchecked" disabled />
+        <Checkbox aria-label="disabled checked" checked disabled onCheckedChange={() => {}} />
+        <Checkbox aria-label="disabled mixed" checked="indeterminate" disabled onCheckedChange={() => {}} />
+        <Checkbox
+          aria-label="disabled focus preview"
+          checked
+          disabled
+          onCheckedChange={() => {}}
+          className="border-neutral5/60 outline outline-1 outline-offset-2 outline-neutral5/35"
+        />
+      </div>
+    </div>
+  ),
 };
 
 export const WithLabel: Story = {

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx
@@ -2,6 +2,42 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Label } from '../Label';
 import { Checkbox } from './checkbox';
 
+const SURFACES: { token: string; label: string; className: string }[] = [
+  { token: 'surface1', label: 'surface1 · 0% (studio shell)', className: 'bg-surface1' },
+  { token: 'surface2', label: 'surface2 · 16% (main frame)', className: 'bg-surface2' },
+  { token: 'surface3', label: 'surface3 · 18%', className: 'bg-surface3' },
+  { token: 'surface4', label: 'surface4 · 22%', className: 'bg-surface4' },
+];
+
+function SurfaceFrame({ className, label, children }: { className: string; label: string; children: React.ReactNode }) {
+  return (
+    <div className={`rounded-2xl border border-border1 p-5 ${className}`}>
+      <p className="mb-4 text-ui-xs uppercase tracking-wide text-neutral3">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+function CheckboxStateGrid({ idPrefix }: { idPrefix: string }) {
+  return (
+    <div className="grid grid-cols-[5rem_repeat(5,minmax(0,1fr))] items-center gap-x-4 gap-y-3 text-ui-sm text-neutral3">
+      <span />
+      <span>Default</span>
+      <span>Checked</span>
+      <span>Mixed</span>
+      <span>Disabled</span>
+      <span>Disabled on</span>
+
+      <span className="text-neutral5">State</span>
+      <Checkbox aria-label={`${idPrefix} default`} />
+      <Checkbox aria-label={`${idPrefix} checked`} checked onCheckedChange={() => {}} />
+      <Checkbox aria-label={`${idPrefix} mixed`} checked="indeterminate" onCheckedChange={() => {}} />
+      <Checkbox aria-label={`${idPrefix} disabled`} disabled />
+      <Checkbox aria-label={`${idPrefix} disabled checked`} checked disabled onCheckedChange={() => {}} />
+    </div>
+  );
+}
+
 const meta: Meta<typeof Checkbox> = {
   title: 'Elements/Checkbox',
   component: Checkbox,
@@ -87,6 +123,21 @@ export const AllStates: Story = {
           className="border-neutral5/60 outline outline-1 outline-offset-2 outline-neutral5/35"
         />
       </div>
+    </div>
+  ),
+};
+
+export const OnSurfaces: Story = {
+  parameters: {
+    layout: 'padded',
+  },
+  render: () => (
+    <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+      {SURFACES.map(({ token, label, className }) => (
+        <SurfaceFrame key={token} className={className} label={label}>
+          <CheckboxStateGrid idPrefix={token} />
+        </SurfaceFrame>
+      ))}
     </div>
   ),
 };

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
@@ -57,7 +57,7 @@ const Checkbox = React.forwardRef<HTMLSpanElement, CheckboxProps>(
           keepMounted
           className={cn(
             'group/checkbox-indicator flex items-center justify-center text-current',
-            'opacity-0 scale-75 transition-[opacity,transform] duration-150 ease-out-custom',
+            'opacity-0 scale-75 transition-[opacity,transform] duration-200 ease-out-custom',
             'data-[checked]:opacity-100 data-[checked]:scale-100',
             'data-[indeterminate]:opacity-100 data-[indeterminate]:scale-100',
             'data-[starting-style]:opacity-0 data-[starting-style]:scale-75',
@@ -79,8 +79,22 @@ Checkbox.displayName = 'Checkbox';
 function CheckboxIndicatorIcon() {
   return (
     <>
-      <Check className="size-3 stroke-[3.25] group-data-[indeterminate]/checkbox-indicator:hidden" />
-      <Minus className="hidden size-3 stroke-[3.25] group-data-[indeterminate]/checkbox-indicator:block" />
+      <Check
+        className={cn(
+          'size-3 scale-95 stroke-[3.25] transition-[stroke-dashoffset,transform] duration-200 ease-out-custom',
+          '[stroke-dasharray:18] [stroke-dashoffset:18]',
+          'group-data-[checked]/checkbox-indicator:[stroke-dashoffset:0]',
+          'group-data-[checked]/checkbox-indicator:scale-100',
+          'group-data-[indeterminate]/checkbox-indicator:hidden',
+        )}
+      />
+      <Minus
+        className={cn(
+          'hidden size-3 scale-95 stroke-[3.25] transition-transform duration-200 ease-out-custom',
+          'group-data-[indeterminate]/checkbox-indicator:block',
+          'group-data-[indeterminate]/checkbox-indicator:scale-100',
+        )}
+      />
     </>
   );
 }

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
@@ -48,7 +48,7 @@ const Checkbox = React.forwardRef<HTMLSpanElement, CheckboxProps>(
           'data-[checked]:active:border-neutral4 data-[checked]:active:bg-neutral4',
           'data-[indeterminate]:active:border-neutral4 data-[indeterminate]:active:bg-neutral4',
           // Base UI's Checkbox.Root is a `<span>`, so `:disabled` never matches; target `data-disabled`.
-          'data-[disabled]:cursor-not-allowed data-[disabled]:border-neutral6/[0.03] data-[disabled]:bg-neutral6/[0.05] data-[disabled]:hover:border-neutral6/[0.03] data-[disabled]:hover:bg-neutral6/[0.05] data-[disabled]:active:scale-100',
+          'data-[disabled]:cursor-not-allowed data-[disabled]:border-neutral6/[0.38] data-[disabled]:bg-neutral6/[0.38] data-[disabled]:hover:border-neutral6/[0.38] data-[disabled]:hover:bg-neutral6/[0.38] data-[disabled]:active:scale-100',
           'data-[disabled]:data-[checked]:border-neutral6/[0.38] data-[disabled]:data-[checked]:bg-neutral6/[0.38] data-[disabled]:data-[checked]:text-neutral6',
           'data-[disabled]:data-[indeterminate]:border-neutral6/[0.38] data-[disabled]:data-[indeterminate]:bg-neutral6/[0.38] data-[disabled]:data-[indeterminate]:text-neutral6',
           className,

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
@@ -36,19 +36,21 @@ const Checkbox = React.forwardRef<HTMLSpanElement, CheckboxProps>(
         data-slot="checkbox"
         className={cn(
           'peer flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-[0.3125rem]',
-          'border border-neutral6/[0.16] bg-neutral6/[0.08] text-surface1 outline-hidden',
+          'border border-neutral6/[0.06] bg-neutral6/[0.12] text-surface1 outline-hidden',
           transitions.all,
-          'hover:border-neutral6/[0.24] hover:bg-neutral6/[0.12]',
-          'active:scale-95 active:border-neutral6/[0.3] active:bg-neutral6/[0.14]',
+          'hover:border-neutral6/[0.12] hover:bg-neutral6/[0.16]',
+          'active:scale-95 active:border-neutral6/[0.18] active:bg-neutral6/[0.18]',
           'focus-visible:border-neutral5/50 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
-          // Base UI's Checkbox.Root is a `<span>`, so `:disabled` never matches — target `data-disabled`.
-          'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-60 data-[disabled]:hover:border-neutral6/[0.16] data-[disabled]:hover:bg-neutral6/[0.08] data-[disabled]:active:scale-100',
           'data-[checked]:border-neutral6 data-[checked]:bg-neutral6 data-[checked]:text-surface1',
           'data-[indeterminate]:border-neutral6 data-[indeterminate]:bg-neutral6 data-[indeterminate]:text-surface1',
           'data-[checked]:hover:border-neutral5 data-[checked]:hover:bg-neutral5',
           'data-[indeterminate]:hover:border-neutral5 data-[indeterminate]:hover:bg-neutral5',
           'data-[checked]:active:border-neutral4 data-[checked]:active:bg-neutral4',
           'data-[indeterminate]:active:border-neutral4 data-[indeterminate]:active:bg-neutral4',
+          // Base UI's Checkbox.Root is a `<span>`, so `:disabled` never matches; target `data-disabled`.
+          'data-[disabled]:cursor-not-allowed data-[disabled]:border-neutral6/[0.03] data-[disabled]:bg-neutral6/[0.05] data-[disabled]:hover:border-neutral6/[0.03] data-[disabled]:hover:bg-neutral6/[0.05] data-[disabled]:active:scale-100',
+          'data-[disabled]:data-[checked]:border-neutral6/[0.38] data-[disabled]:data-[checked]:bg-neutral6/[0.38] data-[disabled]:data-[checked]:text-neutral6',
+          'data-[disabled]:data-[indeterminate]:border-neutral6/[0.38] data-[disabled]:data-[indeterminate]:bg-neutral6/[0.38] data-[disabled]:data-[indeterminate]:text-neutral6',
           className,
         )}
         {...props}

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
@@ -36,13 +36,13 @@ const Checkbox = React.forwardRef<HTMLSpanElement, CheckboxProps>(
         data-slot="checkbox"
         className={cn(
           'peer flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-[0.3125rem]',
-          'border border-neutral6/5 bg-neutral6/5 text-surface1 outline-hidden',
+          'border border-neutral6/[0.16] bg-neutral6/[0.08] text-surface1 outline-hidden',
           transitions.all,
-          'hover:border-border2 hover:bg-surface-overlay-strong',
-          'active:scale-95 active:border-neutral5/35 active:bg-surface-overlay-strong',
+          'hover:border-neutral6/[0.24] hover:bg-neutral6/[0.12]',
+          'active:scale-95 active:border-neutral6/[0.3] active:bg-neutral6/[0.14]',
           'focus-visible:border-neutral5/50 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
           // Base UI's Checkbox.Root is a `<span>`, so `:disabled` never matches — target `data-disabled`.
-          'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-40 data-[disabled]:hover:border-neutral6/5 data-[disabled]:hover:bg-neutral6/5 data-[disabled]:active:scale-100',
+          'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-60 data-[disabled]:hover:border-neutral6/[0.16] data-[disabled]:hover:bg-neutral6/[0.08] data-[disabled]:active:scale-100',
           'data-[checked]:border-neutral6 data-[checked]:bg-neutral6 data-[checked]:text-surface1',
           'data-[indeterminate]:border-neutral6 data-[indeterminate]:bg-neutral6 data-[indeterminate]:text-surface1',
           'data-[checked]:hover:border-neutral5 data-[checked]:hover:bg-neutral5',

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
@@ -35,7 +35,7 @@ const Checkbox = React.forwardRef<HTMLSpanElement, CheckboxProps>(
         indeterminate={indeterminate ?? isCheckedIndeterminate}
         data-slot="checkbox"
         className={cn(
-          'peer flex h-4 w-4 shrink-0 items-center justify-center rounded-[0.3125rem]',
+          'peer flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-[0.3125rem]',
           'border border-neutral6/5 bg-neutral6/5 text-surface1 outline-hidden',
           transitions.all,
           'hover:border-border2 hover:bg-surface-overlay-strong',

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
@@ -82,7 +82,9 @@ function CheckboxIndicatorIcon() {
       <Check
         className={cn(
           'size-3 scale-95 stroke-[3.25] transition-[stroke-dashoffset,transform] duration-200 ease-out-custom',
-          '[stroke-dasharray:18] [stroke-dashoffset:18]',
+          // Lucide's check path is ~22.6 units long. Use a longer dash so the
+          // final checked mark is never clipped.
+          '[stroke-dasharray:28] [stroke-dashoffset:28]',
           'group-data-[checked]/checkbox-indicator:[stroke-dashoffset:0]',
           'group-data-[checked]/checkbox-indicator:scale-100',
           'group-data-[indeterminate]/checkbox-indicator:hidden',

--- a/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
+++ b/packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx
@@ -2,7 +2,6 @@ import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox';
 import { Check, Minus } from 'lucide-react';
 import * as React from 'react';
 
-import { formElementFocus } from '@/ds/primitives/form-element';
 import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
@@ -34,31 +33,37 @@ const Checkbox = React.forwardRef<HTMLSpanElement, CheckboxProps>(
         ref={ref}
         checked={isCheckedIndeterminate ? false : checked}
         indeterminate={indeterminate ?? isCheckedIndeterminate}
+        data-slot="checkbox"
         className={cn(
-          'peer h-4 w-4 shrink-0 rounded-sm border border-neutral3',
-          'flex items-center justify-center',
-          'shadow-sm',
+          'peer flex h-4 w-4 shrink-0 items-center justify-center rounded-[0.3125rem]',
+          'border border-neutral6/5 bg-neutral6/5 text-surface1 outline-hidden',
           transitions.all,
-          'hover:border-neutral5 hover:shadow-md',
-          formElementFocus,
+          'hover:border-border2 hover:bg-surface-overlay-strong',
+          'active:scale-95 active:border-neutral5/35 active:bg-surface-overlay-strong',
+          'focus-visible:border-neutral5/50 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
           // Base UI's Checkbox.Root is a `<span>`, so `:disabled` never matches — target `data-disabled`.
-          'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:hover:border-neutral3 data-[disabled]:hover:shadow-sm',
-          'data-[checked]:bg-accent1 data-[checked]:border-accent1 data-[checked]:text-surface1',
-          'data-[indeterminate]:bg-accent1 data-[indeterminate]:border-accent1 data-[indeterminate]:text-surface1',
-          'data-[checked]:shadow-glow-accent1 data-[indeterminate]:shadow-glow-accent1',
+          'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-40 data-[disabled]:hover:border-neutral6/5 data-[disabled]:hover:bg-neutral6/5 data-[disabled]:active:scale-100',
+          'data-[checked]:border-neutral6 data-[checked]:bg-neutral6 data-[checked]:text-surface1',
+          'data-[indeterminate]:border-neutral6 data-[indeterminate]:bg-neutral6 data-[indeterminate]:text-surface1',
+          'data-[checked]:hover:border-neutral5 data-[checked]:hover:bg-neutral5',
+          'data-[indeterminate]:hover:border-neutral5 data-[indeterminate]:hover:bg-neutral5',
+          'data-[checked]:active:border-neutral4 data-[checked]:active:bg-neutral4',
+          'data-[indeterminate]:active:border-neutral4 data-[indeterminate]:active:bg-neutral4',
           className,
         )}
         {...props}
       >
         <CheckboxPrimitive.Indicator
+          keepMounted
           className={cn(
             'group/checkbox-indicator flex items-center justify-center text-current',
-            'data-[checked]:animate-in data-[checked]:zoom-in-50 data-[checked]:duration-150',
-            'data-[indeterminate]:animate-in data-[indeterminate]:zoom-in-50 data-[indeterminate]:duration-150',
+            'opacity-0 scale-75 transition-[opacity,transform] duration-150 ease-out-custom',
+            'data-[checked]:opacity-100 data-[checked]:scale-100',
+            'data-[indeterminate]:opacity-100 data-[indeterminate]:scale-100',
+            'data-[starting-style]:opacity-0 data-[starting-style]:scale-75',
+            'data-[ending-style]:opacity-0 data-[ending-style]:scale-75',
           )}
         >
-          {/* `keepMounted` is false by default, so the indicator only mounts in
-              the checked/indeterminate states — pick the icon accordingly. */}
           <CheckboxIndicatorIcon />
         </CheckboxPrimitive.Indicator>
       </CheckboxPrimitive.Root>
@@ -69,14 +74,13 @@ Checkbox.displayName = 'Checkbox';
 
 /**
  * Picks the checkmark vs. the dash based on the Indicator's data attributes.
- * The Indicator only renders while checked or indeterminate, so this reads the
- * closest element with a `data-indeterminate` attribute.
+ * The Indicator stays mounted so unchecked transitions can animate out cleanly.
  */
 function CheckboxIndicatorIcon() {
   return (
     <>
-      <Check className="h-3.5 w-3.5 stroke-3 group-data-[indeterminate]/checkbox-indicator:hidden" />
-      <Minus className="hidden h-3.5 w-3.5 stroke-3 group-data-[indeterminate]/checkbox-indicator:block" />
+      <Check className="size-3 stroke-[3.25] group-data-[indeterminate]/checkbox-indicator:hidden" />
+      <Minus className="hidden size-3 stroke-[3.25] group-data-[indeterminate]/checkbox-indicator:block" />
     </>
   );
 }

--- a/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
+++ b/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
@@ -23,7 +23,7 @@ test.describe('Dataset Items List - Behavior Tests', () => {
 
     await page.getByRole('button', { name: /Test input 1/ }).click();
 
-    await expect(page.getByText(/Created May/).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/Created [A-Z][a-z]{2} \d{1,2}, \d{4}/).first()).toBeVisible({ timeout: 5000 });
   });
 
   test('selecting Delete Items from menu enables selection mode with checkboxes', async ({ page }) => {


### PR DESCRIPTION
Updates the playground UI Checkbox to remove the green accent and glow, use neutral checked and mixed states, and give the default unchecked state a subtle filled surface with a softer border.

The Storybook checkbox stories now include indeterminate and all-state review views so enabled, disabled, mixed, checked, and focus preview states are easy to compare.

Validated with eslint on the changed checkbox files, the playground-ui checkbox Vitest run, pnpm build:playground-ui, Storybook iframe inspection, and React Doctor. CodeRabbit CLI is installed but not signed in, so a local CodeRabbit review could not run.

Before:

<img width="1106" height="1179" alt="CleanShot 2026-06-01 at 12 32 50" src="https://github.com/user-attachments/assets/103a91cf-400e-4ffb-878b-2ebdf22115af" />


After:

<img width="935" height="556" alt="CleanShot 2026-06-01 at 12 33 08" src="https://github.com/user-attachments/assets/956855cb-3a9c-40b1-916f-4a34972e7ce1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: This PR makes the checkbox look and behave more neutral and consistent — it removes the green accent/glow, gives unchecked boxes a subtle filled surface, and adds proper indeterminate/mixed visuals. It also updates Storybook so designers/devs can preview every checkbox state across different surfaces.

What changed
- Visual/style
  - Removed green accent and glow from selected/checked states; switched to neutral checked and indeterminate visuals.
  - Default unchecked state now has a subtle filled surface and softer border.
  - Improved focus outlines and smoother state transitions for checked/indeterminate/unchecked interactions.
- Component implementation
  - Checkbox indicator is now kept mounted (keepMounted) for smoother transitions; visibility toggled via data-driven classes and opacity/scale transitions.
  - Focus/disabled and checked/indeterminate styling handled by updated utility class strings and explicit focus-visible rules; removed import of formElementFocus.
  - Check and Minus icons restyled to use stroke-dasharray/dashoffset transitions and refined sizing classes.
- Storybook / docs
  - Added indeterminate story plus AllStates and OnSurfaces views that render enabled/disabled, checked/mixed/default and focus previews across configured SURFACES.
  - Changed story control for checked from boolean to radio with options [false, true, 'indeterminate'].
- Tests & infra
  - E2E: dataset-items-list spec adjusted to use a regex for "Created <Mon dd>, yyyy" so assertions are date-agnostic.
  - Changeset bumps `@mastra/playground-ui` patch version.
  - Validations performed locally on changed checkbox files: eslint, playground-ui Vitest, pnpm build:playground-ui, Storybook iframe inspection, and React Doctor. CodeRabbit CLI present but not signed in so its review was not run.
- API / exports
  - No exported/public API changes.

Files of note
- packages/playground-ui/src/ds/components/Checkbox/checkbox.tsx — implementation & animation/styling updates
- packages/playground-ui/src/ds/components/Checkbox/checkbox.stories.tsx — new stories, SURFACES helpers, updated controls
- .changeset/upset-cats-sniff.md — changeset bump for playground-ui
- packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts — date-agnostic E2E assertion update

Risk & review effort
- Risk: Low — UI styling and Storybook additions only; no public API changes.
- Estimated review effort: Low–Medium (visual/CSS and Storybook behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->