### PR TITLE
fix(playground-ui): refine radio group states

### DIFF
--- a/.changeset/dark-humans-stick.md
+++ b/.changeset/dark-humans-stick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved RadioGroup styling with neutral selected states, cleaner focus outlines, and surface-aware disabled states.

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.stories.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.stories.tsx
@@ -1,6 +1,68 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
 import { Label } from '../Label';
 import { RadioGroup, RadioGroupItem } from './radio-group';
+
+const SURFACES: { token: string; label: string; className: string }[] = [
+  { token: 'surface1', label: 'surface1 · 0% (studio shell)', className: 'bg-surface1' },
+  { token: 'surface2', label: 'surface2 · 16% (main frame)', className: 'bg-surface2' },
+  { token: 'surface3', label: 'surface3 · 18%', className: 'bg-surface3' },
+  { token: 'surface4', label: 'surface4 · 22%', className: 'bg-surface4' },
+];
+
+function SurfaceFrame({ className, label, children }: { className: string; label: string; children: ReactNode }) {
+  return (
+    <div className={`rounded-2xl border border-border1 p-5 ${className}`}>
+      <p className="mb-4 text-ui-xs uppercase tracking-wide text-neutral3">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+function RadioPreview({
+  id,
+  label,
+  checked,
+  disabled,
+  className,
+}: {
+  id: string;
+  label: string;
+  checked?: boolean;
+  disabled?: boolean;
+  className?: string;
+}) {
+  return (
+    <RadioGroup aria-label={label} defaultValue={checked ? id : undefined} disabled={disabled}>
+      <RadioGroupItem aria-label={label} value={id} id={id} className={className} />
+    </RadioGroup>
+  );
+}
+
+function RadioStateGrid({ idPrefix }: { idPrefix: string }) {
+  return (
+    <div className="grid grid-cols-[5rem_repeat(5,minmax(0,1fr))] items-center gap-x-4 gap-y-3 text-ui-sm text-neutral3">
+      <span />
+      <span>Default</span>
+      <span>Selected</span>
+      <span>Focus</span>
+      <span>Disabled</span>
+      <span>Disabled on</span>
+
+      <span className="text-neutral5">State</span>
+      <RadioPreview id={`${idPrefix}-default`} label={`${idPrefix} default`} />
+      <RadioPreview id={`${idPrefix}-selected`} label={`${idPrefix} selected`} checked />
+      <RadioPreview
+        id={`${idPrefix}-focus`}
+        label={`${idPrefix} focus preview`}
+        checked
+        className="border-neutral5/60 outline outline-1 outline-offset-2 outline-neutral5/55"
+      />
+      <RadioPreview id={`${idPrefix}-disabled`} label={`${idPrefix} disabled`} disabled />
+      <RadioPreview id={`${idPrefix}-disabled-selected`} label={`${idPrefix} disabled selected`} checked disabled />
+    </div>
+  );
+}
 
 const meta: Meta<typeof RadioGroup> = {
   title: 'Elements/RadioGroup',
@@ -49,6 +111,32 @@ export const Disabled: Story = {
         <Label htmlFor="disabled-2">Option 2</Label>
       </div>
     </RadioGroup>
+  ),
+};
+
+export const AllStates: Story = {
+  parameters: {
+    layout: 'centered',
+  },
+  render: () => (
+    <div className="grid min-w-[28rem] gap-4 rounded-lg border border-border1 bg-surface2 p-4">
+      <RadioStateGrid idPrefix="all-states" />
+    </div>
+  ),
+};
+
+export const OnSurfaces: Story = {
+  parameters: {
+    layout: 'padded',
+  },
+  render: () => (
+    <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+      {SURFACES.map(({ token, label, className }) => (
+        <SurfaceFrame key={token} className={className} label={label}>
+          <RadioStateGrid idPrefix={token} />
+        </SurfaceFrame>
+      ))}
+    </div>
   ),
 };
 

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.test.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.test.tsx
@@ -112,4 +112,20 @@ describe('RadioGroup', () => {
 
     expect(screen.getByRole('radiogroup').classList.contains('custom-group')).toBe(true);
   });
+
+  it('uses neutral radio styling without accent glow classes', () => {
+    render(
+      <RadioGroup aria-label="Plan" defaultValue="option-1">
+        <RadioGroupItem value="option-1" aria-label="Option 1" />
+      </RadioGroup>,
+    );
+
+    const className = screen.getByLabelText('Option 1').className;
+
+    expect(className).toContain('cursor-pointer');
+    expect(className).toContain('bg-neutral6/[0.12]');
+    expect(className).toContain('data-[checked]:bg-neutral6');
+    expect(className).not.toContain('accent1');
+    expect(className).not.toContain('shadow-glow');
+  });
 });

--- a/packages/playground-ui/src/ds/components/RadioGroup/radio-group.tsx
+++ b/packages/playground-ui/src/ds/components/RadioGroup/radio-group.tsx
@@ -1,9 +1,7 @@
 import { Radio as RadioPrimitive } from '@base-ui/react/radio';
 import { RadioGroup as RadioGroupPrimitive } from '@base-ui/react/radio-group';
-import { Circle } from 'lucide-react';
 import * as React from 'react';
 
-import { formElementFocus } from '@/ds/primitives/form-element';
 import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
@@ -12,7 +10,7 @@ type RadioGroupProps = Omit<RadioGroupPrimitive.Props, 'className'> & {
 };
 
 const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(({ className, ...props }, ref) => {
-  return <RadioGroupPrimitive ref={ref} className={cn('grid gap-2', className)} {...props} />;
+  return <RadioGroupPrimitive ref={ref} data-slot="radio-group" className={cn('grid gap-2', className)} {...props} />;
 });
 RadioGroup.displayName = 'RadioGroup';
 
@@ -24,31 +22,36 @@ const RadioGroupItem = React.forwardRef<HTMLSpanElement, RadioGroupItemProps>(({
   return (
     <RadioPrimitive.Root
       ref={ref}
+      data-slot="radio-group-item"
       className={cn(
-        // Base UI's Radio.Root renders a `<span>` (inline) — unlike Radix's
-        // `<button>`. `flex` + `shrink-0` make the sizing/centering classes
-        // take effect and keep the control square inside flex rows.
-        'flex shrink-0 items-center justify-center',
-        'aspect-square h-4 w-4 rounded-full border border-neutral3 text-neutral6',
-        'shadow-sm',
+        'flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-full',
+        'border border-neutral6/[0.06] bg-neutral6/[0.12] text-surface1 outline-hidden',
         transitions.all,
-        'hover:border-neutral5 hover:shadow-md',
-        formElementFocus,
-        // Base UI's Radio.Root is a `<span>`, so `:disabled` never matches — target `data-disabled`.
-        'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:hover:border-neutral3 data-[disabled]:hover:shadow-sm',
+        'hover:border-neutral6/[0.12] hover:bg-neutral6/[0.16]',
+        'active:scale-95 active:border-neutral6/[0.18] active:bg-neutral6/[0.18]',
+        'focus-visible:border-neutral5/50 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
         // Base UI exposes `data-checked`/`data-unchecked` instead of Radix's `data-state`.
-        'data-[checked]:border-accent1 data-[checked]:shadow-glow-accent1',
+        'data-[checked]:border-neutral6 data-[checked]:bg-neutral6 data-[checked]:text-surface1',
+        'data-[checked]:hover:border-neutral5 data-[checked]:hover:bg-neutral5',
+        'data-[checked]:active:border-neutral4 data-[checked]:active:bg-neutral4',
+        // Base UI's Radio.Root is a `<span>`, so `:disabled` never matches; target `data-disabled`.
+        'data-[disabled]:cursor-not-allowed data-[disabled]:border-neutral6/[0.38] data-[disabled]:bg-neutral6/[0.38] data-[disabled]:hover:border-neutral6/[0.38] data-[disabled]:hover:bg-neutral6/[0.38] data-[disabled]:active:scale-100',
+        'data-[disabled]:data-[checked]:border-neutral6/[0.38] data-[disabled]:data-[checked]:bg-neutral6/[0.38] data-[disabled]:data-[checked]:text-neutral6',
         className,
       )}
       {...props}
     >
       <RadioPrimitive.Indicator
+        keepMounted
         className={cn(
-          'flex items-center justify-center',
-          'data-[checked]:animate-in data-[checked]:zoom-in-50 data-[checked]:duration-150',
+          'flex items-center justify-center text-current',
+          'scale-50 opacity-0 transition-[opacity,scale] duration-200 ease-out-custom',
+          'data-[checked]:scale-100 data-[checked]:opacity-100',
+          'data-[starting-style]:scale-50 data-[starting-style]:opacity-0',
+          'data-[ending-style]:scale-50 data-[ending-style]:opacity-0',
         )}
       >
-        <Circle className="h-2 w-2 fill-accent1 text-accent1" />
+        <span className="size-1.5 rounded-full bg-current" />
       </RadioPrimitive.Indicator>
     </RadioPrimitive.Root>
   );

--- a/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
+++ b/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
@@ -23,7 +23,7 @@ test.describe('Dataset Items List - Behavior Tests', () => {
 
     await page.getByRole('button', { name: /Test input 1/ }).click();
 
-    await expect(page.getByText(/Created May/).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/Created [A-Z][a-z]{2} \d{1,2}, \d{4}/).first()).toBeVisible({ timeout: 5000 });
   });
 
   test('selecting Delete Items from menu enables selection mode with checkboxes', async ({ page }) => {


### PR DESCRIPTION
Updates RadioGroup to match the neutral, surface-aware state treatment used for the refreshed checkbox component. This removes the green selected border/glow, adds cleaner focus and active states, and gives disabled radios a visible muted fill on dark surfaces.

Adds Storybook coverage for all radio states across surface tokens so the defaults, selected state, focus preview, disabled state, and disabled selected state can be reviewed in one place.

Validated with `pnpm --dir packages/playground-ui exec eslint src/ds/components/RadioGroup/radio-group.tsx src/ds/components/RadioGroup/radio-group.stories.tsx src/ds/components/RadioGroup/radio-group.test.tsx`, `pnpm --filter ./packages/playground-ui test -- --run src/ds/components/RadioGroup/radio-group.test.tsx`, `pnpm build:playground-ui`, Storybook on localhost:6007, and React Doctor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR updates the RadioGroup component in the playground UI to have a cleaner, more neutral look by removing the bright green glow effect and replacing it with subtle, balanced styling. It also adds visual examples (Storybook stories) showing how the radio buttons look in different states (selected, focused, disabled) across different background colors.

## Changes Overview

### RadioGroup Component Styling Refinement
- **Migrated from Radix to Base UI primitives** – Updated `RadioGroup` and `RadioGroupItem` to use `@base-ui/react/radio` for improved state management
- **Neutral color scheme** – Replaced accent-based styling (green glow) with neutral color tokens (`neutral6`, `neutral5`, `neutral4`)
- **Updated state indicators** – Changed from a `lucide-react` `Circle` icon to a simple `<span>` element with scaled/opacity transitions
- **Improved focus styling** – Replaced shadow-based focus with a clean outline approach using `focus-visible:outline`
- **Surface-aware disabled states** – Disabled radios now show appropriately muted fills that work across different surface tokens

### State Coverage
- **Default** – Subtle neutral border and background
- **Selected (Checked)** – Darker neutral fill with white dot indicator
- **Focus** – Clean outline with offset
- **Disabled** – Muted appearance with disabled cursor
- **Disabled + Selected** – Muted fill matching disabled state

### Storybook Documentation
- Added `AllStates` story displaying the full matrix of radio states (default/selected/focus/disabled)
- Added `OnSurfaces` story showing all states rendered across different surface tokens (`surface1` through `surface4`)
- Created helper components (`SurfaceFrame`, `RadioPreview`, `RadioStateGrid`) for consistent, reusable state previews

### Test Coverage
- Added test asserting neutral styling classes are applied (`cursor-pointer`, `bg-neutral6/[0.12]`, `data-[checked]:bg-neutral6`)
- Explicitly verifies accent and glow-related classes are NOT present

### E2E Test Update
- Updated dataset items list E2E test to use month-agnostic date regex pattern, allowing tests to pass across month boundaries

### Validation
- ESLint: Passing on RadioGroup files
- Component tests: Passing for RadioGroup test file
- Build: `pnpm build:playground-ui` succeeds
- Storybook: All stories verified on localhost:6007
- React Doctor: Passing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->