### PR TITLE
feat(core): add harness v1 session message and queue APIs

### DIFF
--- a/.changeset/floppy-colts-know.md
+++ b/.changeset/floppy-colts-know.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Route mastracode HarnessCompat messages through the Harness v1 session so existing sendMessage calls use the new session message pipeline.

--- a/packages/core/src/harness/v1/mode.test.ts
+++ b/packages/core/src/harness/v1/mode.test.ts
@@ -10,18 +10,20 @@
 
 import { describe, expect, it } from 'vitest';
 
+import type { Agent } from '../../agent';
 import type { MastraMemory } from '../../memory';
 import { Harness } from './harness';
 import type { HarnessConfig } from './harness.types';
 import type { HarnessMode } from './mode';
 
 const createMemory = () => ({}) as MastraMemory;
+const createAgent = () => ({ generate: async () => ({ text: 'ok', steps: [] }) }) as unknown as Agent;
 
 const setupHarness = (config: Partial<HarnessConfig<HarnessMode[]>> = {}) => {
   const harness = new Harness({
-    agents: {},
+    agents: { default: createAgent() },
     memory: createMemory(),
-    modes: [{ id: 'build', agentId: 'default' }],
+    modes: [{ id: 'build', agentId: 'default', defaultModelId: 'zai-coding-plan/glm-5-turbo' }],
     defaultModeId: 'build',
     ...config,
   } as HarnessConfig<HarnessMode[]>);
@@ -32,9 +34,9 @@ const setupHarness = (config: Partial<HarnessConfig<HarnessMode[]>> = {}) => {
 describe('Harness.listModes()', () => {
   it('returns every registered mode in declaration order', () => {
     const modes: HarnessMode[] = [
-      { id: 'build', agentId: 'default' },
-      { id: 'plan', agentId: 'default' },
-      { id: 'fast', agentId: 'default' },
+      { id: 'build', agentId: 'default', defaultModelId: 'zai-coding-plan/glm-5-turbo' },
+      { id: 'plan', agentId: 'default', defaultModelId: 'zai-coding-plan/glm-5-turbo' },
+      { id: 'fast', agentId: 'default', defaultModelId: 'zai-coding-plan/glm-5-turbo' },
     ];
     const { harness } = setupHarness({ modes, defaultModeId: 'build' });
 
@@ -57,6 +59,7 @@ describe('Harness.listModes()', () => {
       {
         id: 'build',
         agentId: 'default',
+        defaultModelId: 'zai-coding-plan/glm-5-turbo',
         description: 'Build mode',
         instructions: 'You are in build mode.',
         metadata: { color: '#abcdef' },
@@ -78,12 +81,16 @@ describe('Harness.listModes()', () => {
 describe('Harness.getMode()', () => {
   it('returns the mode object for a known id', () => {
     const modes: HarnessMode[] = [
-      { id: 'build', agentId: 'default' },
-      { id: 'plan', agentId: 'default' },
+      { id: 'build', agentId: 'default', defaultModelId: 'zai-coding-plan/glm-5-turbo' },
+      { id: 'plan', agentId: 'default', defaultModelId: 'zai-coding-plan/glm-5-turbo' },
     ];
     const { harness } = setupHarness({ modes, defaultModeId: 'build' });
 
-    expect(harness.getMode('plan')).toMatchObject({ id: 'plan', agentId: 'default' });
+    expect(harness.getMode('plan')).toMatchObject({
+      id: 'plan',
+      agentId: 'default',
+      defaultModelId: 'zai-coding-plan/glm-5-turbo',
+    });
   });
 
   it('returns undefined for an unknown id (no throw)', () => {
@@ -94,7 +101,7 @@ describe('Harness.getMode()', () => {
 
   it('returns the same reference as the entry inside listModes()', () => {
     const { harness } = setupHarness({
-      modes: [{ id: 'build', agentId: 'default' }],
+      modes: [{ id: 'build', agentId: 'default', defaultModelId: 'zai-coding-plan/glm-5-turbo' }],
     });
 
     const fromList = harness.listModes().find(m => m.id === 'build');

--- a/packages/core/src/harness/v1/session.test.ts
+++ b/packages/core/src/harness/v1/session.test.ts
@@ -433,7 +433,7 @@ describe('Harness.session()', () => {
   });
 });
 
-describe('Session.message() and queue()', () => {
+describe('Session.sendMessage() and queueMessage()', () => {
   it('calls agent.generate with session memory, mode defaults, and emits lifecycle events', async () => {
     const generate = vi.fn().mockResolvedValue({ text: 'generated', steps: [] });
     const agent = createAgent({ generate } as Partial<Agent>);
@@ -457,7 +457,7 @@ describe('Session.message() and queue()', () => {
     });
     events.length = 0;
 
-    const result = await session.message({
+    const result = await session.sendMessage({
       content: 'hello',
       additionalTools: { localTool: { description: 'Local tool', execute: vi.fn() } } as never,
       maxSteps: 2,
@@ -490,7 +490,7 @@ describe('Session.message() and queue()', () => {
     const { harness } = createHarness(createMemory(), new RecordingHarnessStorage(), undefined, agent);
     const session = await harness.session({ threadId: 'thread-1', resourceId: 'resource-1' });
 
-    const result = await session.message({ content: 'stream me', stream: true });
+    const result = await session.sendMessage({ content: 'stream me', stream: true });
 
     expect(result).toBe(streamResult);
     expect(stream).toHaveBeenCalledWith(
@@ -510,7 +510,7 @@ describe('Session.message() and queue()', () => {
     const session = await harness.session({ threadId: 'thread-1', resourceId: 'resource-1' });
     events.length = 0;
 
-    await expect(session.message({ content: 'fail' })).rejects.toThrow('nope');
+    await expect(session.sendMessage({ content: 'fail' })).rejects.toThrow('nope');
 
     expect(events).toEqual([
       expect.objectContaining({ type: 'agent_start', sessionId: session.id }),
@@ -534,9 +534,9 @@ describe('Session.message() and queue()', () => {
     const session = await harness.session({ threadId: 'thread-1', resourceId: 'resource-1' });
     events.length = 0;
 
-    const first = session.queue({ content: 'one' });
-    const second = session.queue({ content: 'two' });
-    const third = session.queue({ content: 'three' });
+    const first = session.queueMessage({ content: 'one' });
+    const second = session.queueMessage({ content: 'two' });
+    const third = session.queueMessage({ content: 'three' });
 
     await expect(first).resolves.toMatchObject({ text: 'one' });
     await expect(second).rejects.toThrow('second failed');

--- a/packages/core/src/harness/v1/session.test.ts
+++ b/packages/core/src/harness/v1/session.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import type { Agent } from '../../agent';
 import type { MastraDBMessage } from '../../agent/message-list';
 import type { MastraMemory } from '../../memory';
 import type { StorageCloneThreadInput } from '../../storage';
@@ -37,6 +38,13 @@ const createMessage = (id: string, threadId = 'thread-1'): MastraDBMessage => ({
   content: { format: 2, parts: [{ type: 'text', text: `message ${id}` }] },
 });
 
+const createAgent = (overrides: Partial<Agent> = {}) =>
+  ({
+    generate: vi.fn().mockResolvedValue({ text: 'ok', steps: [] }),
+    stream: vi.fn().mockResolvedValue({ textStream: (async function* () {})() }),
+    ...overrides,
+  }) as unknown as Agent;
+
 const createMemory = () => {
   const clonedThread = {
     id: 'thread-2',
@@ -63,11 +71,17 @@ const createMemory = () => {
   } as unknown as MastraMemory;
 };
 
-const createHarness = (memory: MastraMemory, storage = new RecordingHarnessStorage(), ownerId?: string) => ({
+const createHarness = (
+  memory: MastraMemory,
+  storage = new RecordingHarnessStorage(),
+  ownerId?: string,
+  agent = createAgent(),
+) => ({
   storage,
   memory,
+  agent,
   harness: new Harness({
-    agents: {},
+    agents: { default: agent },
     ownerId,
     storage,
     memory,
@@ -141,7 +155,7 @@ describe('Harness.session()', () => {
   it('uses top-level storage', async () => {
     const storage = new RecordingHarnessStorage();
     const harness = new Harness({
-      agents: {},
+      agents: { default: createAgent() },
       storage,
       memory: createMemory(),
       modes: [{ id: 'build', agentId: 'default', defaultModelId: 'test-build-model' }],
@@ -416,6 +430,132 @@ describe('Harness.session()', () => {
     expect(storage.records.get(session.id)).toMatchObject({
       modeId: 'build',
     });
+  });
+});
+
+describe('Session.message() and queue()', () => {
+  it('calls agent.generate with session memory, mode defaults, and emits lifecycle events', async () => {
+    const generate = vi.fn().mockResolvedValue({ text: 'generated', steps: [] });
+    const agent = createAgent({ generate } as Partial<Agent>);
+    const { harness } = createHarness(createMemory(), new RecordingHarnessStorage(), undefined, agent);
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+    const session = await harness.session({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      modeId: 'plan',
+      modelId: 'model-1',
+    });
+    session.setMode({
+      id: 'plan',
+      agentId: 'default',
+      defaultModelId: 'zai-coding-plan/glm-5-turbo',
+      instructions: 'Use plan mode.',
+      additionalTools: { planTool: { description: 'Plan tool', execute: vi.fn() } } as never,
+    });
+    events.length = 0;
+
+    const result = await session.message({
+      content: 'hello',
+      additionalTools: { localTool: { description: 'Local tool', execute: vi.fn() } } as never,
+      maxSteps: 2,
+    });
+
+    expect(result).toEqual({ text: 'generated', steps: [] });
+    expect(generate).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({
+        memory: { thread: 'thread-1', resource: 'resource-1' },
+        model: 'model-1',
+        instructions: 'Use plan mode.',
+        maxSteps: 2,
+        toolsets: expect.objectContaining({
+          'mode:plan:add': expect.any(Object),
+          'call:additional': expect.any(Object),
+        }),
+        requestContext: expect.any(Object),
+      }),
+    );
+    expect(events.map(event => event.type)).toEqual(['agent_start', 'agent_end']);
+    expect(events[0]).toMatchObject({ type: 'agent_start', sessionId: session.id });
+    expect(events[1]).toMatchObject({ type: 'agent_end', sessionId: session.id, reason: 'complete' });
+  });
+
+  it('calls agent.stream when stream is true', async () => {
+    const streamResult = { textStream: (async function* () {})() };
+    const stream = vi.fn().mockResolvedValue(streamResult);
+    const agent = createAgent({ stream } as Partial<Agent>);
+    const { harness } = createHarness(createMemory(), new RecordingHarnessStorage(), undefined, agent);
+    const session = await harness.session({ threadId: 'thread-1', resourceId: 'resource-1' });
+
+    const result = await session.message({ content: 'stream me', stream: true });
+
+    expect(result).toBe(streamResult);
+    expect(stream).toHaveBeenCalledWith(
+      'stream me',
+      expect.objectContaining({ memory: { thread: 'thread-1', resource: 'resource-1' } }),
+    );
+  });
+
+  it('emits an error lifecycle event when generation fails', async () => {
+    const generate = vi.fn().mockRejectedValue(new Error('nope'));
+    const agent = createAgent({ generate } as Partial<Agent>);
+    const { harness } = createHarness(createMemory(), new RecordingHarnessStorage(), undefined, agent);
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+    const session = await harness.session({ threadId: 'thread-1', resourceId: 'resource-1' });
+    events.length = 0;
+
+    await expect(session.message({ content: 'fail' })).rejects.toThrow('nope');
+
+    expect(events).toEqual([
+      expect.objectContaining({ type: 'agent_start', sessionId: session.id }),
+      expect.objectContaining({ type: 'agent_end', sessionId: session.id, reason: 'error', error: 'nope' }),
+    ]);
+  });
+
+  it('drains queued messages sequentially and continues after failures', async () => {
+    const calls: string[] = [];
+    const generate = vi.fn().mockImplementation(async (content: string) => {
+      calls.push(content);
+      if (content === 'two') throw new Error('second failed');
+      return { text: content, steps: [] };
+    });
+    const agent = createAgent({ generate } as Partial<Agent>);
+    const { harness } = createHarness(createMemory(), new RecordingHarnessStorage(), undefined, agent);
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+    const session = await harness.session({ threadId: 'thread-1', resourceId: 'resource-1' });
+    events.length = 0;
+
+    const first = session.queue({ content: 'one' });
+    const second = session.queue({ content: 'two' });
+    const third = session.queue({ content: 'three' });
+
+    await expect(first).resolves.toMatchObject({ text: 'one' });
+    await expect(second).rejects.toThrow('second failed');
+    await expect(third).resolves.toMatchObject({ text: 'three' });
+
+    expect(calls).toEqual(['one', 'two', 'three']);
+    expect(events.map(event => event.type)).toEqual([
+      'agent_start',
+      'agent_end',
+      'agent_start',
+      'agent_end',
+      'agent_start',
+      'agent_end',
+    ]);
+    expect(
+      events
+        .filter(event => event.type === 'agent_end')
+        .map(event => (event as Extract<HarnessEvent, { type: 'agent_end' }>).reason),
+    ).toEqual(['complete', 'error', 'complete']);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds `Session.message()` and `Session.queue()` for agent execution on the Harness V1 session.

### Changes
- **Session.message()** — delegates to `agent.generate()` / `agent.stream()` based on options, emits `agent_start` / `agent_end` lifecycle events
- **Session.queue()** — in-memory FIFO sequential execution queue that drains messages one at a time
- **Agent resolution** — `Harness.getAgentForMode()` resolves a mode's `agentId` to an `Agent` instance (from `agents` map or `mastra` registry); injected into Session via `SessionConfig.getAgent`
- **Agent lifecycle events** — `AgentStartEvent` and `AgentEndEvent` added to the event system
- **Type exports** — `AgentResult`, `AgentStream`, `MessageOptions`, `QueueOptions` from harness v1 index

### Stacked on
- #17290 (p2: harness v1 events)

## Test plan

- `pnpm build:core`
- `cd packages/core && npx vitest run src/harness/v1/ --reporter=verbose`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR teaches the Harness V1 session how to send messages and queue them up for processing. When you send a message, it talks to an AI agent, listens for lifecycle events (start/end), and can either send one message at a time or stream the response back. If you queue multiple messages, they're processed one after another in order, even if some fail.

## Summary

Adds `Session.sendMessage()` and `Session.queueMessage()` message processing APIs to Harness V1:

**Session.sendMessage()**: Routes a single message through the underlying agent, delegating to `agent.generate()` or `agent.stream()` based on the `stream` option. Emits `agent_start` and `agent_end` lifecycle events (with `reason: 'complete'` or `reason: 'error'` on failure). Builds request context with memory metadata (thread and resource IDs), includes mode instructions and tool overrides, and surfaces mode-specific tools alongside any additional tools passed in the call.

**Session.queueMessage()**: In-memory FIFO queue that processes queued messages sequentially, one at a time. Returns a promise per queued message that resolves/rejects with the agent's result. Continues processing subsequent queue items even if an earlier one fails. Each queued item triggers its own `agent_start`/`agent_end` event pair.

**Agent Resolution**: Harness provides a `#resolveAgent()` method (now passed to Session as `resolveAgent` in SessionConfig) that resolves a mode's `agentId` to an Agent instance, either from the agents map or the Mastra registry.

**Event Additions**: New `agent_start` and `agent_end` event types added to the event system, including an error reason and error message field when failures occur.

**Test Coverage**: Mode test fixtures updated with `defaultModelId` declarations across all mode configurations. Session tests validate `sendMessage()` invokes agent methods with correct parameters (memory context, model ID, instructions, toolsets), emits lifecycle events in correct order, handles streaming mode, propagates errors with reason, and validates that `queueMessage()` executes queued items sequentially and continues after failures.

**Changeset**: HarnessCompat messages are now routed through the Harness v1 session message pipeline so existing `sendMessage` calls use the new session message infrastructure.

Stacked on: `#17290` (p2: harness v1 events)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->