### PR TITLE
fix(core): persist tool errors on history reload

### DIFF
--- a/.changeset/bumpy-doors-crash.md
+++ b/.changeset/bumpy-doors-crash.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed tool execution errors being stored as successful results, which caused failed tool calls to reappear as successes when a conversation was reloaded from history. When a tool throws (or a provider-executed tool reports a failure), the result is now persisted as `state: "output-error"` with `errorText` instead of `state: "result"`, so the error survives history reload via `toAISdkV5Messages()` and matches the live streaming behavior. Fixes #15569.
+Fixed failed tool calls showing up as successful when a conversation is reloaded from history. Previously a tool that threw an error displayed correctly while the agent was running, but reappeared as a successful result once the conversation was loaded from memory. The error is now preserved and displayed on reload, matching what you see during the live run. Fixes #15569.

--- a/.changeset/bumpy-doors-crash.md
+++ b/.changeset/bumpy-doors-crash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool execution errors being stored as successful results, which caused failed tool calls to reappear as successes when a conversation was reloaded from history. When a tool throws (or a provider-executed tool reports a failure), the result is now persisted as `state: "output-error"` with `errorText` instead of `state: "result"`, so the error survives history reload via `toAISdkV5Messages()` and matches the live streaming behavior. Fixes #15569.

--- a/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
@@ -13,6 +13,7 @@ import type {
   MastraDBMessage,
   MastraMessageContentV2,
   MastraMessagePart,
+  MastraToolInvocation,
   UIMessageV4Part,
   MessageSource,
   UIMessageWithMetadata,
@@ -33,10 +34,19 @@ function getDisplayTransform(
 }
 
 function transformV4ToolInvocationForDisplay(
-  invocation: NonNullable<MastraMessageContentV2['toolInvocations']>[number],
+  invocation: MastraToolInvocation,
   providerMetadata: unknown,
   enabled: boolean,
-) {
+): ToolInvocationV4 {
+  if (invocation.state === 'output-error') {
+    return {
+      ...invocation,
+      state: 'result' as const,
+      args: getDisplayTransform(providerMetadata, 'input-available', invocation.args, enabled),
+      result: getDisplayTransform(providerMetadata, 'error', invocation.errorText || '', enabled),
+    };
+  }
+
   return {
     ...invocation,
     args: getDisplayTransform(providerMetadata, 'input-available', invocation.args, enabled),
@@ -50,7 +60,7 @@ function transformV4ToolInvocationForDisplay(
           ),
         }
       : {}),
-  };
+  } as ToolInvocationV4;
 }
 
 /**
@@ -204,30 +214,49 @@ export class AIV4Adapter {
           continue;
         } else if (part.type === 'tool-invocation') {
           // Handle tool invocations with step number logic
-          const toolInvocation = {
-            ...part.toolInvocation,
-            args: getDisplayTransform(
-              part.providerMetadata,
-              'input-available',
-              part.toolInvocation.args,
-              transformToolPayloads,
-            ),
-            ...(part.toolInvocation.state === 'result'
+          const sourceInvocation = part.toolInvocation as MastraToolInvocation;
+          const toolInvocation =
+            sourceInvocation.state === 'output-error'
               ? {
+                  ...sourceInvocation,
+                  state: 'result' as const,
+                  args: getDisplayTransform(
+                    part.providerMetadata,
+                    'input-available',
+                    sourceInvocation.args,
+                    transformToolPayloads,
+                  ),
                   result: getDisplayTransform(
                     part.providerMetadata,
-                    'output-available',
-                    getDisplayTransform(
-                      part.providerMetadata,
-                      'error',
-                      part.toolInvocation.result,
-                      transformToolPayloads,
-                    ),
+                    'error',
+                    sourceInvocation.errorText || '',
                     transformToolPayloads,
                   ),
                 }
-              : {}),
-          };
+              : {
+                  ...sourceInvocation,
+                  args: getDisplayTransform(
+                    part.providerMetadata,
+                    'input-available',
+                    sourceInvocation.args,
+                    transformToolPayloads,
+                  ),
+                  ...(sourceInvocation.state === 'result'
+                    ? {
+                        result: getDisplayTransform(
+                          part.providerMetadata,
+                          'output-available',
+                          getDisplayTransform(
+                            part.providerMetadata,
+                            'error',
+                            sourceInvocation.result,
+                            transformToolPayloads,
+                          ),
+                          transformToolPayloads,
+                        ),
+                      }
+                    : {}),
+                };
 
           // Find the step number for this tool invocation
           let currentStep = -1;
@@ -302,8 +331,8 @@ export class AIV4Adapter {
         reasoning: undefined,
         toolInvocations:
           `toolInvocations` in m.content
-            ? m.content.toolInvocations
-                ?.filter(t => t.state === 'result')
+            ? (m.content.toolInvocations as MastraToolInvocation[] | undefined)
+                ?.filter(t => t.state === 'result' || t.state === 'output-error')
                 .map(toolInvocation => {
                   const partProviderMetadata = m.content.parts?.find(
                     part =>

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
@@ -4,7 +4,7 @@
  */
 import type { AssistantContent, ToolResultPart } from '@internal/ai-sdk-v4';
 import type { MastraMessageV1 } from '../../../memory/types';
-import type { MastraMessageContentV2, MastraDBMessage } from '../../message-list';
+import type { MastraDBMessage, MastraMessageContentV2, MastraToolInvocation } from '../../message-list';
 import { attachmentsToParts } from './attachments-to-parts';
 
 const makePushOrCombine = (v1Messages: MastraMessageV1[]) => {
@@ -54,6 +54,21 @@ const makePushOrCombine = (v1Messages: MastraMessageV1[]) => {
     }
   };
 };
+
+const hasTerminalToolOutput = (toolInvocation: MastraToolInvocation) =>
+  (toolInvocation.state === 'result' && 'result' in toolInvocation) ||
+  (toolInvocation.state === 'output-error' && 'errorText' in toolInvocation);
+
+const toToolResultPart = (toolInvocation: MastraToolInvocation): ToolResultPart => {
+  const { toolCallId, toolName } = toolInvocation;
+  return {
+    type: 'tool-result',
+    toolCallId,
+    toolName,
+    result: toolInvocation.state === 'output-error' ? toolInvocation.errorText || '' : toolInvocation.result,
+  };
+};
+
 export function convertToV1Messages(messages: Array<MastraDBMessage>) {
   const v1Messages: MastraMessageV1[] = [];
   const pushOrCombine = makePushOrCombine(v1Messages);
@@ -195,22 +210,14 @@ export function convertToV1Messages(messages: Array<MastraDBMessage>) {
               .filter(ti => ti.toolName !== 'updateWorkingMemory');
 
             // Only create tool-result message if there are actual results
-            const invocationsWithResults = stepInvocations.filter(ti => ti.state === 'result' && 'result' in ti);
+            const invocationsWithResults = stepInvocations.filter(hasTerminalToolOutput);
 
             if (invocationsWithResults.length > 0) {
               pushOrCombine({
                 role: 'tool',
                 ...fields,
                 type: 'tool-result',
-                content: invocationsWithResults.map((toolInvocation): ToolResultPart => {
-                  const { toolCallId, toolName, result } = toolInvocation;
-                  return {
-                    type: 'tool-result',
-                    toolCallId,
-                    toolName,
-                    result,
-                  };
-                }),
+                content: invocationsWithResults.map(toToolResultPart),
               });
             }
 
@@ -300,22 +307,14 @@ export function convertToV1Messages(messages: Array<MastraDBMessage>) {
                 });
 
                 // Only create tool-result message if there are actual results
-                const invocationsWithResults = stepInvocations.filter(ti => ti.state === 'result' && 'result' in ti);
+                const invocationsWithResults = stepInvocations.filter(hasTerminalToolOutput);
 
                 if (invocationsWithResults.length > 0) {
                   pushOrCombine({
                     role: 'tool',
                     ...fields,
                     type: 'tool-result',
-                    content: invocationsWithResults.map((toolInvocation): ToolResultPart => {
-                      const { toolCallId, toolName, result } = toolInvocation;
-                      return {
-                        type: 'tool-result',
-                        toolCallId,
-                        toolName,
-                        result,
-                      };
-                    }),
+                    content: invocationsWithResults.map(toToolResultPart),
                   });
                 }
               }
@@ -362,22 +361,14 @@ export function convertToV1Messages(messages: Array<MastraDBMessage>) {
           });
 
           // Only create tool-result message if there are actual results
-          const invocationsWithResults = stepInvocations.filter(ti => ti.state === 'result' && 'result' in ti);
+          const invocationsWithResults = stepInvocations.filter(hasTerminalToolOutput);
 
           if (invocationsWithResults.length > 0) {
             pushOrCombine({
               role: 'tool',
               ...fields,
               type: 'tool-result',
-              content: invocationsWithResults.map((toolInvocation): ToolResultPart => {
-                const { toolCallId, toolName, result } = toolInvocation;
-                return {
-                  type: 'tool-result',
-                  toolCallId,
-                  toolName,
-                  result,
-                };
-              }),
+              content: invocationsWithResults.map(toToolResultPart),
             });
           }
         }

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -4302,7 +4302,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4335,7 +4335,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4451,7 +4451,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -4602,7 +4602,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4645,7 +4645,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4771,7 +4771,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -4874,7 +4874,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -4917,7 +4917,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -5043,7 +5043,7 @@ exports[`Loop Tests > AISDK v5 > result.fullStream > should send tool results 1`
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -5842,7 +5842,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -5875,7 +5875,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -5999,7 +5999,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "test error",
                       },
                       "toolCallId": "call-1",
@@ -6158,7 +6158,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -6205,7 +6205,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -6343,7 +6343,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "test error",
                       },
                       "toolCallId": "call-1",
@@ -6454,7 +6454,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -6501,7 +6501,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "test error",
                 },
                 "toolCallId": "call-1",
@@ -6639,7 +6639,7 @@ exports[`Loop Tests > AISDK v5 > tool execution errors > should include tool err
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "test error",
                       },
                       "toolCallId": "call-1",
@@ -11349,7 +11349,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11382,7 +11382,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11504,7 +11504,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -11667,7 +11667,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11710,7 +11710,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -11842,7 +11842,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",
@@ -11957,7 +11957,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -12000,7 +12000,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                   "value": "value",
                 },
                 "output": {
-                  "type": "text",
+                  "type": "error-text",
                   "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                 },
                 "toolCallId": "call-1",
@@ -12132,7 +12132,7 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.fullStream > should send too
                         "value": "value",
                       },
                       "output": {
-                        "type": "text",
+                        "type": "error-text",
                         "value": "expected [ { role: 'user', …(1) } ] to strictly equal [ { role: 'user', …(1) } ]",
                       },
                       "toolCallId": "call-1",

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -8864,4 +8864,364 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
       });
     });
   });
+
+  describe('tool error self-recovery (agent loop)', () => {
+    it('should terminate the loop when a tool fails and the LLM responds with text', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      let responseCount = 0;
+      const resultObject = await loopFn({
+        methodType: 'stream',
+        runId,
+        agentId: 'agent-id',
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async () => {
+                switch (responseCount++) {
+                  case 0:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-1',
+                          toolName: 'failingTool',
+                          input: `{ "value": "test" }`,
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 1:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        {
+                          type: 'text-delta',
+                          id: 'text-1',
+                          delta: 'The tool failed, but I can help another way.',
+                        },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage2,
+                        },
+                      ]),
+                    };
+                  default:
+                    throw new Error(`Unexpected LLM call #${responseCount} — loop should have terminated`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          failingTool: {
+            inputSchema: z.object({ value: z.string() }),
+            execute: async () => {
+              throw new Error('Tool execution failed');
+            },
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(5),
+        options: {},
+      });
+
+      await resultObject.consumeStream();
+
+      // Loop must terminate in exactly 2 steps: tool-call + recovery text
+      const steps = await resultObject.steps;
+      expect(steps).toHaveLength(2);
+
+      // First step should have the tool call
+      expect(steps[0]!.toolCalls).toHaveLength(1);
+      expect(steps[0]!.toolCalls[0]!.payload.toolName).toBe('failingTool');
+
+      // Second step should be the recovery text with no tool calls
+      expect(steps[1]!.toolCalls).toHaveLength(0);
+      expect(steps[1]!.text).toBe('The tool failed, but I can help another way.');
+
+      // finishReason should be 'stop' (loop stopped naturally, not from step limit)
+      expect(steps[1]!.finishReason).toBe('stop');
+    });
+
+    it('should send the tool error to the LLM so it can self-correct', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      const stepInputs: Array<any> = [];
+      let responseCount = 0;
+      const resultObject = await loopFn({
+        methodType: 'stream',
+        runId,
+        agentId: 'agent-id',
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async ({ prompt }) => {
+                stepInputs.push(prompt);
+                switch (responseCount++) {
+                  case 0:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-err',
+                          toolName: 'brokenTool',
+                          input: `{ "query": "hello" }`,
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 1:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        { type: 'text-delta', id: 'text-1', delta: 'recovered' },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage2,
+                        },
+                      ]),
+                    };
+                  default:
+                    throw new Error(`Unexpected LLM call #${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          brokenTool: {
+            inputSchema: z.object({ query: z.string() }),
+            execute: async () => {
+              throw new Error('connection refused');
+            },
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(5),
+        options: {},
+      });
+
+      await resultObject.consumeStream();
+
+      // The LLM must have been called twice
+      expect(stepInputs).toHaveLength(2);
+
+      // On the 2nd call, the prompt must include a tool-result with the error text
+      const secondPrompt = stepInputs[1]!;
+      const toolMessages = secondPrompt.filter((m: any) => m.role === 'tool');
+      expect(toolMessages.length).toBeGreaterThanOrEqual(1);
+
+      const toolResultParts = toolMessages.flatMap((m: any) => m.content);
+      const errorResult = toolResultParts.find((p: any) => p.toolCallId === 'call-err');
+      expect(errorResult).toBeDefined();
+      // The error text must be present so the LLM can see what went wrong
+      // AI SDK wraps tool errors as { type: 'error-text', value: '<message>' }
+      expect(errorResult.output).toBeDefined();
+      expect(errorResult.output.type).toBe('error-text');
+      expect(errorResult.output.value).toContain('connection refused');
+    });
+
+    it('should persist output-error state in the message list', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      let responseCount = 0;
+      const resultObject = await loopFn({
+        methodType: 'stream',
+        runId,
+        agentId: 'agent-id',
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async () => {
+                switch (responseCount++) {
+                  case 0:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-persist',
+                          toolName: 'errorTool',
+                          input: `{ "x": 1 }`,
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 1:
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        { type: 'text-delta', id: 'text-1', delta: 'ok' },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage2,
+                        },
+                      ]),
+                    };
+                  default:
+                    throw new Error(`Unexpected LLM call #${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          errorTool: {
+            inputSchema: z.object({ x: z.number() }),
+            execute: async () => {
+              throw new Error('disk full');
+            },
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(5),
+        options: {},
+      });
+
+      await resultObject.consumeStream();
+
+      // Verify the message list contains the tool invocation with output-error state
+      const allMessages = messageList.get.all.aiV5.ui();
+      const assistantMessages = allMessages.filter((m: any) => m.role === 'assistant');
+
+      // Find tool parts across assistant messages (V5 format: type is 'tool-<toolName>')
+      const toolParts = assistantMessages.flatMap((m: any) => m.parts.filter((p: any) => p.type === 'tool-errorTool'));
+      const errorPart = toolParts.find((p: any) => p.toolCallId === 'call-persist');
+      expect(errorPart).toBeDefined();
+      expect((errorPart as any).state).toBe('output-error');
+      expect((errorPart as any).errorText).toContain('disk full');
+    });
+
+    it('should recover when one tool fails and another succeeds in the same turn', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      let responseCount = 0;
+      const resultObject = await loopFn({
+        methodType: 'stream',
+        runId,
+        agentId: 'agent-id',
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async () => {
+                switch (responseCount++) {
+                  case 0:
+                    // LLM calls two tools: one will fail, one will succeed
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-good',
+                          toolName: 'goodTool',
+                          input: `{ "a": "1" }`,
+                        },
+                        {
+                          type: 'tool-call',
+                          toolCallId: 'call-bad',
+                          toolName: 'badTool',
+                          input: `{ "b": "2" }`,
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  case 1:
+                    // LLM responds after seeing mixed results
+                    return {
+                      stream: convertArrayToReadableStream([
+                        { type: 'text-start', id: 'text-1' },
+                        {
+                          type: 'text-delta',
+                          id: 'text-1',
+                          delta: 'Good tool worked, bad tool failed.',
+                        },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage2,
+                        },
+                      ]),
+                    };
+                  default:
+                    throw new Error(`Unexpected LLM call #${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          goodTool: {
+            inputSchema: z.object({ a: z.string() }),
+            execute: async () => 'success',
+          },
+          badTool: {
+            inputSchema: z.object({ b: z.string() }),
+            execute: async () => {
+              throw new Error('bad tool broke');
+            },
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(5),
+        options: {},
+      });
+
+      await resultObject.consumeStream();
+
+      const steps = await resultObject.steps;
+      expect(steps).toHaveLength(2);
+
+      // First step should have both tool calls
+      expect(steps[0]!.toolCalls).toHaveLength(2);
+
+      // Second step: LLM responds with text, no more tool calls
+      expect(steps[1]!.toolCalls).toHaveLength(0);
+      expect(steps[1]!.finishReason).toBe('stop');
+
+      // Verify the message list has both results — one success, one error
+      // V5 tool parts: type is 'tool-<toolName>', fields are at top level (not nested in toolInvocation)
+      const allMessages = messageList.get.all.aiV5.ui();
+      const assistantParts = allMessages.filter((m: any) => m.role === 'assistant').flatMap((m: any) => m.parts);
+
+      const goodResult = assistantParts.find((p: any) => p.type === 'tool-goodTool' && p.toolCallId === 'call-good');
+      const badResult = assistantParts.find((p: any) => p.type === 'tool-badTool' && p.toolCallId === 'call-bad');
+
+      expect(goodResult).toBeDefined();
+      expect((goodResult as any).state).toBe('output-available');
+
+      expect(badResult).toBeDefined();
+      expect((badResult as any).state).toBe('output-error');
+      expect((badResult as any).errorText).toContain('bad tool broke');
+    });
+  });
 }

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -238,6 +238,38 @@ describe('buildMessagesFromChunks', () => {
     });
   });
 
+  it('should merge tool-call + errored tool-result into an output-error part', () => {
+    // A provider-executed failure arrives as a tool-result with isError set; it must
+    // persist as output-error, not a successful result (#15569).
+    const result = parts([
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'tc1', toolName: 'myTool', args: { q: 'test' } },
+      },
+      {
+        type: 'tool-result',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          result: 'rate limit exceeded',
+          isError: true,
+        },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'output-error',
+        toolCallId: 'tc1',
+        toolName: 'myTool',
+        args: { q: 'test' },
+        errorText: 'rate limit exceeded',
+      },
+    });
+  });
+
   // ── Source and file parts ───────────────────────────────────
 
   it('should produce a source part', () => {

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -239,8 +239,6 @@ describe('buildMessagesFromChunks', () => {
   });
 
   it('should merge tool-call + errored tool-result into an output-error part', () => {
-    // A provider-executed failure arrives as a tool-result with isError set; it must
-    // persist as output-error, not a successful result (#15569).
     const result = parts([
       {
         type: 'tool-call',
@@ -270,7 +268,7 @@ describe('buildMessagesFromChunks', () => {
     });
   });
 
-  it('should merge tool-call + errored nullish tool-result into an output-error part', () => {
+  it('should merge errored tool-result without output', () => {
     const result = parts([
       {
         type: 'tool-call',

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.test.ts
@@ -270,6 +270,36 @@ describe('buildMessagesFromChunks', () => {
     });
   });
 
+  it('should merge tool-call + errored nullish tool-result into an output-error part', () => {
+    const result = parts([
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'tc1', toolName: 'myTool', args: { q: 'test' } },
+      },
+      {
+        type: 'tool-result',
+        payload: {
+          toolCallId: 'tc1',
+          toolName: 'myTool',
+          args: { q: 'test' },
+          result: undefined,
+          isError: true,
+        },
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'output-error',
+        toolCallId: 'tc1',
+        toolName: 'myTool',
+        args: { q: 'test' },
+        errorText: 'Tool execution failed',
+      },
+    });
+  });
+
   // ── Source and file parts ───────────────────────────────────
 
   it('should produce a source part', () => {

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -251,7 +251,6 @@ export function buildMessagesFromChunks({
         const result = toolResults.get(p.toolCallId);
 
         if (result) {
-          // Merge call + result into a single part (output-error when isError is set).
           const resultProviderExecuted = inferProviderExecuted(result.providerExecuted, toolDef);
           parts.push({
             type: 'tool-invocation' as const,

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../../stream/types';
 import { withToolPayloadTransformProviderMetadata } from '../../../tools/payload-transform';
 import { findProviderToolByName, inferProviderExecuted } from '../../../tools/provider-tool-utils';
+import { safeStringify } from '../../../utils';
 
 /**
  * A raw chunk collected during the stream.
@@ -260,7 +261,7 @@ export function buildMessagesFromChunks({
                   toolCallId: p.toolCallId,
                   toolName: p.toolName,
                   args: p.args,
-                  errorText: typeof result.result === 'string' ? result.result : JSON.stringify(result.result),
+                  errorText: typeof result.result === 'string' ? result.result : safeStringify(result.result),
                 }
               : {
                   state: 'result' as const,

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -53,7 +53,14 @@ export function buildMessagesFromChunks({
   // Collect tool results so we can match them to tool calls
   const toolResults = new Map<
     string,
-    { result: any; args: any; providerMetadata: any; providerExecuted: boolean | undefined; toolName: string }
+    {
+      result: any;
+      args: any;
+      providerMetadata: any;
+      providerExecuted: boolean | undefined;
+      toolName: string;
+      isError?: boolean;
+    }
   >();
   for (const chunk of chunks) {
     if (chunk.type === 'tool-result' && chunk.payload.result != null) {
@@ -64,6 +71,7 @@ export function buildMessagesFromChunks({
         providerMetadata: withToolPayloadTransformProviderMetadata(p.providerMetadata, chunk.metadata),
         providerExecuted: p.providerExecuted,
         toolName: p.toolName,
+        isError: p.isError,
       });
     }
   }
@@ -242,17 +250,25 @@ export function buildMessagesFromChunks({
         const result = toolResults.get(p.toolCallId);
 
         if (result) {
-          // Merge call + result into a single 'result' state part
+          // Merge call + result into a single part (output-error when isError is set).
           const resultProviderExecuted = inferProviderExecuted(result.providerExecuted, toolDef);
           parts.push({
             type: 'tool-invocation' as const,
-            toolInvocation: {
-              state: 'result' as const,
-              toolCallId: p.toolCallId,
-              toolName: p.toolName,
-              args: p.args,
-              result: result.result,
-            },
+            toolInvocation: result.isError
+              ? {
+                  state: 'output-error' as const,
+                  toolCallId: p.toolCallId,
+                  toolName: p.toolName,
+                  args: p.args,
+                  errorText: typeof result.result === 'string' ? result.result : JSON.stringify(result.result),
+                }
+              : {
+                  state: 'result' as const,
+                  toolCallId: p.toolCallId,
+                  toolName: p.toolName,
+                  args: p.args,
+                  result: result.result,
+                },
             providerMetadata: result.providerMetadata ?? providerMetadata,
             providerExecuted: resultProviderExecuted,
           } as MastraMessagePart);

--- a/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/build-messages-from-chunks.ts
@@ -64,7 +64,7 @@ export function buildMessagesFromChunks({
     }
   >();
   for (const chunk of chunks) {
-    if (chunk.type === 'tool-result' && chunk.payload.result != null) {
+    if (chunk.type === 'tool-result' && (chunk.payload.isError || chunk.payload.result != null)) {
       const p = chunk.payload as ToolResultPayload;
       toolResults.set(p.toolCallId, {
         result: p.result,
@@ -261,7 +261,12 @@ export function buildMessagesFromChunks({
                   toolCallId: p.toolCallId,
                   toolName: p.toolName,
                   args: p.args,
-                  errorText: typeof result.result === 'string' ? result.result : safeStringify(result.result),
+                  errorText:
+                    typeof result.result === 'string'
+                      ? result.result
+                      : result.result == null
+                        ? 'Tool execution failed'
+                        : safeStringify(result.result),
                 }
               : {
                   state: 'result' as const,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -250,7 +250,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     expect(toolResult.result).toBeUndefined();
   });
 
-  it('should persist streamed provider tool errors even when result is undefined', async () => {
+  it('should persist streamed provider tool errors without output', async () => {
     const tools = {
       perplexitySearch: {
         type: 'provider' as const,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -276,7 +276,7 @@ describe('createLLMExecutionStep gateway provider tools', () => {
           model: {
             specificationVersion: 'v2' as const,
             provider: 'mock-provider',
-            modelId: 'mock-model-id',
+            modelId: MODEL_TOKENS.__GATEWAY_OPENAI_MODEL_BASE__,
             supportedUrls: {},
             doGenerate: vi.fn(),
             doStream: vi.fn(async () => ({

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -250,6 +250,90 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     expect(toolResult.result).toBeUndefined();
   });
 
+  it('should persist streamed provider tool errors even when result is undefined', async () => {
+    const tools = {
+      perplexitySearch: {
+        type: 'provider' as const,
+        id: 'gateway.perplexity_search',
+        args: {},
+      },
+    };
+    const updateToolInvocation = vi.spyOn(messageList, 'updateToolInvocation');
+
+    const llmExecutionStep = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream: vi.fn(async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call-1',
+                  toolName: 'perplexity_search',
+                  result: undefined,
+                  isError: true,
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: testUsage,
+                },
+              ]),
+              request: {},
+              response: {
+                headers: undefined,
+              },
+              warnings: [],
+            })),
+          } as any,
+        },
+      ],
+      tools,
+      streamState: {
+        serialize: vi.fn(),
+        deserialize: vi.fn(),
+      },
+      _internal: {
+        generateId: () => 'generated-id',
+      },
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      } as any,
+    } as unknown as OuterLLMRun<typeof tools>);
+
+    await llmExecutionStep.execute(createExecuteParams(createIterationInput()));
+
+    expect(updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'output-error',
+          toolCallId: 'call-1',
+          toolName: 'perplexity_search',
+          args: undefined,
+          errorText: 'Tool execution failed',
+        },
+      }),
+    );
+  });
+
   it('does not continue when finishReason is length with pending tool calls', async () => {
     const tools = {
       echo: createTool({

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -684,7 +684,7 @@ async function processOutputStream<OUTPUT = undefined>({
         // so the messageList is up-to-date as early as possible.
         // For same-stream results (call + result in one step), no matching part exists yet
         // so updateToolInvocation returns false — buildMessagesFromChunks handles the merge.
-        if (chunk.payload.result != null) {
+        if (chunk.payload.isError || chunk.payload.result != null) {
           const resultToolDef = resolveDirectOrProviderTool(chunk.payload.toolName);
           messageList.updateToolInvocation({
             type: 'tool-invocation',
@@ -698,7 +698,9 @@ async function processOutputStream<OUTPUT = undefined>({
                   errorText:
                     typeof chunk.payload.result === 'string'
                       ? chunk.payload.result
-                      : safeStringify(chunk.payload.result),
+                      : chunk.payload.result == null
+                        ? 'Tool execution failed'
+                        : safeStringify(chunk.payload.result),
                 }
               : {
                   state: 'result',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -688,7 +688,6 @@ async function processOutputStream<OUTPUT = undefined>({
           const resultToolDef = resolveDirectOrProviderTool(chunk.payload.toolName);
           messageList.updateToolInvocation({
             type: 'tool-invocation',
-            // A failed provider-executed tool sets isError — persist it as output-error.
             toolInvocation: chunk.payload.isError
               ? {
                   state: 'output-error',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -688,13 +688,25 @@ async function processOutputStream<OUTPUT = undefined>({
           const resultToolDef = resolveDirectOrProviderTool(chunk.payload.toolName);
           messageList.updateToolInvocation({
             type: 'tool-invocation',
-            toolInvocation: {
-              state: 'result',
-              toolCallId: chunk.payload.toolCallId,
-              toolName: chunk.payload.toolName,
-              args: chunk.payload.args,
-              result: chunk.payload.result,
-            },
+            // A failed provider-executed tool sets isError — persist it as output-error.
+            toolInvocation: chunk.payload.isError
+              ? {
+                  state: 'output-error',
+                  toolCallId: chunk.payload.toolCallId,
+                  toolName: chunk.payload.toolName,
+                  args: chunk.payload.args,
+                  errorText:
+                    typeof chunk.payload.result === 'string'
+                      ? chunk.payload.result
+                      : JSON.stringify(chunk.payload.result),
+                }
+              : {
+                  state: 'result',
+                  toolCallId: chunk.payload.toolCallId,
+                  toolName: chunk.payload.toolName,
+                  args: chunk.payload.args,
+                  result: chunk.payload.result,
+                },
             providerMetadata: withToolPayloadTransformProviderMetadata(chunk.payload.providerMetadata, chunk.metadata),
             providerExecuted: inferProviderExecuted(chunk.payload.providerExecuted, resultToolDef),
           });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -44,7 +44,7 @@ import {
 import { findProviderToolByName, inferProviderExecuted } from '../../../tools/provider-tool-utils';
 import type { ToolToConvert } from '../../../tools/tool-builder/builder';
 import { getProviderToolName, isMastraTool, isProviderTool } from '../../../tools/toolchecks';
-import { makeCoreTool } from '../../../utils';
+import { makeCoreTool, safeStringify } from '../../../utils';
 import { createStep } from '../../../workflows/workflow';
 import type { Workspace } from '../../../workspace/workspace';
 import type { LoopConfig, OuterLLMRun } from '../../types';
@@ -698,7 +698,7 @@ async function processOutputStream<OUTPUT = undefined>({
                   errorText:
                     typeof chunk.payload.result === 'string'
                       ? chunk.payload.result
-                      : JSON.stringify(chunk.payload.result),
+                      : safeStringify(chunk.payload.result),
                 }
               : {
                   state: 'result',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -603,6 +603,35 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
     expect(result.stepResult.isContinued).toBe(true);
   });
 
+  it('should persist tool execution errors as output-error with errorText', async () => {
+    // A thrown tool error must be stored as output-error, not a successful result, or it
+    // is indistinguishable from a real result on history reload (#15569).
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'myTool',
+        args: { param: 'test' },
+        result: undefined,
+        error: new Error('boom'),
+      },
+    ];
+
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    expect(messageList.updateToolInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'output-error',
+          toolCallId: 'call-1',
+          toolName: 'myTool',
+          args: { param: 'test' },
+          errorText: 'boom',
+        },
+      }),
+    );
+  });
+
   it('should continue the loop when a tool execution error occurs alongside successful tool results', async () => {
     // Mixed scenario: one tool succeeds, one throws at runtime.
     // The model should see both the success and the error, and be allowed to retry.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -604,8 +604,6 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
   });
 
   it('should persist tool execution errors as output-error with errorText', async () => {
-    // A thrown tool error must be stored as output-error, not a successful result, or it
-    // is indistinguishable from a real result on history reload (#15569).
     const inputData: ToolCallOutput[] = [
       {
         toolCallId: 'call-1',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -12,6 +12,7 @@ import {
   withToolPayloadTransformProviderMetadata,
 } from '../../../tools/payload-transform';
 import { findProviderToolByName } from '../../../tools/provider-tool-utils';
+import { safeStringify } from '../../../utils';
 import { createStep } from '../../../workflows/workflow';
 import type { OuterLLMRun } from '../../types';
 import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
@@ -298,7 +299,12 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
                 toolCallId: toolCall.toolCallId,
                 toolName: sanitizeToolName(toolCall.toolName),
                 args: toolCall.args,
-                errorText: String(toolCall.error?.message ?? toolCall.error),
+                errorText:
+                  toolCall.error instanceof Error
+                    ? toolCall.error.message
+                    : toolCall.error == null
+                      ? 'Tool execution failed'
+                      : safeStringify(toolCall.error),
               },
               ...(withToolPayloadTransformProviderMetadata(
                 toolCall.providerMetadata as ProviderMetadata,

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -294,11 +294,11 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
             rest.messageList.updateToolInvocation({
               type: 'tool-invocation' as const,
               toolInvocation: {
-                state: 'result' as const,
+                state: 'output-error' as const,
                 toolCallId: toolCall.toolCallId,
                 toolName: sanitizeToolName(toolCall.toolName),
                 args: toolCall.args,
-                result: toolCall.error?.message ?? toolCall.error,
+                errorText: String(toolCall.error?.message ?? toolCall.error),
               },
               ...(withToolPayloadTransformProviderMetadata(
                 toolCall.providerMetadata as ProviderMetadata,

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -758,6 +758,12 @@ describe('safeStringify', () => {
     const result = safeStringify(obj);
     expect(JSON.parse(result)).toEqual({ count: '42', name: 'test' });
   });
+
+  it('should return strings for top-level values JSON.stringify omits', () => {
+    expect(safeStringify(undefined)).toBe('undefined');
+    expect(safeStringify(Symbol('tool-error'))).toBe('Symbol(tool-error)');
+    expect(safeStringify(function toolError() {})).toContain('function toolError()');
+  });
 });
 
 describe('ensureSerializable', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -34,7 +34,7 @@ export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, 
  */
 export function safeStringify(value: unknown, space?: string | number): string {
   const stack: unknown[] = [];
-  return JSON.stringify(
+  const result = JSON.stringify(
     value,
     function (this: unknown, _key: string, val: unknown) {
       if (typeof val === 'bigint') return val.toString();
@@ -51,6 +51,8 @@ export function safeStringify(value: unknown, space?: string | number): string {
     },
     space,
   );
+
+  return result ?? String(value);
 }
 
 /**


### PR DESCRIPTION
## Description

This PR fixes failed tool calls being restored from history as successful results. Tool execution errors are now persisted as `output-error` states and preserved across message rebuilds and V1/V4/V5 history conversion paths.

- Updated agentic execution to persist failed tool results as `state: 'output-error'` with `errorText`
- Updated history rebuild logic to preserve errored tool outputs instead of treating them as successful results
- Added V1 and V4 message conversion support for `output-error` tool invocations
- Updated `safeStringify` so error serialization always returns a string
- Added focused tests for execution, mapping, history rebuild, conversion, snapshots, utility behavior, and agent loop recovery
- Added a changeset for `@mastra/core`

## Related Issue(s)

Fixes #15569

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a tool used by the AI fails, the system used to forget and show it as successful after reloading a conversation. This PR makes sure tool failures are saved and shown as errors when you reload.

## Overview

Fixes `#15569` by ensuring tool execution errors are persisted and reconstructed as errors (state "output-error" with errorText) across agent execution, streamed provider results, and historical message conversions (V1/V4/V5). Also ensures error payloads are stringified reliably.

## Key Changes

- Persist tool errors as output-error with errorText
  - llm-mapping-step.ts: persist thrown tool errors as toolInvocation.state = 'output-error' and set errorText (safe-stringified fallback).
  - llm-execution-step.ts: respect chunk.payload.isError for provider-executed tool-result streams and update messageList with state 'output-error' and derived errorText when appropriate.
  - build-messages-from-chunks.ts: collect isError tool-results and emit tool-invocation parts with state 'output-error', using safeStringify/fallback messages for errorText.

- Preserve errors in history conversion and adapters
  - convert-to-mastra-v1.ts: generate tool-result messages from both successful results and output-error:errorText.
  - AIV4Adapter/AIV5Adapter/AIV6Adapter: added explicit handling/mapping for 'output-error' so history rebuild and UI conversions preserve errorText and error state.
  - message-list/message-list.ts and related merger/conversion logic: updated to include output-error when building UI tool invocation lists and to carry errorText through transforms.

- Utility: safeStringify
  - utils.ts: safeStringify now guarantees a string return (falls back to String(value) when JSON.stringify yields nullish), stabilizing serialization of errors and unusual values.

## Tests

Added and updated tests covering:
- buildMessagesFromChunks error merging into output-error parts
- llm-execution-step handling of provider error chunks
- llm-mapping-step persisting thrown tool errors
- agent loop self-recovery behavior when tools fail (error forwarded into next LLM call, loop termination, persisted output-error)
- convertToV1 and V4/V5 adapter conversions preserving output-error and errorText
- safeStringify behavior for non-JSON values

## Related

- Adds a changeset for `@mastra/core` and documentation/UI mappings already reference output-error handling.
- Fixes: `#15569`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->