### PR TITLE
fix(core): move hono from dependencies to peerDependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -776,8 +776,6 @@
     "execa": "^9.6.1",
     "fastq": "^1.19.1",
     "gray-matter": "^4.0.3",
-    "hono": "^4.12.8",
-    "hono-openapi": "^1.3.0",
     "ignore": "^7.0.5",
     "json-schema": "^0.4.0",
     "lru-cache": "^11.2.7",
@@ -787,10 +785,12 @@
     "posthog-node": "^5.30.6",
     "tokenx": "^1.3.0",
     "ws": "^8.20.0",
-    "xxhash-wasm": "^1.1.0"
+    "xxhash-wasm": "^1.1.0",
+    "hono-openapi": "^1.3.0"
   },
   "peerDependencies": {
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^3.25.0 || ^4.0.0",
+    "hono": "^4.12.8"
   },
   "devDependencies": {
     "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.79",


### PR DESCRIPTION
Fixes #17395

When `hono` is listed as a regular `dependency` of `@mastra/core`, package managers may resolve a separate `hono` instance from the one the user installs. Because Hono uses a unique `GET_MATCH_RESULT` symbol internally, two different instances produce incompatible `Handler` types — causing TypeScript errors when users register `chatRoute()` handlers on their own `Hono` router.

Moving `hono` to `peerDependencies` ensures both `@mastra/core` and the consuming application share the same instance, making the `Handler` types fully compatible.

Users who don't use the Hono integration are unaffected — their package manager simply ignores the uninstalled peer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR fixes a compatibility problem where applications using `@mastra/core` couldn't properly use their own Hono web server because `@mastra/core` was bringing its own version of Hono. The fix tells `@mastra/core` to use the same Hono instance that the application already has installed, instead of its own separate copy.

## Changes
- **packages/core/package.json**: Moved `hono` from `dependencies` to `peerDependencies` to ensure `@mastra/core` and consuming applications share the same Hono instance, eliminating TypeScript type incompatibility issues caused by Hono's internal unique symbol `GET_MATCH_RESULT`.
- `hono-openapi` remains in `dependencies` with adjusted positioning in the dependency list.

## Rationale
When `hono` was listed as a regular dependency, package managers could resolve a different Hono instance than the consumer's application, causing the `GET_MATCH_RESULT` unique symbol to differ between instances. This made Handler types from `@mastra/core` incompatible with the consumer's own Hono router, resulting in TypeScript errors when registering `chatRoute()` handlers. By moving `hono` to `peerDependencies`, both `@mastra/core` and the consuming application are guaranteed to use the same Hono instance. This approach is unopinionated for users who don't use the Hono integration, as uninstalled peer dependencies are ignored by package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->