### PR TITLE
fix(convex): use indexed message lookups

### DIFF
--- a/.changeset/easy-berries-scream.md
+++ b/.changeset/easy-berries-scream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Fixed Convex message lookups so they use indexed ids instead of a capped full-table scan.

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -1,4 +1,5 @@
 import {
+  TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_SCHEDULES,
   TABLE_THREADS,
@@ -16,7 +17,7 @@ type StorageHandlerForTest = typeof mastraStorage & {
 };
 type TestDoc = { _id: GenericId<string>; id?: string; record?: Record<string, unknown> };
 type TestQueryBuilder = {
-  eq: (field: string, value: unknown) => TestQueryBuilder;
+  eq: (field: string, value: string) => TestQueryBuilder;
   lte?: (field: string, value: number) => TestQueryBuilder;
   gte?: (field: string, value: number) => TestQueryBuilder;
   lt?: (field: string, value: number) => TestQueryBuilder;
@@ -60,6 +61,85 @@ describe('mastraStorage typed load', () => {
     expect(builder.eq).toHaveBeenNthCalledWith(2, 'run_id', 'run-1');
     expect(unique).toHaveBeenCalledTimes(1);
     expect(take).not.toHaveBeenCalled();
+  });
+
+  it('loads multiple typed records through by_record_id without scanning the table', async () => {
+    const docsById = new Map([
+      ['message-1', { _id: asConvexId('doc-message-1'), id: 'message-1' }],
+      ['message-2', { _id: asConvexId('doc-message-2'), id: 'message-2' }],
+    ]);
+    const requestedFilters: Array<{ field: string; value: string }> = [];
+    const take = vi.fn(async () => {
+      throw new Error('loadMany should not scan the table');
+    });
+    const withIndex = vi.fn((_indexName: string, queryBuilder: (q: TestQueryBuilder) => TestQueryBuilder) => {
+      let lookupId = '';
+      const builder: TestQueryBuilder = {
+        eq: vi.fn((field: string, value: string) => {
+          requestedFilters.push({ field, value });
+          lookupId = value;
+          return builder;
+        }),
+      };
+      queryBuilder(builder);
+      return {
+        unique: vi.fn(async () => docsById.get(lookupId) ?? null),
+        take,
+      };
+    });
+    const query = vi.fn(() => ({ withIndex, take }));
+    const ctx = { db: { query } } as unknown as TypedOperationCtx;
+
+    const result = await handleTypedOperation(ctx, 'mastra_messages', {
+      op: 'loadMany',
+      tableName: TABLE_MESSAGES,
+      ids: ['message-2', 'missing-message', 'message-1', 'message-2'],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      result: [
+        { _id: asConvexId('doc-message-2'), id: 'message-2' },
+        { _id: asConvexId('doc-message-1'), id: 'message-1' },
+      ],
+    });
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(withIndex).toHaveBeenCalledTimes(3);
+    expect(withIndex).toHaveBeenCalledWith('by_record_id', expect.any(Function));
+    expect(requestedFilters).toEqual([
+      { field: 'id', value: 'message-2' },
+      { field: 'id', value: 'missing-message' },
+      { field: 'id', value: 'message-1' },
+    ]);
+    expect(take).not.toHaveBeenCalled();
+  });
+
+  it('rejects loadMany requests that exceed the mutation-boundary id limit', async () => {
+    const query = vi.fn();
+    const ctx = { db: { query } } as unknown as TypedOperationCtx;
+
+    await expect(
+      handleTypedOperation(ctx, 'mastra_messages', {
+        op: 'loadMany',
+        tableName: TABLE_MESSAGES,
+        ids: Array.from({ length: 11 }, (_, index) => `message-${index}`),
+      }),
+    ).rejects.toThrow('loadMany supports at most 10 ids per request');
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate-heavy loadMany requests before deduping ids', async () => {
+    const query = vi.fn();
+    const ctx = { db: { query } } as unknown as TypedOperationCtx;
+
+    await expect(
+      handleTypedOperation(ctx, 'mastra_messages', {
+        op: 'loadMany',
+        tableName: TABLE_MESSAGES,
+        ids: Array.from({ length: 11 }, () => 'message-1'),
+      }),
+    ).rejects.toThrow('loadMany supports at most 10 ids per request');
+    expect(query).not.toHaveBeenCalled();
   });
 });
 
@@ -1690,6 +1770,36 @@ describe('mastraStorage bulk mutations', () => {
     expect(batchCtx.inserts).toEqual([]);
   });
 
+  it('background task loadMany preserves request order across typed and legacy fallback rows', async () => {
+    const batchCtx = createBatchInsertCtx(
+      new Map([
+        ['typed-task', { _id: asConvexId('typed-task-doc'), id: 'typed-task', status: 'running' }],
+        [
+          'mastra_background_tasks|legacy-task',
+          {
+            _id: asConvexId('legacy-task-doc'),
+            record: { id: 'legacy-task', status: 'pending' },
+          },
+        ],
+      ]),
+    );
+
+    const result = await handleTypedOperation(batchCtx.ctx, 'mastra_background_tasks', {
+      op: 'loadMany',
+      tableName: 'mastra_background_tasks',
+      ids: ['legacy-task', 'typed-task'],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      result: [
+        { id: 'legacy-task', status: 'pending' },
+        { _id: asConvexId('typed-task-doc'), id: 'typed-task', status: 'running' },
+      ],
+    });
+    expect(batchCtx.lookupKeys).toEqual(['legacy-task', 'typed-task', 'mastra_background_tasks|legacy-task']);
+  });
+
   it('vector batchInsert keeps the last record for duplicate ids and scopes lookups by vector index', async () => {
     const batchCtx = createBatchInsertCtx(new Map([['embeddings|existing', { _id: asConvexId('vector-existing') }]]));
 
@@ -1739,6 +1849,30 @@ describe('mastraStorage bulk mutations', () => {
       },
     ]);
     expect(batchCtx.inserts).toEqual([]);
+  });
+
+  it('vector loadMany scopes indexed lookups by vector index without scanning the vector table', async () => {
+    const batchCtx = createBatchInsertCtx(
+      new Map([
+        ['embeddings|one', { _id: asConvexId('vector-one'), id: 'one', indexName: 'embeddings' }],
+        ['embeddings|two', { _id: asConvexId('vector-two'), id: 'two', indexName: 'embeddings' }],
+      ]),
+    );
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(batchCtx.ctx, {
+      op: 'loadMany',
+      tableName: 'mastra_vector_embeddings',
+      ids: ['one', 'missing', 'two', 'one'],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      result: [
+        { _id: asConvexId('vector-one'), id: 'one', indexName: 'embeddings' },
+        { _id: asConvexId('vector-two'), id: 'two', indexName: 'embeddings' },
+      ],
+    });
+    expect(batchCtx.lookupKeys).toEqual(['embeddings|one', 'embeddings|missing', 'embeddings|two']);
   });
 
   it('generic batchInsert keeps the last duplicate record for fallback tables', async () => {

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -25,6 +25,9 @@ const CONVEX_TABLE_WORKFLOW_SNAPSHOTS = 'mastra_workflow_snapshots';
 const CONVEX_TABLE_BACKGROUND_TASKS = 'mastra_background_tasks';
 const CONVEX_TABLE_DOCUMENTS = 'mastra_documents';
 const STORAGE_MUTATION_BATCH_SIZE = 25;
+// Keep this in sync with ConvexDB's loadMany client chunk size. The low cap
+// bounds full-doc responses per request; individual document size still matters.
+const LOAD_MANY_MAX_IDS_PER_REQUEST = 10;
 const DEFAULT_SCHEDULE_QUERY_LIMIT = 100;
 
 type ConvexDocWithId = { _id: GenericId<string> };
@@ -56,6 +59,13 @@ const BACKGROUND_TASK_FIELD_ALIASES: Record<string, string> = {
 function normalizeScheduleQueryLimit(limit: number | undefined): number {
   if (limit == null || !Number.isFinite(limit)) return DEFAULT_SCHEDULE_QUERY_LIMIT;
   return Math.max(0, Math.floor(limit));
+}
+
+function normalizeLoadManyIds(ids: string[]): string[] {
+  if (ids.length > LOAD_MANY_MAX_IDS_PER_REQUEST) {
+    throw new Error(`loadMany supports at most ${LOAD_MANY_MAX_IDS_PER_REQUEST} ids per request`);
+  }
+  return [...new Set(ids)];
 }
 
 function applyConvexEqualityFilters(
@@ -621,6 +631,37 @@ export async function handleTypedOperation(
       return { ok: true, result: match || null };
     }
 
+    case 'loadMany': {
+      const ids = normalizeLoadManyIds(request.ids);
+      const docs = await mapInBatches(ids, STORAGE_MUTATION_BATCH_SIZE, id =>
+        ctx.db
+          .query(convexTable)
+          .withIndex('by_record_id', (q: any) => q.eq('id', id))
+          .unique(),
+      );
+      const typedDocs = docs.filter(Boolean);
+
+      if (!isBackgroundTasksTable(convexTable, request)) {
+        return { ok: true, result: typedDocs };
+      }
+
+      const typedDocsById = new Map(typedDocs.map(doc => [String((doc as Record<string, unknown>).id), doc]));
+      const legacyDocs = await mapInBatches(
+        ids.filter(id => !typedDocsById.has(id)),
+        STORAGE_MUTATION_BATCH_SIZE,
+        id => findGenericDocumentById(ctx, request.tableName, id),
+      );
+      const legacyRecordsById = new Map(
+        legacyDocs
+          .filter((doc): doc is GenericDocumentDoc => Boolean(doc))
+          .map(doc => [String(doc.record.id), doc.record]),
+      );
+      return {
+        ok: true,
+        result: ids.map(id => typedDocsById.get(id) ?? legacyRecordsById.get(id)).filter(Boolean),
+      };
+    }
+
     case 'queryTable': {
       // Use take() to avoid hitting Convex's 32k document limit
       const maxDocs = request.limit ? Math.min(request.limit * 2, 10000) : 10000;
@@ -888,6 +929,16 @@ async function handleVectorOperation(ctx: MutationCtx<any>, request: StorageRequ
       return { ok: true, result: null };
     }
 
+    case 'loadMany': {
+      const docs = await findExistingDocsByIds(normalizeLoadManyIds(request.ids), id =>
+        ctx.db
+          .query(convexTable)
+          .withIndex('by_index_id', (q: any) => q.eq('indexName', indexName).eq('id', id))
+          .unique(),
+      );
+      return { ok: true, result: docs };
+    }
+
     case 'queryTable': {
       if (request.cursor !== undefined && request.pageSize === undefined) {
         throw new Error('queryTable cursor requires pageSize');
@@ -1065,6 +1116,16 @@ async function handleGenericOperation(ctx: MutationCtx<any>, request: StorageReq
         .take(10000);
       const match = docs.find((doc: any) => Object.entries(keys).every(([key, value]) => doc.record?.[key] === value));
       return { ok: true, result: match ? match.record : null };
+    }
+
+    case 'loadMany': {
+      const docs = await mapInBatches(normalizeLoadManyIds(request.ids), STORAGE_MUTATION_BATCH_SIZE, id =>
+        findGenericDocumentById(ctx, tableName, id),
+      );
+      return {
+        ok: true,
+        result: docs.filter((doc): doc is GenericDocumentDoc => Boolean(doc)).map(doc => doc.record),
+      };
     }
 
     case 'queryTable': {

--- a/stores/convex/src/storage/db/index.ts
+++ b/stores/convex/src/storage/db/index.ts
@@ -15,6 +15,9 @@ import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 import { ConvexAdminClient } from '../client';
 import type { EqualityFilter, IndexHint } from '../types';
 
+// Must not exceed the server-side loadMany id cap in server/storage.ts.
+const LOAD_MANY_REQUEST_BATCH_SIZE = 10;
+
 /**
  * Configuration for standalone domain usage.
  * Accepts either:
@@ -200,6 +203,23 @@ export class ConvexDB extends MastraBase {
     });
 
     return result;
+  }
+
+  async loadMany<R>(tableName: TABLE_NAMES, ids: string[]): Promise<R[]> {
+    const uniqueIds = [...new Set(ids)];
+    if (uniqueIds.length === 0) return [];
+
+    const rows: R[] = [];
+    for (let index = 0; index < uniqueIds.length; index += LOAD_MANY_REQUEST_BATCH_SIZE) {
+      rows.push(
+        ...(await this.client.callStorage<R[]>({
+          op: 'loadMany',
+          tableName,
+          ids: uniqueIds.slice(index, index + LOAD_MANY_REQUEST_BATCH_SIZE),
+        })),
+      );
+    }
+    return rows;
   }
 
   public async queryTable<R>(

--- a/stores/convex/src/storage/domains/memory/index.ts
+++ b/stores/convex/src/storage/domains/memory/index.ts
@@ -349,8 +349,8 @@ export class MemoryConvex extends MemoryStorage {
     if (messageIds.length === 0) {
       return { messages: [] };
     }
-    const rows = await this.#db.queryTable<StoredMessage>(TABLE_MESSAGES, undefined);
-    const filtered = rows.filter(row => messageIds.includes(row.id)).map(row => this.parseStoredMessage(row));
+    const rows = await this.#db.loadMany<StoredMessage>(TABLE_MESSAGES, messageIds);
+    const filtered = rows.map(row => this.parseStoredMessage(row));
     const list = new MessageList().add(filtered, 'memory');
     return { messages: list.get.all.db() };
   }
@@ -407,12 +407,16 @@ export class MemoryConvex extends MemoryStorage {
   }): Promise<MastraDBMessage[]> {
     if (messages.length === 0) return [];
 
-    const existing = await this.#db.queryTable<StoredMessage>(TABLE_MESSAGES, undefined);
+    const existingRows = await this.#db.loadMany<StoredMessage>(
+      TABLE_MESSAGES,
+      messages.map(message => message.id),
+    );
+    const existing = new Map(existingRows.map(row => [row.id, row]));
     const updated: MastraDBMessage[] = [];
     const affectedThreadIds = new Set<string>();
 
     for (const update of messages) {
-      const current = existing.find(row => row.id === update.id);
+      const current = existing.get(update.id);
       if (!current) continue;
 
       // Track old thread for timestamp update

--- a/stores/convex/src/storage/domains/memory/memory.test.ts
+++ b/stores/convex/src/storage/domains/memory/memory.test.ts
@@ -192,9 +192,37 @@ describe('MemoryConvex atomic memory writes', () => {
     });
   });
 
+  it('loads messages by id through indexed point lookups', async () => {
+    const storedMessage = {
+      id: 'message-1',
+      thread_id: 'thread-1',
+      resourceId: 'resource-1',
+      role: 'user',
+      type: 'v2',
+      content: JSON.stringify({ format: 2, parts: [{ type: 'text', text: 'hello' }], content: 'hello' }),
+      createdAt: '2026-05-29T00:00:00.000Z',
+    };
+    const { calls, memory } = createMemoryDomain(request => {
+      if (request.op === 'loadMany') return [storedMessage];
+      throw new Error(`Unexpected storage op ${request.op}`);
+    });
+
+    await expect(memory.listMessagesById({ messageIds: ['message-1'] })).resolves.toMatchObject({
+      messages: [expect.objectContaining({ id: 'message-1', threadId: 'thread-1' })],
+    });
+
+    expect(calls).toEqual([
+      {
+        op: 'loadMany',
+        tableName: TABLE_MESSAGES,
+        ids: ['message-1'],
+      },
+    ]);
+  });
+
   it('bumps updated-message threads with timestamp-only patches', async () => {
     const { calls, memory } = createMemoryDomain(request => {
-      if (request.op === 'queryTable') {
+      if (request.op === 'loadMany') {
         return [
           {
             id: 'message-1',
@@ -217,12 +245,18 @@ describe('MemoryConvex atomic memory writes', () => {
         {
           id: 'message-1',
           threadId: 'new-thread',
-          content: { content: 'new' },
+          content: { format: 2, parts: [{ type: 'text', text: 'new' }], content: 'new' },
         },
       ],
     });
 
     expect(calls.filter(call => call.op === 'load')).toEqual([]);
+    expect(calls.filter(call => call.op === 'queryTable')).toEqual([]);
+    expect(calls[0]).toMatchObject({
+      op: 'loadMany',
+      tableName: TABLE_MESSAGES,
+      ids: ['message-1'],
+    });
     expect(calls.filter(call => call.op === 'patch')).toEqual([
       {
         op: 'patch',

--- a/stores/convex/src/storage/index.test.ts
+++ b/stores/convex/src/storage/index.test.ts
@@ -4,6 +4,7 @@ import {
   createClientAcceptanceTests,
   createDomainDirectTests,
 } from '@internal/storage-test-utils';
+import { TABLE_MESSAGES } from '@mastra/core/storage';
 import dotenv from 'dotenv';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -386,6 +387,42 @@ describe('ConvexDB schedule operations', () => {
     await expect(db.recordScheduleTrigger({ schedule_id: 'schedule-1' })).rejects.toThrow(
       'Schedule trigger is missing an id',
     );
+
+    expect(callStorage).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConvexDB loadMany', () => {
+  it('dedupes and chunks ids before calling storage', async () => {
+    const callStorage = vi.fn(async request => request.ids.map((id: string) => ({ id })));
+    const db = new ConvexDB({ callStorage } as unknown as ConvexAdminClient);
+    const ids = [...Array.from({ length: 205 }, (_, index) => `message-${index}`), 'message-0', 'message-100'];
+
+    await expect(db.loadMany(TABLE_MESSAGES, ids)).resolves.toHaveLength(205);
+
+    expect(callStorage).toHaveBeenCalledTimes(21);
+    expect(callStorage).toHaveBeenNthCalledWith(1, {
+      op: 'loadMany',
+      tableName: TABLE_MESSAGES,
+      ids: ids.slice(0, 10),
+    });
+    expect(callStorage).toHaveBeenNthCalledWith(20, {
+      op: 'loadMany',
+      tableName: TABLE_MESSAGES,
+      ids: ids.slice(190, 200),
+    });
+    expect(callStorage).toHaveBeenNthCalledWith(21, {
+      op: 'loadMany',
+      tableName: TABLE_MESSAGES,
+      ids: ids.slice(200, 205),
+    });
+  });
+
+  it('skips storage calls for empty id lists', async () => {
+    const callStorage = vi.fn();
+    const db = new ConvexDB({ callStorage } as unknown as ConvexAdminClient);
+
+    await expect(db.loadMany(TABLE_MESSAGES, [])).resolves.toEqual([]);
 
     expect(callStorage).not.toHaveBeenCalled();
   });

--- a/stores/convex/src/storage/types.ts
+++ b/stores/convex/src/storage/types.ts
@@ -49,6 +49,11 @@ export type StorageRequest =
       keys: Record<string, any>;
     }
   | {
+      op: 'loadMany';
+      tableName: TABLE_NAMES | string;
+      ids: string[];
+    }
+  | {
       op: 'clearTable' | 'dropTable';
       tableName: TABLE_NAMES | string;
     }


### PR DESCRIPTION
This fixes two Convex memory paths that loaded the capped full messages table and filtered in memory.

`listMessagesById` and `updateMessages` now use a bounded internal `loadMany` operation that resolves requested ids through existing Convex indexes. The storage handler caps each request, chunks client calls, and preserves typed, vector, generic, and background-task fallback behavior.

This is a query-shape and correctness fix, not an end-to-end performance claim. It avoids relying on a broad capped table read when the caller already has specific message ids.

Fixes #17407

Validation:
- `pnpm --filter ./stores/convex test`
- `pnpm --filter ./stores/convex build:lib`
- `pnpm --filter ./stores/convex lint`
- `pnpm --filter ./stores/convex exec tsc --noEmit --project tsconfig.json`
- `pnpm prettier --check stores/convex/src/server/storage.ts stores/convex/src/storage/db/index.ts stores/convex/src/server/storage.test.ts stores/convex/src/storage/index.test.ts stores/convex/src/storage/domains/memory/index.ts stores/convex/src/storage/domains/memory/memory.test.ts stores/convex/src/storage/types.ts .changeset/easy-berries-scream.md`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Instead of reading through an entire messages table to find specific messages (which is slow and might miss messages if the table is too big), this PR teaches the system to use an index to jump directly to the messages you're looking for by their ID, similar to how using a book's index is faster than reading every page.

## Overview

This PR replaces two Convex memory operations that performed capped full-table reads with indexed lookups. `listMessagesById` and `updateMessages` now use a new `loadMany` operation that resolves requested IDs via existing Convex indexes, avoiding broad table scans when specific message IDs are provided.

## Changes

### New `loadMany` Storage Operation
- **Type definition** (`stores/convex/src/storage/types.ts`): Added `loadMany` variant to `StorageRequest` discriminated union, accepting `tableName` and `ids: string[]`
- **Core storage client** (`stores/convex/src/storage/db/index.ts`): Implemented `ConvexDB.loadMany` method that deduplicates input IDs, batches requests (with `LOAD_MANY_REQUEST_BATCH_SIZE` constant), and aggregates results from `callStorage`

### Storage Handler Implementation
- **Typed tables** (`stores/convex/src/server/storage.ts`): Added `loadMany` handler that fetches records via the `by_record_id` index for typed tables. For background-task tables, it supplements missing typed records with lookups in the generic table and preserves original request order
- **Vector table** (`stores/convex/src/server/storage.ts`): Added `loadMany` handler using the `by_index_id` composite index for vector lookups
- **Generic fallback** (`stores/convex/src/server/storage.ts`): Added `loadMany` handler for fallback generic document queries
- Request validation: Introduced `LOAD_MANY_MAX_IDS_PER_REQUEST` cap and `normalizeLoadManyIds` helper that deduplicates and validates request size

### Message Domain Updates
- **`listMessagesById`** (`stores/convex/src/storage/domains/memory/index.ts`): Replaced full-table message query with `#db.loadMany` to fetch only requested records
- **`updateMessages`** (`stores/convex/src/storage/domains/memory/index.ts`): Replaced full-table message query with `#db.loadMany` to load only messages being updated, avoiding in-memory search

## Testing Coverage

- **Typed `loadMany` tests** (`stores/convex/src/server/storage.test.ts`): Verify indexed lookups via `by_record_id` without table scans, request size validation (10 ID limit), handling of duplicates pre-dedup, and result ordering preservation
- **Background-task `loadMany` test**: Confirms fallback lookup merging and request-order preservation for mixed typed/legacy results
- **Vector `loadMany` test**: Asserts indexed lookups via `by_index_id` for present and missing entries
- **Memory operation tests** (`stores/convex/src/storage/domains/memory/memory.test.ts`): Verify `listMessagesById` and `updateMessages` use `loadMany` via single indexed storage call
- **Integration tests** (`stores/convex/src/storage/index.test.ts`): Confirm `ConvexDB.loadMany` batching behavior and empty ID list handling

## Release
- Changeset added for `@mastra/convex` with patch version bump

<!-- end of auto-generated comment: release notes by coderabbit.ai -->