### PR TITLE
docs(editor): document code source and per-agent editor ownership

### DIFF
--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -61,6 +61,41 @@ See the [MastraEditor reference](/reference/editor/mastra-editor) for all config
 
 :::
 
+## Code and database sources
+
+The editor stores agent overrides in one of two sources, set with the `source` option on `MastraEditor`:
+
+| Source | Where overrides live | Studio actions |
+| - | - | - |
+| `db` (default) | The configured storage backend. | Save and publish drafts. |
+| `code` | Per-agent JSON files on disk, tracked in your repository. | Download the override file or save it to the filesystem. |
+
+The default `db` source is best when non-developers iterate through Studio and you want versioning, drafts, and runtime version targeting. The `code` source is best when overrides should live in your repository alongside the rest of your code, reviewed through pull requests and deployed with your application.
+
+To use the code source, set `source: 'code'`:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { MastraEditor } from '@mastra/editor'
+
+export const mastra = new Mastra({
+  agents: {
+    /* your existing agents */
+  },
+  editor: new MastraEditor({
+    source: 'code',
+  }),
+})
+```
+
+When `source` is `'code'`, the editor writes each override to a deterministic JSON file under `./mastra/editor/agents/<agentId>.json`. Set `codePath` to change the directory. Because the files are deterministic, every save produces a clean diff you can commit and review.
+
+### Versioning with the code source
+
+The code source uses the Git history of each per-agent JSON file as its version history. Each commit that changes a file appears as a read-only version in Studio, labeled with the commit message. Saving in Studio updates the working file in place rather than creating a database draft, so the version dropdown reflects your actual commit history.
+
+This means versions and rollbacks are managed through Git rather than through draft and publish actions.
+
 ## Studio
 
 <VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1775596827/editor-overview_obqupx.mp4" />
@@ -118,8 +153,9 @@ The same operations are available over HTTP through the Mastra server. Use these
 | `GET` | `/stored/agents/:storedAgentId` | Get a stored agent by ID. |
 | `PATCH` | `/stored/agents/:storedAgentId` | Update a stored agent. |
 | `DELETE` | `/stored/agents/:storedAgentId` | Delete a stored agent. |
+| `POST` | `/stored/agents/:storedAgentId/export` | Export a stored agent's override as a deterministic JSON config. |
 
-The Client SDK wraps these endpoints with `client.listStoredAgents()`, `client.createStoredAgent()`, and `client.getStoredAgent()`. Version management endpoints live under `/stored/agents/:storedAgentId/versions`, see [version management](/reference/client-js/agents#version-management) for the full list.
+The export endpoint returns only the fields the agent's [`editor` config](/reference/agents/agent#editor-overrides) allows, so the output matches the per-agent file the code source writes to disk. The Client SDK wraps these endpoints with `client.listStoredAgents()`, `client.createStoredAgent()`, `client.getStoredAgent()`, and `client.getStoredAgent(id).export()`. Version management endpoints live under `/stored/agents/:storedAgentId/versions`, see [version management](/reference/client-js/agents#version-management) for the full list.
 
 ### Automated experimentation
 
@@ -149,6 +185,32 @@ When you edit a code-defined agent through the editor, only specific fields can 
 | Tools | Add tools from the tool registry, integration providers, or MCP clients. Code-defined tools remain available. |
 
 Fields like the agent's `id`, `name`, and `model` come from your code and can't be changed through the editor for code-defined agents. The variables are also read-only.
+
+### Controlling what is editable
+
+Use the `editor` field on a code-defined agent to control which fields the editor can override. This lets you keep some fields code-owned while allowing edits to others:
+
+```typescript title="src/mastra/agents/support-agent.ts"
+import { Agent } from '@mastra/core/agent'
+
+export const supportAgent = new Agent({
+  name: 'support-agent',
+  model: 'openai/gpt-4o',
+  editor: { instructions: true, tools: { description: true } },
+})
+```
+
+The `editor` field accepts these shapes:
+
+| Value | Result |
+| - | - |
+| Omitted | Instructions and tools are editable. |
+| `false` | Nothing is editable. The agent is locked. |
+| `{ instructions: true }` | Instructions are editable. |
+| `{ tools: true }` | Tool membership and descriptions are editable. |
+| `{ tools: { description: true } }` | Only tool descriptions are editable. Membership is locked. |
+
+When a field is owned by code, Studio shows it as read-only and the server strips it from saved overrides, so the stored config only contains the fields you allow. See the [`editor` overrides reference](/reference/agents/agent#editor-overrides) for the full type.
 
 ## Versioning
 

--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -195,7 +195,7 @@ import { Agent } from '@mastra/core/agent'
 
 export const supportAgent = new Agent({
   name: 'support-agent',
-  model: 'openai/gpt-4o',
+  model: '__GATEWAY_OPENAI_MODEL__',
   editor: { instructions: true, tools: { description: true } },
 })
 ```

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -462,8 +462,33 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
     description:
       'Standard JSON Schema for validating request context values. When provided, the context is validated at the start of generate() or stream(), throwing a MastraError if validation fails.',
   },
+  {
+    name: 'editor',
+    type: 'false | { instructions?: boolean; tools?: boolean | { description?: boolean } }',
+    isOptional: true,
+    description:
+      'Controls which fields the editor can override for this code-defined agent. Omit to allow editing instructions and tools. See Editor overrides below.',
+  },
 ]}
 />
+
+## Editor overrides
+
+When you register the [`MastraEditor`](/reference/editor/mastra-editor), the `editor` field controls which parts of a code-defined agent can be changed through the editor. Fields owned by code are read-only in Studio and are stripped from saved overrides.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'editor',
+    type: 'false | { instructions?: boolean; tools?: boolean | { description?: boolean } }',
+    isOptional: true,
+    description:
+      'Omit to allow editing instructions and tools. Set to `false` to lock the agent. Set `instructions: true` to allow instruction edits. Set `tools: true` to allow tool membership and description edits, or `tools: { description: true }` to allow only description edits.',
+  },
+]}
+/>
+
+The agent's `id`, `name`, and `model` always come from code and can't be overridden through the editor. See the [Editor overview](/docs/editor/overview#controlling-what-is-editable) for usage.
 
 ## Returns
 

--- a/docs/src/content/en/reference/editor/mastra-editor.mdx
+++ b/docs/src/content/en/reference/editor/mastra-editor.mdx
@@ -98,6 +98,21 @@ export const mastra = new Mastra({
       'Agent Builder configuration. See the AgentBuilderOptions reference. Omit or set `enabled: false` to disable the Builder.',
     isOptional: true,
   },
+  {
+    name: 'source',
+    type: "'code' | 'db'",
+    description:
+      "Where agent overrides are stored. With 'db', overrides live in the configured storage backend and Studio shows the save and publish flow. With 'code', overrides live as per-agent JSON files on disk (routed through a local FilesystemStore) and Studio shows filesystem actions. See the Editor overview for the difference.",
+    isOptional: true,
+    defaultValue: "'db'",
+  },
+  {
+    name: 'codePath',
+    type: 'string',
+    description: "Directory used by the 'code' source for per-agent JSON files. Ignored when source is not 'code'.",
+    isOptional: true,
+    defaultValue: "'./mastra/editor/'",
+  },
 ]}
 />
 
@@ -449,3 +464,15 @@ Returns all registered sandbox providers.
 #### `getBlobStoreProviders()`
 
 Returns all registered blob store providers.
+
+### Source
+
+#### `getSource()`
+
+Returns the configured source (`'code'` or `'db'`), or `undefined` when the editor was constructed without an explicit `source`.
+
+```typescript
+const source = mastra.getEditor()?.getSource()
+```
+
+Returns: `'code' | 'db' | undefined`


### PR DESCRIPTION
## Summary

Adds documentation for the code-source editor feature that recently landed across the editor stack (PRs #17227-#17229). These user-facing surfaces shipped without docs; this PR fills the gap.

What's documented:

- MastraEditor({ source: 'code' }): persists agent overrides as deterministic per-agent JSON files on disk, alongside the default db source.
- codePath: the directory the code source writes to (./mastra/editor/ by default).
- Git-backed versioning: how the code source surfaces each file's Git commit history as read-only versions in Studio.
- Per-agent editor ownership: the editor field on Agent (false | { instructions?, tools? }) controlling which fields the editor can override.
- Stored-agent export endpoint: POST /stored/agents/:storedAgentId/export and the client.getStoredAgent(id).export() Client SDK method.

Files: editor overview, MastraEditor reference, Agent reference.

## Test plan

- remark passes on all three files.
- prettier applied. Vale runs in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR documents a new option to store editor changes as per-agent JSON files in your repo (so Git tracks them) and adds controls for which agent fields the editor is allowed to change.

## Changes

### Overview Documentation (`docs/src/content/en/docs/editor/overview.mdx`)
- Documents `source: 'code'` for `MastraEditor` so overrides can be stored as deterministic per-agent JSON files instead of the default DB source.
- Specifies the default file location: `./mastra/editor/agents/<agentId>.json` and that `codePath` can change the directory.
- Describes Git-backed versioning: the Git commit history for each file appears as read-only versions in Studio; saving updates the working file (versions/rollbacks managed via Git).
- Adds `POST /stored/agents/:storedAgentId/export` endpoint documenting export of a stored agent override as deterministic JSON; response is limited to fields allowed by the agent’s `editor` config.
- Notes Client SDK wrappers and usage including `client.getStoredAgent(id).export()` and other stored-agent CRUD/version endpoints.
- Expands "What can be overridden" with a "Controlling what is editable" section and examples of the `editor` field on code-defined agents.

### Agent Reference (`docs/src/content/en/reference/agents/agent.mdx`)
- Documents the new `editor` constructor parameter that controls which agent fields can be overridden by the editor.
- Describes supported shapes: omitted (default: instructions & tools editable), `false` (locked), `{ instructions?: boolean }`, `{ tools?: boolean | { description?: boolean } }`, and the semantics (e.g., membership vs description editing).
- Clarifies `id`, `name`, and `model` remain code-owned and are read-only in Studio; server strips code-owned fields from saved overrides.

### MastraEditor Reference (`docs/src/content/en/reference/editor/mastra-editor.mdx`)
- Documents new constructor options:
  - `source: 'code' | 'db'` (optional; default `'db'`) — controls where overrides are stored.
  - `codePath: string` (optional; ignored unless `source === 'code'`; default `'./mastra/editor/'`) — directory for per-agent JSON files.
- Adds `getSource()` method (returns `'code' | 'db' | undefined`) to inspect the configured source.
- Notes filesystem actions in Studio when using the `code` source.

## Other notes
- Files updated: editor overview, MastraEditor reference, Agent reference.
- PR includes minor example adjustments (model token placeholder usage) and passes remark/prettier/CI checks per the test plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->