### PR TITLE
fix(duckdb): release file lock on shutdown to fix dev hot-reload lock conflict

### DIFF
--- a/.changeset/duckdb-deployer-graceful-shutdown.md
+++ b/.changeset/duckdb-deployer-graceful-shutdown.md
@@ -2,4 +2,4 @@
 '@mastra/deployer': patch
 ---
 
-Added graceful shutdown to the server. On SIGINT/SIGTERM it now runs `mastra.shutdown()` before exiting, letting storage backends release resources (such as DuckDB's file lock) instead of being killed mid-flight. This fixes lock and resource leaks on `mastra dev` hot reloads.
+The server now installs SIGINT/SIGTERM handlers and runs `mastra.shutdown()` before exiting, allowing storage backends to release resources cleanly instead of being terminated mid-flight.

--- a/.changeset/duckdb-deployer-graceful-shutdown.md
+++ b/.changeset/duckdb-deployer-graceful-shutdown.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Added graceful shutdown to the server. On SIGINT/SIGTERM it now runs `mastra.shutdown()` before exiting, letting storage backends release resources (such as DuckDB's file lock) instead of being killed mid-flight. This fixes lock and resource leaks on `mastra dev` hot reloads.

--- a/.changeset/fruity-meals-sip.md
+++ b/.changeset/fruity-meals-sip.md
@@ -1,0 +1,5 @@
+---
+'@mastra/duckdb': patch
+---
+
+Fixed DuckDB "Conflicting lock is held" error on `mastra dev` hot reload. `DuckDBStore` now releases its native file lock on shutdown so the restarted dev process can reopen the same database file.

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -602,6 +602,7 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
   // native file lock) before the process exits. On `mastra dev` hot reloads
   // the old process is sent SIGINT; without this the lock can linger and the
   // restarted process fails with "Conflicting lock is held".
+  const SHUTDOWN_TIMEOUT_MS = 5000;
   let shuttingDown = false;
   const shutdown = async (signal: NodeJS.Signals) => {
     if (shuttingDown) {
@@ -614,10 +615,21 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
     // Feature-detect for older @mastra/core versions without shutdown().
     const lifecycle = mastra as unknown as { shutdown?: () => Promise<void> };
     if (typeof lifecycle.shutdown === 'function') {
+      // Bound the wait so a hanging shutdown can't block process exit.
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const timedOut = Symbol('shutdown-timeout');
+      const timeoutPromise = new Promise<typeof timedOut>(resolve => {
+        timeout = setTimeout(() => resolve(timedOut), SHUTDOWN_TIMEOUT_MS);
+      });
       try {
-        await lifecycle.shutdown();
+        const result = await Promise.race([lifecycle.shutdown(), timeoutPromise]);
+        if (result === timedOut) {
+          logger.warn('Mastra shutdown timed out; forcing exit', { timeoutMs: SHUTDOWN_TIMEOUT_MS });
+        }
       } catch (error) {
         logger.error('Error during Mastra shutdown', { error });
+      } finally {
+        clearTimeout(timeout);
       }
     }
     process.exit(0);

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -598,5 +598,32 @@ export async function createNodeServer(mastra: Mastra, options: ServerBundleOpti
     await workerLifecycle.startEventEngine();
   }
 
+  // Graceful shutdown so storage backends release resources (e.g. DuckDB's
+  // native file lock) before the process exits. On `mastra dev` hot reloads
+  // the old process is sent SIGINT; without this the lock can linger and the
+  // restarted process fails with "Conflicting lock is held".
+  let shuttingDown = false;
+  const shutdown = async (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    const logger = mastra.getLogger();
+    logger.info('Shutting down Mastra server', { signal });
+    server.close();
+    // Feature-detect for older @mastra/core versions without shutdown().
+    const lifecycle = mastra as unknown as { shutdown?: () => Promise<void> };
+    if (typeof lifecycle.shutdown === 'function') {
+      try {
+        await lifecycle.shutdown();
+      } catch (error) {
+        logger.error('Error during Mastra shutdown', { error });
+      }
+    }
+    process.exit(0);
+  };
+  process.once('SIGINT', () => void shutdown('SIGINT'));
+  process.once('SIGTERM', () => void shutdown('SIGTERM'));
+
   return server;
 }

--- a/stores/duckdb/src/storage/close.test.ts
+++ b/stores/duckdb/src/storage/close.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { DuckDBStore } from './index';
+
+describe('DuckDBStore.close()', () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'duckdb-close-'));
+    dbPath = join(dir, 'observability.duckdb');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('releases the native file lock so the same file can be reopened', async () => {
+    const first = new DuckDBStore({ id: 'close-first', path: dbPath });
+    await first.init();
+    await first.close();
+
+    // If close() did not release the native DuckDB lock, this would throw
+    // "Conflicting lock is held" -- the exact hot-reload failure we fixed.
+    const second = new DuckDBStore({ id: 'close-second', path: dbPath });
+    await second.init();
+    await second.close();
+  });
+
+  it('is idempotent -- a second close() is a no-op', async () => {
+    const store = new DuckDBStore({ id: 'close-idempotent', path: dbPath });
+    await store.init();
+
+    await store.close();
+    await expect(store.close()).resolves.toBeUndefined();
+  });
+});

--- a/stores/duckdb/src/storage/index.ts
+++ b/stores/duckdb/src/storage/index.ts
@@ -502,4 +502,15 @@ export class DuckDBStore extends MastraCompositeStore {
   get observability(): ObservabilityStorageDuckDB {
     return this.observabilityStore;
   }
+
+  /**
+   * Release the underlying DuckDB instance so the file lock is freed.
+   * Called automatically by Mastra.shutdown(). Without this, the DuckDB
+   * native write lock persists past process exit during dev hot reloads,
+   * causing "Conflicting lock is held" errors on the next start.
+   * Safe to call more than once; subsequent calls are no-ops.
+   */
+  async close(): Promise<void> {
+    await this.db.close();
+  }
 }


### PR DESCRIPTION
Running `mastra dev` with a DuckDB store would fail on the second hot reload with `Could not set lock on file ...duckdb: Conflicting lock is held`. DuckDB keeps an exclusive file lock for the whole process lifetime, but nothing released it on shutdown and the server had no signal handlers, so when a hot reload SIGINT'd the old process the lock lingered and the restarted process couldn't reopen the file.

This adds a `close()` to `DuckDBStore` that releases the lock, and wires graceful shutdown into the server so storage backends actually clean up on SIGINT/SIGTERM.

Before, on the second reload:

```
Error: Could not set lock on file "mastra-observability.duckdb": Conflicting lock is held by node (PID 93003)
```

After, hot reloads release the lock cleanly:

```ts
// DuckDBStore now releases the native file lock on shutdown
async close(): Promise<void> {
  await this.db.close();
}

// server installs handlers so mastra.shutdown() runs before exit
process.once('SIGINT', () => void shutdown('SIGINT'));
process.once('SIGTERM', () => void shutdown('SIGTERM'));
```

The shutdown step feature-detects `mastra.shutdown()` so it stays compatible with older `@mastra/core` versions, and is guarded against double-invocation. Verified with repeated hot reloads (zero lock conflicts) plus a new test covering lock release and idempotency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When developing with DuckDB, restarting the dev server left a lock on the database file so the new process couldn't open it. This PR ensures the database connection is closed on shutdown and the server runs a graceful shutdown so hot-reloads no longer fail with lock conflicts.

## Changes Overview
Fixes a hot-reload failure in `mastra dev` caused by DuckDB’s native file lock persisting across process shutdowns and preventing the restarted process from reopening the DB (error: `Could not set lock on file "...duckdb": Conflicting lock is held`).

## Key Changes

**DuckDB Storage (stores/duckdb/src/storage/index.ts)**
- Added `async close(): Promise<void>` on `DuckDBStore` that calls the underlying `this.db.close()` to release the native DuckDB file lock.
- `close()` is safe to call multiple times (idempotent).

**Server Graceful Shutdown (packages/deployer/src/server/index.ts)**
- `createNodeServer` installs `SIGINT`/`SIGTERM` handlers to run shutdown logic before exiting.
- Shutdown sequence:
  - Uses a `shuttingDown` guard to prevent re-entry and stop accepting new requests.
  - Calls `server.close()` and feature-detects `mastra.shutdown()` (for compatibility with older `@mastra/core`), racing it against a 5s timeout; warns and proceeds if shutdown hangs.
  - Catches and logs shutdown errors, then exits the process.
- Handlers are registered with `process.once` and guarded against double-invocation.

**Tests (stores/duckdb/src/storage/close.test.ts)**
- Added tests verifying:
  - `close()` releases DuckDB’s native file lock so a second `DuckDBStore` can reopen the same database.
  - `close()` is idempotent (calling it twice resolves cleanly).

**Changesets / Docs**
- Added changeset notes documenting the `@mastra/deployer` graceful-shutdown behavior and the `@mastra/duckdb` lock-release fix; adjusted deployer changeset wording to remove DuckDB-specific phrasing.

## Result
Hot-reloads in `mastra dev` now release DuckDB file locks on shutdown and complete cleanly; graceful shutdown is bounded (5s) and robust to older core versions and repeated invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->