### PR TITLE
fix(playground-ui): refine switch interaction states

### DIFF
--- a/.changeset/wide-bears-melt.md
+++ b/.changeset/wide-bears-melt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved switch focus, disabled, and motion states.

--- a/packages/playground-ui/src/ds/components/Switch/switch.css
+++ b/packages/playground-ui/src/ds/components/Switch/switch.css
@@ -1,0 +1,51 @@
+/* State-change motion lives in CSS so the switch does not need React state just
+ * to time a visual-only settling effect. Base UI swaps `data-checked` and
+ * `data-unchecked`; distinct animation names make each direction restart. */
+
+@keyframes switch-thumb-settle-on {
+  0% {
+    transform: scaleY(1);
+  }
+
+  48% {
+    transform: scaleY(0.8);
+  }
+
+  100% {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes switch-thumb-settle-off {
+  0% {
+    transform: scaleY(1);
+  }
+
+  48% {
+    transform: scaleY(0.8);
+  }
+
+  100% {
+    transform: scaleY(1);
+  }
+}
+
+.switch-thumb-motion {
+  transform: scaleY(1);
+  transform-origin: center;
+}
+
+.switch-thumb-motion[data-checked] {
+  animation: switch-thumb-settle-on 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.switch-thumb-motion[data-unchecked] {
+  animation: switch-thumb-settle-off 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch-thumb-motion[data-checked],
+  .switch-thumb-motion[data-unchecked] {
+    animation: none;
+  }
+}

--- a/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
@@ -2,6 +2,40 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Label } from '../Label';
 import { Switch } from './switch';
 
+const SURFACES: { token: string; label: string; className: string }[] = [
+  { token: 'surface1', label: 'surface1 · 0% (studio shell)', className: 'bg-surface1' },
+  { token: 'surface2', label: 'surface2 · 16% (main frame)', className: 'bg-surface2' },
+  { token: 'surface3', label: 'surface3 · 18%', className: 'bg-surface3' },
+  { token: 'surface4', label: 'surface4 · 22%', className: 'bg-surface4' },
+];
+
+function SurfaceFrame({ className, label, children }: { className: string; label: string; children: React.ReactNode }) {
+  return (
+    <div className={`rounded-2xl border border-border1 p-5 ${className}`}>
+      <p className="mb-4 text-ui-xs uppercase tracking-wide text-neutral3">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+function SwitchStateGrid({ idPrefix }: { idPrefix: string }) {
+  return (
+    <div className="grid grid-cols-[5rem_repeat(4,minmax(0,1fr))] items-center gap-x-4 gap-y-3 text-ui-sm text-neutral3">
+      <span />
+      <span>Default</span>
+      <span>On</span>
+      <span>Disabled</span>
+      <span>Disabled on</span>
+
+      <span className="text-neutral5">State</span>
+      <Switch aria-label={`${idPrefix} default`} />
+      <Switch aria-label={`${idPrefix} on`} checked onCheckedChange={() => {}} />
+      <Switch aria-label={`${idPrefix} disabled`} disabled />
+      <Switch aria-label={`${idPrefix} disabled on`} checked disabled onCheckedChange={() => {}} />
+    </div>
+  );
+}
+
 const meta: Meta<typeof Switch> = {
   title: 'Elements/Switch',
   component: Switch,
@@ -42,6 +76,58 @@ export const DisabledChecked: Story = {
     disabled: true,
     checked: true,
   },
+};
+
+export const AllStates: Story = {
+  parameters: {
+    layout: 'centered',
+  },
+  render: () => (
+    <div className="grid min-w-[27rem] gap-4 rounded-lg border border-border1 bg-surface2 p-4">
+      <div className="grid grid-cols-[9rem_repeat(3,minmax(0,1fr))] items-center gap-x-5 gap-y-3 text-ui-sm text-neutral3">
+        <span />
+        <span>Default</span>
+        <span>On</span>
+        <span>Focus</span>
+
+        <span className="text-neutral5">Enabled</span>
+        <Switch aria-label="enabled off" />
+        <Switch aria-label="enabled on" checked onCheckedChange={() => {}} />
+        <Switch
+          aria-label="focused on"
+          checked
+          onCheckedChange={() => {}}
+          className="border-neutral5/60 outline outline-1 outline-offset-2 outline-neutral5/55"
+        />
+
+        <span className="text-neutral5">Disabled</span>
+        <Switch aria-label="disabled off" disabled />
+        <Switch aria-label="disabled on" checked disabled onCheckedChange={() => {}} />
+        <Switch
+          aria-label="disabled focus preview"
+          checked
+          disabled
+          onCheckedChange={() => {}}
+          className="border-neutral5/50 outline outline-1 outline-offset-2 outline-neutral5/35"
+        />
+      </div>
+    </div>
+  ),
+};
+
+export const OnSurfaces: Story = {
+  parameters: {
+    layout: 'padded',
+  },
+  render: () => (
+    <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+      {SURFACES.map(({ token, label, className }) => (
+        <SurfaceFrame key={token} className={className} label={label}>
+          <SwitchStateGrid idPrefix={token} />
+        </SurfaceFrame>
+      ))}
+    </div>
+  ),
 };
 
 export const WithLabel: Story = {

--- a/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.stories.tsx
@@ -11,7 +11,7 @@ const SURFACES: { token: string; label: string; className: string }[] = [
 
 function SurfaceFrame({ className, label, children }: { className: string; label: string; children: React.ReactNode }) {
   return (
-    <div className={`rounded-2xl border border-border1 p-5 ${className}`}>
+    <div className={`rounded-2xl border border-border1/70 p-5 ${className}`}>
       <p className="mb-4 text-ui-xs uppercase tracking-wide text-neutral3">{label}</p>
       {children}
     </div>
@@ -83,7 +83,7 @@ export const AllStates: Story = {
     layout: 'centered',
   },
   render: () => (
-    <div className="grid min-w-[27rem] gap-4 rounded-lg border border-border1 bg-surface2 p-4">
+    <div className="grid min-w-[27rem] gap-4 rounded-lg bg-surface2 p-4">
       <div className="grid grid-cols-[9rem_repeat(3,minmax(0,1fr))] items-center gap-x-5 gap-y-3 text-ui-sm text-neutral3">
         <span />
         <span>Default</span>
@@ -97,7 +97,7 @@ export const AllStates: Story = {
           aria-label="focused on"
           checked
           onCheckedChange={() => {}}
-          className="border-neutral5/60 outline outline-1 outline-offset-2 outline-neutral5/55"
+          className="outline outline-1 outline-offset-2 outline-neutral5/55"
         />
 
         <span className="text-neutral5">Disabled</span>
@@ -108,7 +108,7 @@ export const AllStates: Story = {
           checked
           disabled
           onCheckedChange={() => {}}
-          className="border-neutral5/50 outline outline-1 outline-offset-2 outline-neutral5/35"
+          className="outline outline-1 outline-offset-2 outline-neutral5/35"
         />
       </div>
     </div>

--- a/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
@@ -89,18 +89,18 @@ describe('Switch', () => {
     expect(switchEl.className).toContain('overflow-hidden');
     expect(switchEl.className).toContain('focus-visible:outline-neutral5/55');
     expect(switchEl.className).not.toContain('active:scale');
-    expect(thumbEl?.className).toContain('transition-[background-color,translate,width,scale]');
+    expect(thumbEl?.className).toContain('transition-[background-color,translate,width,transform]');
+    expect(thumbEl?.className).toContain('switch-thumb-motion');
     expect(thumbEl?.className).toContain('w-5');
     expect(thumbEl?.className).toContain('data-[checked]:translate-x-3');
     expect(thumbEl?.className).toContain('group-active/switch:w-6');
-    expect(thumbEl?.className).toContain('data-[settling]:scale-y-90');
     expect(thumbEl?.className).not.toContain('group-active/switch:scale');
     expect(thumbEl?.className).toContain('group-active/switch:data-[checked]:translate-x-2');
     expect(switchEl.className).not.toContain('accent1');
     expect(switchEl.className).not.toContain('shadow-glow');
   });
 
-  it('only applies the thumb settling state while the value changes', () => {
+  it('keeps switch motion CSS-only without transient React data attributes', () => {
     render(<Switch aria-label="Toggle" />);
 
     const switchEl = screen.getByRole('switch');
@@ -109,7 +109,7 @@ describe('Switch', () => {
 
     fireEvent.click(switchEl);
 
-    expect(thumbEl?.hasAttribute('data-settling')).toBe(true);
+    expect(thumbEl?.hasAttribute('data-settling')).toBe(false);
   });
 
   it('applies the id to the visible switch control, not a hidden input', () => {

--- a/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
@@ -89,6 +89,8 @@ describe('Switch', () => {
     expect(switchEl.className).toContain('overflow-hidden');
     expect(switchEl.className).toContain('focus-visible:outline-neutral5/55');
     expect(switchEl.className).not.toContain('active:scale');
+    expect(switchEl.className).not.toContain('hover:scale');
+    expect(switchEl.className).not.toContain('transition-[background-color,scale]');
     expect(thumbEl?.className).toContain('transition-[background-color,translate,width,transform]');
     expect(thumbEl?.className).toContain('switch-thumb-motion');
     expect(thumbEl?.className).toContain('w-5');

--- a/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
@@ -83,8 +83,11 @@ describe('Switch', () => {
     render(<Switch aria-label="Toggle" defaultChecked />);
 
     const switchEl = screen.getByRole('switch');
+    const thumbEl = switchEl.querySelector('[data-slot="switch-thumb"]');
     expect(switchEl.className).toContain('data-[checked]:bg-neutral6');
+    expect(switchEl.className).toContain('border-transparent');
     expect(switchEl.className).toContain('focus-visible:outline-neutral5/55');
+    expect(thumbEl?.className).toContain('group-active/switch:w-5');
     expect(switchEl.className).not.toContain('accent1');
     expect(switchEl.className).not.toContain('shadow-glow');
   });

--- a/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
@@ -88,14 +88,28 @@ describe('Switch', () => {
     expect(switchEl.className).toContain('border-0');
     expect(switchEl.className).toContain('overflow-hidden');
     expect(switchEl.className).toContain('focus-visible:outline-neutral5/55');
+    expect(switchEl.className).not.toContain('active:scale');
     expect(thumbEl?.className).toContain('transition-[background-color,translate,width,scale]');
     expect(thumbEl?.className).toContain('w-5');
     expect(thumbEl?.className).toContain('data-[checked]:translate-x-3');
     expect(thumbEl?.className).toContain('group-active/switch:w-6');
-    expect(thumbEl?.className).toContain('group-active/switch:scale-y-95');
+    expect(thumbEl?.className).toContain('data-[settling]:scale-y-90');
+    expect(thumbEl?.className).not.toContain('group-active/switch:scale');
     expect(thumbEl?.className).toContain('group-active/switch:data-[checked]:translate-x-2');
     expect(switchEl.className).not.toContain('accent1');
     expect(switchEl.className).not.toContain('shadow-glow');
+  });
+
+  it('only applies the thumb settling state while the value changes', () => {
+    render(<Switch aria-label="Toggle" />);
+
+    const switchEl = screen.getByRole('switch');
+    const thumbEl = switchEl.querySelector('[data-slot="switch-thumb"]');
+    expect(thumbEl?.hasAttribute('data-settling')).toBe(false);
+
+    fireEvent.click(switchEl);
+
+    expect(thumbEl?.hasAttribute('data-settling')).toBe(true);
   });
 
   it('applies the id to the visible switch control, not a hidden input', () => {

--- a/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
@@ -85,9 +85,15 @@ describe('Switch', () => {
     const switchEl = screen.getByRole('switch');
     const thumbEl = switchEl.querySelector('[data-slot="switch-thumb"]');
     expect(switchEl.className).toContain('data-[checked]:bg-neutral6');
-    expect(switchEl.className).toContain('border-transparent');
+    expect(switchEl.className).toContain('border-0');
+    expect(switchEl.className).toContain('overflow-hidden');
     expect(switchEl.className).toContain('focus-visible:outline-neutral5/55');
-    expect(thumbEl?.className).toContain('group-active/switch:w-5');
+    expect(thumbEl?.className).toContain('transition-[background-color,translate,width,scale]');
+    expect(thumbEl?.className).toContain('w-5');
+    expect(thumbEl?.className).toContain('data-[checked]:translate-x-3');
+    expect(thumbEl?.className).toContain('group-active/switch:w-6');
+    expect(thumbEl?.className).toContain('group-active/switch:scale-y-95');
+    expect(thumbEl?.className).toContain('group-active/switch:data-[checked]:translate-x-2');
     expect(switchEl.className).not.toContain('accent1');
     expect(switchEl.className).not.toContain('shadow-glow');
   });

--- a/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.test.tsx
@@ -79,6 +79,16 @@ describe('Switch', () => {
     expect(screen.getByRole('switch').classList.contains('custom-switch')).toBe(true);
   });
 
+  it('uses neutral switch states without the old accent glow', () => {
+    render(<Switch aria-label="Toggle" defaultChecked />);
+
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl.className).toContain('data-[checked]:bg-neutral6');
+    expect(switchEl.className).toContain('focus-visible:outline-neutral5/55');
+    expect(switchEl.className).not.toContain('accent1');
+    expect(switchEl.className).not.toContain('shadow-glow');
+  });
+
   it('applies the id to the visible switch control, not a hidden input', () => {
     render(<Switch aria-label="Toggle" id="my-switch" />);
 

--- a/packages/playground-ui/src/ds/components/Switch/switch.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.tsx
@@ -25,14 +25,14 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, as
       data-slot="switch"
       className={cn(
         'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center overflow-hidden rounded-full border-0 bg-neutral6/[0.14] p-0.5 outline-hidden',
-        'transition-[background-color,scale] duration-normal ease-out-custom motion-reduce:transition-none',
-        'hover:scale-[1.015] hover:bg-neutral6/[0.18]',
+        'transition-colors duration-normal ease-out-custom motion-reduce:transition-none',
+        'hover:bg-neutral6/[0.18]',
         'active:bg-neutral6/[0.22]',
         'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
         'data-[checked]:bg-neutral6/[0.92]',
         'data-[checked]:hover:bg-neutral6',
         'data-[checked]:active:bg-neutral5',
-        'data-[disabled]:cursor-not-allowed data-[disabled]:bg-neutral6/[0.16] data-[disabled]:hover:scale-100 data-[disabled]:hover:bg-neutral6/[0.16]',
+        'data-[disabled]:cursor-not-allowed data-[disabled]:bg-neutral6/[0.16] data-[disabled]:hover:bg-neutral6/[0.16]',
         'data-[disabled]:data-[checked]:bg-neutral6/[0.3] data-[disabled]:data-[checked]:hover:bg-neutral6/[0.3]',
         className,
       )}

--- a/packages/playground-ui/src/ds/components/Switch/switch.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.tsx
@@ -1,8 +1,6 @@
 import { Switch as SwitchPrimitive } from '@base-ui/react/switch';
 import * as React from 'react';
 
-import { formElementFocus } from '@/ds/primitives/form-element';
-import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
 type SwitchProps = Omit<SwitchPrimitive.Root.Props, 'className'> & {
@@ -25,13 +23,16 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, as
       ref={ref}
       data-slot="switch"
       className={cn(
-        'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent',
-        transitions.all,
-        formElementFocus,
-        'hover:brightness-110',
-        'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:brightness-100',
-        'data-[checked]:bg-accent1 data-[checked]:shadow-glow-accent1',
-        'data-[unchecked]:bg-neutral2',
+        'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-neutral6/[0.08] bg-neutral6/[0.12] p-0.5 outline-hidden',
+        'transition-[background-color,border-color,transform] duration-normal ease-out-custom motion-reduce:transition-none',
+        'hover:scale-[1.02] hover:border-neutral6/[0.12] hover:bg-neutral6/[0.16]',
+        'active:scale-[0.98] active:border-neutral6/[0.18] active:bg-neutral6/[0.18]',
+        'focus-visible:border-neutral5/50 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
+        'data-[checked]:border-neutral6 data-[checked]:bg-neutral6',
+        'data-[checked]:hover:border-neutral5 data-[checked]:hover:bg-neutral5',
+        'data-[checked]:active:border-neutral4 data-[checked]:active:bg-neutral4',
+        'data-[disabled]:cursor-not-allowed data-[disabled]:border-neutral6/[0.2] data-[disabled]:bg-neutral6/[0.14] data-[disabled]:hover:scale-100 data-[disabled]:hover:border-neutral6/[0.2] data-[disabled]:hover:bg-neutral6/[0.14] data-[disabled]:active:scale-100',
+        'data-[disabled]:data-[checked]:border-neutral6/[0.38] data-[disabled]:data-[checked]:bg-neutral6/[0.38] data-[disabled]:data-[checked]:hover:border-neutral6/[0.38] data-[disabled]:data-[checked]:hover:bg-neutral6/[0.38]',
         className,
       )}
       {...renderProps}
@@ -39,11 +40,13 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, as
     >
       {asChild ? undefined : children}
       <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
         className={cn(
-          'pointer-events-none block h-4 w-4 rounded-full bg-white shadow-md',
-          'transition-all duration-normal ease-out-custom',
-          'data-[checked]:translate-x-4 data-[unchecked]:translate-x-0',
-          'data-[checked]:shadow-lg',
+          'pointer-events-none block size-4 rounded-full bg-neutral6',
+          'transition-[background-color,transform] duration-normal ease-out-custom motion-reduce:transition-none',
+          'group-hover/switch:scale-105 group-active/switch:scale-95 group-data-[disabled]/switch:scale-100',
+          'data-[checked]:translate-x-4 data-[checked]:bg-surface1 data-[unchecked]:translate-x-0',
+          'data-[disabled]:data-[unchecked]:bg-neutral6/[0.5] data-[disabled]:data-[checked]:bg-surface1/80',
         )}
       />
     </SwitchPrimitive.Root>

--- a/packages/playground-ui/src/ds/components/Switch/switch.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.tsx
@@ -2,106 +2,58 @@ import { Switch as SwitchPrimitive } from '@base-ui/react/switch';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import './switch.css';
 
 type SwitchProps = Omit<SwitchPrimitive.Root.Props, 'className'> & {
   className?: string;
   asChild?: boolean;
 };
 
-const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
-  ({ className, asChild, children, checked, onCheckedChange, ...props }, ref) => {
-    const [isSettling, setIsSettling] = React.useState(false);
-    const settlingTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-    const previousCheckedRef = React.useRef(checked);
+const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, asChild, children, ...props }, ref) => {
+  // Base UI's Switch.Root defaults to a `<span>` and forwards `id` to its
+  // hidden checkbox input. Render a native `<button>` (with `nativeButton`) so
+  // the consumer's `id` — and the click target — lands on the visible control,
+  // matching the previous Radix behavior.
+  const renderProps =
+    asChild && React.isValidElement(children)
+      ? { render: children as React.ReactElement }
+      : { render: <button type="button" />, nativeButton: true };
 
-    const triggerSettling = React.useCallback(() => {
-      if (settlingTimeoutRef.current) {
-        clearTimeout(settlingTimeoutRef.current);
-      }
-
-      setIsSettling(true);
-      settlingTimeoutRef.current = setTimeout(() => {
-        setIsSettling(false);
-      }, 160);
-    }, []);
-
-    React.useEffect(() => {
-      return () => {
-        if (settlingTimeoutRef.current) {
-          clearTimeout(settlingTimeoutRef.current);
-        }
-      };
-    }, []);
-
-    React.useEffect(() => {
-      if (checked !== previousCheckedRef.current) {
-        previousCheckedRef.current = checked;
-
-        if (checked !== undefined) {
-          triggerSettling();
-        }
-      }
-    }, [checked, triggerSettling]);
-
-    const handleCheckedChange = React.useCallback<NonNullable<SwitchPrimitive.Root.Props['onCheckedChange']>>(
-      (nextChecked, eventDetails) => {
-        if (checked === undefined) {
-          triggerSettling();
-        }
-
-        onCheckedChange?.(nextChecked, eventDetails);
-      },
-      [checked, onCheckedChange, triggerSettling],
-    );
-
-    // Base UI's Switch.Root defaults to a `<span>` and forwards `id` to its
-    // hidden checkbox input. Render a native `<button>` (with `nativeButton`) so
-    // the consumer's `id` — and the click target — lands on the visible control,
-    // matching the previous Radix behavior.
-    const renderProps =
-      asChild && React.isValidElement(children)
-        ? { render: children as React.ReactElement }
-        : { render: <button type="button" />, nativeButton: true };
-
-    return (
-      <SwitchPrimitive.Root
-        ref={ref}
-        data-slot="switch"
+  return (
+    <SwitchPrimitive.Root
+      ref={ref}
+      data-slot="switch"
+      className={cn(
+        'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center overflow-hidden rounded-full border-0 bg-neutral6/[0.14] p-0.5 outline-hidden',
+        'transition-[background-color,scale] duration-normal ease-out-custom motion-reduce:transition-none',
+        'hover:scale-[1.015] hover:bg-neutral6/[0.18]',
+        'active:bg-neutral6/[0.22]',
+        'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
+        'data-[checked]:bg-neutral6/[0.92]',
+        'data-[checked]:hover:bg-neutral6',
+        'data-[checked]:active:bg-neutral5',
+        'data-[disabled]:cursor-not-allowed data-[disabled]:bg-neutral6/[0.16] data-[disabled]:hover:scale-100 data-[disabled]:hover:bg-neutral6/[0.16]',
+        'data-[disabled]:data-[checked]:bg-neutral6/[0.3] data-[disabled]:data-[checked]:hover:bg-neutral6/[0.3]',
+        className,
+      )}
+      {...renderProps}
+      {...props}
+    >
+      {asChild ? undefined : children}
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
         className={cn(
-          'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center overflow-hidden rounded-full border-0 bg-neutral6/[0.14] p-0.5 outline-hidden',
-          'transition-[background-color,scale] duration-normal ease-out-custom motion-reduce:transition-none',
-          'hover:scale-[1.015] hover:bg-neutral6/[0.18]',
-          'active:bg-neutral6/[0.22]',
-          'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
-          'data-[checked]:bg-neutral6/[0.92]',
-          'data-[checked]:hover:bg-neutral6',
-          'data-[checked]:active:bg-neutral5',
-          'data-[disabled]:cursor-not-allowed data-[disabled]:bg-neutral6/[0.16] data-[disabled]:hover:scale-100 data-[disabled]:hover:bg-neutral6/[0.16]',
-          'data-[disabled]:data-[checked]:bg-neutral6/[0.3] data-[disabled]:data-[checked]:hover:bg-neutral6/[0.3]',
-          className,
+          'switch-thumb-motion pointer-events-none block h-4 w-5 rounded-full bg-neutral6',
+          'transition-[background-color,translate,width,transform] duration-normal ease-out-custom motion-reduce:transition-none',
+          'group-active/switch:w-6 group-data-[disabled]/switch:w-5',
+          'data-[checked]:translate-x-3 data-[checked]:bg-surface1 data-[unchecked]:translate-x-0',
+          'group-active/switch:data-[checked]:translate-x-2',
+          'data-[disabled]:data-[unchecked]:bg-neutral6/[0.42] data-[disabled]:data-[checked]:bg-surface1/80',
         )}
-        {...renderProps}
-        checked={checked}
-        onCheckedChange={handleCheckedChange}
-        {...props}
-      >
-        {asChild ? undefined : children}
-        <SwitchPrimitive.Thumb
-          data-slot="switch-thumb"
-          data-settling={isSettling ? '' : undefined}
-          className={cn(
-            'pointer-events-none block h-4 w-5 rounded-full bg-neutral6',
-            'transition-[background-color,translate,width,scale] duration-normal ease-out-custom motion-reduce:transition-none',
-            'data-[settling]:scale-y-90 group-active/switch:w-6 group-data-[disabled]/switch:w-5',
-            'data-[checked]:translate-x-3 data-[checked]:bg-surface1 data-[unchecked]:translate-x-0',
-            'group-active/switch:data-[checked]:translate-x-2',
-            'data-[disabled]:data-[unchecked]:bg-neutral6/[0.42] data-[disabled]:data-[checked]:bg-surface1/80',
-          )}
-        />
-      </SwitchPrimitive.Root>
-    );
-  },
-);
+      />
+    </SwitchPrimitive.Root>
+  );
+});
 Switch.displayName = 'Switch';
 
 export { Switch };

--- a/packages/playground-ui/src/ds/components/Switch/switch.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.tsx
@@ -23,11 +23,11 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, as
       ref={ref}
       data-slot="switch"
       className={cn(
-        'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-neutral6/[0.14] p-0.5 outline-hidden',
-        'transition-[background-color,border-color,transform] duration-normal ease-out-custom motion-reduce:transition-none',
+        'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center overflow-hidden rounded-full border-0 bg-neutral6/[0.14] p-0.5 outline-hidden',
+        'transition-[background-color,scale] duration-normal ease-out-custom motion-reduce:transition-none',
         'hover:scale-[1.015] hover:bg-neutral6/[0.18]',
-        'active:scale-[0.99] active:bg-neutral6/[0.22]',
-        'focus-visible:border-neutral5/50 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
+        'active:scale-[0.985] active:bg-neutral6/[0.22]',
+        'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
         'data-[checked]:bg-neutral6/[0.92]',
         'data-[checked]:hover:bg-neutral6',
         'data-[checked]:active:bg-neutral5',
@@ -42,11 +42,11 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, as
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          'pointer-events-none block h-4 w-4 rounded-full bg-neutral6',
-          'transition-[background-color,transform,width] duration-normal ease-out-custom motion-reduce:transition-none',
-          'group-hover/switch:scale-[1.03] group-active/switch:w-5 group-active/switch:scale-100 group-data-[disabled]/switch:w-4 group-data-[disabled]/switch:scale-100',
-          'data-[checked]:translate-x-4 data-[checked]:bg-surface1 data-[unchecked]:translate-x-0',
-          'group-active/switch:data-[checked]:translate-x-3',
+          'pointer-events-none block h-4 w-5 rounded-full bg-neutral6',
+          'transition-[background-color,translate,width,scale] duration-normal ease-out-custom motion-reduce:transition-none',
+          'group-active/switch:w-6 group-active/switch:scale-y-95 group-data-[disabled]/switch:w-5 group-data-[disabled]/switch:scale-100',
+          'data-[checked]:translate-x-3 data-[checked]:bg-surface1 data-[unchecked]:translate-x-0',
+          'group-active/switch:data-[checked]:translate-x-2',
           'data-[disabled]:data-[unchecked]:bg-neutral6/[0.42] data-[disabled]:data-[checked]:bg-surface1/80',
         )}
       />

--- a/packages/playground-ui/src/ds/components/Switch/switch.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.tsx
@@ -23,16 +23,16 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, as
       ref={ref}
       data-slot="switch"
       className={cn(
-        'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-neutral6/[0.08] bg-neutral6/[0.12] p-0.5 outline-hidden',
+        'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-neutral6/[0.14] p-0.5 outline-hidden',
         'transition-[background-color,border-color,transform] duration-normal ease-out-custom motion-reduce:transition-none',
-        'hover:scale-[1.02] hover:border-neutral6/[0.12] hover:bg-neutral6/[0.16]',
-        'active:scale-[0.98] active:border-neutral6/[0.18] active:bg-neutral6/[0.18]',
+        'hover:scale-[1.015] hover:bg-neutral6/[0.18]',
+        'active:scale-[0.99] active:bg-neutral6/[0.22]',
         'focus-visible:border-neutral5/50 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
-        'data-[checked]:border-neutral6 data-[checked]:bg-neutral6',
-        'data-[checked]:hover:border-neutral5 data-[checked]:hover:bg-neutral5',
-        'data-[checked]:active:border-neutral4 data-[checked]:active:bg-neutral4',
-        'data-[disabled]:cursor-not-allowed data-[disabled]:border-neutral6/[0.2] data-[disabled]:bg-neutral6/[0.14] data-[disabled]:hover:scale-100 data-[disabled]:hover:border-neutral6/[0.2] data-[disabled]:hover:bg-neutral6/[0.14] data-[disabled]:active:scale-100',
-        'data-[disabled]:data-[checked]:border-neutral6/[0.38] data-[disabled]:data-[checked]:bg-neutral6/[0.38] data-[disabled]:data-[checked]:hover:border-neutral6/[0.38] data-[disabled]:data-[checked]:hover:bg-neutral6/[0.38]',
+        'data-[checked]:bg-neutral6/[0.92]',
+        'data-[checked]:hover:bg-neutral6',
+        'data-[checked]:active:bg-neutral5',
+        'data-[disabled]:cursor-not-allowed data-[disabled]:bg-neutral6/[0.16] data-[disabled]:hover:scale-100 data-[disabled]:hover:bg-neutral6/[0.16] data-[disabled]:active:scale-100',
+        'data-[disabled]:data-[checked]:bg-neutral6/[0.3] data-[disabled]:data-[checked]:hover:bg-neutral6/[0.3]',
         className,
       )}
       {...renderProps}
@@ -42,11 +42,12 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, as
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          'pointer-events-none block size-4 rounded-full bg-neutral6',
-          'transition-[background-color,transform] duration-normal ease-out-custom motion-reduce:transition-none',
-          'group-hover/switch:scale-105 group-active/switch:scale-95 group-data-[disabled]/switch:scale-100',
+          'pointer-events-none block h-4 w-4 rounded-full bg-neutral6',
+          'transition-[background-color,transform,width] duration-normal ease-out-custom motion-reduce:transition-none',
+          'group-hover/switch:scale-[1.03] group-active/switch:w-5 group-active/switch:scale-100 group-data-[disabled]/switch:w-4 group-data-[disabled]/switch:scale-100',
           'data-[checked]:translate-x-4 data-[checked]:bg-surface1 data-[unchecked]:translate-x-0',
-          'data-[disabled]:data-[unchecked]:bg-neutral6/[0.5] data-[disabled]:data-[checked]:bg-surface1/80',
+          'group-active/switch:data-[checked]:translate-x-3',
+          'data-[disabled]:data-[unchecked]:bg-neutral6/[0.42] data-[disabled]:data-[checked]:bg-surface1/80',
         )}
       />
     </SwitchPrimitive.Root>

--- a/packages/playground-ui/src/ds/components/Switch/switch.tsx
+++ b/packages/playground-ui/src/ds/components/Switch/switch.tsx
@@ -8,51 +8,100 @@ type SwitchProps = Omit<SwitchPrimitive.Root.Props, 'className'> & {
   asChild?: boolean;
 };
 
-const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(({ className, asChild, children, ...props }, ref) => {
-  // Base UI's Switch.Root defaults to a `<span>` and forwards `id` to its
-  // hidden checkbox input. Render a native `<button>` (with `nativeButton`) so
-  // the consumer's `id` — and the click target — lands on the visible control,
-  // matching the previous Radix behavior.
-  const renderProps =
-    asChild && React.isValidElement(children)
-      ? { render: children as React.ReactElement }
-      : { render: <button type="button" />, nativeButton: true };
+const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+  ({ className, asChild, children, checked, onCheckedChange, ...props }, ref) => {
+    const [isSettling, setIsSettling] = React.useState(false);
+    const settlingTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const previousCheckedRef = React.useRef(checked);
 
-  return (
-    <SwitchPrimitive.Root
-      ref={ref}
-      data-slot="switch"
-      className={cn(
-        'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center overflow-hidden rounded-full border-0 bg-neutral6/[0.14] p-0.5 outline-hidden',
-        'transition-[background-color,scale] duration-normal ease-out-custom motion-reduce:transition-none',
-        'hover:scale-[1.015] hover:bg-neutral6/[0.18]',
-        'active:scale-[0.985] active:bg-neutral6/[0.22]',
-        'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
-        'data-[checked]:bg-neutral6/[0.92]',
-        'data-[checked]:hover:bg-neutral6',
-        'data-[checked]:active:bg-neutral5',
-        'data-[disabled]:cursor-not-allowed data-[disabled]:bg-neutral6/[0.16] data-[disabled]:hover:scale-100 data-[disabled]:hover:bg-neutral6/[0.16] data-[disabled]:active:scale-100',
-        'data-[disabled]:data-[checked]:bg-neutral6/[0.3] data-[disabled]:data-[checked]:hover:bg-neutral6/[0.3]',
-        className,
-      )}
-      {...renderProps}
-      {...props}
-    >
-      {asChild ? undefined : children}
-      <SwitchPrimitive.Thumb
-        data-slot="switch-thumb"
+    const triggerSettling = React.useCallback(() => {
+      if (settlingTimeoutRef.current) {
+        clearTimeout(settlingTimeoutRef.current);
+      }
+
+      setIsSettling(true);
+      settlingTimeoutRef.current = setTimeout(() => {
+        setIsSettling(false);
+      }, 160);
+    }, []);
+
+    React.useEffect(() => {
+      return () => {
+        if (settlingTimeoutRef.current) {
+          clearTimeout(settlingTimeoutRef.current);
+        }
+      };
+    }, []);
+
+    React.useEffect(() => {
+      if (checked !== previousCheckedRef.current) {
+        previousCheckedRef.current = checked;
+
+        if (checked !== undefined) {
+          triggerSettling();
+        }
+      }
+    }, [checked, triggerSettling]);
+
+    const handleCheckedChange = React.useCallback<NonNullable<SwitchPrimitive.Root.Props['onCheckedChange']>>(
+      (nextChecked, eventDetails) => {
+        if (checked === undefined) {
+          triggerSettling();
+        }
+
+        onCheckedChange?.(nextChecked, eventDetails);
+      },
+      [checked, onCheckedChange, triggerSettling],
+    );
+
+    // Base UI's Switch.Root defaults to a `<span>` and forwards `id` to its
+    // hidden checkbox input. Render a native `<button>` (with `nativeButton`) so
+    // the consumer's `id` — and the click target — lands on the visible control,
+    // matching the previous Radix behavior.
+    const renderProps =
+      asChild && React.isValidElement(children)
+        ? { render: children as React.ReactElement }
+        : { render: <button type="button" />, nativeButton: true };
+
+    return (
+      <SwitchPrimitive.Root
+        ref={ref}
+        data-slot="switch"
         className={cn(
-          'pointer-events-none block h-4 w-5 rounded-full bg-neutral6',
-          'transition-[background-color,translate,width,scale] duration-normal ease-out-custom motion-reduce:transition-none',
-          'group-active/switch:w-6 group-active/switch:scale-y-95 group-data-[disabled]/switch:w-5 group-data-[disabled]/switch:scale-100',
-          'data-[checked]:translate-x-3 data-[checked]:bg-surface1 data-[unchecked]:translate-x-0',
-          'group-active/switch:data-[checked]:translate-x-2',
-          'data-[disabled]:data-[unchecked]:bg-neutral6/[0.42] data-[disabled]:data-[checked]:bg-surface1/80',
+          'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center overflow-hidden rounded-full border-0 bg-neutral6/[0.14] p-0.5 outline-hidden',
+          'transition-[background-color,scale] duration-normal ease-out-custom motion-reduce:transition-none',
+          'hover:scale-[1.015] hover:bg-neutral6/[0.18]',
+          'active:bg-neutral6/[0.22]',
+          'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-neutral5/55',
+          'data-[checked]:bg-neutral6/[0.92]',
+          'data-[checked]:hover:bg-neutral6',
+          'data-[checked]:active:bg-neutral5',
+          'data-[disabled]:cursor-not-allowed data-[disabled]:bg-neutral6/[0.16] data-[disabled]:hover:scale-100 data-[disabled]:hover:bg-neutral6/[0.16]',
+          'data-[disabled]:data-[checked]:bg-neutral6/[0.3] data-[disabled]:data-[checked]:hover:bg-neutral6/[0.3]',
+          className,
         )}
-      />
-    </SwitchPrimitive.Root>
-  );
-});
+        {...renderProps}
+        checked={checked}
+        onCheckedChange={handleCheckedChange}
+        {...props}
+      >
+        {asChild ? undefined : children}
+        <SwitchPrimitive.Thumb
+          data-slot="switch-thumb"
+          data-settling={isSettling ? '' : undefined}
+          className={cn(
+            'pointer-events-none block h-4 w-5 rounded-full bg-neutral6',
+            'transition-[background-color,translate,width,scale] duration-normal ease-out-custom motion-reduce:transition-none',
+            'data-[settling]:scale-y-90 group-active/switch:w-6 group-data-[disabled]/switch:w-5',
+            'data-[checked]:translate-x-3 data-[checked]:bg-surface1 data-[unchecked]:translate-x-0',
+            'group-active/switch:data-[checked]:translate-x-2',
+            'data-[disabled]:data-[unchecked]:bg-neutral6/[0.42] data-[disabled]:data-[checked]:bg-surface1/80',
+          )}
+        />
+      </SwitchPrimitive.Root>
+    );
+  },
+);
 Switch.displayName = 'Switch';
 
 export { Switch };


### PR DESCRIPTION
This updates the playground Switch styling to match the cleaner checkbox and radio direction: no accent glow, no halo focus, neutral checked states, clearer disabled contrast, and subtle hover/active scale motion. It also adds all-states and surface review stories so contrast can be checked quickly.

Validated with `pnpm --filter ./packages/playground-ui test -- src/ds/components/Switch/switch.test.tsx --run`, `pnpm --filter ./packages/playground-ui typecheck`, `pnpm --filter ./packages/playground-ui build`, `pnpm --filter ./packages/playground-ui lint`, and Storybook at `elements-switch--on-surfaces` / `elements-switch--all-states`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the on/off Switch simpler and more consistent: it removes the bright accent glow, uses neutral colors that adapt to different backgrounds, and gives the thumb smoother, CSS-only motion so it stops jumping or overflowing.

---

## Changes Overview

### Component Styling & Behavior
- Replaces accent glow and halo focus with neutral, surface-aware styling and clearer disabled contrast.
- Moves checked/disabled/focus/hover/active visuals to neutral/surface-driven variants keyed off data attributes.
- Softens track border and refines pressed/thumb interactions (pressed thumb stretch → short settling squash).
- Prevents thumb jump/overflow by explicitly animating translate/scale and clipping the capsule.
- Migrates motion to CSS-only settling animations (introduced `@keyframes` for thumb settle on/off) and respects `prefers-reduced-motion`.
- Avoids transient React-driven `data-settling` state for motion; also avoids settling when a controlled Switch receives the same checked prop value.
- Removes final hover scale (hover scale was introduced then removed across commits).

### API / Exports
- No public component signatures changed. Thumb now uses `data-slot="switch-thumb"` and root uses `data-slot="switch"` (implementation detail only).

### Storybook
- Added comprehensive stories:
  - AllStates — grid of enabled/disabled/focus variants including focus preview outline.
  - OnSurfaces — renders Switches on each surface token to review contrast.
- Storybook verification performed for elements-switch--on-surfaces and elements-switch--all-states.

### Tests & Validation
- Added unit tests verifying neutral checked styling (no accent/glow) and that motion is CSS-only (no transient `data-settling` attribute after click).
- Validation steps run: component unit tests, typecheck, package build and lint for packages/playground-ui, plus Storybook checks.

### Release
- Added a Changeset entry marking `@mastra/playground-ui` for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->