### PR TITLE
feat(agent-browser): add waitUntil to interaction tools

### DIFF
--- a/.changeset/agent-browser-waituntil-interaction-tools.md
+++ b/.changeset/agent-browser-waituntil-interaction-tools.md
@@ -4,4 +4,10 @@
 
 Add `waitUntil` support to `browser_click`, `browser_press`, and `browser_select`. When provided, the tool waits for the page to reach the given load state (`load`, `domcontentloaded`, or `networkidle`) after the action completes, preventing the next `browser_snapshot` from capturing stale DOM when the interaction triggers navigation. The parameter is optional and behaviour is unchanged when omitted.
 
+Usage example:
+
+```ts
+await browser_click({ ref: '@e1', waitUntil: 'domcontentloaded', timeout: 5000 });
+```
+
 Fixes #17397.

--- a/.changeset/agent-browser-waituntil-interaction-tools.md
+++ b/.changeset/agent-browser-waituntil-interaction-tools.md
@@ -1,0 +1,7 @@
+---
+'@mastra/agent-browser': minor
+---
+
+Add `waitUntil` support to `browser_click`, `browser_press`, and `browser_select`. When provided, the tool waits for the page to reach the given load state (`load`, `domcontentloaded`, or `networkidle`) after the action completes, preventing the next `browser_snapshot` from capturing stale DOM when the interaction triggers navigation. The parameter is optional and behaviour is unchanged when omitted.
+
+Fixes #17397.

--- a/browser/agent-browser/src/__tests__/agent-browser.test.ts
+++ b/browser/agent-browser/src/__tests__/agent-browser.test.ts
@@ -387,9 +387,12 @@ describe('AgentBrowser', () => {
     });
 
     it('waits for load state when waitUntil is set', async () => {
-      await browser.click({ ref: '@e1', waitUntil: 'networkidle' });
+      await browser.click({ ref: '@e1', waitUntil: 'networkidle', timeout: 1234 });
 
-      expect(mockPage.waitForNavigation).toHaveBeenCalledWith(expect.objectContaining({ waitUntil: 'networkidle' }));
+      expect(mockPage.waitForNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({ waitUntil: 'networkidle', timeout: 1234 }),
+      );
+      expect(mockLocator.click).toHaveBeenCalledWith(expect.objectContaining({ timeout: 1234 }));
     });
 
     it('does not wait for load state when waitUntil is omitted', async () => {
@@ -440,9 +443,11 @@ describe('AgentBrowser', () => {
     });
 
     it('waits for load state when waitUntil is set', async () => {
-      await browser.press({ key: 'Enter', waitUntil: 'load' });
+      await browser.press({ key: 'Enter', waitUntil: 'load', timeout: 1234 });
 
-      expect(mockPage.waitForNavigation).toHaveBeenCalledWith(expect.objectContaining({ waitUntil: 'load' }));
+      expect(mockPage.waitForNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({ waitUntil: 'load', timeout: 1234 }),
+      );
     });
 
     it('does not wait for load state when waitUntil is omitted', async () => {
@@ -467,10 +472,14 @@ describe('AgentBrowser', () => {
     });
 
     it('waits for load state when waitUntil is set', async () => {
-      await browser.select({ ref: '@e1', value: 'option1', waitUntil: 'domcontentloaded' });
+      await browser.select({ ref: '@e1', value: 'option1', waitUntil: 'domcontentloaded', timeout: 1234 });
 
       expect(mockPage.waitForNavigation).toHaveBeenCalledWith(
-        expect.objectContaining({ waitUntil: 'domcontentloaded' }),
+        expect.objectContaining({ waitUntil: 'domcontentloaded', timeout: 1234 }),
+      );
+      expect(mockLocator.selectOption).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ timeout: 1234 }),
       );
     });
 

--- a/browser/agent-browser/src/__tests__/agent-browser.test.ts
+++ b/browser/agent-browser/src/__tests__/agent-browser.test.ts
@@ -16,7 +16,7 @@ const { mockPage, mockLocator, mockManager } = vi.hoisted(() => {
     viewportSize: () => ({ width: 1280, height: 720 }),
     content: vi.fn().mockResolvedValue('<html></html>'),
     waitForTimeout: vi.fn(),
-    waitForLoadState: vi.fn(),
+    waitForNavigation: vi.fn(),
     keyboard: {
       press: vi.fn(),
       type: vi.fn(),
@@ -389,13 +389,13 @@ describe('AgentBrowser', () => {
     it('waits for load state when waitUntil is set', async () => {
       await browser.click({ ref: '@e1', waitUntil: 'networkidle' });
 
-      expect(mockPage.waitForLoadState).toHaveBeenCalledWith('networkidle', expect.any(Object));
+      expect(mockPage.waitForNavigation).toHaveBeenCalledWith(expect.objectContaining({ waitUntil: 'networkidle' }));
     });
 
     it('does not wait for load state when waitUntil is omitted', async () => {
       await browser.click({ ref: '@e1' });
 
-      expect(mockPage.waitForLoadState).not.toHaveBeenCalled();
+      expect(mockPage.waitForNavigation).not.toHaveBeenCalled();
     });
   });
 
@@ -442,13 +442,13 @@ describe('AgentBrowser', () => {
     it('waits for load state when waitUntil is set', async () => {
       await browser.press({ key: 'Enter', waitUntil: 'load' });
 
-      expect(mockPage.waitForLoadState).toHaveBeenCalledWith('load', expect.any(Object));
+      expect(mockPage.waitForNavigation).toHaveBeenCalledWith(expect.objectContaining({ waitUntil: 'load' }));
     });
 
     it('does not wait for load state when waitUntil is omitted', async () => {
       await browser.press({ key: 'Enter' });
 
-      expect(mockPage.waitForLoadState).not.toHaveBeenCalled();
+      expect(mockPage.waitForNavigation).not.toHaveBeenCalled();
     });
   });
 
@@ -469,13 +469,15 @@ describe('AgentBrowser', () => {
     it('waits for load state when waitUntil is set', async () => {
       await browser.select({ ref: '@e1', value: 'option1', waitUntil: 'domcontentloaded' });
 
-      expect(mockPage.waitForLoadState).toHaveBeenCalledWith('domcontentloaded', expect.any(Object));
+      expect(mockPage.waitForNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({ waitUntil: 'domcontentloaded' }),
+      );
     });
 
     it('does not wait for load state when waitUntil is omitted', async () => {
       await browser.select({ ref: '@e1', value: 'option1' });
 
-      expect(mockPage.waitForLoadState).not.toHaveBeenCalled();
+      expect(mockPage.waitForNavigation).not.toHaveBeenCalled();
     });
   });
 

--- a/browser/agent-browser/src/__tests__/agent-browser.test.ts
+++ b/browser/agent-browser/src/__tests__/agent-browser.test.ts
@@ -16,6 +16,7 @@ const { mockPage, mockLocator, mockManager } = vi.hoisted(() => {
     viewportSize: () => ({ width: 1280, height: 720 }),
     content: vi.fn().mockResolvedValue('<html></html>'),
     waitForTimeout: vi.fn(),
+    waitForLoadState: vi.fn(),
     keyboard: {
       press: vi.fn(),
       type: vi.fn(),
@@ -384,6 +385,18 @@ describe('AgentBrowser', () => {
 
       expect(mockLocator.click).toHaveBeenCalledWith(expect.objectContaining({ button: 'right' }));
     });
+
+    it('waits for load state when waitUntil is set', async () => {
+      await browser.click({ ref: '@e1', waitUntil: 'networkidle' });
+
+      expect(mockPage.waitForLoadState).toHaveBeenCalledWith('networkidle', expect.any(Object));
+    });
+
+    it('does not wait for load state when waitUntil is omitted', async () => {
+      await browser.click({ ref: '@e1' });
+
+      expect(mockPage.waitForLoadState).not.toHaveBeenCalled();
+    });
   });
 
   describe('type', () => {
@@ -425,6 +438,18 @@ describe('AgentBrowser', () => {
 
       expect(mockPage.keyboard.press).toHaveBeenCalledWith('Control+a');
     });
+
+    it('waits for load state when waitUntil is set', async () => {
+      await browser.press({ key: 'Enter', waitUntil: 'load' });
+
+      expect(mockPage.waitForLoadState).toHaveBeenCalledWith('load', expect.any(Object));
+    });
+
+    it('does not wait for load state when waitUntil is omitted', async () => {
+      await browser.press({ key: 'Enter' });
+
+      expect(mockPage.waitForLoadState).not.toHaveBeenCalled();
+    });
   });
 
   describe('select', () => {
@@ -439,6 +464,18 @@ describe('AgentBrowser', () => {
       expect(result.success).toBe(true);
       expect(result.selected).toEqual(['value1']);
       expect(mockLocator.selectOption).toHaveBeenCalled();
+    });
+
+    it('waits for load state when waitUntil is set', async () => {
+      await browser.select({ ref: '@e1', value: 'option1', waitUntil: 'domcontentloaded' });
+
+      expect(mockPage.waitForLoadState).toHaveBeenCalledWith('domcontentloaded', expect.any(Object));
+    });
+
+    it('does not wait for load state when waitUntil is omitted', async () => {
+      await browser.select({ ref: '@e1', value: 'option1' });
+
+      expect(mockPage.waitForLoadState).not.toHaveBeenCalled();
     });
   });
 

--- a/browser/agent-browser/src/__tests__/types.test.ts
+++ b/browser/agent-browser/src/__tests__/types.test.ts
@@ -97,6 +97,16 @@ describe('clickInputSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('accepts non-negative timeout', () => {
+    const result = clickInputSchema.safeParse({ ref: '@e5', timeout: 1000 });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid timeout values', () => {
+    expect(clickInputSchema.safeParse({ ref: '@e5', timeout: -1 }).success).toBe(false);
+    expect(clickInputSchema.safeParse({ ref: '@e5', timeout: '1000' }).success).toBe(false);
+  });
+
   it('requires ref', () => {
     const result = clickInputSchema.safeParse({});
     expect(result.success).toBe(false);
@@ -156,6 +166,16 @@ describe('pressInputSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('accepts non-negative timeout', () => {
+    const result = pressInputSchema.safeParse({ key: 'Enter', timeout: 1000 });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid timeout values', () => {
+    expect(pressInputSchema.safeParse({ key: 'Enter', timeout: -1 }).success).toBe(false);
+    expect(pressInputSchema.safeParse({ key: 'Enter', timeout: '1000' }).success).toBe(false);
+  });
+
   it('requires key', () => {
     const result = pressInputSchema.safeParse({});
     expect(result.success).toBe(false);
@@ -186,6 +206,16 @@ describe('selectInputSchema', () => {
   it('rejects invalid waitUntil values', () => {
     const result = selectInputSchema.safeParse({ ref: '@e5', value: 'option1', waitUntil: 'invalid' });
     expect(result.success).toBe(false);
+  });
+
+  it('accepts non-negative timeout', () => {
+    const result = selectInputSchema.safeParse({ ref: '@e5', value: 'option1', timeout: 1000 });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid timeout values', () => {
+    expect(selectInputSchema.safeParse({ ref: '@e5', value: 'option1', timeout: -1 }).success).toBe(false);
+    expect(selectInputSchema.safeParse({ ref: '@e5', value: 'option1', timeout: '1000' }).success).toBe(false);
   });
 
   it('requires ref', () => {

--- a/browser/agent-browser/src/__tests__/types.test.ts
+++ b/browser/agent-browser/src/__tests__/types.test.ts
@@ -87,6 +87,16 @@ describe('clickInputSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts ref with waitUntil', () => {
+    const result = clickInputSchema.safeParse({ ref: '@e5', waitUntil: 'networkidle' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid waitUntil values', () => {
+    const result = clickInputSchema.safeParse({ ref: '@e5', waitUntil: 'invalid' });
+    expect(result.success).toBe(false);
+  });
+
   it('requires ref', () => {
     const result = clickInputSchema.safeParse({});
     expect(result.success).toBe(false);
@@ -136,6 +146,16 @@ describe('pressInputSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts key with waitUntil', () => {
+    const result = pressInputSchema.safeParse({ key: 'Enter', waitUntil: 'load' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid waitUntil values', () => {
+    const result = pressInputSchema.safeParse({ key: 'Enter', waitUntil: 'invalid' });
+    expect(result.success).toBe(false);
+  });
+
   it('requires key', () => {
     const result = pressInputSchema.safeParse({});
     expect(result.success).toBe(false);
@@ -156,6 +176,16 @@ describe('selectInputSchema', () => {
   it('accepts ref with index', () => {
     const result = selectInputSchema.safeParse({ ref: '@e5', index: 0 });
     expect(result.success).toBe(true);
+  });
+
+  it('accepts ref with value and waitUntil', () => {
+    const result = selectInputSchema.safeParse({ ref: '@e5', value: 'option1', waitUntil: 'domcontentloaded' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid waitUntil values', () => {
+    const result = selectInputSchema.safeParse({ ref: '@e5', value: 'option1', waitUntil: 'invalid' });
+    expect(result.success).toBe(false);
   });
 
   it('requires ref', () => {

--- a/browser/agent-browser/src/agent-browser.ts
+++ b/browser/agent-browser/src/agent-browser.ts
@@ -765,6 +765,8 @@ export class AgentBrowser extends MastraBrowser {
 
       const timeout = input.timeout ?? this.defaultTimeout;
 
+      const navigation = input.waitUntil ? page.waitForNavigation({ waitUntil: input.waitUntil, timeout }) : undefined;
+
       await locator.click({
         button: input.button ?? 'left',
         clickCount: input.clickCount ?? 1,
@@ -772,9 +774,7 @@ export class AgentBrowser extends MastraBrowser {
         timeout,
       });
 
-      if (input.waitUntil) {
-        await page.waitForLoadState(input.waitUntil, { timeout });
-      }
+      await navigation;
 
       return {
         success: true,
@@ -869,13 +869,12 @@ export class AgentBrowser extends MastraBrowser {
   ): Promise<{ success: true; url: string; hint: string } | BrowserToolError> {
     try {
       const page = await this.getPage(threadId);
+      const timeout = input.timeout ?? this.defaultTimeout;
+      const navigation = input.waitUntil ? page.waitForNavigation({ waitUntil: input.waitUntil, timeout }) : undefined;
+
       await page.keyboard.press(input.key);
 
-      if (input.waitUntil) {
-        await page.waitForLoadState(input.waitUntil, {
-          timeout: input.timeout ?? this.defaultTimeout,
-        });
-      }
+      await navigation;
 
       return {
         success: true,
@@ -913,12 +912,11 @@ export class AgentBrowser extends MastraBrowser {
       if (input.index !== undefined) selectValue.index = input.index;
 
       const timeout = input.timeout ?? this.defaultTimeout;
+      const navigation = input.waitUntil ? page.waitForNavigation({ waitUntil: input.waitUntil, timeout }) : undefined;
 
       const selected = await locator.selectOption(selectValue, { timeout });
 
-      if (input.waitUntil) {
-        await page.waitForLoadState(input.waitUntil, { timeout });
-      }
+      await navigation;
 
       return {
         success: true,

--- a/browser/agent-browser/src/agent-browser.ts
+++ b/browser/agent-browser/src/agent-browser.ts
@@ -763,12 +763,18 @@ export class AgentBrowser extends MastraBrowser {
         );
       }
 
+      const timeout = input.timeout ?? this.defaultTimeout;
+
       await locator.click({
         button: input.button ?? 'left',
         clickCount: input.clickCount ?? 1,
         modifiers: input.modifiers,
-        timeout: this.defaultTimeout,
+        timeout,
       });
+
+      if (input.waitUntil) {
+        await page.waitForLoadState(input.waitUntil, { timeout });
+      }
 
       return {
         success: true,
@@ -865,6 +871,12 @@ export class AgentBrowser extends MastraBrowser {
       const page = await this.getPage(threadId);
       await page.keyboard.press(input.key);
 
+      if (input.waitUntil) {
+        await page.waitForLoadState(input.waitUntil, {
+          timeout: input.timeout ?? this.defaultTimeout,
+        });
+      }
+
       return {
         success: true,
         url: page.url(),
@@ -900,9 +912,13 @@ export class AgentBrowser extends MastraBrowser {
       if (input.label) selectValue.label = input.label;
       if (input.index !== undefined) selectValue.index = input.index;
 
-      const selected = await locator.selectOption(selectValue, {
-        timeout: this.defaultTimeout,
-      });
+      const timeout = input.timeout ?? this.defaultTimeout;
+
+      const selected = await locator.selectOption(selectValue, { timeout });
+
+      if (input.waitUntil) {
+        await page.waitForLoadState(input.waitUntil, { timeout });
+      }
 
       return {
         success: true,

--- a/browser/agent-browser/src/schemas.ts
+++ b/browser/agent-browser/src/schemas.ts
@@ -53,7 +53,7 @@ export const clickInputSchema = z.object({
     .enum(['load', 'domcontentloaded', 'networkidle'])
     .optional()
     .describe('If the click triggers a navigation, wait for this page load state before returning'),
-  timeout: z.number().optional().describe('Timeout in milliseconds for the click and optional waitUntil'),
+  timeout: z.number().nonnegative().optional().describe('Timeout in milliseconds for the click and optional waitUntil'),
 });
 export type ClickInput = z.output<typeof clickInputSchema>;
 
@@ -81,7 +81,7 @@ export const pressInputSchema = z.object({
     .enum(['load', 'domcontentloaded', 'networkidle'])
     .optional()
     .describe('If the key press triggers a navigation, wait for this page load state before returning'),
-  timeout: z.number().optional().describe('Timeout in milliseconds for the optional waitUntil'),
+  timeout: z.number().nonnegative().optional().describe('Timeout in milliseconds for the optional waitUntil'),
 });
 export type PressInput = z.output<typeof pressInputSchema>;
 
@@ -98,7 +98,11 @@ export const selectInputSchema = z
       .enum(['load', 'domcontentloaded', 'networkidle'])
       .optional()
       .describe('If the selection triggers a navigation, wait for this page load state before returning'),
-    timeout: z.number().optional().describe('Timeout in milliseconds for the selection and optional waitUntil'),
+    timeout: z
+      .number()
+      .nonnegative()
+      .optional()
+      .describe('Timeout in milliseconds for the selection and optional waitUntil'),
   })
   .superRefine((data, ctx) => {
     if (data.value === undefined && data.label === undefined && data.index === undefined) {

--- a/browser/agent-browser/src/schemas.ts
+++ b/browser/agent-browser/src/schemas.ts
@@ -49,6 +49,11 @@ export const clickInputSchema = z.object({
     .array(z.enum(['Alt', 'Control', 'Meta', 'Shift']))
     .optional()
     .describe('Modifier keys to hold'),
+  waitUntil: z
+    .enum(['load', 'domcontentloaded', 'networkidle'])
+    .optional()
+    .describe('If the click triggers a navigation, wait for this page load state before returning'),
+  timeout: z.number().optional().describe('Timeout in milliseconds for the click and optional waitUntil'),
 });
 export type ClickInput = z.output<typeof clickInputSchema>;
 
@@ -72,6 +77,11 @@ export const pressInputSchema = z.object({
     .array(z.enum(['Alt', 'Control', 'Meta', 'Shift']))
     .optional()
     .describe('Modifier keys to hold'),
+  waitUntil: z
+    .enum(['load', 'domcontentloaded', 'networkidle'])
+    .optional()
+    .describe('If the key press triggers a navigation, wait for this page load state before returning'),
+  timeout: z.number().optional().describe('Timeout in milliseconds for the optional waitUntil'),
 });
 export type PressInput = z.output<typeof pressInputSchema>;
 
@@ -84,6 +94,11 @@ export const selectInputSchema = z
     value: z.string().optional().describe('Option value to select'),
     label: z.string().optional().describe('Option label to select'),
     index: z.number().int().min(0).optional().describe('Option index to select (0-based)'),
+    waitUntil: z
+      .enum(['load', 'domcontentloaded', 'networkidle'])
+      .optional()
+      .describe('If the selection triggers a navigation, wait for this page load state before returning'),
+    timeout: z.number().optional().describe('Timeout in milliseconds for the selection and optional waitUntil'),
   })
   .superRefine((data, ctx) => {
     if (data.value === undefined && data.label === undefined && data.index === undefined) {

--- a/browser/agent-browser/src/tools/click.ts
+++ b/browser/agent-browser/src/tools/click.ts
@@ -10,7 +10,8 @@ import { BROWSER_TOOLS } from './constants';
 export function createClickTool(browser: AgentBrowser) {
   return createTool({
     id: BROWSER_TOOLS.CLICK,
-    description: 'Click an element using its ref from a snapshot. Use clickCount: 2 for double-click.',
+    description:
+      'Click an element using its ref from a snapshot. Use clickCount: 2 for double-click. Pass waitUntil when the click triggers navigation so the page settles before the next snapshot.',
     inputSchema: clickInputSchema,
     execute: async (input, { agent }) => {
       const threadId = agent?.threadId;

--- a/browser/agent-browser/src/tools/press.ts
+++ b/browser/agent-browser/src/tools/press.ts
@@ -8,7 +8,8 @@ import { BROWSER_TOOLS } from './constants';
 export function createPressTool(browser: AgentBrowser) {
   return createTool({
     id: BROWSER_TOOLS.PRESS,
-    description: 'Press a keyboard key (e.g., Enter, Tab, Escape, Control+a).',
+    description:
+      'Press a keyboard key (e.g., Enter, Tab, Escape, Control+a). Pass waitUntil when the keypress triggers navigation (e.g., Enter to submit a form) so the page settles before the next snapshot.',
     inputSchema: pressInputSchema,
     execute: async (input, { agent }) => {
       const threadId = agent?.threadId;

--- a/browser/agent-browser/src/tools/select.ts
+++ b/browser/agent-browser/src/tools/select.ts
@@ -8,7 +8,8 @@ import { BROWSER_TOOLS } from './constants';
 export function createSelectTool(browser: AgentBrowser) {
   return createTool({
     id: BROWSER_TOOLS.SELECT,
-    description: 'Select an option from a dropdown by value, label, or index.',
+    description:
+      'Select an option from a dropdown by value, label, or index. Pass waitUntil when the selection triggers navigation so the page settles before the next snapshot.',
     inputSchema: selectInputSchema,
     execute: async (input, { agent }) => {
       const threadId = agent?.threadId;


### PR DESCRIPTION
## Description

Adds an optional `waitUntil` parameter to `browser_click`, `browser_press`, and `browser_select` so interactions that trigger navigation can wait for the requested page load state before returning. This helps prevent the next `browser_snapshot` from capturing stale or partially-loaded DOM after clicks, keypresses, or select changes that navigate the page.

- Add `waitUntil` and timeout support to the click, press, and select input schemas
- Wait for `page.waitForLoadState()` after click, press, or select when `waitUntil` is provided
- Update tool descriptions so agents know when to pass `waitUntil`
- Add runtime tests for waiting and non-waiting behavior on each tool
- Add schema validation tests for valid and invalid `waitUntil` values
- Add a changeset for `@mastra/agent-browser`

## Related Issue(s)

Fixes #17397

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test plan

- `pnpm --filter ./browser/agent-browser exec vitest run src/__tests__/agent-browser.test.ts src/__tests__/types.test.ts`
- `pnpm --filter ./browser/agent-browser build`
- `pnpm --filter ./browser/agent-browser lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a click, keypress, or dropdown selection causes a page change, this PR lets those actions optionally wait until the new page finishes loading before continuing, so subsequent snapshots capture the new page rather than a stale one.

## Changes Overview

Adds optional waitUntil+timeout support to browser interaction tools: browser_click, browser_press, and browser_select. When provided, the tools wait for the requested page load state (load, domcontentloaded, or networkidle) before returning; behavior is unchanged when waitUntil is omitted.

## Key Implementation Changes

- Schemas (browser/agent-browser/src/schemas.ts)
  - Added optional waitUntil enum ('load' | 'domcontentloaded' | 'networkidle') and optional non-negative timeout to clickInputSchema, pressInputSchema, and selectInputSchema.
  - Exported types ClickInput, PressInput, SelectInput updated accordingly.

- Runtime (browser/agent-browser/src/agent-browser.ts)
  - Each tool resolves timeout = input.timeout ?? this.defaultTimeout.
  - When input.waitUntil is provided, the tool starts navigation waiting and awaits the page reaching the requested load state after performing the interaction.
  - browser_select now passes the resolved timeout into locator.selectOption(..., { timeout }).

- Tool descriptions (browser/agent-browser/src/tools/click.ts, press.ts, select.ts)
  - Updated descriptions to advise agents to pass waitUntil when interactions can trigger navigation so the page settles before the next snapshot.

## Testing

- Unit tests (browser/agent-browser/src/__tests__/agent-browser.test.ts)
  - Added tests verifying that when waitUntil+timeout are provided the mock page's navigation/wait is invoked with the correct options and that no wait is performed when waitUntil is omitted.
  - Tests also assert timeout forwarding to locator interactions where applicable.

- Schema tests (browser/agent-browser/src/__tests__/types.test.ts)
  - Added acceptance tests for valid waitUntil values and non-negative timeout values, and rejection tests for invalid waitUntil and invalid timeout inputs.

## Metadata

- Changeset: bumps `@mastra/agent-browser` (minor) documenting added waitUntil support.
- Related issue: fixes `#17397`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->