### PR TITLE
fix(core/adapters): convert non-user signals to role:user in UI messages

### DIFF
--- a/.changeset/fix-signal-message-render-crash.md
+++ b/.changeset/fix-signal-message-render-crash.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': patch
+---
+
+Fix Mastra Studio chat history crash when a thread contains a non-user-message signal (e.g. `system-reminder`).
+
+The `toUIMessage` path in the AIV4/AIV5/AIV6 adapters was converting historical signals (`role: 'signal'`) to a UI message with `role: 'system'` and a single signal data part. assistant-ui rejects system messages that aren't a single text part with `System messages must have exactly one text message part.`, which crashed the chat view on refresh whenever the thread had a stored signal.
+
+Map all historical signals to `role: 'user'`, matching what `signalToLLMMessage` already does at runtime. The signal payload still rides as a `data-<tagName>` UI part, so UIs see the same shape from history that they see on the live stream — they just need to look for the data part instead of branching on the message role.
+
+Also widens the historical signal data part in AIV5/AIV6 to carry `attributes`, `acceptedAt`, and `providerOptions` alongside `metadata`, matching the live-stream signal data part shape.
+
+Fixes mastra-ai/mastra#17414.

--- a/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV4Adapter.ts
@@ -326,7 +326,7 @@ export class AIV4Adapter {
 
     const uiMessage: UIMessageWithMetadata = {
       id: m.id,
-      role: m.role === 'signal' ? (isUserMessageSignal ? 'user' : 'system') : m.role,
+      role: m.role === 'signal' ? 'user' : m.role,
       content: m.role === 'signal' && !isUserMessageSignal ? '' : m.content.content || contentString,
       createdAt: m.createdAt,
       parts: v4Parts,

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
@@ -73,6 +73,14 @@ function toSignalDataPart(message: MastraDBMessage): AIV5Type.DataUIPart<AIV5.UI
     signal.metadata && typeof signal.metadata === 'object' && !Array.isArray(signal.metadata)
       ? (signal.metadata as Record<string, unknown>)
       : {};
+  const attributes =
+    signal.attributes && typeof signal.attributes === 'object' && !Array.isArray(signal.attributes)
+      ? (signal.attributes as Record<string, unknown>)
+      : {};
+  const providerOptions =
+    signal.providerOptions && typeof signal.providerOptions === 'object' && !Array.isArray(signal.providerOptions)
+      ? (signal.providerOptions as Record<string, unknown>)
+      : {};
 
   const type = getSignalType(message) ?? 'signal';
   const tagName = getSignalTagName(message) ?? type;
@@ -85,7 +93,10 @@ function toSignalDataPart(message: MastraDBMessage): AIV5Type.DataUIPart<AIV5.UI
       tagName,
       contents: 'contents' in signal ? signal.contents : getTextContent(message),
       createdAt: typeof signal.createdAt === 'string' ? signal.createdAt : message.createdAt.toISOString(),
+      ...(typeof signal.acceptedAt === 'string' ? { acceptedAt: signal.acceptedAt } : {}),
+      ...(Object.keys(attributes).length ? { attributes } : {}),
       ...(Object.keys(metadata).length ? { metadata } : {}),
+      ...(Object.keys(providerOptions).length ? { providerOptions } : {}),
     },
   } as AIV5Type.DataUIPart<AIV5.UIDataTypes>;
 }
@@ -233,7 +244,7 @@ export class AIV5Adapter {
     if (dbMsg.role === 'signal' && !isUserMessageSignal) {
       return {
         id: dbMsg.id,
-        role: 'system',
+        role: 'user',
         metadata,
         parts,
       };
@@ -530,7 +541,7 @@ export class AIV5Adapter {
 
     return {
       id: dbMsg.id,
-      role: dbMsg.role === 'signal' ? (isUserMessageSignal ? 'user' : 'system') : dbMsg.role,
+      role: dbMsg.role === 'signal' ? 'user' : dbMsg.role,
       metadata,
       parts,
     };

--- a/packages/core/src/agent/message-list/adapters/AIV6Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV6Adapter.ts
@@ -268,13 +268,21 @@ export class AIV6Adapter {
     const metadata = (v5Message.metadata || {}) as Record<string, unknown>;
     const parts: AIV6Type.UIMessage['parts'] = [];
 
-    if (dbMsg.role === 'signal' && v5Message.role !== 'user') {
-      return {
-        id: dbMsg.id,
-        role: 'system',
-        metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
-        parts: v5Message.parts.map(part => AIV6Adapter.toUIPartFromV5(part)),
-      };
+    if (dbMsg.role === 'signal') {
+      const signalMeta = dbMsg.content.metadata?.signal;
+      const signalType =
+        signalMeta && typeof signalMeta === 'object' && !Array.isArray(signalMeta)
+          ? (signalMeta as Record<string, unknown>).type
+          : undefined;
+      const isUserMessageSignal = signalType === 'user-message';
+      if (!isUserMessageSignal) {
+        return {
+          id: dbMsg.id,
+          role: 'user',
+          metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+          parts: v5Message.parts.map(part => AIV6Adapter.toUIPartFromV5(part)),
+        };
+      }
     }
 
     const dbParts = dbMsg.content.parts || [];

--- a/packages/core/src/agent/message-list/adapters/agent-signal-ui-conversion.test.ts
+++ b/packages/core/src/agent/message-list/adapters/agent-signal-ui-conversion.test.ts
@@ -46,7 +46,7 @@ describe('agent signal UI conversion', () => {
       AIV5Adapter.toUIMessage(dbMessage),
       AIV6Adapter.toUIMessage(dbMessage),
     ]) {
-      expect(uiMessage.role).toBe('system');
+      expect(uiMessage.role).toBe('user');
       expect(uiMessage.parts).toEqual([
         {
           type: 'data-system-reminder',


### PR DESCRIPTION
## Summary

Fix Mastra Studio chat history crash when a thread contains a non-user-message signal (e.g. `system-reminder`). Reported in #17414.

## Problem

The `toUIMessage` path in the AIV4/AIV5/AIV6 adapters was converting historical signals (`role: 'signal'`) to a UI message with `role: 'system'` and a single signal data part. assistant-ui rejects system messages that aren't a single text part with:

```
System messages must have exactly one text message part.
```

This crashed the chat view on refresh whenever a thread had any stored signal — visible on `@mastra/agent-browser` threads with stored `system-reminder` messages and any thread that has used heartbeats.

## Fix

Map all historical signals to `role: 'user'`, matching what `signalToLLMMessage` already does at runtime. The signal payload still rides as a `data-<tagName>` UI part, so UIs see the same shape from history that they see on the live stream — they just need to look for the data part instead of branching on the message role.

Also widens the historical signal data part in AIV5/AIV6 to carry `attributes`, `acceptedAt`, and `providerOptions` alongside `metadata`, matching the live-stream signal data part shape (so historical signals don't lose structured data when reloading from storage.

## Test plan

- 
> @mastra/core@1.38.0-alpha.5 test:unit
> vitest run --exclude '**/tool-builder/**' agent-signal-ui-conversion


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.5 [39m[90m/Users/caleb/.superset/worktrees/mastra/caleb/heartbeats/packages/core[39m

 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/adapters/agent-signal-ui-conversion.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 4[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2mType Errors [22m [2mno errors[22m
[2m   Start at [22m 13:01:15
[2m   Duration [22m 389ms[2m (transform 234ms, setup 18ms, import 307ms, tests 4ms, environment 0ms)[22m — 2/2 pass
- 
> @mastra/core@1.38.0-alpha.5 test:unit
> vitest run --exclude '**/tool-builder/**' message-list


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.5 [39m[90m/Users/caleb/.superset/worktrees/mastra/caleb/heartbeats/packages/core[39m

 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/prompt/attachments-to-parts.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/prompt/download-assets.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/conversion/output-converter-provider-executed.test.ts [2m([22m[2m31 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/message-list-sealed.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/empty-tool-input.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/utils/convert-messages.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/update-tool-invocation.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/openai-reasoning-roundtrip.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/prompt/convert-to-mastra-v1.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/message-list-gemini.test.ts [2m([22m[2m26 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/message-list-v5.test.ts [2m([22m[2m77 tests[22m[2m | [22m[33m2 skipped[39m[2m)[22m[32m 21[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/message-list-ordering.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 23[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/conversion/output-converter-file-metadata.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/message-list.test.ts [2m([22m[2m90 tests[22m[2m)[22m[32m 56[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/message-list-url-handling.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 97[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/utils/provider-compat.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/prompt/convert-to-mastra-v1-reasoning.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/adapters/AIV5Adapter-suspended-parts.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/adapters/agent-signal-ui-conversion.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/adapters/AIV5Adapter-part-createdAt.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/adapters/AIV5Adapter-file-ui-part.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/split-tool-call-args.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/cache/CacheKeyGenerator-tool-invocation-guard.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/conversion/to-prompt-tool-name-sanitization.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/message-list-aisdk-attachments.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/message-list-aisdk-v5-url.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/conversion/output-converter-provider-options.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/openai-reasoning-multistep-bug.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/step-start.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/message-list-om-multistep.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/adapters/AIV5Adapter-tool-name-sanitization.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/adapters/AIV5Adapter-provider-executed.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m [30m[42m unit:packages/core [49m[39m src/agent/message-list/tests/message-list-v6.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 6[2mms[22m[39m

[2m Test Files [22m [1m[32m33 passed[39m[22m[90m (33)[39m
[2m      Tests [22m [1m[32m433 passed[39m[22m[2m | [22m[33m2 skipped[39m[90m (435)[39m
[2mType Errors [22m [2mno errors[22m
[2m   Start at [22m 13:01:16
[2m   Duration [22m 2.27s[2m (transform 5.73s, setup 483ms, import 12.45s, tests 346ms, environment 1ms)[22m — 433/433 pass (33 files)
- Manually: load a thread with a stored  signal in Studio — chat view renders instead of crashing.

Fixes #17414.
EOF
)