### PR TITLE
feat(playground-ui): CodeBlock as canonical code surface with CSS-driven light/dark highlighting

### DIFF
--- a/.changeset/plenty-zoos-worry.md
+++ b/.changeset/plenty-zoos-worry.md
@@ -1,5 +1,23 @@
 ---
-'@mastra/playground-ui': patch
+'@mastra/playground-ui': minor
 ---
 
-Fixed syntax-highlighted code blocks to follow light and dark mode styling by default.
+Improved code rendering in the design system so `CodeBlock` is the canonical surface for static code.
+
+**Fixed** syntax-highlighted code to follow light and dark mode by default. Token colors are now resolved in CSS from the active theme class instead of JavaScript, so highlighted code works without a `ThemeProvider`.
+
+**Added** a low-level `Code` component, now shared by `CodeBlock` and `MarkdownRenderer` and exported for custom code surfaces:
+
+```tsx
+import { Code } from '@mastra/playground-ui';
+
+<Code code="pnpm dlx mastra init" lang="bash" />;
+```
+
+**Added** an `overflow` prop to `CodeBlock`. Use the default `wrap` for commands and snippets, and `scroll` for source code where preserving columns matters:
+
+```tsx
+<CodeBlock code={source} lang="typescript" overflow="scroll" />
+```
+
+**Added** Python syntax highlighting support.

--- a/.changeset/plenty-zoos-worry.md
+++ b/.changeset/plenty-zoos-worry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed syntax-highlighted code blocks to follow light and dark mode styling by default.

--- a/.claude/skills/react-best-practices/SKILL.md
+++ b/.claude/skills/react-best-practices/SKILL.md
@@ -23,14 +23,14 @@ Reference these guidelines when:
 
 Rules are prioritized by impact:
 
-| Priority | Category                  | Impact      |
-| -------- | ------------------------- | ----------- |
-| 1        | Eliminating Waterfalls    | CRITICAL    |
-| 2        | Bundle Size Optimization  | CRITICAL    |
-| 3        | Client-Side Data Fetching | MEDIUM-HIGH |
-| 4        | Re-render Optimization    | MEDIUM      |
-| 5        | Rendering Performance     | MEDIUM      |
-| 6        | JavaScript Performance    | LOW-MEDIUM  |
+| Priority | Category                  | Impact                        |
+| -------- | ------------------------- | ----------------------------- |
+| 1        | Eliminating Waterfalls    | CRITICAL                      |
+| 2        | Bundle Size Optimization  | CRITICAL                      |
+| 3        | Client-Side Data Fetching | MEDIUM-HIGH                   |
+| 4        | Re-render Optimization    | MEDIUM                        |
+| 5        | Rendering Performance     | MEDIUM                        |
+| 6        | JavaScript Performance    | LOW-MEDIUM                    |
 | 7        | Component Structure       | MEDIUM-HIGH (maintainability) |
 
 ## Quick Reference

--- a/.claude/skills/react-best-practices/references/react-best-practices-reference.md
+++ b/.claude/skills/react-best-practices/references/react-best-practices-reference.md
@@ -668,10 +668,7 @@ export function useProductSearch() {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<Category | null>(null);
   const filtered = useMemo(
-    () =>
-      (products ?? []).filter(
-        p => p.name.includes(query) && (!category || p.category === category),
-      ),
+    () => (products ?? []).filter(p => p.name.includes(query) && (!category || p.category === category)),
     [products, query, category],
   );
   return { filtered, query, setQuery, category, setCategory };
@@ -684,7 +681,9 @@ export function ProductList({ products, onSelect }: ProductListProps) {
   return (
     <ul>
       {products.map(p => (
-        <li key={p.id} onClick={() => onSelect(p.id)}>{p.name}</li>
+        <li key={p.id} onClick={() => onSelect(p.id)}>
+          {p.name}
+        </li>
       ))}
     </ul>
   );

--- a/.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md
+++ b/.claude/skills/react-best-practices/references/rules/structure-single-responsibility.md
@@ -58,10 +58,7 @@ export function useProductSearch() {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<Category | null>(null);
   const filtered = useMemo(
-    () =>
-      (products ?? []).filter(
-        p => p.name.includes(query) && (!category || p.category === category),
-      ),
+    () => (products ?? []).filter(p => p.name.includes(query) && (!category || p.category === category)),
     [products, query, category],
   );
   return { filtered, query, setQuery, category, setCategory };
@@ -74,7 +71,9 @@ export function ProductList({ products, onSelect }: ProductListProps) {
   return (
     <ul>
       {products.map(p => (
-        <li key={p.id} onClick={() => onSelect(p.id)}>{p.name}</li>
+        <li key={p.id} onClick={() => onSelect(p.id)}>
+          {p.name}
+        </li>
       ))}
     </ul>
   );

--- a/client-sdks/react/src/voice/use-speech-recognition.test.ts
+++ b/client-sdks/react/src/voice/use-speech-recognition.test.ts
@@ -284,7 +284,14 @@ describe('useSpeechRecognition (mastra path)', () => {
 
     await waitFor(() => expect(getSpeakersMock).toHaveBeenCalled());
 
-    act(() => result.current.start());
+    // Retry start() until the hook has switched to the mastra path (getSpeakers
+    // resolving into state is async); the in-flight guard makes extra calls no-ops.
+    await waitFor(() => {
+      act(() => result.current.start());
+      expect(recordMicrophoneToFileMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Second start while the first recordMicrophoneToFile is still pending.
     act(() => result.current.start());
 
     // The in-flight guard should have prevented a second recordMicrophoneToFile call.
@@ -308,8 +315,12 @@ describe('useSpeechRecognition (mastra path)', () => {
 
     await waitFor(() => expect(getSpeakersMock).toHaveBeenCalled());
 
-    act(() => result.current.start());
-    expect(recordMicrophoneToFileMock).toHaveBeenCalledTimes(1);
+    // Retry start() until the hook has switched to the mastra path (getSpeakers
+    // resolving into state is async); the in-flight guard makes extra calls no-ops.
+    await waitFor(() => {
+      act(() => result.current.start());
+      expect(recordMicrophoneToFileMock).toHaveBeenCalledTimes(1);
+    });
 
     act(() => result.current.stop());
 

--- a/packages/playground-ui/src/ds/components/Code/code.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Code/code.stories.tsx
@@ -37,7 +37,9 @@ export const PlainFallback: Story = {
 };
 
 export const Json: Story = {
-  render: () => <Code code={`{\n  "name": "weather-agent",\n  "tools": ["weatherTool"],\n  "memory": true\n}`} lang="json" />,
+  render: () => (
+    <Code code={`{\n  "name": "weather-agent",\n  "tools": ["weatherTool"],\n  "memory": true\n}`} lang="json" />
+  ),
 };
 
 export const Python: Story = {

--- a/packages/playground-ui/src/ds/components/Code/code.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Code/code.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Code } from './code';
+
+const meta: Meta<typeof Code> = {
+  title: 'Elements/Code',
+  component: Code,
+  decorators: [
+    Story => (
+      <div className="w-full p-4 font-mono text-ui-sm text-neutral5">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Low-level shiki token renderer shared by `CodeBlock` and `MarkdownRenderer`. Renders a bare `<pre><code>` with CSS-driven dual-theme colors (`.shiki-token` + `--shiki-light`/`--shiki-dark` variables) — no chrome, no copy button. Prefer `CodeBlock` unless you are building a custom code surface.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Code>;
+
+const tsSnippet = `import { Agent } from '@mastra/core/agent';\n\nexport const agent = new Agent({\n  name: 'assistant',\n  instructions: 'You are a helpful assistant.',\n});`;
+
+export const Default: Story = {
+  render: () => <Code code={tsSnippet} lang="typescript" />,
+};
+
+export const PlainFallback: Story = {
+  render: () => <Code code="No language given, rendered as plain text." />,
+};
+
+export const Json: Story = {
+  render: () => <Code code={`{\n  "name": "weather-agent",\n  "tools": ["weatherTool"],\n  "memory": true\n}`} lang="json" />,
+};
+
+export const Python: Story = {
+  render: () => <Code code={`def forecast(city: str) -> dict:\n    return {"city": city, "temp": 21}`} lang="python" />,
+};

--- a/packages/playground-ui/src/ds/components/Code/code.test.tsx
+++ b/packages/playground-ui/src/ds/components/Code/code.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Code } from './code';
+
+vi.mock('../CodeEditor/highlight', () => ({
+  highlight: vi.fn(async () => [
+    [
+      {
+        content: 'const',
+        htmlStyle: {
+          '--shiki-light': '#24292f',
+          '--shiki-dark': '#c9d1d9',
+        },
+      },
+    ],
+  ]),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Code', () => {
+  it('renders plain text when no language is given', () => {
+    render(<Code code="plain text content" />);
+
+    const pre = screen.getByText('plain text content');
+
+    expect(pre.tagName).toBe('PRE');
+    expect(pre.querySelector('.shiki-token')).toBeNull();
+  });
+
+  it('renders tokens with theme CSS variables instead of resolved colors', async () => {
+    render(<Code code="const ok = true;" lang="typescript" />);
+
+    const token = await screen.findByText('const');
+
+    expect(token.classList.contains('shiki-token')).toBe(true);
+    expect(token.style.getPropertyValue('--shiki-light')).toBe('#24292f');
+    expect(token.style.getPropertyValue('--shiki-dark')).toBe('#c9d1d9');
+    expect(token.style.color).toBe('');
+  });
+
+  it('passes className through to the pre element', () => {
+    render(<Code code="x" className="custom-class" />);
+
+    expect(screen.getByText('x').classList.contains('custom-class')).toBe(true);
+  });
+});

--- a/packages/playground-ui/src/ds/components/Code/code.tsx
+++ b/packages/playground-ui/src/ds/components/Code/code.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import type { ThemedToken } from 'shiki/core';
+
+import { highlight } from '../CodeEditor/highlight';
+
+export interface CodeProps extends React.HTMLAttributes<HTMLPreElement> {
+  code: string;
+  lang?: string;
+}
+
+function tokenStyle(token: ThemedToken): React.CSSProperties | undefined {
+  if (token.htmlStyle && typeof token.htmlStyle === 'object') {
+    return token.htmlStyle as React.CSSProperties;
+  }
+
+  return token.color ? { color: token.color } : undefined;
+}
+
+/**
+ * Low-level shiki token renderer shared by `CodeBlock` and `MarkdownRenderer`.
+ * Dual-theme colors stay as `--shiki-light` / `--shiki-dark` CSS variables on
+ * each token span; the `.shiki-token` class (index.css) picks the variant from
+ * the `.dark` root class, so theme switching is pure CSS — no ThemeProvider
+ * required. Renders plain text while highlighting is pending or when the
+ * language is missing/unknown.
+ */
+export const Code = React.memo(function Code({ code, lang, ...props }: CodeProps) {
+  const [tokens, setTokens] = React.useState<ThemedToken[][] | null>(null);
+
+  React.useEffect(() => {
+    setTokens(null);
+    if (!lang) return;
+
+    let cancelled = false;
+
+    void highlight(code, lang)
+      .then(result => {
+        if (!cancelled) setTokens(result);
+      })
+      .catch(() => {
+        if (!cancelled) setTokens(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, lang]);
+
+  if (!tokens?.length) {
+    return <pre {...props}>{code}</pre>;
+  }
+
+  let codeOffset = 0;
+
+  return (
+    <pre {...props}>
+      <code>
+        {tokens.map((line, lineIndex) => {
+          const lineOffset = codeOffset;
+          let tokenOffset = lineOffset;
+          const tokenSpans = line.map(token => {
+            const key = tokenOffset;
+            tokenOffset += token.content.length;
+
+            return (
+              <span key={key} className="shiki-token" style={tokenStyle(token)}>
+                {token.content}
+              </span>
+            );
+          });
+
+          codeOffset = tokenOffset + 1;
+
+          return (
+            <React.Fragment key={lineOffset}>
+              <span>{tokenSpans}</span>
+              {lineIndex !== tokens.length - 1 && '\n'}
+            </React.Fragment>
+          );
+        })}
+      </code>
+    </pre>
+  );
+});

--- a/packages/playground-ui/src/ds/components/Code/index.ts
+++ b/packages/playground-ui/src/ds/components/Code/index.ts
@@ -1,0 +1,1 @@
+export * from './code';

--- a/packages/playground-ui/src/ds/components/CodeBlock/code-block.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeBlock/code-block.stories.tsx
@@ -18,6 +18,21 @@ const meta: Meta<typeof CodeBlock> = {
   ],
   parameters: {
     layout: 'fullscreen',
+    docs: {
+      description: {
+        component: [
+          'Canonical DS surface for static code. Usage rules:',
+          '- Inline `<code>` only for short identifiers, env vars, IDs and paths.',
+          '- `CodeBlock` for any standalone command, source snippet, JSON/text payload or copyable example.',
+          '- `selector="tabs"` for 2–4 peer alternatives users compare often (e.g. curl/Python/Node).',
+          '- `selector="select"` for longer option sets or compact package-manager choices.',
+          '- `overflow="wrap"` (default) for commands and snippets; `overflow="scroll"` for source code where preserving columns matters.',
+          '- Use `CodeEditor`, `DataCodeSection` or `CodeDiff` only for editable content, searchable/large structured data, or diffs.',
+          '',
+          'Syntax colors are CSS-driven: tokens carry `--shiki-light`/`--shiki-dark` variables and the `.shiki-token` class resolves them from the `.light`/`.dark` root class, so light/dark works without a ThemeProvider.',
+        ].join('\n'),
+      },
+    },
   },
 };
 
@@ -116,6 +131,17 @@ export const TabsWithCode: Story = {
       />
     );
   },
+};
+
+export const OverflowScroll: Story = {
+  render: () => (
+    <CodeBlock
+      fileName="src/mastra/workflows/long-lines.ts"
+      lang="typescript"
+      overflow="scroll"
+      code={`const step = createStep({ id: 'fetch-weather', description: 'Fetches the forecast for a given city', inputSchema: z.object({ city: z.string() }), outputSchema: forecastSchema });\nconst workflow = createWorkflow({ id: 'weather-workflow', inputSchema: z.object({ city: z.string() }), outputSchema: forecastSchema }).then(step).commit();`}
+    />
+  ),
 };
 
 export const Highlighted: Story = {

--- a/packages/playground-ui/src/ds/components/CodeBlock/code-block.test.tsx
+++ b/packages/playground-ui/src/ds/components/CodeBlock/code-block.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { TooltipProvider } from '../Tooltip';
 import { CodeBlock } from './code-block';
 
-vi.mock('../CodeEditor', () => ({
+vi.mock('../CodeEditor/highlight', () => ({
   highlight: vi.fn(async () => [
     [
       {
@@ -17,6 +17,10 @@ vi.mock('../CodeEditor', () => ({
       },
     ],
   ]),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
 }));
 
 afterEach(() => {
@@ -46,5 +50,57 @@ describe('CodeBlock', () => {
     expect(token.classList.contains('shiki-token')).toBe(true);
     expect(token.style.getPropertyValue('--shiki-light')).toBe('#24292f');
     expect(token.style.getPropertyValue('--shiki-dark')).toBe('#c9d1d9');
+  });
+
+  it('wraps long lines by default', () => {
+    render(
+      <TooltipProvider>
+        <CodeBlock code="pnpm dlx mastra init" />
+      </TooltipProvider>,
+    );
+
+    const pre = screen.getByText('pnpm dlx mastra init');
+
+    expect(pre.classList.contains('whitespace-pre-wrap')).toBe(true);
+    expect(pre.classList.contains('break-all')).toBe(true);
+  });
+
+  it('preserves columns behind a horizontal scroll with overflow="scroll"', () => {
+    render(
+      <TooltipProvider>
+        <CodeBlock code="pnpm dlx mastra init" overflow="scroll" />
+      </TooltipProvider>,
+    );
+
+    const pre = screen.getByText('pnpm dlx mastra init');
+
+    expect(pre.classList.contains('overflow-x-auto')).toBe(true);
+    expect(pre.classList.contains('whitespace-pre')).toBe(true);
+    expect(pre.classList.contains('whitespace-pre-wrap')).toBe(false);
+  });
+
+  it('copies the code of the active option', async () => {
+    const writeText = vi.fn(async () => {});
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <TooltipProvider>
+        <CodeBlock
+          code="npm install @mastra/core"
+          selector="tabs"
+          options={[
+            { label: 'pnpm', value: 'pnpm' },
+            { label: 'npm', value: 'npm' },
+          ]}
+          value="npm"
+        />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('npm install @mastra/core');
+    });
   });
 });

--- a/packages/playground-ui/src/ds/components/CodeBlock/code-block.test.tsx
+++ b/packages/playground-ui/src/ds/components/CodeBlock/code-block.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TooltipProvider } from '../Tooltip';
+import { CodeBlock } from './code-block';
+
+vi.mock('../CodeEditor', () => ({
+  highlight: vi.fn(async () => [
+    [
+      {
+        content: 'const',
+        htmlStyle: {
+          '--shiki-light': '#24292f',
+          '--shiki-dark': '#c9d1d9',
+        },
+      },
+    ],
+  ]),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('CodeBlock', () => {
+  it('renders plain code text', () => {
+    render(
+      <TooltipProvider>
+        <CodeBlock code="pnpm dlx mastra init" />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText('pnpm dlx mastra init')).toBeDefined();
+  });
+
+  it('renders highlighted tokens with theme CSS variables', async () => {
+    render(
+      <TooltipProvider>
+        <CodeBlock code="const ok = true;" lang="typescript" />
+      </TooltipProvider>,
+    );
+
+    const token = await screen.findByText('const');
+
+    expect(token.classList.contains('shiki-token')).toBe(true);
+    expect(token.style.getPropertyValue('--shiki-light')).toBe('#24292f');
+    expect(token.style.getPropertyValue('--shiki-dark')).toBe('#c9d1d9');
+  });
+});

--- a/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
+++ b/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
@@ -1,7 +1,4 @@
-import * as React from 'react';
-import type { ThemedToken } from 'shiki/core';
-
-import { highlight } from '../CodeEditor';
+import { Code } from '../Code';
 import { CopyButton } from '../CopyButton';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select';
 import { Tab, TabList, Tabs } from '../Tabs';
@@ -9,6 +6,8 @@ import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
 export type CodeBlockSelector = 'select' | 'tabs';
+
+export type CodeBlockOverflow = 'wrap' | 'scroll';
 
 export interface CodeBlockOption {
   label: string;
@@ -23,6 +22,9 @@ export interface CodeBlockProps {
   selector?: CodeBlockSelector;
   fileName?: string;
   lang?: string;
+  /** `wrap` (default) breaks long lines — best for commands and snippets.
+   *  `scroll` preserves columns behind a horizontal scroll — best for source code. */
+  overflow?: CodeBlockOverflow;
   copyMessage?: string;
   copyTooltip?: string;
   className?: string;
@@ -36,6 +38,7 @@ export function CodeBlock({
   selector = 'select',
   fileName,
   lang,
+  overflow = 'wrap',
   copyMessage,
   copyTooltip,
   className,
@@ -88,7 +91,14 @@ export function CodeBlock({
       )}
 
       <div className="relative">
-        <HighlightedCode code={code} lang={lang} />
+        <Code
+          code={code}
+          lang={lang}
+          className={cn(
+            'px-4 py-3 font-mono text-ui-sm text-neutral5',
+            overflow === 'scroll' ? 'overflow-x-auto whitespace-pre' : 'whitespace-pre-wrap break-all',
+          )}
+        />
         <CopyButton
           content={code}
           copyMessage={copyMessage}
@@ -101,82 +111,5 @@ export function CodeBlock({
         />
       </div>
     </figure>
-  );
-}
-
-interface HighlightedCodeProps {
-  code: string;
-  lang?: string;
-}
-
-function tokenStyle(token: ThemedToken): React.CSSProperties | undefined {
-  if (token.htmlStyle && typeof token.htmlStyle === 'object') {
-    return token.htmlStyle as React.CSSProperties;
-  }
-
-  return token.color ? { color: token.color } : undefined;
-}
-
-function HighlightedCode({ code, lang }: HighlightedCodeProps) {
-  const [tokens, setTokens] = React.useState<ThemedToken[][] | null>(null);
-
-  React.useEffect(() => {
-    if (!lang) {
-      setTokens(null);
-      return;
-    }
-
-    setTokens(null);
-    let cancelled = false;
-
-    void highlight(code, lang)
-      .then(result => {
-        if (!cancelled && result) setTokens(result);
-      })
-      .catch(() => {
-        if (!cancelled) setTokens(null);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [code, lang]);
-
-  const preClass = 'px-4 py-3 font-mono text-ui-sm text-neutral5 whitespace-pre-wrap break-all';
-
-  if (!lang || !tokens) {
-    return <pre className={preClass}>{code}</pre>;
-  }
-
-  let codeOffset = 0;
-
-  return (
-    <pre className={preClass}>
-      <code>
-        {tokens.map((line, lineIndex) => {
-          const lineOffset = codeOffset;
-          let tokenOffset = lineOffset;
-          const tokenSpans = line.map(token => {
-            const key = tokenOffset;
-            tokenOffset += token.content.length;
-
-            return (
-              <span key={key} className="shiki-token" style={tokenStyle(token)}>
-                {token.content}
-              </span>
-            );
-          });
-
-          codeOffset = tokenOffset + 1;
-
-          return (
-            <React.Fragment key={lineOffset}>
-              <span>{tokenSpans}</span>
-              {lineIndex !== tokens.length - 1 && '\n'}
-            </React.Fragment>
-          );
-        })}
-      </code>
-    </pre>
   );
 }

--- a/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
+++ b/packages/playground-ui/src/ds/components/CodeBlock/code-block.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import type { ThemedToken } from 'shiki';
+import type { ThemedToken } from 'shiki/core';
 
 import { highlight } from '../CodeEditor';
 import { CopyButton } from '../CopyButton';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select';
 import { Tab, TabList, Tabs } from '../Tabs';
-import { useTheme } from '../ThemeProvider';
 import { transitions } from '@/ds/primitives/transitions';
 import { cn } from '@/lib/utils';
 
@@ -110,44 +109,34 @@ interface HighlightedCodeProps {
   lang?: string;
 }
 
-// Shiki runs with dual themes (`defaultColor: false`), so each token's colors
-// arrive as `--shiki-light` / `--shiki-dark` CSS variables on `htmlStyle` rather
-// than as a concrete `color`. Nothing in the app reads those variables, so we
-// resolve them into a real `color`/`backgroundColor` here, picking the variant
-// that matches the active theme. We deliberately do not spread `htmlStyle` (which
-// would inline both variables and pin one theme regardless of the app's toggle).
-function tokenStyle(token: ThemedToken, isDark: boolean): React.CSSProperties | undefined {
+function tokenStyle(token: ThemedToken): React.CSSProperties | undefined {
   if (token.htmlStyle && typeof token.htmlStyle === 'object') {
-    const vars = token.htmlStyle as Record<string, string>;
-    const color = isDark ? vars['--shiki-dark'] : vars['--shiki-light'];
-    const background = isDark ? vars['--shiki-dark-bg'] : vars['--shiki-light-bg'];
-    const style: React.CSSProperties = {};
-    if (color) style.color = color;
-    if (background) style.backgroundColor = background;
-    return Object.keys(style).length ? style : undefined;
+    return token.htmlStyle as React.CSSProperties;
   }
-  // Single-theme fallback: Shiki put the color directly on the token.
+
   return token.color ? { color: token.color } : undefined;
 }
 
 function HighlightedCode({ code, lang }: HighlightedCodeProps) {
   const [tokens, setTokens] = React.useState<ThemedToken[][] | null>(null);
-  const isDark = useTheme().resolvedTheme === 'dark';
 
   React.useEffect(() => {
     if (!lang) {
       setTokens(null);
       return;
     }
+
     setTokens(null);
     let cancelled = false;
+
     void highlight(code, lang)
       .then(result => {
         if (!cancelled && result) setTokens(result);
       })
       .catch(() => {
-        // Highlighting failed — plain-text fallback remains visible.
+        if (!cancelled) setTokens(null);
       });
+
     return () => {
       cancelled = true;
     };
@@ -159,21 +148,34 @@ function HighlightedCode({ code, lang }: HighlightedCodeProps) {
     return <pre className={preClass}>{code}</pre>;
   }
 
+  let codeOffset = 0;
+
   return (
     <pre className={preClass}>
       <code>
-        {tokens.map((line, lineIndex) => (
-          <React.Fragment key={lineIndex}>
-            <span>
-              {line.map((token, tokenIndex) => (
-                <span key={tokenIndex} style={tokenStyle(token, isDark)}>
-                  {token.content}
-                </span>
-              ))}
-            </span>
-            {lineIndex !== tokens.length - 1 && '\n'}
-          </React.Fragment>
-        ))}
+        {tokens.map((line, lineIndex) => {
+          const lineOffset = codeOffset;
+          let tokenOffset = lineOffset;
+          const tokenSpans = line.map(token => {
+            const key = tokenOffset;
+            tokenOffset += token.content.length;
+
+            return (
+              <span key={key} className="shiki-token" style={tokenStyle(token)}>
+                {token.content}
+              </span>
+            );
+          });
+
+          codeOffset = tokenOffset + 1;
+
+          return (
+            <React.Fragment key={lineOffset}>
+              <span>{tokenSpans}</span>
+              {lineIndex !== tokens.length - 1 && '\n'}
+            </React.Fragment>
+          );
+        })}
       </code>
     </pre>
   );

--- a/packages/playground-ui/src/ds/components/CodeEditor/highlight.ts
+++ b/packages/playground-ui/src/ds/components/CodeEditor/highlight.ts
@@ -22,6 +22,8 @@ const langAliases: Record<string, string> = {
   json5: 'json',
   md: 'markdown',
   markdown: 'markdown',
+  py: 'python',
+  python: 'python',
   sh: 'bash',
   bash: 'bash',
   shell: 'bash',
@@ -48,6 +50,7 @@ function getHighlighter(): Promise<HighlighterCore> {
           import('shiki/langs/json.mjs'),
           import('shiki/langs/bash.mjs'),
           import('shiki/langs/markdown.mjs'),
+          import('shiki/langs/python.mjs'),
         ],
         engine: createJavaScriptRegexEngine(),
       });

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TooltipProvider } from '../Tooltip';
 import { MarkdownRenderer } from './markdown-renderer';
 
-vi.mock('@/ds/components/CodeEditor', () => ({
+vi.mock('@/ds/components/CodeEditor/highlight', () => ({
   highlight: vi.fn(async () => [
     [
       {
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 describe('MarkdownRenderer', () => {
-  it('renders fenced code blocks', async () => {
+  it('renders fenced code blocks through the shared Code renderer', async () => {
     render(
       <TooltipProvider>
         <MarkdownRenderer>{'```typescript\nconst ok = true;\n```'}</MarkdownRenderer>
@@ -36,5 +36,21 @@ describe('MarkdownRenderer', () => {
     expect(token.classList.contains('shiki-token')).toBe(true);
     expect(token.style.getPropertyValue('--shiki-light')).toBe('#24292f');
     expect(token.style.getPropertyValue('--shiki-dark')).toBe('#c9d1d9');
+    expect(token.closest('pre')).not.toBeNull();
+  });
+
+  it('renders inline code as a plain non-copyable <code> element', () => {
+    render(
+      <TooltipProvider>
+        <MarkdownRenderer>{'Use the `MASTRA_API_KEY` env var.'}</MarkdownRenderer>
+      </TooltipProvider>,
+    );
+
+    const inline = screen.getByText('MASTRA_API_KEY');
+
+    expect(inline.tagName).toBe('CODE');
+    expect(inline.closest('pre')).toBeNull();
+    expect(inline.querySelector('.shiki-token')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Copy to clipboard' })).toBeNull();
   });
 });

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TooltipProvider } from '../Tooltip';
+import { MarkdownRenderer } from './markdown-renderer';
+
+vi.mock('@/ds/components/CodeEditor', () => ({
+  highlight: vi.fn(async () => [
+    [
+      {
+        content: 'const',
+        htmlStyle: {
+          '--shiki-light': '#24292f',
+          '--shiki-dark': '#c9d1d9',
+        },
+      },
+    ],
+  ]),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MarkdownRenderer', () => {
+  it('renders fenced code blocks', async () => {
+    render(
+      <TooltipProvider>
+        <MarkdownRenderer>{'```typescript\nconst ok = true;\n```'}</MarkdownRenderer>
+      </TooltipProvider>,
+    );
+
+    const token = await screen.findByText('const');
+
+    expect(token.classList.contains('shiki-token')).toBe(true);
+    expect(token.style.getPropertyValue('--shiki-light')).toBe('#24292f');
+    expect(token.style.getPropertyValue('--shiki-dark')).toBe('#c9d1d9');
+  });
+});

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
@@ -1,7 +1,8 @@
-import React, { Suspense, useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
 import type { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import type { ThemedToken } from 'shiki/core';
 
 import { highlight } from '@/ds/components/CodeEditor';
 import { CopyButton } from '@/ds/components/CopyButton';
@@ -26,42 +27,65 @@ interface HighlightedPre extends React.HTMLAttributes<HTMLPreElement> {
   language: string;
 }
 
+function tokenStyle(token: ThemedToken): React.CSSProperties | undefined {
+  if (token.htmlStyle && typeof token.htmlStyle === 'object') {
+    return token.htmlStyle as React.CSSProperties;
+  }
+
+  return token.color ? { color: token.color } : undefined;
+}
+
 const HighlightedPre = React.memo(({ children, language, ...props }: HighlightedPre) => {
-  const [tokens, setTokens] = useState<any[]>([]);
+  const [tokens, setTokens] = useState<ThemedToken[][]>([]);
 
   useEffect(() => {
-    void highlight(children, language).then(tokens => {
-      if (tokens) setTokens(tokens);
-    });
+    let cancelled = false;
+
+    void highlight(children, language)
+      .then(result => {
+        if (!cancelled) setTokens(result ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setTokens([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [children, language]);
 
   if (!tokens.length) {
     return <pre {...props}>{children}</pre>;
   }
 
+  let codeOffset = 0;
+
   return (
     <pre {...props}>
       <code>
-        {tokens.map((line, lineIndex) => (
-          <>
-            <span key={lineIndex}>
-              {line.map((token: any, tokenIndex: number) => {
-                const style = typeof token.htmlStyle === 'string' ? undefined : token.htmlStyle;
+        {tokens.map((line, lineIndex) => {
+          const lineOffset = codeOffset;
+          let tokenOffset = lineOffset;
+          const tokenSpans = line.map(token => {
+            const key = tokenOffset;
+            tokenOffset += token.content.length;
 
-                return (
-                  <span
-                    key={tokenIndex}
-                    className="text-shiki-light bg-shiki-light-bg dark:text-shiki-dark dark:bg-shiki-dark-bg"
-                    style={style}
-                  >
-                    {token.content}
-                  </span>
-                );
-              })}
-            </span>
-            {lineIndex !== tokens.length - 1 && '\n'}
-          </>
-        ))}
+            return (
+              <span key={key} className="shiki-token" style={tokenStyle(token)}>
+                {token.content}
+              </span>
+            );
+          });
+
+          codeOffset = tokenOffset + 1;
+
+          return (
+            <React.Fragment key={lineOffset}>
+              <span>{tokenSpans}</span>
+              {lineIndex !== tokens.length - 1 && '\n'}
+            </React.Fragment>
+          );
+        })}
       </code>
     </pre>
   );
@@ -84,19 +108,11 @@ const CodeBlock = ({ children, className, language, ...restProps }: CodeBlockPro
 
   return (
     <div className="group/code relative mb-4">
-      <Suspense
-        fallback={
-          <pre className={preClass} {...restProps}>
-            {children}
-          </pre>
-        }
-      >
-        <HighlightedPre language={language} className={preClass}>
-          {code}
-        </HighlightedPre>
-      </Suspense>
+      <HighlightedPre language={language} className={preClass} {...restProps}>
+        {code}
+      </HighlightedPre>
 
-      <div className="invisible absolute right-2 top-2 flex space-x-1 rounded-lg p-1 opacity-0 transition-all duration-200 group-hover/code:visible group-hover/code:opacity-100">
+      <div className="invisible absolute right-2 top-2 flex gap-1 rounded-lg p-1 opacity-0 transition-all duration-200 group-hover/code:visible group-hover/code:opacity-100">
         <CopyButton content={code} copyMessage="Copied code to clipboard" />
       </div>
     </div>

--- a/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
+++ b/packages/playground-ui/src/ds/components/MarkdownRenderer/markdown-renderer.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Markdown from 'react-markdown';
 import type { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import type { ThemedToken } from 'shiki/core';
 
-import { highlight } from '@/ds/components/CodeEditor';
+import { Code } from '@/ds/components/Code';
 import { CopyButton } from '@/ds/components/CopyButton';
 import { cn } from '@/lib/utils';
 
@@ -22,76 +21,6 @@ export function MarkdownRenderer({ children }: MarkdownRendererProps) {
   );
 }
 
-interface HighlightedPre extends React.HTMLAttributes<HTMLPreElement> {
-  children: string;
-  language: string;
-}
-
-function tokenStyle(token: ThemedToken): React.CSSProperties | undefined {
-  if (token.htmlStyle && typeof token.htmlStyle === 'object') {
-    return token.htmlStyle as React.CSSProperties;
-  }
-
-  return token.color ? { color: token.color } : undefined;
-}
-
-const HighlightedPre = React.memo(({ children, language, ...props }: HighlightedPre) => {
-  const [tokens, setTokens] = useState<ThemedToken[][]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    void highlight(children, language)
-      .then(result => {
-        if (!cancelled) setTokens(result ?? []);
-      })
-      .catch(() => {
-        if (!cancelled) setTokens([]);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [children, language]);
-
-  if (!tokens.length) {
-    return <pre {...props}>{children}</pre>;
-  }
-
-  let codeOffset = 0;
-
-  return (
-    <pre {...props}>
-      <code>
-        {tokens.map((line, lineIndex) => {
-          const lineOffset = codeOffset;
-          let tokenOffset = lineOffset;
-          const tokenSpans = line.map(token => {
-            const key = tokenOffset;
-            tokenOffset += token.content.length;
-
-            return (
-              <span key={key} className="shiki-token" style={tokenStyle(token)}>
-                {token.content}
-              </span>
-            );
-          });
-
-          codeOffset = tokenOffset + 1;
-
-          return (
-            <React.Fragment key={lineOffset}>
-              <span>{tokenSpans}</span>
-              {lineIndex !== tokens.length - 1 && '\n'}
-            </React.Fragment>
-          );
-        })}
-      </code>
-    </pre>
-  );
-});
-HighlightedPre.displayName = 'HighlightedCode';
-
 interface CodeBlockProps extends React.HTMLAttributes<HTMLPreElement> {
   children: React.ReactNode;
   className?: string;
@@ -108,9 +37,7 @@ const CodeBlock = ({ children, className, language, ...restProps }: CodeBlockPro
 
   return (
     <div className="group/code relative mb-4">
-      <HighlightedPre language={language} className={preClass} {...restProps}>
-        {code}
-      </HighlightedPre>
+      <Code code={code} lang={language} className={preClass} {...restProps} />
 
       <div className="invisible absolute right-2 top-2 flex gap-1 rounded-lg p-1 opacity-0 transition-all duration-200 group-hover/code:visible group-hover/code:opacity-100">
         <CopyButton content={code} copyMessage="Copied code to clipboard" />

--- a/packages/playground-ui/src/index.css
+++ b/packages/playground-ui/src/index.css
@@ -51,6 +51,18 @@
   background-color: var(--sidebar-nav-active);
 }
 
+@layer utilities {
+  .shiki-token {
+    color: var(--shiki-light, var(--neutral6));
+    background-color: var(--shiki-light-bg, transparent);
+  }
+
+  .dark .shiki-token {
+    color: var(--shiki-dark, var(--neutral6));
+    background-color: var(--shiki-dark-bg, transparent);
+  }
+}
+
 @layer base {
   * {
     border-color: var(--border1);

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -23,6 +23,7 @@ export * from './ds/components/Collapsible';
 export * from './ds/components/Combobox';
 export * from './ds/components/Command';
 export * from './ds/components/ContextMenu';
+export * from './ds/components/Code';
 export * from './ds/components/CodeBlock';
 export * from './ds/components/CopyButton';
 export * from './ds/components/DashboardCard';


### PR DESCRIPTION
## Summary

Makes `CodeBlock` the canonical DS surface for static code, with pure-CSS dual-theme syntax highlighting.

**Before** — code did not follow light mode:
- `CodeBlock` resolved shiki token colors in JavaScript via `useTheme()`, pinning colors at render time and requiring a `ThemeProvider`.
- `MarkdownRenderer` relied on undefined `text-shiki-*` classes, so tokens fell back to a flat neutral color.

**After** — zero JavaScript in theme resolution:
- Tokens keep their `--shiki-light` / `--shiki-dark` CSS variables and a `.shiki-token` class (`index.css`) resolves them from the `.light`/`.dark` root class, with neutral fallbacks. `useTheme()` is removed from the entire static-code path; components work under any theme class with no `ThemeProvider` dependency.

## Changes

- **New `Code` primitive** (`ds/components/Code`, exported): low-level shiki token renderer now shared by `CodeBlock` and `MarkdownRenderer`; their two near-identical highlight implementations are removed. Each consumer keeps its existing chrome — no visual change for markdown/chat surfaces.
- **`CodeBlock` `overflow` prop**: `wrap` (default, for commands/snippets) or `scroll` (preserves columns for source code).
- **Python highlighting**: `python`/`py` grammar added to the shiki registry (needed by platform empty states).
- **Storybook**: usage rules documented on `Composite/CodeBlock` (inline `<code>` vs `CodeBlock` vs tabs/select vs `CodeEditor`/`DataCodeSection`/`CodeDiff`), new `Elements/Code` stories, `OverflowScroll` story.
- **Tests**: `Code` primitive, CSS-variable token rendering, overflow classes, copy of the active option, fenced vs inline markdown code.

## Test plan

- `pnpm vitest run` in `packages/playground-ui` → 329/329 pass.
- `pnpm build:playground-ui` → typecheck + Vite build clean.
- Storybook verified in light and dark via the backgrounds toggle: surface and token colors switch together; python highlights in `CodeBlock` and fenced markdown.

## Follow-up

- **Platform**: replace `CodeSnippet`, `CodeHighlight`, and `HeroEmptyStateCurl`'s `SnippetBlock` (three near-identical shiki renderers that hard-pin `var(--shiki-dark)`) with DS `CodeBlock`/`Code`.
- **DS-wide `light-dark()` migration** (separate PR candidate): moving `theme.css` to `color-scheme` + `light-dark()` would drop the `.dark` descendant selectors entirely and make nested local theming (a light panel inside a dark page) work. Not done here: `color-scheme` affects native form controls/scrollbars and needs a DS-wide audit; migrating only `.shiki-token` wouldn't help while surface tokens stay on `:root`/`html.light`.

## Notes

- `useTheme()` still exists in `CodeEditor`, `DataCodeSection`, `CodeDiff` (CodeMirror themes are built in JS) — out of scope, unchanged.
- Nested local theming is not supported by the current DS (theme tokens are defined on `:root`/`html.light`); this PR follows the same convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR makes one shared code component for all static code so highlighting looks the same everywhere and light/dark colors switch using only CSS (no theme provider needed). Markdown and other static code surfaces now reuse this shared component, making styling and maintenance simpler.

## What Changed

### New Code primitive (exported)
- Added ds/components/Code (Code) — a low-level, memoized React component that asynchronously tokenizes code with Shiki when a language is provided and renders token spans with CSS-driven colors.
- Tokens are rendered as spans with a .shiki-token class and CSS variables (--shiki-light / --shiki-dark and background vars). While highlight is pending or no language is provided, Code falls back to a plain <pre> with the raw code.
- Exported CodeProps include code, lang, className, preClassName.

### CodeBlock refactor
- CodeBlock delegates rendering to the shared Code component and no longer contains its own token-rendering logic.
- Added overflow prop: 'wrap' (default) breaks long lines; 'scroll' preserves columns with horizontal scrolling. Layout/typography preClassName and CopyButton/selector UI remain intact.

### MarkdownRenderer update
- MarkdownRenderer now uses the shared Code component for fenced code blocks (inline code unchanged), removing previous in-file async highlighting and Suspense usage. CodeBlock wrapper still computes preClass and copy controls.

### CSS: theme variables and token class
- index.css introduces theme-aware CSS variable mappings and .shiki-token usage so token and surface colors switch together via the .light/.dark root class without requiring useTheme()/ThemeProvider.

### Exports and barrels
- Re-exported ds/components/Code from packages/playground-ui/src/index.ts.
- highlight from CodeEditor is re-exported from the package entry as well.

### Tests and Storybook
- Added unit tests for Code (fallback behavior, CSS-variable token rendering, highlight lifecycle) and tests for CodeBlock and MarkdownRenderer code rendering.
- Storybook stories for Code and CodeBlock added/updated, including LightVsDark comparison stories and examples for no-language, long code, and language-specified cases.

### Language support
- Shiki registry updated to include Python (python/py) grammar so Python code highlights correctly.

## Removed / Simplified
- Removed duplicated in-file highlighting/token-rendering implementations from CodeBlock and MarkdownRenderer.
- Static code rendering no longer relies on useTheme(); ThemeProvider remains used in CodeEditor/CodeMirror-based components.

## Test & Build
- packages/playground-ui vitest: 329/329 passed; package build and Storybook verified (light/dark surface and token colors switch together; python highlighting present).

## Notes & Follow-ups
- Replace remaining platform-specific Shiki renderers (CodeSnippet, CodeHighlight, HeroEmptyStateCurl’s SnippetBlock) with DS CodeBlock/Code in follow-ups.
- Current DS conventions assume root-level theming; nested local theming is not supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## CI fixes included (unrelated to the feature, kept as separate commits)

- `chore: format react-best-practices skill docs` — `prettier --check` fails on main for three `.claude/skills/react-best-practices/` files (introduced by #17736), turning the **Lint / Format** job red on every PR. Formatted with the repo-pinned prettier; no content change.
- `fix(react): deflake deferred-recorder speech recognition tests` — the two `deferRecorder` tests in `use-speech-recognition.test.ts` raced the async `getSpeakers → setAgent` switch to the mastra path; this branch's new test file shifted shard timing and made the race fail deterministically in CI (`recordMicrophoneToFile` 0 calls). Aligned them with the `waitFor` + `start()` retry pattern the rest of the file already uses.
