### PR TITLE
feat(core): use native @ai-sdk/alibaba provider for Qwen models

### DIFF
--- a/.changeset/funny-ways-stick.md
+++ b/.changeset/funny-ways-stick.md
@@ -2,4 +2,21 @@
 '@mastra/core': patch
 ---
 
-Add native @ai-sdk/alibaba provider support for Qwen models. Alibaba variants now use the native provider instead of OpenAI-compatible mode for better type safety and Alibaba-specific features.
+Added Alibaba provider support for Qwen models. You can now use Qwen, DashScope, and other Alibaba models with automatic provider detection.
+
+**Example usage:**
+
+```typescript
+import { Mastra } from '@mastra/core';
+
+const mastra = new Mastra();
+
+// Use any Alibaba variant - automatically detected
+const agent = mastra.getAgent('myAgent');
+const result = await agent.generate({
+  model: '__GATEWAY_ALIBABA_MODEL__',
+  messages: [{ role: 'user', content: 'Hello' }],
+});
+```
+
+Works with all Alibaba variants (alibaba, alibaba-cn, alibaba-coding-plan, etc.) and future variants like alibaba-coding-plan-cn-v2.

--- a/.changeset/funny-ways-stick.md
+++ b/.changeset/funny-ways-stick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add native @ai-sdk/alibaba provider support for Qwen models. Alibaba variants now use the native provider instead of OpenAI-compatible mode for better type safety and Alibaba-specific features.

--- a/docs/src/plugins/remark-model-tokens/models.ts
+++ b/docs/src/plugins/remark-model-tokens/models.ts
@@ -24,4 +24,7 @@ export const MODEL_TOKENS: Record<string, string> = {
 
   // ── Google ────────────────────────────────────────────────
   __GATEWAY_GOOGLE_MODEL__: 'google/gemini-2.5-flash',
+
+  // ── Alibaba ───────────────────────────────────────────────
+  __GATEWAY_ALIBABA_MODEL__: 'alibaba/qwen-max',
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -793,6 +793,7 @@
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {
+    "@ai-sdk/alibaba-v6": "npm:@ai-sdk/alibaba@1.0.25",
     "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.79",
     "@ai-sdk/anthropic-v6": "npm:@ai-sdk/anthropic@3.0.76",
     "@ai-sdk/azure": "^2.0.108",

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -1,3 +1,4 @@
+import { createAlibaba } from '@ai-sdk/alibaba-v6';
 import { createAnthropic } from '@ai-sdk/anthropic-v6';
 import { createCerebras } from '@ai-sdk/cerebras-v5';
 import { createDeepInfra } from '@ai-sdk/deepinfra-v5';
@@ -309,6 +310,12 @@ export class ModelsDevGateway extends MastraModelGateway {
         // Check if this provider uses a specific SDK package (e.g., kimi-for-coding uses @ai-sdk/anthropic)
         const config = this.providerConfigs[providerId];
         const npm = config?.npm;
+
+        // Pattern match for any alibaba variant (alibaba, alibaba-cn, alibaba-coding-plan, etc.)
+        if (providerId.includes('alibaba')) {
+          if (!baseURL) throw new Error(`No API URL found for ${providerId}/${modelId}`);
+          return createAlibaba({ apiKey, baseURL, headers: mastraHeaders })(modelId);
+        }
 
         if (npm === '@ai-sdk/anthropic') {
           if (!baseURL) throw new Error(`No API URL found for ${providerId}/${modelId}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3431,6 +3431,9 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
     devDependencies:
+      '@ai-sdk/alibaba-v6':
+        specifier: npm:@ai-sdk/alibaba@1.0.25
+        version: '@ai-sdk/alibaba@1.0.25(zod@4.4.3)'
       '@ai-sdk/anthropic-v5':
         specifier: npm:@ai-sdk/anthropic@2.0.79
         version: '@ai-sdk/anthropic@2.0.79(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.3)'
@@ -8124,6 +8127,12 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  '@ai-sdk/alibaba@1.0.25':
+    resolution: {integrity: sha512-2XkJWCZ57ZahuXyz3FNHvcK6RpcEYHy39MJ7DZ8l04O2PBq2nPzkDi2rGz92JST+Q3kAJ/d8zI2OMk/ovjaNzg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/amazon-bedrock@3.0.99':
     resolution: {integrity: sha512-d/WsYOlqjQeEwTewawjrlhoWfHt3q1vRT5/XdFJ6U+KYd/3HnAlrA3rg0+T7xMk98XmctaILJb45Ct/8zrGxSA==}
     engines: {node: '>=18'}
@@ -8306,6 +8315,12 @@ packages:
 
   '@ai-sdk/openai-compatible@2.0.47':
     resolution: {integrity: sha512-Enm5UlL0zUCrW3792opk5h7hRWxZOZzDe6eQYVFqX9LUOGGCe1h8MZWAGim765nwzgnjlpeYOsuzZmLtRsTPlg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@2.0.48':
+    resolution: {integrity: sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -29264,6 +29279,13 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
+  '@ai-sdk/alibaba@1.0.25(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 2.0.48(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/amazon-bedrock@3.0.99(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.3)':
     dependencies:
       '@ai-sdk/anthropic': 2.0.79(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.3)
@@ -29740,6 +29762,12 @@ snapshots:
       zod: 4.3.6
 
   '@ai-sdk/openai-compatible@2.0.47(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@2.0.48(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)


### PR DESCRIPTION
Alibaba and all Alibaba variants (alibaba, alibaba-cn, alibaba-coding-plan, etc.) now use the native @ai-sdk/alibaba provider instead of OpenAI-compatible mode.

Uses pattern matching (`providerId.includes('alibaba')`) to automatically handle any alibaba variant without explicit enumeration. Provides better type safety and Alibaba-specific features while maintaining consistency with other native providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Instead of pretending Alibaba's Qwen models are OpenAI models, this PR makes Mastra talk to Alibaba's native SDK directly so it works more reliably and enables Alibaba-specific features.

## Changes

### Changeset Documentation
Added a changeset recording a patch release for `@mastra/core` that documents migration to the native `@ai-sdk/alibaba` provider for Qwen (and other Alibaba/DashScope) models, with a TypeScript usage example showing the __GATEWAY_ALIBABA_MODEL__ token and notes about supported and future Alibaba variants.

### Dependencies
Added a devDependency mapping for `@ai-sdk/alibaba-v6` (npm:`@ai-sdk/alibaba`@1.0.25) in packages/core/package.json.

### Provider Logic
Updated packages/core/src/llm/model/gateways/models-dev.ts to:
- Import createAlibaba from `@ai-sdk/alibaba-v6`.
- Detect Alibaba variants generically via providerId.includes('alibaba') and treat them as native Alibaba providers.
- Require a resolved base URL for Alibaba providers and return an Alibaba-backed language model instance (using createAlibaba).
- Preserve existing provider-selection heuristics for other providers.

This enables stronger type safety and Alibaba-specific features while keeping consistency with other native providers.

### Docs / Tokens
Added __GATEWAY_ALIBABA_MODEL__: 'alibaba/qwen-max' to docs/src/plugins/remark-model-tokens/models.ts for documentation examples and code-block token replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->