### PR TITLE
fix(playground): filter signal-role messages to prevent Studio crash on browser agent threads

### DIFF
--- a/.changeset/fix-studio-crash-signal-role.md
+++ b/.changeset/fix-studio-crash-signal-role.md
@@ -1,0 +1,16 @@
+---
+"@mastra/playground-ui": patch
+---
+
+Fix Studio crash when loading a browser agent thread containing `system-reminder` messages.
+
+`signal`-role messages (e.g. browser context reminders from `@mastra/agent-browser`) are now filtered out before being passed to the chat renderer. Previously these caused a React crash because `@assistant-ui/react` only accepts `user`, `assistant`, and `system` roles.
+
+```typescript
+// Before: Studio crashed with
+// "Unknown message role: signal" or
+// "System messages must have exactly one text message part"
+
+// After: signal-role messages are silently filtered — the agent page
+// loads correctly and existing threads remain usable
+```

--- a/packages/playground/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground/src/services/mastra-runtime-provider.tsx
@@ -861,7 +861,13 @@ export function MastraRuntimeProvider({
   // tracked in `streamErrors` (which survives the post-stream initialMessages
   // refresh). Without filtering here we would briefly render duplicate errors
   // during the streaming window.
-  const vnextmessages = [...messages.filter(msg => msg.metadata?.status !== 'error'), ...streamErrors].map(msg => {
+  const vnextmessages = [
+    // Filter out signal-role messages (e.g. system-reminder from @mastra/agent-browser)
+    // before passing to toAssistantUIMessage. @assistant-ui/react only accepts
+    // 'user' | 'assistant' | 'system' roles and throws on unknown roles like 'signal'.
+    ...messages.filter(msg => msg.metadata?.status !== 'error' && msg.role !== 'signal'),
+    ...streamErrors,
+  ].map(msg => {
     const converted = convertOmPartsInMastraMessage(msg, globalOmParts);
     return toAssistantUIMessage(converted);
   });


### PR DESCRIPTION
## Description

When a browser agent (configured with `@mastra/agent-browser`) stores a `system-reminder` message with `role: "signal"`, navigating to that agent page in Studio caused a React render crash:

**Root cause:** `@assistant-ui/react` only accepts `"user" | "assistant" | "system"` roles. When a stored thread contains a `role: "signal"` message (e.g. a browser context reminder with the current URL), it hit the unknown-role error path and crashed the entire page. The only workaround was manually deleting the thread from the database.

**Fix:** Filter out `role: "signal"` messages before they reach `toAssistantUIMessage`. These are internal browser-context markers and should never be rendered in the chat UI. The filter is applied to both loaded (`initialMessages`) and streamed messages since both flow through the same `messages` state.

**Before:** Any browser agent thread with a stored `system-reminder` message caused a blank "Something went wrong" crash on page load.  
**After:** The agent page loads correctly and existing threads remain fully usable.

## Related issue(s)

Fixes #17414

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the chat interface loads old conversations from browser agents, some messages are stored in a special internal format that the chat display library doesn't understand. This PR filters out those special internal messages before showing them, so the app doesn't crash when you try to view these conversations.

---

## Changes

### Changeset: `fix-studio-crash-signal-role.md`
Added changeset documenting a patch release for `@mastra/playground-ui` that fixes the Studio crash when loading browser agent threads with `system-reminder` messages.

### Code Fix: `packages/playground/src/services/mastra-runtime-provider.tsx`
Updated the message filtering logic in `MastraRuntimeProvider` to exclude messages with `role: "signal"` (in addition to the existing filter for messages with `metadata.status: 'error'`) before they are processed and passed to the Assistant UI renderer. This prevents validation errors in `@assistant-ui/react`, which only accepts `"user"`, `"assistant"`, or `"system"` roles.

---

## Impact

**Before:** Loading a browser agent thread containing stored `system-reminder` messages with `role: "signal"` caused Studio to crash with the error "Something went wrong" (or "System messages must have exactly one text message part"), requiring manual thread deletion from the database.

**After:** Browser agent threads load successfully. Internal `signal`-role messages (which represent browser context metadata rather than actual chat messages) are silently filtered out and do not appear in the chat UI, preventing the crash while preserving the thread.

---

## Related Issue
Fixes `#17414`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->