### PR TITLE
fix(core): use stable key-order-independent stringify in CacheKeyGenerator to fix duplicate rs_* on tool-approval resume

### DIFF
--- a/.changeset/fix-jsonb-key-order-dedup.md
+++ b/.changeset/fix-jsonb-key-order-dedup.md
@@ -2,13 +2,6 @@
 "@mastra/core": patch
 ---
 
-Fix duplicate OpenAI reasoning item (`rs_*`) on tool-approval resume caused by jsonb vs text key-order mismatch.
+Fixes a crash where OpenAI rejects resumed tool-approval requests with `AI_APICallError: Duplicate item found with id rs_*`.
 
-`CacheKeyGenerator.fromDBParts` used `JSON.stringify` to hash `data-*` parts, which is sensitive to object key order. PostgreSQL's `jsonb` column (workflow snapshot) normalizes key order, while the `text` column (messages) preserves insertion order. This caused functionally-equal messages to compare unequal, minting duplicate copies with the same `rs_*` reasoning id — which OpenAI rejects with `AI_APICallError: Duplicate item found`.
-
-The fix replaces `JSON.stringify` with a stable, key-order-independent stringify so jsonb-reordered and text-preserved representations of the same message always produce the same cache key.
-
-```typescript
-// Before: { a: 1, b: 2 } and { b: 2, a: 1 } produced different cache keys
-// After: both produce the same key regardless of key order
-```
+The same message stored in PostgreSQL's `jsonb` column (workflow snapshot) and `text` column (messages) could have different JSON key orders, causing the deduplication check to treat them as different messages and send the same reasoning item twice. Both representations now compare equal regardless of key order.

--- a/.changeset/fix-jsonb-key-order-dedup.md
+++ b/.changeset/fix-jsonb-key-order-dedup.md
@@ -1,0 +1,14 @@
+---
+"@mastra/core": patch
+---
+
+Fix duplicate OpenAI reasoning item (`rs_*`) on tool-approval resume caused by jsonb vs text key-order mismatch.
+
+`CacheKeyGenerator.fromDBParts` used `JSON.stringify` to hash `data-*` parts, which is sensitive to object key order. PostgreSQL's `jsonb` column (workflow snapshot) normalizes key order, while the `text` column (messages) preserves insertion order. This caused functionally-equal messages to compare unequal, minting duplicate copies with the same `rs_*` reasoning id — which OpenAI rejects with `AI_APICallError: Duplicate item found`.
+
+The fix replaces `JSON.stringify` with a stable, key-order-independent stringify so jsonb-reordered and text-preserved representations of the same message always produce the same cache key.
+
+```typescript
+// Before: { a: 1, b: 2 } and { b: 2, a: 1 } produced different cache keys
+// After: both produce the same key regardless of key order
+```

--- a/packages/core/src/agent/message-list/cache/CacheKeyGenerator-tool-invocation-guard.test.ts
+++ b/packages/core/src/agent/message-list/cache/CacheKeyGenerator-tool-invocation-guard.test.ts
@@ -52,6 +52,60 @@ describe('CacheKeyGenerator tool-invocation null guard (#16756)', () => {
     expect(() => CacheKeyGenerator.fromDBParts(parts as any)).not.toThrow();
   });
 
+  it('fromDBParts should generate the same key for data parts with reordered object keys', () => {
+    const messagePartsFromTextStorage = [
+      {
+        type: 'data-om-status' as const,
+        data: {
+          windows: {
+            buffered: {
+              observations: {
+                chunks: 0,
+                messageTokens: 0,
+                projectedMessageRemoval: 0,
+                observationTokens: 0,
+                status: 'idle',
+              },
+              reflection: {
+                inputObservationTokens: 0,
+                observationTokens: 0,
+                status: 'idle',
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const messagePartsFromJsonbSnapshot = [
+      {
+        type: 'data-om-status' as const,
+        data: {
+          windows: {
+            buffered: {
+              reflection: {
+                status: 'idle',
+                observationTokens: 0,
+                inputObservationTokens: 0,
+              },
+              observations: {
+                chunks: 0,
+                status: 'idle',
+                messageTokens: 0,
+                observationTokens: 0,
+                projectedMessageRemoval: 0,
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    expect(CacheKeyGenerator.fromDBParts(messagePartsFromTextStorage as any)).toBe(
+      CacheKeyGenerator.fromDBParts(messagePartsFromJsonbSnapshot as any),
+    );
+  });
+
   it('fromAIV4Part should still work correctly with valid tool-invocation parts', () => {
     const validPart = {
       type: 'tool-invocation' as const,

--- a/packages/core/src/agent/message-list/cache/CacheKeyGenerator.ts
+++ b/packages/core/src/agent/message-list/cache/CacheKeyGenerator.ts
@@ -1,4 +1,5 @@
 import type { UIMessage as UIMessageV4 } from '@internal/ai-sdk-v4';
+import { stableStringify } from './stable-stringify';
 import * as AIV5 from '@internal/ai-sdk-v5';
 
 import { getImageCacheKey } from '../prompt/image-utils';
@@ -109,7 +110,7 @@ export class CacheKeyGenerator {
       if (part.type.startsWith('data-')) {
         // Stringify data for proper cache key comparison since data can be any type
         const data = (part as AIV5Type.DataUIPart<AIV5.UIDataTypes>).data;
-        key += JSON.stringify(data);
+        key += stableStringify(data); // order-independent: jsonb vs text storage may reorder keys
       } else {
         // Cast to UIMessageV4Part since we've already handled data-* parts above
         key += CacheKeyGenerator.fromAIV4Part(part as UIMessageV4Part);

--- a/packages/core/src/agent/message-list/cache/CacheKeyGenerator.ts
+++ b/packages/core/src/agent/message-list/cache/CacheKeyGenerator.ts
@@ -1,10 +1,10 @@
 import type { UIMessage as UIMessageV4 } from '@internal/ai-sdk-v4';
-import { stableStringify } from './stable-stringify';
 import * as AIV5 from '@internal/ai-sdk-v5';
 
 import { getImageCacheKey } from '../prompt/image-utils';
 import type { AIV5Type, CoreMessageV4 } from '../types';
 import { getResponseProviderItemKeys } from '../utils/response-item-metadata';
+import { stableStringify } from './stable-stringify';
 import type { MastraMessagePart, UIMessageV4Part } from './types';
 
 function appendResponseProviderItemKeys(cacheKey: string, ...providerSources: unknown[]): string {

--- a/packages/core/src/agent/message-list/cache/index.ts
+++ b/packages/core/src/agent/message-list/cache/index.ts
@@ -1,2 +1,3 @@
 export { CacheKeyGenerator } from './CacheKeyGenerator';
 export type { MastraMessageContentV2, MastraMessagePart, UIMessageV4Part } from './types';
+export { stableStringify } from './stable-stringify';

--- a/packages/core/src/agent/message-list/cache/stable-stringify.ts
+++ b/packages/core/src/agent/message-list/cache/stable-stringify.ts
@@ -1,0 +1,24 @@
+/**
+ * `JSON.stringify` with deterministic key ordering at every level.
+ *
+ * Required because object key order is preserved by `JSON.stringify`, and we
+ * don't want `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` to hash to different keys.
+ *
+ * This is critical for cache key generation when comparing messages restored
+ * from different storage backends: jsonb columns (e.g. mastra_workflow_snapshot
+ * in PostgreSQL) normalize key order, while text columns (mastra_messages)
+ * preserve insertion order. Without stable stringification, functionally-equal
+ * data-* parts produce different cache keys, causing false dedup misses.
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(val as Record<string, unknown>).sort()) {
+        sorted[k] = (val as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return val;
+  });
+}

--- a/packages/core/src/processors/processors/response-cache.ts
+++ b/packages/core/src/processors/processors/response-cache.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import type { MastraServerCache } from '../../cache';
 import { MASTRA_RESOURCE_ID_KEY, RequestContext } from '../../request-context';
+import { stableStringify } from '../../agent/message-list/cache/stable-stringify';
 import type {
   CachedLLMStepResponse,
   ProcessLLMRequestArgs,
@@ -497,25 +498,7 @@ function normalizeForHash(value: unknown): unknown {
   return String(value);
 }
 
-/**
- * `JSON.stringify` with deterministic key ordering at every level. Required
- * because object key order is preserved by `JSON.stringify`, and we don't
- * want `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` to hash to different keys.
- *
- * @internal
- */
-function stableStringify(value: unknown): string {
-  return JSON.stringify(value, (_key, val) => {
-    if (val && typeof val === 'object' && !Array.isArray(val)) {
-      const sorted: Record<string, unknown> = {};
-      for (const k of Object.keys(val as Record<string, unknown>).sort()) {
-        sorted[k] = (val as Record<string, unknown>)[k];
-      }
-      return sorted;
-    }
-    return val;
-  });
-}
+
 
 /**
  * Re-export the cached payload shape so consumers can type their own custom

--- a/packages/core/src/processors/processors/response-cache.ts
+++ b/packages/core/src/processors/processors/response-cache.ts
@@ -1,8 +1,8 @@
 import { createHash } from 'node:crypto';
 import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
+import { stableStringify } from '../../agent/message-list/cache/stable-stringify';
 import type { MastraServerCache } from '../../cache';
 import { MASTRA_RESOURCE_ID_KEY, RequestContext } from '../../request-context';
-import { stableStringify } from '../../agent/message-list/cache/stable-stringify';
 import type {
   CachedLLMStepResponse,
   ProcessLLMRequestArgs,
@@ -497,8 +497,6 @@ function normalizeForHash(value: unknown): unknown {
   }
   return String(value);
 }
-
-
 
 /**
  * Re-export the cached payload shape so consumers can type their own custom


### PR DESCRIPTION
## Description

When an agent using PostgreSQL storage (`@mastra/pg`) resumes after a tool-approval suspend, OpenAI rejects the request with:

**Root cause:** `CacheKeyGenerator.fromDBParts` used `JSON.stringify` to hash `data-*` parts, which is sensitive to object key order. PostgreSQL's `jsonb` column (`mastra_workflow_snapshot`) normalizes key order, while the `text` column (`mastra_messages`) preserves insertion order. This caused functionally-equal messages to compare unequal in `messagesAreEqual`, causing `MessageList.addOne` to mint a duplicate copy with the same `rs_*` reasoning id — which OpenAI rejects.

**Fix:**
- Extract a shared `stableStringify` util (key-order-independent `JSON.stringify`) into `agent/message-list/cache/stable-stringify.ts`
- Use it in `CacheKeyGenerator.fromDBParts` instead of `JSON.stringify` for `data-*` parts
- Remove the duplicate `stableStringify` from `response-cache.ts` and import the shared version

**Before/After:**
```typescript
// Before: jsonb-reordered and text-preserved keys compared unequal
JSON.stringify({ a: 1, b: 2 }) !== JSON.stringify({ b: 2, a: 1 }) // true — bug

// After: both produce the same key regardless of storage backend key order
stableStringify({ a: 1, b: 2 }) === stableStringify({ b: 2, a: 1 }) // true — fixed
```

## Related issue(s)

Fixes #17432

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Some messages were stored with the same fields in different orders, which made the app think they were different and create duplicate entries. This PR makes message comparison ignore the order of object keys so identical messages are treated the same and duplicates stop appearing.

## Root Cause

CacheKeyGenerator.fromDBParts used JSON.stringify for `data-*` parts; JSON.stringify is sensitive to key order. PostgreSQL jsonb normalizes object key order while the messages table (text) preserves insertion order, so functionally-identical messages restored from different backends produced different cache keys. That caused messagesAreEqual to return false and MessageList.addOne to create duplicate messages with identical rs_* reasoning IDs, leading OpenAI errors like "Duplicate item found."

## Changes Made

- Added packages/core/src/agent/message-list/cache/stable-stringify.ts: exported stableStringify(value: unknown): string which deterministically orders object keys at every level before stringifying.
- Updated packages/core/src/agent/message-list/cache/CacheKeyGenerator.ts to use stableStringify instead of JSON.stringify for `data-*` parts in fromDBParts.
- Re-exported stableStringify from packages/core/src/agent/message-list/cache/index.ts.
- Removed duplicate stableStringify in packages/core/src/processors/processors/response-cache.ts and imported the shared utility instead.
- Updated .changeset/fix-jsonb-key-order-dedup.md to publish a patch release for `@mastra/core`.
- Added a regression test (CacheKeyGenerator-tool-invocation-guard.test.ts) ensuring reordered object keys produce the same cache key.

## Impact

Cache keys for messages are now key-order-independent, so messages that differ only by object key ordering (e.g., jsonb vs text storage) compare equal and will not produce duplicate messages or duplicate rs_* reasoning IDs during resume flows. This prevents the OpenAI "Duplicate item found" errors in resumed tool-approval / observational memory scenarios.

## Related

Fixes `#17432`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->