### PR TITLE
fix(server): prevent duplicate custom providers in Studio provider selector

### DIFF
--- a/.changeset/fix-duplicate-custom-providers.md
+++ b/.changeset/fix-duplicate-custom-providers.md
@@ -1,0 +1,9 @@
+---
+"@mastra/server": patch
+---
+
+Fix custom providers appearing twice in Studio's provider selector.
+
+In dev mode, `GatewayRegistry` registers custom gateways so `PROVIDER_REGISTRY` already contains them with prefixed keys (e.g. `"melioffice/genai"`). The `/agents/providers` handler then called `gateway.fetchProviders()` again and re-added them, but the live call returns raw unprefixed keys (e.g. `"genai"`) which after prefixing produce the same key — however in some cases the keys differed, causing both entries to appear in the UI.
+
+The fix skips adding a provider from the live `fetchProviders()` call if it is already present in `allProviders` from `PROVIDER_REGISTRY`.

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -1511,7 +1511,12 @@ export const GET_PROVIDERS_ROUTE = createRoute({
                 // If providerId matches gateway.id, it's a unified gateway — use just the gateway ID.
                 // Otherwise, prefix with gateway.id (e.g., "netlify/anthropic").
                 const prefixedId = providerId === gateway.id ? gateway.id : `${gateway.id}/${providerId}`;
-                allProviders[prefixedId] = config;
+                // Only add if not already present from PROVIDER_REGISTRY to prevent
+                // duplicates when PROVIDER_REGISTRY already has the prefixed key
+                // (e.g. dev mode where GatewayRegistry includes custom gateways).
+                if (!(prefixedId in allProviders)) {
+                  allProviders[prefixedId] = config;
+                }
               }
             } catch (error) {
               console.warn(`Failed to fetch providers from gateway "${gateway.id}":`, error);


### PR DESCRIPTION
## Description

When registering a custom `MastraModelGateway`, the provider appeared twice in Studio's provider selector.

**Root cause:** In dev mode, `GatewayRegistry.registerCustomGateways()` is called during Mastra initialization, so `PROVIDER_REGISTRY` already contains custom gateway providers with prefixed keys (e.g. `"melioffice/genai"`). The `/agents/providers` handler then calls `gateway.fetchProviders()` live and re-adds them. When the prefixed key from the live call matches what's already in `allProviders`, it overwrites harmlessly — but when the keys differ (e.g. `"genai"` vs `"melioffice/genai"`), both entries land in the response and render as duplicates in the UI.

**Fix:** Skip adding a provider from the live `fetchProviders()` result if the prefixed key is already present in `allProviders` from `PROVIDER_REGISTRY`.

## Related issue(s)

Fixes #17440

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Think of it like a shopping list: the system was accidentally adding the same item twice - once when the app started, and again when it fetched the latest list. This fix makes it check if something's already on the list before adding it again, so you only see each provider once in the studio's provider selector.

---

## Overview

This PR fixes a bug where custom MastraModelGateway providers appeared twice in Studio's provider selector. The issue occurred because the system was registering custom providers twice: once during initialization (with a prefixed name like "melioffice/genai") and again when fetching live provider data (sometimes with an unprefixed name like "genai"), resulting in duplicate entries in the UI.

## Root Cause

During Mastra initialization in dev mode, `GatewayRegistry.registerCustomGateways()` populates `PROVIDER_REGISTRY` with prefixed provider keys. Later, the `/agents/providers` handler calls `gateway.fetchProviders()` at runtime, which could re-add providers with different naming conventions. Since the prefixed and unprefixed keys differed, both entries were included in the response, causing duplicates in the provider selector.

## Changes

**Changesets Entry** (`fix-duplicate-custom-providers.md`)
- Documents a patch-level fix for `@mastra/server`

**Handler Update** (`packages/server/src/server/handlers/agents.ts`)
- Modified the provider-fetching logic in the `GET /agents/providers` endpoint to skip adding a provider from `fetchProviders()` if its prefixed key already exists in `allProviders` (which is populated from `PROVIDER_REGISTRY`)
- Changed from unconditionally overwriting `prefixedId` assignments to checking existence first

## Impact

- Eliminates duplicate custom provider entries in Studio's provider selector
- Non-breaking change that refines the deduplication logic
- Ensures consistent provider listing regardless of initialization mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->