### PR TITLE
fix(react): keep thread signals opt-in

### DIFF
--- a/.changeset/upset-frogs-sit.md
+++ b/.changeset/upset-frogs-sit.md
@@ -1,5 +1,6 @@
 ---
 'mastra': patch
+'@internal/playground': patch
 '@mastra/react': patch
 '@mastra/deployer': patch
 '@mastra/deployer-vercel': patch

--- a/.changeset/upset-frogs-sit.md
+++ b/.changeset/upset-frogs-sit.md
@@ -1,9 +1,8 @@
 ---
 'mastra': patch
-'@internal/playground': patch
 '@mastra/react': patch
 '@mastra/deployer': patch
 '@mastra/deployer-vercel': patch
 ---
 
-Enabled Studio, Playground, and deployers to use agent signal subscriptions by default while preserving `MASTRA_AGENT_SIGNALS=false`, `enableThreadSignals: false`, and explicit legacy Stream as opt-outs. The React `useChat()` hook remains opt-in for SDK consumers via `enableThreadSignals: true`.
+Enabled Studio via the CLI and deployers to use agent signal subscriptions by default while preserving `MASTRA_AGENT_SIGNALS=false`, `enableThreadSignals: false`, and explicit legacy Stream as opt-outs. The React `useChat()` hook remains opt-in for SDK consumers via `enableThreadSignals: true`.

--- a/.changeset/upset-frogs-sit.md
+++ b/.changeset/upset-frogs-sit.md
@@ -5,4 +5,4 @@
 '@mastra/deployer-vercel': patch
 ---
 
-Enabled Studio, Playground, deployers, and `useChat()` to use agent signal subscriptions by default while preserving `MASTRA_AGENT_SIGNALS=false` and explicit legacy Stream as opt-outs.
+Enabled Studio, Playground, and deployers to use agent signal subscriptions by default while preserving `MASTRA_AGENT_SIGNALS=false`, `enableThreadSignals: false`, and explicit legacy Stream as opt-outs. The React `useChat()` hook remains opt-in for SDK consumers via `enableThreadSignals: true`.

--- a/client-sdks/react/src/agent/hooks.test.ts
+++ b/client-sdks/react/src/agent/hooks.test.ts
@@ -133,7 +133,7 @@ describe('useChat forwards clientTools', () => {
     vi.clearAllMocks();
   });
 
-  it('uses thread signals by default when threadId is provided', async () => {
+  it('uses the legacy stream path by default when threadId is provided', async () => {
     const { result } = renderHook(
       () =>
         useChat({
@@ -152,9 +152,9 @@ describe('useChat forwards clientTools', () => {
       });
     });
 
-    expect(subscribeToThreadMock).toHaveBeenCalledTimes(1);
-    expect(sendSignalMock).toHaveBeenCalledTimes(1);
-    expect(streamUntilIdleMock).not.toHaveBeenCalled();
+    expect(subscribeToThreadMock).not.toHaveBeenCalled();
+    expect(sendSignalMock).not.toHaveBeenCalled();
+    expect(streamUntilIdleMock).toHaveBeenCalledTimes(1);
   });
 
   it('marks subscription streams idle while waiting for tool approval', async () => {

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -79,7 +79,7 @@ export interface MastraChatProps {
   onThreadSignalsUnsupported?: () => void;
   /**
    * Use the agent-signals streaming path (sendSignal + subscribeToThread).
-   * Defaults to `true`; set to `false` to force the legacy `streamUntilIdle` route.
+   * Defaults to `false`; set to `true` to opt into thread signals.
    */
   enableThreadSignals?: boolean;
 }
@@ -135,7 +135,7 @@ export const useChat = ({
   onSignalSent,
   onSignalEcho,
   onThreadSignalsUnsupported,
-  enableThreadSignals = true,
+  enableThreadSignals = false,
 }: MastraChatProps) => {
   const threadSignalsDisabled = enableThreadSignals === false;
   const _currentRunId = useRef<string | undefined>(undefined);

--- a/deployers/vercel/src/index.ts
+++ b/deployers/vercel/src/index.ts
@@ -109,7 +109,7 @@ export const HEAD = handle(app);
       telemetryDisabled: `''`,
       requestContextPresets: `''`,
       experimentalUI: `'false'`,
-      agentSignals: `'true'`,
+      agentSignals: process.env.MASTRA_AGENT_SIGNALS === 'false' ? `'false'` : `'true'`,
     });
 
     writeFileSync(indexPath, html);

--- a/packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx
+++ b/packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx
@@ -138,7 +138,7 @@ describe('MastraRuntimeProvider', () => {
     delete (window as any).MASTRA_AGENT_SIGNALS;
   });
 
-  it('enables thread signals by default', () => {
+  it('opts Playground into thread signals by default', () => {
     render(
       <MastraRuntimeProvider agentId="agent-1" threadId="thread-1" initialMessages={[]} modelVersion="v2">
         <div />


### PR DESCRIPTION
## Summary
- Restore `useChat()` to legacy stream by default so SDK consumers explicitly opt into thread signals with `enableThreadSignals: true`
- Keep Playground as the default opt-in surface through its runtime provider
- Make the Vercel deployer honor `MASTRA_AGENT_SIGNALS=false` instead of hardcoding signals on

## Test plan
- pnpm --filter @mastra/react test src/agent/hooks.test.ts -- --run --bail 1 --reporter=dot
- pnpm --filter @internal/playground test src/services/__tests__/mastra-runtime-provider.test.tsx -- --run --bail 1 --reporter=dot
- pnpm --filter @mastra/cli test src/commands/studio.test.ts -- --run --bail 1 --reporter=dot
- pnpm --filter @mastra/deployer test -- --run --bail 1 --reporter=dot
- pnpm build:clients
- pnpm build:server
- pnpm --filter @mastra/deployer-vercel build
- pnpm run prettier:changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the React chat hook keep the old, stable streaming behavior by default — apps must explicitly opt into the newer thread-signals behavior. Playground still opts into thread signals for experimentation, and the Vercel deployer will respect MASTRA_AGENT_SIGNALS=false to disable signals.

## Summary of Changes

1. React SDK (useChat)
   - Defaulted enableThreadSignals to false in MastraChatProps and the useChat hook so SDK consumers must pass enableThreadSignals: true to opt into thread-signals streaming.
   - Updated unit tests to assert legacy stream behavior is used by default when a threadId is provided.

2. Vercel Deployer
   - injectStudioConfig now sets agentSignals based on process.env.MASTRA_AGENT_SIGNALS === 'false' ? 'false' : 'true', allowing deploy-time opt-out.

3. Playground
   - Playground remains the default opt-in surface for thread signals via its runtime provider; test description updated to reflect that.
   - Note: the release changeset was scoped to released packages (CLI, React SDK, deployers) and the internal Playground entry was removed from the changeset.

## Files Modified

- client-sdks/react/src/agent/hooks.ts — change enableThreadSignals default from true to false.
- client-sdks/react/src/agent/hooks.test.ts — adjust tests to expect legacy stream behavior by default.
- deployers/vercel/src/index.ts — respect MASTRA_AGENT_SIGNALS when injecting agentSignals into studio config.
- packages/playground/src/services/__tests__/mastra-runtime-provider.test.tsx — clarify test description for Playground opt-in.
- .changeset/upset-frogs-sit.md — updated release notes; changeset scoped to released packages (CLI, React SDK, deployers).

## Impact

- Conservative default for SDK consumers: existing apps using useChat keep legacy stream behavior unless they explicitly opt into thread signals.
- Playground continues to exercise thread signals by default for testing/experimentation.
- Vercel deployments can opt out of agent signals by setting MASTRA_AGENT_SIGNALS=false.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->